### PR TITLE
jupyter update 2024-06-08

### DIFF
--- a/pkgs/development/python-modules/einops/default.nix
+++ b/pkgs/development/python-modules/einops/default.nix
@@ -55,6 +55,8 @@ buildPythonPackage rec {
 
   disabledTestPaths = [ "tests/test_layers.py" ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = with lib; {
     description = "Flexible and powerful tensor operations for readable and reliable code";
     homepage = "https://github.com/arogozhnikov/einops";

--- a/pkgs/development/python-modules/ipywidgets/default.nix
+++ b/pkgs/development/python-modules/ipywidgets/default.nix
@@ -17,12 +17,12 @@
 
 buildPythonPackage rec {
   pname = "ipywidgets";
-  version = "8.1.2";
+  version = "8.1.3";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-0Lm0Hkm66SaoZuYTo5sPAJd0XSufHz3UBmQbSlfsQsk=";
+    hash = "sha256-9fnuquCCsYI86erCV1JylS9A10iJOXKVbcCXAKY5LZw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/jupyter-server/default.nix
+++ b/pkgs/development/python-modules/jupyter-server/default.nix
@@ -35,14 +35,14 @@
 
 buildPythonPackage rec {
   pname = "jupyter-server";
-  version = "2.14.0";
+  version = "2.14.1";
   pyproject = true;
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     pname = "jupyter_server";
     inherit version;
-    hash = "sha256-ZZFUzqUSCDQ0/XyTt/4Il696L9C53UdJKCtC6qxK5nc=";
+    hash = "sha256-ElWNFY7HoGU7+WzCcrx6154BJ9UDuYLtFEOZNGaU9yY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/jupyterlab-widgets/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-widgets/default.nix
@@ -7,13 +7,13 @@
 
 buildPythonPackage rec {
   pname = "jupyterlab-widgets";
-  version = "3.0.10";
+  version = "3.0.11";
   pyproject = true;
 
   src = fetchPypi {
     pname = "jupyterlab_widgets";
     inherit version;
-    hash = "sha256-BPKsBJdnJ+T50PqRzcLxq4YPll5QTCnb1qZciCydBMA=";
+    hash = "sha256-3VrGeVk8lprynJvtBUwk8mhCuqUTUhFHNnVrwDXe7ic=";
   };
 
   # jupyterlab is required to build from source but we use the pre-build package

--- a/pkgs/development/python-modules/marimo/default.nix
+++ b/pkgs/development/python-modules/marimo/default.nix
@@ -23,14 +23,14 @@
 
 buildPythonPackage rec {
   pname = "marimo";
-  version = "0.6.14";
+  version = "0.6.17";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-9rbRoBshVK0P8eqdOHyKQCwNkPsp2HiIhzyST3QXJpc=";
+    hash = "sha256-vK4pa7CnVQp78DhEFIkNLNS5y35x9YV2nV3d0JOBTIA=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/mediapy/default.nix
+++ b/pkgs/development/python-modules/mediapy/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "mediapy";
-  version = "1.2.1";
+  version = "1.2.2";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-jINA5J69gPywaVGcOOIrgVwlss4nF4I6qk2W34blxK4=";
+    hash = "sha256-QtmhqpPBg1ULgk27Tw3l2mGqXITbjwHwY6zR8juQ7wo=";
   };
 
   nativeBuildInputs = [ flit-core ];

--- a/pkgs/development/python-modules/mkdocs-jupyter/default.nix
+++ b/pkgs/development/python-modules/mkdocs-jupyter/default.nix
@@ -53,6 +53,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "mkdocs_jupyter" ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = with lib; {
     description = "Use Jupyter Notebook in mkdocs";
     homepage = "https://github.com/danielfrg/mkdocs-jupyter";

--- a/pkgs/development/python-modules/nbdev/default.nix
+++ b/pkgs/development/python-modules/nbdev/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "nbdev";
-  version = "2.3.23";
+  version = "2.3.25";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-+HbGHyJ2TX6qnBBPNivFVklrf+Ma2QM3u/2a67NxfIs=";
+    hash = "sha256-MntVdZ6LazdFCm+h5FaTxvzEwCtoJjrW/EJPTt2fdnU=";
   };
 
   nativeBuildInputs = [ pythonRelaxDepsHook ];

--- a/pkgs/development/python-modules/nbexec/default.nix
+++ b/pkgs/development/python-modules/nbexec/default.nix
@@ -7,6 +7,7 @@
   jupyter-client,
   nbformat,
   nbconvert,
+  setuptools,
   # check inputs
   unittestCheckHook,
   ipykernel,
@@ -17,7 +18,7 @@ let
 in
 buildPythonPackage {
   inherit pname version;
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.9";
 
@@ -28,7 +29,9 @@ buildPythonPackage {
     hash = "sha256-Vv6EHX6WlnSmzQAYlO1mHnz5t078z3RQfVfte1+X2pw=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     jupyter-client
     nbformat
     nbconvert

--- a/pkgs/development/python-modules/nbexec/default.nix
+++ b/pkgs/development/python-modules/nbexec/default.nix
@@ -52,6 +52,8 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "nbexec" ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = with lib; {
     description = "A dead-simple tool for executing Jupyter notebooks from the command line.";
     mainProgram = "nbexec";

--- a/pkgs/development/python-modules/notebook/default.nix
+++ b/pkgs/development/python-modules/notebook/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "notebook";
-  version = "7.2.0";
-  disabled = pythonOlder "3.8";
+  version = "7.2.1";
+  pyproject = true;
 
-  format = "pyproject";
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-NKK6SwitXRnskw23SE+3l0aheEvp4aX4IY+a+GVqFB8=";
+    hash = "sha256-Qoe22ll0CzIXPQHWQfdj0pL0nDDnpRuJxGuoRzEmNB4=";
   };
 
   postPatch = ''
@@ -32,13 +32,13 @@ buildPythonPackage rec {
       --replace "timeout = 300" ""
   '';
 
-  nativeBuildInputs = [
+  build-system = [
     hatch-jupyter-builder
     hatchling
     jupyterlab
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     jupyter-server
     jupyterlab
     jupyterlab-server

--- a/pkgs/development/python-modules/oauthenticator/default.nix
+++ b/pkgs/development/python-modules/oauthenticator/default.nix
@@ -5,13 +5,18 @@
   fetchPypi,
   google-api-python-client,
   google-auth-oauthlib,
+  jsonschema,
   jupyterhub,
   mwoauth,
   pyjwt,
   pytest-asyncio,
   pytestCheckHook,
+  requests,
   requests-mock,
+  ruamel-yaml,
   setuptools,
+  tornado,
+  traitlets,
 }:
 
 buildPythonPackage rec {
@@ -34,8 +39,13 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   dependencies = [
+    jsonschema
     jupyterhub
     pyjwt
+    requests
+    ruamel-yaml
+    tornado
+    traitlets
   ];
 
   passthru.optional-dependencies = {

--- a/pkgs/development/python-modules/pytest-notebook/default.nix
+++ b/pkgs/development/python-modules/pytest-notebook/default.nix
@@ -75,6 +75,8 @@ buildPythonPackage rec {
     "test_run_pass_with_meta"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = {
     changelog = "https://github.com/chrisjsewell/pytest-notebook/blob/${src.rev}/docs/source/changelog.md";
     description = "Pytest plugin for regression testing and regenerating Jupyter Notebooks";

--- a/pkgs/development/python-modules/wasabi/default.nix
+++ b/pkgs/development/python-modules/wasabi/default.nix
@@ -32,6 +32,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "wasabi" ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = with lib; {
     description = "A lightweight console printing and formatting toolkit";
     homepage = "https://github.com/ines/wasabi";

--- a/pkgs/development/python-modules/widgetsnbextension/default.nix
+++ b/pkgs/development/python-modules/widgetsnbextension/default.nix
@@ -8,12 +8,12 @@
 
 buildPythonPackage rec {
   pname = "widgetsnbextension";
-  version = "4.0.10";
+  version = "4.0.11";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-ZBlsX/O5qRg6jmmaQif7C3AC8lLIFAmOZsTRzQZEaI8=";
+    hash = "sha256-iyKo8ZEL/RiOWW/n/AXcvYfoEMikugEL2z2oZjc5hHQ=";
   };
 
   nativeBuildInputs = [ jupyter-packaging ];


### PR DESCRIPTION
## Description of changes

Update jupyter-related packages at once to avoid building hundreds of packages over and over again.

This PR is based on the commits generated by the following command.

```
nix search nixpkgs#python311Packages 'ipython|jupyter|notebook' --json | jq -r 'keys | .[]' | cut -d . -f 3,4 | xargs -n 1 nix-update --commit
```

closes #319226

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
