### PR TITLE
(23.11) openssl_3: 3.0.13 -> 3.0.14; openssl_3_1: 3.1.5 -> 3.1.6

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -280,8 +280,8 @@ in {
   };
 
   openssl_3_1 = common {
-    version = "3.1.5";
-    hash = "sha256-auAVRn2r8EabE5rakzGTJ74kuYJR/67O2gIhhI3AkmI=";
+    version = "3.1.6";
+    hash = "sha256-XSvkA2tHjvPLCoVMqbNTByw6DibYpW+PCrn7btMtONc=";
 
     patches = [
       ./3.0/nix-ssl-cert-file.patch

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -257,8 +257,8 @@ in {
   };
 
   openssl_3 = common {
-    version = "3.0.13";
-    hash = "sha256-iFJXU/edO+wn0vp8ZqoLkrOqlJja/ZPXz6SzeAza4xM=";
+    version = "3.0.14";
+    hash = "sha256-7soDXU3U6E/CWEbZUtpil0hK+gZQpvhMaC453zpBI8o=";
 
     patches = [
       ./3.0/nix-ssl-cert-file.patch


### PR DESCRIPTION
## Description of changes

### openssl_3: 3.0.13 -> 3.0.14

Changelog: https://github.com/openssl/openssl/blob/openssl-3.0/CHANGES.md#changes-between-3013-and-3014-4-jun-2024

CVEs fixed:
- Fixed potential use after free after SSL_free_buffers() is called.
  (CVE-2024-4741)
- Fixed an issue where checking excessively long DSA keys or parameters may be very slow.
  (CVE-2024-4603)
- Fixed an issue where some non-default TLS server configurations can cause unbounded
  memory growth when processing TLSv1.3 sessions. An attacker may exploit certain
  server configurations to trigger unbounded memory growth that would lead to a
  Denial of Service.
  (CVE-2024-2511)

### openssl_3_1: 3.1.5 -> 3.1.6

Changelog: https://github.com/openssl/openssl/blob/openssl-3.1/CHANGES.md#changes-between-315-and-316-4-jun-2024

CVEs fixed:
- Fixed potential use after free after SSL_free_buffers() is called.
  (CVE-2024-4741)
- Fixed an issue where checking excessively long DSA keys or parameters may be very slow.
  (CVE-2024-4603)
- Fixed an issue where some non-default TLS server configurations can cause unbounded
  memory growth when processing TLSv1.3 sessions. An attacker may exploit certain
  server configurations to trigger unbounded memory growth that would lead to a
  Denial of Service.
  (CVE-2024-2511)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
