### PR TITLE
grafana-alloy: add NixOS module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -834,6 +834,7 @@
   ./services/misc/zoneminder.nix
   ./services/misc/zookeeper.nix
   ./services/monitoring/alerta.nix
+  ./services/monitoring/alloy.nix
   ./services/monitoring/apcupsd.nix
   ./services/monitoring/arbtt.nix
   ./services/monitoring/below.nix

--- a/nixos/modules/services/monitoring/alloy.nix
+++ b/nixos/modules/services/monitoring/alloy.nix
@@ -5,7 +5,7 @@ let
 in
 {
   meta = {
-    maintainers = with maintainers; [ flokli ];
+    maintainers = with maintainers; [ flokli hbjydev ];
   };
 
   options.services.alloy = {

--- a/nixos/modules/services/monitoring/alloy.nix
+++ b/nixos/modules/services/monitoring/alloy.nix
@@ -1,0 +1,80 @@
+{ lib, pkgs, config, ... }:
+with lib;
+let
+  cfg = config.services.alloy;
+in
+{
+  meta = {
+    maintainers = with maintainers; [ flokli ];
+  };
+
+  options.services.alloy = {
+    enable = mkEnableOption "Grafana Alloy";
+
+    package = mkPackageOption pkgs "grafana-alloy" { };
+
+    configPath = mkOption {
+      type = lib.types.path;
+      default = "/etc/alloy";
+      description = ''
+        Alloy configuration file/directory path.
+
+        We default to `/etc/alloy` here, and expect the user to configure a
+        configuration file via `environment.etc."alloy/config.alloy"`.
+
+        This allows config reload, contrary to specifying a store path.
+        A `reloadTrigger` for `config.alloy` is configured.
+
+        Other `*.alloy` files in the same directory (ignoring subdirs) are also
+        honored, but it's necessary to manually extend
+        `systemd.services.alloy.reloadTriggers` to enable config reload
+        during nixos-rebuild switch.
+
+        This can also point to another directory containing `*.alloy` files, or
+        a single Alloy file in the Nix store (at the cost of reload).
+
+        Component names must be unique across all Alloy configuration files, and
+        configuration blocks must not be repeated.
+
+        Alloy will continue to run if subsequent reloads of the configuration
+        file fail, potentially marking components as unhealthy depending on
+        the nature of the failure. When this happens, Alloy will continue
+        functioning in the last valid state.
+      '';
+    };
+
+    extraFlags = mkOption {
+      type = with lib.types; listOf str;
+      default = [ ];
+      example = [ "--server.http.listen-addr=127.0.0.1:12346" "--disable-reporting" ];
+      description = ''
+        Extra command-line flags passed to {command}`alloy run`.
+
+        See <https://grafana.com/docs/alloy/latest/reference/cli/run/>
+      '';
+    };
+  };
+
+
+  config = mkIf cfg.enable {
+    systemd.services.alloy = {
+      wantedBy = [ "multi-user.target" ];
+      reloadTriggers = [ config.environment.etc."alloy/config.alloy".source or null ];
+      serviceConfig = {
+        Restart = "always";
+        DynamicUser = true;
+        RestartSec = 2;
+        SupplementaryGroups = [
+          # allow to read the systemd journal for loki log forwarding
+          "systemd-journal"
+        ];
+        ExecStart = "${lib.getExe cfg.package} run ${cfg.configPath} ${escapeShellArgs cfg.extraFlags}";
+        ExecReload = "${pkgs.coreutils}/bin/kill -SIGHUP $MAINPID";
+        ConfigurationDirectory = "alloy";
+        StateDirectory = "alloy";
+        WorkingDirectory = "%S/alloy";
+        Type = "simple";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -115,6 +115,7 @@ in {
   akkoma = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./akkoma.nix {};
   akkoma-confined = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./akkoma.nix { confined = true; };
   alice-lg = handleTest ./alice-lg.nix {};
+  alloy = handleTest ./alloy.nix {};
   allTerminfo = handleTest ./all-terminfo.nix {};
   alps = handleTest ./alps.nix {};
   amazon-init-shell = handleTest ./amazon-init-shell.nix {};

--- a/nixos/tests/alloy.nix
+++ b/nixos/tests/alloy.nix
@@ -1,0 +1,32 @@
+import ./make-test-python.nix ({ lib, pkgs, ... }:
+
+  let
+    nodes = {
+      machine = {
+        services.alloy = {
+          enable = true;
+        };
+        environment.etc."alloy/config.alloy".text = "";
+      };
+    };
+  in
+  {
+    name = "alloy";
+
+    meta = with lib.maintainers; {
+      maintainers = [ flokli ];
+    };
+
+    inherit nodes;
+
+    testScript = ''
+      start_all()
+
+      machine.wait_for_unit("alloy.service")
+      machine.wait_for_open_port(12345)
+      machine.succeed(
+          "curl -sSfN http://127.0.0.1:12345/-/healthy"
+      )
+      machine.shutdown()
+    '';
+  })

--- a/nixos/tests/alloy.nix
+++ b/nixos/tests/alloy.nix
@@ -14,7 +14,7 @@ import ./make-test-python.nix ({ lib, pkgs, ... }:
     name = "alloy";
 
     meta = with lib.maintainers; {
-      maintainers = [ flokli ];
+      maintainers = [ flokli hbjydev ];
     };
 
     inherit nodes;

--- a/pkgs/by-name/gr/grafana-alloy/package.nix
+++ b/pkgs/by-name/gr/grafana-alloy/package.nix
@@ -121,7 +121,7 @@ buildGoModule rec {
     mainProgram = "alloy";
     license = licenses.asl20;
     homepage = "https://grafana.com/oss/alloy";
-    maintainers = with maintainers; [ flokli emilylange ];
+    maintainers = with maintainers; [ flokli emilylange hbjydev ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/gr/grafana-alloy/package.nix
+++ b/pkgs/by-name/gr/grafana-alloy/package.nix
@@ -8,6 +8,7 @@
 , fixup-yarn-lock
 , nodejs
 , grafana-alloy
+, nixosTests
 , nix-update-script
 , installShellFiles
 , testers
@@ -103,6 +104,7 @@ buildGoModule rec {
 
   passthru = {
     tests = {
+      inherit (nixosTests) alloy;
       version = testers.testVersion {
         version = "v${version}";
         command = "${lib.getExe grafana-alloy} --version";


### PR DESCRIPTION
cc @vunso @hbjydev @claudiiii 

## Description of changes

    This adds a NixOS module for grafana-alloy.
    
    I started from the grafana-agent, one but dropped all settings and
    config management whatsoever.
    
    grafana-alloy uses its own Alloy config format (similar to HCL), which
    is not really possible to express in Nix.
    Simply pointing to a path in `/etc`, and leaving it up to the user to configure
    it via `environment.etc` allows the user to arrange config files however
    it makes most sense for them.

    It also adds a VM test, ensuring it starts up healthy (with empty config),
    and adds it to the package passthru.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
