### PR TITLE
syshud: init at 0-unstable-2024-06-20

### DIFF
--- a/pkgs/by-name/sy/syshud/package.nix
+++ b/pkgs/by-name/sy/syshud/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gtk4-layer-shell,
+  gtkmm4,
+  nix-update-script,
+  pkg-config,
+  wireplumber,
+  wrapGAppsHook4,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "syshud";
+  version = "0-unstable-2024-06-20";
+
+  src = fetchFromGitHub {
+    owner = "System64fumo";
+    repo = "syshud";
+    rev = "2b97f3441970efe67c788a8313eb58182aa7965b";
+    hash = "sha256-XPAKjBLaTGEyDgiZT8tYinYzMivOocOEeauzR4leOjI=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail 'pkg-config' ''${PKG_CONFIG}
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gtk4-layer-shell
+    gtkmm4
+    wireplumber
+  ];
+
+  makeFlags = [
+    "DESTDIR=${placeholder "out"}"
+  ];
+
+  # populate version info used by `syshud -v`:
+  configurePhase = ''
+    runHook preConfigure
+
+    echo '#define GIT_COMMIT_MESSAGE "${finalAttrs.src.rev}"' >> src/git_info.hpp
+    echo '#define GIT_COMMIT_DATE "${lib.removePrefix "0-unstable-" finalAttrs.version}"' >> src/git_info.hpp
+
+    runHook postConfigure
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version" "branch" ];
+  };
+
+  meta = {
+    description = "simple heads up display written in gtkmm 4";
+    mainProgram = "syshud";
+    homepage = "https://github.com/System64fumo/syshud";
+    license = lib.licenses.wtfpl;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ colinsane ];
+  };
+})


### PR DESCRIPTION
## Description of changes

[syshud](https://github.com/System64fumo/syshud) (formerly known as "sysvol") is a GTK4 volume indicator, similar to packages like `wob`, `avizo`, or `swayosd`. built for wayland and pipewire (or pulse -- if you pass `PULSEAUDIO=1` to makeFlags -- but it can only be built for one or the other). `nix-build -A syshud` and run the binary, then adjust the system volume externally, and you should see an overlay like as shown on the project's readme.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
