### PR TITLE
Add stdenv & CC support for Zig

### DIFF
--- a/pkgs/build-support/cc-wrapper/add-flags.sh
+++ b/pkgs/build-support/cc-wrapper/add-flags.sh
@@ -27,8 +27,11 @@ for var in "${var_templates_bool[@]}"; do
     mangleVarBool "$var" ${role_suffixes[@]+"${role_suffixes[@]}"}
 done
 
-# `-B@out@/bin' forces cc to use ld-wrapper.sh when calling ld.
-NIX_CFLAGS_COMPILE_@suffixSalt@="-B@out@/bin/ $NIX_CFLAGS_COMPILE_@suffixSalt@"
+# Arocc does not support "-B"
+if [[ -z "@isArocc@" ]]; then
+    # `-B@out@/bin' forces cc to use ld-wrapper.sh when calling ld.
+    NIX_CFLAGS_COMPILE_@suffixSalt@="-B@out@/bin/ $NIX_CFLAGS_COMPILE_@suffixSalt@"
+fi
 
 # Export and assign separately in order that a failing $(..) will fail
 # the script.

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -79,6 +79,11 @@ if [ "$nonFlagArgs" = 0 ]; then
     dontLink=1
 fi
 
+# Arocc does not link
+if [ "@isArocc@" = 1 ]; then
+    dontLink=1
+fi
+
 # Optionally filter out paths not refering to the store.
 if [[ "${NIX_ENFORCE_PURITY:-}" = 1 && -n "$NIX_STORE" ]]; then
     kept=()

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -15,7 +15,8 @@
 , propagateDoc ? cc != null && cc ? man
 , extraTools ? [], extraPackages ? [], extraBuildCommands ? ""
 , nixSupport ? {}
-, isGNU ? false, isClang ? cc.isClang or false, isZig ? cc.isZig or false, isCcache ? cc.isCcache or false
+, isGNU ? false, isClang ? cc.isClang or false, isZig ? cc.isZig or false
+, isArocc ? cc.isArocc or false, isCcache ? cc.isCcache or false
 , gnugrep ? null
 , expand-response-params
 , libcxx ? null
@@ -305,6 +306,9 @@ stdenvNoCC.mkDerivation {
 
   outputs = [ "out" ] ++ optionals propagateDoc [ "man" "info" ];
 
+  # Cannot be in "passthru" due to "substituteAll"
+  inherit isArocc;
+
   passthru = {
     inherit targetPrefix suffixSalt;
     # "cc" is the generic name for a C compiler, but there is no one for package
@@ -392,6 +396,10 @@ stdenvNoCC.mkDerivation {
         ln -s ${targetPrefix}clang $out/bin/${targetPrefix}cc
         export named_cc=${targetPrefix}clang
         export named_cxx=${targetPrefix}clang++
+      elif [ -e $ccPath/arocc ]; then
+        wrap ${targetPrefix}arocc $wrapper $ccPath/arocc
+        ln -s ${targetPrefix}arocc $out/bin/${targetPrefix}cc
+        export named_cc=${targetPrefix}arocc
       fi
 
       if [ -e $ccPath/${targetPrefix}g++ ]; then
@@ -476,7 +484,7 @@ stdenvNoCC.mkDerivation {
     #
     # TODO(@Ericson2314): Remove this after stable release and force
     # everyone to refer to bintools-wrapper directly.
-    + ''
+    + optionalString (!isArocc) ''
       if [[ -f "$bintools/nix-support/dynamic-linker" ]]; then
         ln -s "$bintools/nix-support/dynamic-linker" "$out/nix-support"
       fi
@@ -492,7 +500,7 @@ stdenvNoCC.mkDerivation {
 
       echo "-B${gccForLibs}/lib/gcc/${targetPlatform.config}/${gccForLibs.version}" >> $out/nix-support/cc-cflags
     ''
-    + optionalString useGccForLibs ''
+    + optionalString (useGccForLibs && !isArocc) ''
       echo "-L${gccForLibs}/lib/gcc/${targetPlatform.config}/${gccForLibs.version}" >> $out/nix-support/cc-ldflags
       echo "-L${gccForLibs_solib}/lib" >> $out/nix-support/cc-ldflags
     ''
@@ -518,9 +526,9 @@ stdenvNoCC.mkDerivation {
     ''
     # this ensures that when clang passes -lgcc_s to lld (as it does
     # when building e.g. firefox), lld is able to find libgcc_s.so
-    + concatMapStrings (libgcc: ''
+    + optionals (!isArocc) (concatMapStrings (libgcc: ''
       echo "-L${libgcc}/lib" >> $out/nix-support/cc-ldflags
-    '') (toList (gccForLibs.libgcc or [])))
+    '') (toList (gccForLibs.libgcc or []))))
 
     ##
     ## General libc support
@@ -540,9 +548,10 @@ stdenvNoCC.mkDerivation {
     + optionalString (libc != null) (''
       touch "$out/nix-support/libc-cflags"
       touch "$out/nix-support/libc-ldflags"
+    '' + optionalString (!isArocc) ''
       echo "-B${libc_lib}${libc.libdir or "/lib/"}" >> $out/nix-support/libc-crt1-cflags
     '' + optionalString (!(cc.langD or false)) ''
-      echo "-idirafter ${libc_dev}${libc.incdir or "/include"}" >> $out/nix-support/libc-cflags
+      echo "-${if isArocc then "I" else "idirafter"} ${libc_dev}${libc.incdir or "/include"}" >> $out/nix-support/libc-cflags
     '' + optionalString (isGNU && (!(cc.langD or false))) ''
       for dir in "${cc}"/lib/gcc/*/*/include-fixed; do
         echo '-idirafter' ''${dir} >> $out/nix-support/libc-cflags
@@ -598,7 +607,7 @@ stdenvNoCC.mkDerivation {
     # ${cc_solib}/lib64 (even though it does actually search there...)..
     # This confuses libtool.  So add it to the compiler tool search
     # path explicitly.
-    + optionalString (!nativeTools) ''
+    + optionalString (!nativeTools && !isArocc) ''
       if [ -e "${cc_solib}/lib64" -a ! -L "${cc_solib}/lib64" ]; then
         ccLDFlags+=" -L${cc_solib}/lib64"
         ccCFlags+=" -B${cc_solib}/lib64"
@@ -606,7 +615,7 @@ stdenvNoCC.mkDerivation {
       ccLDFlags+=" -L${cc_solib}/lib"
       ccCFlags+=" -B${cc_solib}/lib"
 
-    '' + optionalString cc.langAda or false ''
+    '' + optionalString (cc.langAda or false && !isArocc) ''
       touch "$out/nix-support/gnat-cflags"
       touch "$out/nix-support/gnat-ldflags"
       basePath=$(echo $cc/lib/*/*/*)
@@ -627,7 +636,7 @@ stdenvNoCC.mkDerivation {
     + optionalString propagateDoc ''
       ln -s ${cc.man} $man
       ln -s ${cc.info} $info
-    '' + optionalString (cc.langD or cc.langJava or false) ''
+    '' + optionalString (cc.langD or cc.langJava or false && !isArocc) ''
       echo "-B${zlib}${zlib.libdir or "/lib/"}" >> $out/nix-support/libc-cflags
     ''
 
@@ -668,7 +677,7 @@ stdenvNoCC.mkDerivation {
       hardening_unsupported_flags+=" stackprotector"
     ''
 
-    + optionalString (libc != null && targetPlatform.isAvr) ''
+    + optionalString (libc != null && targetPlatform.isAvr && !isArocc) ''
       for isa in avr5 avr3 avr4 avr6 avr25 avr31 avr35 avr51 avrxmega2 avrxmega4 avrxmega5 avrxmega6 avrxmega7 tiny-stack; do
         echo "-B${getLib libc}/avr/lib/$isa" >> $out/nix-support/libc-crt1-cflags
       done

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -15,7 +15,8 @@
 , propagateDoc ? cc != null && cc ? man
 , extraTools ? [], extraPackages ? [], extraBuildCommands ? ""
 , nixSupport ? {}
-, isGNU ? false, isClang ? cc.isClang or false, isCcache ? cc.isCcache or false, gnugrep ? null
+, isGNU ? false, isClang ? cc.isClang or false, isZig ? cc.isZig or false, isCcache ? cc.isCcache or false
+, gnugrep ? null
 , expand-response-params
 , libcxx ? null
 
@@ -311,7 +312,7 @@ stdenvNoCC.mkDerivation {
     # Binutils, and Apple's "cctools"; "bintools" as an attempt to find an
     # unused middle-ground name that evokes both.
     inherit bintools;
-    inherit cc libc libcxx nativeTools nativeLibc nativePrefix isGNU isClang;
+    inherit cc libc libcxx nativeTools nativeLibc nativePrefix isGNU isClang isZig;
 
     emacsBufferSetup = pkgs: ''
       ; We should handle propagation here too

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -90,6 +90,14 @@ python3.pkgs.buildPythonApplication rec {
     # Fix extraframework lookup on case-sensitive APFS.
     # https://github.com/mesonbuild/meson/pull/13038
     ./007-case-sensitive-fs.patch
+
+    # Fix meson's detection for zig's linker
+    # https://github.com/mesonbuild/meson/pull/12293
+    (fetchpatch {
+      name = "linker-support-zig-cc.patch";
+      url = "https://github.com/mesonbuild/meson/pull/12293/commits/2baae244c995794d9addfe6ed924dfa72f01be82.patch";
+      hash = "sha256-dDOmSRBKl/gs7I3kmLXIyQk3zsOdlaYov72pPSel4+I=";
+    })
   ];
 
   buildInputs = lib.optionals (python3.pythonOlder "3.9") [

--- a/pkgs/development/compilers/arocc/default.nix
+++ b/pkgs/development/compilers/arocc/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  fetchFromGitHub,
+  callPackage,
+  zig_0_13,
+}:
+let
+  versions = [
+    {
+      zig = zig_0_13;
+      version = "0-unstable-06-01";
+      src = fetchFromGitHub {
+        owner = "Vexu";
+        repo = "arocc";
+        rev = "55cb6d1b682b83f75ad4f60e34c6fcd2336e8531";
+        hash = "sha256-xs3zNQIC5drrQYT4nxL7Q69xSEdbdMv5+3hQpsX3q5A=";
+      };
+    }
+  ];
+
+  mkPackage =
+    {
+      zig,
+      version,
+      src,
+    }:
+    callPackage ./package.nix { inherit zig version src; };
+
+  pkgsList = lib.map mkPackage versions;
+
+  pkgsAttrsUnwrapped = lib.listToAttrs (
+    lib.map (pkg: lib.nameValuePair "${pkg.version}-unwrapped" pkg) pkgsList
+  );
+  pkgsAttrsWrapped = lib.listToAttrs (
+    lib.map (pkg: lib.nameValuePair pkg.version pkg.wrapped) pkgsList
+  );
+
+  pkgsAttrs = pkgsAttrsWrapped // pkgsAttrsUnwrapped;
+in
+{
+  latest-unwrapped = lib.last pkgsList;
+  latest = (lib.last pkgsList).wrapped;
+}
+// pkgsAttrs

--- a/pkgs/development/compilers/arocc/package.nix
+++ b/pkgs/development/compilers/arocc/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  stdenv,
+  wrapCCWith,
+  overrideCC,
+  zig,
+  version,
+  src,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "arocc";
+  inherit version src;
+
+  nativeBuildInputs = [ zig.hook ];
+
+  passthru = {
+    inherit zig;
+    isArocc = true;
+    wrapped = wrapCCWith { cc = finalAttrs.finalPackage; };
+    stdenv = overrideCC stdenv finalAttrs.passthru.wrapped;
+  };
+
+  meta = {
+    description = "C compiler written in Zig.";
+    homepage = "http://aro.vexu.eu/";
+    license = with lib.licenses; [
+      mit
+      unicode-30
+    ];
+    maintainers = with lib.maintainers; [ RossComputerGuy ];
+    mainProgram = "arocc";
+  };
+})

--- a/pkgs/development/compilers/zig/0.10/default.nix
+++ b/pkgs/development/compilers/zig/0.10/default.nix
@@ -89,9 +89,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     hook = callPackage ./hook.nix { zig = finalAttrs.finalPackage; };
-    cc = callPackage ../cc.nix {
-      zig = finalAttrs.finalPackage;
-    };
+    cc = callPackage ../cc.nix { zig = finalAttrs.finalPackage; };
+    stdenv = callPackage ../stdenv.nix { zig = finalAttrs.finalPackage; };
     tests = {
       version = testers.testVersion {
         package = finalAttrs.finalPackage;

--- a/pkgs/development/compilers/zig/0.10/default.nix
+++ b/pkgs/development/compilers/zig/0.10/default.nix
@@ -89,6 +89,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     hook = callPackage ./hook.nix { zig = finalAttrs.finalPackage; };
+    cc = callPackage ../cc.nix {
+      zig = finalAttrs.finalPackage;
+    };
     tests = {
       version = testers.testVersion {
         package = finalAttrs.finalPackage;

--- a/pkgs/development/compilers/zig/0.11/default.nix
+++ b/pkgs/development/compilers/zig/0.11/default.nix
@@ -83,9 +83,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     hook = callPackage ./hook.nix { zig = finalAttrs.finalPackage; };
-    cc = callPackage ../cc.nix {
-      zig = finalAttrs.finalPackage;
-    };
+    cc = callPackage ../cc.nix { zig = finalAttrs.finalPackage; };
+    stdenv = callPackage ../stdenv.nix { zig = finalAttrs.finalPackage; };
     tests = {
       version = testers.testVersion {
         package = finalAttrs.finalPackage;

--- a/pkgs/development/compilers/zig/0.11/default.nix
+++ b/pkgs/development/compilers/zig/0.11/default.nix
@@ -83,6 +83,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     hook = callPackage ./hook.nix { zig = finalAttrs.finalPackage; };
+    cc = callPackage ../cc.nix {
+      zig = finalAttrs.finalPackage;
+    };
     tests = {
       version = testers.testVersion {
         package = finalAttrs.finalPackage;

--- a/pkgs/development/compilers/zig/0.12/default.nix
+++ b/pkgs/development/compilers/zig/0.12/default.nix
@@ -95,6 +95,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     hook = callPackage ./hook.nix { zig = finalAttrs.finalPackage; };
+    cc = callPackage ../cc.nix {
+      zig = finalAttrs.finalPackage;
+    };
     tests = {
       version = testers.testVersion {
         package = finalAttrs.finalPackage;

--- a/pkgs/development/compilers/zig/0.12/default.nix
+++ b/pkgs/development/compilers/zig/0.12/default.nix
@@ -95,9 +95,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     hook = callPackage ./hook.nix { zig = finalAttrs.finalPackage; };
-    cc = callPackage ../cc.nix {
-      zig = finalAttrs.finalPackage;
-    };
+    cc = callPackage ../cc.nix { zig = finalAttrs.finalPackage; };
+    stdenv = callPackage ../stdenv.nix { zig = finalAttrs.finalPackage; };
     tests = {
       version = testers.testVersion {
         package = finalAttrs.finalPackage;

--- a/pkgs/development/compilers/zig/0.13/default.nix
+++ b/pkgs/development/compilers/zig/0.13/default.nix
@@ -95,6 +95,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     hook = callPackage ./hook.nix { zig = finalAttrs.finalPackage; };
+    cc = callPackage ../cc.nix { zig = finalAttrs.finalPackage; };
+    stdenv = callPackage ../stdenv.nix { zig = finalAttrs.finalPackage; };
     tests = {
       version = testers.testVersion {
         package = finalAttrs.finalPackage;

--- a/pkgs/development/compilers/zig/0.9/default.nix
+++ b/pkgs/development/compilers/zig/0.9/default.nix
@@ -91,9 +91,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     hook = callPackage ./hook.nix { zig = finalAttrs.finalPackage; };
-    cc = callPackage ../cc.nix {
-      zig = finalAttrs.finalPackage;
-    };
+    cc = callPackage ../cc.nix { zig = finalAttrs.finalPackage; };
+    stdenv = callPackage ../stdenv.nix { zig = finalAttrs.finalPackage; };
     tests = {
       version = testers.testVersion {
         package = finalAttrs.finalPackage;

--- a/pkgs/development/compilers/zig/0.9/default.nix
+++ b/pkgs/development/compilers/zig/0.9/default.nix
@@ -91,6 +91,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     hook = callPackage ./hook.nix { zig = finalAttrs.finalPackage; };
+    cc = callPackage ../cc.nix {
+      zig = finalAttrs.finalPackage;
+    };
     tests = {
       version = testers.testVersion {
         package = finalAttrs.finalPackage;

--- a/pkgs/development/compilers/zig/cc.nix
+++ b/pkgs/development/compilers/zig/cc.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  wrapCCWith,
+  makeWrapper,
+  runCommand,
+  targetPlatform,
+  targetPackages,
+  zig,
+}:
+wrapCCWith {
+  cc =
+    runCommand "zig-cc-${zig.version}"
+      {
+        pname = "zig-cc";
+        inherit (zig) version meta;
+
+        nativeBuildInputs = [ makeWrapper ];
+
+        passthru.isZig = true;
+        inherit zig;
+      }
+      ''
+        mkdir -p $out/bin
+        for tool in ar cc c++ objcopy; do
+          makeWrapper "$zig/bin/zig" "$out/bin/$tool" \
+            --add-flags "$tool" \
+            --run "export ZIG_GLOBAL_CACHE_DIR=\$(mktemp -d)"
+        done
+
+        mv $out/bin/c++ $out/bin/clang++
+        mv $out/bin/cc $out/bin/clang
+      '';
+
+  nixSupport.cc-cflags =
+    [
+      "-target"
+      "${targetPlatform.parsed.cpu.name}-${targetPlatform.parsed.kernel.name}-${targetPlatform.parsed.abi.name}"
+    ]
+    ++ lib.optional (
+      targetPlatform.isLinux && !(targetPackages.isStatic or false)
+    ) "-Wl,-dynamic-linker=${targetPackages.stdenv.cc.bintools.dynamicLinker}";
+}

--- a/pkgs/development/compilers/zig/generic.nix
+++ b/pkgs/development/compilers/zig/generic.nix
@@ -71,6 +71,9 @@ stdenv.mkDerivation (finalAttrs: {
     hook = callPackage ./hook.nix {
       zig = finalAttrs.finalPackage;
     };
+    cc = callPackage ./cc.nix {
+      zig = finalAttrs.finalPackage;
+    };
   };
 
   meta = {

--- a/pkgs/development/compilers/zig/generic.nix
+++ b/pkgs/development/compilers/zig/generic.nix
@@ -74,6 +74,9 @@ stdenv.mkDerivation (finalAttrs: {
     cc = callPackage ./cc.nix {
       zig = finalAttrs.finalPackage;
     };
+    stdenv = callPackage ./stdenv.nix {
+      zig = finalAttrs.finalPackage;
+    };
   };
 
   meta = {

--- a/pkgs/development/compilers/zig/stdenv.nix
+++ b/pkgs/development/compilers/zig/stdenv.nix
@@ -1,0 +1,6 @@
+{
+  stdenv,
+  overrideCC,
+  zig,
+}:
+overrideCC stdenv zig.cc

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
     fi
 
     # Necessary for FTS5 on Linux
-    export NIX_LDFLAGS="$NIX_LDFLAGS -lm"
+    export NIX_CFLAGS_LINK="$NIX_CFLAGS_LINK -lm"
 
     echo ""
     echo "NIX_CFLAGS_COMPILE = $NIX_CFLAGS_COMPILE"

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -75,6 +75,8 @@ in lib.init bootStages ++ [
                then buildPackages.llvmPackages.libcxxClang
              else if crossSystem.useLLVM or false
                then buildPackages.llvmPackages.clang
+             else if crossSystem.useZig or false
+               then buildPackages.zig.cc
              else buildPackages.gcc;
 
         extraNativeBuildInputs = old.extraNativeBuildInputs

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -77,6 +77,8 @@ in lib.init bootStages ++ [
                then buildPackages.llvmPackages.clang
              else if crossSystem.useZig or false
                then buildPackages.zig.cc
+             else if crossSystem.useArocc or false
+               then buildPackages.arocc
              else buildPackages.gcc;
 
         extraNativeBuildInputs = old.extraNativeBuildInputs

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24696,6 +24696,8 @@ with pkgs;
   };
   zig = zig_0_13;
 
+  zigStdenv = if stdenv.cc.isZig then stdenv else lowPrio zig.passthru.stdenv;
+
   zimlib = callPackage ../development/libraries/zimlib { };
 
   zita-convolver = callPackage ../development/libraries/audio/zita-convolver { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16662,6 +16662,7 @@ with pkgs;
 
     isGNU = cc.isGNU or false;
     isClang = cc.isClang or false;
+    isArocc = cc.isArocc or false;
     isZig = cc.isZig or false;
 
     inherit cc bintools libc libcxx extraPackages nixSupport zlib;
@@ -24697,6 +24698,11 @@ with pkgs;
   zig = zig_0_13;
 
   zigStdenv = if stdenv.cc.isZig then stdenv else lowPrio zig.passthru.stdenv;
+
+  aroccPackages = recurseIntoAttrs (callPackage ../development/compilers/arocc {});
+  arocc = aroccPackages.latest;
+
+  aroccStdenv = if stdenv.cc.isArocc then stdenv else lowPrio arocc.cc.passthru.stdenv;
 
   zimlib = callPackage ../development/libraries/zimlib { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16662,6 +16662,7 @@ with pkgs;
 
     isGNU = cc.isGNU or false;
     isClang = cc.isClang or false;
+    isZig = cc.isZig or false;
 
     inherit cc bintools libc libcxx extraPackages nixSupport zlib;
   } // extraArgs; in self);

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -291,6 +291,7 @@ let
       agdaPackages = packagePlatforms pkgs.agdaPackages;
 
       pkgsLLVM.stdenv = [ "x86_64-linux" "aarch64-linux" ];
+      pkgsZig.stdenv = [ "x86_64-linux" "aarch64-linux" ];
       pkgsMusl.stdenv = [ "x86_64-linux" "aarch64-linux" ];
       pkgsStatic.stdenv = [ "x86_64-linux" "aarch64-linux" ];
 

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -291,6 +291,7 @@ let
       agdaPackages = packagePlatforms pkgs.agdaPackages;
 
       pkgsLLVM.stdenv = [ "x86_64-linux" "aarch64-linux" ];
+      pkgsArocc.stdenv = [ "x86_64-linux" "aarch64-linux" ];
       pkgsZig.stdenv = [ "x86_64-linux" "aarch64-linux" ];
       pkgsMusl.stdenv = [ "x86_64-linux" "aarch64-linux" ];
       pkgsStatic.stdenv = [ "x86_64-linux" "aarch64-linux" ];

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -203,6 +203,21 @@ let
       };
     };
 
+    pkgsArocc = nixpkgsFun {
+      overlays = [
+        (self': super': {
+          pkgsArocc = super';
+        })
+      ] ++ overlays;
+      # Bootstrap a cross stdenv using the Aro C compiler.
+      # This is currently not possible when compiling natively,
+      # so we don't need to check hostPlatform != buildPlatform.
+      crossSystem = stdenv.hostPlatform // {
+        useArocc = true;
+        linker = "lld";
+      };
+    };
+
     pkgsZig = nixpkgsFun {
       overlays = [
         (self': super': {

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -203,6 +203,21 @@ let
       };
     };
 
+    pkgsZig = nixpkgsFun {
+      overlays = [
+        (self': super': {
+          pkgsZig = super';
+        })
+      ] ++ overlays;
+      # Bootstrap a cross stdenv using the Zig toolchain.
+      # This is currently not possible when compiling natively,
+      # so we don't need to check hostPlatform != buildPlatform.
+      crossSystem = stdenv.hostPlatform // {
+        useZig = true;
+        linker = "lld";
+      };
+    };
+
     # All packages built with the Musl libc. This will override the
     # default GNU libc on Linux systems. Non-Linux systems are not
     # supported. 32-bit is also not supported.


### PR DESCRIPTION
## Description of changes

Introduces the ability to compile programs in nixpkgs using Zig with its own `zigStdenv` and CC adapter. This is kinda broken at the moment but it does not break anything critical so rebuilds should be 0 (except patching things like meson). However, the only problem seems to be an issue with Zig trying to link glibc right now. It is linking the `libc.so` linker script instead of the shared library.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
