### PR TITLE
gpu-screen-recorder-gtk: 3.2.5 -> 3.7.6

### DIFF
--- a/pkgs/applications/video/gpu-screen-recorder/gpu-screen-recorder-gtk.nix
+++ b/pkgs/applications/video/gpu-screen-recorder/gpu-screen-recorder-gtk.nix
@@ -1,6 +1,6 @@
 { stdenv
 , lib
-, fetchurl
+, fetchgit
 , pkg-config
 , makeWrapper
 , gtk3
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation {
   pname = "gpu-screen-recorder-gtk";
-  version = "3.2.5";
+  version = "3.7.6";
 
-  src = fetchurl {
-    url = "https://dec05eba.com/snapshot/gpu-screen-recorder-gtk.git.r175.cfd18af.tar.gz";
-    hash = "sha256-HhZe22Hm9yGoy5WoyuP2+Wj8E3nMs4uf96mzmP6CMqU=";
+  src = fetchgit {
+    url = "https://repo.dec05eba.com/gpu-screen-recorder-gtk";
+    rev = "cd777c1506e20514df4b97345e480051cbaf9693";
+    hash = "sha256-ZBYYsW75tq8TaZp0F4v7YIHKHk/DFBIGy3X781ho2oE=";
   };
-  sourceRoot = ".";
 
   nativeBuildInputs = [
     pkg-config
@@ -46,12 +46,12 @@ stdenv.mkDerivation {
     gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libglvnd ]}:/run/opengl-driver/lib)
   '';
 
-  meta = with lib; {
-    description = "GTK frontend for gpu-screen-recorder";
+  meta = {
+    description = "GTK frontend for gpu-screen-recorder.";
     mainProgram = "gpu-screen-recorder-gtk";
     homepage = "https://git.dec05eba.com/gpu-screen-recorder-gtk/about/";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ babbaj ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ babbaj ];
     platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
## Description of changes

Version bump related to pr #315118 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

