### PR TITLE
homebank: fix clang build

### DIFF
--- a/pkgs/applications/office/homebank/default.nix
+++ b/pkgs/applications/office/homebank/default.nix
@@ -9,6 +9,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-YMNf6v40GuyP7Z3ksKh13A9cFnTF9YBP9xkKbGxT3AE=";
   };
 
+  patches = [
+    ./fix-clang-build.diff
+  ];
+
   nativeBuildInputs = [ pkg-config wrapGAppsHook3 intltool ];
   buildInputs = [ gtk libofx libsoup_3 gnome.adwaita-icon-theme];
 

--- a/pkgs/applications/office/homebank/fix-clang-build.diff
+++ b/pkgs/applications/office/homebank/fix-clang-build.diff
@@ -1,0 +1,23 @@
+C Standard says in 6.8.1:
+
+    labeled-statement:
+      identifier : statement
+      case constant-expression : statement
+      default : statement
+
+Notably, only expressions and no declarations are allowed. A common workaround for this
+is adding an empty statement.
+
+diff --git a/src/rep-budget.c b/src/rep-budget.c
+index eb5cce6..61e2e77 100644
+--- a/src/rep-budget.c
++++ b/src/rep-budget.c
+@@ -255,7 +255,7 @@ gint tmpmode;
+ 	}
+ 	else
+ 	{
+-libname:
++libname: ;
+ 	gchar *name;
+ 	
+ 		gtk_tree_model_get(model, iter, 


### PR DESCRIPTION

## Description of changes
Labels always require a statement behind that. GCC permits declarations for some reason, but it's against the standard and clang (rightfully) rejects this.

Adding an empty statement to work around this.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
