### PR TITLE
xsimd: disable test_error_gamma failing on darwin

### DIFF
--- a/pkgs/development/libraries/xsimd/default.nix
+++ b/pkgs/development/libraries/xsimd/default.nix
@@ -23,6 +23,9 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/xtensor-stack/xsimd/commit/c8a87ed6e04b6782f48f94713adfb0cad6c11ddf.patch";
       hash = "sha256-2/FvBGdqTPcayD7rdHPSzL+F8IYKAfMW0WBJ0cW9EZ0=";
     })
+  ] ++ lib.optionals stdenv.isDarwin [
+    # https://github.com/xtensor-stack/xsimd/issues/1030
+    ./disable-test_error_gamma.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/xsimd/disable-test_error_gamma.patch
+++ b/pkgs/development/libraries/xsimd/disable-test_error_gamma.patch
@@ -1,0 +1,30 @@
+diff --git i/test/test_error_gamma.cpp w/test/test_error_gamma.cpp
+index 214cbb5..299e5b8 100644
+--- i/test/test_error_gamma.cpp
++++ w/test/test_error_gamma.cpp
+@@ -131,25 +131,6 @@ struct error_gamma_test
+             INFO("lgamma");
+             CHECK_EQ(diff, 0);
+         }
+-#if !(XSIMD_WITH_AVX && !XSIMD_WITH_AVX2)
+-
+-        // tgamma (negative input)
+-        {
+-            std::transform(gamma_neg_input.cbegin(), gamma_neg_input.cend(), expected.begin(),
+-                           [](const value_type& v)
+-                           { return std::lgamma(v); });
+-            batch_type in, out;
+-            for (size_t i = 0; i < nb_input; i += size)
+-            {
+-                detail::load_batch(in, gamma_neg_input, i);
+-                out = lgamma(in);
+-                detail::store_batch(out, res, i);
+-            }
+-            size_t diff = detail::get_nb_diff(res, expected);
+-            INFO("lgamma (negative input)");
+-            CHECK_EQ(diff, 0);
+-        }
+-#endif
+     }
+ };
+ 


### PR DESCRIPTION
###### Motivation for this change

cc @vcunat

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
