### PR TITLE
cc-wrapper: add stack clash protection hardening flag

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1677,6 +1677,10 @@ Adds the `-ftrivial-auto-var-init=pattern` compiler option. This causes "trivial
 
 Use of this flag is controversial as it can prevent tools that detect uninitialized variable use (such as valgrind) from operating correctly.
 
+#### `stackclashprotection` {#stackclashprotection}
+
+This flag adds the `-fstack-clash-protection` compiler option, which causes growth of a program's stack to access each successive page in order. This should force the guard page to be accessed and cause an attempt to "jump over" this guard page to crash.
+
 [^footnote-stdenv-ignored-build-platform]: The build platform is ignored because it is a mere implementation detail of the package satisfying the dependency: As a general programming principle, dependencies are always *specified* as interfaces, not concrete implementation.
 [^footnote-stdenv-native-dependencies-in-path]: Currently, this means for native builds all dependencies are put on the `PATH`. But in the future that may not be the case for sake of matching cross: the platforms would be assumed to be unique for native and cross builds alike, so only the `depsBuild*` and `nativeBuildInputs` would be added to the `PATH`.
 [^footnote-stdenv-propagated-dependencies]: Nix itself already takes a package’s transitive dependencies into account, but this propagation ensures nixpkgs-specific infrastructure like [setup hooks](#ssec-setup-hooks) also are run as if it were a propagated dependency.

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -62,6 +62,8 @@
 
 - The `zerocallusedregs` hardening flag is enabled by default on compilers that support it.
 
+- The `stackclashprotection` hardening flag has been added, though disabled by default.
+
 - `hareHook` has been added as the language framework for Hare. From now on, it,
   not the `hare` package, should be added to `nativeBuildInputs` when building
   Hare programs.

--- a/pkgs/applications/emulators/wine/base.nix
+++ b/pkgs/applications/emulators/wine/base.nix
@@ -176,7 +176,7 @@ lib.optionalAttrs (buildScript != null) { builder = buildScript; }
 
   # https://bugs.winehq.org/show_bug.cgi?id=43530
   # https://github.com/NixOS/nixpkgs/issues/31989
-  hardeningDisable = [ "bindnow" ]
+  hardeningDisable = [ "bindnow" "stackclashprotection" ]
     ++ lib.optional (stdenv.hostPlatform.isDarwin) "fortify"
     ++ lib.optional (supportFlags.mingwSupport) "format";
 

--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -32,7 +32,7 @@ if [[ -n "${hardeningEnableMap[fortify3]-}" ]]; then
 fi
 
 if (( "${NIX_DEBUG:-0}" >= 1 )); then
-  declare -a allHardeningFlags=(fortify fortify3 stackprotector pie pic strictoverflow format trivialautovarinit zerocallusedregs)
+  declare -a allHardeningFlags=(fortify fortify3 stackprotector stackclashprotection pie pic strictoverflow format trivialautovarinit zerocallusedregs)
   declare -A hardeningDisableMap=()
 
   # Determine which flags were effectively disabled so we can report below.
@@ -78,6 +78,10 @@ for flag in "${!hardeningEnableMap[@]}"; do
     stackprotector)
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling stackprotector >&2; fi
       hardeningCFlagsBefore+=('-fstack-protector-strong' '--param' 'ssp-buffer-size=4')
+      ;;
+    stackclashprotection)
+      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling stack-clash-protection >&2; fi
+      hardeningCFlagsBefore+=('-fstack-clash-protection')
       ;;
     pie)
       # NB: we do not use `+=` here, because PIE flags must occur before any PIC flags

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -280,7 +280,7 @@ pipe ((callFile ./common/builder.nix {}) ({
 
   libc_dev = stdenv.cc.libc_dev;
 
-  hardeningDisable = [ "format" "pie" ]
+  hardeningDisable = [ "format" "pie" "stackclashprotection" ]
   ++ optionals (is11 && langAda) [ "fortify3" ];
 
   postPatch = optionalString atLeast7 ''
@@ -425,6 +425,9 @@ pipe ((callFile ./common/builder.nix {}) ({
     inherit langC langCC langObjC langObjCpp langAda langFortran langGo langD langJava version;
     isGNU = true;
     hardeningUnsupportedFlags = optional is48 "stackprotector"
+      ++ optional (
+        (targetPlatform.isAarch64 && !atLeast9) || !atLeast8
+      ) "stackclashprotection"
       ++ optional (!atLeast11) "zerocallusedregs"
       ++ optionals (!atLeast12) [ "fortify3" "trivialautovarinit" ]
       ++ optionals (langFortran) [ "fortify" "format" ];

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -134,16 +134,26 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
-    } // (lib.optionalAttrs (lib.versionAtLeast release_version "15") {
-      hardeningUnsupportedFlags = [
-        "fortify3"
-      ];
       hardeningUnsupportedFlagsByTargetPlatform = targetPlatform:
-        lib.optional (!(targetPlatform.isx86_64 || targetPlatform.isAarch64)) "zerocallusedregs"
+        [ "fortify3" ]
+        ++ lib.optional (
+          (lib.versionOlder release_version "11")
+          || (targetPlatform.isAarch64 && (lib.versionOlder release_version "18.1"))
+          || (targetPlatform.isFreeBSD && (lib.versionOlder release_version "15"))
+          || !(targetPlatform.isLinux || targetPlatform.isFreeBSD)
+          || !(
+            targetPlatform.isx86
+            || targetPlatform.isPower64
+            || targetPlatform.isS390x
+            || targetPlatform.isAarch64
+          )
+        ) "stackclashprotection"
+        ++ lib.optional (
+          (lib.versionOlder release_version "15")
+          || !(targetPlatform.isx86_64 || targetPlatform.isAarch64)
+        ) "zerocallusedregs"
         ++ (finalAttrs.passthru.hardeningUnsupportedFlags or []);
-    }) // (lib.optionalAttrs (lib.versionOlder release_version "15") {
-      hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" ];
-    });
+    };
 
     meta = llvm_meta // {
       homepage = "https://clang.llvm.org/";

--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -29,7 +29,7 @@ in stdenv.mkDerivation {
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ windows.mingw_w64_headers ];
-  hardeningDisable = [ "stackprotector" "fortify" ];
+  hardeningDisable = [ "stackprotector" "stackclashprotection" "fortify" ];
 
   meta = {
     platforms = lib.platforms.windows;

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -327,7 +327,11 @@ in
               '';
               passthru = {
                 isFromBootstrapFiles = true;
-                hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" ];
+                hardeningUnsupportedFlags = [
+                  "fortify3"
+                  "stackclashprotection"
+                  "zerocallusedregs"
+                ];
               };
             };
             clang-unwrapped = selfTools.libclang;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -119,6 +119,7 @@ let
     "pie"
     "relro"
     "stackprotector"
+    "stackclashprotection"
     "strictoverflow"
     "trivialautovarinit"
     "zerocallusedregs"

--- a/pkgs/stdenv/linux/bootstrap-tools/default.nix
+++ b/pkgs/stdenv/linux/bootstrap-tools/default.nix
@@ -15,5 +15,10 @@ derivation ({
   langC = true;
   langCC = true;
   isGNU = true;
-  hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" "trivialautovarinit" ];
+  hardeningUnsupportedFlags = [
+    "fortify3"
+    "stackclashprotection"
+    "trivialautovarinit"
+    "zerocallusedregs"
+  ];
 } // extraAttrs)

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -292,6 +292,7 @@ let
           pkgsExtraHardening = super';
           stdenv = super'.withDefaultHardeningFlags (
             super'.stdenv.cc.defaultHardeningFlags ++ [
+              "stackclashprotection"
               "trivialautovarinit"
             ]
           ) super'.stdenv;


### PR DESCRIPTION
## Description of changes
Based on #288748, which appears to have stalled.

This caused me to refactor clang's `hardeningUnsupportedFlagsByTargetPlatform` to something more logical. Individual commits have more information on changes.

Built quite a lot of packages on nixos x86_64 with this enabled, not running into any problems.

Bootstrapped `hello` on macos 12 x86_64, nixos x86_64 `pkgsStatic`, `pkgsMusl`, `pkgsCross.aarch64-multiplatform`, `pkgsi686Linux`, `pkgsLLVM` successfully.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
