### PR TITLE
nixos/vaultwarden: backup all rsa_keys

### DIFF
--- a/nixos/modules/services/security/vaultwarden/backup.sh
+++ b/nixos/modules/services/security/vaultwarden/backup.sh
@@ -1,17 +1,21 @@
 #!/usr/bin/env bash
 
+# Allow use of !() when copying to not copy certain files
+shopt -s extglob
+
 # Based on: https://github.com/dani-garcia/vaultwarden/wiki/Backing-up-your-vault
 if [ ! -d "$BACKUP_FOLDER" ]; then
   echo "Backup folder '$BACKUP_FOLDER' does not exist" >&2
   exit 1
 fi
 
-if [[ ! -f "$DATA_FOLDER"/db.sqlite3 ]]; then
-  echo "Could not find SQLite database file '$DATA_FOLDER/db.sqlite3'" >&2
-  exit 1
+if [[ -f "$DATA_FOLDER"/db.sqlite3 ]]; then
+  sqlite3 "$DATA_FOLDER"/db.sqlite3 ".backup '$BACKUP_FOLDER/db.sqlite3'"
 fi
 
-sqlite3 "$DATA_FOLDER"/db.sqlite3 ".backup '$BACKUP_FOLDER/db.sqlite3'"
-cp "$DATA_FOLDER"/rsa_key.{der,pem,pub.der} "$BACKUP_FOLDER"
-cp -r "$DATA_FOLDER"/attachments "$BACKUP_FOLDER"
-cp -r "$DATA_FOLDER"/icon_cache "$BACKUP_FOLDER"
+if [ ! -d "$DATA_FOLDER" ]; then
+  echo "No data folder (yet). This will happen on first launch if backup is triggered before vaultwarden has started."
+  exit 0
+fi
+
+cp -r "$DATA_FOLDER"/!(db.*) "$BACKUP_FOLDER"/

--- a/nixos/tests/vaultwarden.nix
+++ b/nixos/tests/vaultwarden.nix
@@ -205,6 +205,10 @@ builtins.mapAttrs (k: v: makeVaultwardenTest k v) {
           server.succeed('[ -d "/var/lib/vaultwarden/backups" ]')
           server.succeed('[ -f "/var/lib/vaultwarden/backups/db.sqlite3" ]')
           server.succeed('[ -d "/var/lib/vaultwarden/backups/attachments" ]')
+          server.succeed('[ -f "/var/lib/vaultwarden/backups/rsa_key.pem" ]')
+          server.succeed('[ -f "/var/lib/vaultwarden/backups/rsa_key.pub.pem" ]')
+          # Ensure only the db backed up with the backup command exists and not the other db files.
+          server.succeed('[ ! -f "/var/lib/vaultwarden/backups/db.sqlite3-shm" ]')
     '';
   };
 }


### PR DESCRIPTION
The official documentation mentions rsa_key* as what should be backed up (https://github.com/dani-garcia/vaultwarden/wiki/Backing-up-your-vault#the-rsa_key-files). My particular install has rsa_key.pem and rsa_key.pub.pem so the existing command fails when trying to copy rsa_key.der. This change better aligns with the official documentation.

## Description of changes

This is a simple change to just copy all rsa_key.* files instead of specific extensions. This commit to vaultwarden actually removed the use of .der files: https://github.com/dani-garcia/vaultwarden/commit/46e0f3c43a81ce9411612c152e414162a9c220ac

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
