### PR TITLE
glances: update to unstable 4.0.8 to fix tests on aarch64

### DIFF
--- a/pkgs/applications/system/glances/default.nix
+++ b/pkgs/applications/system/glances/default.nix
@@ -26,14 +26,15 @@
 
 buildPythonApplication rec {
   pname = "glances";
-  version = "4.0.7";
+  # use unstable to fix a build error for aarch64.
+  version = "4.0.8-unstable-2024-06-09";
   disabled = isPyPy;
 
   src = fetchFromGitHub {
     owner = "nicolargo";
     repo = "glances";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-Vfsco8Wno57aPM7PtwCc/gI+6FnAG3H/t5OAUngDU5o=";
+    rev = "051006e12f7c90281dda4af60871b535b0dcdcb9";
+    hash = "sha256-iCK5soTACQwtCVMmMsFaqXvZtTKX9WbTul0mUeSWC2M=";
   };
 
   # On Darwin this package segfaults due to mismatch of pure and impure


### PR DESCRIPTION
## Description of changes

Test 105 and 107 fail on aarch64. 
See upstream issue on https://github.com/nicolargo/glances/issues/2819 and https://hydra.nixos.org/build/262259380/log

~~This PR fetches upstreams fix.~~

Just pulling in the commit did not fix the issue for version 4.0.7. Also version 4.0.8 fails to build with just the upstream fix.
It seems there are a number of changes in the test framework between 4.0.8 and the commit which fixes the issue (https://github.com/nicolargo/glances/commit/051006e12f7c90281dda4af60871b535b0dcdcb9). So updateing to this specific commit is easier than pulling in several intermedate commits.

Release notes for 4.0.8: https://github.com/nicolargo/glances/releases/tag/v4.0.8

Maintainers:
@jonringer @primeos @k0ral  

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
