### PR TITLE
treewide: `"${pkg}/bin/${pkg.meta.mainProgram}"` -> `"${lib.getExe pkg}"`

### DIFF
--- a/pkgs/applications/audio/aaxtomp3/default.nix
+++ b/pkgs/applications/audio/aaxtomp3/default.nix
@@ -45,7 +45,7 @@ resholve.mkDerivation rec {
       "bin/aaxtomp3"
       "bin/interactiveaaxtomp3"
     ];
-    interpreter = "${bash}/bin/bash";
+    interpreter = "${lib.getExe bash}";
     inputs = [
       bc
       coreutils

--- a/pkgs/applications/audio/aaxtomp3/default.nix
+++ b/pkgs/applications/audio/aaxtomp3/default.nix
@@ -45,7 +45,7 @@ resholve.mkDerivation rec {
       "bin/aaxtomp3"
       "bin/interactiveaaxtomp3"
     ];
-    interpreter = "${lib.getExe bash}";
+    interpreter = lib.getExe bash;
     inputs = [
       bc
       coreutils

--- a/pkgs/applications/audio/ardour/7.nix
+++ b/pkgs/applications/audio/ardour/7.nix
@@ -95,7 +95,7 @@ stdenv.mkDerivation rec {
     sed 's|/usr/include/libintl.h|${glibc.dev}/include/libintl.h|' -i wscript
     patchShebangs ./tools/
     substituteInPlace libs/ardour/video_tools_paths.cc \
-      --replace 'ffmpeg_exe = X_("");' 'ffmpeg_exe = X_("${ffmpeg}/bin/ffmpeg");' \
+      --replace 'ffmpeg_exe = X_("");' 'ffmpeg_exe = X_("${lib.getExe ffmpeg}");' \
       --replace 'ffprobe_exe = X_("");' 'ffprobe_exe = X_("${ffmpeg}/bin/ffprobe");'
   '';
 

--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -94,7 +94,7 @@ stdenv.mkDerivation rec {
     sed 's|/usr/include/libintl.h|${glibc.dev}/include/libintl.h|' -i wscript
     patchShebangs ./tools/
     substituteInPlace libs/ardour/video_tools_paths.cc \
-      --replace 'ffmpeg_exe = X_("");' 'ffmpeg_exe = X_("${ffmpeg}/bin/ffmpeg");' \
+      --replace 'ffmpeg_exe = X_("");' 'ffmpeg_exe = X_("${lib.getExe ffmpeg}");' \
       --replace 'ffprobe_exe = X_("");' 'ffprobe_exe = X_("${ffmpeg}/bin/ffprobe");'
   '';
 

--- a/pkgs/applications/audio/castopod/default.nix
+++ b/pkgs/applications/audio/castopod/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
 
     # ffmpeg is required for Video Clips feature
     substituteInPlace modules/MediaClipper/VideoClipper.php \
-      --replace "ffmpeg" "${ffmpeg-headless}/bin/ffmpeg"
+      --replace "ffmpeg" "${lib.getExe ffmpeg-headless}"
     substituteInPlace modules/Admin/Controllers/VideoClipsController.php \
       --replace "which ffmpeg" "echo ${ffmpeg-headless}/bin/ffmpeg"
   '';

--- a/pkgs/applications/audio/crip/default.nix
+++ b/pkgs/applications/audio/crip/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
       cp $script $out/bin/
 
       substituteInPlace $out/bin/$script \
-        --replace '$editor = "vim";' '$editor = "${nano}/bin/nano";'
+        --replace '$editor = "vim";' '$editor = "${lib.getExe nano}";'
 
       wrapProgram $out/bin/$script \
         --set PERL5LIB "${perlPackages.makePerlPath [ perlPackages.CDDB_get ]}" \

--- a/pkgs/applications/audio/deadbeef/plugins/statusnotifier.nix
+++ b/pkgs/applications/audio/deadbeef/plugins/statusnotifier.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace tools/glib-mkenums \
-      --replace /usr/bin/perl "${perl}/bin/perl"
+      --replace /usr/bin/perl "${lib.getExe perl}"
   '';
 
   installPhase = ''

--- a/pkgs/applications/audio/easyabc/default.nix
+++ b/pkgs/applications/audio/easyabc/default.nix
@@ -49,7 +49,7 @@ in python.pkgs.buildPythonApplication {
       src = ./hardcoded-paths.patch;
       fluidsynth = "${fluidsynth}/lib/libfluidsynth.so";
       soundfont = "${soundfont-fluid}/share/soundfonts/FluidR3_GM2-2.sf2";
-      ghostscript = "${ghostscript}/bin/gs";
+      ghostscript = "${lib.getExe ghostscript}";
     })
   ];
 

--- a/pkgs/applications/audio/easyabc/default.nix
+++ b/pkgs/applications/audio/easyabc/default.nix
@@ -49,7 +49,7 @@ in python.pkgs.buildPythonApplication {
       src = ./hardcoded-paths.patch;
       fluidsynth = "${fluidsynth}/lib/libfluidsynth.so";
       soundfont = "${soundfont-fluid}/share/soundfonts/FluidR3_GM2-2.sf2";
-      ghostscript = "${lib.getExe ghostscript}";
+      ghostscript = lib.getExe ghostscript;
     })
   ];
 

--- a/pkgs/applications/audio/hqplayer-desktop/default.nix
+++ b/pkgs/applications/audio/hqplayer-desktop/default.nix
@@ -89,7 +89,7 @@ mkDerivation rec {
     done
     substituteInPlace "$doc/share/applications/hqplayer4desktop-manual.desktop" \
         --replace /usr/share/doc/hqplayer4desktop "$doc/share/doc/${pname}" \
-        --replace evince "${evince}/bin/evince"
+        --replace evince "${lib.getExe evince}"
   '';
 
   postFixup = ''

--- a/pkgs/applications/audio/midisheetmusic/default.nix
+++ b/pkgs/applications/audio/midisheetmusic/default.nix
@@ -19,7 +19,7 @@ in stdenv.mkDerivation {
   buildPhase = ''
     for i in Classes/MidiPlayer.cs Classes/MidiSheetMusic.cs
     do
-      substituteInPlace $i --replace "/usr/bin/timidity" "${timidity}/bin/timidity"
+      substituteInPlace $i --replace "/usr/bin/timidity" "${lib.getExe timidity}"
     done
 
     ./build.sh

--- a/pkgs/applications/audio/sfizz/default.nix
+++ b/pkgs/applications/audio/sfizz/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     cp ${catch2}/include/catch2/catch.hpp tests/catch2/catch.hpp
 
     substituteInPlace plugins/editor/external/vstgui4/vstgui/lib/platform/linux/x11fileselector.cpp \
-      --replace 'zenitypath = "zenity"' 'zenitypath = "${gnome.zenity}/bin/zenity"'
+      --replace 'zenitypath = "zenity"' 'zenitypath = "${lib.getExe gnome.zenity}"'
     substituteInPlace plugins/editor/src/editor/NativeHelpers.cpp \
       --replace '/usr/bin/zenity' '${gnome.zenity}/bin/zenity'
   '';

--- a/pkgs/applications/audio/vcv-rack/default.nix
+++ b/pkgs/applications/audio/vcv-rack/default.nix
@@ -173,7 +173,7 @@ stdenv.mkDerivation rec {
 
     # Fix reference to zenity
     substituteInPlace dep/osdialog/osdialog_zenity.c \
-      --replace 'zenityBin[] = "zenity"' 'zenityBin[] = "${gnome.zenity}/bin/zenity"'
+      --replace 'zenityBin[] = "zenity"' 'zenityBin[] = "${lib.getExe gnome.zenity}"'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/applications/blockchains/polkadot/default.nix
+++ b/pkgs/applications/blockchains/polkadot/default.nix
@@ -85,7 +85,7 @@ rustPlatform.buildRustPackage rec {
   # NOTE: we need to force lld otherwise rust-lld is not found for wasm32 target
   CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_LINKER = "lld";
   OPENSSL_NO_VENDOR = 1;
-  PROTOC = "${lib.getExe protobuf}";
+  PROTOC = lib.getExe protobuf;
   ROCKSDB_LIB_DIR = "${rocksdb}/lib";
 
   meta = with lib; {

--- a/pkgs/applications/blockchains/polkadot/default.nix
+++ b/pkgs/applications/blockchains/polkadot/default.nix
@@ -85,7 +85,7 @@ rustPlatform.buildRustPackage rec {
   # NOTE: we need to force lld otherwise rust-lld is not found for wasm32 target
   CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_LINKER = "lld";
   OPENSSL_NO_VENDOR = 1;
-  PROTOC = "${protobuf}/bin/protoc";
+  PROTOC = "${lib.getExe protobuf}";
   ROCKSDB_LIB_DIR = "${rocksdb}/lib";
 
   meta = with lib; {

--- a/pkgs/applications/blockchains/sparrow/fhsenv.nix
+++ b/pkgs/applications/blockchains/sparrow/fhsenv.nix
@@ -6,7 +6,7 @@
 buildFHSEnv {
   name = "sparrow-desktop";
 
-  runScript = "${sparrow-unwrapped}/bin/sparrow-desktop";
+  runScript = "${lib.getExe sparrow-unwrapped}";
 
   targetPkgs = pkgs: with pkgs; [
     sparrow-unwrapped

--- a/pkgs/applications/blockchains/sparrow/fhsenv.nix
+++ b/pkgs/applications/blockchains/sparrow/fhsenv.nix
@@ -6,7 +6,7 @@
 buildFHSEnv {
   name = "sparrow-desktop";
 
-  runScript = "${lib.getExe sparrow-unwrapped}";
+  runScript = lib.getExe sparrow-unwrapped;
 
   targetPkgs = pkgs: with pkgs; [
     sparrow-unwrapped

--- a/pkgs/applications/display-managers/lightdm-slick-greeter/default.nix
+++ b/pkgs/applications/display-managers/lightdm-slick-greeter/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace src/slick-greeter.vala \
-      --replace-fail "/usr/bin/numlockx" "${numlockx}/bin/numlockx" \
+      --replace-fail "/usr/bin/numlockx" "${lib.getExe numlockx}" \
       --replace-fail "/usr/share/xsessions/" "/run/current-system/sw/share/xsessions/" \
       --replace-fail "/usr/share/wayland-sessions/" "/run/current-system/sw/share/wayland-sessions/" \
       --replace-fail "/usr/bin/slick-greeter" "${placeholder "out"}/bin/slick-greeter"

--- a/pkgs/applications/editors/flpsed/default.nix
+++ b/pkgs/applications/editors/flpsed/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     # replace the execvp call to ghostscript
-    sed -e '/exec_gs/ {n; s|"gs"|"${lib.getBin ghostscript}/bin/gs"|}' \
+    sed -e '/exec_gs/ {n; s|"gs"|"${lib.getExe ghostscript}"|}' \
         -i src/GsWidget.cxx
   '';
 

--- a/pkgs/applications/editors/jupyter-kernels/xeus-cling/default.nix
+++ b/pkgs/applications/editors/jupyter-kernels/xeus-cling/default.nix
@@ -31,7 +31,7 @@ let
       {
         displayName = "C++" + versionSuffix;
         argv = [
-          "${xeus-cling}/bin/xcpp"
+          "${lib.getExe xeus-cling}"
         ]
         ++ cling.flags
         ++ [

--- a/pkgs/applications/editors/kakoune/plugins/overrides.nix
+++ b/pkgs/applications/editors/kakoune/plugins/overrides.nix
@@ -21,7 +21,7 @@ self: super: {
 
   fzf-kak = super.fzf-kak.overrideAttrs(oldAttrs: rec {
     preFixup = ''
-      if [[ -x "${fzf}/bin/fzf" ]]; then
+      if [[ -x "${lib.getExe fzf}" ]]; then
         fzfImpl='${fzf}/bin/fzf'
       else
         fzfImpl='${fzf}/bin/sk'

--- a/pkgs/applications/editors/kakoune/wrapper.nix
+++ b/pkgs/applications/editors/kakoune/wrapper.nix
@@ -1,4 +1,4 @@
-{ symlinkJoin, makeWrapper, kakoune, plugins ? [], configure ? {} }:
+{ lib, symlinkJoin, makeWrapper, kakoune, plugins ? [], configure ? {} }:
 
 let
   # "plugins" is the preferred way, but some configurations may be
@@ -17,7 +17,7 @@ in
       # location of kak binary is used to find ../share/kak/autoload,
       # unless explicitly overriden with KAKOUNE_RUNTIME
       rm "$out/bin/kak"
-      makeWrapper "${kakoune}/bin/kak" "$out/bin/kak" --set KAKOUNE_RUNTIME "$out/share/kak"
+      makeWrapper "${lib.getExe kakoune}" "$out/bin/kak" --set KAKOUNE_RUNTIME "$out/share/kak"
 
       # currently kakoune ignores doc files if they are symlinks, so workaround by
       # copying doc files over, so they become regular files...

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -76,7 +76,7 @@ let
     # wrapper with most arguments we need, excluding those that cause problems to
     # generate rplugin.vim, but still required for the final wrapper.
     finalMakeWrapperArgs =
-      [ "${neovim-unwrapped}/bin/nvim" "${placeholder "out"}/bin/nvim" ]
+      [ "${lib.getExe neovim-unwrapped}" "${placeholder "out"}/bin/nvim" ]
       ++ [ "--set" "NVIM_SYSTEM_RPLUGIN_MANIFEST" "${placeholder "out"}/rplugin.vim" ]
       ++ lib.optionals finalAttrs.wrapRc [ "--add-flags" "-u ${writeText "init.lua" rcContent}" ]
       ++ finalAttrs.generatedWrapperArgs
@@ -125,7 +125,7 @@ let
       ''
       + lib.optionalString (manifestRc != null) (let
         manifestWrapperArgs =
-          [ "${neovim-unwrapped}/bin/nvim" "${placeholder "out"}/bin/nvim-wrapper" ] ++ finalAttrs.generatedWrapperArgs;
+          [ "${lib.getExe neovim-unwrapped}" "${placeholder "out"}/bin/nvim-wrapper" ] ++ finalAttrs.generatedWrapperArgs;
       in ''
         echo "Generating remote plugin manifest"
         export NVIM_RPLUGIN_MANIFEST=$out/rplugin.vim

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -484,7 +484,7 @@
     patches = [ ./patches/cornelis/0001-Unconditionally-use-global-binary.patch ];
     postInstall = ''
       substituteInPlace $out/ftplugin/agda.vim \
-        --subst-var-by CORNELIS "${lib.getBin cornelis}/bin/cornelis"
+        --subst-var-by CORNELIS "${lib.getExe cornelis}"
     '';
   };
 
@@ -941,9 +941,9 @@
   minimap-vim = super.minimap-vim.overrideAttrs {
     preFixup = ''
       substituteInPlace $out/plugin/minimap.vim \
-        --replace "code-minimap" "${code-minimap}/bin/code-minimap"
+        --replace "code-minimap" "${lib.getExe code-minimap}"
       substituteInPlace $out/bin/minimap_generator.sh \
-        --replace "code-minimap" "${code-minimap}/bin/code-minimap"
+        --replace "code-minimap" "${lib.getExe code-minimap}"
     '';
 
     doInstallCheck = true;
@@ -1757,7 +1757,7 @@
       + ''
         substituteInPlace ftplugin/haskell/stylish-haskell.vim --replace \
           'g:stylish_haskell_command = "stylish-haskell"' \
-          'g:stylish_haskell_command = "${stylish-haskell}/bin/stylish-haskell"'
+          'g:stylish_haskell_command = "${lib.getExe stylish-haskell}"'
       '';
   });
 

--- a/pkgs/applications/editors/vim/plugins/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/vim-utils.nix
@@ -365,7 +365,7 @@ rec {
       name = "vim-gen-doc-hook";
       propagatedBuildInputs = [ vim ];
       substitutions = {
-        vimBinary = "${lib.getExe vim}";
+        vimBinary = lib.getExe vim;
         inherit rtpPath;
       };
     } ./vim-gen-doc-hook.sh) {};
@@ -375,7 +375,7 @@ rec {
       name = "vim-command-check-hook";
       propagatedBuildInputs = [ neovim-unwrapped ];
       substitutions = {
-        vimBinary = "${lib.getExe neovim-unwrapped}";
+        vimBinary = lib.getExe neovim-unwrapped;
         inherit rtpPath;
       };
     } ./vim-command-check-hook.sh) {};
@@ -385,7 +385,7 @@ rec {
       name = "neovim-require-check-hook";
       propagatedBuildInputs = [ neovim-unwrapped ];
       substitutions = {
-        nvimBinary = "${lib.getExe neovim-unwrapped}";
+        nvimBinary = lib.getExe neovim-unwrapped;
         inherit rtpPath;
       };
     } ./neovim-require-check-hook.sh) {};

--- a/pkgs/applications/editors/vim/plugins/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/vim-utils.nix
@@ -365,7 +365,7 @@ rec {
       name = "vim-gen-doc-hook";
       propagatedBuildInputs = [ vim ];
       substitutions = {
-        vimBinary = "${vim}/bin/vim";
+        vimBinary = "${lib.getExe vim}";
         inherit rtpPath;
       };
     } ./vim-gen-doc-hook.sh) {};
@@ -375,7 +375,7 @@ rec {
       name = "vim-command-check-hook";
       propagatedBuildInputs = [ neovim-unwrapped ];
       substitutions = {
-        vimBinary = "${neovim-unwrapped}/bin/nvim";
+        vimBinary = "${lib.getExe neovim-unwrapped}";
         inherit rtpPath;
       };
     } ./vim-command-check-hook.sh) {};
@@ -385,7 +385,7 @@ rec {
       name = "neovim-require-check-hook";
       propagatedBuildInputs = [ neovim-unwrapped ];
       substitutions = {
-        nvimBinary = "${neovim-unwrapped}/bin/nvim";
+        nvimBinary = "${lib.getExe neovim-unwrapped}";
         inherit rtpPath;
       };
     } ./neovim-require-check-hook.sh) {};

--- a/pkgs/applications/editors/vscode/extensions/azdavis.millet/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/azdavis.millet/default.nix
@@ -19,7 +19,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
   ];
   postInstall = ''
     cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."millet.server.path".default = "${millet}/bin/millet-ls"' package.json | sponge package.json
+    jq '.contributes.configuration.properties."millet.server.path".default = "${lib.getExe millet}"' package.json | sponge package.json
   '';
   meta = {
     description = "Standard ML support for VS Code";

--- a/pkgs/applications/editors/vscode/extensions/b4dm4n.vscode-nixpkgs-fmt/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/b4dm4n.vscode-nixpkgs-fmt/default.nix
@@ -19,7 +19,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
   ];
   postInstall = ''
     cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."nixpkgs-fmt.path".default = "${nixpkgs-fmt}/bin/nixpkgs-fmt"' package.json | sponge package.json
+    jq '.contributes.configuration.properties."nixpkgs-fmt.path".default = "${lib.getExe nixpkgs-fmt}"' package.json | sponge package.json
   '';
   meta = {
     license = lib.licenses.mit;

--- a/pkgs/applications/editors/vscode/extensions/betterthantomorrow.calva/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/betterthantomorrow.calva/default.nix
@@ -19,7 +19,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
   ];
   postInstall = ''
     cd "$out/$installPrefix"
-    jq '.contributes.configuration[0].properties."calva.clojureLspPath".default = "${clojure-lsp}/bin/clojure-lsp"' package.json | sponge package.json
+    jq '.contributes.configuration[0].properties."calva.clojureLspPath".default = "${lib.getExe clojure-lsp}"' package.json | sponge package.json
   '';
   meta = {
     license = lib.licenses.mit;

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -4903,7 +4903,7 @@ let
         ];
         postInstall = ''
           cd "$out/$installPrefix"
-          jq '.contributes.configuration.properties.protoc.properties.path.default = "${protobuf}/bin/protoc"' package.json | sponge package.json
+          jq '.contributes.configuration.properties.protoc.properties.path.default = "${lib.getExe protobuf}"' package.json | sponge package.json
         '';
         meta = {
           license = lib.licenses.mit;

--- a/pkgs/applications/editors/vscode/extensions/foxundermoon.shell-format/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/foxundermoon.shell-format/default.nix
@@ -21,7 +21,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
 
   postInstall = ''
     cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."shellformat.path".default = "${shfmt}/bin/shfmt"' package.json | sponge package.json
+    jq '.contributes.configuration.properties."shellformat.path".default = "${lib.getExe shfmt}"' package.json | sponge package.json
   '';
 
   meta = {

--- a/pkgs/applications/editors/vscode/extensions/jebbs.plantuml/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/jebbs.plantuml/default.nix
@@ -19,7 +19,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
   ];
   postInstall = ''
     cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."plantuml.java".default = "${plantuml}/bin/plantuml"' package.json | sponge package.json
+    jq '.contributes.configuration.properties."plantuml.java".default = "${lib.getExe plantuml}"' package.json | sponge package.json
   '';
 
   meta = {

--- a/pkgs/applications/editors/vscode/extensions/kamadorueda.alejandra/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/kamadorueda.alejandra/default.nix
@@ -22,9 +22,9 @@ vscode-utils.buildVscodeMarketplaceExtension {
 
     jq -e '
       .contributes.configuration.properties."alejandra.program".default =
-        "${alejandra}/bin/alejandra" |
+        "${lib.getExe alejandra}" |
       .contributes.configurationDefaults."alejandra.program" =
-        "${alejandra}/bin/alejandra"
+        "${lib.getExe alejandra}"
     ' \
     < package.json \
     | sponge package.json

--- a/pkgs/applications/editors/vscode/extensions/ms-vsliveshare.vsliveshare/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-vsliveshare.vsliveshare/default.nix
@@ -14,7 +14,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
 
   postPatch = ''
     substituteInPlace extension.js \
-      --replace-fail '"xsel"' '"${xsel}/bin/xsel"'
+      --replace-fail '"xsel"' '"${lib.getExe xsel}"'
   '';
 
   meta = {

--- a/pkgs/applications/editors/vscode/extensions/rust-lang.rust-analyzer/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/rust-lang.rust-analyzer/default.nix
@@ -88,7 +88,7 @@ vscode-utils.buildVscodeExtension {
 
   preInstall = lib.optionalString setDefaultServerPath ''
     jq '.contributes.configuration.properties."rust-analyzer.server.path".default = $s' \
-      --arg s "${rust-analyzer}/bin/rust-analyzer" \
+      --arg s "${lib.getExe rust-analyzer}" \
       package.json | sponge package.json
   '';
 

--- a/pkgs/applications/editors/vscode/extensions/timonwong.shellcheck/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/timonwong.shellcheck/default.nix
@@ -19,7 +19,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
   ];
   postInstall = ''
     cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."shellcheck.executablePath".default = "${shellcheck}/bin/shellcheck"' package.json | sponge package.json
+    jq '.contributes.configuration.properties."shellcheck.executablePath".default = "${lib.getExe shellcheck}"' package.json | sponge package.json
   '';
   meta = {
     description = "Integrates ShellCheck into VS Code, a linter for Shell scripts";

--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -222,7 +222,7 @@ in
     asar extract "$packed" "$unpacked"
     substituteInPlace $unpacked/@vscode/sudo-prompt/index.js \
       --replace "/usr/bin/pkexec" "/run/wrappers/bin/pkexec" \
-      --replace "/bin/bash" "${bash}/bin/bash"
+      --replace "/bin/bash" "${lib.getExe bash}"
     rm -rf "$packed"
 
     # without this symlink loading JsChardet, the library that is used for auto encoding detection when files.autoGuessEncoding is true,

--- a/pkgs/applications/graphics/fig2dev/default.nix
+++ b/pkgs/applications/graphics/fig2dev/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ libpng ];
 
-  GSEXE="${ghostscript}/bin/gs";
+  GSEXE="${lib.getExe ghostscript}";
 
   configureFlags = [ "--enable-transfig" ];
 

--- a/pkgs/applications/graphics/inkscape/with-extensions.nix
+++ b/pkgs/applications/graphics/inkscape/with-extensions.nix
@@ -20,7 +20,7 @@ symlinkJoin {
 
   postBuild = ''
     rm -f $out/bin/inkscape
-    makeWrapper "${inkscape}/bin/inkscape" "$out/bin/inkscape" --set INKSCAPE_DATADIR "$out/share"
+    makeWrapper "${lib.getExe inkscape}" "$out/bin/inkscape" --set INKSCAPE_DATADIR "$out/share"
   '';
 
   inherit (inkscape) meta;

--- a/pkgs/applications/kde/kdegraphics-thumbnailers/default.nix
+++ b/pkgs/applications/kde/kdegraphics-thumbnailers/default.nix
@@ -16,7 +16,7 @@ mkDerivation {
     # Hardcode patches to Ghostscript so PDF thumbnails work OOTB.
     # Intentionally not doing the same for dvips because TeX is big.
     (substituteAll {
-      gs = "${ghostscript}/bin/gs";
+      gs = "${lib.getExe ghostscript}";
       src = ./gs-paths.patch;
     })
   ];

--- a/pkgs/applications/kde/kdegraphics-thumbnailers/default.nix
+++ b/pkgs/applications/kde/kdegraphics-thumbnailers/default.nix
@@ -16,7 +16,7 @@ mkDerivation {
     # Hardcode patches to Ghostscript so PDF thumbnails work OOTB.
     # Intentionally not doing the same for dvips because TeX is big.
     (substituteAll {
-      gs = "${lib.getExe ghostscript}";
+      gs = lib.getExe ghostscript;
       src = ./gs-paths.patch;
     })
   ];

--- a/pkgs/applications/misc/brewtarget/default.nix
+++ b/pkgs/applications/misc/brewtarget/default.nix
@@ -28,7 +28,7 @@ mkDerivation rec {
 
   preConfigure = ''
     chmod +x configure
-    substituteInPlace configure --replace /bin/bash "${bash}/bin/bash"
+    substituteInPlace configure --replace /bin/bash "${lib.getExe bash}"
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/cura/default.nix
+++ b/pkgs/applications/misc/cura/default.nix
@@ -38,7 +38,7 @@ mkDerivation rec {
 
   postPatch = ''
     sed -i 's,/python''${PYTHON_VERSION_MAJOR}/dist-packages,/python''${PYTHON_VERSION_MAJOR}.''${PYTHON_VERSION_MINOR}/site-packages,g' CMakeLists.txt
-    sed -i 's, executable_name = .*, executable_name = "${curaengine}/bin/CuraEngine",' plugins/CuraEngineBackend/CuraEngineBackend.py
+    sed -i 's, executable_name = .*, executable_name = "${lib.getExe curaengine}",' plugins/CuraEngineBackend/CuraEngineBackend.py
   '';
 
   postInstall = ''

--- a/pkgs/applications/misc/debian-goodies/default.nix
+++ b/pkgs/applications/misc/debian-goodies/default.nix
@@ -22,11 +22,11 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace debmany/debmany \
-      --replace "/usr/bin/dialog" "${dialog}/bin/dialog" \
+      --replace "/usr/bin/dialog" "${lib.getExe dialog}" \
       --replace "/usr/bin/whiptail" "${python3.pkgs.snack}/bin/whiptail"
 
     substituteInPlace dman \
-      --replace "curl" "${curl}/bin/curl"
+      --replace "curl" "${lib.getExe curl}"
   '';
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/deco/default.nix
+++ b/pkgs/applications/misc/deco/default.nix
@@ -18,9 +18,9 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = ''
-    substituteInPlace $out/bin/deco --replace "/usr/bin/env scsh" "${scsh}/bin/scsh"
-    substituteInPlace $out/bin/deco --replace "feh" "${feh}/bin/feh"
-    substituteInPlace $out/bin/deco --replace "xdpyinfo" "${xorg.xdpyinfo}/bin/xdpyinfo"
+    substituteInPlace $out/bin/deco --replace "/usr/bin/env scsh" "${lib.getExe scsh}"
+    substituteInPlace $out/bin/deco --replace "feh" "${lib.getExe feh}"
+    substituteInPlace $out/bin/deco --replace "xdpyinfo" "${lib.getExe xorg.xdpyinfo}"
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/gammu/default.nix
+++ b/pkgs/applications/misc/gammu/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     ./systemd.patch
     (substituteAll {
       src = ./gammu-config-dialog.patch;
-      dialog = "${lib.getExe dialog}";
+      dialog = lib.getExe dialog;
     })
   ];
 

--- a/pkgs/applications/misc/gammu/default.nix
+++ b/pkgs/applications/misc/gammu/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     ./systemd.patch
     (substituteAll {
       src = ./gammu-config-dialog.patch;
-      dialog = "${dialog}/bin/dialog";
+      dialog = "${lib.getExe dialog}";
     })
   ];
 

--- a/pkgs/applications/misc/gpg-mdp/default.nix
+++ b/pkgs/applications/misc/gpg-mdp/default.nix
@@ -29,11 +29,11 @@ in stdenv.mkDerivation {
       --replace "alias echo=/bin/echo" ""
 
     substituteInPlace ./src/config.c \
-      --replace "/usr/bin/gpg" "${gnupg}/bin/gpg" \
+      --replace "/usr/bin/gpg" "${lib.getExe gnupg}" \
       --replace "/usr/bin/vi" "vi"
 
     substituteInPlace ./mdp.1 \
-      --replace "/usr/bin/gpg" "${gnupg}/bin/gpg"
+      --replace "/usr/bin/gpg" "${lib.getExe gnupg}"
   '';
   # we add symlinks to the binary and man page with the name 'gpg-mdp', in case
   # the completely unrelated program also named 'mdp' is already installed.

--- a/pkgs/applications/misc/gv/default.nix
+++ b/pkgs/applications/misc/gv/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     sed 's|\<gs\>|${ghostscriptX}/bin/gs|g' -i "src/"*.in
-    sed 's|"gs"|"${ghostscriptX}/bin/gs"|g' -i "src/"*.c
+    sed 's|"gs"|"${lib.getExe ghostscriptX}"|g' -i "src/"*.c
   '';
 
   doCheck = true;

--- a/pkgs/applications/misc/k40-whisperer/default.nix
+++ b/pkgs/applications/misc/k40-whisperer/default.nix
@@ -35,7 +35,7 @@ in stdenv.mkDerivation rec {
 
   patchPhase = ''
     substituteInPlace svg_reader.py \
-      --replace '"/usr/bin/inkscape"' '"${inkscape}/bin/inkscape"'
+      --replace '"/usr/bin/inkscape"' '"${lib.getExe inkscape}"'
   '';
 
   buildPhase = "";

--- a/pkgs/applications/misc/mysql-workbench/default.nix
+++ b/pkgs/applications/misc/mysql-workbench/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     (substituteAll {
       src = ./hardcode-paths.patch;
       catchsegv = "${glibc.bin}/bin/catchsegv";
-      bash = "${lib.getExe bash}";
+      bash = lib.getExe bash;
       cp = "${coreutils}/bin/cp";
       dd = "${coreutils}/bin/dd";
       ls = "${coreutils}/bin/ls";
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
       rm = "${coreutils}/bin/rm";
       rmdir = "${coreutils}/bin/rmdir";
       stat = "${coreutils}/bin/stat";
-      sudo = "${lib.getExe sudo}";
+      sudo = lib.getExe sudo;
     })
 
     # Fix swig not being able to find headers

--- a/pkgs/applications/misc/mysql-workbench/default.nix
+++ b/pkgs/applications/misc/mysql-workbench/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     (substituteAll {
       src = ./hardcode-paths.patch;
       catchsegv = "${glibc.bin}/bin/catchsegv";
-      bash = "${bash}/bin/bash";
+      bash = "${lib.getExe bash}";
       cp = "${coreutils}/bin/cp";
       dd = "${coreutils}/bin/dd";
       ls = "${coreutils}/bin/ls";
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
       rm = "${coreutils}/bin/rm";
       rmdir = "${coreutils}/bin/rmdir";
       stat = "${coreutils}/bin/stat";
-      sudo = "${sudo}/bin/sudo";
+      sudo = "${lib.getExe sudo}";
     })
 
     # Fix swig not being able to find headers

--- a/pkgs/applications/misc/nut/default.nix
+++ b/pkgs/applications/misc/nut/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     substituteInPlace $out/lib/systemd/system-shutdown/nutshutdown \
-      --replace /bin/sed "${gnused}/bin/sed" \
+      --replace /bin/sed "${lib.getExe gnused}" \
       --replace /bin/sleep "${coreutils}/bin/sleep" \
       --replace /bin/systemctl "${systemd}/bin/systemctl"
 

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -250,7 +250,7 @@ in
     preConfigure = ''
       # PrintTimeGenius ships with marlin-calc binaries for multiple architectures
       rm */analyzers/marlin-calc*
-      sed 's@"{}.{}".format(binary_base_name, machine)@"${marlin-calc}/bin/marlin-calc"@' -i */analyzers/analyze_progress.py
+      sed 's@"{}.{}".format(binary_base_name, machine)@"${lib.getExe marlin-calc}"@' -i */analyzers/analyze_progress.py
     '';
 
     meta = with lib; {

--- a/pkgs/applications/misc/oil-buku/default.nix
+++ b/pkgs/applications/misc/oil-buku/default.nix
@@ -16,7 +16,7 @@ stdenvNoCC.mkDerivation rec {
       "LIBDIR=/usr/local/lib/oil" "LIBDIR=${placeholder "out"}/lib"
 
     substituteInPlace src/json-to-line.jq --replace \
-      "/usr/bin/env -S jq" "${jq}/bin/jq"
+      "/usr/bin/env -S jq" "${lib.getExe jq}"
 
     substituteInPlace src/format-columns.awk --replace \
       "/usr/bin/env -S awk" "${gawk}/bin/awk"

--- a/pkgs/applications/misc/pell/default.nix
+++ b/pkgs/applications/misc/pell/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = ''
-    substituteInPlace $out/bin/pell --replace "/usr/bin/env scsh" "${scsh}/bin/scsh"
+    substituteInPlace $out/bin/pell --replace "/usr/bin/env scsh" "${lib.getExe scsh}"
     substituteInPlace $out/bin/pell --replace "(play " "(${sox}/bin/play "
     substituteInPlace $out/bin/pell --replace "(notify-send " "(${libnotify}/bin/notify-send "
     substituteInPlace $out/bin/pell --replace "/usr/share/pell/online.mp3" "$out/share/online.mp3"

--- a/pkgs/applications/misc/plank/default.nix
+++ b/pkgs/applications/misc/plank/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace ./configure \
-      --replace "/usr/bin/file" "${file}/bin/file"
+      --replace "/usr/bin/file" "${lib.getExe file}"
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/pop-launcher/default.nix
+++ b/pkgs/applications/misc/pop-launcher/default.nix
@@ -22,9 +22,9 @@ rustPlatform.buildRustPackage rec {
     substituteInPlace plugins/src/scripts/mod.rs \
         --replace '/usr/lib/pop-launcher' "$out/share/pop-launcher"
     substituteInPlace plugins/src/calc/mod.rs \
-        --replace 'Command::new("qalc")' 'Command::new("${libqalculate}/bin/qalc")'
+        --replace 'Command::new("qalc")' 'Command::new("${lib.getExe libqalculate}")'
     substituteInPlace plugins/src/find/mod.rs \
-        --replace 'spawn("fd")' 'spawn("${fd}/bin/fd")'
+        --replace 'spawn("fd")' 'spawn("${lib.getExe fd}")'
     substituteInPlace plugins/src/terminal/mod.rs \
         --replace '/usr/bin/gnome-terminal' 'gnome-terminal'
   '';

--- a/pkgs/applications/misc/qsyncthingtray/default.nix
+++ b/pkgs/applications/misc/qsyncthingtray/default.nix
@@ -33,13 +33,13 @@ mkDerivation rec {
   postPatch = ''
     ${lib.optionalString stdenv.isLinux ''
       substituteInPlace includes/platforms/linux/posixUtils.hpp \
-        --replace '"/usr/local/bin/syncthing"'         '"${syncthing}/bin/syncthing"' \
+        --replace '"/usr/local/bin/syncthing"'         '"${lib.getExe syncthing}"' \
         --replace '"pgrep -x'                          '"${procps}/bin/pgrep -x'
     ''}
 
     ${lib.optionalString stdenv.isDarwin ''
       substituteInPlace includes/platforms/darwin/macUtils.hpp \
-        --replace '"/usr/local/bin/syncthing"'         '"${syncthing}/bin/syncthing"'
+        --replace '"/usr/local/bin/syncthing"'         '"${lib.getExe syncthing}"'
     ''}
   '';
 

--- a/pkgs/applications/misc/qtpass/default.nix
+++ b/pkgs/applications/misc/qtpass/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace src/qtpass.cpp \
-      --replace "/usr/bin/qrencode" "${qrencode}/bin/qrencode"
+      --replace "/usr/bin/qrencode" "${lib.getExe qrencode}"
   '';
 
   buildInputs = [ git gnupg pass qtbase qtsvg ];

--- a/pkgs/applications/misc/styx/default.nix
+++ b/pkgs/applications/misc/styx/default.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-f6iA/nHpKnm3BALoQq8SzdcSzJLCFSferEf69SpgD2Y=";
   };
 
-  server = "${lib.getExe caddy}";
-  linkcheck = "${lib.getExe linkchecker}";
+  server = lib.getExe caddy;
+  linkcheck = lib.getExe linkchecker;
 
   nativeBuildInputs = [ asciidoctor ];
 

--- a/pkgs/applications/misc/styx/default.nix
+++ b/pkgs/applications/misc/styx/default.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-f6iA/nHpKnm3BALoQq8SzdcSzJLCFSferEf69SpgD2Y=";
   };
 
-  server = "${caddy}/bin/caddy";
-  linkcheck = "${linkchecker}/bin/linkchecker";
+  server = "${lib.getExe caddy}";
+  linkcheck = "${lib.getExe linkchecker}";
 
   nativeBuildInputs = [ asciidoctor ];
 

--- a/pkgs/applications/misc/synergy/default.nix
+++ b/pkgs/applications/misc/synergy/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace src/gui/src/SslCertificate.cpp \
-      --replace 'kUnixOpenSslCommand[] = "openssl";' 'kUnixOpenSslCommand[] = "${openssl}/bin/openssl";'
+      --replace 'kUnixOpenSslCommand[] = "openssl";' 'kUnixOpenSslCommand[] = "${lib.getExe openssl}";'
   '' + lib.optionalString stdenv.isLinux ''
     substituteInPlace src/lib/synergy/unix/AppUtilUnix.cpp \
       --replace "/usr/share/X11/xkb/rules/evdev.xml" "${xkeyboardconfig}/share/X11/xkb/rules/evdev.xml"

--- a/pkgs/applications/misc/usync/default.nix
+++ b/pkgs/applications/misc/usync/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = ''
-    substituteInPlace $out/bin/$pname --replace "/usr/bin/env scsh" "${scsh}/bin/scsh"
+    substituteInPlace $out/bin/$pname --replace "/usr/bin/env scsh" "${lib.getExe scsh}"
     substituteInPlace $out/bin/$pname --replace "(rsync " "(${rsync}/bin/rsync "
     substituteInPlace $out/bin/$pname --replace "(unison " "(${unison}/bin/unison "
   '';

--- a/pkgs/applications/misc/vym/default.nix
+++ b/pkgs/applications/misc/vym/default.nix
@@ -28,8 +28,8 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     (substituteAll {
       src = ./000-fix-zip-paths.diff;
-      zipPath = "${zip}/bin/zip";
-      unzipPath = "${unzip}/bin/unzip";
+      zipPath = "${lib.getExe zip}";
+      unzipPath = "${lib.getExe unzip}";
     })
   ];
 

--- a/pkgs/applications/misc/vym/default.nix
+++ b/pkgs/applications/misc/vym/default.nix
@@ -28,8 +28,8 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     (substituteAll {
       src = ./000-fix-zip-paths.diff;
-      zipPath = "${lib.getExe zip}";
-      unzipPath = "${lib.getExe unzip}";
+      zipPath = lib.getExe zip;
+      unzipPath = lib.getExe unzip;
     })
   ];
 

--- a/pkgs/applications/misc/whalebird/default.nix
+++ b/pkgs/applications/misc/whalebird/default.nix
@@ -94,7 +94,7 @@ stdenv.mkDerivation rec {
     install -Dm644 "resources/icons/icon.iconset/icon_32x32@2x.png" \
       "$out/share/icons/hicolor/64x64/apps/whalebird.png"
 
-    makeWrapper "${electron}/bin/electron" "$out/bin/whalebird" \
+    makeWrapper "${lib.getExe electron}" "$out/bin/whalebird" \
       --add-flags "$out/opt/Whalebird/resources/app.asar" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
 

--- a/pkgs/applications/networking/appgate-sdp/default.nix
+++ b/pkgs/applications/networking/appgate-sdp/default.nix
@@ -124,11 +124,11 @@ stdenv.mkDerivation rec {
         --replace "InaccessiblePaths=/mnt /srv /boot /media" "InaccessiblePaths=-/mnt -/srv -/boot -/media"
 
     substituteInPlace $out/lib/systemd/system/appgate-resolver.service \
-        --replace "/usr/sbin/dnsmasq" "${dnsmasq}/bin/dnsmasq" \
+        --replace "/usr/sbin/dnsmasq" "${lib.getExe dnsmasq}" \
         --replace "/opt/" "$out/opt/"
 
     substituteInPlace $out/opt/appgate/linux/nm.py \
-        --replace "/usr/sbin/dnsmasq" "${dnsmasq}/bin/dnsmasq"
+        --replace "/usr/sbin/dnsmasq" "${lib.getExe dnsmasq}"
 
     substituteInPlace $out/opt/appgate/linux/set_dns \
         --replace "/etc/appgate.conf" "$out/etc/appgate.conf"

--- a/pkgs/applications/networking/browsers/w3m/default.nix
+++ b/pkgs/applications/networking/browsers/w3m/default.nix
@@ -33,8 +33,8 @@ in stdenv.mkDerivation rec {
 
   # we must set these so that the generated files (e.g. w3mhelp.cgi) contain
   # the correct paths.
-  PERL = "${lib.getExe perl}";
-  MAN = "${lib.getExe man}";
+  PERL = lib.getExe perl;
+  MAN = lib.getExe man;
 
   makeFlags = [ "AR=${stdenv.cc.bintools.targetPrefix}ar" ];
 

--- a/pkgs/applications/networking/browsers/w3m/default.nix
+++ b/pkgs/applications/networking/browsers/w3m/default.nix
@@ -33,8 +33,8 @@ in stdenv.mkDerivation rec {
 
   # we must set these so that the generated files (e.g. w3mhelp.cgi) contain
   # the correct paths.
-  PERL = "${perl}/bin/perl";
-  MAN = "${man}/bin/man";
+  PERL = "${lib.getExe perl}";
+  MAN = "${lib.getExe man}";
 
   makeFlags = [ "AR=${stdenv.cc.bintools.targetPrefix}ar" ];
 

--- a/pkgs/applications/networking/cluster/k3sup/default.nix
+++ b/pkgs/applications/networking/cluster/k3sup/default.nix
@@ -24,7 +24,7 @@ buildGoModule rec {
 
   postConfigure = ''
     substituteInPlace vendor/github.com/alexellis/go-execute/v2/exec.go \
-      --replace "/bin/bash" "${bash}/bin/bash"
+      --replace "/bin/bash" "${lib.getExe bash}"
   '';
 
   CGO_ENABLED = 0;

--- a/pkgs/applications/networking/cluster/kanif/default.nix
+++ b/pkgs/applications/networking/cluster/kanif/default.nix
@@ -10,8 +10,8 @@ stdenv.mkDerivation rec {
   };
 
   preBuild = ''
-      substituteInPlace ./kanif --replace "/usr/bin/perl" "${perl}/bin/perl"
-      substituteInPlace ./kanif --replace '$taktuk_command = "taktuk";' '$taktuk_command = "${taktuk}/bin/taktuk";'
+      substituteInPlace ./kanif --replace "/usr/bin/perl" "${lib.getExe perl}"
+      substituteInPlace ./kanif --replace '$taktuk_command = "taktuk";' '$taktuk_command = "${lib.getExe taktuk}";'
   '';
 
   meta = {

--- a/pkgs/applications/networking/cluster/taktuk/default.nix
+++ b/pkgs/applications/networking/cluster/taktuk/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   preBuild = ''
-      substituteInPlace ./taktuk --replace "/usr/bin/perl" "${perl}/bin/perl"
+      substituteInPlace ./taktuk --replace "/usr/bin/perl" "${lib.getExe perl}"
   '';
 
   meta = {

--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -146,7 +146,7 @@ let
 
               # Create a wrapper for terraform to point it to the plugins dir.
               mkdir -p $out/bin/
-              makeWrapper "${terraform}/bin/terraform" "$out/bin/terraform" \
+              makeWrapper "${lib.getExe terraform}" "$out/bin/terraform" \
                 --set NIX_TERRAFORM_PLUGIN_DIR $out/libexec/terraform-providers \
                 --prefix PATH : "${lib.makeBinPath wrapperInputs}"
             '';

--- a/pkgs/applications/networking/compactor/default.nix
+++ b/pkgs/applications/networking/compactor/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     substituteInPlace configure \
-      --replace "/usr/bin/file" "${file}/bin/file"
+      --replace "/usr/bin/file" "${lib.getExe file}"
   '';
 
   configureFlags = [

--- a/pkgs/applications/networking/dropbox/cli.nix
+++ b/pkgs/applications/networking/dropbox/cli.nix
@@ -13,7 +13,7 @@
 
 let
   version = "2024.04.17";
-  dropboxd = "${dropbox}/bin/dropbox";
+  dropboxd = "${lib.getExe dropbox}";
 in
 stdenv.mkDerivation {
   pname = "dropbox-cli";

--- a/pkgs/applications/networking/dropbox/cli.nix
+++ b/pkgs/applications/networking/dropbox/cli.nix
@@ -13,7 +13,7 @@
 
 let
   version = "2024.04.17";
-  dropboxd = "${lib.getExe dropbox}";
+  dropboxd = lib.getExe dropbox;
 in
 stdenv.mkDerivation {
   pname = "dropbox-cli";

--- a/pkgs/applications/networking/ids/suricata/default.nix
+++ b/pkgs/applications/networking/ids/suricata/default.nix
@@ -84,9 +84,9 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace ./configure \
-      --replace "/usr/bin/file" "${file}/bin/file"
+      --replace "/usr/bin/file" "${lib.getExe file}"
     substituteInPlace ./libhtp/configure \
-      --replace "/usr/bin/file" "${file}/bin/file"
+      --replace "/usr/bin/file" "${lib.getExe file}"
 
     mkdir -p bpf_stubs_workaround/gnu
     touch bpf_stubs_workaround/gnu/stubs-32.h

--- a/pkgs/applications/networking/instant-messengers/caprine-bin/build-from-appimage.nix
+++ b/pkgs/applications/networking/instant-messengers/caprine-bin/build-from-appimage.nix
@@ -1,4 +1,5 @@
-{ fetchurl
+{ lib
+, fetchurl
 , appimageTools
 , xorg
 , pname
@@ -28,7 +29,7 @@ in
 
   extraInstallCommands = ''
     mkdir -p $out/share
-    "${xorg.lndir}/bin/lndir" -silent "${extracted}/usr/share" "$out/share"
+    "${lib.getExe xorg.lndir}" -silent "${extracted}/usr/share" "$out/share"
     ln -s ${extracted}/caprine.png $out/share/icons/caprine.png
     mkdir $out/share/applications
     cp ${extracted}/caprine.desktop $out/share/applications/

--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-matrix-bridge/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-matrix-bridge/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
 
   postPatch = ''
     substituteInPlace matrix.lua \
-      --replace "/usr/bin/curl" "${curl}/bin/curl" \
+      --replace "/usr/bin/curl" "${lib.getExe curl}" \
       --replace "__NIX_LIB_PATH__" "$out/lib/?.so" \
       --replace "__NIX_OLM_PATH__" "$out/share/?.lua"
 

--- a/pkgs/applications/networking/sync/lsyncd/default.nix
+++ b/pkgs/applications/networking/sync/lsyncd/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace default-rsync.lua \
-      --replace "/usr/bin/rsync" "${rsync}/bin/rsync"
+      --replace "/usr/bin/rsync" "${lib.getExe rsync}"
   '';
 
   # Special flags needed on Darwin:

--- a/pkgs/applications/office/pdfmm/default.nix
+++ b/pkgs/applications/office/pdfmm/default.nix
@@ -30,7 +30,7 @@ resholve.mkDerivation rec {
     scripts = [
       "bin/pdfmm"
     ];
-    interpreter = "${bash}/bin/bash";
+    interpreter = "${lib.getExe bash}";
     inputs = [
       coreutils
       ghostscript

--- a/pkgs/applications/office/pdfmm/default.nix
+++ b/pkgs/applications/office/pdfmm/default.nix
@@ -30,7 +30,7 @@ resholve.mkDerivation rec {
     scripts = [
       "bin/pdfmm"
     ];
-    interpreter = "${lib.getExe bash}";
+    interpreter = lib.getExe bash;
     inputs = [
       coreutils
       ghostscript

--- a/pkgs/applications/radio/cqrlog/default.nix
+++ b/pkgs/applications/radio/cqrlog/default.nix
@@ -47,11 +47,11 @@ stdenv.mkDerivation rec {
     substituteInPlace src/fPreferences.pas \
       --replace "/usr/bin/rigctld" "${hamlib}/bin/rigctld" \
       --replace "/usr/bin/rotctld" "${hamlib}/bin/rotctld" \
-      --replace "/usr/bin/xplanet" "${xplanet}/bin/xplanet"
+      --replace "/usr/bin/xplanet" "${lib.getExe xplanet}"
     substituteInPlace src/fLoTWExport.pas \
-      --replace "/usr/bin/tqsl" "${tqsl}/bin/tqsl"
+      --replace "/usr/bin/tqsl" "${lib.getExe tqsl}"
     substituteInPlace src/dUtils.pas \
-      --replace "/usr/bin/xplanet" "${xplanet}/bin/xplanet" \
+      --replace "/usr/bin/xplanet" "${lib.getExe xplanet}" \
       --replace "/usr/bin/rigctld" "${hamlib}/bin/rigctld"
     # Order is important
     substituteInPlace src/dData.pas \

--- a/pkgs/applications/science/biology/kent/default.nix
+++ b/pkgs/applications/science/biology/kent/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace ./src/checkUmask.sh \
-      --replace "/bin/bash" "${bash}/bin/bash"
+      --replace "/bin/bash" "${lib.getExe bash}"
 
     substituteInPlace ./src/hg/sqlEnvTest.sh \
       --replace "which mysql_config" "${which}/bin/which ${libmysqlclient}/bin/mysql_config"

--- a/pkgs/applications/science/biology/quast/default.nix
+++ b/pkgs/applications/science/biology/quast/default.nix
@@ -24,7 +24,7 @@ pythonPackages.buildPythonApplication rec {
 
   installPhase = ''
     substituteInPlace quast_libs/bedtools/Makefile \
-      --replace "/bin/bash" "${bash}/bin/bash"
+      --replace "/bin/bash" "${lib.getExe bash}"
     mkdir -p "$out/${python.sitePackages}"
     export PYTHONPATH="$out/${python.sitePackages}:$PYTHONPATH"
     ${python.pythonOnBuildForHost.interpreter} setup.py install \

--- a/pkgs/applications/science/logic/symbiyosys/default.nix
+++ b/pkgs/applications/science/logic/symbiyosys/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
 
     # Fix various executable references
     substituteInPlace sbysrc/sby_core.py \
-      --replace '"/usr/bin/env", "bash"' '"${bash}/bin/bash"' \
+      --replace '"/usr/bin/env", "bash"' '"${lib.getExe bash}"' \
       --replace ', "btormc"'             ', "${boolector}/bin/btormc"' \
       --replace ', "aigbmc"'             ', "${aiger}/bin/aigbmc"'
 

--- a/pkgs/applications/science/math/R/default.nix
+++ b/pkgs/applications/science/math/R/default.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
       AWK=$(type -p gawk)
       CC=$(type -p cc)
       CXX=$(type -p c++)
-      FC="${gfortran}/bin/gfortran" F77="${gfortran}/bin/gfortran"
+      FC="${lib.getExe gfortran}" F77="${lib.getExe gfortran}"
       JAVA_HOME="${jdk}"
       RANLIB=$(type -p ranlib)
       r_cv_have_curl728=yes

--- a/pkgs/applications/science/math/maxima/default.nix
+++ b/pkgs/applications/science/math/maxima/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    substituteInPlace doc/info/Makefile.am --replace "/usr/bin/env perl" "${perl}/bin/perl"
+    substituteInPlace doc/info/Makefile.am --replace "/usr/bin/env perl" "${lib.getExe perl}"
   '';
 
   postInstall = ''

--- a/pkgs/applications/science/math/mxnet/default.nix
+++ b/pkgs/applications/science/math/mxnet/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace 3rdparty/mkldnn/tests/CMakeLists.txt \
-      --replace "/bin/bash" "${bash}/bin/bash"
+      --replace "/bin/bash" "${lib.getExe bash}"
 
     # Build against the system version of OpenMP.
     # https://github.com/apache/incubator-mxnet/pull/12160

--- a/pkgs/applications/science/math/nasc/default.nix
+++ b/pkgs/applications/science/math/nasc/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
 
     # patch subproject. same code in libqalculate expression
     substituteInPlace subprojects/libqalculate/libqalculate/Calculator-plot.cc \
-      --replace 'commandline = "gnuplot"' 'commandline = "${gnuplot}/bin/gnuplot"' \
+      --replace 'commandline = "gnuplot"' 'commandline = "${lib.getExe gnuplot}"' \
       --replace '"gnuplot - ' '"${gnuplot}/bin/gnuplot - '
     substituteInPlace subprojects/libqalculate/libqalculate/meson.build \
       --replace "link_with: 'libqalculate_lib_static'" "link_with: libqalculate_lib_static"

--- a/pkgs/applications/system/booster/default.nix
+++ b/pkgs/applications/system/booster/default.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
   vendorHash = "sha256-RmRY+HoNuijfcK8gNbOIyWCOa50BVJd3IZv2+Pc3FYw=";
 
   postPatch = ''
-    substituteInPlace init/main.go --replace "/usr/bin/fsck" "${unixtools.fsck}/bin/fsck"
+    substituteInPlace init/main.go --replace "/usr/bin/fsck" "${lib.getExe unixtools.fsck}"
   '';
 
   # integration tests are run against the current kernel

--- a/pkgs/applications/terminal-emulators/rxvt-unicode-plugins/urxvt-font-size/default.nix
+++ b/pkgs/applications/terminal-emulators/rxvt-unicode-plugins/urxvt-font-size/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     substituteInPlace font-size \
       --replace "xrdb -merge" "${xrdb}/bin/xrdb -merge" \
-      --replace "xlsfonts" "${xlsfonts}/bin/xlsfonts"
+      --replace "xlsfonts" "${lib.getExe xlsfonts}"
 
     mkdir -p $out/lib/urxvt/perl
     cp font-size $out/lib/urxvt/perl

--- a/pkgs/applications/terminal-emulators/rxvt-unicode-plugins/urxvt-perl/default.nix
+++ b/pkgs/applications/terminal-emulators/rxvt-unicode-plugins/urxvt-perl/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
     substituteInPlace fullscreen \
-      --replace "wmctrl" "${wmctrl}/bin/wmctrl"
+      --replace "wmctrl" "${lib.getExe wmctrl}"
 
     mkdir -p $out/lib/urxvt/perl
     cp fullscreen $out/lib/urxvt/perl

--- a/pkgs/applications/version-management/cgit/common.nix
+++ b/pkgs/applications/version-management/cgit/common.nix
@@ -23,9 +23,9 @@ stdenv.mkDerivation {
   pythonPath = with python3Packages; [ pygments markdown ];
 
   postPatch = ''
-    sed -e 's|"gzip"|"${gzip}/bin/gzip"|' \
+    sed -e 's|"gzip"|"${lib.getExe gzip}"|' \
         -e 's|"bzip2"|"${bzip2.bin}/bin/bzip2"|' \
-        -e 's|"lzip"|"${lzip}/bin/lzip"|' \
+        -e 's|"lzip"|"${lib.getExe lzip}"|' \
         -e 's|"xz"|"${xz.bin}/bin/xz"|' \
         -e 's|"zstd"|"${zstd}/bin/zstd"|' \
         -i ui-snapshot.c

--- a/pkgs/applications/version-management/git-ftp/default.nix
+++ b/pkgs/applications/version-management/git-ftp/default.nix
@@ -47,7 +47,7 @@ resholve.mkDerivation rec {
   solutions = {
     git-ftp = {
       scripts = [ "bin/git-ftp" ];
-      interpreter = "${bash}/bin/bash";
+      interpreter = "${lib.getExe bash}";
       inputs = [
         coreutils
         git

--- a/pkgs/applications/version-management/git-ftp/default.nix
+++ b/pkgs/applications/version-management/git-ftp/default.nix
@@ -47,7 +47,7 @@ resholve.mkDerivation rec {
   solutions = {
     git-ftp = {
       scripts = [ "bin/git-ftp" ];
-      interpreter = "${lib.getExe bash}";
+      interpreter = lib.getExe bash;
       inputs = [
         coreutils
         git

--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
   '' + lib.optionalString withSsh ''
     for x in connect.c git-gui/lib/remote_add.tcl ; do
       substituteInPlace "$x" \
-        --subst-var-by ssh "${openssh}/bin/ssh"
+        --subst-var-by ssh "${lib.getExe openssh}"
     done
   '';
 

--- a/pkgs/applications/version-management/gitolite/default.nix
+++ b/pkgs/applications/version-management/gitolite/default.nix
@@ -20,9 +20,9 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace ./install --replace " 2>/dev/null" ""
     substituteInPlace src/lib/Gitolite/Hooks/PostUpdate.pm \
-      --replace /usr/bin/perl "${perl}/bin/perl"
+      --replace /usr/bin/perl "${lib.getExe perl}"
     substituteInPlace src/lib/Gitolite/Hooks/Update.pm \
-      --replace /usr/bin/perl "${perl}/bin/perl"
+      --replace /usr/bin/perl "${lib.getExe perl}"
     substituteInPlace src/lib/Gitolite/Setup.pm \
       --replace hostname "${nettools}/bin/hostname"
     substituteInPlace src/commands/sskm \

--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -158,7 +158,7 @@ let
     test-patchbomb-tls.t
     EOF
 
-    export HGTEST_REAL_HG="${mercurial}/bin/hg"
+    export HGTEST_REAL_HG="${lib.getExe mercurial}"
     # include tests for native components
     export HGMODULEPOLICY="rust+c"
     # extended timeout necessary for tests to pass on the busy CI workers

--- a/pkgs/applications/video/clipgrab/default.nix
+++ b/pkgs/applications/video/clipgrab/default.nix
@@ -24,7 +24,7 @@ mkDerivation rec {
   postPatch = ''
   substituteInPlace youtube_dl.cpp \
     --replace 'QString YoutubeDl::path = QString();' \
-              'QString YoutubeDl::path = QString("${yt-dlp}/bin/yt-dlp");'
+              'QString YoutubeDl::path = QString("${lib.getExe yt-dlp}");'
   '' + lib.optionalString (ffmpeg != null) ''
   substituteInPlace converter_ffmpeg.cpp \
     --replace '"ffmpeg"' '"${ffmpeg.bin}/bin/ffmpeg"' \

--- a/pkgs/applications/video/mpv/scripts/autosubsync-mpv.nix
+++ b/pkgs/applications/video/mpv/scripts/autosubsync-mpv.nix
@@ -20,7 +20,7 @@ buildLua {
   patchPhase = ''
     runHook prePatch
     substituteInPlace autosubsync.lua                                            \
-      --replace-warn 'alass_path = ""' 'alass_path = "${alass}/bin/alass-cli"'   \
+      --replace-warn 'alass_path = ""' 'alass_path = "${lib.getExe alass}"'   \
       --replace-warn 'audio_subsync_tool = "ask"' 'audio_subsync_tool = "alass"' \
       --replace-warn 'altsub_subsync_tool = "ask"' 'altsub_subsync_tool = "alass"'
     runHook postPatch

--- a/pkgs/applications/video/mpv/wrapper.nix
+++ b/pkgs/applications/video/mpv/wrapper.nix
@@ -93,7 +93,7 @@ let
       postBuild = ''
         # wrapProgram can't operate on symlinks
         rm "$out/bin/mpv"
-        makeWrapper "${mpv}/bin/mpv" "$out/bin/mpv" ${mostMakeWrapperArgs}
+        makeWrapper "${lib.getExe mpv}" "$out/bin/mpv" ${mostMakeWrapperArgs}
         rm "$out/bin/umpv"
         makeWrapper "${mpv}/bin/umpv" "$out/bin/umpv" ${umpvWrapperArgs}
       '' + lib.optionalString stdenv.isDarwin ''

--- a/pkgs/applications/window-managers/i3/lock-fancy-rapid.nix
+++ b/pkgs/applications/window-managers/i3/lock-fancy-rapid.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
   postPatch = ''
     substituteInPlace i3lock-fancy-rapid.c \
-      --replace '"i3lock"' '"${i3lock}/bin/i3lock"'
+      --replace '"i3lock"' '"${lib.getExe i3lock}"'
   '';
 
   installPhase = ''

--- a/pkgs/applications/window-managers/stumpish/default.nix
+++ b/pkgs/applications/window-managers/stumpish/default.nix
@@ -18,9 +18,9 @@ stdenv.mkDerivation {
   patches = [
     (substituteAll {
       src = ./paths.patch;
-      sed = "${lib.getExe gnused}";
-      xprop = "${lib.getExe xorg.xprop}";
-      rlwrap = "${lib.getExe rlwrap}";
+      sed = lib.getExe gnused;
+      xprop = lib.getExe xorg.xprop;
+      rlwrap = lib.getExe rlwrap;
       tput = "${ncurses}/bin/tput";
     })
   ];

--- a/pkgs/applications/window-managers/stumpish/default.nix
+++ b/pkgs/applications/window-managers/stumpish/default.nix
@@ -18,9 +18,9 @@ stdenv.mkDerivation {
   patches = [
     (substituteAll {
       src = ./paths.patch;
-      sed = "${gnused}/bin/sed";
-      xprop = "${xorg.xprop}/bin/xprop";
-      rlwrap = "${rlwrap}/bin/rlwrap";
+      sed = "${lib.getExe gnused}";
+      xprop = "${lib.getExe xorg.xprop}";
+      rlwrap = "${lib.getExe rlwrap}";
       tput = "${ncurses}/bin/tput";
     })
   ];

--- a/pkgs/applications/window-managers/wmderland/default.nix
+++ b/pkgs/applications/window-managers/wmderland/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
 
   postPatch = ''
     substituteInPlace src/util.cc \
-      --replace "notify-send" "${libnotify}/bin/notify-send"
+      --replace "notify-send" "${lib.getExe libnotify}"
   '';
 
   buildInputs = [

--- a/pkgs/applications/window-managers/wmii/default.nix
+++ b/pkgs/applications/window-managers/wmii/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   # for dlopen-ing
   postPatch = ''
     substituteInPlace lib/libstuff/x11/xft.c --replace "libXft.so" "$(pkg-config --variable=libdir xft)/libXft.so.2"
-    substituteInPlace cmd/wmii.sh.sh --replace "\$(which which)" "${which}/bin/which"
+    substituteInPlace cmd/wmii.sh.sh --replace "\$(which which)" "${lib.getExe which}"
   '';
 
   postConfigure = ''

--- a/pkgs/build-support/writers/scripts.nix
+++ b/pkgs/build-support/writers/scripts.nix
@@ -186,8 +186,8 @@ rec {
   #     ''
   writeBash = name: argsOrScript:
     if lib.isAttrs argsOrScript && ! lib.isDerivation argsOrScript
-    then makeScriptWriter (argsOrScript // { interpreter = "${lib.getExe pkgs.bash}"; }) name
-    else makeScriptWriter { interpreter = "${lib.getExe pkgs.bash}"; } name argsOrScript;
+    then makeScriptWriter (argsOrScript // { interpreter = lib.getExe pkgs.bash; }) name
+    else makeScriptWriter { interpreter = lib.getExe pkgs.bash; } name argsOrScript;
 
   # Like writeScriptBin but the first line is a shebang to bash
   #
@@ -232,8 +232,8 @@ rec {
   #     ''
   writeDash = name: argsOrScript:
     if lib.isAttrs argsOrScript && ! lib.isDerivation argsOrScript
-    then makeScriptWriter (argsOrScript // { interpreter = "${lib.getExe pkgs.dash}"; }) name
-    else makeScriptWriter { interpreter = "${lib.getExe pkgs.dash}"; } name argsOrScript;
+    then makeScriptWriter (argsOrScript // { interpreter = lib.getExe pkgs.dash; }) name
+    else makeScriptWriter { interpreter = lib.getExe pkgs.dash; } name argsOrScript;
 
   # Like writeScriptBin but the first line is a shebang to dash
   #
@@ -539,7 +539,7 @@ rec {
     makeScriptWriter (
       (builtins.removeAttrs args ["libraries"])
       // {
-        interpreter = "${lib.getExe (pkgs.perl.withPackages (p: libraries))}";
+        interpreter = lib.getExe (pkgs.perl.withPackages (p: libraries));
       }
     ) name;
 

--- a/pkgs/by-name/af/affine/package.nix
+++ b/pkgs/by-name/af/affine/package.nix
@@ -33,7 +33,7 @@ in {
     cp -r ./resources/* -t $out/lib/
     cp LICENSE* $out/
     install -Dm644 ${icon} $out/share/pixmaps/affine.png
-    makeWrapper "${electron}/bin/electron" $out/bin/affine \
+    makeWrapper "${lib.getExe electron}" $out/bin/affine \
       --inherit-argv0 \
       --add-flags $out/lib/app.asar \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \

--- a/pkgs/by-name/cr/crabfit-api/package.nix
+++ b/pkgs/by-name/cr/crabfit-api/package.nix
@@ -60,7 +60,7 @@ rustPlatform.buildRustPackage {
 
   buildFeatures = [ "${adaptor}-adaptor" ];
 
-  PROTOC = "${lib.getExe protobuf}";
+  PROTOC = lib.getExe protobuf;
 
   passthru.tests = [ nixosTests.crabfit ];
 

--- a/pkgs/by-name/cr/crabfit-api/package.nix
+++ b/pkgs/by-name/cr/crabfit-api/package.nix
@@ -60,7 +60,7 @@ rustPlatform.buildRustPackage {
 
   buildFeatures = [ "${adaptor}-adaptor" ];
 
-  PROTOC = "${protobuf}/bin/protoc";
+  PROTOC = "${lib.getExe protobuf}";
 
   passthru.tests = [ nixosTests.crabfit ];
 

--- a/pkgs/by-name/db/dbqn/package.nix
+++ b/pkgs/by-name/db/dbqn/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/${pname}
     mv BQN.jar $out/share/${pname}/
 
-    makeWrapper "${lib.getBin jdk}/bin/java" "$out/bin/dbqn" \
+    makeWrapper "${lib.getExe jdk}" "$out/bin/dbqn" \
       --add-flags "-jar $out/share/${pname}/BQN.jar"
   '') + ''
     ln -s $out/bin/dbqn $out/bin/bqn

--- a/pkgs/by-name/dg/dgoss/package.nix
+++ b/pkgs/by-name/dg/dgoss/package.nix
@@ -24,7 +24,7 @@ resholve.mkDerivation rec {
   solutions = {
     default = {
       scripts = [ "bin/dgoss" ];
-      interpreter = "${bash}/bin/bash";
+      interpreter = "${lib.getExe bash}";
       inputs = [
         coreutils
         gnused

--- a/pkgs/by-name/dg/dgoss/package.nix
+++ b/pkgs/by-name/dg/dgoss/package.nix
@@ -24,7 +24,7 @@ resholve.mkDerivation rec {
   solutions = {
     default = {
       scripts = [ "bin/dgoss" ];
-      interpreter = "${lib.getExe bash}";
+      interpreter = lib.getExe bash;
       inputs = [
         coreutils
         gnused

--- a/pkgs/by-name/di/digikam/package.nix
+++ b/pkgs/by-name/di/digikam/package.nix
@@ -134,8 +134,8 @@ stdenv.mkDerivation rec {
     qtWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ gnumake hugin enblend-enfuse ]})
     qtWrapperArgs+=(--suffix DK_PLUGIN_PATH : ${placeholder "out"}/${libsForQt5.qtbase.qtPluginPrefix}/${pname})
     substituteInPlace $out/bin/digitaglinktree \
-      --replace "/usr/bin/perl" "${perl}/bin/perl" \
-      --replace "/usr/bin/sqlite3" "${sqlite}/bin/sqlite3"
+      --replace "/usr/bin/perl" "${lib.getExe perl}" \
+      --replace "/usr/bin/sqlite3" "${lib.getExe sqlite}"
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/dm/dmd/generic.nix
+++ b/pkgs/by-name/dm/dmd/generic.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
   '' + lib.optionalString (lib.versionAtLeast version "2.089.0" && lib.versionOlder version "2.092.2") ''
     rm dmd/compiler/test/dshell/test6952.d
   '' + lib.optionalString (lib.versionAtLeast version "2.092.2") ''
-    substituteInPlace dmd/compiler/test/dshell/test6952.d --replace-fail "/usr/bin/env bash" "${bash}/bin/bash"
+    substituteInPlace dmd/compiler/test/dshell/test6952.d --replace-fail "/usr/bin/env bash" "${lib.getExe bash}"
   '' + lib.optionalString stdenv.isLinux ''
     substituteInPlace phobos/std/socket.d --replace-fail "assert(ih.addrList[0] == 0x7F_00_00_01);" ""
   '' + lib.optionalString stdenv.isDarwin ''

--- a/pkgs/by-name/dp/dps8m/package.nix
+++ b/pkgs/by-name/dp/dps8m/package.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
 
   env = {
     ENV = "${coreutils-full}/bin/env";
-    GREP = "${lib.getExe gnugrep}";
-    SED = "${lib.getExe gnused}";
+    GREP = lib.getExe gnugrep;
+    SED = lib.getExe gnused;
     PREFIX = placeholder "out";
   };
 

--- a/pkgs/by-name/dp/dps8m/package.nix
+++ b/pkgs/by-name/dp/dps8m/package.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
 
   env = {
     ENV = "${coreutils-full}/bin/env";
-    GREP = "${gnugrep}/bin/grep";
-    SED = "${gnused}/bin/sed";
+    GREP = "${lib.getExe gnugrep}";
+    SED = "${lib.getExe gnused}";
     PREFIX = placeholder "out";
   };
 

--- a/pkgs/by-name/gi/gitprompt-rs/package.nix
+++ b/pkgs/by-name/gi/gitprompt-rs/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage {
 
   postPatch = ''
     substituteInPlace src/main.rs \
-      --replace 'Command::new("git")' 'Command::new("${git}/bin/git")'
+      --replace 'Command::new("git")' 'Command::new("${lib.getExe git}")'
   '';
 
   meta = {

--- a/pkgs/by-name/gl/glycin-loaders/package.nix
+++ b/pkgs/by-name/gl/glycin-loaders/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     glycinPathsPatch = substituteAll {
       src = ./fix-glycin-paths.patch;
-      bwrap = "${bubblewrap}/bin/bwrap";
+      bwrap = "${lib.getExe bubblewrap}";
     };
   };
 

--- a/pkgs/by-name/gl/glycin-loaders/package.nix
+++ b/pkgs/by-name/gl/glycin-loaders/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     glycinPathsPatch = substituteAll {
       src = ./fix-glycin-paths.patch;
-      bwrap = "${lib.getExe bubblewrap}";
+      bwrap = lib.getExe bubblewrap;
     };
   };
 

--- a/pkgs/by-name/ka/kanidm/package.nix
+++ b/pkgs/by-name/ka/kanidm/package.nix
@@ -40,7 +40,7 @@ rustPlatform.buildRustPackage rec {
         admin_bind_path = "/run/kanidmd/sock";
         cpu_flags = if stdenv.isx86_64 then "x86_64_legacy" else "none";
         default_config_path = "/etc/kanidm/server.toml";
-        default_unix_shell_path = "${lib.getBin bashInteractive}/bin/bash";
+        default_unix_shell_path = "${lib.getExe bashInteractive}";
         web_ui_pkg_path = "@web_ui_pkg_path@";
       };
     in

--- a/pkgs/by-name/ka/kanidm/package.nix
+++ b/pkgs/by-name/ka/kanidm/package.nix
@@ -40,7 +40,7 @@ rustPlatform.buildRustPackage rec {
         admin_bind_path = "/run/kanidmd/sock";
         cpu_flags = if stdenv.isx86_64 then "x86_64_legacy" else "none";
         default_config_path = "/etc/kanidm/server.toml";
-        default_unix_shell_path = "${lib.getExe bashInteractive}";
+        default_unix_shell_path = lib.getExe bashInteractive;
         web_ui_pkg_path = "@web_ui_pkg_path@";
       };
     in

--- a/pkgs/by-name/ke/keepass/package.nix
+++ b/pkgs/by-name/ke/keepass/package.nix
@@ -24,11 +24,11 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      xsel = "${xsel}/bin/xsel";
-      xprop = "${xorg.xprop}/bin/xprop";
-      xdotool = "${xdotool}/bin/xdotool";
+      xsel = "${lib.getExe xsel}";
+      xprop = "${lib.getExe xorg.xprop}";
+      xdotool = "${lib.getExe xdotool}";
       uname = "${coreutils}/bin/uname";
-      whereis = "${unixtools.whereis}/bin/whereis";
+      whereis = "${lib.getExe unixtools.whereis}";
       gsettings = "${glib}/bin/gsettings";
     })
   ];

--- a/pkgs/by-name/ke/keepass/package.nix
+++ b/pkgs/by-name/ke/keepass/package.nix
@@ -24,11 +24,11 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      xsel = "${lib.getExe xsel}";
-      xprop = "${lib.getExe xorg.xprop}";
-      xdotool = "${lib.getExe xdotool}";
+      xsel = lib.getExe xsel;
+      xprop = lib.getExe xorg.xprop;
+      xdotool = lib.getExe xdotool;
       uname = "${coreutils}/bin/uname";
-      whereis = "${lib.getExe unixtools.whereis}";
+      whereis = lib.getExe unixtools.whereis;
       gsettings = "${glib}/bin/gsettings";
     })
   ];

--- a/pkgs/by-name/ku/kubo/test-repoVersion.nix
+++ b/pkgs/by-name/ku/kubo/test-repoVersion.nix
@@ -1,8 +1,8 @@
-{ runCommand, kubo }:
+{ lib, runCommand, kubo }:
 
 runCommand "kubo-test-repoVersion" { } ''
   export IPFS_PATH="$TMPDIR"
-  "${kubo}/bin/ipfs" init --empty-repo
+  "${lib.getExe kubo}" init --empty-repo
   declared_repo_version='${kubo.repoVersion}'
   actual_repo_version="$(cat "$IPFS_PATH/version")"
   if [ "$declared_repo_version" != "$actual_repo_version" ]; then

--- a/pkgs/by-name/lm/lms/package.nix
+++ b/pkgs/by-name/lm/lms/package.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
 
   postInstall = ''
-    substituteInPlace $out/share/lms/lms.conf --replace-fail "/usr/bin/ffmpeg" "${ffmpeg}/bin/ffmpeg"
+    substituteInPlace $out/share/lms/lms.conf --replace-fail "/usr/bin/ffmpeg" "${lib.getExe ffmpeg}"
     substituteInPlace $out/share/lms/lms.conf --replace-fail "/usr/share/Wt/resources" "${wt}/share/Wt/resources"
     substituteInPlace $out/share/lms/lms.conf --replace-fail "/usr/share/lms/docroot" "$out/share/lms/docroot"
     substituteInPlace $out/share/lms/lms.conf --replace-fail "/usr/share/lms/approot" "$out/share/lms/approot"

--- a/pkgs/by-name/ne/neovide/package.nix
+++ b/pkgs/by-name/ne/neovide/package.nix
@@ -58,8 +58,8 @@ rustPlatform.buildRustPackage.override { stdenv = clangStdenv; } rec {
     ''
   ;
 
-  SKIA_GN_COMMAND = "${lib.getExe gn}";
-  SKIA_NINJA_COMMAND = "${lib.getExe ninja}";
+  SKIA_GN_COMMAND = lib.getExe gn;
+  SKIA_NINJA_COMMAND = lib.getExe ninja;
 
   nativeBuildInputs = [
     makeWrapper

--- a/pkgs/by-name/ne/neovide/package.nix
+++ b/pkgs/by-name/ne/neovide/package.nix
@@ -58,8 +58,8 @@ rustPlatform.buildRustPackage.override { stdenv = clangStdenv; } rec {
     ''
   ;
 
-  SKIA_GN_COMMAND = "${gn}/bin/gn";
-  SKIA_NINJA_COMMAND = "${ninja}/bin/ninja";
+  SKIA_GN_COMMAND = "${lib.getExe gn}";
+  SKIA_NINJA_COMMAND = "${lib.getExe ninja}";
 
   nativeBuildInputs = [
     makeWrapper

--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -41,7 +41,7 @@ python3.pkgs.buildPythonApplication rec {
     (substituteAll {
       src = ./fix-paths.patch;
       cat = "${coreutils}/bin/cat";
-      lsof = "${lsof}/bin/lsof";
+      lsof = "${lib.getExe lsof}";
       pgrep = "${procps}/bin/pgrep";
       xkbcomp = "${xkbcomp}/bin/xkbcomp";
     })

--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -41,7 +41,7 @@ python3.pkgs.buildPythonApplication rec {
     (substituteAll {
       src = ./fix-paths.patch;
       cat = "${coreutils}/bin/cat";
-      lsof = "${lib.getExe lsof}";
+      lsof = lib.getExe lsof;
       pgrep = "${procps}/bin/pgrep";
       xkbcomp = "${xkbcomp}/bin/xkbcomp";
     })

--- a/pkgs/by-name/st/streamrip/package.nix
+++ b/pkgs/by-name/st/streamrip/package.nix
@@ -60,7 +60,7 @@ python3Packages.buildPythonApplication rec {
     sed -i 's#pytest-asyncio = ".*"#pytest-asyncio = "*"#' pyproject.toml
     sed -i 's#tomlkit = ".*"#tomlkit = "*"#' pyproject.toml
 
-    sed -i 's#"ffmpeg"#"${lib.getBin ffmpeg}/bin/ffmpeg"#g' streamrip/client/downloadable.py
+    sed -i 's#"ffmpeg"#"${lib.getExe ffmpeg}"#g' streamrip/client/downloadable.py
   '';
 
   preCheck = ''

--- a/pkgs/by-name/su/surrealdb/package.nix
+++ b/pkgs/by-name/su/surrealdb/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     rm .cargo/config.toml
   '';
 
-  PROTOC = "${protobuf}/bin/protoc";
+  PROTOC = "${lib.getExe protobuf}";
   PROTOC_INCLUDE = "${protobuf}/include";
 
   ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";

--- a/pkgs/by-name/su/surrealdb/package.nix
+++ b/pkgs/by-name/su/surrealdb/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     rm .cargo/config.toml
   '';
 
-  PROTOC = "${lib.getExe protobuf}";
+  PROTOC = lib.getExe protobuf;
   PROTOC_INCLUDE = "${protobuf}/include";
 
   ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";

--- a/pkgs/by-name/su/surrealist/package.nix
+++ b/pkgs/by-name/su/surrealist/package.nix
@@ -103,7 +103,7 @@ in stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-3x/GKgVX0mnxTZmINe/qTtr/vI0h5IqPYt9N0l/VGzg=";
     };
 
-    ESBUILD_BINARY_PATH = "${lib.getExe esbuild-18-20}";
+    ESBUILD_BINARY_PATH = lib.getExe esbuild-18-20;
 
     nativeBuildInputs = [ nodejs pnpm.configHook ];
 

--- a/pkgs/by-name/sv/svix-server/package.nix
+++ b/pkgs/by-name/sv/svix-server/package.nix
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   # needed for internal protobuf c wrapper library
-  PROTOC = "${protobuf}/bin/protoc";
+  PROTOC = "${lib.getExe protobuf}";
   PROTOC_INCLUDE = "${protobuf}/include";
 
   OPENSSL_NO_VENDOR = 1;

--- a/pkgs/by-name/sv/svix-server/package.nix
+++ b/pkgs/by-name/sv/svix-server/package.nix
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   # needed for internal protobuf c wrapper library
-  PROTOC = "${lib.getExe protobuf}";
+  PROTOC = lib.getExe protobuf;
   PROTOC_INCLUDE = "${protobuf}/include";
 
   OPENSSL_NO_VENDOR = 1;

--- a/pkgs/by-name/un/unipicker/package.nix
+++ b/pkgs/by-name/un/unipicker/package.nix
@@ -25,10 +25,10 @@ stdenv.mkDerivation (finalAttrs: {
   preInstall = ''
     substituteInPlace unipicker \
       --replace-fail "/etc/unipickerrc" "$out/etc/unipickerrc" \
-      --replace-fail "fzf" "${fzf}/bin/fzf"
+      --replace-fail "fzf" "${lib.getExe fzf}"
     substituteInPlace unipickerrc \
       --replace-fail "/usr/local" "$out" \
-      --replace-fail "fzf" "${fzf}/bin/fzf"
+      --replace-fail "fzf" "${lib.getExe fzf}"
   '';
 
   makeFlags = [

--- a/pkgs/by-name/un/unix-privesc-check/package.nix
+++ b/pkgs/by-name/un/unix-privesc-check/package.nix
@@ -36,7 +36,7 @@ resholve.mkDerivation rec {
   solutions = {
     unix-privesc-check = {
       scripts = [ "bin/unix-privesc-check" ];
-      interpreter = "${lib.getExe bash}";
+      interpreter = lib.getExe bash;
       inputs = [
         gawk
         bash

--- a/pkgs/by-name/un/unix-privesc-check/package.nix
+++ b/pkgs/by-name/un/unix-privesc-check/package.nix
@@ -36,7 +36,7 @@ resholve.mkDerivation rec {
   solutions = {
     unix-privesc-check = {
       scripts = [ "bin/unix-privesc-check" ];
-      interpreter = "${bash}/bin/bash";
+      interpreter = "${lib.getExe bash}";
       inputs = [
         gawk
         bash

--- a/pkgs/by-name/wi/windmill/package.nix
+++ b/pkgs/by-name/wi/windmill/package.nix
@@ -110,7 +110,7 @@ rustPlatform.buildRustPackage {
 
   postPatch = ''
     substituteInPlace windmill-worker/src/bash_executor.rs \
-      --replace '"/bin/bash"' '"${bash}/bin/bash"'
+      --replace '"/bin/bash"' '"${lib.getExe bash}"'
 
     substituteInPlace windmill-api/src/lib.rs \
       --replace 'unknown-version' 'v${version}'
@@ -151,9 +151,9 @@ rustPlatform.buildRustPackage {
       --prefix PATH : ${lib.makeBinPath [go pythonEnv deno nsjail bash]} \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [stdenv.cc.cc.lib]} \
       --set PYTHON_PATH "${pythonEnv}/bin/python3" \
-      --set GO_PATH "${go}/bin/go" \
-      --set DENO_PATH "${deno}/bin/deno" \
-      --set NSJAIL_PATH "${nsjail}/bin/nsjail"
+      --set GO_PATH "${lib.getExe go}" \
+      --set DENO_PATH "${lib.getExe deno}" \
+      --set NSJAIL_PATH "${lib.getExe nsjail}"
   '';
 
   meta = {

--- a/pkgs/by-name/xi/xivlauncher/package.nix
+++ b/pkgs/by-name/xi/xivlauncher/package.nix
@@ -31,7 +31,7 @@ in
 
     postPatch = ''
       substituteInPlace lib/FFXIVQuickLauncher/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/AriaHttpPatchAcquisition.cs \
-        --replace 'ariaPath = "aria2c"' 'ariaPath = "${aria2}/bin/aria2c"'
+        --replace 'ariaPath = "aria2c"' 'ariaPath = "${lib.getExe aria2}"'
     '';
 
     postInstall = ''

--- a/pkgs/by-name/yd/ydotool/package.nix
+++ b/pkgs/by-name/yd/ydotool/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace Daemon/ydotoold.c \
-      --replace "/usr/bin/xinput" "${xorg.xinput}/bin/xinput"
+      --replace "/usr/bin/xinput" "${lib.getExe xorg.xinput}"
     substituteInPlace Daemon/ydotool.service.in \
       --replace "/usr/bin/kill" "${util-linux}/bin/kill"
   '';

--- a/pkgs/data/misc/papirus-folders/default.nix
+++ b/pkgs/data/misc/papirus-folders/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   patchPhase = ''
-    substituteInPlace ./papirus-folders --replace "getent" "${getent}/bin/getent"
+    substituteInPlace ./papirus-folders --replace "getent" "${lib.getExe getent}"
   '';
 
   meta = with lib; {

--- a/pkgs/data/themes/pop-gtk/default.nix
+++ b/pkgs/data/themes/pop-gtk/default.nix
@@ -49,9 +49,9 @@ stdenv.mkDerivation rec {
     for file in $(find -name render-\*.sh); do
       substituteInPlace "$file" \
         --replace 'INKSCAPE="/usr/bin/inkscape"' \
-                  'INKSCAPE="${inkscape}/bin/inkscape"' \
+                  'INKSCAPE="${lib.getExe inkscape}"' \
         --replace 'OPTIPNG="/usr/bin/optipng"' \
-                  'OPTIPNG="${optipng}/bin/optipng"'
+                  'OPTIPNG="${lib.getExe optipng}"'
     done
   '';
 

--- a/pkgs/desktops/budgie/budgie-session/default.nix
+++ b/pkgs/desktops/budgie/budgie-session/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
       src = ./fix-paths.patch;
       gsettings = "${glib.bin}/bin/gsettings";
       dbusLaunch = "${dbus.lib}/bin/dbus-launch";
-      bash = "${lib.getExe bash}";
+      bash = lib.getExe bash;
     })
   ];
 

--- a/pkgs/desktops/budgie/budgie-session/default.nix
+++ b/pkgs/desktops/budgie/budgie-session/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
       src = ./fix-paths.patch;
       gsettings = "${glib.bin}/bin/gsettings";
       dbusLaunch = "${dbus.lib}/bin/dbus-launch";
-      bash = "${bash}/bin/bash";
+      bash = "${lib.getExe bash}";
     })
   ];
 

--- a/pkgs/desktops/cinnamon/cinnamon-common/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-common/default.nix
@@ -165,7 +165,7 @@ stdenv.mkDerivation rec {
       substituteInPlace ./bin/Spices.py                   --replace "subprocess.run(['/usr/bin/" "subprocess.run(['" \
                                                           --replace 'subprocess.run(["/usr/bin/' 'subprocess.run(["' \
                                                           --replace "msgfmt" "${gettext}/bin/msgfmt"
-      substituteInPlace ./modules/cs_info.py              --replace "lspci" "${pciutils}/bin/lspci"
+      substituteInPlace ./modules/cs_info.py              --replace "lspci" "${lib.getExe pciutils}"
       substituteInPlace ./modules/cs_themes.py            --replace "$out/share/cinnamon/styles.d" "/run/current-system/sw/share/cinnamon/styles.d"
     popd
 

--- a/pkgs/desktops/cinnamon/warpinator/default.nix
+++ b/pkgs/desktops/cinnamon/warpinator/default.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
     # landlock mode is not supported in old kernels.
     substituteInPlace src/warpinator-launch.py \
       --replace '"/bin/python3"' '"${pythonEnv.interpreter}"' \
-      --replace "/bin/bwrap" "${bubblewrap}/bin/bwrap" \
+      --replace "/bin/bwrap" "${lib.getExe bubblewrap}" \
       --replace 'GLib.find_program_in_path("bwrap")' "True"
   '';
 

--- a/pkgs/desktops/gnome/core/gnome-session/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-session/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
       src = ./fix-paths.patch;
       gsettings = "${glib.bin}/bin/gsettings";
       dbusLaunch = "${dbus.lib}/bin/dbus-launch";
-      bash = "${lib.getExe bash}";
+      bash = lib.getExe bash;
     })
   ];
 

--- a/pkgs/desktops/gnome/core/gnome-session/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-session/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
       src = ./fix-paths.patch;
       gsettings = "${glib.bin}/bin/gsettings";
       dbusLaunch = "${dbus.lib}/bin/dbus-launch";
-      bash = "${bash}/bin/bash";
+      bash = "${lib.getExe bash}";
     })
   ];
 

--- a/pkgs/desktops/gnome/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-shell/default.nix
@@ -81,8 +81,8 @@ stdenv.mkDerivation (finalAttrs: {
       src = ./fix-paths.patch;
       glib_compile_schemas = "${glib.dev}/bin/glib-compile-schemas";
       gsettings = "${glib.bin}/bin/gsettings";
-      tecla = "${lib.getExe gnome-tecla}";
-      unzip = "${lib.getExe unzip}";
+      tecla = lib.getExe gnome-tecla;
+      unzip = lib.getExe unzip;
     })
 
     # Use absolute path for libshew installation to make our patched gobject-introspection

--- a/pkgs/desktops/gnome/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-shell/default.nix
@@ -81,8 +81,8 @@ stdenv.mkDerivation (finalAttrs: {
       src = ./fix-paths.patch;
       glib_compile_schemas = "${glib.dev}/bin/glib-compile-schemas";
       gsettings = "${glib.bin}/bin/gsettings";
-      tecla = "${lib.getBin gnome-tecla}/bin/tecla";
-      unzip = "${lib.getBin unzip}/bin/unzip";
+      tecla = "${lib.getExe gnome-tecla}";
+      unzip = "${lib.getExe unzip}";
     })
 
     # Use absolute path for libshew installation to make our patched gobject-introspection

--- a/pkgs/desktops/gnome/extensions/no-title-bar/default.nix
+++ b/pkgs/desktops/gnome/extensions/no-title-bar/default.nix
@@ -16,8 +16,8 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      xprop = "${xorg.xprop}/bin/xprop";
-      xwininfo = "${xorg.xwininfo}/bin/xwininfo";
+      xprop = "${lib.getExe xorg.xprop}";
+      xwininfo = "${lib.getExe xorg.xwininfo}";
     })
   ];
 

--- a/pkgs/desktops/gnome/extensions/no-title-bar/default.nix
+++ b/pkgs/desktops/gnome/extensions/no-title-bar/default.nix
@@ -16,8 +16,8 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      xprop = "${lib.getExe xorg.xprop}";
-      xwininfo = "${lib.getExe xorg.xwininfo}";
+      xprop = lib.getExe xorg.xprop;
+      xwininfo = lib.getExe xorg.xwininfo;
     })
   ];
 

--- a/pkgs/desktops/gnome/extensions/taskwhisperer/default.nix
+++ b/pkgs/desktops/gnome/extensions/taskwhisperer/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      task = "${taskwarrior}/bin/task";
+      task = "${lib.getExe taskwarrior}";
       shell = runtimeShell;
     })
   ];

--- a/pkgs/desktops/gnome/extensions/taskwhisperer/default.nix
+++ b/pkgs/desktops/gnome/extensions/taskwhisperer/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      task = "${lib.getExe taskwarrior}";
+      task = lib.getExe taskwarrior;
       shell = runtimeShell;
     })
   ];

--- a/pkgs/desktops/gnome/misc/gitg/default.nix
+++ b/pkgs/desktops/gnome/misc/gitg/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     patchShebangs meson_post_install.py
 
-    substituteInPlace tests/libgitg/test-commit.vala --replace-fail "/bin/bash" "${bash}/bin/bash"
+    substituteInPlace tests/libgitg/test-commit.vala --replace-fail "/bin/bash" "${lib.getExe bash}"
   '';
 
   preFixup = ''

--- a/pkgs/desktops/mate/caja-dropbox/default.nix
+++ b/pkgs/desktops/mate/caja-dropbox/default.nix
@@ -13,7 +13,7 @@
 }:
 
 let
-  dropboxd = "${lib.getExe dropbox}";
+  dropboxd = lib.getExe dropbox;
 in
 stdenv.mkDerivation rec {
   pname = "caja-dropbox";

--- a/pkgs/desktops/mate/caja-dropbox/default.nix
+++ b/pkgs/desktops/mate/caja-dropbox/default.nix
@@ -13,7 +13,7 @@
 }:
 
 let
-  dropboxd = "${dropbox}/bin/dropbox";
+  dropboxd = "${lib.getExe dropbox}";
 in
 stdenv.mkDerivation rec {
   pname = "caja-dropbox";

--- a/pkgs/desktops/mate/marco/default.nix
+++ b/pkgs/desktops/mate/marco/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace src/core/util.c \
-      --replace-fail 'argvl[i++] = "zenity"' 'argvl[i++] = "${gnome.zenity}/bin/zenity"'
+      --replace-fail 'argvl[i++] = "zenity"' 'argvl[i++] = "${lib.getExe gnome.zenity}"'
   '';
 
   env.NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/keyboard/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/keyboard/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      gkbd_keyboard_display = "${libgnomekbd}/bin/gkbd-keyboard-display";
+      gkbd_keyboard_display = "${lib.getExe libgnomekbd}";
     })
   ];
 

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/keyboard/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/keyboard/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      gkbd_keyboard_display = "${lib.getExe libgnomekbd}";
+      gkbd_keyboard_display = lib.getExe libgnomekbd;
     })
   ];
 

--- a/pkgs/development/beam-modules/fetch-mix-deps.nix
+++ b/pkgs/development/beam-modules/fetch-mix-deps.nix
@@ -27,8 +27,8 @@ stdenvNoCC.mkDerivation (attrs // {
   MIX_DEBUG = if debug then 1 else 0;
   DEBUG = if debug then 1 else 0; # for rebar3
   # the api with `mix local.rebar rebar path` makes a copy of the binary
-  MIX_REBAR = "${rebar}/bin/rebar";
-  MIX_REBAR3 = "${rebar3}/bin/rebar3";
+  MIX_REBAR = "${lib.getExe rebar}";
+  MIX_REBAR3 = "${lib.getExe rebar3}";
   # there is a persistent download failure with absinthe 1.6.3
   # those defaults reduce the failure rate
   HEX_HTTP_CONCURRENCY = 1;

--- a/pkgs/development/beam-modules/fetch-mix-deps.nix
+++ b/pkgs/development/beam-modules/fetch-mix-deps.nix
@@ -27,8 +27,8 @@ stdenvNoCC.mkDerivation (attrs // {
   MIX_DEBUG = if debug then 1 else 0;
   DEBUG = if debug then 1 else 0; # for rebar3
   # the api with `mix local.rebar rebar path` makes a copy of the binary
-  MIX_REBAR = "${lib.getExe rebar}";
-  MIX_REBAR3 = "${lib.getExe rebar3}";
+  MIX_REBAR = lib.getExe rebar;
+  MIX_REBAR3 = lib.getExe rebar3;
   # there is a persistent download failure with absinthe 1.6.3
   # those defaults reduce the failure rate
   HEX_HTTP_CONCURRENCY = 1;

--- a/pkgs/development/beam-modules/mix-release.nix
+++ b/pkgs/development/beam-modules/mix-release.nix
@@ -100,8 +100,8 @@ stdenv.mkDerivation (overridable // {
   DEBUG = if enableDebugInfo then 1 else 0; # for Rebar3 compilation
   # The API with `mix local.rebar rebar path` makes a copy of the binary
   # some older dependencies still use rebar.
-  MIX_REBAR = "${lib.getExe rebar}";
-  MIX_REBAR3 = "${lib.getExe rebar3}";
+  MIX_REBAR = lib.getExe rebar;
+  MIX_REBAR3 = lib.getExe rebar3;
 
   ERL_COMPILER_OPTIONS =
     let

--- a/pkgs/development/beam-modules/mix-release.nix
+++ b/pkgs/development/beam-modules/mix-release.nix
@@ -100,8 +100,8 @@ stdenv.mkDerivation (overridable // {
   DEBUG = if enableDebugInfo then 1 else 0; # for Rebar3 compilation
   # The API with `mix local.rebar rebar path` makes a copy of the binary
   # some older dependencies still use rebar.
-  MIX_REBAR = "${rebar}/bin/rebar";
-  MIX_REBAR3 = "${rebar3}/bin/rebar3";
+  MIX_REBAR = "${lib.getExe rebar}";
+  MIX_REBAR3 = "${lib.getExe rebar3}";
 
   ERL_COMPILER_OPTIONS =
     let

--- a/pkgs/development/compilers/inform7/default.nix
+++ b/pkgs/development/compilers/inform7/default.nix
@@ -18,7 +18,7 @@ in stdenv.mkDerivation {
     popd
 
     substituteInPlace "$out/bin/i7" \
-      --replace "/usr/bin/perl" "${perl}/bin/perl"
+      --replace "/usr/bin/perl" "${lib.getExe perl}"
   '';
 
   meta = with lib; {

--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -57,7 +57,7 @@ let
 
     preConfigure = ''
       chmod +x configure
-      substituteInPlace configure --replace /bin/bash "${bash}/bin/bash"
+      substituteInPlace configure --replace /bin/bash "${lib.getExe bash}"
     '';
 
     configureFlags = [

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -61,7 +61,7 @@ let
 
     preConfigure = ''
       chmod +x configure
-      substituteInPlace configure --replace /bin/bash "${bash}/bin/bash"
+      substituteInPlace configure --replace /bin/bash "${lib.getExe bash}"
       substituteInPlace hotspot/make/linux/adlc_updater --replace /bin/sh "${stdenv.shell}"
       substituteInPlace hotspot/make/linux/makefiles/dtrace.make --replace /usr/include/sys/sdt.h "/no-such-path"
     '';

--- a/pkgs/development/compilers/squeak/default.nix
+++ b/pkgs/development/compilers/squeak/default.nix
@@ -194,7 +194,7 @@ in stdenv.mkDerivation {
     fi
 
     substituteInPlace ./platforms/unix/config/configure \
-      --replace "/usr/bin/file" "${file}/bin/file"
+      --replace "/usr/bin/file" "${lib.getExe file}"
     cd ./"build.$vmBuild"/squeak.cog.spur/build
     substituteInPlace ./mvm \
       --replace 'read a' 'a=y' \

--- a/pkgs/development/compilers/urweb/default.nix
+++ b/pkgs/development/compilers/urweb/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     export SQHEADER="${sqlite.dev}/include/sqlite3.h";
     export ICU_INCLUDES="-I${icu.dev}/include";
 
-    export CC="${gcc}/bin/gcc";
+    export CC="${lib.getExe gcc}";
     export CCARGS="-I$out/include \
                    -L${lib.getLib openssl}/lib \
                    -L${libmysqlclient}/lib \

--- a/pkgs/development/embedded/fpga/apio/default.nix
+++ b/pkgs/development/embedded/fpga/apio/default.nix
@@ -36,7 +36,7 @@ buildPythonApplication rec {
       'return "${tinyprog}/bin/tinyprog --libusb --program"'
     substituteInPlace apio/util.py --replace \
       '_command = join(get_bin_dir(), "tinyprog")' \
-      '_command = "${tinyprog}/bin/tinyprog"'
+      '_command = "${lib.getExe tinyprog}"'
 
     # semantic-version seems to not support version numbers like the one of tinyprog in Nixpkgs (1.0.24.dev114+gxxxxxxx).
     # See https://github.com/rbarrois/python-semanticversion/issues/47.

--- a/pkgs/development/interpreters/babashka/wrapped.nix
+++ b/pkgs/development/interpreters/babashka/wrapped.nix
@@ -27,13 +27,13 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ makeWrapper installShellFiles ];
 
   installPhase =
-    let unwrapped-bin = "${babashka-unwrapped}/bin/bb"; in
+    let unwrapped-bin = "${lib.getExe babashka-unwrapped}"; in
     ''
       mkdir -p $out/clojure_tools
       ln -s -t $out/clojure_tools ${clojureToolsBabashka}/*.edn
       ln -s -t $out/clojure_tools ${clojureToolsBabashka}/libexec/*
 
-      makeWrapper "${babashka-unwrapped}/bin/bb" "$out/bin/bb" \
+      makeWrapper "${lib.getExe babashka-unwrapped}" "$out/bin/bb" \
         --inherit-argv0 \
         --set-default DEPS_CLJ_TOOLS_DIR $out/clojure_tools \
         --set-default JAVA_HOME ${jdkBabashka}
@@ -44,7 +44,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     '' +
     lib.optionalString withRlwrap ''
       substituteInPlace $out/bin/bb \
-        --replace '"${unwrapped-bin}"' '"${rlwrap}/bin/rlwrap" "${unwrapped-bin}"'
+        --replace '"${unwrapped-bin}"' '"${lib.getExe rlwrap}" "${unwrapped-bin}"'
     '';
 
   installCheckPhase = ''

--- a/pkgs/development/interpreters/babashka/wrapped.nix
+++ b/pkgs/development/interpreters/babashka/wrapped.nix
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ makeWrapper installShellFiles ];
 
   installPhase =
-    let unwrapped-bin = "${lib.getExe babashka-unwrapped}"; in
+    let unwrapped-bin = lib.getExe babashka-unwrapped; in
     ''
       mkdir -p $out/clojure_tools
       ln -s -t $out/clojure_tools ${clojureToolsBabashka}/*.edn

--- a/pkgs/development/interpreters/bats/default.nix
+++ b/pkgs/development/interpreters/bats/default.nix
@@ -51,7 +51,7 @@ resholve.mkDerivation rec {
         "libexec/bats-core/*"
         "lib/bats-core/*"
       ];
-      interpreter = "${lib.getExe bash}";
+      interpreter = lib.getExe bash;
       inputs = [
         bash
         coreutils
@@ -99,8 +99,8 @@ resholve.mkDerivation rec {
         "$BATS_TEST_NAME" = true;
         "${placeholder "out"}/libexec/bats-core/bats-exec-test" = true;
         "$BATS_LINE_REFERENCE_FORMAT" = "comma_line";
-        "$BATS_LOCKING_IMPLEMENTATION" = "${lib.getExe flock}";
-        "$parallel_binary_name" = "${lib.getExe parallel}";
+        "$BATS_LOCKING_IMPLEMENTATION" = lib.getExe flock;
+        "$parallel_binary_name" = lib.getExe parallel;
         "${placeholder "out"}/libexec/bats-core/bats-preprocess" = true;
       };
       execer = [

--- a/pkgs/development/interpreters/bats/default.nix
+++ b/pkgs/development/interpreters/bats/default.nix
@@ -51,7 +51,7 @@ resholve.mkDerivation rec {
         "libexec/bats-core/*"
         "lib/bats-core/*"
       ];
-      interpreter = "${bash}/bin/bash";
+      interpreter = "${lib.getExe bash}";
       inputs = [
         bash
         coreutils
@@ -99,8 +99,8 @@ resholve.mkDerivation rec {
         "$BATS_TEST_NAME" = true;
         "${placeholder "out"}/libexec/bats-core/bats-exec-test" = true;
         "$BATS_LINE_REFERENCE_FORMAT" = "comma_line";
-        "$BATS_LOCKING_IMPLEMENTATION" = "${flock}/bin/flock";
-        "$parallel_binary_name" = "${parallel}/bin/parallel";
+        "$BATS_LOCKING_IMPLEMENTATION" = "${lib.getExe flock}";
+        "$parallel_binary_name" = "${lib.getExe parallel}";
         "${placeholder "out"}/libexec/bats-core/bats-preprocess" = true;
       };
       execer = [
@@ -213,7 +213,7 @@ resholve.mkDerivation rec {
 
         # test generates file with absolute shebang dynamically
         substituteInPlace test/install.bats --replace \
-          "/usr/bin/env bash" "${bash}/bin/bash"
+          "/usr/bin/env bash" "${lib.getExe bash}"
 
         ${bats}/bin/bats test
         touch $out

--- a/pkgs/development/interpreters/dzaima-apl/default.nix
+++ b/pkgs/development/interpreters/dzaima-apl/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/${pname}
     mv APL.jar $out/share/${pname}/
 
-    makeWrapper "${lib.getBin jdk}/bin/java" "$out/bin/dapl" \
+    makeWrapper "${lib.getExe jdk}" "$out/bin/dapl" \
       --add-flags "-jar $out/share/${pname}/APL.jar"
   '') + ''
     ln -s $out/bin/dapl $out/bin/apl

--- a/pkgs/development/interpreters/python/update-python-libraries/default.nix
+++ b/pkgs/development/interpreters/python/update-python-libraries/default.nix
@@ -1,4 +1,4 @@
-{ python3, runCommand, git, nix, nix-prefetch-git }:
+{ lib, python3, runCommand, git, nix, nix-prefetch-git }:
 
 runCommand "update-python-libraries" {
   buildInputs = [
@@ -10,5 +10,5 @@ runCommand "update-python-libraries" {
 } ''
   cp ${./update-python-libraries.py} $out
   patchShebangs $out
-  substituteInPlace $out --replace 'GIT = "git"' 'GIT = "${git}/bin/git"'
+  substituteInPlace $out --replace 'GIT = "git"' 'GIT = "${lib.getExe git}"'
 ''

--- a/pkgs/development/libraries/appstream-glib/default.nix
+++ b/pkgs/development/libraries/appstream-glib/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./paths.patch;
-      pngquant = "${pngquant}/bin/pngquant";
+      pngquant = "${lib.getExe pngquant}";
     })
   ];
 

--- a/pkgs/development/libraries/appstream-glib/default.nix
+++ b/pkgs/development/libraries/appstream-glib/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./paths.patch;
-      pngquant = "${lib.getExe pngquant}";
+      pngquant = lib.getExe pngquant;
     })
   ];
 

--- a/pkgs/development/libraries/bashup-events/generic.nix
+++ b/pkgs/development/libraries/bashup-events/generic.nix
@@ -71,7 +71,7 @@ resholve.mkDerivation rec {
   nativeInstallCheckInputs = [ bash ];
   installCheckPhase = ''
     runHook preInstallCheck
-    ${installCheck "${bash}/bin/bash"}
+    ${installCheck "${lib.getExe bash}"}
     runHook postInstallCheck
   '';
 

--- a/pkgs/development/libraries/catboost/default.nix
+++ b/pkgs/development/libraries/catboost/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace cmake/common.cmake \
-      --replace-fail  "\''${RAGEL_BIN}" "${ragel}/bin/ragel" \
+      --replace-fail  "\''${RAGEL_BIN}" "${lib.getExe ragel}" \
       --replace-fail "\''${YASM_BIN}" "${yasm}/bin/yasm"
 
     shopt -s globstar

--- a/pkgs/development/libraries/gnome-desktop/default.nix
+++ b/pkgs/development/libraries/gnome-desktop/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   patches = lib.optionals stdenv.isLinux [
     (substituteAll {
       src = ./bubblewrap-paths.patch;
-      bubblewrap_bin = "${lib.getExe bubblewrap}";
+      bubblewrap_bin = lib.getExe bubblewrap;
       inherit (builtins) storeDir;
     })
   ];

--- a/pkgs/development/libraries/gnome-desktop/default.nix
+++ b/pkgs/development/libraries/gnome-desktop/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   patches = lib.optionals stdenv.isLinux [
     (substituteAll {
       src = ./bubblewrap-paths.patch;
-      bubblewrap_bin = "${bubblewrap}/bin/bwrap";
+      bubblewrap_bin = "${lib.getExe bubblewrap}";
       inherit (builtins) storeDir;
     })
   ];

--- a/pkgs/development/libraries/gtkextra/default.nix
+++ b/pkgs/development/libraries/gtkextra/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace configure \
-      --replace "/usr/bin/file" "${file}/bin/file"
+      --replace "/usr/bin/file" "${lib.getExe file}"
   '';
 
   nativeBuildInputs = [ gobject-introspection pkg-config ];

--- a/pkgs/development/libraries/gvfs/default.nix
+++ b/pkgs/development/libraries/gvfs/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     (substituteAll {
       src = ./hardcode-ssh-path.patch;
-      ssh_program = "${lib.getExe openssh}";
+      ssh_program = lib.getExe openssh;
     })
   ];
 

--- a/pkgs/development/libraries/gvfs/default.nix
+++ b/pkgs/development/libraries/gvfs/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     (substituteAll {
       src = ./hardcode-ssh-path.patch;
-      ssh_program = "${lib.getBin openssh}/bin/ssh";
+      ssh_program = "${lib.getExe openssh}";
     })
   ];
 

--- a/pkgs/development/libraries/java/dbus-java/default.nix
+++ b/pkgs/development/libraries/java/dbus-java/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0cyaxd8x6sxmi6pklkkx45j311a6w51fxl4jc5j3inc4cailwh5y";
   };
   JAVA_HOME=jdk8;
-  JAVA="${jdk8}/bin/java";
+  JAVA="${lib.getExe jdk8}";
   PREFIX="\${out}";
   JAVAUNIXLIBDIR="${libmatthew_java}/lib/jni";
   JAVAUNIXJARDIR="${libmatthew_java}/share/java";

--- a/pkgs/development/libraries/libnixxml/default.nix
+++ b/pkgs/development/libraries/libnixxml/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
 
     # Fix bash path
     substituteInPlace scripts/nixexpr2xml.in \
-      --replace "/bin/bash" "${bash}/bin/bash"
+      --replace "/bin/bash" "${lib.getExe bash}"
   '';
 
   preAutoreconf = ''

--- a/pkgs/development/libraries/libqalculate/default.nix
+++ b/pkgs/development/libraries/libqalculate/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patchPhase = ''
     substituteInPlace libqalculate/Calculator-plot.cc \
-      --replace 'commandline = "gnuplot"' 'commandline = "${gnuplot}/bin/gnuplot"' \
+      --replace 'commandline = "gnuplot"' 'commandline = "${lib.getExe gnuplot}"' \
       --replace '"gnuplot - ' '"${gnuplot}/bin/gnuplot - '
   '' + lib.optionalString stdenv.cc.isClang ''
     substituteInPlace src/qalc.cc \

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -140,7 +140,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals enableZfs [
     (substituteAll {
       src = ./0002-substitute-zfs-and-zpool-commands.patch;
-      zfs = "${zfs}/bin/zfs";
+      zfs = "${lib.getExe zfs}";
       zpool = "${zfs}/bin/zpool";
     })
   ];

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -140,7 +140,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals enableZfs [
     (substituteAll {
       src = ./0002-substitute-zfs-and-zpool-commands.patch;
-      zfs = "${lib.getExe zfs}";
+      zfs = lib.getExe zfs;
       zpool = "${zfs}/bin/zpool";
     })
   ];

--- a/pkgs/development/libraries/physics/rivet/default.nix
+++ b/pkgs/development/libraries/physics/rivet/default.nix
@@ -32,14 +32,14 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     substituteInPlace bin/rivet-build.in \
       --replace 'num_jobs=$(getconf _NPROCESSORS_ONLN)' 'num_jobs=''${NIX_BUILD_CORES:-$(getconf _NPROCESSORS_ONLN)}' \
-      --replace 'which' '"${which}/bin/which"' \
+      --replace 'which' '"${lib.getExe which}"' \
       --replace 'mycxx=' 'mycxx=${stdenv.cc}/bin/${if stdenv.cc.isClang or false then "clang++" else "g++"}  #' \
       --replace 'mycxxflags="' "mycxxflags=\"$NIX_CFLAGS_COMPILE $NIX_CXXSTDLIB_COMPILE $NIX_CFLAGS_LINK "
   '';
 
   preInstall = ''
     substituteInPlace bin/make-plots \
-      --replace '"which"' '"${which}/bin/which"' \
+      --replace '"which"' '"${lib.getExe which}"' \
       --replace '"latex"' '"'$latex'/bin/latex"' \
       --replace '"dvips"' '"'$latex'/bin/dvips"' \
       --replace '"ps2pdf"' '"${ghostscript}/bin/ps2pdf"' \
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
       --replace '"kpsewhich"' '"'$latex'/bin/kpsewhich"' \
       --replace '"convert"' '"${imagemagick.out}/bin/convert"'
     substituteInPlace bin/rivet \
-      --replace '"less"' '"${less}/bin/less"'
+      --replace '"less"' '"${lib.getExe less}"'
     substituteInPlace bin/rivet-mkhtml \
       --replace '"make-plots"' \"$out/bin/make-plots\" \
       --replace '"rivet-cmphistos"' \"$out/bin/rivet-cmphistos\" \

--- a/pkgs/development/libraries/webp-pixbuf-loader/default.nix
+++ b/pkgs/development/libraries/webp-pixbuf-loader/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
     # It assumes gdk-pixbuf-thumbnailer can find the webp loader in the loaders.cache referenced by environment variable, breaking containment.
     # So we replace it with a wrapped executable.
     mkdir -p "$out/bin"
-    makeWrapper "${gdk-pixbuf}/bin/gdk-pixbuf-thumbnailer" "$out/libexec/gdk-pixbuf-thumbnailer-webp" \
+    makeWrapper "${lib.getExe gdk-pixbuf}" "$out/libexec/gdk-pixbuf-thumbnailer-webp" \
       --set GDK_PIXBUF_MODULE_FILE "$out/${loadersPath}"
   '';
 

--- a/pkgs/development/misc/resholve/test.nix
+++ b/pkgs/development/misc/resholve/test.nix
@@ -141,7 +141,7 @@ rec {
       install conjure.sh $out/bin/conjure.sh
       ${resholve.phraseSolution "conjure" {
         scripts = [ "bin/conjure.sh" ];
-        interpreter = "${lib.getExe bash}";
+        interpreter = lib.getExe bash;
         inputs = [ module1 ];
         fake = {
           external = [ "jq" "openssl" ];
@@ -177,7 +177,7 @@ rec {
     PKG_PARSED = "${lib.makeBinPath parsed_packages}";
 
     # explicit interpreter for demo suite; maybe some better way...
-    INTERP = "${lib.getExe bash}";
+    INTERP = lib.getExe bash;
 
     checkPhase = ''
       patchShebangs .
@@ -203,14 +203,14 @@ rec {
   # Caution: ci.nix asserts the equality of both of these w/ diff
   resholvedScript = resholve.writeScript "resholved-script" {
     inputs = [ file ];
-    interpreter = "${lib.getExe bash}";
+    interpreter = lib.getExe bash;
   } ''
     echo "Hello"
     file .
   '';
   resholvedScriptBin = resholve.writeScriptBin "resholved-script-bin" {
     inputs = [ file ];
-    interpreter = "${lib.getExe bash}";
+    interpreter = lib.getExe bash;
   } ''
     echo "Hello"
     file .

--- a/pkgs/development/misc/resholve/test.nix
+++ b/pkgs/development/misc/resholve/test.nix
@@ -141,7 +141,7 @@ rec {
       install conjure.sh $out/bin/conjure.sh
       ${resholve.phraseSolution "conjure" {
         scripts = [ "bin/conjure.sh" ];
-        interpreter = "${bash}/bin/bash";
+        interpreter = "${lib.getExe bash}";
         inputs = [ module1 ];
         fake = {
           external = [ "jq" "openssl" ];
@@ -177,7 +177,7 @@ rec {
     PKG_PARSED = "${lib.makeBinPath parsed_packages}";
 
     # explicit interpreter for demo suite; maybe some better way...
-    INTERP = "${bash}/bin/bash";
+    INTERP = "${lib.getExe bash}";
 
     checkPhase = ''
       patchShebangs .
@@ -203,14 +203,14 @@ rec {
   # Caution: ci.nix asserts the equality of both of these w/ diff
   resholvedScript = resholve.writeScript "resholved-script" {
     inputs = [ file ];
-    interpreter = "${bash}/bin/bash";
+    interpreter = "${lib.getExe bash}";
   } ''
     echo "Hello"
     file .
   '';
   resholvedScriptBin = resholve.writeScriptBin "resholved-script-bin" {
     inputs = [ file ];
-    interpreter = "${bash}/bin/bash";
+    interpreter = "${lib.getExe bash}";
   } ''
     echo "Hello"
     file .

--- a/pkgs/development/php-packages/gnupg/default.nix
+++ b/pkgs/development/php-packages/gnupg/default.nix
@@ -37,10 +37,10 @@ buildPecl {
       --replace 'run-tests.php' 'run-tests.php -q --offline'
     substituteInPlace tests/gnupg_res_init_file_name.phpt \
       --replace '/usr/bin/gpg' '${gnupg}/bin/gpg' \
-      --replace 'string(12)' 'string(${toString (stringLength "${gnupg}/bin/gpg")})'
+      --replace 'string(12)' 'string(${toString (stringLength "${lib.getExe gnupg}")})'
     substituteInPlace tests/gnupg_oo_init_file_name.phpt \
       --replace '/usr/bin/gpg' '${gnupg}/bin/gpg' \
-      --replace 'string(12)' 'string(${toString (stringLength "${gnupg}/bin/gpg")})'
+      --replace 'string(12)' 'string(${toString (stringLength "${lib.getExe gnupg}")})'
   '';
 
   doCheck = true;

--- a/pkgs/development/python-modules/clustershell/default.nix
+++ b/pkgs/development/python-modules/clustershell/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace lib/ClusterShell/Worker/Ssh.py \
-      --replace '"ssh"' '"${openssh}/bin/ssh"' \
+      --replace '"ssh"' '"${lib.getExe openssh}"' \
       --replace '"scp"' '"${openssh}/bin/scp"'
 
     substituteInPlace lib/ClusterShell/Worker/fastsubprocess.py \

--- a/pkgs/development/python-modules/cram/default.nix
+++ b/pkgs/development/python-modules/cram/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   postPatch = ''
     patchShebangs scripts/cram
     substituteInPlace tests/test.t \
-      --replace "/bin/bash" "${bash}/bin/bash"
+      --replace "/bin/bash" "${lib.getExe bash}"
   '';
 
   checkPhase = ''

--- a/pkgs/development/python-modules/cupy/default.nix
+++ b/pkgs/development/python-modules/cupy/default.nix
@@ -76,7 +76,7 @@ buildPythonPackage rec {
     nccl
   ];
 
-  NVCC = "${lib.getExe cudaPackages.cuda_nvcc}"; # FIXME: splicing/buildPackages
+  NVCC = lib.getExe cudaPackages.cuda_nvcc; # FIXME: splicing/buildPackages
   CUDA_PATH = "${cudatoolkit-joined}";
   LDFLAGS = "-L${cudaPackages.cuda_cudart}/lib/stubs";
 

--- a/pkgs/development/python-modules/dragonfly/default.nix
+++ b/pkgs/development/python-modules/dragonfly/default.nix
@@ -38,11 +38,11 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace setup.py --replace 'lark-parser == 0.8.*' 'lark'
     substituteInPlace dragonfly/actions/keyboard/_x11_xdotool.py \
-      --replace 'xdotool = "xdotool"'${" "}'xdotool = "${xdotool}/bin/xdotool"'
+      --replace 'xdotool = "xdotool"'${" "}'xdotool = "${lib.getExe xdotool}"'
     substituteInPlace dragonfly/windows/x11_window.py \
-      --replace 'xdotool = "xdotool"'${" "}'xdotool = "${xdotool}/bin/xdotool"' \
-      --replace 'xprop = "xprop"'${" "}'xprop = "${xorg.xprop}/bin/xprop"' \
-      --replace 'wmctrl = "wmctrl"'${" "}'wmctrl = "${wmctrl}/bin/wmctrl"'
+      --replace 'xdotool = "xdotool"'${" "}'xdotool = "${lib.getExe xdotool}"' \
+      --replace 'xprop = "xprop"'${" "}'xprop = "${lib.getExe xorg.xprop}"' \
+      --replace 'wmctrl = "wmctrl"'${" "}'wmctrl = "${lib.getExe wmctrl}"'
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/ffmpy/default.nix
+++ b/pkgs/development/python-modules/ffmpy/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   postPatch = ''
     # default to store ffmpeg
     substituteInPlace ffmpy.py \
-      --replace-fail 'executable="ffmpeg",' 'executable="${ffmpeg-headless}/bin/ffmpeg",'
+      --replace-fail 'executable="ffmpeg",' 'executable="${lib.getExe ffmpeg-headless}",'
 
     #  The tests test a mock that does not behave like ffmpeg. If we default to the nix-store ffmpeg they fail.
     for fname in tests/*.py; do

--- a/pkgs/development/python-modules/git-annex-adapter/default.nix
+++ b/pkgs/development/python-modules/git-annex-adapter/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     })
     (substituteAll {
       src = ./git-annex-path.patch;
-      gitAnnex = "${lib.getExe git-annex}";
+      gitAnnex = lib.getExe git-annex;
     })
   ];
 

--- a/pkgs/development/python-modules/git-annex-adapter/default.nix
+++ b/pkgs/development/python-modules/git-annex-adapter/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     })
     (substituteAll {
       src = ./git-annex-path.patch;
-      gitAnnex = "${git-annex}/bin/git-annex";
+      gitAnnex = "${lib.getExe git-annex}";
     })
   ];
 

--- a/pkgs/development/python-modules/imageio-ffmpeg/default.nix
+++ b/pkgs/development/python-modules/imageio-ffmpeg/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   patches = [
     (substituteAll {
       src = ./ffmpeg-path.patch;
-      ffmpeg = "${ffmpeg_4}/bin/ffmpeg";
+      ffmpeg = "${lib.getExe ffmpeg_4}";
     })
   ];
 

--- a/pkgs/development/python-modules/imageio-ffmpeg/default.nix
+++ b/pkgs/development/python-modules/imageio-ffmpeg/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   patches = [
     (substituteAll {
       src = ./ffmpeg-path.patch;
-      ffmpeg = "${lib.getExe ffmpeg_4}";
+      ffmpeg = lib.getExe ffmpeg_4;
     })
   ];
 

--- a/pkgs/development/python-modules/iterfzf/default.nix
+++ b/pkgs/development/python-modules/iterfzf/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
       --replace-fail 'build-backend = "build_dist"' '# build-backend = "build_dist"'
 
     substituteInPlace iterfzf/test_iterfzf.py \
-      --replace-fail 'executable="fzf"' 'executable="${fzf}/bin/fzf"'
+      --replace-fail 'executable="fzf"' 'executable="${lib.getExe fzf}"'
   '';
 
   build-system = [

--- a/pkgs/development/python-modules/jupyterhub-systemdspawner/default.nix
+++ b/pkgs/development/python-modules/jupyterhub-systemdspawner/default.nix
@@ -24,10 +24,10 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace systemdspawner/systemd.py \
-      --replace "/bin/bash" "${bash}/bin/bash"
+      --replace "/bin/bash" "${lib.getExe bash}"
 
     substituteInPlace systemdspawner/systemdspawner.py \
-      --replace "/bin/bash" "${bash}/bin/bash"
+      --replace "/bin/bash" "${lib.getExe bash}"
   '';
 
   buildInputs = [ bash ];

--- a/pkgs/development/python-modules/mat2/default.nix
+++ b/pkgs/development/python-modules/mat2/default.nix
@@ -44,8 +44,8 @@ buildPythonPackage rec {
       (substituteAll (
         {
           src = ./paths.patch;
-          exiftool = "${lib.getExe exiftool}";
-          ffmpeg = "${lib.getExe ffmpeg}";
+          exiftool = lib.getExe exiftool;
+          ffmpeg = lib.getExe ffmpeg;
         }
         // lib.optionalAttrs dolphinIntegration { kdialog = "${plasma5Packages.kdialog}/bin/kdialog"; }
       ))
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     ++ lib.optionals (stdenv.hostPlatform.isLinux) [
       (substituteAll {
         src = ./bubblewrap-path.patch;
-        bwrap = "${lib.getExe bubblewrap}";
+        bwrap = lib.getExe bubblewrap;
       })
     ];
 

--- a/pkgs/development/python-modules/mat2/default.nix
+++ b/pkgs/development/python-modules/mat2/default.nix
@@ -44,8 +44,8 @@ buildPythonPackage rec {
       (substituteAll (
         {
           src = ./paths.patch;
-          exiftool = "${exiftool}/bin/exiftool";
-          ffmpeg = "${ffmpeg}/bin/ffmpeg";
+          exiftool = "${lib.getExe exiftool}";
+          ffmpeg = "${lib.getExe ffmpeg}";
         }
         // lib.optionalAttrs dolphinIntegration { kdialog = "${plasma5Packages.kdialog}/bin/kdialog"; }
       ))
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     ++ lib.optionals (stdenv.hostPlatform.isLinux) [
       (substituteAll {
         src = ./bubblewrap-path.patch;
-        bwrap = "${bubblewrap}/bin/bwrap";
+        bwrap = "${lib.getExe bubblewrap}";
       })
     ];
 

--- a/pkgs/development/python-modules/nextcord/default.nix
+++ b/pkgs/development/python-modules/nextcord/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   patches = [
     (substituteAll {
       src = ./paths.patch;
-      ffmpeg = "${ffmpeg}/bin/ffmpeg";
+      ffmpeg = "${lib.getExe ffmpeg}";
       libopus = "${libopus}/lib/libopus${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
   ];

--- a/pkgs/development/python-modules/nextcord/default.nix
+++ b/pkgs/development/python-modules/nextcord/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   patches = [
     (substituteAll {
       src = ./paths.patch;
-      ffmpeg = "${lib.getExe ffmpeg}";
+      ffmpeg = lib.getExe ffmpeg;
       libopus = "${libopus}/lib/libopus${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
   ];

--- a/pkgs/development/python-modules/nipype/default.nix
+++ b/pkgs/development/python-modules/nipype/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace nipype/interfaces/base/tests/test_core.py \
-      --replace "/usr/bin/env bash" "${bash}/bin/bash"
+      --replace "/usr/bin/env bash" "${lib.getExe bash}"
   '';
 
   nativeBuildInputs = [ pythonRelaxDepsHook ];

--- a/pkgs/development/python-modules/nodeenv/default.nix
+++ b/pkgs/development/python-modules/nodeenv/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
 
   preFixup = ''
     substituteInPlace $out/${python.sitePackages}/nodeenv.py \
-      --replace '["which", candidate]' '["${lib.getBin which}/bin/which", candidate]'
+      --replace '["which", candidate]' '["${lib.getExe which}", candidate]'
   '';
 
   pythonImportsCheck = [ "nodeenv" ];

--- a/pkgs/development/python-modules/notify-py/default.nix
+++ b/pkgs/development/python-modules/notify-py/default.nix
@@ -37,14 +37,14 @@ buildPythonPackage rec {
       (substituteAll {
         src = ./linux-paths.patch;
         aplay = "${alsa-utils}/bin/aplay";
-        notifysend = "${libnotify}/bin/notify-send";
+        notifysend = "${lib.getExe libnotify}";
       })
     ]
     ++ lib.optionals stdenv.isDarwin [
       # hardcode path to which
       (substituteAll {
         src = ./darwin-paths.patch;
-        which = "${which}/bin/which";
+        which = "${lib.getExe which}";
       })
     ];
 

--- a/pkgs/development/python-modules/notify-py/default.nix
+++ b/pkgs/development/python-modules/notify-py/default.nix
@@ -37,14 +37,14 @@ buildPythonPackage rec {
       (substituteAll {
         src = ./linux-paths.patch;
         aplay = "${alsa-utils}/bin/aplay";
-        notifysend = "${lib.getExe libnotify}";
+        notifysend = lib.getExe libnotify;
       })
     ]
     ++ lib.optionals stdenv.isDarwin [
       # hardcode path to which
       (substituteAll {
         src = ./darwin-paths.patch;
-        which = "${lib.getExe which}";
+        which = lib.getExe which;
       })
     ];
 

--- a/pkgs/development/python-modules/oslo-concurrency/default.nix
+++ b/pkgs/development/python-modules/oslo-concurrency/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     rm test-requirements.txt
 
     substituteInPlace oslo_concurrency/tests/unit/test_processutils.py \
-      --replace "/bin/bash" "${bash}/bin/bash" \
+      --replace "/bin/bash" "${lib.getExe bash}" \
       --replace "/bin/true" "${coreutils}/bin/true" \
       --replace "/usr/bin/env" "${coreutils}/bin/env" \
       --replace "/usr/bin/true" "${coreutils}/bin/true"

--- a/pkgs/development/python-modules/pycoin/default.nix
+++ b/pkgs/development/python-modules/pycoin/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ setuptools ];
 
   postPatch = ''
-    substituteInPlace ./pycoin/cmds/tx.py --replace '"gpg"' '"${gnupg}/bin/gpg"'
+    substituteInPlace ./pycoin/cmds/tx.py --replace '"gpg"' '"${lib.getExe gnupg}"'
   '';
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/pylama/default.nix
+++ b/pkgs/development/python-modules/pylama/default.nix
@@ -35,7 +35,7 @@ let
     patches = [
       (substituteAll {
         src = ./paths.patch;
-        git = "${lib.getExe git}";
+        git = lib.getExe git;
       })
     ];
 

--- a/pkgs/development/python-modules/pylama/default.nix
+++ b/pkgs/development/python-modules/pylama/default.nix
@@ -35,7 +35,7 @@ let
     patches = [
       (substituteAll {
         src = ./paths.patch;
-        git = "${lib.getBin git}/bin/git";
+        git = "${lib.getExe git}";
       })
     ];
 

--- a/pkgs/development/python-modules/pymystem3/default.nix
+++ b/pkgs/development/python-modules/pymystem3/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   doCheck = isPy3k; # fails on linting
 
   postPatch = ''
-    sed -i 's#^_mystem_info = .*#_mystem_info = ["${mystem}/bin", "${mystem}/bin/mystem"]#' pymystem3/constants.py
+    sed -i 's#^_mystem_info = .*#_mystem_info = ["${mystem}/bin", "${lib.getExe mystem}"]#' pymystem3/constants.py
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pypandoc/default.nix
+++ b/pkgs/development/python-modules/pypandoc/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   patches = [
     (substituteAll {
       src = ./static-pandoc-path.patch;
-      pandoc = "${lib.getExe pandoc}";
+      pandoc = lib.getExe pandoc;
       pandocVersion = pandoc.version;
     })
     ./skip-tests.patch

--- a/pkgs/development/python-modules/pypandoc/default.nix
+++ b/pkgs/development/python-modules/pypandoc/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   patches = [
     (substituteAll {
       src = ./static-pandoc-path.patch;
-      pandoc = "${lib.getBin pandoc}/bin/pandoc";
+      pandoc = "${lib.getExe pandoc}";
       pandocVersion = pandoc.version;
     })
     ./skip-tests.patch

--- a/pkgs/development/python-modules/pypass/default.nix
+++ b/pkgs/development/python-modules/pypass/default.nix
@@ -33,11 +33,11 @@ buildPythonPackage rec {
   patches = [
     (substituteAll {
       src = ./mark-executables.patch;
-      git_exec = "${git}/bin/git";
-      grep_exec = "${gnugrep}/bin/grep";
+      git_exec = "${lib.getExe git}";
+      grep_exec = "${lib.getExe gnugrep}";
       gpg_exec = "${gnupg}/bin/gpg2";
-      tree_exec = "${tree}/bin/tree";
-      xclip_exec = "${xclip}/bin/xclip";
+      tree_exec = "${lib.getExe tree}";
+      xclip_exec = "${lib.getExe xclip}";
     })
   ];
 

--- a/pkgs/development/python-modules/pypass/default.nix
+++ b/pkgs/development/python-modules/pypass/default.nix
@@ -33,11 +33,11 @@ buildPythonPackage rec {
   patches = [
     (substituteAll {
       src = ./mark-executables.patch;
-      git_exec = "${lib.getExe git}";
-      grep_exec = "${lib.getExe gnugrep}";
+      git_exec = lib.getExe git;
+      grep_exec = lib.getExe gnugrep;
       gpg_exec = "${gnupg}/bin/gpg2";
-      tree_exec = "${lib.getExe tree}";
-      xclip_exec = "${lib.getExe xclip}";
+      tree_exec = lib.getExe tree;
+      xclip_exec = lib.getExe xclip;
     })
   ];
 

--- a/pkgs/development/python-modules/pysmart/default.nix
+++ b/pkgs/development/python-modules/pysmart/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pySMART/utils.py \
-      --replace "which('smartctl')" '"${smartmontools}/bin/smartctl"'
+      --replace "which('smartctl')" '"${lib.getExe smartmontools}"'
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pytest-cram/default.nix
+++ b/pkgs/development/python-modules/pytest-cram/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pytest_cram/tests/test_options.py \
-      --replace "/bin/bash" "${bash}/bin/bash"
+      --replace "/bin/bash" "${lib.getExe bash}"
   '';
 
   # Remove __init__.py from tests folder, otherwise pytest raises an error that

--- a/pkgs/development/python-modules/python-lsp-ruff/default.nix
+++ b/pkgs/development/python-modules/python-lsp-ruff/default.nix
@@ -26,8 +26,8 @@ buildPythonPackage rec {
   postPatch = ''
     # ruff binary is used directly, the ruff python package is not needed
     sed -i '/"ruff>=/d' pyproject.toml
-    sed -i 's|sys.executable, "-m", "ruff"|"${ruff}/bin/ruff"|' pylsp_ruff/plugin.py
-    sed -i -e '/sys.executable/,+2c"${ruff}/bin/ruff",' -e 's|assert "ruff" in call_args|assert "${ruff}/bin/ruff" in call_args|' tests/test_ruff_lint.py
+    sed -i 's|sys.executable, "-m", "ruff"|"${lib.getExe ruff}"|' pylsp_ruff/plugin.py
+    sed -i -e '/sys.executable/,+2c"${lib.getExe ruff}",' -e 's|assert "ruff" in call_args|assert "${lib.getExe ruff}" in call_args|' tests/test_ruff_lint.py
     # Nix builds everything in /build/ but ruff somehow doesn't run on files in /build/ and outputs empty results.
     sed -i -e "s|workspace.root_path|'/tmp/'|g" tests/*.py
   '';

--- a/pkgs/development/python-modules/pywal/default.nix
+++ b/pkgs/development/python-modules/pywal/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pywal/backends/wal.py --subst-var-by convert "${imagemagick}/bin/convert"
-    substituteInPlace pywal/wallpaper.py --subst-var-by feh "${feh}/bin/feh"
+    substituteInPlace pywal/wallpaper.py --subst-var-by feh "${lib.getExe feh}"
   '';
 
   # Invalid syntax

--- a/pkgs/development/python-modules/skia-pathops/default.nix
+++ b/pkgs/development/python-modules/skia-pathops/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     ''
       substituteInPlace setup.py \
         --replace "build_cmd = [sys.executable, build_skia_py, build_dir]" \
-          'build_cmd = [sys.executable, build_skia_py, "--no-fetch-gn", "--no-virtualenv", "--gn-path", "${gn}/bin/gn", build_dir]'
+          'build_cmd = [sys.executable, build_skia_py, "--no-fetch-gn", "--no-virtualenv", "--gn-path", "${lib.getExe gn}", build_dir]'
     ''
     + lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) ''
       substituteInPlace src/cpp/skia-builder/skia/gn/skia/BUILD.gn \

--- a/pkgs/development/python-modules/unstructured-api-tools/default.nix
+++ b/pkgs/development/python-modules/unstructured-api-tools/default.nix
@@ -66,7 +66,7 @@ buildPythonPackage {
   # preCheck = ''
   #   substituteInPlace Makefile \
   #     --replace "PYTHONPATH=." "" \
-  #     --replace "mypy" "${mypy}/bin/mypy"
+  #     --replace "mypy" "${lib.getExe mypy}"
   #   make generate-test-api
   # '';
 

--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -72,7 +72,7 @@ buildPythonPackage rec {
     # Replace git paths
     (substituteAll {
       src = ./hardcode-git-path.patch;
-      git = "${lib.getExe git}";
+      git = lib.getExe git;
     })
   ];
 

--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -72,7 +72,7 @@ buildPythonPackage rec {
     # Replace git paths
     (substituteAll {
       src = ./hardcode-git-path.patch;
-      git = "${lib.getBin git}/bin/git";
+      git = "${lib.getExe git}";
     })
   ];
 

--- a/pkgs/development/python-modules/yq/default.nix
+++ b/pkgs/development/python-modules/yq/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   patches = [
     (substituteAll {
       src = ./jq-path.patch;
-      jq = "${lib.getExe jq}";
+      jq = lib.getExe jq;
     })
   ];
 

--- a/pkgs/development/python-modules/yq/default.nix
+++ b/pkgs/development/python-modules/yq/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   patches = [
     (substituteAll {
       src = ./jq-path.patch;
-      jq = "${lib.getBin jq}/bin/jq";
+      jq = "${lib.getExe jq}";
     })
   ];
 

--- a/pkgs/development/rocm-modules/5/hipcc/default.nix
+++ b/pkgs/development/rocm-modules/5/hipcc/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace src/hipBin_amd.h \
-      --replace "/usr/bin/lsb_release" "${lsb-release}/bin/lsb_release"
+      --replace "/usr/bin/lsb_release" "${lib.getExe lsb-release}"
   '';
 
   postInstall = ''

--- a/pkgs/development/rocm-modules/6/hipcc/default.nix
+++ b/pkgs/development/rocm-modules/6/hipcc/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace src/hipBin_amd.h \
-      --replace "/usr/bin/lsb_release" "${lsb-release}/bin/lsb_release"
+      --replace "/usr/bin/lsb_release" "${lib.getExe lsb-release}"
   '';
 
   postInstall = ''

--- a/pkgs/development/tools/build-managers/fac/default.nix
+++ b/pkgs/development/tools/build-managers/fac/default.nix
@@ -24,10 +24,10 @@ rustPlatform.buildRustPackage rec {
   postPatch = ''
     substituteInPlace src/git.rs \
         --replace 'std::process::Command::new("git")' \
-        'std::process::Command::new("${git}/bin/git")'
+        'std::process::Command::new("${lib.getExe git}")'
     substituteInPlace tests/lib.rs \
         --replace 'std::process::Command::new("git")' \
-        'std::process::Command::new("${git}/bin/git")'
+        'std::process::Command::new("${lib.getExe git}")'
   '';
 
   meta = with lib; {

--- a/pkgs/development/tools/build-managers/redo-apenwarr/default.nix
+++ b/pkgs/development/tools/build-managers/redo-apenwarr/default.nix
@@ -33,7 +33,7 @@
       --replace "/usr/include" "${lib.getDev stdenv.cc.libc}/include"
 
     substituteInPlace t/200-shell/nonshelltest.do \
-      --replace "/usr/bin/env perl" "${perl}/bin/perl"
+      --replace "/usr/bin/env perl" "${lib.getExe perl}"
 
   '';
 

--- a/pkgs/development/tools/build-managers/sbt-extras/default.nix
+++ b/pkgs/development/tools/build-managers/sbt-extras/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/bin
 
-    substituteInPlace bin/sbt --replace 'declare java_cmd="java"' 'declare java_cmd="${jdk}/bin/java"'
+    substituteInPlace bin/sbt --replace 'declare java_cmd="java"' 'declare java_cmd="${lib.getExe jdk}"'
 
     install bin/sbt $out/bin
 

--- a/pkgs/development/tools/database/indradb/default.nix
+++ b/pkgs/development/tools/database/indradb/default.nix
@@ -31,7 +31,7 @@ in
 
     buildAndTestSubdir = "server";
 
-    PROTOC = "${lib.getExe protobuf}";
+    PROTOC = lib.getExe protobuf;
 
     nativeBuildInputs = [ rustfmt rustPlatform.bindgenHook ];
 
@@ -47,7 +47,7 @@ in
 
     cargoSha256 = "sha256-pxan6W/CEsOxv8DbbytEBuIqxWn/C4qT4ze/RnvESOM=";
 
-    PROTOC = "${lib.getExe protobuf}";
+    PROTOC = lib.getExe protobuf;
 
     nativeBuildInputs = [ rustfmt rustPlatform.bindgenHook ];
 

--- a/pkgs/development/tools/database/indradb/default.nix
+++ b/pkgs/development/tools/database/indradb/default.nix
@@ -31,7 +31,7 @@ in
 
     buildAndTestSubdir = "server";
 
-    PROTOC = "${protobuf}/bin/protoc";
+    PROTOC = "${lib.getExe protobuf}";
 
     nativeBuildInputs = [ rustfmt rustPlatform.bindgenHook ];
 
@@ -47,7 +47,7 @@ in
 
     cargoSha256 = "sha256-pxan6W/CEsOxv8DbbytEBuIqxWn/C4qT4ze/RnvESOM=";
 
-    PROTOC = "${protobuf}/bin/protoc";
+    PROTOC = "${lib.getExe protobuf}";
 
     nativeBuildInputs = [ rustfmt rustPlatform.bindgenHook ];
 

--- a/pkgs/development/tools/database/shmig/default.nix
+++ b/pkgs/development/tools/database/shmig/default.nix
@@ -23,11 +23,11 @@ stdenv.mkDerivation rec {
     substituteInPlace shmig \
       --replace "\`which mysql\`" "${lib.optionalString withMySQL "${mariadb.client}/bin/mysql"}" \
       --replace "\`which psql\`" "${lib.optionalString withPSQL "${postgresql}/bin/psql"}" \
-      --replace "\`which sqlite3\`" "${lib.optionalString withSQLite "${sqlite}/bin/sqlite3"}" \
+      --replace "\`which sqlite3\`" "${lib.optionalString withSQLite "${lib.getExe sqlite}"}" \
       --replace "awk" "${gawk}/bin/awk" \
-      --replace "grep" "${gnugrep}/bin/grep" \
-      --replace "find" "${findutils}/bin/find" \
-      --replace "sed" "${gnused}/bin/sed"
+      --replace "grep" "${lib.getExe gnugrep}" \
+      --replace "find" "${lib.getExe findutils}" \
+      --replace "sed" "${lib.getExe gnused}"
   '';
 
   preBuild = ''

--- a/pkgs/development/tools/flatpak-builder/default.nix
+++ b/pkgs/development/tools/flatpak-builder/default.nix
@@ -63,14 +63,14 @@ in stdenv.mkDerivation (finalAttrs: {
     # Hardcode paths
     (substituteAll {
       src = ./fix-paths.patch;
-      brz = "${breezy}/bin/brz";
+      brz = "${lib.getExe breezy}";
       cp = "${coreutils}/bin/cp";
       patch = "${patch}/bin/patch";
-      tar = "${gnutar}/bin/tar";
-      unzip = "${unzip}/bin/unzip";
+      tar = "${lib.getExe gnutar}";
+      unzip = "${lib.getExe unzip}";
       rpm2cpio = "${rpm}/bin/rpm2cpio";
-      cpio = "${cpio}/bin/cpio";
-      git = "${gitMinimal}/bin/git";
+      cpio = "${lib.getExe cpio}";
+      git = "${lib.getExe gitMinimal}";
       rofilesfuse = "${ostree}/bin/rofiles-fuse";
       strip = "${binutils}/bin/strip";
       eustrip = "${elfutils}/bin/eu-strip";

--- a/pkgs/development/tools/flatpak-builder/default.nix
+++ b/pkgs/development/tools/flatpak-builder/default.nix
@@ -63,14 +63,14 @@ in stdenv.mkDerivation (finalAttrs: {
     # Hardcode paths
     (substituteAll {
       src = ./fix-paths.patch;
-      brz = "${lib.getExe breezy}";
+      brz = lib.getExe breezy;
       cp = "${coreutils}/bin/cp";
       patch = "${patch}/bin/patch";
-      tar = "${lib.getExe gnutar}";
-      unzip = "${lib.getExe unzip}";
+      tar = lib.getExe gnutar;
+      unzip = lib.getExe unzip;
       rpm2cpio = "${rpm}/bin/rpm2cpio";
-      cpio = "${lib.getExe cpio}";
-      git = "${lib.getExe gitMinimal}";
+      cpio = lib.getExe cpio;
+      git = lib.getExe gitMinimal;
       rofilesfuse = "${ostree}/bin/rofiles-fuse";
       strip = "${binutils}/bin/strip";
       eustrip = "${elfutils}/bin/eu-strip";

--- a/pkgs/development/tools/global-platform-pro/default.nix
+++ b/pkgs/development/tools/global-platform-pro/default.nix
@@ -45,7 +45,7 @@ mavenJdk8.buildMavenPackage rec {
   installPhase = ''
     mkdir -p "$out/lib/java" "$out/share/java"
     cp tool/target/gp.jar "$out/share/java"
-    makeWrapper "${jre8_headless}/bin/java" "$out/bin/gp" \
+    makeWrapper "${lib.getExe jre8_headless}" "$out/bin/gp" \
       --add-flags "-jar '$out/share/java/gp.jar'" \
       --prefix LD_LIBRARY_PATH : "${lib.getLib pcsclite}/lib"
   '';

--- a/pkgs/development/tools/literate-programming/noweb/default.nix
+++ b/pkgs/development/tools/literate-programming/noweb/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
         # NOTE: substituteInPlace breaks Icon binaries, so make sure the script
         #       uses (n)awk before calling.
         if grep -q nawk "$f"; then
-            substituteInPlace "$f" --replace "nawk" "${nawk}/bin/nawk"
+            substituteInPlace "$f" --replace "nawk" "${lib.getExe nawk}"
         fi
     done
 

--- a/pkgs/development/tools/misc/abi-dumper/default.nix
+++ b/pkgs/development/tools/misc/abi-dumper/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     substituteInPlace abi-dumper.pl \
       --replace eu-readelf ${elfutils}/bin/eu-readelf \
       --replace vtable-dumper ${vtable-dumper}/bin/vtable-dumper \
-      --replace '"ctags"' '"${ctags}/bin/ctags"'
+      --replace '"ctags"' '"${lib.getExe ctags}"'
   '';
 
   buildInputs = [ elfutils ctags perl vtable-dumper ];

--- a/pkgs/development/tools/misc/libtool/libtool2.nix
+++ b/pkgs/development/tools/misc/libtool/libtool2.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   # FILECMD was added in libtool 2.4.7; previous versions hardwired `/usr/bin/file`
   #   https://lists.gnu.org/archive/html/autotools-announce/2022-03/msg00000.html
-  FILECMD = "${lib.getExe file}";
+  FILECMD = lib.getExe file;
 
   postPatch =
   # libtool commit da2e352735722917bf0786284411262195a6a3f6 changed

--- a/pkgs/development/tools/misc/libtool/libtool2.nix
+++ b/pkgs/development/tools/misc/libtool/libtool2.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   # FILECMD was added in libtool 2.4.7; previous versions hardwired `/usr/bin/file`
   #   https://lists.gnu.org/archive/html/autotools-announce/2022-03/msg00000.html
-  FILECMD = "${file}/bin/file";
+  FILECMD = "${lib.getExe file}";
 
   postPatch =
   # libtool commit da2e352735722917bf0786284411262195a6a3f6 changed

--- a/pkgs/development/tools/misc/polylith/default.nix
+++ b/pkgs/development/tools/misc/polylith/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
       ARGS="$ARGS $1"
       shift
     done
-    exec "${jdk}/bin/java" "-jar" "${src}" $ARGS
+    exec "${lib.getExe jdk}" "-jar" "${src}" $ARGS
   '';
 
   installPhase = ''

--- a/pkgs/development/tools/misc/sloccount/default.nix
+++ b/pkgs/development/tools/misc/sloccount/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
       then
           echo "patching \`$file'..."
           substituteInPlace "$file" --replace \
-            "/usr/bin/perl" "${perl}/bin/perl"
+            "/usr/bin/perl" "${lib.getExe perl}"
       fi
     done
 

--- a/pkgs/development/tools/ocaml/merlin/4.x.nix
+++ b/pkgs/development/tools/ocaml/merlin/4.x.nix
@@ -57,8 +57,8 @@ buildDunePackage {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      dot_merlin_reader = "${lib.getExe dot-merlin-reader}";
-      dune = "${lib.getExe dune_3}";
+      dot_merlin_reader = lib.getExe dot-merlin-reader;
+      dune = lib.getExe dune_3;
     })
   ];
 

--- a/pkgs/development/tools/ocaml/merlin/4.x.nix
+++ b/pkgs/development/tools/ocaml/merlin/4.x.nix
@@ -57,8 +57,8 @@ buildDunePackage {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      dot_merlin_reader = "${dot-merlin-reader}/bin/dot-merlin-reader";
-      dune = "${dune_3}/bin/dune";
+      dot_merlin_reader = "${lib.getExe dot-merlin-reader}";
+      dune = "${lib.getExe dune_3}";
     })
   ];
 

--- a/pkgs/development/tools/ocaml/merlin/default.nix
+++ b/pkgs/development/tools/ocaml/merlin/default.nix
@@ -15,8 +15,8 @@ buildDunePackage rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      dot_merlin_reader = "${dot-merlin-reader}/bin/dot-merlin-reader";
-      dune = "${dune_2}/bin/dune";
+      dot_merlin_reader = "${lib.getExe dot-merlin-reader}";
+      dune = "${lib.getExe dune_2}";
     })
   ];
 

--- a/pkgs/development/tools/ocaml/merlin/default.nix
+++ b/pkgs/development/tools/ocaml/merlin/default.nix
@@ -15,8 +15,8 @@ buildDunePackage rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      dot_merlin_reader = "${lib.getExe dot-merlin-reader}";
-      dune = "${lib.getExe dune_2}";
+      dot_merlin_reader = lib.getExe dot-merlin-reader;
+      dune = lib.getExe dune_2;
     })
   ];
 

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -462,7 +462,7 @@ let
   updateImpl = passArgs "updateImpl-with-args"
     {
       binaries = {
-        curl = "${lib.getExe curl}";
+        curl = lib.getExe curl;
         nix-prefetch-git = "${nix-prefetch-git}/bin/nix-prefetch-git";
         printf = "${coreutils}/bin/printf";
       };

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -462,7 +462,7 @@ let
   updateImpl = passArgs "updateImpl-with-args"
     {
       binaries = {
-        curl = "${curl}/bin/curl";
+        curl = "${lib.getExe curl}";
         nix-prefetch-git = "${nix-prefetch-git}/bin/nix-prefetch-git";
         printf = "${coreutils}/bin/printf";
       };

--- a/pkgs/development/tools/prototool/default.nix
+++ b/pkgs/development/tools/prototool/default.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
 
   postInstall = ''
     wrapProgram "$out/bin/prototool" \
-      --prefix PROTOTOOL_PROTOC_BIN_PATH : "${protobuf}/bin/protoc" \
+      --prefix PROTOTOOL_PROTOC_BIN_PATH : "${lib.getExe protobuf}" \
       --prefix PROTOTOOL_PROTOC_WKT_PATH : "${protobuf}/include"
   '';
 

--- a/pkgs/games/heroic/default.nix
+++ b/pkgs/games/heroic/default.nix
@@ -92,13 +92,13 @@ in stdenv.mkDerivation rec {
     rm -rf "$out/share/${appName}/public/bin" "$out/share/${appName}/build/bin"
     mkdir -p "$out/share/${appName}/build/bin/${binPlatform}"
     ln -s \
-      "${gogdl}/bin/gogdl" \
-      "${legendary-gl}/bin/legendary" \
-      "${nile}/bin/nile" \
-      "${lib.optionalString stdenv.isLinux "${vulkan-helper}/bin/vulkan-helper"}" \
+      "${lib.getExe gogdl}" \
+      "${lib.getExe legendary-gl}" \
+      "${lib.getExe nile}" \
+      "${lib.optionalString stdenv.isLinux "${lib.getExe vulkan-helper}"}" \
       "$out/share/${appName}/build/bin/${binPlatform}"
 
-    makeWrapper "${electron}/bin/electron" "$out/bin/heroic" \
+    makeWrapper "${lib.getExe electron}" "$out/bin/heroic" \
       --inherit-argv0 \
       --add-flags --disable-gpu-compositing \
       --add-flags $out/share/${appName} \

--- a/pkgs/games/klavaro/default.nix
+++ b/pkgs/games/klavaro/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   # Fixes /usr/bin/file: No such file or directory
   preConfigure = ''
     substituteInPlace configure \
-      --replace "/usr/bin/file" "${file}/bin/file"
+      --replace "/usr/bin/file" "${lib.getExe file}"
   '';
 
   # remove forbidden references to $TMPDIR

--- a/pkgs/games/npush/run.nix
+++ b/pkgs/games/npush/run.nix
@@ -1,4 +1,5 @@
-{ runtimeShell
+{ lib
+, runtimeShell
 , symlinkJoin
 , writeShellScriptBin
 , npush
@@ -18,7 +19,7 @@ let
       chmod 644 levels/*
     fi
     echo "Now calling npush"
-    exec "${npush}/bin/npush"
+    exec "${lib.getExe npush}"
   '';
 in
 symlinkJoin {

--- a/pkgs/games/simutrans/default.nix
+++ b/pkgs/games/simutrans/default.nix
@@ -76,7 +76,7 @@ let
       in ''
         mkdir -p "$out/share/simutrans/${pakName}"
         cd "$out/share/simutrans/${pakName}"
-        "${unzip}/bin/unzip" "${src}"
+        "${lib.getExe unzip}" "${src}"
         chmod -R +w . # some zipfiles need that
 
         set +o pipefail # no idea why it's needed

--- a/pkgs/games/snis/default.nix
+++ b/pkgs/games/snis/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
       --replace "PREFIX=." "PREFIX=$out"
     substituteInPlace snis_text_to_speech.sh \
       --replace "pico2wave" "${sox}/bin/pico2wave" \
-      --replace "espeak" "${espeak-classic}/bin/espeak" \
+      --replace "espeak" "${lib.getExe espeak-classic}" \
       --replace "play" "${sox}/bin/play" \
       --replace "aplay" "${alsa-utils}/bin/aplay" \
       --replace "/bin/rm" "${coreutils}/bin/rm"

--- a/pkgs/games/steam/steam.nix
+++ b/pkgs/games/steam/steam.nix
@@ -32,7 +32,7 @@ in stdenv.mkDerivation {
     mkdir -p $out/etc/udev/rules.d/
     cp ./subprojects/steam-devices/*.rules $out/etc/udev/rules.d/
     substituteInPlace $out/etc/udev/rules.d/60-steam-input.rules \
-      --replace "/bin/sh" "${bash}/bin/bash"
+      --replace "/bin/sh" "${lib.getExe bash}"
 
     # this just installs a link, "steam.desktop -> /lib/steam/steam.desktop"
     rm $out/share/applications/steam.desktop

--- a/pkgs/kde/gear/kdegraphics-thumbnailers/default.nix
+++ b/pkgs/kde/gear/kdegraphics-thumbnailers/default.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkKdeDerivation,
   substituteAll,
   ghostscript,
@@ -10,7 +11,7 @@ mkKdeDerivation {
     # Hardcode patches to Ghostscript so PDF thumbnails work OOTB.
     # Intentionally not doing the same for dvips because TeX is big.
     (substituteAll {
-      gs = "${ghostscript}/bin/gs";
+      gs = "${lib.getExe ghostscript}";
       src = ./gs-paths.patch;
     })
   ];

--- a/pkgs/kde/gear/kdegraphics-thumbnailers/default.nix
+++ b/pkgs/kde/gear/kdegraphics-thumbnailers/default.nix
@@ -11,7 +11,7 @@ mkKdeDerivation {
     # Hardcode patches to Ghostscript so PDF thumbnails work OOTB.
     # Intentionally not doing the same for dvips because TeX is big.
     (substituteAll {
-      gs = "${lib.getExe ghostscript}";
+      gs = lib.getExe ghostscript;
       src = ./gs-paths.patch;
     })
   ];

--- a/pkgs/kde/plasma/plasma-workspace/default.nix
+++ b/pkgs/kde/plasma/plasma-workspace/default.nix
@@ -21,8 +21,8 @@ mkKdeDerivation {
   patches = [
     (substituteAll {
       src = ./tool-paths.patch;
-      xmessage = "${lib.getExe xorg.xmessage}";
-      xsetroot = "${lib.getExe xorg.xsetroot}";
+      xmessage = lib.getExe xorg.xmessage;
+      xsetroot = lib.getExe xorg.xsetroot;
       qdbus = "${lib.getBin qttools}/bin/qdbus";
     })
     (substituteAll {

--- a/pkgs/kde/plasma/plasma-workspace/default.nix
+++ b/pkgs/kde/plasma/plasma-workspace/default.nix
@@ -21,8 +21,8 @@ mkKdeDerivation {
   patches = [
     (substituteAll {
       src = ./tool-paths.patch;
-      xmessage = "${lib.getBin xorg.xmessage}/bin/xmessage";
-      xsetroot = "${lib.getBin xorg.xsetroot}/bin/xsetroot";
+      xmessage = "${lib.getExe xorg.xmessage}";
+      xsetroot = "${lib.getExe xorg.xsetroot}";
       qdbus = "${lib.getBin qttools}/bin/qdbus";
     })
     (substituteAll {

--- a/pkgs/misc/ananicy/default.nix
+++ b/pkgs/misc/ananicy/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
       --prefix PATH : ${lib.makeBinPath [ schedtool util-linux ]}
 
     substituteInPlace $out/lib/systemd/system/ananicy.service \
-      --replace "/sbin/sysctl" "${sysctl}/bin/sysctl" \
+      --replace "/sbin/sysctl" "${lib.getExe sysctl}" \
       --replace "/usr/bin/ananicy" "$out/bin/ananicy"
   '';
 

--- a/pkgs/misc/cups/drivers/brother/mfc465cnlpr/default.nix
+++ b/pkgs/misc/cups/drivers/brother/mfc465cnlpr/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
         gnused
       ]}
     substituteInPlace $dir/lpd/psconvertij2 \
-      --replace '`which gs`' "${ghostscript}/bin/gs"
+      --replace '`which gs`' "${lib.getExe ghostscript}"
     wrapProgram $dir/lpd/psconvertij2 \
       --prefix PATH : ${lib.makeBinPath [
         gnused

--- a/pkgs/misc/cups/drivers/canon/default.nix
+++ b/pkgs/misc/cups/drivers/canon/default.nix
@@ -182,7 +182,7 @@ stdenv.mkDerivation rec {
       install -m 644 cnsetuputil* $out/usr/share/cnsetuputil2
     )
 
-    makeWrapper "${ghostscript}/bin/gs" "$out/bin/gs" \
+    makeWrapper "${lib.getExe ghostscript}" "$out/bin/gs" \
       --prefix LD_LIBRARY_PATH ":" "$out/lib" \
       --prefix PATH ":" "$out/bin"
 

--- a/pkgs/misc/cups/drivers/mfc5890cnlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfc5890cnlpr/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
       ]}
 
     substituteInPlace $dir/lpd/psconvertij2 \
-      --replace '`which gs`' "${ghostscript}/bin/gs"
+      --replace '`which gs`' "${lib.getExe ghostscript}"
 
     wrapProgram $dir/lpd/psconvertij2 \
       --prefix PATH : ${lib.makeBinPath [

--- a/pkgs/misc/cups/drivers/mfc9140cdnlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfc9140cdnlpr/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
       ]}
 
     substituteInPlace $dir/lpd/psconvertij2 \
-      --replace '`which gs`' "${ghostscript}/bin/gs"
+      --replace '`which gs`' "${lib.getExe ghostscript}"
 
     wrapProgram $dir/lpd/psconvertij2 \
       --prefix PATH : ${lib.makeBinPath [

--- a/pkgs/misc/screensavers/i3lock-pixeled/default.nix
+++ b/pkgs/misc/screensavers/i3lock-pixeled/default.nix
@@ -24,10 +24,10 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     substituteInPlace i3lock-pixeled \
-       --replace i3lock    "${i3lock}/bin/i3lock" \
+       --replace i3lock    "${lib.getExe i3lock}" \
        --replace convert   "${imagemagick}/bin/convert" \
-       --replace scrot     "${scrot}/bin/scrot" \
-       --replace playerctl "${playerctl}/bin/playerctl"
+       --replace scrot     "${lib.getExe scrot}" \
+       --replace playerctl "${lib.getExe playerctl}"
   '';
 
   meta = with lib; {

--- a/pkgs/os-specific/darwin/cctools/apple.nix
+++ b/pkgs/os-specific/darwin/cctools/apple.nix
@@ -71,7 +71,7 @@ ld64 = stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace ld64.xcodeproj/project.pbxproj \
-      --replace "/bin/csh" "${tcsh}/bin/tcsh" \
+      --replace "/bin/csh" "${lib.getExe tcsh}" \
       --replace 'F9E8D4BE07FCAF2A00FD5801 /* PBXBuildRule */,' "" \
       --replace 'F9E8D4BD07FCAF2000FD5801 /* PBXBuildRule */,' ""
 

--- a/pkgs/os-specific/linux/checksec/default.nix
+++ b/pkgs/os-specific/linux/checksec/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
       mkdir -p $out/bin
       install checksec $out/bin
       substituteInPlace $out/bin/checksec \
-        --replace "/bin/sed" "${gnused}/bin/sed" \
+        --replace "/bin/sed" "${lib.getExe gnused}" \
         --replace "/usr/bin/id" "${coreutils}/bin/id" \
         --replace "/lib/libc.so.6" "${glibc}/lib/libc.so.6"
       wrapProgram $out/bin/checksec \

--- a/pkgs/os-specific/linux/fwts/default.nix
+++ b/pkgs/os-specific/linux/fwts/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace src/lib/include/fwts_binpaths.h \
-      --replace "/usr/bin/lspci"      "${pciutils}/bin/lspci" \
+      --replace "/usr/bin/lspci"      "${lib.getExe pciutils}" \
       --replace "/usr/sbin/dmidecode" "${dmidecode}/bin/dmidecode" \
       --replace "/usr/bin/iasl"       "${acpica-tools}/bin/iasl"
 

--- a/pkgs/os-specific/linux/game-devices-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/game-devices-udev-rules/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     install -Dm444 -t "$out/lib/udev/rules.d" *.rules
     substituteInPlace $out/lib/udev/rules.d/71-powera-controllers.rules \
-    --replace-fail "/bin/sh" "${bash}/bin/bash"
+    --replace-fail "/bin/sh" "${lib.getExe bash}"
   '';
 
   meta = with lib; {

--- a/pkgs/os-specific/linux/prl-tools/default.nix
+++ b/pkgs/os-specific/linux/prl-tools/default.nix
@@ -157,7 +157,7 @@ stdenv.mkDerivation (finalAttrs: {
       install -Dm644 ../mount.prl_fs.8 $out/share/man/man8
 
       substituteInPlace ../99prltoolsd-hibernate \
-        --replace "/bin/bash" "${bash}/bin/bash"
+        --replace "/bin/bash" "${lib.getExe bash}"
 
       mkdir -p $out/etc/pm/sleep.d
       install -Dm644 ../99prltoolsd-hibernate $out/etc/pm/sleep.d

--- a/pkgs/os-specific/linux/rdma-core/default.nix
+++ b/pkgs/os-specific/linux/rdma-core/default.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     for pls in $out/bin/{ibfindnodesusing.pl,ibidsverify.pl}; do
       echo "wrapping $pls"
       substituteInPlace $pls --replace \
-        "${perl}/bin/perl" "${perl}/bin/perl -I $out/${perl.libPrefix}"
+        "${lib.getExe perl}" "${lib.getExe perl} -I $out/${perl.libPrefix}"
     done
   '';
 

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -650,7 +650,7 @@ stdenv.mkDerivation (finalAttrs: {
       binaryReplacements = [
         {
           search = "/usr/bin/getent";
-          replacement = "${lib.getExe getent}";
+          replacement = lib.getExe getent;
           where = [ "src/nspawn/nspawn-setuid.c" ];
         }
         {

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -494,7 +494,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonOption "version-tag" version)
     (lib.mesonOption "mode" "release")
     (lib.mesonOption "tty-gid" "3") # tty in NixOS has gid 3
-    (lib.mesonOption "debug-shell" "${bashInteractive}/bin/bash")
+    (lib.mesonOption "debug-shell" "${lib.getExe bashInteractive}")
     (lib.mesonOption "pamconfdir" "${placeholder "out"}/etc/pam.d")
     # Use cgroupsv2. This is already the upstream default, but better be explicit.
     (lib.mesonOption "default-hierarchy" "unified")
@@ -650,7 +650,7 @@ stdenv.mkDerivation (finalAttrs: {
       binaryReplacements = [
         {
           search = "/usr/bin/getent";
-          replacement = "${getent}/bin/getent";
+          replacement = "${lib.getExe getent}";
           where = [ "src/nspawn/nspawn-setuid.c" ];
         }
         {
@@ -762,7 +762,7 @@ stdenv.mkDerivation (finalAttrs: {
         --replace /usr/lib/systemd/catalog/ $out/lib/systemd/catalog/
 
       substituteInPlace src/import/pull-tar.c \
-        --replace 'wait_for_terminate_and_check("tar"' 'wait_for_terminate_and_check("${gnutar}/bin/tar"'
+        --replace 'wait_for_terminate_and_check("tar"' 'wait_for_terminate_and_check("${lib.getExe gnutar}"'
     '';
 
   # These defines are overridden by CFLAGS and would trigger annoying

--- a/pkgs/os-specific/linux/udisks/2-default.nix
+++ b/pkgs/os-specific/linux/udisks/2-default.nix
@@ -22,11 +22,11 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      bash = "${lib.getExe bash}";
+      bash = lib.getExe bash;
       false = "${coreutils}/bin/false";
-      mdadm = "${lib.getExe mdadm}";
+      mdadm = lib.getExe mdadm;
       mkswap = "${util-linux}/bin/mkswap";
-      sed = "${lib.getExe gnused}";
+      sed = lib.getExe gnused;
       sh = "${bash}/bin/sh";
       sleep = "${coreutils}/bin/sleep";
       swapon = "${util-linux}/bin/swapon";

--- a/pkgs/os-specific/linux/udisks/2-default.nix
+++ b/pkgs/os-specific/linux/udisks/2-default.nix
@@ -22,11 +22,11 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      bash = "${bash}/bin/bash";
+      bash = "${lib.getExe bash}";
       false = "${coreutils}/bin/false";
-      mdadm = "${mdadm}/bin/mdadm";
+      mdadm = "${lib.getExe mdadm}";
       mkswap = "${util-linux}/bin/mkswap";
-      sed = "${gnused}/bin/sed";
+      sed = "${lib.getExe gnused}";
       sh = "${bash}/bin/sh";
       sleep = "${coreutils}/bin/sleep";
       swapon = "${util-linux}/bin/swapon";

--- a/pkgs/os-specific/linux/uhk-agent/default.nix
+++ b/pkgs/os-specific/linux/uhk-agent/default.nix
@@ -60,7 +60,7 @@ stdenvNoCC.mkDerivation {
     asar extract "$out/opt/${pname}/app.asar" "$out/opt/${pname}/app.asar.unpacked"
     rm           "$out/opt/${pname}/app.asar"
 
-    makeWrapper "${electron}/bin/electron" "$out/bin/${pname}" \
+    makeWrapper "${lib.getExe electron}" "$out/bin/${pname}" \
       --add-flags "$out/opt/${pname}/app.asar.unpacked" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
       --set-default ELECTRON_IS_DEV 0 \

--- a/pkgs/os-specific/linux/vmware/default.nix
+++ b/pkgs/os-specific/linux/vmware/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     for module in "vmmon-only" "vmnet-only"; do
       substituteInPlace "./$module/Makefile" \
         --replace '/lib/modules/' "${kernel.dev}/lib/modules/" \
-        --replace /bin/grep "${gnugrep}/bin/grep"
+        --replace /bin/grep "${lib.getExe gnugrep}"
     done
   '';
 

--- a/pkgs/servers/aeron/default.nix
+++ b/pkgs/servers/aeron/default.nix
@@ -99,7 +99,7 @@ in stdenv.mkDerivation {
 
   postFixup = ''
     function wrap {
-      makeWrapper "${jdk11}/bin/java" "$out/bin/$1" \
+      makeWrapper "${lib.getExe jdk11}" "$out/bin/$1" \
         --add-flags "--add-opens java.base/sun.nio.ch=ALL-UNNAMED" \
         --add-flags "--class-path ${aeronAll.jar}" \
         --add-flags "$2"

--- a/pkgs/servers/atlassian/jira.nix
+++ b/pkgs/servers/atlassian/jira.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     rm -r work; ln -sf /run/atlassian-jira/work/ .
     rm -r temp; ln -sf /run/atlassian-jira/temp/ .
     substituteInPlace bin/check-java.sh \
-      --replace "awk" "${gawk}/bin/gawk"
+      --replace "awk" "${lib.getExe gawk}"
   '' + lib.optionalString enableSSO ''
     substituteInPlace atlassian-jira/WEB-INF/classes/seraph-config.xml \
       --replace com.atlassian.jira.security.login.JiraSeraphAuthenticator \

--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
 
   '' + (lib.optionalString enableX11 ''
     substituteInPlace src/common/x11_util.c \
-        --replace '"/usr/bin/xauth"' '"${xorg.xauth}/bin/xauth"'
+        --replace '"/usr/bin/xauth"' '"${lib.getExe xorg.xauth}"'
   '');
 
   # nixos test fails to start slurmd with 'undefined symbol: slurm_job_preempt_mode'

--- a/pkgs/servers/freeradius/default.nix
+++ b/pkgs/servers/freeradius/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace src/main/checkrad.in \
-      --replace "/usr/bin/finger" "${bsd-finger}/bin/finger"
+      --replace "/usr/bin/finger" "${lib.getExe bsd-finger}"
   '';
 
   # By default, freeradius will generate Diffie-Hellman parameters and

--- a/pkgs/servers/gonic/default.nix
+++ b/pkgs/servers/gonic/default.nix
@@ -38,7 +38,7 @@ buildGoModule rec {
       jukebox/jukebox.go \
       --replace \
         '"mpv"' \
-        '"${lib.getBin mpv}/bin/mpv"'
+        '"${lib.getExe mpv}"'
   '' + ''
     substituteInPlace server/ctrlsubsonic/testdata/test* \
       --replace \

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -596,7 +596,7 @@ in python.pkgs.buildPythonApplication rec {
     # Patch path to ffmpeg binary
     (substituteAll {
       src = ./patches/ffmpeg-path.patch;
-      ffmpeg = "${lib.getExe ffmpeg-headless}";
+      ffmpeg = lib.getExe ffmpeg-headless;
     })
   ];
 

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -596,7 +596,7 @@ in python.pkgs.buildPythonApplication rec {
     # Patch path to ffmpeg binary
     (substituteAll {
       src = ./patches/ffmpeg-path.patch;
-      ffmpeg = "${lib.getBin ffmpeg-headless}/bin/ffmpeg";
+      ffmpeg = "${lib.getExe ffmpeg-headless}";
     })
   ];
 

--- a/pkgs/servers/http/pomerium/default.nix
+++ b/pkgs/servers/http/pomerium/default.nix
@@ -67,7 +67,7 @@ buildGoModule rec {
         ProjectURL = "github.com/pomerium/pomerium";
       };
       "github.com/pomerium/pomerium/pkg/envoy" = {
-        OverrideEnvoyPath = "${envoy}/bin/envoy";
+        OverrideEnvoyPath = "${lib.getExe envoy}";
       };
     };
     concatStringsSpace = list: concatStringsSep " " list;

--- a/pkgs/servers/http/pomerium/default.nix
+++ b/pkgs/servers/http/pomerium/default.nix
@@ -67,7 +67,7 @@ buildGoModule rec {
         ProjectURL = "github.com/pomerium/pomerium";
       };
       "github.com/pomerium/pomerium/pkg/envoy" = {
-        OverrideEnvoyPath = "${lib.getExe envoy}";
+        OverrideEnvoyPath = lib.getExe envoy;
       };
     };
     concatStringsSpace = list: concatStringsSep " " list;

--- a/pkgs/servers/lidarr/default.nix
+++ b/pkgs/servers/lidarr/default.nix
@@ -28,7 +28,7 @@ in stdenv.mkDerivation rec {
 
     mkdir -p $out/{bin,share/${pname}-${version}}
     cp -r * $out/share/${pname}-${version}/.
-    makeWrapper "${dotnet-runtime}/bin/dotnet" $out/bin/Lidarr \
+    makeWrapper "${lib.getExe dotnet-runtime}" $out/bin/Lidarr \
       --add-flags "$out/share/${pname}-${version}/Lidarr.dll" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
         curl sqlite libmediainfo icu  openssl ]}

--- a/pkgs/servers/meteor/default.nix
+++ b/pkgs/servers/meteor/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation {
     substituteInPlace $out/tools/cli/main.js \
       --replace "@INTERPRETER@" "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       --replace "@RPATH@" "${lib.makeLibraryPath [ stdenv.cc.cc zlib curl xz ]}" \
-      --replace "@PATCHELF@" "${patchelf}/bin/patchelf"
+      --replace "@PATCHELF@" "${lib.getExe patchelf}"
 
     # Patch node.
     patchelf \

--- a/pkgs/servers/monitoring/librenms/default.nix
+++ b/pkgs/servers/monitoring/librenms/default.nix
@@ -70,7 +70,7 @@ in phpPackage.buildComposerProject rec {
       --replace '"default": "traceroute",' '"default": "/run/wrappers/bin/traceroute",' \
       --replace '"default": "/usr/bin/dot",' '"default": "${graphviz}/bin/dot",' \
       --replace '"default": "/usr/bin/ipmitool",' '"default": "${ipmitool}/bin/ipmitool",' \
-      --replace '"default": "/usr/bin/mtr",' '"default": "${mtr}/bin/mtr",' \
+      --replace '"default": "/usr/bin/mtr",' '"default": "${lib.getExe mtr}",' \
       --replace '"default": "/usr/bin/nfdump",' '"default": "${nfdump}/bin/nfdump",' \
       --replace '"default": "/usr/bin/nmap",' '"default": "${nmap}/bin/nmap",' \
       --replace '"default": "/usr/bin/sfdp",' '"default": "${graphviz}/bin/sfdp",' \
@@ -79,9 +79,9 @@ in phpPackage.buildComposerProject rec {
       --replace '"default": "/usr/bin/snmptranslate",' '"default": "${net-snmp}/bin/snmptranslate",' \
       --replace '"default": "/usr/bin/snmpwalk",' '"default": "${net-snmp}/bin/snmpwalk",' \
       --replace '"default": "/usr/bin/virsh",' '"default": "${libvirt}/bin/virsh",' \
-      --replace '"default": "/usr/bin/whois",' '"default": "${whois}/bin/whois",' \
+      --replace '"default": "/usr/bin/whois",' '"default": "${lib.getExe whois}",' \
       --replace '"default": "/usr/lib/nagios/plugins",' '"default": "${monitoring-plugins}/libexec",' \
-      --replace '"default": "/usr/sbin/sendmail",' '"default": "${system-sendmail}/bin/sendmail",'
+      --replace '"default": "/usr/sbin/sendmail",' '"default": "${lib.getExe system-sendmail}",'
 
     substituteInPlace $out/LibreNMS/wrapper.py --replace '/usr/bin/env php' '${phpPackage}/bin/php'
     substituteInPlace $out/LibreNMS/__init__.py --replace '"/usr/bin/env", "php"' '"${phpPackage}/bin/php"'

--- a/pkgs/servers/monitoring/nagios/plugins/smartmon.nix
+++ b/pkgs/servers/monitoring/nagios/plugins/smartmon.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     patchShebangs check_smartmon.py
     substituteInPlace check_smartmon.py \
-      --replace '"/usr/sbin/smartctl"' '"${smartmontools}/bin/smartctl"'
+      --replace '"/usr/sbin/smartctl"' '"${lib.getExe smartmontools}"'
   '';
 
   installPhase = ''

--- a/pkgs/servers/prowlarr/default.nix
+++ b/pkgs/servers/prowlarr/default.nix
@@ -44,7 +44,7 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/{bin,share/${pname}-${version}}
     cp -r * $out/share/${pname}-${version}/.
 
-    makeWrapper "${dotnet-runtime}/bin/dotnet" $out/bin/Prowlarr \
+    makeWrapper "${lib.getExe dotnet-runtime}" $out/bin/Prowlarr \
       --add-flags "$out/share/${pname}-${version}/Prowlarr.dll" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
         curl sqlite libmediainfo mono openssl icu zlib ]}

--- a/pkgs/servers/radarr/default.nix
+++ b/pkgs/servers/radarr/default.nix
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/{bin,share/${pname}-${version}}
     cp -r * $out/share/${pname}-${version}/.
 
-    makeWrapper "${dotnet-runtime}/bin/dotnet" $out/bin/Radarr \
+    makeWrapper "${lib.getExe dotnet-runtime}" $out/bin/Radarr \
       --add-flags "$out/share/${pname}-${version}/Radarr.dll" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
         curl sqlite libmediainfo mono openssl icu zlib ]}

--- a/pkgs/servers/readarr/default.nix
+++ b/pkgs/servers/readarr/default.nix
@@ -28,7 +28,7 @@ in stdenv.mkDerivation rec {
 
     mkdir -p $out/{bin,share/${pname}-${version}}
     cp -r * $out/share/${pname}-${version}/.
-    makeWrapper "${dotnet-runtime}/bin/dotnet" $out/bin/Readarr \
+    makeWrapper "${lib.getExe dotnet-runtime}" $out/bin/Readarr \
       --add-flags "$out/share/${pname}-${version}/Readarr.dll" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ curl sqlite libmediainfo icu openssl ]}
 

--- a/pkgs/servers/search/quickwit/default.nix
+++ b/pkgs/servers/search/quickwit/default.nix
@@ -51,7 +51,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   # needed for internal protobuf c wrapper library
-  PROTOC = "${protobuf}/bin/protoc";
+  PROTOC = "${lib.getExe protobuf}";
   PROTOC_INCLUDE = "${protobuf}/include";
 
   passthru = {

--- a/pkgs/servers/search/quickwit/default.nix
+++ b/pkgs/servers/search/quickwit/default.nix
@@ -51,7 +51,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   # needed for internal protobuf c wrapper library
-  PROTOC = "${lib.getExe protobuf}";
+  PROTOC = lib.getExe protobuf;
   PROTOC_INCLUDE = "${protobuf}/include";
 
   passthru = {

--- a/pkgs/servers/sonarr/default.nix
+++ b/pkgs/servers/sonarr/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/{bin,share/sonarr-${version}}
     cp -r * $out/share/sonarr-${version}/.
 
-    makeWrapper "${dotnet-runtime}/bin/dotnet" $out/bin/NzbDrone \
+    makeWrapper "${lib.getExe dotnet-runtime}" $out/bin/NzbDrone \
       --add-flags "$out/share/sonarr-${version}/Sonarr.dll" \
       --prefix PATH : ${lib.makeBinPath [ ffmpeg ]} \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ curl sqlite openssl icu ]}

--- a/pkgs/servers/sql/materialize/default.nix
+++ b/pkgs/servers/sql/materialize/default.nix
@@ -68,7 +68,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   # needed for internal protobuf c wrapper library
-  env.PROTOC = "${protobuf}/bin/protoc";
+  env.PROTOC = "${lib.getExe protobuf}";
   env.PROTOC_INCLUDE = "${protobuf}/include";
   # needed to dynamically link rdkafka
   env.CARGO_FEATURE_DYNAMIC_LINKING=1;

--- a/pkgs/servers/sql/materialize/default.nix
+++ b/pkgs/servers/sql/materialize/default.nix
@@ -68,7 +68,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   # needed for internal protobuf c wrapper library
-  env.PROTOC = "${lib.getExe protobuf}";
+  env.PROTOC = lib.getExe protobuf;
   env.PROTOC_INCLUDE = "${protobuf}/include";
   # needed to dynamically link rdkafka
   env.CARGO_FEATURE_DYNAMIC_LINKING=1;

--- a/pkgs/servers/web-apps/lemmy/server.nix
+++ b/pkgs/servers/web-apps/lemmy/server.nix
@@ -43,7 +43,7 @@ rustPlatform.buildRustPackage rec {
   OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
   OPENSSL_INCLUDE_DIR = "${openssl.dev}/include";
 
-  PROTOC = "${protobuf}/bin/protoc";
+  PROTOC = "${lib.getExe protobuf}";
   PROTOC_INCLUDE = "${protobuf}/include";
   nativeBuildInputs = [ protobuf rustfmt ];
 

--- a/pkgs/servers/web-apps/lemmy/server.nix
+++ b/pkgs/servers/web-apps/lemmy/server.nix
@@ -43,7 +43,7 @@ rustPlatform.buildRustPackage rec {
   OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
   OPENSSL_INCLUDE_DIR = "${openssl.dev}/include";
 
-  PROTOC = "${lib.getExe protobuf}";
+  PROTOC = lib.getExe protobuf;
   PROTOC_INCLUDE = "${protobuf}/include";
   nativeBuildInputs = [ protobuf rustfmt ];
 

--- a/pkgs/servers/web-apps/pict-rs/0.3.nix
+++ b/pkgs/servers/web-apps/pict-rs/0.3.nix
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   # needed for internal protobuf c wrapper library
-  PROTOC = "${lib.getExe protobuf}";
+  PROTOC = lib.getExe protobuf;
   PROTOC_INCLUDE = "${protobuf}/include";
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/servers/web-apps/pict-rs/0.3.nix
+++ b/pkgs/servers/web-apps/pict-rs/0.3.nix
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   # needed for internal protobuf c wrapper library
-  PROTOC = "${protobuf}/bin/protoc";
+  PROTOC = "${lib.getExe protobuf}";
   PROTOC_INCLUDE = "${protobuf}/include";
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/servers/web-apps/pict-rs/default.nix
+++ b/pkgs/servers/web-apps/pict-rs/default.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-NjNfMyNEliyJQuwWJ/owyKOz+P5gT8Ov0w298I6A/Bk=";
 
   # needed for internal protobuf c wrapper library
-  PROTOC = "${protobuf}/bin/protoc";
+  PROTOC = "${lib.getExe protobuf}";
   PROTOC_INCLUDE = "${protobuf}/include";
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/servers/web-apps/pict-rs/default.nix
+++ b/pkgs/servers/web-apps/pict-rs/default.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-NjNfMyNEliyJQuwWJ/owyKOz+P5gT8Ov0w298I6A/Bk=";
 
   # needed for internal protobuf c wrapper library
-  PROTOC = "${lib.getExe protobuf}";
+  PROTOC = lib.getExe protobuf;
   PROTOC_INCLUDE = "${protobuf}/include";
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/servers/x11/xquartz/default.nix
+++ b/pkgs/servers/x11/xquartz/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, buildEnv, makeFontsConf, gnused, writeScript, xorg, bashInteractive, xterm, xcbuild, makeWrapper
 , quartz-wm, fontconfig, xlsfonts, xfontsel
 , ttf_bitstream_vera, freefont_ttf, liberation_ttf
-, shell ? "${bashInteractive}/bin/bash"
+, shell ? "${lib.getExe bashInteractive}"
 , unfreeFonts ? false
 , extraFontDirs ? []
 }:
@@ -148,7 +148,7 @@ in stdenv.mkDerivation {
     cp ${./10-fontdir.sh} $out/etc/X11/xinit/xinitrc.d/10-fontdir.sh
     substituteInPlace $out/etc/X11/xinit/xinitrc.d/10-fontdir.sh \
       --subst-var-by "SYSTEM_FONTS" "${fonts}/share/X11-fonts/" \
-      --subst-var-by "XSET"         "${xorg.xset}/bin/xset"
+      --subst-var-by "XSET"         "${lib.getExe xorg.xset}"
 
     cp ${./98-user.sh} $out/etc/X11/xinit/xinitrc.d/98-user.sh
 

--- a/pkgs/servers/zoneminder/default.nix
+++ b/pkgs/servers/zoneminder/default.nix
@@ -53,7 +53,7 @@ let
 
   user    = "zoneminder";
   dirName = "zoneminder";
-  perlBin = "${perl}/bin/perl";
+  perlBin = "${lib.getExe perl}";
 
 in stdenv.mkDerivation rec {
   pname = "zoneminder";

--- a/pkgs/servers/zoneminder/default.nix
+++ b/pkgs/servers/zoneminder/default.nix
@@ -53,7 +53,7 @@ let
 
   user    = "zoneminder";
   dirName = "zoneminder";
-  perlBin = "${lib.getExe perl}";
+  perlBin = lib.getExe perl;
 
 in stdenv.mkDerivation rec {
   pname = "zoneminder";

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -163,7 +163,7 @@ let inherit (localSystem) system;
                         "--with-ca-bundle=${cacert}"
                       ];
     };
-    bashExe = "${bash}/bin/bash";
+    bashExe = "${lib.getExe bash}";
 in
 [
 

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -163,7 +163,7 @@ let inherit (localSystem) system;
                         "--with-ca-bundle=${cacert}"
                       ];
     };
-    bashExe = "${lib.getExe bash}";
+    bashExe = lib.getExe bash;
 in
 [
 

--- a/pkgs/tools/X11/xdg-utils/default.nix
+++ b/pkgs/tools/X11/xdg-utils/default.nix
@@ -36,7 +36,7 @@ let
   solutions = [
     {
       scripts = [ "bin/xdg-desktop-icon" ];
-      interpreter = "${lib.getExe bash}";
+      interpreter = lib.getExe bash;
       inputs = commonDeps ++ [ xdg-user-dirs ];
       execer = [
         "cannot:${xdg-user-dirs}/bin/xdg-user-dir"
@@ -52,7 +52,7 @@ let
 
     {
       scripts = [ "bin/xdg-desktop-menu" ];
-      interpreter = "${lib.getExe bash}";
+      interpreter = lib.getExe bash;
       inputs = commonDeps ++ [ gawk ];
       fake.external = commonFakes;
       keep."$KDE_SESSION_VERSION" = true;
@@ -61,7 +61,7 @@ let
 
     {
       scripts = [ "bin/xdg-email" ];
-      interpreter = "${lib.getExe bash}";
+      interpreter = lib.getExe bash;
       inputs = commonDeps ++ [ gawk glib.bin "${placeholder "out"}/bin" ];
       execer = [
         "cannot:${placeholder "out"}/bin/xdg-mime"
@@ -89,7 +89,7 @@ let
 
     {
       scripts = [ "bin/xdg-icon-resource" ];
-      interpreter = "${lib.getExe bash}";
+      interpreter = lib.getExe bash;
       inputs = commonDeps;
       fake.external = commonFakes;
       keep."$KDE_SESSION_VERSION" = true;
@@ -98,7 +98,7 @@ let
 
     {
       scripts = [ "bin/xdg-mime" ];
-      interpreter = "${lib.getExe bash}";
+      interpreter = lib.getExe bash;
       inputs = commonDeps ++ [ file gawk ];
       # These are desktop-specific, so we don't want xdg-utils to be able to
       # call them when in a different setup.
@@ -130,7 +130,7 @@ let
 
     {
       scripts = [ "bin/xdg-open" ];
-      interpreter = "${lib.getExe bash}";
+      interpreter = lib.getExe bash;
       inputs = commonDeps ++ [ nettools glib.bin "${placeholder "out"}/bin" ];
       execer = [
         "cannot:${placeholder "out"}/bin/xdg-mime"
@@ -166,7 +166,7 @@ let
 
     {
       scripts = [ "bin/xdg-screensaver" ];
-      interpreter = "${lib.getExe bash}";
+      interpreter = lib.getExe bash;
       inputs = commonDeps ++ [ nettools perl procmail procps ];
       # These are desktop-specific, so we don't want xdg-utils to be able to
       # call them when in a different setup.
@@ -193,7 +193,7 @@ let
 
     {
       scripts = [ "bin/xdg-settings" ];
-      interpreter = "${lib.getExe bash}";
+      interpreter = lib.getExe bash;
       inputs = commonDeps ++ [ jq "${placeholder "out"}/bin" ];
       execer = [
         "cannot:${placeholder "out"}/bin/xdg-mime"
@@ -220,7 +220,7 @@ let
 
     {
       scripts = [ "bin/xdg-terminal" ];
-      interpreter = "${lib.getExe bash}";
+      interpreter = lib.getExe bash;
       inputs = commonDeps ++ [ bash glib.bin which ];
       fake.external = commonFakes ++ [
         "gconftool-2"    # GNOME

--- a/pkgs/tools/X11/xdg-utils/default.nix
+++ b/pkgs/tools/X11/xdg-utils/default.nix
@@ -36,7 +36,7 @@ let
   solutions = [
     {
       scripts = [ "bin/xdg-desktop-icon" ];
-      interpreter = "${bash}/bin/bash";
+      interpreter = "${lib.getExe bash}";
       inputs = commonDeps ++ [ xdg-user-dirs ];
       execer = [
         "cannot:${xdg-user-dirs}/bin/xdg-user-dir"
@@ -52,7 +52,7 @@ let
 
     {
       scripts = [ "bin/xdg-desktop-menu" ];
-      interpreter = "${bash}/bin/bash";
+      interpreter = "${lib.getExe bash}";
       inputs = commonDeps ++ [ gawk ];
       fake.external = commonFakes;
       keep."$KDE_SESSION_VERSION" = true;
@@ -61,7 +61,7 @@ let
 
     {
       scripts = [ "bin/xdg-email" ];
-      interpreter = "${bash}/bin/bash";
+      interpreter = "${lib.getExe bash}";
       inputs = commonDeps ++ [ gawk glib.bin "${placeholder "out"}/bin" ];
       execer = [
         "cannot:${placeholder "out"}/bin/xdg-mime"
@@ -89,7 +89,7 @@ let
 
     {
       scripts = [ "bin/xdg-icon-resource" ];
-      interpreter = "${bash}/bin/bash";
+      interpreter = "${lib.getExe bash}";
       inputs = commonDeps;
       fake.external = commonFakes;
       keep."$KDE_SESSION_VERSION" = true;
@@ -98,7 +98,7 @@ let
 
     {
       scripts = [ "bin/xdg-mime" ];
-      interpreter = "${bash}/bin/bash";
+      interpreter = "${lib.getExe bash}";
       inputs = commonDeps ++ [ file gawk ];
       # These are desktop-specific, so we don't want xdg-utils to be able to
       # call them when in a different setup.
@@ -130,7 +130,7 @@ let
 
     {
       scripts = [ "bin/xdg-open" ];
-      interpreter = "${bash}/bin/bash";
+      interpreter = "${lib.getExe bash}";
       inputs = commonDeps ++ [ nettools glib.bin "${placeholder "out"}/bin" ];
       execer = [
         "cannot:${placeholder "out"}/bin/xdg-mime"
@@ -166,7 +166,7 @@ let
 
     {
       scripts = [ "bin/xdg-screensaver" ];
-      interpreter = "${bash}/bin/bash";
+      interpreter = "${lib.getExe bash}";
       inputs = commonDeps ++ [ nettools perl procmail procps ];
       # These are desktop-specific, so we don't want xdg-utils to be able to
       # call them when in a different setup.
@@ -193,7 +193,7 @@ let
 
     {
       scripts = [ "bin/xdg-settings" ];
-      interpreter = "${bash}/bin/bash";
+      interpreter = "${lib.getExe bash}";
       inputs = commonDeps ++ [ jq "${placeholder "out"}/bin" ];
       execer = [
         "cannot:${placeholder "out"}/bin/xdg-mime"
@@ -220,7 +220,7 @@ let
 
     {
       scripts = [ "bin/xdg-terminal" ];
-      interpreter = "${bash}/bin/bash";
+      interpreter = "${lib.getExe bash}";
       inputs = commonDeps ++ [ bash glib.bin which ];
       fake.external = commonFakes ++ [
         "gconftool-2"    # GNOME

--- a/pkgs/tools/admin/colmena/default.nix
+++ b/pkgs/tools/admin/colmena/default.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ nix-eval-jobs ];
 
-  NIX_EVAL_JOBS = "${nix-eval-jobs}/bin/nix-eval-jobs";
+  NIX_EVAL_JOBS = "${lib.getExe nix-eval-jobs}";
 
   postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
     installShellCompletion --cmd colmena \

--- a/pkgs/tools/admin/colmena/default.nix
+++ b/pkgs/tools/admin/colmena/default.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ nix-eval-jobs ];
 
-  NIX_EVAL_JOBS = "${lib.getExe nix-eval-jobs}";
+  NIX_EVAL_JOBS = lib.getExe nix-eval-jobs;
 
   postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
     installShellCompletion --cmd colmena \

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -396,7 +396,7 @@ in rec {
         --replace "char command[128];" "char command[256];" \
         --replace "/sbin/modinfo"  "${kmod}/bin/modinfo" \
         --replace "/sbin/modprobe" "${kmod}/bin/modprobe" \
-        --replace "/bin/grep" "${gnugrep}/bin/grep"
+        --replace "/bin/grep" "${lib.getExe gnugrep}"
 
       # install target needs to be in PYTHONPATH for "*.pth support" check to succeed
       # set PYTHONPATH, so the build system doesn't silently skip installing ceph-volume and others

--- a/pkgs/tools/filesystems/xtreemfs/default.nix
+++ b/pkgs/tools/filesystems/xtreemfs/default.nix
@@ -87,13 +87,13 @@ stdenv.mkDerivation {
       --replace "/bin/bash" "${stdenv.shell}"
 
     substituteInPlace cpp/thirdparty/gtest-1.7.0/configure \
-      --replace "/usr/bin/file" "${file}/bin/file"
+      --replace "/usr/bin/file" "${lib.getExe file}"
 
     substituteInPlace cpp/thirdparty/protobuf-2.5.0/configure \
-      --replace "/usr/bin/file" "${file}/bin/file"
+      --replace "/usr/bin/file" "${lib.getExe file}"
 
     substituteInPlace cpp/thirdparty/protobuf-2.5.0/gtest/configure \
-      --replace "/usr/bin/file" "${file}/bin/file"
+      --replace "/usr/bin/file" "${lib.getExe file}"
 
     # do not put cmake into buildInputs
     export PATH="$PATH:${cmake}/bin"

--- a/pkgs/tools/inputmethods/libinput-gestures/default.nix
+++ b/pkgs/tools/inputmethods/libinput-gestures/default.nix
@@ -27,8 +27,8 @@ stdenv.mkDerivation rec {
 
       substituteInPlace libinput-gestures \
         --replace      /etc     "$out/etc" \
-        --subst-var-by libinput "${libinput}/bin/libinput" \
-        --subst-var-by wmctrl   "${wmctrl}/bin/wmctrl"
+        --subst-var-by libinput "${lib.getExe libinput}" \
+        --subst-var-by wmctrl   "${lib.getExe wmctrl}"
     '';
   installPhase =
     ''

--- a/pkgs/tools/inputmethods/m17n-lib/otf.nix
+++ b/pkgs/tools/inputmethods/m17n-lib/otf.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     mkdir -p $dev/bin
     mv $out/bin/libotf-config $dev/bin/
     substituteInPlace $dev/bin/libotf-config \
-      --replace "pkg-config" "${pkg-config}/bin/pkg-config"
+      --replace "pkg-config" "${lib.getExe pkg-config}"
   '';
 
   meta = {

--- a/pkgs/tools/misc/arch-install-scripts/default.nix
+++ b/pkgs/tools/misc/arch-install-scripts/default.nix
@@ -58,7 +58,7 @@ resholve.mkDerivation rec {
       scripts = [ "bin/arch-chroot" "bin/genfstab" "bin/pacstrap" ];
 
       # "none" for no shebang, "${lib.getExe bash}" for bash, etc.
-      interpreter = "${lib.getExe bash}";
+      interpreter = lib.getExe bash;
 
       # packages resholve should resolve executables from
       inputs = [ coreutils gawk gnugrep pacman util-linux ];

--- a/pkgs/tools/misc/arch-install-scripts/default.nix
+++ b/pkgs/tools/misc/arch-install-scripts/default.nix
@@ -57,8 +57,8 @@ resholve.mkDerivation rec {
       # fixup (to correctly resolve in-package sourcing).
       scripts = [ "bin/arch-chroot" "bin/genfstab" "bin/pacstrap" ];
 
-      # "none" for no shebang, "${bash}/bin/bash" for bash, etc.
-      interpreter = "${bash}/bin/bash";
+      # "none" for no shebang, "${lib.getExe bash}" for bash, etc.
+      interpreter = "${lib.getExe bash}";
 
       # packages resholve should resolve executables from
       inputs = [ coreutils gawk gnugrep pacman util-linux ];
@@ -72,7 +72,7 @@ resholve.mkDerivation rec {
         umount = true;
       };
 
-      keep = [ "$setup" "$pid_unshare" "$mount_unshare" "${pacman}/bin/pacman" ];
+      keep = [ "$setup" "$pid_unshare" "$mount_unshare" "${lib.getExe pacman}" ];
     };
   };
 

--- a/pkgs/tools/misc/bdf2psf/default.nix
+++ b/pkgs/tools/misc/bdf2psf/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
-    substituteInPlace usr/bin/bdf2psf --replace /usr/bin/perl "${perl}/bin/perl"
+    substituteInPlace usr/bin/bdf2psf --replace /usr/bin/perl "${lib.getExe perl}"
     rm usr/share/doc/bdf2psf/changelog.gz
     mv usr "$out"
     runHook postInstall

--- a/pkgs/tools/misc/calamares/default.nix
+++ b/pkgs/tools/misc/calamares/default.nix
@@ -80,7 +80,7 @@ mkDerivation rec {
     sed -e 's,/usr/share/X11/xkb/rules/base.lst,${xkeyboard_config}/share/X11/xkb/rules/base.lst,' \
         -i src/modules/keyboard/keyboardwidget/keyboardglobal.cpp
 
-    sed -e 's,"ckbcomp","${ckbcomp}/bin/ckbcomp",' \
+    sed -e 's,"ckbcomp","${lib.getExe ckbcomp}",' \
         -i src/modules/keyboard/keyboardwidget/keyboardpreview.cpp
 
     sed "s,\''${POLKITQT-1_POLICY_FILES_INSTALL_DIR},''${out}/share/polkit-1/actions," \

--- a/pkgs/tools/misc/colorless/default.nix
+++ b/pkgs/tools/misc/colorless/default.nix
@@ -3,7 +3,7 @@
 , stdenvNoCC
 , coreutils
 , bash
-, binSh ? "${bash}/bin/bash"
+, binSh ? "${lib.getExe bash}"
 , gnused
 , less
 }:

--- a/pkgs/tools/misc/direnv/default.nix
+++ b/pkgs/tools/misc/direnv/default.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
   # we have no bash at the moment for windows
   BASH_PATH =
     lib.optionalString (!stdenv.hostPlatform.isWindows)
-    "${bash}/bin/bash";
+    "${lib.getExe bash}";
 
   # replace the build phase to use the GNUMakefile instead
   buildPhase = ''

--- a/pkgs/tools/misc/ffsend/default.nix
+++ b/pkgs/tools/misc/ffsend/default.nix
@@ -65,9 +65,9 @@ rustPlatform.buildRustPackage rec {
 
   preBuild = lib.optionalString (x11Support && usesX11) (
     if preferXsel && xsel != null then ''
-      export XSEL_PATH="${xsel}/bin/xsel"
+      export XSEL_PATH="${lib.getExe xsel}"
     '' else ''
-      export XCLIP_PATH="${xclip}/bin/xclip"
+      export XCLIP_PATH="${lib.getExe xclip}"
     ''
   );
 

--- a/pkgs/tools/misc/ix/default.nix
+++ b/pkgs/tools/misc/ix/default.nix
@@ -23,7 +23,7 @@ resholve.mkDerivation {
 
   solutions.default = {
     scripts = [ "bin/ix" ];
-    interpreter = "${lib.getExe bash}";
+    interpreter = lib.getExe bash;
     inputs = [ curl ];
   };
 

--- a/pkgs/tools/misc/lesspipe/default.nix
+++ b/pkgs/tools/misc/lesspipe/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
 
     ${resholve.phraseSolution "lesspipe.sh" {
       scripts = [ "bin/lesspipe.sh" ];
-      interpreter = "${lib.getExe bash}";
+      interpreter = lib.getExe bash;
       inputs = [
         coreutils
         file
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
     }}
     ${resholve.phraseSolution "lesscomplete" {
       scripts = [ "bin/lesscomplete" ];
-      interpreter = "${lib.getExe bash}";
+      interpreter = lib.getExe bash;
       inputs = [
         coreutils
         file

--- a/pkgs/tools/misc/lesspipe/default.nix
+++ b/pkgs/tools/misc/lesspipe/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
 
     ${resholve.phraseSolution "lesspipe.sh" {
       scripts = [ "bin/lesspipe.sh" ];
-      interpreter = "${bash}/bin/bash";
+      interpreter = "${lib.getExe bash}";
       inputs = [
         coreutils
         file
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
     }}
     ${resholve.phraseSolution "lesscomplete" {
       scripts = [ "bin/lesscomplete" ];
-      interpreter = "${bash}/bin/bash";
+      interpreter = "${lib.getExe bash}";
       inputs = [
         coreutils
         file

--- a/pkgs/tools/misc/locate-dominating-file/default.nix
+++ b/pkgs/tools/misc/locate-dominating-file/default.nix
@@ -50,7 +50,7 @@ resholve.mkDerivation {
 
   solutions.default = {
     scripts = [ "bin/locate-dominating-file" ];
-    interpreter = "${bash}/bin/bash";
+    interpreter = "${lib.getExe bash}";
     inputs = [
       coreutils
       getopt

--- a/pkgs/tools/misc/locate-dominating-file/default.nix
+++ b/pkgs/tools/misc/locate-dominating-file/default.nix
@@ -50,7 +50,7 @@ resholve.mkDerivation {
 
   solutions.default = {
     scripts = [ "bin/locate-dominating-file" ];
-    interpreter = "${lib.getExe bash}";
+    interpreter = lib.getExe bash;
     inputs = [
       coreutils
       getopt

--- a/pkgs/tools/misc/mise/default.nix
+++ b/pkgs/tools/misc/mise/default.nix
@@ -45,11 +45,11 @@ rustPlatform.buildRustPackage rec {
       ./test/cwd/.mise/tasks/filetask
 
     substituteInPlace ./src/env_diff.rs \
-      --replace '"bash"' '"${bash}/bin/bash"'
+      --replace '"bash"' '"${lib.getExe bash}"'
 
     substituteInPlace ./src/cli/direnv/exec.rs \
       --replace '"env"' '"${coreutils}/bin/env"' \
-      --replace 'cmd!("direnv"' 'cmd!("${direnv}/bin/direnv"'
+      --replace 'cmd!("direnv"' 'cmd!("${lib.getExe direnv}"'
   '';
 
   checkFlags = [

--- a/pkgs/tools/misc/rmate-sh/default.nix
+++ b/pkgs/tools/misc/rmate-sh/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     substituteInPlace rmate \
       --replace-fail \
         'echo "hostname"' \
-        'echo "${hostname}/bin/hostname"'
+        'echo "${lib.getExe hostname}"'
     patsh -f rmate -s ${builtins.storeDir}
 
     runHook preBuild

--- a/pkgs/tools/misc/sharedown/default.nix
+++ b/pkgs/tools/misc/sharedown/default.nix
@@ -105,10 +105,10 @@ stdenvNoCC.mkDerivation rec {
       cp build/icon.png "$out/share/icons/hicolor/512x512/apps/Sharedown.png"
 
       # Install electron wrapper script
-      makeWrapper "${electron}/bin/electron" "$out/bin/Sharedown" \
+      makeWrapper "${lib.getExe electron}" "$out/bin/Sharedown" \
         --add-flags "$out/share/Sharedown" \
         --prefix PATH : "${binPath}" \
-        --set PUPPETEER_EXECUTABLE_PATH "${chromium}/bin/chromium"
+        --set PUPPETEER_EXECUTABLE_PATH "${lib.getExe chromium}"
 
       runHook postInstall
     '';

--- a/pkgs/tools/misc/taoup/default.nix
+++ b/pkgs/tools/misc/taoup/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
      --subst-var-by pname ${pname}
     substituteInPlace taoup-fortune \
       --subst-var-by out $out \
-      --replace "/bin/bash" "${bash}/bin/bash"
+      --replace "/bin/bash" "${lib.getExe bash}"
   '';
 
   dontConfigure = true;

--- a/pkgs/tools/misc/tremor-rs/default.nix
+++ b/pkgs/tools/misc/tremor-rs/default.nix
@@ -60,7 +60,7 @@ rustPlatform.buildRustPackage rec {
   OPENSSL_NO_VENDOR = 1;
 
   # needed for internal protobuf c wrapper library
-  PROTOC = "${lib.getExe protobuf}";
+  PROTOC = lib.getExe protobuf;
   PROTOC_INCLUDE = "${protobuf}/include";
 
   env = lib.optionalAttrs (stdenv.system == "x86_64-darwin") {

--- a/pkgs/tools/misc/tremor-rs/default.nix
+++ b/pkgs/tools/misc/tremor-rs/default.nix
@@ -60,7 +60,7 @@ rustPlatform.buildRustPackage rec {
   OPENSSL_NO_VENDOR = 1;
 
   # needed for internal protobuf c wrapper library
-  PROTOC = "${protobuf}/bin/protoc";
+  PROTOC = "${lib.getExe protobuf}";
   PROTOC_INCLUDE = "${protobuf}/include";
 
   env = lib.optionalAttrs (stdenv.system == "x86_64-darwin") {

--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -74,7 +74,7 @@ rustPlatform.buildRustPackage {
     ++ lib.optionals stdenv.isDarwin [ rust-jemalloc-sys Security libiconv coreutils CoreServices SystemConfiguration ];
 
   # needed for internal protobuf c wrapper library
-  PROTOC = "${lib.getExe protobuf}";
+  PROTOC = lib.getExe protobuf;
   PROTOC_INCLUDE = "${protobuf}/include";
   RUSTONIG_SYSTEM_LIBONIG = true;
 

--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -74,7 +74,7 @@ rustPlatform.buildRustPackage {
     ++ lib.optionals stdenv.isDarwin [ rust-jemalloc-sys Security libiconv coreutils CoreServices SystemConfiguration ];
 
   # needed for internal protobuf c wrapper library
-  PROTOC = "${protobuf}/bin/protoc";
+  PROTOC = "${lib.getExe protobuf}";
   PROTOC_INCLUDE = "${protobuf}/include";
   RUSTONIG_SYSTEM_LIBONIG = true;
 

--- a/pkgs/tools/misc/you-get/default.nix
+++ b/pkgs/tools/misc/you-get/default.nix
@@ -23,8 +23,8 @@ python3.pkgs.buildPythonApplication rec {
   patches = [
     (substituteAll {
       src = ./ffmpeg-path.patch;
-      ffmpeg = "${lib.getExe ffmpeg}";
-      ffprobe = "${lib.getExe ffmpeg}";
+      ffmpeg = lib.getExe ffmpeg;
+      ffprobe = lib.getExe ffmpeg;
       version = lib.getVersion ffmpeg;
     })
   ];

--- a/pkgs/tools/misc/you-get/default.nix
+++ b/pkgs/tools/misc/you-get/default.nix
@@ -23,8 +23,8 @@ python3.pkgs.buildPythonApplication rec {
   patches = [
     (substituteAll {
       src = ./ffmpeg-path.patch;
-      ffmpeg = "${lib.getBin ffmpeg}/bin/ffmpeg";
-      ffprobe = "${lib.getBin ffmpeg}/bin/ffmpeg";
+      ffmpeg = "${lib.getExe ffmpeg}";
+      ffprobe = "${lib.getExe ffmpeg}";
       version = lib.getVersion ffmpeg;
     })
   ];

--- a/pkgs/tools/misc/zoxide/default.nix
+++ b/pkgs/tools/misc/zoxide/default.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
 
   postPatch = lib.optionalString withFzf ''
     substituteInPlace src/util.rs \
-      --replace '"fzf"' '"${fzf}/bin/fzf"'
+      --replace '"fzf"' '"${lib.getExe fzf}"'
   '';
 
   cargoHash = "sha256-t6GVoMBCD0s36GhtqJu9Z2bwwq5P+beEObG+gSC+QUw=";

--- a/pkgs/tools/networking/ivpn/default.nix
+++ b/pkgs/tools/networking/ivpn/default.nix
@@ -58,7 +58,7 @@ builtins.mapAttrs (pname: attrs: buildGoModule (attrs // rec {
     postPatch = ''
       substituteInPlace daemon/service/platform/platform_linux.go \
         --replace 'openVpnBinaryPath = "/usr/sbin/openvpn"' \
-        'openVpnBinaryPath = "${openvpn}/bin/openvpn"' \
+        'openVpnBinaryPath = "${lib.getExe openvpn}"' \
         --replace 'routeCommand = "/sbin/ip route"' \
         'routeCommand = "${iproute2}/bin/ip route"'
 
@@ -73,9 +73,9 @@ builtins.mapAttrs (pname: attrs: buildGoModule (attrs // rec {
         --replace 'wgBinaryPath = path.Join(installDir, "wireguard-tools/wg-quick")' \
         'wgBinaryPath = "${wireguard-tools}/bin/wg-quick"' \
         --replace 'wgToolBinaryPath = path.Join(installDir, "wireguard-tools/wg")' \
-        'wgToolBinaryPath = "${wireguard-tools}/bin/wg"' \
+        'wgToolBinaryPath = "${lib.getExe wireguard-tools}"' \
         --replace 'dnscryptproxyBinPath = path.Join(installDir, "dnscrypt-proxy/dnscrypt-proxy")' \
-        'dnscryptproxyBinPath = "${dnscrypt-proxy}/bin/dnscrypt-proxy"'
+        'dnscryptproxyBinPath = "${lib.getExe dnscrypt-proxy}"'
     '';
 
     postFixup = ''

--- a/pkgs/tools/networking/mosh/default.nix
+++ b/pkgs/tools/networking/mosh/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace scripts/mosh.pl \
-      --subst-var-by ssh "${openssh}/bin/ssh" \
+      --subst-var-by ssh "${lib.getExe openssh}" \
       --subst-var-by mosh-client "$out/bin/mosh-client"
   '';
 

--- a/pkgs/tools/networking/namespaced-openvpn/default.nix
+++ b/pkgs/tools/networking/namespaced-openvpn/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace namespaced-openvpn \
-      --replace-fail "/usr/sbin/openvpn" "${openvpn}/bin/openvpn" \
+      --replace-fail "/usr/sbin/openvpn" "${lib.getExe openvpn}" \
       --replace-fail "/sbin/ip" "${iproute2}/bin/ip" \
       --replace-fail "/usr/bin/nsenter" "${util-linux}/bin/nsenter" \
       --replace-fail "/bin/mount" "${util-linux}/bin/mount" \

--- a/pkgs/tools/networking/vpnc-scripts/default.nix
+++ b/pkgs/tools/networking/vpnc-scripts/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
       --replace "which" "type -P"
   '' + lib.optionalString stdenv.isLinux ''
     substituteInPlace $out/bin/vpnc-script \
-      --replace "/sbin/resolvconf" "${openresolv}/bin/resolvconf" \
+      --replace "/sbin/resolvconf" "${lib.getExe openresolv}" \
       --replace "/usr/bin/resolvectl" "${systemd}/bin/resolvectl"
   '' + ''
     wrapProgram $out/bin/vpnc-script \

--- a/pkgs/tools/networking/zs-apc-spdu-ctl/default.nix
+++ b/pkgs/tools/networking/zs-apc-spdu-ctl/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace src/confent.cxx \
-      --replace /usr/sbin/fping "${fping}/bin/fping"
+      --replace /usr/sbin/fping "${lib.getExe fping}"
   '';
 
   meta = with lib; {

--- a/pkgs/tools/package-management/appimagekit/default.nix
+++ b/pkgs/tools/package-management/appimagekit/default.nix
@@ -101,7 +101,7 @@ in stdenv.mkDerivation rec {
 
   postInstall = ''
     mkdir -p $out/lib/appimagekit
-    cp "${squashfsTools}/bin/mksquashfs" "$out/lib/appimagekit/"
+    cp "${lib.getExe squashfsTools}" "$out/lib/appimagekit/"
     cp "${desktop-file-utils}/bin/desktop-file-validate" "$out/bin"
 
     wrapProgram "$out/bin/appimagetool" \

--- a/pkgs/tools/package-management/dpkg/default.nix
+++ b/pkgs/tools/package-management/dpkg/default.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
       for i in $out/bin/*; do
         if head -n 1 $i | grep -q perl; then
           substituteInPlace $i --replace \
-            "${perl}/bin/perl" "${perl}/bin/perl -I $out/${perl.libPrefix}"
+            "${lib.getExe perl}" "${perl}/bin/perl -I $out/${perl.libPrefix}"
         fi
       done
 

--- a/pkgs/tools/security/aflplusplus/default.nix
+++ b/pkgs/tools/security/aflplusplus/default.nix
@@ -49,8 +49,8 @@ let
       # Replace LLVM_BINDIR with a non-existing path to give a hard error when it's used.
       substituteInPlace src/afl-cc.c \
         --replace "CLANGPP_BIN" '"${clang}/bin/clang++"' \
-        --replace "CLANG_BIN" '"${clang}/bin/clang"' \
-        --replace '"gcc"' '"${gcc}/bin/gcc"' \
+        --replace "CLANG_BIN" '"${lib.getExe clang}"' \
+        --replace '"gcc"' '"${lib.getExe gcc}"' \
         --replace '"g++"' '"${gcc}/bin/g++"' \
         --replace 'getenv("AFL_PATH")' "(getenv(\"AFL_PATH\") ? getenv(\"AFL_PATH\") : \"$out/lib/afl\")"
 
@@ -63,7 +63,7 @@ let
         --replace 'LLVM_BINDIR = ' 'LLVM_BINDIR = ${clang}/bin/'
 
       substituteInPlace GNUmakefile.llvm \
-        --replace "\$(LLVM_BINDIR)/clang" "${clang}/bin/clang"
+        --replace "\$(LLVM_BINDIR)/clang" "${lib.getExe clang}"
     '';
 
     env.NIX_CFLAGS_COMPILE = toString [

--- a/pkgs/tools/security/ccid/default.nix
+++ b/pkgs/tools/security/ccid/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     install -Dm 0444 -t $out/lib/udev/rules.d src/92_pcscd_ccid.rules
     substituteInPlace $out/lib/udev/rules.d/92_pcscd_ccid.rules \
-      --replace "/usr/sbin/pcscd" "${pcsclite}/bin/pcscd"
+      --replace "/usr/sbin/pcscd" "${lib.getExe pcsclite}"
   '';
 
   # The resulting shared object ends up outside of the default paths which are

--- a/pkgs/tools/security/fwknop/default.nix
+++ b/pkgs/tools/security/fwknop/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     "--with-iptables=${iptables}/sbin/iptables"
     (lib.enableFeature buildServer "server")
     (lib.enableFeature buildClient "client")
-    (lib.withFeatureAs wgetSupport "wget" "${wget}/bin/wget")
+    (lib.withFeatureAs wgetSupport "wget" "${lib.getExe wget}")
   ] ++ lib.optionalString gnupgSupport [
     "--with-gpgme"
     "--with-gpgme-prefix=${gpgme.dev}"

--- a/pkgs/tools/security/ghidra/extensions/ghidraninja-ghidra-scripts/default.nix
+++ b/pkgs/tools/security/ghidra/extensions/ghidraninja-ghidra-scripts/default.nix
@@ -19,9 +19,9 @@ buildGhidraScripts {
 
   postPatch = ''
     # Replace subprocesses with store versions
-    substituteInPlace binwalk.py --replace-fail 'subprocess.call(["binwalk"' 'subprocess.call(["${binwalk}/bin/binwalk"'
+    substituteInPlace binwalk.py --replace-fail 'subprocess.call(["binwalk"' 'subprocess.call(["${lib.getExe binwalk}"'
     substituteInPlace swift_demangler.py --replace-fail '"swift"' '"${swift}/bin/swift"'
-    substituteInPlace yara.py --replace-fail 'subprocess.check_output(["yara"' 'subprocess.check_output(["${yara}/bin/yara"'
+    substituteInPlace yara.py --replace-fail 'subprocess.check_output(["yara"' 'subprocess.check_output(["${lib.getExe yara}"'
     substituteInPlace YaraSearch.py --replace-fail '"yara "' '"${yara}/bin/yara "'
   '';
 

--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -23,7 +23,7 @@ buildGoModule rec {
   patches = [
     (substituteAll {
       src = ./fix-paths-keybase.patch;
-      gpg = "${lib.getExe gnupg}";
+      gpg = lib.getExe gnupg;
       gpg2 = "${gnupg}/bin/gpg2";
     })
   ];

--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -23,7 +23,7 @@ buildGoModule rec {
   patches = [
     (substituteAll {
       src = ./fix-paths-keybase.patch;
-      gpg = "${gnupg}/bin/gpg";
+      gpg = "${lib.getExe gnupg}";
       gpg2 = "${gnupg}/bin/gpg2";
     })
   ];

--- a/pkgs/tools/security/p0f/default.nix
+++ b/pkgs/tools/security/p0f/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     substituteInPlace config.h --replace "p0f.fp" "$out/etc/p0f.fp"
-    substituteInPlace build.sh --replace "/bin/bash" "${bash}/bin/bash"
+    substituteInPlace build.sh --replace "/bin/bash" "${lib.getExe bash}"
     ./build.sh
     cd tools && make && cd ..
   '';

--- a/pkgs/tools/security/passff-host/default.nix
+++ b/pkgs/tools/security/passff-host/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "VERSION=${version}" ];
 
   patchPhase = ''
-    sed -i 's#COMMAND = "pass"#COMMAND = "${pass}/bin/pass"#' src/passff.py
+    sed -i 's#COMMAND = "pass"#COMMAND = "${lib.getExe pass}"#' src/passff.py
   '';
 
   installPhase = ''

--- a/pkgs/tools/system/cron/default.nix
+++ b/pkgs/tools/system/cron/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     #define _PATH_SENDMAIL "${sendmailPath}"
 
     #undef _PATH_VI
-    #define _PATH_VI "${vim}/bin/vim"
+    #define _PATH_VI "${lib.getExe vim}"
 
     #undef _PATH_DEFPATH
     #define _PATH_DEFPATH "/run/wrappers/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/usr/bin:/bin"

--- a/pkgs/tools/text/bashblog/default.nix
+++ b/pkgs/tools/text/bashblog/default.nix
@@ -14,7 +14,7 @@ let
   # As bashblog supports various markdown processors
   # we can set flags to enable a certain processor
   markdownpl_path = "${perlPackages.TextMarkdown}/bin/Markdown.pl";
-  pandoc_path = "${pandoc}/bin/pandoc";
+  pandoc_path = "${lib.getExe pandoc}";
 
 in stdenv.mkDerivation {
   pname = "bashblog";

--- a/pkgs/tools/text/bashblog/default.nix
+++ b/pkgs/tools/text/bashblog/default.nix
@@ -14,7 +14,7 @@ let
   # As bashblog supports various markdown processors
   # we can set flags to enable a certain processor
   markdownpl_path = "${perlPackages.TextMarkdown}/bin/Markdown.pl";
-  pandoc_path = "${lib.getExe pandoc}";
+  pandoc_path = lib.getExe pandoc;
 
 in stdenv.mkDerivation {
   pname = "bashblog";

--- a/pkgs/tools/text/goawk/default.nix
+++ b/pkgs/tools/text/goawk/default.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
 
   checkFlags = [
     "-awk"
-    "${gawk}/bin/gawk"
+    "${lib.getExe gawk}"
   ];
 
   doCheck = (stdenv.system != "aarch64-darwin");

--- a/pkgs/tools/text/groff/default.nix
+++ b/pkgs/tools/text/groff/default.nix
@@ -41,8 +41,8 @@ stdenv.mkDerivation rec {
       --replace "@PNMTOPS_NOSETPAGE@" "${lib.getBin netpbm}/bin/pnmtops -nosetpage"
   '' + lib.optionalString (enableGhostscript || enableHtml) ''
     substituteInPlace contrib/pdfmark/pdfroff.sh \
-      --replace '$GROFF_GHOSTSCRIPT_INTERPRETER' "${lib.getBin ghostscript}/bin/gs" \
-      --replace '$GROFF_AWK_INTERPRETER' "${lib.getBin gawk}/bin/gawk"
+      --replace '$GROFF_GHOSTSCRIPT_INTERPRETER' "${lib.getExe ghostscript}" \
+      --replace '$GROFF_AWK_INTERPRETER' "${lib.getExe gawk}"
   '';
 
   strictDeps = true;

--- a/pkgs/tools/text/wgetpaste/default.nix
+++ b/pkgs/tools/text/wgetpaste/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   # currently zsh-autocompletion support is not installed
 
   prePatch = ''
-    substituteInPlace wgetpaste --replace "/usr/bin/env bash" "${bash}/bin/bash"
+    substituteInPlace wgetpaste --replace "/usr/bin/env bash" "${lib.getExe bash}"
     substituteInPlace wgetpaste --replace "LC_ALL=C wget" "LC_ALL=C ${wget}/bin/wget"
   '';
 

--- a/pkgs/tools/typesetting/pdfchain/default.nix
+++ b/pkgs/tools/typesetting/pdfchain/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace src/constant.h \
-        --replace '"pdftk"' '"${pdftk}/bin/pdftk"' \
+        --replace '"pdftk"' '"${lib.getExe pdftk}"' \
         --replace "/usr/share" "$out/share"
   '';
 

--- a/pkgs/tools/typesetting/ps2eps/default.nix
+++ b/pkgs/tools/typesetting/ps2eps/default.nix
@@ -20,7 +20,7 @@ perlPackages.buildPerlPackage rec {
   patches = [
     (substituteAll {
       src = ./hardcode-deps.patch;
-      gs = "${ghostscript}/bin/gs";
+      gs = "${lib.getExe ghostscript}";
       # bbox cannot be substituted here because substituteAll doesn't know what
       # will be the $out path of the main derivation
     })

--- a/pkgs/tools/typesetting/ps2eps/default.nix
+++ b/pkgs/tools/typesetting/ps2eps/default.nix
@@ -20,7 +20,7 @@ perlPackages.buildPerlPackage rec {
   patches = [
     (substituteAll {
       src = ./hardcode-deps.patch;
-      gs = "${lib.getExe ghostscript}";
+      gs = lib.getExe ghostscript;
       # bbox cannot be substituted here because substituteAll doesn't know what
       # will be the $out path of the main derivation
     })

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -378,7 +378,7 @@ dvipng = stdenv.mkDerivation {
   configureFlags = common.configureFlags
     ++ [ "--with-system-kpathsea" "--with-gs=yes" "--disable-debug" ];
 
-  GS="${ghostscript}/bin/gs";
+  GS="${lib.getExe ghostscript}";
 
   enableParallelBuilding = true;
 };

--- a/pkgs/tools/typesetting/xmlroff/default.nix
+++ b/pkgs/tools/typesetting/xmlroff/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   ];
 
   preBuild = ''
-    substituteInPlace tools/insert-file-as-string.pl --replace "/usr/bin/perl" "${perl}/bin/perl"
+    substituteInPlace tools/insert-file-as-string.pl --replace "/usr/bin/perl" "${lib.getExe perl}"
     substituteInPlace Makefile --replace "docs" ""  # docs target wants to download from network
   '';
 

--- a/pkgs/tools/typesetting/xmlto/default.nix
+++ b/pkgs/tools/typesetting/xmlto/default.nix
@@ -47,12 +47,12 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs xmlif/test/run-test
 
     substituteInPlace "xmlto.in" \
-      --replace-fail "@BASH@" "${bash}/bin/bash" \
-      --replace-fail "@FIND@" "${findutils}/bin/find" \
-      --replace-fail "@GETOPT@" "${getopt}/bin/getopt" \
-      --replace-fail "@GREP@" "${gnugrep}/bin/grep" \
+      --replace-fail "@BASH@" "${lib.getExe bash}" \
+      --replace-fail "@FIND@" "${lib.getExe findutils}" \
+      --replace-fail "@GETOPT@" "${lib.getExe getopt}" \
+      --replace-fail "@GREP@" "${lib.getExe gnugrep}" \
       --replace-fail "@MKTEMP@" "$(type -P mktemp)" \
-      --replace-fail "@SED@" "${gnused}/bin/sed" \
+      --replace-fail "@SED@" "${lib.getExe gnused}" \
       --replace-fail "@TAIL@" "${coreutils}/bin/tail"
 
     for f in format/docbook/* xmlto.in; do

--- a/pkgs/tools/virtualization/google-compute-engine/default.nix
+++ b/pkgs/tools/virtualization/google-compute-engine/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     for file in $(find google_compute_engine -type f); do
       substituteInPlace "$file" \
         --replace /bin/systemctl "/run/current-system/systemd/bin/systemctl" \
-        --replace /bin/bash "${bashInteractive}/bin/bash" \
+        --replace /bin/bash "${lib.getExe bashInteractive}" \
         --replace /sbin/hwclock "${util-linux}/bin/hwclock"
       # SELinux tool ???  /sbin/restorecon
     done

--- a/pkgs/tools/virtualization/google-guest-configs/default.nix
+++ b/pkgs/tools/virtualization/google-guest-configs/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substitute ${./fix-paths.patch} fix-paths.patch \
       --subst-var out \
-      --subst-var-by nvme "${nvme-cli}/bin/nvme" \
+      --subst-var-by nvme "${lib.getExe nvme-cli}" \
       --subst-var-by sh "${stdenv.shell}" \
       --subst-var-by umount "${util-linux}/bin/umount" \
       --subst-var-by logger "${util-linux}/bin/logger"

--- a/pkgs/tools/wayland/wl-color-picker/default.nix
+++ b/pkgs/tools/wayland/wl-color-picker/default.nix
@@ -28,10 +28,10 @@ stdenv.mkDerivation rec {
   patchPhase = ''
     substituteInPlace Makefile \
       --replace 'which' 'ls' \
-      --replace 'grim' "${grim}/bin/grim" \
-      --replace 'slurp' "${slurp}/bin/slurp" \
+      --replace 'grim' "${lib.getExe grim}" \
+      --replace 'slurp' "${lib.getExe slurp}" \
       --replace 'convert' "${imagemagick}/bin/convert" \
-      --replace 'zenity' "${gnome.zenity}/bin/zenity" \
+      --replace 'zenity' "${lib.getExe gnome.zenity}" \
       --replace 'wl-copy' "${wl-clipboard}/bin/wl-copy"
   '';
 


### PR DESCRIPTION
## Description of changes

Made with

```shell
if test ! -f packages.json; then
  nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f ./. -qaP --json --meta --show-trace --no-allow-import-from-derivation > packages.json
fi

jq <packages.json '
    to_entries[]
    | {attr: .key, exe: .value.meta.mainProgram}
    | select(.exe == null|not)
' -c |
while read line; do
    attr="$(jq <<<"$line" .attr -r)"
    exe="$(jq <<<"$line" .exe -r)"
    echo| ( set -x
        rg -F "\"\${$attr}/bin/$exe\"" -tnix -l pkgs/ | xe sd -F "\"\${$attr}/bin/$exe\"" "\"\${lib.getExe $attr}\""
        rg -F "\"\${lib.getBin $attr}/bin/$exe\"" -tnix -l pkgs/ | xe sd -F "\"\${lib.getBin $attr}/bin/$exe\"" "\"\${lib.getExe $attr}\""
    )
done
```

and reviewed with `git add --patch`.

Should cause zero rebuilds

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
