### PR TITLE
nixos/amdvlk: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -4,7 +4,8 @@
 
 ## Highlights {#sec-release-24.11-highlights}
 
-- Create the first release note entry in this section!
+- [AMDVLK](https://github.com/GPUOpen-Drivers/AMDVLK), AMD's open source Vulkan driver, is now available to be configured as `hardware.amdgpu.amdvlk` option.
+  This also allows configuring runtime settings of AMDVLK and enabling experimental features.
 
 ## New Services {#sec-release-24.11-new-services}
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -548,6 +548,7 @@
   ./services/games/xonotic.nix
   ./services/hardware/acpid.nix
   ./services/hardware/actkbd.nix
+  ./services/hardware/amdvlk.nix
   ./services/hardware/argonone.nix
   ./services/hardware/asusd.nix
   ./services/hardware/auto-cpufreq.nix

--- a/nixos/modules/services/hardware/amdvlk.nix
+++ b/nixos/modules/services/hardware/amdvlk.nix
@@ -1,0 +1,40 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.hardware.amdgpu.amdvlk;
+in {
+  options.hardware.amdgpu.amdvlk = {
+    enable = lib.mkEnableOption "AMDVLK Vulkan driver";
+
+    package = lib.mkPackageOption pkgs "amdvlk" { };
+
+    supportExperimental.enable = lib.mkEnableOption "Experimental features support";
+
+    support32Bit.enable = lib.mkEnableOption "32-bit driver support";
+    support32Bit.package = lib.mkPackageOption pkgs.driversi686Linux "amdvlk" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    hardware.opengl = lib.mkMerge [
+      {
+        enable = lib.mkDefault true;
+        driSupport = lib.mkDefault true;
+        extraPackages = [ cfg.package ];
+      }
+      (lib.mkIf cfg.support32Bit.enable {
+        driSupport32Bit = lib.mkDefault true;
+        extraPackages32 = [ cfg.support32Bit.package ];
+      })
+    ];
+
+    services.xserver.videoDrivers = [ "amdgpu" ];
+
+    environment.sessionVariables = lib.mkIf cfg.supportExperimental.enable {
+      AMDVLK_ENABLE_DEVELOPING_EXT = "all";
+    };
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ johnrtitor ];
+  };
+}

--- a/nixos/modules/services/hardware/amdvlk.nix
+++ b/nixos/modules/services/hardware/amdvlk.nix
@@ -12,6 +12,22 @@ in {
 
     support32Bit.enable = lib.mkEnableOption "32-bit driver support";
     support32Bit.package = lib.mkPackageOption pkgs.driversi686Linux "amdvlk" { };
+
+    settings = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      example = {
+        AllowVkPipelineCachingToDisk = 1;
+        ShaderCacheMode = 1;
+        IFH = 0;
+        EnableVmAlwaysValid = 1;
+        IdleAfterSubmitGpuMask = 1;
+      };
+      description = ''
+        Runtime settings for AMDVLK to be configured {file}`/etc/amd/amdVulkanSettings.cfg`.
+        See [AMDVLK GitHub page](https://github.com/GPUOpen-Drivers/AMDVLK?tab=readme-ov-file#runtime-settings).
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -31,6 +47,15 @@ in {
 
     environment.sessionVariables = lib.mkIf cfg.supportExperimental.enable {
       AMDVLK_ENABLE_DEVELOPING_EXT = "all";
+    };
+
+    environment.etc = lib.mkIf (cfg.settings != { }) {
+      "amd/amdVulkanSettings.cfg".text = lib.concatStrings
+        (lib.mapAttrsToList
+          (n: v: ''
+            ${n},${builtins.toString v}
+          '')
+          cfg.settings);
     };
   };
 

--- a/nixos/modules/services/hardware/amdvlk.nix
+++ b/nixos/modules/services/hardware/amdvlk.nix
@@ -11,10 +11,10 @@ in {
     supportExperimental.enable = lib.mkEnableOption "Experimental features support";
 
     support32Bit.enable = lib.mkEnableOption "32-bit driver support";
-    support32Bit.package = lib.mkPackageOption pkgs.driversi686Linux "amdvlk" { };
+    support32Bit.package = lib.mkPackageOption pkgs [ "driversi686Linux" "amdvlk" ] { };
 
     settings = lib.mkOption {
-      type = lib.types.attrs;
+      type = with lib.types; attrsOf (either str int);
       default = { };
       example = {
         AllowVkPipelineCachingToDisk = 1;
@@ -31,17 +31,13 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    hardware.opengl = lib.mkMerge [
-      {
-        enable = lib.mkDefault true;
-        driSupport = lib.mkDefault true;
-        extraPackages = [ cfg.package ];
-      }
-      (lib.mkIf cfg.support32Bit.enable {
-        driSupport32Bit = lib.mkDefault true;
-        extraPackages32 = [ cfg.support32Bit.package ];
-      })
-    ];
+    hardware.opengl = {
+      enable = true;
+      driSupport = true;
+      extraPackages = [ cfg.package ];
+      driSupport32Bit = cfg.support32Bit.enable;
+      extraPackages32 = [ cfg.support32Bit.package ];
+    };
 
     services.xserver.videoDrivers = [ "amdgpu" ];
 


### PR DESCRIPTION
## Description of changes

- Adds `hardware.amdgpu.amdvlk` option.
- This module enables amdvlk via `hardware.opengl.extraPackages`.
- The main use case I see for this module is configuring [runtime settings](https://github.com/GPUOpen-Drivers/AMDVLK?tab=readme-ov-file#runtime-settings) of AMDVLK.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

CC: @Flakebi maintainer of AMDVLK

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
