### PR TITLE
cmake:  fix strictDeps

### DIFF
--- a/pkgs/by-name/cm/cmake/000-nixpkgs-cmake-prefix-path.diff
+++ b/pkgs/by-name/cm/cmake/000-nixpkgs-cmake-prefix-path.diff
@@ -1,0 +1,28 @@
+diff --git a/Source/cmFindBase.cxx b/Source/cmFindBase.cxx
+index 8840cdcb..c34b7ee9 100644
+--- a/Source/cmFindBase.cxx
++++ b/Source/cmFindBase.cxx
+@@ -280,6 +280,11 @@ void cmFindBase::FillCMakeEnvironmentPath()
+   // Add CMAKE_*_PATH environment variables
+   std::string var = cmStrCat("CMAKE_", this->CMakePathName, "_PATH");
+   paths.AddEnvPrefixPath("CMAKE_PREFIX_PATH");
++  if (this->CMakePathName != "PROGRAM") {
++    // Like CMAKE_PREFIX_PATH except when searching for programs. Programs need
++    // to be located via PATH
++    paths.AddEnvPrefixPath("NIXPKGS_CMAKE_PREFIX_PATH");
++  }
+   paths.AddEnvPath(var);
+ 
+   if (this->CMakePathName == "PROGRAM") {
+diff --git a/Source/cmFindPackageCommand.cxx b/Source/cmFindPackageCommand.cxx
+index 9b51b1ad..6acc676c 100644
+--- a/Source/cmFindPackageCommand.cxx
++++ b/Source/cmFindPackageCommand.cxx
+@@ -2039,6 +2039,7 @@ void cmFindPackageCommand::FillPrefixesCMakeEnvironment()
+ 
+   // And now the general CMake environment variables
+   paths.AddEnvPath("CMAKE_PREFIX_PATH");
++  paths.AddEnvPath("NIXPKGS_CMAKE_PREFIX_PATH");
+   if (this->DebugMode) {
+     debugBuffer = cmStrCat(debugBuffer,
+                            "CMAKE_PREFIX_PATH env variable "

--- a/pkgs/by-name/cm/cmake/package.nix
+++ b/pkgs/by-name/cm/cmake/package.nix
@@ -56,6 +56,9 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
+    # Add NIXPKGS_CMAKE_PREFIX_PATH to cmake which is like CMAKE_PREFIX_PATH
+    # except it is not searched for programs
+    ./000-nixpkgs-cmake-prefix-path.diff
     # Don't search in non-Nix locations such as /usr, but do search in our libc.
     ./001-search-path.diff
     # Don't depend on frameworks.

--- a/pkgs/by-name/cm/cmake/setup-hook.sh
+++ b/pkgs/by-name/cm/cmake/setup-hook.sh
@@ -151,22 +151,22 @@ makeCmakeFindLibs(){
   for flag in ${NIX_CFLAGS_COMPILE-} ${NIX_LDFLAGS-}; do
     if test -n "$isystem_seen" && test -d "$flag"; then
       isystem_seen=
-      export CMAKE_INCLUDE_PATH="${CMAKE_INCLUDE_PATH-}${CMAKE_INCLUDE_PATH:+:}${flag}"
+      addToSearchPath CMAKE_INCLUDE_PATH "${flag}"
     elif test -n "$iframework_seen" && test -d "$flag"; then
       iframework_seen=
-      export CMAKE_FRAMEWORK_PATH="${CMAKE_FRAMEWORK_PATH-}${CMAKE_FRAMEWORK_PATH:+:}${flag}"
+      addToSearchPath CMAKE_FRAMEWORK_PATH "${flag}"
     else
       isystem_seen=
       iframework_seen=
       case $flag in
         -I*)
-          export CMAKE_INCLUDE_PATH="${CMAKE_INCLUDE_PATH-}${CMAKE_INCLUDE_PATH:+:}${flag:2}"
+          addToSearchPath CMAKE_INCLUDE_PATH "${flag:2}"
           ;;
         -L*)
-          export CMAKE_LIBRARY_PATH="${CMAKE_LIBRARY_PATH-}${CMAKE_LIBRARY_PATH:+:}${flag:2}"
+          addToSearchPath CMAKE_LIBRARY_PATH "${flag:2}"
           ;;
         -F*)
-          export CMAKE_FRAMEWORK_PATH="${CMAKE_FRAMEWORK_PATH-}${CMAKE_FRAMEWORK_PATH:+:}${flag:2}"
+          addToSearchPath CMAKE_FRAMEWORK_PATH "${flag:2}"
           ;;
         -isystem)
           isystem_seen=1

--- a/pkgs/by-name/cm/cmake/setup-hook.sh
+++ b/pkgs/by-name/cm/cmake/setup-hook.sh
@@ -1,5 +1,7 @@
 addCMakeParams() {
-    addToSearchPath CMAKE_PREFIX_PATH $1
+    # NIXPKGS_CMAKE_PREFIX_PATH is like CMAKE_PREFIX_PATH except cmake
+    # will not search it for programs
+    addToSearchPath NIXPKGS_CMAKE_PREFIX_PATH $1
 }
 
 fixCmakeFiles() {

--- a/pkgs/by-name/me/meson/000-nixpkgs-cmake-prefix-path.patch
+++ b/pkgs/by-name/me/meson/000-nixpkgs-cmake-prefix-path.patch
@@ -1,0 +1,12 @@
+diff --git a/mesonbuild/dependencies/data/CMakePathInfo.txt b/mesonbuild/dependencies/data/CMakePathInfo.txt
+index 662ec58..4d5f4e4 100644
+--- a/mesonbuild/dependencies/data/CMakePathInfo.txt
++++ b/mesonbuild/dependencies/data/CMakePathInfo.txt
+@@ -5,6 +5,7 @@ list(APPEND TMP_PATHS_LIST ${CMAKE_PREFIX_PATH})
+ list(APPEND TMP_PATHS_LIST ${CMAKE_FRAMEWORK_PATH})
+ list(APPEND TMP_PATHS_LIST ${CMAKE_APPBUNDLE_PATH})
+ list(APPEND TMP_PATHS_LIST $ENV{CMAKE_PREFIX_PATH})
++list(APPEND TMP_PATHS_LIST $ENV{NIXPKGS_CMAKE_PREFIX_PATH})
+ list(APPEND TMP_PATHS_LIST $ENV{CMAKE_FRAMEWORK_PATH})
+ list(APPEND TMP_PATHS_LIST $ENV{CMAKE_APPBUNDLE_PATH})
+ list(APPEND TMP_PATHS_LIST ${CMAKE_SYSTEM_PREFIX_PATH})

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -31,6 +31,9 @@ python3.pkgs.buildPythonApplication rec {
   };
 
   patches = [
+    # Nixpkgs cmake uses NIXPKGS_CMAKE_PREFIX_PATH for the search path
+    ./000-nixpkgs-cmake-prefix-path.patch
+
     # In typical distributions, RPATH is only needed for internal libraries so
     # meson removes everything else. With Nix, the locations of libraries
     # are not as predictable, therefore we need to keep them in the RPATH.


### PR DESCRIPTION
## Description of changes

patch cmake (and meson) to use a new `NIXPKGS_CMAKE_PREFIX_PATH` variable which is like `CMAKE_PREFIX_PATH` but doesn't provide a search path to `find_program`

cmake uses `CMAKE_PREFIX_PATH` to search for libraries, header files, binaries, cmake modules, etc. This is mostly fine except for binaries. We set `CMAKE_PREFIX_PATH` to the derivation output locations, which results in cmake finding and using binaries which are not set in PATH. when strictDeps is true, nativeBuildInputs is not added to `CMAKE_PREFIX_PATH` but buildInputs so binaries are first searched for in the buildInputs packages before falling back to PATH.

This change attempts to fix the cmake search path such that cmake will only locate binaries accessible via PATH.

the meson patch is required when it falls back on cmake to find modules, it needs to know about the `NIXPKGS_CMAKE_PREFIX_PATH` env variable.

the following PRs fix various packages that enable `strictDeps` but fail to build due to packages missing from `nativeBuildInputs`

- https://github.com/NixOS/nixpkgs/pull/324545
- https://github.com/NixOS/nixpkgs/pull/324951
- https://github.com/NixOS/nixpkgs/pull/329977


### testing
- 908 builds where cmake in nativeBuildInputs and  strictDeps set
- 54 builds where cmake + meson in nativeBuildInputs
- random sample of 865 builds where cmake in nativeBuildInputs and strictDeps not set (out of 3480 attributes)

tests were usually run on master with the cmake modifications contained in a new cmake2 package to skip unnecessary rebuilds. packages that required cmake were then built using an override to the modified cmake or manually edited/hacked when overriding was not supported, eg:

```
# breaks with clang when using strictDeps and unmodified cmake
nix-build -E 'with import ./.{}; castxml.override { stdenv = clangStdenv; cmake = cmake2; }'
# meson build but uses cmake to locate packages
nix-build -E 'with import ./.{}; wf-touch.override { cmake = cmake2; meson = meson2; }'
[...]
```
packages that require cmake were found using a variation of the following script run from the root of the source tree
<details><summary>example script to get a json list of packages using cmake but not strict deps</summary>
 
```sh
nix-instantiate --show-trace --eval --strict --json -A devs - <<EOF
{
  paths ? (import ./pkgs/top-level/release-attrpaths-superset.nix { }).paths,
  pkgs ? (import ./. { }),
}:

let
  inherit (pkgs) lib;
  inherit (builtins) currentSystem tryEval;

  usesCmake =
    let
      isCmakeOverridable = p: p ? override && lib.hasAttr "cmake" (lib.functionArgs p.override);

      hasCmakeNativeBuildInputs =
        p: p ? nativeBuildInputs && lib.lists.any (x: x == pkgs.cmake) p.nativeBuildInputs;

      usesCmake' =
        p:
        p != null
        && !(p.strictDeps or false)     # reverse logic to get list of only strict deps
        && !(p.meta.broken or false)
        && isCmakeOverridable p         # comment out remove overrideable filter 
        && lib.meta.availableOn p currentSystem
        && hasCmakeNativeBuildInputs p;
    in
    path: (tryEval (usesCmake' (lib.attrByPath path null pkgs))).value;
in
{
  devs = map (f: lib.concatStringsSep "." f) (lib.filter usesCmake paths);
}
EOF
```
</details>

then iterate over the packages (or a sample of) passing in the modified `cmake2`


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
