### PR TITLE
python311Packages.rich-argparse: 1.4.0 -> 1.5.1

### DIFF
--- a/pkgs/development/python-modules/rich-argparse/default.nix
+++ b/pkgs/development/python-modules/rich-argparse/default.nix
@@ -3,14 +3,17 @@
   buildPythonPackage,
   fetchFromGitHub,
   hatchling,
-  rich,
   pytestCheckHook,
+  pythonOlder,
+  rich,
 }:
 
 buildPythonPackage rec {
   pname = "rich-argparse";
   version = "1.5.1";
-  format = "pyproject";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "hamdanal";
@@ -19,17 +22,16 @@ buildPythonPackage rec {
     hash = "sha256-NcsEGImUAqwZI6Ga3UIqnoELvz6WRKyVqGkR4jPIKPI=";
   };
 
-  propagatedBuildInputs = [
-    hatchling
-    rich
-  ];
+  build-system = [ hatchling ];
+
+  dependencies = [ rich ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "rich_argparse" ];
 
   meta = with lib; {
-    description = "Format argparse help output using rich.";
+    description = "Format argparse help output using rich";
     homepage = "https://github.com/hamdanal/rich-argparse";
     changelog = "https://github.com/hamdanal/rich-argparse/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;

--- a/pkgs/development/python-modules/rich-argparse/default.nix
+++ b/pkgs/development/python-modules/rich-argparse/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "rich-argparse";
-  version = "1.4.0";
+  version = "1.5.1";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "hamdanal";
     repo = "rich-argparse";
     rev = "refs/tags/v${version}";
-    hash = "sha256-iQ8x8UM0zmb2qYUpSh6RSEaBMrDpwY0ZHaJ9GJqn4Hs=";
+    hash = "sha256-NcsEGImUAqwZI6Ga3UIqnoELvz6WRKyVqGkR4jPIKPI=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
## Description of changes

https://github.com/hamdanal/rich-argparse/releases/tag/v1.5.1
https://github.com/hamdanal/rich-argparse/releases/tag/v1.5.0

Current version has a failed test when building with `nix build nixpkgs#python311Packages.rich-argparse`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
