### PR TITLE
lrcget: init at 0.4.0

### DIFF
--- a/pkgs/by-name/lr/lrcget/package.nix
+++ b/pkgs/by-name/lr/lrcget/package.nix
@@ -108,7 +108,10 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/tranxuanthang/lrcget";
     changelog = "https://github.com/tranxuanthang/lrcget/releases/tag/${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ anas ];
+    maintainers = with lib.maintainers; [
+      anas
+      Scrumplex
+    ];
     mainProgram = "lrcget";
     platforms = with lib.platforms; unix ++ windows;
   };

--- a/pkgs/by-name/lr/lrcget/package.nix
+++ b/pkgs/by-name/lr/lrcget/package.nix
@@ -1,0 +1,115 @@
+{
+  dbus,
+  openssl,
+  gtk3,
+  webkitgtk,
+  pkg-config,
+  wrapGAppsHook3,
+  fetchFromGitHub,
+  buildNpmPackage,
+  rustPlatform,
+  lib,
+  stdenv,
+  copyDesktopItems,
+  makeDesktopItem,
+  alsa-lib,
+  darwin,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "lrcget";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "tranxuanthang";
+    repo = "lrcget";
+    rev = "${version}";
+    hash = "sha256-OrmSaRKhGCl5sTirzICx8PBsQm23pYUBBtb07+P1ZbY=";
+  };
+
+  sourceRoot = "${src.name}/src-tauri";
+
+  cargoHash = "sha256-V9+/sfCxeZJ39nOuMBv2YlkzewoS+N3kFyBGdIqkw/A=";
+
+  frontend = buildNpmPackage {
+    inherit version src;
+    pname = "lrcget-ui";
+    # FIXME: This is a workaround, because we have a git dependency node_modules/lrc-kit contains install scripts
+    # but has no lockfile, which is something that will probably break.
+    forceGitDeps = true;
+    distPhase = "true";
+    dontInstall = true;
+    # To fix `npm ERR! Your cache folder contains root-owned files`
+    makeCacheWritable = true;
+
+    npmDepsHash = "sha256-qQ5UMO3UuD6IvUveTRF35qTlGq5PMbxp1Q4UroDqVtk=";
+
+    postBuild = ''
+      cp -r dist/ $out
+    '';
+  };
+
+  # copy the frontend static resources to final build directory
+  # Also modify tauri.conf.json so that it expects the resources at the new location
+  postPatch = ''
+    cp -r $frontend ./frontend
+
+    substituteInPlace tauri.conf.json --replace-fail '"distDir": "../dist"' '"distDir": "./frontend"'
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook3
+    copyDesktopItems
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs =
+    [
+      dbus
+      openssl
+      gtk3
+    ]
+    ++ lib.optionals (!stdenv.isDarwin) [
+      webkitgtk
+      alsa-lib
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.apple_sdk.frameworks.CoreAudio
+      darwin.apple_sdk.frameworks.WebKit
+    ];
+
+  # Disable checkPhase, since the project doesn't contain tests
+  doCheck = false;
+
+  postInstall = ''
+    install -DT icons/128x128@2x.png $out/share/icons/hicolor/128x128@2/apps/lrcget.png
+    install -DT icons/128x128.png $out/share/icons/hicolor/128x128/apps/lrcget.png
+    install -DT icons/32x32.png $out/share/icons/hicolor/32x32/apps/lrcget.png
+  '';
+
+  # WEBKIT_DISABLE_COMPOSITING_MODE essential in NVIDIA + compositor https://github.com/NixOS/nixpkgs/issues/212064#issuecomment-1400202079
+  postFixup = ''
+    wrapProgram "$out/bin/lrcget" \
+      --set WEBKIT_DISABLE_COMPOSITING_MODE 1
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "LRCGET";
+      exec = "lrcget";
+      icon = "lrcget";
+      desktopName = "LRCGET";
+      comment = meta.description;
+    })
+  ];
+
+  meta = {
+    description = "Utility for mass-downloading LRC synced lyrics for your offline music library";
+    homepage = "https://github.com/tranxuanthang/lrcget";
+    changelog = "https://github.com/tranxuanthang/lrcget/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ anas ];
+    mainProgram = "lrcget";
+    platforms = with lib.platforms; unix ++ windows;
+  };
+}


### PR DESCRIPTION
## Description of changes

Create `lrcget` package, requested in #312996

### Try it
```sh
nix run github:anas-contribs/nixpkgs/lrcget#lrcget

```

- Closes: #312996

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [ ] [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
