### PR TITLE
julius: darwin build, add maintainer

### DIFF
--- a/pkgs/games/julius/darwin-fixes.patch
+++ b/pkgs/games/julius/darwin-fixes.patch
@@ -1,0 +1,49 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 038a34ba..d46b9258 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -669,16 +669,14 @@ endif()
+ if(APPLE)
+     # generating a macOS icns file (see https://stackoverflow.com/a/20703594)
+     add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/res/julius.icns
+-        COMMAND mkdir -p julius.iconset
+-        COMMAND sips -z 16 16    julius_256.png --out julius.iconset/icon_16x16.png
+-        COMMAND sips -z 32 32    julius_256.png --out julius.iconset/icon_16x16@2x.png
+-        COMMAND sips -z 32 32    julius_256.png --out julius.iconset/icon_32x32.png
+-        COMMAND sips -z 64 64    julius_256.png --out julius.iconset/icon_32x32@2x.png
+-        COMMAND sips -z 128 128  julius_256.png --out julius.iconset/icon_128x128.png
+-        COMMAND sips -z 256 256  julius_256.png --out julius.iconset/icon_128x128@2x.png
+-        COMMAND sips -z 256 256  julius_256.png --out julius.iconset/icon_256x256.png
+-        COMMAND sips -z 512 512  julius_512.png --out julius.iconset/icon_256x256@2x.png
+-        COMMAND iconutil -c icns julius.iconset
++        COMMAND mkdir julius.iconset
++        COMMAND convert julius_256.png -resize 16x16 julius.iconset/icon_16.png
++        COMMAND convert julius_256.png -resize 32x32 julius.iconset/icon_32.png
++        COMMAND convert julius_256.png -resize 64x64 julius.iconset/icon_64.png
++        COMMAND convert julius_256.png -resize 128x128 julius.iconset/icon_128.png
++        COMMAND cp julius_256.png julius.iconset/icon_256.png
++        COMMAND cp julius_512.png julius.iconset/icon_512.png
++        COMMAND png2icns julius.icns julius.iconset/icon_{16,32,64,128,256,512}.png
+         COMMAND rm -R julius.iconset
+         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/res)
+     set_source_files_properties(${PROJECT_SOURCE_DIR}/res/julius.icns PROPERTIES
+@@ -687,7 +685,6 @@ if(APPLE)
+     # setting variables that will populate Info.plist
+     set(MACOSX_BUNDLE_GUI_IDENTIFIER "com.github.bvschaik.julius")
+     set(MACOSX_BUNDLE_BUNDLE_NAME ${USER_FRIENDLY_NAME})
+-    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.10" CACHE STRING "Minimum OS X deployment version" FORCE)
+     set(MACOSX_BUNDLE_ICON_FILE "julius.icns")
+     set(MACOSX_BUNDLE_BUNDLE_VERSION
+         "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}${VERSION_REVISION}")
+diff --git a/cmake/FindSDL2_mixer.cmake b/cmake/FindSDL2_mixer.cmake
+index 29cc683c..1fa28a1f 100644
+--- a/cmake/FindSDL2_mixer.cmake
++++ b/cmake/FindSDL2_mixer.cmake
+@@ -93,7 +93,6 @@ ELSE()
+         PATH_SUFFIXES include include/SDL2
+         PATHS ${SDL2_SEARCH_PATHS}
+       )
+-      set(SDL2_MIXER_INCLUDE_DIR "${SDL2_MIXER_INCLUDE_DIR}/Headers")
+     endif()
+ 
+     if(NOT APPLE OR NOT EXISTS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h")

--- a/pkgs/games/julius/default.nix
+++ b/pkgs/games/julius/default.nix
@@ -5,8 +5,10 @@
 , SDL2_mixer
 , cmake
 , libpng
+, darwin
+, libicns
+, imagemagick
 }:
-
 stdenv.mkDerivation rec {
   pname = "julius";
   version = "1.7.0";
@@ -18,16 +20,41 @@ stdenv.mkDerivation rec {
     hash = "sha256-I5GTaVWzz0ryGLDSS3rzxp+XFVXZa9hZmgwon/6r83A=";
   };
 
-  nativeBuildInputs = [ cmake ];
-  buildInputs = [ SDL2 SDL2_mixer libpng ];
+  patches = [
+    # This fixes the darwin bundle generation, sets min. deployment version
+    # and patches SDL2_mixer include
+    ./darwin-fixes.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.sigtool
+    libicns
+    imagemagick
+  ];
+
+  buildInputs = [
+    SDL2
+    SDL2_mixer
+    libpng
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Cocoa
+  ];
+
+  installPhase = lib.optionalString stdenv.isDarwin ''
+    runHook preInstall
+    mkdir -p $out/Applications
+    cp -r julius.app $out/Applications/
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/bvschaik/julius";
     description = "An open source re-implementation of Caesar III";
     mainProgram = "julius";
     license = licenses.agpl3Only;
-    maintainers = with maintainers; [ Thra11 ];
+    maintainers = with maintainers; [ Thra11 matteopacini ];
     platforms = platforms.all;
-    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
## Description of changes

Added Darwin support to Julius.

List of changes:
- Disabled `fixup_bundle` CMake directive - gave a few errors and doesn't really makes sense on Nix
- Disabled unit tests - they don't compile 
- Set min deployment target to macOS 11.0
- Cmake app bundle generation :
    - replaced `sips` with `convert` (`imagemagick`)
    - replaced `iconutil` with `png2icns` (`libicns`)
    - replaced `codesign` binary with the one from `darwin.sigtool`
- Added myself as second maintainer for Darwin

The screenshot below is from the compiled `julius.app` running on my M1 machine (macOS 14.5).

<img width="1728" alt="Screenshot 2024-06-07 at 17 52 43" src="https://github.com/NixOS/nixpkgs/assets/3139724/976718fb-5b75-495e-97db-38c0e826fe29">

Binaries tested both on `aarch64-darwin` and `aarch64-linux`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
