### PR TITLE
gnomeExtensions.easyScreenCast: 1.7.1 -> 1.9.0

### DIFF
--- a/pkgs/desktops/gnome/extensions/EasyScreenCast/default.nix
+++ b/pkgs/desktops/gnome/extensions/EasyScreenCast/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-shell-extension-EasyScreenCast";
-  version = "1.7.1";
+  version = "1.9.0";
 
   src = fetchFromGitHub {
     owner = "EasyScreenCast";
     repo = "EasyScreenCast";
     rev = finalAttrs.version;
-    hash = "sha256-G7wdRFA0qL+6inVRLAmKoP0E0IOyvlmQIUwbDv/DbLI=";
+    hash = "sha256-rRRMFAdWseTxW6W194TE3yNlnpPX7gLViLPLQW6zuSI=";
   };
 
   patches = [
@@ -32,6 +32,5 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ doronbehar ];
     platforms = platforms.linux;
-    broken = true;
   };
 })

--- a/pkgs/desktops/gnome/extensions/EasyScreenCast/fix-gi-path.patch
+++ b/pkgs/desktops/gnome/extensions/EasyScreenCast/fix-gi-path.patch
@@ -1,19 +1,32 @@
-diff --git a/prefs.js b/prefs.js
-index 97b85a3..2fc6539 100644
---- a/prefs.js
-+++ b/prefs.js
-@@ -14,8 +14,8 @@
+diff --git i/extension.js w/extension.js
+index c151057..1b6dfc3 100644
+--- i/extension.js
++++ w/extension.js
+@@ -717,7 +717,7 @@ const EasyScreenCastIndicator = GObject.registerClass({
+             Lib.TalkativeLog('-*-execute post command');
+ 
+             // launch cmd after registration
+-            const tmpCmd = `/usr/bin/sh -c "${this._settings.getOption('s', Settings.POST_CMD_SETTING_KEY)}"`;
++            const tmpCmd = `/bin/sh -c "${this._settings.getOption('s', Settings.POST_CMD_SETTING_KEY)}"`;
+ 
+             const mapObj = {
+                 _fpath: pathFile,
+diff --git i/prefs.js w/prefs.js
+index e0dd1a2..9dcb87a 100644
+--- i/prefs.js
++++ w/prefs.js
+@@ -13,8 +13,8 @@
  'use strict';
  
- const GIRepository = imports.gi.GIRepository;
+ import GIRepository from 'gi://GIRepository';
 -GIRepository.Repository.prepend_search_path('/usr/lib64/gnome-shell');
 -GIRepository.Repository.prepend_library_path('/usr/lib64/gnome-shell');
 +GIRepository.Repository.prepend_search_path('@gnomeShell@/lib/gnome-shell');
 +GIRepository.Repository.prepend_library_path('@gnomeShell@/lib/gnome-shell');
  
- const GObject = imports.gi.GObject;
- const Gio = imports.gi.Gio;
-@@ -746,7 +746,7 @@ const EasyScreenCastSettingsWidget = GObject.registerClass({
+ import Adw from 'gi://Adw';
+ import GObject from 'gi://GObject';
+@@ -713,7 +713,7 @@ const EasyScreenCastSettingsWidget = GObject.registerClass({
                  Lib.TalkativeLog('-^-NOT SET xdg-user video');
  
                  ctx.CtrlExe.Execute(
@@ -22,19 +35,29 @@ index 97b85a3..2fc6539 100644
                      true,
                      (success, out) => {
                          Lib.TalkativeLog(`-^-CALLBACK sync S: ${success} out: ${out}`);
-diff --git a/utilaudio.js b/utilaudio.js
-index 957eda2..84af241 100644
---- a/utilaudio.js
-+++ b/utilaudio.js
-@@ -15,10 +15,7 @@
+@@ -883,7 +883,7 @@ const EasyScreenCastSettingsWidget = GObject.registerClass({
+                 );
  
- const GObject = imports.gi.GObject;
- const GIRepository = imports.gi.GIRepository;
+                 ctx.CtrlExe.Execute(
+-                    'journalctl /usr/bin/gnome-shell --since "15 min ago" --output=cat --no-pager',
++                    'journalctl @gnomeShell@/bin/.gnome-shell-wrapped --since "15 min ago" --output=cat --no-pager',
+                     false,
+                     success => {
+                         Lib.TalkativeLog(`-^-CALLBACK async S= ${success}`);
+diff --git i/utilaudio.js w/utilaudio.js
+index b07e181..ed7d3ba 100644
+--- i/utilaudio.js
++++ w/utilaudio.js
+@@ -14,10 +14,8 @@
+ 
+ import GObject from 'gi://GObject';
+ import GIRepository from 'gi://GIRepository';
 -GIRepository.Repository.prepend_search_path('/usr/lib/gnome-shell');
 -GIRepository.Repository.prepend_library_path('/usr/lib/gnome-shell');
 -GIRepository.Repository.prepend_search_path('/usr/lib64/gnome-shell');
 -GIRepository.Repository.prepend_library_path('/usr/lib64/gnome-shell');
-+GIRepository.Repository.prepend_search_path("@gnomeShell@/lib/gnome-shell");
- const Gvc = imports.gi.Gvc;
++GIRepository.Repository.prepend_search_path('@gnomeShell@/lib/gnome-shell');
++GIRepository.Repository.prepend_library_path('@gnomeShell@/lib/gnome-shell');
+ import Gvc from 'gi://Gvc';
  
- const ExtensionUtils = imports.misc.extensionUtils;
+ import * as Lib from './convenience.js';


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
