### PR TITLE
showtime: init at 46.3

### DIFF
--- a/pkgs/by-name/sh/showtime/package.nix
+++ b/pkgs/by-name/sh/showtime/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitLab,
+  appstream,
+  blueprint-compiler,
+  desktop-file-utils,
+  glib,
+  gobject-introspection,
+  gst_all_1,
+  libadwaita,
+  meson,
+  ninja,
+  pkg-config,
+  wrapGAppsHook4,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "showtime";
+  version = "46.3";
+  pyproject = false;
+
+  src = fetchFromGitLab {
+    group = "GNOME";
+    owner = "Incubator";
+    repo = "showtime";
+    rev = "refs/tags/${version}";
+    hash = "sha256-0qT62VoodRcrxYNTtZk+KqxzhflxFU/HPtj2u0wRSH0=";
+    domain = "gitlab.gnome.org";
+  };
+
+  nativeBuildInputs = [
+    appstream
+    blueprint-compiler
+    desktop-file-utils
+    glib # for `glib-compile-schemas`
+    gobject-introspection
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-rs
+    gst_all_1.gst-plugins-ugly
+    libadwaita
+  ];
+
+  dependencies = with python3Packages; [ pygobject3 ];
+
+  dontWrapGApps = true;
+  makeWrapperArgs = [ "\${gappsWrapperArgs[@]}" ];
+
+  pythonImportsCheck = [ "showtime" ];
+
+  meta = {
+    description = "Watch without distraction";
+    homepage = "https://apps.gnome.org/Showtime";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ getchoo ];
+    mainProgram = "showtime";
+  };
+}


### PR DESCRIPTION
## Description of changes

[showtime](https://gitlab.gnome.org/GNOME/Incubator/showtime) is a new video player for GNOME, meant to eventually replace `totem`

~~draft for now as it depends on gtk >= 4.15~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
