### PR TITLE
python3Packages: unbreak packages that no longer seem to be broken (mostly on Darwin)

### DIFF
--- a/pkgs/applications/science/physics/nnpdf/default.nix
+++ b/pkgs/applications/science/physics/nnpdf/default.nix
@@ -60,7 +60,5 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Only;
     maintainers = [ maintainers.veprbl ];
     platforms = platforms.unix;
-    # never built on aarch64-darwin since first introduction in nixpkgs
-    broken = (stdenv.isDarwin && stdenv.isAarch64) || (stdenv.isLinux && stdenv.isAarch64);
   };
 }

--- a/pkgs/development/python-modules/dask-jobqueue/default.nix
+++ b/pkgs/development/python-modules/dask-jobqueue/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   buildPythonPackage,
   cryptography,
@@ -79,7 +78,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "dask_jobqueue" ];
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "Deploy Dask on job schedulers like PBS, SLURM, and SGE";
     homepage = "https://github.com/dask/dask-jobqueue";
     license = licenses.bsd3;

--- a/pkgs/development/python-modules/dask-yarn/default.nix
+++ b/pkgs/development/python-modules/dask-yarn/default.nix
@@ -11,7 +11,6 @@
   grpcio,
   skein,
   pytestCheckHook,
-  stdenv,
 }:
 
 buildPythonPackage rec {
@@ -84,6 +83,5 @@ buildPythonPackage rec {
     homepage = "https://yarn.dask.org/";
     license = licenses.bsd3;
     maintainers = with maintainers; [ illustris ];
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/dbus-next/default.nix
+++ b/pkgs/development/python-modules/dbus-next/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   buildPythonPackage,
   fetchFromGitHub,
@@ -49,6 +48,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/altdesktop/python-dbus-next/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ sfrijters ];
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/ducc0/default.nix
+++ b/pkgs/development/python-modules/ducc0/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   buildPythonPackage,
   fetchFromGitLab,
@@ -36,7 +35,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "ducc0" ];
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     homepage = "https://gitlab.mpcdf.mpg.de/mtr/ducc";
     description = "Efficient algorithms for Fast Fourier transforms and more";
     license = licenses.gpl2Plus;

--- a/pkgs/development/python-modules/mouseinfo/default.nix
+++ b/pkgs/development/python-modules/mouseinfo/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   buildPythonPackage,
   pyperclip,
@@ -7,7 +6,7 @@
   xlib,
   pillow,
 }:
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "mouseinfo";
   version = "0.1.3";
 
@@ -34,7 +33,6 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "Application to display XY position and RGB color information for the pixel currently under the mouse. Works on Python 2 and 3";
     homepage = "https://github.com/asweigart/mouseinfo";
     license = licenses.gpl3;

--- a/pkgs/development/python-modules/netutils/default.nix
+++ b/pkgs/development/python-modules/netutils/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   jinja2,
@@ -66,6 +65,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/networktocode/netutils/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ fab ];
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/numba-scipy/default.nix
+++ b/pkgs/development/python-modules/numba-scipy/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   buildPythonPackage,
   fetchPypi,
@@ -39,7 +38,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "numba_scipy" ];
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "Extends Numba to make it aware of SciPy";
     homepage = "https://github.com/numba/numba-scipy";
     changelog = "https://github.com/numba/numba-scipy/blob/master/CHANGE_LOG";

--- a/pkgs/development/python-modules/omorfi/default.nix
+++ b/pkgs/development/python-modules/omorfi/default.nix
@@ -2,7 +2,6 @@
   buildPythonPackage,
   pkgs,
   lib,
-  stdenv,
   hfst,
 }:
 
@@ -26,7 +25,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/flammie/omorfi";
     license = licenses.gpl3;
     maintainers = with maintainers; [ lurkki ];
-    # Ofborg build error (hfst not found?)
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/oslo-concurrency/default.nix
+++ b/pkgs/development/python-modules/oslo-concurrency/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   buildPythonPackage,
   fetchPypi,
@@ -71,7 +70,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "oslo_concurrency" ];
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "Oslo Concurrency library";
     mainProgram = "lockutils-wrapper";
     homepage = "https://github.com/openstack/oslo.concurrency";

--- a/pkgs/development/python-modules/oslo-log/default.nix
+++ b/pkgs/development/python-modules/oslo-log/default.nix
@@ -59,6 +59,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/openstack/oslo.log";
     license = licenses.asl20;
     maintainers = teams.openstack.members;
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/persim/default.nix
+++ b/pkgs/development/python-modules/persim/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   buildPythonPackage,
   fetchPypi,
@@ -70,6 +69,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/scikit-tda/persim/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ ];
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/pescea/default.nix
+++ b/pkgs/development/python-modules/pescea/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   async-timeout,
   buildPythonPackage,
@@ -49,7 +48,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "pescea" ];
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "Python interface to Escea fireplaces";
     homepage = "https://github.com/lazdavila/pescea";
     license = licenses.gpl3Plus;

--- a/pkgs/development/python-modules/power/default.nix
+++ b/pkgs/development/python-modules/power/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   buildPythonPackage,
   fetchPypi,
@@ -19,7 +18,6 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "Cross-platform system power status information";
     homepage = "https://github.com/Kentzo/Power";
     license = licenses.mit;

--- a/pkgs/development/python-modules/proxy-py/default.nix
+++ b/pkgs/development/python-modules/proxy-py/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   bash,
   buildPythonPackage,
   fetchFromGitHub,
@@ -89,6 +88,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/abhinavsingh/proxy.py/releases/tag/v${version}";
     license = with licenses; [ bsd3 ];
     maintainers = with maintainers; [ fab ];
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/pydmd/default.nix
+++ b/pkgs/development/python-modules/pydmd/default.nix
@@ -58,7 +58,6 @@ let
       changelog = "https://github.com/PyDMD/PyDMD/releases/tag/v${version}";
       license = licenses.mit;
       maintainers = with maintainers; [ yl3dy ];
-      broken = stdenv.hostPlatform.isAarch64;
     };
   };
 in

--- a/pkgs/development/python-modules/pylibjpeg/default.nix
+++ b/pkgs/development/python-modules/pylibjpeg/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   buildPythonPackage,
   fetchFromGitHub,
@@ -13,7 +12,7 @@
 }:
 
 let
-  pylibjpeg-data = buildPythonPackage rec {
+  pylibjpeg-data = buildPythonPackage {
     pname = "pylibjpeg-data";
     version = "1.0.0dev0";
     pyproject = true;
@@ -64,8 +63,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/pydicom/pylibjpeg/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ bcdarwin ];
-    # several test failures of form
-    # "pydicom.errors.InvalidDicomError: File is missing DICOM File Meta Information header or the 'DICM' prefix is missing from the header. ..."
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/pynetdicom/default.nix
+++ b/pkgs/development/python-modules/pynetdicom/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   poetry-core,
@@ -88,7 +87,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/pydicom/pynetdicom/releases/tag/v${version}";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
-    # Tests are not passing on Darwin/Aarch64, thus it's assumed that it doesn't work
-    broken = stdenv.isDarwin || stdenv.isAarch64;
   };
 }

--- a/pkgs/development/python-modules/pysendfile/default.nix
+++ b/pkgs/development/python-modules/pysendfile/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchPypi,
   pythonOlder,
@@ -32,6 +31,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/giampaolo/pysendfile/blob/release-${version}/HISTORY.rst";
     license = licenses.mit;
     maintainers = with maintainers; [ ];
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/pytest-annotate/default.nix
+++ b/pkgs/development/python-modules/pytest-annotate/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchPypi,
   pyannotate,
@@ -32,7 +31,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "pytest_annotate" ];
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "Generate PyAnnotate annotations from your pytest tests";
     homepage = "https://github.com/kensho-technologies/pytest-annotate";
     license = licenses.asl20;

--- a/pkgs/development/python-modules/python3-application/default.nix
+++ b/pkgs/development/python-modules/python3-application/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   isPy3k,
   buildPythonPackage,
@@ -30,7 +29,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "application" ];
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "Collection of modules that are useful when building python applications";
     homepage = "https://github.com/AGProjects/python3-application";
     license = licenses.lgpl21Plus;

--- a/pkgs/development/python-modules/pytikz-allefeld/default.nix
+++ b/pkgs/development/python-modules/pytikz-allefeld/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   fetchFromGitHub,
   buildPythonPackage,
   pythonOlder,
@@ -11,7 +10,7 @@
   texlive,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "pytikz-allefeld"; # "pytikz" on pypi is a different module
   version = "unstable-2022-11-01";
   pyproject = true;
@@ -54,6 +53,5 @@ buildPythonPackage rec {
     description = "Python interface to TikZ";
     license = licenses.gpl3;
     maintainers = with maintainers; [ pbsds ];
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/pyttsx3/default.nix
+++ b/pkgs/development/python-modules/pyttsx3/default.nix
@@ -1,9 +1,7 @@
 {
-  stdenv,
   lib,
   buildPythonPackage,
   fetchPypi,
-  espeak-ng,
 }:
 
 buildPythonPackage rec {
@@ -22,7 +20,6 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "Offline text-to-speech synthesis library";
     homepage = "https://github.com/nateshmbhat/pyttsx3";
     license = licenses.mpl20;

--- a/pkgs/development/python-modules/ropper/default.nix
+++ b/pkgs/development/python-modules/ropper/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   buildPythonPackage,
   fetchFromGitHub,
@@ -38,6 +37,5 @@ buildPythonPackage rec {
     homepage = "https://scoding.de/ropper/";
     license = licenses.bsd3;
     maintainers = with maintainers; [ bennofs ];
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/selectors2/default.nix
+++ b/pkgs/development/python-modules/selectors2/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   buildPythonPackage,
   fetchPypi,
@@ -36,7 +35,6 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
     homepage = "https://www.github.com/SethMichaelLarson/selectors2";
     description = "Back-ported, durable, and portable selectors";
     license = licenses.mit;

--- a/pkgs/development/python-modules/sfepy/default.nix
+++ b/pkgs/development/python-modules/sfepy/default.nix
@@ -17,12 +17,9 @@
   python,
   sympy,
   meshio,
-  mpi4py,
-  psutil,
   openssh,
   pyvista,
   pytest,
-  stdenv,
 }:
 
 buildPythonPackage rec {
@@ -89,6 +86,5 @@ buildPythonPackage rec {
     description = "Simple Finite Elements in Python";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ wd15 ];
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/shiboken2/default.nix
+++ b/pkgs/development/python-modules/shiboken2/default.nix
@@ -59,6 +59,6 @@ stdenv.mkDerivation {
     ];
     homepage = "https://wiki.qt.io/Qt_for_Python";
     maintainers = with maintainers; [ gebner ];
-    broken = stdenv.isDarwin || pythonAtLeast "3.12";
+    broken = pythonAtLeast "3.12";
   };
 }

--- a/pkgs/development/python-modules/sphinx-markdown-parser/default.nix
+++ b/pkgs/development/python-modules/sphinx-markdown-parser/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   commonmark,
   fetchFromGitHub,
@@ -16,7 +15,7 @@
   yapf,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "sphinx-markdown-parser";
   version = "0.2.4";
   pyproject = true;
@@ -62,6 +61,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/clayrisser/sphinx-markdown-parser";
     license = licenses.mit;
     maintainers = with maintainers; [ FlorianFranzen ];
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/streamdeck/default.nix
+++ b/pkgs/development/python-modules/streamdeck/default.nix
@@ -33,6 +33,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/abcminiuser/python-elgato-streamdeck";
     license = licenses.mit;
     maintainers = with maintainers; [ majiir ];
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/streamz/default.nix
+++ b/pkgs/development/python-modules/streamz/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   pythonOlder,
   fetchPypi,
@@ -79,7 +78,6 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "Pipelines to manage continuous streams of data";
     homepage = "https://github.com/python-streamz/streamz";
     license = licenses.bsd3;

--- a/pkgs/development/python-modules/vowpalwabbit/default.nix
+++ b/pkgs/development/python-modules/vowpalwabbit/default.nix
@@ -69,7 +69,8 @@ buildPythonPackage rec {
     description = "Vowpal Wabbit is a fast machine learning library for online learning, and this is the python wrapper for the project";
     homepage = "https://github.com/JohnLangford/vowpal_wabbit";
     license = licenses.bsd3;
-    broken = stdenv.isAarch64;
     maintainers = with maintainers; [ teh ];
+    # Test again when new version is released
+    broken = stdenv.isLinux;
   };
 }

--- a/pkgs/development/python-modules/wrf-python/default.nix
+++ b/pkgs/development/python-modules/wrf-python/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   fetchFromGitHub,
   pythonOlder,
@@ -54,6 +53,5 @@ buildPythonPackage rec {
     homepage = "http://wrf-python.rtfd.org";
     license = licenses.asl20;
     maintainers = with maintainers; [ mhaselsteiner ];
-    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
## Description of changes

I ran the following very hacky command to generate a list of all `python311Packages` that were marked as `broken`, but where the build process on `aarch64-darwin` "succeeds" (in that it exits with status 0):
```fish
nix eval --json -f . python3Packages --apply \
  'builtins.mapAttrs (name: value: if (builtins.tryEval value).success && value != null then value.meta.broken or null else null)' | \
    jq -r 'to_entries | map(select(.value == true) | .key) | .[]' | \
    sed -E 's/(.*)/python311Packages.\1/' | \
    env NIXPKGS_ALLOW_BROKEN=1 NIXPKGS_ALLOW_UNFREE=1 parallel -j8 \
      'nix build -f . {} 2>/dev/null && echo "{}" || true'
```

For each of those I then inspected the package definition, and if there wasn't any obvious reason why they were marked as `broken` (aside from having simply failed to build in the past on the relevant platform), I unmarked them as `broken`, and built them on `aarch64-{darwin,linux}` and `x86_64-darwin` while scanning the build log. If the packages built without issue, and nothing caught my eye in the build log, I commit the changes.

Here's the list of packages I left marked as `broken` (mostly due to there being some sort of clear evidence they might have runtime issues, etc.) even though their builds did succeed:
```
dataset
django-q
imagecodecs-lite
prometrix
sqlalchemy-migrate
stytra
sunpy
telethon-session-sqlalchemy
```

I opted to create a commit for each package, but would be happy to bundle all the changes into one commit if that would be preferable.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
