### PR TITLE
bash-language-server: use pnpm.fetchDeps instead of node2nix

### DIFF
--- a/pkgs/by-name/ba/bash-language-server/package.nix
+++ b/pkgs/by-name/ba/bash-language-server/package.nix
@@ -1,0 +1,73 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pnpm_8
+, nodejs
+, npmHooks
+, makeBinaryWrapper
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bash-language-server";
+  version = "5.4.0";
+
+  src = fetchFromGitHub {
+    owner = "bash-lsp";
+    repo = "bash-language-server";
+    rev = "server-${finalAttrs.version}";
+    hash = "sha256-yJ81oGd9aNsWQMLvDSgMVVH1//Mw/SVFYFIPsJTQYzE=";
+  };
+
+  pnpmDeps = pnpm_8.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-W25xehcxncBs9QgQBt17F5YHK0b+GDEmt27XzTkyYWg=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm_8.configHook
+    npmHooks.npmBuildHook
+    makeBinaryWrapper
+  ];
+  npmBuildScript = "compile";
+  # We are only interested in the bash-language-server executable, which is
+  # part of the `./server` directory. From some reason, the `./vscode-client`
+  # directory is not included in upstream's `pnpm-workspace.yaml`, so perhaps
+  # that's why our ${pnpmDeps} don't include the dependencies required for it.
+  preBuild = ''
+    rm -r vscode-client
+    substituteInPlace tsconfig.json \
+      --replace-fail '{ "path": "./vscode-client" },' ""
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    pnpm --offline \
+      --frozen-lockfile --ignore-script \
+      --filter=bash-language-server \
+      deploy $out/lib/bash-language-server
+    # Cleanup directory a bit, to save space, and make fixup phase a bit faster
+    rm -r $out/lib/bash-language-server/src
+    find $out/lib/bash-language-server -name '*.ts' -delete
+    rm -r \
+      $out/lib/bash-language-server/node_modules/.bin \
+      $out/lib/bash-language-server/node_modules/*/bin
+
+    # Create the executable, based upon what happens in npmHooks.npmInstallHook
+    makeWrapper ${lib.getExe nodejs} $out/bin/bash-language-server \
+      --inherit-argv0 \
+      --add-flags $out/lib/bash-language-server/out/cli.js
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A language server for Bash";
+    homepage = "https://github.com/bash-lsp/bash-language-server";
+    license = licenses.mit;
+    maintainers = with maintainers; [ doronbehar ];
+    mainProgram = "bash-language-server";
+    platforms = platforms.all;
+  };
+})

--- a/pkgs/development/node-packages/aliases.nix
+++ b/pkgs/development/node-packages/aliases.nix
@@ -57,6 +57,7 @@ mapAliases {
   inherit (pkgs) asar; # added 2023-08-26
   inherit (pkgs) aws-azure-login; # added 2023-09-30
   balanceofsatoshis = pkgs.balanceofsatoshis; # added 2023-07-31
+  inherit (pkgs) bash-language-server; # added 2024-06-07
   bibtex-tidy = pkgs.bibtex-tidy; # added 2023-07-30
   bitwarden-cli = pkgs.bitwarden-cli; # added 2023-07-25
   inherit (pkgs) btc-rpc-explorer; # added 2023-08-17

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -25,7 +25,6 @@
 , "auto-changelog"
 , "aws-cdk"
 , "awesome-lint"
-, "bash-language-server"
 , "bower"
 , "bower2nix"
 , "browserify"


### PR DESCRIPTION
###### Motivation for this change

CC @malob per https://github.com/NixOS/nixpkgs/commit/75942540fafbfeb6d4ba39db64ab1573083683d9 .

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
