### PR TITLE
caddy: add support for compiling with Caddy modules (plugins)

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -294,6 +294,33 @@
 - `nix.channel.enable = false` no longer implies `nix.settings.nix-path = []`.
   Since Nix 2.13, a `nix-path` set in `nix.conf` cannot be overriden by the `NIX_PATH` configuration variable.
 
+- Caddy can now be built with Caddy modules (plugins) by using `caddy.withPlugins`, a `passthru` function that accepts a list of attribute sets as a parameter.
+  The `caddyModules` argument represents a list of Caddy modules, with each Caddy module being an attribute set. The valid attributes for a Caddy module are `repo` and `version`.
+  `vendorHash` represents the `vendorHash` of the added dependencies of Caddy modules. The package name of the resulting output of the `caddy.withPlugins` function is `caddy-with-plugins`.
+
+  Example:
+  ```
+  services.caddy = {
+    enable = true;
+    package = pkgs.caddy.withPlugins {
+      caddyModules = [
+        { repo = "github.com/corazawaf/coraza-caddy/v2"; version = "v2.0.0-rc.3"; }
+        { repo = "github.com/caddyserver/cache-handler"; version = "v0.9.0"; }
+        { repo = "github.com/mholt/caddy-ratelimit"; version = "2dc0d586f0b87e983757c403bc0929ddeb84a537"; }
+      ];
+      vendorHash = "<SHA256 hash>";
+    };
+  };
+  ```
+
+  To get the necessary SHA256 hash of the vendored dependencies, set `vendorHash = "";` or
+  simply don't set its value at all (as `vendorHash` defaults to the value of `lib.fakeHash`).
+  The first build will fail, but it will produce the correct `vendorHash` in the error message.
+  Setting `vendorHash = ""` (or unsetting `vendorHash`) is also important when the configuration
+  of your plugins change (for example, changing the value of `version`). If you keep the `vendorHash`
+  with the same value that worked for a previous compilation of `caddy-with-plugins`, the old version that
+  does not reflect your new plugin changes will be used instead.
+
 ## Detailed migration information {#sec-release-24.11-migration}
 
 ### `sound` options removal {#sec-release-24.11-migration-sound}

--- a/pkgs/by-name/ca/caddy/package.nix
+++ b/pkgs/by-name/ca/caddy/package.nix
@@ -1,24 +1,26 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
+, gnused
+, installShellFiles
 , nixosTests
 , caddy
 , testers
-, installShellFiles
 , stdenv
 }:
 let
+  attrsToModule = map (plugin: plugin.repo);
+  attrsToVersionedModule = map ({ repo, version, ... }: lib.escapeShellArg "${repo}@${version}");
+
+  pname = "caddy";
   version = "2.8.4";
+
   dist = fetchFromGitHub {
     owner = "caddyserver";
     repo = "dist";
     rev = "v${version}";
     hash = "sha256-O4s7PhSUTXoNEIi+zYASx8AgClMC5rs7se863G6w+l0=";
   };
-in
-buildGoModule {
-  pname = "caddy";
-  inherit version;
 
   src = fetchFromGitHub {
     owner = "caddyserver";
@@ -26,8 +28,6 @@ buildGoModule {
     rev = "v${version}";
     hash = "sha256-CBfyqtWp3gYsYwaIxbfXO3AYaBiM7LutLC7uZgYXfkQ=";
   };
-
-  vendorHash = "sha256-1Api8bBZJ1/oYk4ZGIiwWCSraLzK9L+hsKXkFtk6iVM=";
 
   subPackages = [ "cmd/caddy" ];
 
@@ -39,7 +39,7 @@ buildGoModule {
   # matches upstream since v2.8.0
   tags = [ "nobadger" ];
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [ gnused installShellFiles ];
 
   postInstall = ''
     install -Dm644 ${dist}/init/caddy.service ${dist}/init/caddy-api.service -t $out/lib/systemd/system
@@ -61,19 +61,80 @@ buildGoModule {
       --zsh <($out/bin/caddy completion zsh)
   '';
 
-  passthru.tests = {
-    inherit (nixosTests) caddy;
-    version = testers.testVersion {
-      command = "${caddy}/bin/caddy version";
-      package = caddy;
-    };
-  };
-
   meta = with lib; {
     homepage = "https://caddyserver.com";
     description = "Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS";
     license = licenses.asl20;
     mainProgram = "caddy";
     maintainers = with maintainers; [ Br1ght0ne emilylange techknowlogick ];
+  };
+in
+buildGoModule {
+  inherit
+    pname
+    version
+    src
+    subPackages
+    ldflags
+    tags
+    nativeBuildInputs
+    postInstall
+    meta
+    ;
+
+  vendorHash = "sha256-1Api8bBZJ1/oYk4ZGIiwWCSraLzK9L+hsKXkFtk6iVM=";
+
+  passthru = {
+    withPlugins =
+      {
+        caddyModules,
+        vendorHash ? lib.fakeHash,
+      }:
+      buildGoModule {
+        pname = "${caddy.pname}-with-plugins";
+
+        inherit
+          version
+          src
+          subPackages
+          ldflags
+          tags
+          nativeBuildInputs
+          postInstall
+          meta
+          ;
+
+        modBuildPhase = ''
+          for module in ${toString (attrsToModule caddyModules)}; do
+            sed -i "/standard/a _ \"$module\"" ./cmd/caddy/main.go
+          done
+          for plugin in ${toString (attrsToVersionedModule caddyModules)}; do
+            go get $plugin
+          done
+          go mod vendor
+        '';
+
+        modInstallPhase = ''
+          mv -t vendor go.mod go.sum
+          cp -r vendor "$out"
+        '';
+
+        preBuild = ''
+          chmod -R u+w vendor
+          [ -f vendor/go.mod ] && mv -t . vendor/go.{mod,sum}
+          for module in ${toString (attrsToModule caddyModules)}; do
+            sed -i "/standard/a _ \"$module\"" ./cmd/caddy/main.go
+          done
+        '';
+
+        inherit vendorHash;
+      };
+    tests = {
+      inherit (nixosTests) caddy;
+      version = testers.testVersion {
+        command = "${caddy}/bin/caddy version";
+        package = caddy;
+      };
+    };
   };
 }

--- a/pkgs/by-name/ca/caddy/package.nix
+++ b/pkgs/by-name/ca/caddy/package.nix
@@ -1,12 +1,13 @@
-{ lib
-, buildGoModule
-, fetchFromGitHub
-, gnused
-, installShellFiles
-, nixosTests
-, caddy
-, testers
-, stdenv
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  gnused,
+  installShellFiles,
+  nixosTests,
+  caddy,
+  testers,
+  stdenv,
 }:
 let
   attrsToModule = map (plugin: plugin.repo);
@@ -32,41 +33,51 @@ let
   subPackages = [ "cmd/caddy" ];
 
   ldflags = [
-    "-s" "-w"
+    "-s"
+    "-w"
     "-X github.com/caddyserver/caddy/v2.CustomVersion=${version}"
   ];
 
   # matches upstream since v2.8.0
   tags = [ "nobadger" ];
 
-  nativeBuildInputs = [ gnused installShellFiles ];
+  nativeBuildInputs = [
+    gnused
+    installShellFiles
+  ];
 
-  postInstall = ''
-    install -Dm644 ${dist}/init/caddy.service ${dist}/init/caddy-api.service -t $out/lib/systemd/system
+  postInstall =
+    ''
+      install -Dm644 ${dist}/init/caddy.service ${dist}/init/caddy-api.service -t $out/lib/systemd/system
 
-    substituteInPlace $out/lib/systemd/system/caddy.service \
-      --replace-fail "/usr/bin/caddy" "$out/bin/caddy"
-    substituteInPlace $out/lib/systemd/system/caddy-api.service \
-      --replace-fail "/usr/bin/caddy" "$out/bin/caddy"
-  '' + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-    # Generating man pages and completions fail on cross-compilation
-    # https://github.com/NixOS/nixpkgs/issues/308283
+      substituteInPlace $out/lib/systemd/system/caddy.service \
+        --replace-fail "/usr/bin/caddy" "$out/bin/caddy"
+      substituteInPlace $out/lib/systemd/system/caddy-api.service \
+        --replace-fail "/usr/bin/caddy" "$out/bin/caddy"
+    ''
+    + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      # Generating man pages and completions fail on cross-compilation
+      # https://github.com/NixOS/nixpkgs/issues/308283
 
-    $out/bin/caddy manpage --directory manpages
-    installManPage manpages/*
+      $out/bin/caddy manpage --directory manpages
+      installManPage manpages/*
 
-    installShellCompletion --cmd caddy \
-      --bash <($out/bin/caddy completion bash) \
-      --fish <($out/bin/caddy completion fish) \
-      --zsh <($out/bin/caddy completion zsh)
-  '';
+      installShellCompletion --cmd caddy \
+        --bash <($out/bin/caddy completion bash) \
+        --fish <($out/bin/caddy completion fish) \
+        --zsh <($out/bin/caddy completion zsh)
+    '';
 
   meta = with lib; {
     homepage = "https://caddyserver.com";
     description = "Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS";
     license = licenses.asl20;
     mainProgram = "caddy";
-    maintainers = with maintainers; [ Br1ght0ne emilylange techknowlogick ];
+    maintainers = with maintainers; [
+      Br1ght0ne
+      emilylange
+      techknowlogick
+    ];
   };
 in
 buildGoModule {


### PR DESCRIPTION
## Description of changes
Solves: https://github.com/NixOS/nixpkgs/issues/14671

This PR continues the work of @jpds in #259275 toward adding support for building `caddy` with Caddy modules (plugins). A few recommendations given in code reviews of the PR were used, along with its previous changes being rebased. The PR is split in three commits: one adding support for compiling `caddy` with plugins (`caddy-with-plugins`), one formatting it with `nixfmt-rfc-style`, and one adding its documentation to the `24.11` release notes.

To support the compilation of `caddy` with plugins, a `passthru` function named `withPlugins` has been added that takes in a list of attribute sets and a string as arguments (`caddyModules` and `vendorHash`, respectively), resulting in a `caddy-with-plugins` package. `caddyModules` is the list of attribute sets that represents a list of `caddy` plugins. The valid attributes for a plugin are `repo` and `version`. Adding plugins changes the `buildGoModule` `vendorHash` from that of vanilla `caddy`, so the string argument also named `vendorHash` is used to change the former hash for `caddy-with-plugins` . 

The value of the `vendorHash` argument defaults to `lib.fakeHash`, which allows for one to find the correct hash by attempting to build `caddy.withPlugins [<attrset(s) of plugins>]` without setting the `vendorHash`. Using `caddy.withPlugins [<attrset(s) of plugins>]` on the result of overriding `caddy` with the correct `vendorHash` produces a `caddy-with-plugins` package, compiled with the inputted plugins.

Example:
  ```
  services.caddy = {
    enable = true;
    package = pkgs.caddy.withPlugins {
      caddyModules = [
        { repo = "github.com/corazawaf/coraza-caddy/v2"; version = "v2.0.0-rc.3"; }
        { repo = "github.com/caddyserver/cache-handler"; version = "v0.9.0"; }
        { repo = "github.com/mholt/caddy-ratelimit"; version = "2dc0d586f0b87e983757c403bc0929ddeb84a537"; }
      ];
      vendorHash = "<SHA256 hash>";
    };
  };
  ```
Adapted from Brendan Taylor's CoreDNS change in commit 95e66809debf42dbe1e4935fd31c8c275914d2eb.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
