### PR TITLE
openipmi: enable compile with openssl

### DIFF
--- a/pkgs/tools/system/openipmi/default.nix
+++ b/pkgs/tools/system/openipmi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, popt, ncurses, python3, readline, lib }:
+{ stdenv, fetchurl, popt, ncurses, python3, readline, lib, openssl }:
 
 stdenv.mkDerivation rec {
   pname = "OpenIPMI";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-sFkRT2KZ1z8E/252oIV6Crgao2Le6ZZE0layI4ckN60=";
   };
 
-  buildInputs = [ ncurses popt python3 readline ];
+  buildInputs = [ ncurses popt python3 readline openssl ];
 
   outputs = [ "out" "lib" "dev" "man" ];
 


### PR DESCRIPTION
## Description of changes

`openipmi` must be compiled with `openssl` to use encrypted connection to an IPMI host. Specifically `zabbix` cannot connect to remote IPMI devices without it. 

>By default OpenIPMI is compiled with OpenSSL enabled which enables working with any privilege level: "callback" (1), >"user" (2), "operator" (3), or "admin" (4).
>
>Unfortunately Debian (and Ubuntu) OpenIPMI packages are compiled with ssl turned off which leads to only one >available privilege level - “callback”. This is the explanation by Debian package maintainer Noèl Köthe:
>
><noel> http://www.openssl.org/support/faq.html#LEGAL2
><noel> https://en.wikipedia.org/wiki/OpenSSL#Licensing
>
>The solution is recompiling OpenIPMI library with openssl enabled.

[Source](https://support.zabbix.com/browse/ZBX-6139)

So this PR adds `openssl` support


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
