### PR TITLE
cantata: 2.5.0 -> 3.2.0

### DIFF
--- a/pkgs/applications/audio/cantata/dont-check-for-perl-in-PATH.diff
+++ b/pkgs/applications/audio/cantata/dont-check-for-perl-in-PATH.diff
@@ -1,17 +1,16 @@
 diff --git a/playlists/dynamicplaylists.cpp b/playlists/dynamicplaylists.cpp
-index 07b6dce3..6a3f97c9 100644
+index b85e93b5..3c29f775 100644
 --- a/playlists/dynamicplaylists.cpp
 +++ b/playlists/dynamicplaylists.cpp
-@@ -211,11 +211,6 @@ void DynamicPlaylists::start(const QString &name)
-         return;
-     }
+@@ -205,11 +205,6 @@ void DynamicPlaylists::start(const QString& name)
+ 		return;
+ 	}
  
--    if (Utils::findExe("perl").isEmpty()) {
--        emit error(tr("You need to install \"perl\" on your system in order for Cantata's dynamic mode to function."));
--        return;
--    }
+-	if (Utils::findExe("perl").isEmpty()) {
+-		emit error(tr("You need to install \"perl\" on your system in order for Cantata's dynamic mode to function."));
+-		return;
+-	}
 -
-     QString fName(Utils::dataDir(rulesDir, false)+name+constExtension);
+ 	QString fName(Utils::dataDir(rulesDir, false) + name + constExtension);
  
-     if (!QFile::exists(fName)) {
-
+ 	if (!QFile::exists(fName)) {

--- a/pkgs/development/libraries/taglib/2.x.nix
+++ b/pkgs/development/libraries/taglib/2.x.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, zlib
+, testers
+, utf8cpp
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "taglib";
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "taglib";
+    repo = "taglib";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-zoZir1TtYtEEZBudlGRLYPFIFJl5oad4+l64lytJ+bc=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ zlib utf8cpp ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+    # Workaround unconditional ${prefix} until upstream is fixed:
+    #   https://github.com/taglib/taglib/issues/1098
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ];
+
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+  meta = with lib; {
+    homepage = "https://taglib.org/";
+    description = "A library for reading and editing audio file metadata";
+    mainProgram = "taglib-config";
+    longDescription = ''
+      TagLib is a library for reading and editing the meta-data of several
+      popular audio formats. Currently it supports both ID3v1 and ID3v2 for MP3
+      files, Ogg Vorbis comments and ID3 tags and Vorbis comments in FLAC, MPC,
+      Speex, WavPack, TrueAudio, WAV, AIFF, MP4 and ASF files.
+    '';
+    license = with licenses; [ lgpl3 mpl11 ];
+    maintainers = with maintainers; [ ttuegel ];
+    pkgConfigModules = [ "taglib" "taglib_c" ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24549,6 +24549,7 @@ with pkgs;
   ta-lib = callPackage ../development/libraries/ta-lib { };
 
   taglib = callPackage ../development/libraries/taglib { };
+  taglib2 = callPackage ../development/libraries/taglib/2.x.nix { };
 
   taglib_extras = callPackage ../development/libraries/taglib-extras { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6517,7 +6517,7 @@ with pkgs;
 
   davix-copy = davix.override { enableThirdPartyCopy = true; };
 
-  cantata = libsForQt5.callPackage ../applications/audio/cantata { };
+  cantata = qt6Packages.callPackage ../applications/audio/cantata { };
 
   cantoolz = callPackage ../tools/networking/cantoolz { };
 


### PR DESCRIPTION
## Description of changes

Original developer archived the repo a few years ago: https://github.com/CDrummond/cantata

Switched to an updated Qt6 fork: https://github.com/nullobsi/cantata

Also enabled libvlc for playback over http.

p.s. Also packaged taglib2.

- Built on platform(s)
  - [x] x86_64-linux

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
