### PR TITLE
freebsd.sys: make patched source visible, fix build

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/lib/default.nix
+++ b/pkgs/os-specific/bsd/freebsd/lib/default.nix
@@ -1,4 +1,8 @@
-{ version }:
+{
+  version,
+  lib,
+  writeText,
+}:
 
 {
   inherit version;
@@ -15,4 +19,61 @@
     .${stdenv'.hostPlatform.parsed.cpu.name} or stdenv'.hostPlatform.parsed.cpu.name;
 
   install-wrapper = builtins.readFile ../../lib/install-wrapper.sh;
+
+  filterPatches =
+    patches: paths:
+    let
+      isDir =
+        file:
+        let
+          base = baseNameOf file;
+          type = (builtins.readDir (dirOf file)).${base} or null;
+        in
+        file == /. || type == "directory";
+      consolidatePatches =
+        patches:
+        if (lib.isDerivation patches) then
+          [ patches ]
+        else if (builtins.isPath patches) then
+          (if (isDir patches) then (lib.filesystem.listFilesRecursive patches) else [ patches ])
+        else if (builtins.isList patches) then
+          (lib.flatten (builtins.map consolidatePatches patches))
+        else
+          throw "Bad patches - must be path or derivation or list thereof";
+      consolidated = consolidatePatches patches;
+      splitPatch =
+        patchFile:
+        let
+          allLines' = lib.strings.splitString "\n" (builtins.readFile patchFile);
+          allLines = builtins.filter (
+            line: !((lib.strings.hasPrefix "diff --git" line) || (lib.strings.hasPrefix "index " line))
+          ) allLines';
+          foldFunc =
+            a: b:
+            if ((lib.strings.hasPrefix "--- " b) || (lib.strings.hasPrefix "diff --git " b)) then
+              (a ++ [ [ b ] ])
+            else
+              ((lib.lists.init a) ++ (lib.lists.singleton ((lib.lists.last a) ++ [ b ])));
+          partitionedPatches' = lib.lists.foldl foldFunc [ [ ] ] allLines;
+          partitionedPatches =
+            if (builtins.length partitionedPatches' > 1) then
+              (lib.lists.drop 1 partitionedPatches')
+            else
+              (throw "${patchFile} does not seem to be a unified patch (diff -u). this is required for FreeBSD.");
+          filterFunc =
+            patchLines:
+            let
+              prefixedPath = builtins.elemAt (builtins.split " |\t" (builtins.elemAt patchLines 1)) 2;
+              unfixedPath = lib.path.subpath.join (lib.lists.drop 1 (lib.path.subpath.components prefixedPath));
+            in
+            lib.lists.any (included: lib.path.hasPrefix (/. + ("/" + included)) (/. + ("/" + unfixedPath))) (
+              paths
+            );
+          filteredLines = builtins.filter filterFunc partitionedPatches;
+          derive = patchLines: writeText "freebsd-patch" (lib.concatLines patchLines);
+          derivedPatches = builtins.map derive filteredLines;
+        in
+        derivedPatches;
+    in
+    lib.lists.concatMap splitPatch consolidated;
 }

--- a/pkgs/os-specific/bsd/freebsd/package-set.nix
+++ b/pkgs/os-specific/bsd/freebsd/package-set.nix
@@ -7,6 +7,7 @@
   versionData,
   buildFreebsd,
   patchesRoot,
+  writeText,
 }:
 
 self:
@@ -39,6 +40,7 @@ lib.packagesFromDirectoryRecursive {
         ]
       )
     );
+    inherit lib writeText;
   };
 
   # The manual callPackages below should in principle be unnecessary, but are

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
@@ -6,7 +6,6 @@
   overrideCC,
   buildPackages,
   versionData,
-  writeText,
   patches,
   compatIfNeeded,
   freebsd-lib,
@@ -117,61 +116,10 @@ lib.makeOverridable (
     }
     // {
       patches =
-        let
-          isDir =
-            file:
-            let
-              base = baseNameOf file;
-              type = (builtins.readDir (dirOf file)).${base} or null;
-            in
-            file == /. || type == "directory";
-          consolidatePatches =
-            patches:
-            if (lib.isDerivation patches) then
-              [ patches ]
-            else if (builtins.isPath patches) then
-              (if (isDir patches) then (lib.filesystem.listFilesRecursive patches) else [ patches ])
-            else if (builtins.isList patches) then
-              (lib.flatten (builtins.map consolidatePatches patches))
-            else
-              throw "Bad patches - must be path or derivation or list thereof";
-          consolidated = consolidatePatches patches;
-          splitPatch =
-            patchFile:
-            let
-              allLines' = lib.strings.splitString "\n" (builtins.readFile patchFile);
-              allLines = builtins.filter (
-                line: !((lib.strings.hasPrefix "diff --git" line) || (lib.strings.hasPrefix "index " line))
-              ) allLines';
-              foldFunc =
-                a: b:
-                if ((lib.strings.hasPrefix "--- " b) || (lib.strings.hasPrefix "diff --git " b)) then
-                  (a ++ [ [ b ] ])
-                else
-                  ((lib.lists.init a) ++ (lib.lists.singleton ((lib.lists.last a) ++ [ b ])));
-              partitionedPatches' = lib.lists.foldl foldFunc [ [ ] ] allLines;
-              partitionedPatches =
-                if (builtins.length partitionedPatches' > 1) then
-                  (lib.lists.drop 1 partitionedPatches')
-                else
-                  (throw "${patchFile} does not seem to be a unified patch (diff -u). this is required for FreeBSD.");
-              filterFunc =
-                patchLines:
-                let
-                  prefixedPath = builtins.elemAt (builtins.split " |\t" (builtins.elemAt patchLines 1)) 2;
-                  unfixedPath = lib.path.subpath.join (lib.lists.drop 1 (lib.path.subpath.components prefixedPath));
-                in
-                lib.lists.any (included: lib.path.hasPrefix (/. + ("/" + included)) (/. + ("/" + unfixedPath))) (
-                  (attrs.extraPaths or [ ]) ++ [ attrs.path ]
-                );
-              filteredLines = builtins.filter filterFunc partitionedPatches;
-              derive = patchLines: writeText "freebsd-patch" (lib.concatLines patchLines);
-              derivedPatches = builtins.map derive filteredLines;
-            in
-            derivedPatches;
-          picked = lib.lists.concatMap splitPatch consolidated;
-        in
-        picked ++ attrs.patches or [ ];
+        (lib.optionals (attrs.autoPickPatches or true) (
+          freebsd-lib.filterPatches patches (attrs.extraPaths or [ ] ++ [ attrs.path ])
+        ))
+        ++ attrs.patches or [ ];
     }
   )
 )

--- a/pkgs/os-specific/bsd/freebsd/pkgs/sys/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/sys/package.nix
@@ -1,85 +1,140 @@
 {
-  stdenv,
+  lib,
   mkDerivation,
-  freebsd-lib,
+  stdenv,
   buildPackages,
+  freebsd-lib,
+  patches,
+  filterSource,
+  applyPatches,
+  baseConfig ? "GENERIC",
+  extraFlags ? { },
   bsdSetupHook,
+  mandoc,
+  groff,
+  gawk,
   freebsdSetupHook,
   makeMinimal,
   install,
-  mandoc,
-  groff,
   config,
   rpcgen,
   file2c,
-  gawk,
-  uudecode,
+  bintrans,
   xargs-j,
 }:
 
-mkDerivation (
-  let
-    cfg = "MINIMAL";
-  in
-  rec {
+let
+  hostArchBsd = freebsd-lib.mkBsdArch stdenv;
+
+  filteredSource = filterSource {
+    pname = "sys";
     path = "sys";
+    extraPaths = [ "include" ];
+  };
 
-    nativeBuildInputs = [
-      bsdSetupHook
-      freebsdSetupHook
-      makeMinimal
-      install
-      mandoc
-      groff
-
-      config
-      rpcgen
-      file2c
-      gawk
-      uudecode
-      xargs-j
+  patchedSource = applyPatches {
+    src = filteredSource;
+    patches = freebsd-lib.filterPatches patches [
+      "sys"
+      "include"
     ];
-
-    # --dynamic-linker /red/herring is used when building the kernel.
-    NIX_ENFORCE_PURITY = 0;
-
-    AWK = "${buildPackages.gawk}/bin/awk";
-
-    CWARNEXTRA = "-Wno-error=shift-negative-value -Wno-address-of-packed-member";
-
-    MK_CTF = "no";
-
-    KODIR = "${builtins.placeholder "out"}/kernel";
-    KMODDIR = "${builtins.placeholder "out"}/kernel";
-    DTBDIR = "${builtins.placeholder "out"}/dbt";
-
-    KERN_DEBUGDIR = "${builtins.placeholder "out"}/debug";
-    KERN_DEBUGDIR_KODIR = "${KERN_DEBUGDIR}/kernel";
-    KERN_DEBUGDIR_KMODDIR = "${KERN_DEBUGDIR}/kernel";
-
-    skipIncludesPhase = true;
-
-    configurePhase = ''
-      runHook preConfigure
-
-      for f in conf/kmod.mk contrib/dev/acpica/acpica_prep.sh; do
-        substituteInPlace "$f" --replace 'xargs -J' 'xargs-j '
+    postPatch = ''
+      for f in sys/conf/kmod.mk sys/contrib/dev/acpica/acpica_prep.sh; do
+        substituteInPlace "$f" --replace-warn 'xargs -J' 'xargs-j '
       done
 
-      for f in conf/*.mk; do
-        substituteInPlace "$f" --replace 'KERN_DEBUGDIR}''${' 'KERN_DEBUGDIR_'
+      for f in sys/conf/*.mk; do
+        substituteInPlace "$f" --replace-quiet 'KERN_DEBUGDIR}''${' 'KERN_DEBUGDIR_'
       done
 
-      cd ${freebsd-lib.mkBsdArch stdenv}/conf
-      sed -i ${cfg} \
+      sed -i sys/${hostArchBsd}/conf/${baseConfig} \
         -e 's/WITH_CTF=1/WITH_CTF=0/' \
         -e '/KDTRACE/d'
-      config ${cfg}
+    '';
+  };
 
-      runHook postConfigure
-    '';
-    preBuild = ''
-      cd ../compile/${cfg}
-    '';
-  }
-)
+  # Kernel modules need this for kern.opts.mk
+  env =
+    {
+      MK_CTF = "no";
+    }
+    // (lib.flip lib.mapAttrs' extraFlags (
+      name: value: {
+        name = "MK_${lib.toUpper name}";
+        value = if value then "yes" else "no";
+      }
+    ));
+in
+mkDerivation rec {
+  pname = "sys";
+
+  # Patch source outside of this derivation so out-of-tree modules can use it
+  src = patchedSource;
+  path = "sys";
+  autoPickPatches = false;
+
+  nativeBuildInputs = [
+    bsdSetupHook
+    mandoc
+    groff
+    gawk
+    freebsdSetupHook
+    makeMinimal
+    install
+    config
+    rpcgen
+    file2c
+    bintrans
+    xargs-j
+  ];
+
+  # --dynamic-linker /red/herring is used when building the kernel.
+  NIX_ENFORCE_PURITY = 0;
+
+  AWK = "${buildPackages.gawk}/bin/awk";
+
+  CWARNEXTRA = "-Wno-error=shift-negative-value -Wno-address-of-packed-member";
+
+  hardeningDisable = [
+    "pic" # generates relocations the linker can't handle
+    "stackprotector" # generates stack protection for the function generating the stack canary
+  ];
+
+  # hardeningDisable = stackprotector doesn't seem to be enough, put it in cflags too
+  NIX_CFLAGS_COMPILE = "-fno-stack-protector";
+
+  inherit env;
+  passthru.env = env;
+
+  KODIR = "${builtins.placeholder "out"}/kernel";
+  KMODDIR = "${builtins.placeholder "out"}/kernel";
+  DTBDIR = "${builtins.placeholder "out"}/dbt";
+
+  KERN_DEBUGDIR = "${builtins.placeholder "debug"}/lib/debug";
+  KERN_DEBUGDIR_KODIR = "${KERN_DEBUGDIR}/kernel";
+  KERN_DEBUGDIR_KMODDIR = "${KERN_DEBUGDIR}/kernel";
+
+  skipIncludesPhase = true;
+
+  configurePhase = ''
+    runHook preConfigure
+
+    cd ${hostArchBsd}/conf
+    config ${baseConfig}
+
+    runHook postConfigure
+  '';
+  preBuild = ''
+    cd ../compile/${baseConfig}
+  '';
+
+  outputs = [
+    "out"
+    "debug"
+  ];
+
+  meta = {
+    description = "FreeBSD kernel and modules";
+    platforms = lib.platforms.freebsd;
+  };
+}


### PR DESCRIPTION
## Description of changes

Wow, a kernel! The diff looks really jank unless you view it with ignore-whitespace.

See commit messages. In order to support the separate source derivation, I added a separate commit moving the patch filtering code into freebsd-lib. I'm told that the packages that require this include drm-kmod and lsof.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
