### PR TITLE
azure-cli-extensions.rdbms-connect: init at 1.0.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15346,6 +15346,12 @@
       fingerprint = "D5E4 A51D F8D2 55B9 FAC6  A9BB 2F96 07F0 9B36 0F2D";
     }];
   };
+  obreitwi = {
+    email = "oliver@breitwieser.eu";
+    github = "obreitwi";
+    githubId = 123140;
+    name = "Oliver Breitwieser";
+  };
   obsidian-systems-maintenance = {
     name = "Obsidian Systems Maintenance";
     email = "maintainer@obsidian.systems";

--- a/pkgs/tools/admin/azure-cli/default.nix
+++ b/pkgs/tools/admin/azure-cli/default.nix
@@ -233,7 +233,7 @@ py.pkgs.toPythonApplication (py.pkgs.buildAzureCliPackage rec {
     # pip is required to install extensions locally, but it's not needed if
     # we're using the default immutable configuration.
     pip
-  ];
+  ] ++ lib.concatMap (extension: extension.propagatedBuildInputs) withExtensions;
 
   postInstall = ''
     substituteInPlace az.completion.sh \

--- a/pkgs/tools/admin/azure-cli/default.nix
+++ b/pkgs/tools/admin/azure-cli/default.nix
@@ -50,8 +50,8 @@ let
         changelog = "https://github.com/Azure/azure-cli-extensions/blob/main/src/${pname}/HISTORY.rst";
         license = lib.licenses.mit;
         sourceProvenance = [ lib.sourceTypes.fromSource ];
-      };
-    } // (removeAttrs args [ "url" "sha256" "description" ]));
+      } // args.meta or { };
+    } // (removeAttrs args [ "url" "sha256" "description" "meta" ]));
 
   extensions =
     callPackages ./extensions-generated.nix { inherit mkAzExtension; }

--- a/pkgs/tools/admin/azure-cli/extensions-manual.nix
+++ b/pkgs/tools/admin/azure-cli/extensions-manual.nix
@@ -1,4 +1,6 @@
-{ mkAzExtension
+{ lib
+, mkAzExtension
+, mycli
 , python3Packages
 }:
 
@@ -9,9 +11,24 @@
     url = "https://github.com/Azure/azure-devops-cli-extension/releases/download/20240206.1/azure_devops-${version}-py2.py3-none-any.whl";
     sha256 = "658a2854d8c80f874f9382d421fa45abf6a38d00334737dda006f8dec64cf70a";
     description = "Tools for managing Azure DevOps";
-    propagatedBuildInputs = with python3Packages; [
-      distro
+    propagatedBuildInputs = with python3Packages; [ distro ];
+  };
+
+  rdbms-connect = mkAzExtension rec {
+    pname = "rdbms-connect";
+    version = "1.0.6";
+    url = "https://azcliprod.blob.core.windows.net/cli-extensions/rdbms_connect-${version}-py2.py3-none-any.whl";
+    sha256 = "49cbe8d9b7ea07a8974a29ad90247e864ed798bed5f28d0e3a57a4b37f5939e7";
+    description = "Support for testing connection to Azure Database for MySQL & PostgreSQL servers";
+    propagatedBuildInputs = (with python3Packages; [
+      pgcli
+      psycopg2
+      pymysql
+      setproctitle
+    ]) ++ [
+      mycli
     ];
+    meta.maintainers = with lib.maintainers; [ obreitwi ];
   };
 
   # Removed extensions


### PR DESCRIPTION
## Description of changes

* Added the [azure-cli-extensions.rdbms-connect](https://github.com/Azure/azure-cli-extensions/tree/main/src/rdbms-connect) at `v1.0.6`.
* As drive-by, applied `nixfmt-rfc-style` to 
  * `pkgs/tools/admin/azure-cli/default.nix` (in a [separate commit](https://github.com/NixOS/nixpkgs/commit/ae557fe541d6a7c230169c92480d01ad9c4764f3))
  * `pkgs/tools/admin/azure-cli/extensions-manual.nix` 
* Since `rdbms-connect` has its [own dependencies](https://github.com/Azure/azure-cli-extensions/blob/a8a793eb4a88a7045233733573e4ee338fdc0f6d/src/rdbms-connect/setup.py#L38C1-L43C2), this required [forwarding](https://github.com/NixOS/nixpkgs/commit/c06c1b780ae96d3c15e1f840e5cdb0ca3e0e0b78) of `propagatedBuildInputs` of extensions to the base derivation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
