### PR TITLE
castxml: unbreak binary by adding llvm to buildInputs

### DIFF
--- a/pkgs/by-name/ca/castxml/package.nix
+++ b/pkgs/by-name/ca/castxml/package.nix
@@ -7,6 +7,7 @@
   llvmPackages,
   python3,
   stdenv,
+  testers,
   zlib,
   # Boolean flags
   withHTML ? true,
@@ -65,6 +66,10 @@ stdenv.mkDerivation (finalAttrs: {
     ctest -E 'cmd.cc-(gnu|msvc)-((c-src-c)|(src-cxx))-cmd'
     runHook postCheck
   '';
+
+  passthru.tests = testers.testVersion {
+    package = finalAttrs.finalPackage;
+  };
 
   meta = {
     homepage = "https://github.com/CastXML/CastXML";

--- a/pkgs/by-name/ca/castxml/package.nix
+++ b/pkgs/by-name/ca/castxml/package.nix
@@ -30,7 +30,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    (lib.getDev llvm)
   ]
   ++ lib.optionals (withManual || withHTML) [
     sphinx
@@ -39,6 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     libffi
     libxml2
+    llvm
     zlib
   ] ++ lib.optionals (!stdenv.isDarwin) [
     libclang

--- a/pkgs/by-name/ca/castxml/package.nix
+++ b/pkgs/by-name/ca/castxml/package.nix
@@ -46,26 +46,18 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    (lib.cmakeOptionType "path" "CLANG_RESOURCE_DIR" "${lib.getDev libclang}")
+    (lib.cmakeOptionType "path" "CLANG_RESOURCE_DIR"
+       "${lib.getLib libclang}/lib/clang/${lib.versions.major libclang.version}")
+
     (lib.cmakeBool "SPHINX_HTML" withHTML)
     (lib.cmakeBool "SPHINX_MAN" withManual)
   ] ++ lib.optionals stdenv.isDarwin [
     (lib.cmakeOptionType "path" "Clang_DIR" "${lib.getDev libclang}/lib/cmake/clang")
   ];
 
-  # 97% tests passed, 97 tests failed out of 2881
-  # mostly because it checks command line and nix append -isystem and all
-  doCheck = false;
+  doCheck = true;
 
   strictDeps = true;
-
-  # -E exclude 4 tests based on names
-  # see https://github.com/CastXML/CastXML/issues/90
-  checkPhase = ''
-    runHook preCheck
-    ctest -E 'cmd.cc-(gnu|msvc)-((c-src-c)|(src-cxx))-cmd'
-    runHook postCheck
-  '';
 
   passthru.tests = testers.testVersion {
     package = finalAttrs.finalPackage;


### PR DESCRIPTION
Adds LLVM to `buildInputs`.

Also sets `CLANG_RESOURCE_DIR` correctly and enables tests.

Fixes #318055.

## Description of changes

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
