### PR TITLE
blockstream-electrs: init at 0.4.1-unstable-2024-11-25

### DIFF
--- a/pkgs/by-name/bl/blockstream-electrs/package.nix
+++ b/pkgs/by-name/bl/blockstream-electrs/package.nix
@@ -1,0 +1,86 @@
+{
+  bitcoind,
+  electrum,
+  fetchFromGitHub,
+  lib,
+  rocksdb_8_3,
+  rustPlatform,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "blockstream-electrs";
+  version = "0.4.1-unstable-2024-11-25";
+
+  src = fetchFromGitHub {
+    owner = "Blockstream";
+    repo = "electrs";
+    rev = "680eacaa8360d5f46eaae9611a3097ba183795c6";
+    hash = "sha256-oDM4arH3aplgcS49t/hy5Rqt36glrVufd3F4tw3j1zo=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-X2C69ui3XiYP1cg9FgfBbJlLLMq1SCw+oAL20B1Fs30=";
+
+  nativeBuildInputs = [
+    # Needed for librocksdb-sys
+    rustPlatform.bindgenHook
+  ];
+
+  env = {
+    # Dynamically link rocksdb
+    ROCKSDB_INCLUDE_DIR = "${rocksdb_8_3}/include";
+    ROCKSDB_LIB_DIR = "${rocksdb_8_3}/lib";
+
+    # External binaries for integration tests are provided via nixpkgs. Skip
+    # trying to download them.
+    BITCOIND_SKIP_DOWNLOAD = true;
+    ELECTRUMD_SKIP_DOWNLOAD = true;
+    ELEMENTSD_SKIP_DOWNLOAD = true;
+  };
+
+  # Only build the service
+  cargoBuildFlags = [
+    "--package=electrs"
+    "--bin=electrs"
+  ];
+
+  # Some upstream dev-dependencies (electrumd, elementsd) currently fail to
+  # build on non-x86_64-linux platforms, even if downloading is skipped.
+  # TODO(phlip9): submit a PR to fix this
+  doCheck = stdenv.hostPlatform.system == "x86_64-linux";
+
+  # Build tests in debug mode to reduce build time
+  checkType = "debug";
+
+  # Integration tests require us to pass in some external deps via env.
+  preCheck = lib.optionalString doCheck ''
+    export BITCOIND_EXE=${bitcoind}/bin/bitcoind
+    export ELECTRUMD_EXE=${electrum}/bin/electrum
+  '';
+
+  # Make sure the final binary actually runs
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/electrs --version
+  '';
+
+  meta = {
+    description = "Efficient re-implementation of Electrum Server in Rust";
+    longDescription = ''
+      A blockchain index engine and HTTP API written in Rust based on
+      [romanz/electrs](https://github.com/romanz/electrs).
+
+      Used as the backend for the [Esplora block explorer](https://github.com/Blockstream/esplora)
+      powering <https://blockstream.info>.
+
+      API documentation [is available here](https://github.com/blockstream/esplora/blob/master/API.md).
+
+      Documentation for the database schema and indexing process [is available here](https://github.com/Blockstream/electrs/blob/new-index/doc/schema.md).
+    '';
+    homepage = "https://github.com/Blockstream/electrs";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ phlip9 ];
+    mainProgram = "electrs";
+  };
+}


### PR DESCRIPTION
## Description of changes

This PR packages [Blockstream/electrs](https://github.com/Blockstream/electrs/), an efficient BTC chain indexer. It forms part of the backend for <https://blockstream.info>, but many others also use it.

`Blockstream/electrs` is actually a fork of [`romanz/electrs`](https://github.com/romanz/electrs), though the two projects diverged several years ago. `romanz/electrs` is also packaged in nixpkgs as [`electrs`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/blockchains/electrs/default.nix)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
