### PR TITLE
modrinth-app: use `pnpm.fetchDeps`

### DIFF
--- a/pkgs/by-name/mo/modrinth-app-unwrapped/package.nix
+++ b/pkgs/by-name/mo/modrinth-app-unwrapped/package.nix
@@ -1,27 +1,23 @@
 {
   lib,
   stdenv,
-  stdenvNoCC,
   fetchFromGitHub,
   rustPlatform,
   buildGoModule,
   nix-update-script,
   modrinth-app-unwrapped,
-  cacert,
   cargo-tauri,
   desktop-file-utils,
   esbuild,
   darwin,
-  jq,
   libsoup,
-  moreutils,
-  pnpm_8,
   nodejs,
   openssl,
   pkg-config,
+  pnpm_8,
   webkitgtk,
 }:
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage rec {
   pname = "modrinth-app-unwrapped";
   version = "0.7.1";
 
@@ -39,47 +35,18 @@ rustPlatform.buildRustPackage {
     };
   };
 
-  pnpm-deps = stdenvNoCC.mkDerivation (finalAttrs: {
-    pname = "${modrinth-app-unwrapped.pname}-pnpm-deps";
-    inherit (modrinth-app-unwrapped) version src;
-    sourceRoot = "${finalAttrs.src.name}/theseus_gui";
-
-    dontConfigure = true;
-    dontBuild = true;
-    doCheck = false;
-
-    nativeBuildInputs = [
-      cacert
-      jq
-      moreutils
-      pnpm_8
-    ];
-
-    # https://github.com/NixOS/nixpkgs/blob/763e59ffedb5c25774387bf99bc725df5df82d10/pkgs/applications/misc/pot/default.nix#L56
-    installPhase = ''
-      export HOME=$(mktemp -d)
-
-      pnpm config set store-dir "$out"
-      pnpm install --frozen-lockfile --ignore-script --force
-
-      # remove timestamp and sort json files
-      rm -rf "$out"/v3/tmp
-      for f in $(find "$out" -name "*.json"); do
-        sed -i -E -e 's/"checkedAt":[0-9]+,//g' $f
-        jq --sort-keys . "$f" | sponge "$f"
-      done
-    '';
-
-    dontFixup = true;
-    outputHashMode = "recursive";
-    outputHash = "sha256-g/uUGfC9TQh0LE8ed51oFY17FySoeTvfaeEpzpNeMao=";
-  });
+  pnpmDeps = pnpm_8.fetchDeps {
+    inherit pname version src;
+    sourceRoot = "${src.name}/theseus_gui";
+    hash = "sha256-g/uUGfC9TQh0LE8ed51oFY17FySoeTvfaeEpzpNeMao=";
+  };
+  pnpmRoot = "theseus_gui";
 
   nativeBuildInputs = [
     cargo-tauri
     desktop-file-utils
-    pnpm_8
     nodejs
+    pnpm_8.configHook
     pkg-config
   ];
 
@@ -123,19 +90,6 @@ rustPlatform.buildRustPackage {
       }
     );
   };
-
-  postPatch = ''
-    export HOME=$(mktemp -d)
-    export STORE_PATH=$(mktemp -d)
-
-    pushd theseus_gui
-    cp -rT ${modrinth-app-unwrapped.pnpm-deps} "$STORE_PATH"
-    chmod -R +w "$STORE_PATH"
-
-    pnpm config set store-dir "$STORE_PATH"
-    pnpm install --offline --frozen-lockfile --ignore-script
-    popd
-  '';
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/mo/modrinth-app-unwrapped/package.nix
+++ b/pkgs/by-name/mo/modrinth-app-unwrapped/package.nix
@@ -5,7 +5,6 @@
   rustPlatform,
   buildGoModule,
   nix-update-script,
-  modrinth-app-unwrapped,
   cargo-tauri,
   desktop-file-utils,
   esbuild,
@@ -24,7 +23,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "modrinth";
     repo = "theseus";
-    rev = "v${modrinth-app-unwrapped.version}";
+    rev = "v${version}";
     sha256 = "sha256-JWR0e2vOBvOLosr22Oo2mAlR0KAhL+261RRybhNctlM=";
   };
 
@@ -73,7 +72,7 @@ rustPlatform.buildRustPackage rec {
         Darwin = "app";
       }
       .${stdenv.hostPlatform.uname.system}
-      or (builtins.throw "No tauri bundle available for ${stdenv.hostPlatform.uname.system}!");
+      or (throw "No tauri bundle available for ${stdenv.hostPlatform.uname.system}!");
 
     ESBUILD_BINARY_PATH = lib.getExe (
       esbuild.override {
@@ -133,14 +132,14 @@ rustPlatform.buildRustPackage rec {
       A unique, open source launcher that allows you to play your favorite mods,
       and keep them up to date, all in one neat little package
     '';
-    mainProgram = "modrinth-app";
     homepage = "https://modrinth.com";
-    changelog = "https://github.com/modrinth/theseus/releases/tag/v${modrinth-app-unwrapped.version}";
+    changelog = "https://github.com/modrinth/theseus/releases/tag/v${version}";
     license = with lib.licenses; [
       gpl3Plus
       unfreeRedistributable
     ];
     maintainers = with lib.maintainers; [ getchoo ];
+    mainProgram = "modrinth-app";
     platforms = with lib; platforms.linux ++ platforms.darwin;
     # this builds on architectures like aarch64, but the launcher itself does not support them yet
     broken = !stdenv.isx86_64;


### PR DESCRIPTION
## Description of changes

Adopts the new tooling from #290715
Follows advice from #312345

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
