### PR TITLE
lightdm-slick-greeter: 2.0.3 -> 2.0.4

### DIFF
--- a/pkgs/applications/display-managers/lightdm-slick-greeter/default.nix
+++ b/pkgs/applications/display-managers/lightdm-slick-greeter/default.nix
@@ -1,11 +1,11 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, meson
+, ninja
 , pkg-config
 , python3
 , vala
-, intltool
-, autoreconfHook
 , wrapGAppsHook3
 , cinnamon
 , lightdm
@@ -22,20 +22,20 @@
 
 stdenv.mkDerivation rec {
   pname = "lightdm-slick-greeter";
-  version = "2.0.3";
+  version = "2.0.4";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "slick-greeter";
     rev = version;
-    sha256 = "sha256-ROOCxOjqJ8dTZjfQpjmE9oDQJzt6QFVVf3nrJ26mFU8=";
+    sha256 = "sha256-1UOODak5YkoMLdIkN1rBIrlr3Zjj5SS2yx90vmF1prA=";
   };
 
   nativeBuildInputs = [
+    meson
+    ninja
     pkg-config
     vala
-    intltool
-    autoreconfHook
     wrapGAppsHook3
     python3
     python3.pkgs.wrapPython
@@ -58,43 +58,28 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace src/slick-greeter.vala \
-      --replace "/usr/bin/numlockx" "${numlockx}/bin/numlockx" \
-      --replace "/usr/share/xsessions/" "/run/current-system/sw/share/xsessions/" \
-      --replace "/usr/share/wayland-sessions/" "/run/current-system/sw/share/wayland-sessions/" \
-      --replace "/usr/bin/slick-greeter" "${placeholder "out"}/bin/slick-greeter"
+      --replace-fail "/usr/bin/numlockx" "${numlockx}/bin/numlockx" \
+      --replace-fail "/usr/share/xsessions/" "/run/current-system/sw/share/xsessions/" \
+      --replace-fail "/usr/share/wayland-sessions/" "/run/current-system/sw/share/wayland-sessions/" \
+      --replace-fail "/usr/bin/slick-greeter" "${placeholder "out"}/bin/slick-greeter"
 
     substituteInPlace src/session-list.vala \
-      --replace "/usr/share" "${placeholder "out"}/share"
+      --replace-fail "/usr/share" "${placeholder "out"}/share"
 
     # We prefer stable path here.
     substituteInPlace data/x.dm.slick-greeter.gschema.xml \
-      --replace "/usr/share/onboard" "/run/current-system/sw/share/onboard"
+      --replace-fail "/usr/share/onboard" "/run/current-system/sw/share/onboard"
 
     patchShebangs files/usr/bin/*
   '';
 
-  preAutoreconf = ''
-    # intltoolize fails during autoreconfPhase unless this
-    # directory is created manually.
-    mkdir m4
-  '';
-
-  configureFlags = [
-    "--localstatedir=/var"
-    "--sysconfdir=/etc"
+  mesonFlags = [
     "--sbindir=${placeholder "out"}/bin"
-  ];
-
-  installFlags = [
-    "localstatedir=\${TMPDIR}"
-    "sysconfdir=${placeholder "out"}/etc"
   ];
 
   postInstall = ''
     substituteInPlace "$out/share/xgreeters/slick-greeter.desktop" \
-      --replace "Exec=slick-greeter" "Exec=$out/bin/slick-greeter"
-
-    cp -r files/usr/* $out
+      --replace-fail "Exec=slick-greeter" "Exec=$out/bin/slick-greeter"
   '';
 
   preFixup = ''


### PR DESCRIPTION
https://github.com/linuxmint/slick-greeter/compare/2.0.3...2.0.4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

