### PR TITLE
metis: 5.1.0 -> 5.2.1; gklib: init at 5.1.1-unstable-2023-03-27

### DIFF
--- a/pkgs/by-name/gk/gklib/package.nix
+++ b/pkgs/by-name/gk/gklib/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  llvmPackages,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gklib";
+  version = "5.1.1-unstable-2023-03-27";
+
+  src = fetchFromGitHub {
+    owner = "KarypisLab";
+    repo = "GKlib";
+    rev = "8bd6bad750b2b0d90800c632cf18e8ee93ad72d7";
+    hash = "sha256-tunepMLaRDR5FQVL/9S7/w6e1j+f2+pg01H/0/z/ZCI=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = lib.optional stdenv.hostPlatform.isDarwin llvmPackages.openmp;
+
+  cmakeFlags = [
+    (lib.cmakeBool "OPENMP" true)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    # https://github.com/KarypisLab/GKlib/issues/11#issuecomment-1532597211
+    (lib.cmakeBool "NO_X86" (!stdenv.hostPlatform.isx86_64))
+  ];
+
+  meta = {
+    description = "Library of various helper routines and frameworks used by many of the lab's software";
+    homepage = "https://github.com/KarypisLab/GKlib";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ natsukium ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/libraries/science/math/metis/default.nix
+++ b/pkgs/development/libraries/science/math/metis/default.nix
@@ -1,20 +1,37 @@
-{ lib, stdenv, fetchurl, unzip, cmake }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, gklib, llvmPackages }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "metis";
-  version = "5.1.0";
+  version = "5.2.1";
 
-  src = fetchurl {
-    url = "http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-${version}.tar.gz";
-    sha256 = "1cjxgh41r8k6j029yxs8msp3z6lcnpm16g5pvckk35kc7zhfpykn";
+  src = fetchFromGitHub {
+    owner = "KarypisLab";
+    repo = "METIS";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-eddLR6DvZ+2LeR0DkknN6zzRvnW+hLN2qeI+ETUPcac=";
   };
 
-  cmakeFlags = [
-    "-DGKLIB_PATH=../GKlib"
-    # remove once updated past https://github.com/KarypisLab/METIS/commit/521a2c360dc21ace5c4feb6dc0b7992433e3cb0f
-    "-DCMAKE_SKIP_BUILD_RPATH=ON"
+  patches = [
+    # fix gklib link error
+    (fetchpatch {
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sci-libs/metis/files/metis-5.2.1-add-gklib-as-required.patch?id=c78ecbd3fdf9b33e307023baf0de12c4448dd283";
+      hash = "sha256-uoXMi6pMs5VrzUmjsLlQYFLob1A8NAt9CbFi8qhQXVQ=";
+    })
   ];
-  nativeBuildInputs = [ unzip cmake ];
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ gklib ] ++ lib.optional stdenv.hostPlatform.isDarwin llvmPackages.openmp;
+
+  preConfigure = ''
+    make config
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeFeature "GKLIB_PATH" "${gklib}")
+    (lib.cmakeBool "OPENMP" true)
+    (lib.cmakeBool "SHARED" (!stdenv.hostPlatform.isStatic))
+  ];
 
   meta = {
     description = "Serial graph partitioning and fill-reducing matrix ordering";
@@ -22,4 +39,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.asl20;
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

https://github.com/KarypisLab/METIS

https://github.com/KarypisLab/GKlib
A library of various helper routines and frameworks used by many of the lab's software

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
