### PR TITLE
markdownlint-cli2: 0.9.0 -> 0.13.0

### DIFF
--- a/pkgs/tools/text/markdownlint-cli2/default.nix
+++ b/pkgs/tools/text/markdownlint-cli2/default.nix
@@ -1,32 +1,56 @@
-{ lib
-, buildNpmPackage
-, fetchFromGitHub
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  makeWrapper,
+  markdownlint-cli2,
+  nodejs,
+  runCommand,
+  zstd,
 }:
 
-buildNpmPackage rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "markdownlint-cli2";
-  version = "0.9.0";
+  version = "0.13.0";
 
-  src = fetchFromGitHub {
-    owner = "DavidAnson";
-    repo = "markdownlint-cli2";
-    rev = "v${version}";
-    hash = "sha256-qtdR7Rhz+HLZJX82OrN+twOsvFOv99e4BBDVV1UayPI=";
+  # upstream is not interested in including package-lock.json in the source
+  # https://github.com/DavidAnson/markdownlint-cli2/issues/198#issuecomment-1690529976
+  # see also https://github.com/DavidAnson/markdownlint-cli2/issues/186
+  # so use the tarball from the archlinux mirror
+  src = fetchurl {
+    url = "https://us.mirrors.cicku.me/archlinux/extra/os/x86_64/markdownlint-cli2-${finalAttrs.version}-1-any.pkg.tar.zst";
+    hash = "sha256-ioSVse3fS6n2wauZ0VsF6TQKy/ZsyLACQ4anNybIe+I=";
   };
 
-  npmDepsHash = "sha256-Fx0lDcvzLRVSAX0apKmu1CBfnGmGQR9FQEdhHUtue/c=";
+  nativeBuildInputs = [
+    makeWrapper
+    zstd
+  ];
 
-  postPatch = ''
-    ln -s npm-shrinkwrap.json package-lock.json
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -r lib share $out
+    makeWrapper "${lib.getExe nodejs}" "$out/bin/markdownlint-cli2" \
+      --add-flags "$out/lib/node_modules/markdownlint-cli2/markdownlint-cli2.js"
+
+    runHook postInstall
   '';
 
-  dontNpmBuild = true;
+  passthru.tests = {
+    smoke = runCommand "${finalAttrs.pname}-test" { nativeBuildInputs = [ markdownlint-cli2 ]; } ''
+      markdownlint-cli2 ${markdownlint-cli2}/share/doc/markdownlint-cli2/README.md > $out
+    '';
+  };
 
   meta = {
-    changelog = "https://github.com/DavidAnson/markdownlint-cli2/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/DavidAnson/markdownlint-cli2/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     description = "Fast, flexible, configuration-based command-line interface for linting Markdown/CommonMark files with the markdownlint library";
     homepage = "https://github.com/DavidAnson/markdownlint-cli2";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ natsukium ];
   };
-}
+})

--- a/pkgs/tools/text/markdownlint-cli2/default.nix
+++ b/pkgs/tools/text/markdownlint-cli2/default.nix
@@ -47,7 +47,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    changelog = "https://github.com/DavidAnson/markdownlint-cli2/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/DavidAnson/markdownlint-cli2/blob/v${finalAttrs.version}/CHANGELOG.md";
     description = "Fast, flexible, configuration-based command-line interface for linting Markdown/CommonMark files with the markdownlint library";
     homepage = "https://github.com/DavidAnson/markdownlint-cli2";
     license = lib.licenses.mit;


### PR DESCRIPTION
upstream is not interested in including package-lock.json in the source, so use the tarball from the archlinux mirror

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
