### PR TITLE
wstunnel: 0.5.1.0 -> 9.6.2

### DIFF
--- a/pkgs/by-name/ws/wstunnel/package.nix
+++ b/pkgs/by-name/ws/wstunnel/package.nix
@@ -1,0 +1,32 @@
+{ fetchFromGitHub
+, rustPlatform
+, lib
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "wstunnel";
+  version = "9.6.2";
+
+  src = fetchFromGitHub {
+    owner = "erebe";
+    repo  = "wstunnel";
+    rev = "v${version}";
+    hash = "sha256-0r+8C8Gf3/s3opzplzc22d9VVp39FtBq1bYkxlmtqjg=";
+  };
+
+  cargoHash = "sha256-hHVxa7Ihmuuf26ZSzGmrHA2RczhzXtse3h1M4cNCvhw=";
+
+  checkFlags = [
+    # make use of network connection
+    "--skip=tcp::tests::test_proxy_connection"
+  ];
+
+  meta = {
+    description = "Tunneling program over websocket protocol";
+    mainProgram = "wstunnel";
+    homepage    = "https://github.com/erebe/wstunnel";
+    license     = with lib.licenses; [ bsd3 ];
+    maintainers = with lib.maintainers; [ neverbehave ];
+    platforms   = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14281,8 +14281,6 @@ with pkgs;
 
   wsmancli = callPackage ../tools/system/wsmancli { };
 
-  wstunnel = haskell.lib.compose.justStaticExecutables haskellPackages.wstunnel;
-
   wolfebin = callPackage ../tools/networking/wolfebin { };
 
   wthrr = callPackage ../applications/misc/wthrr { };


### PR DESCRIPTION
## Description of changes

Add https://github.com/erebe/wstunnel , wstunnel rewritten in rust.

There is one exists in haskell but it seems the author abandon it: https://search.nixos.org/packages?channel=24.05&from=0&size=50&sort=relevance&type=packages&query=wstunnel

I renamed the package to `wstunnel-rust` for now, but maybe we should just replace it with the haskell one? @gebner



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
