### PR TITLE
python3Packages.momepy: init at 0.7.0

### DIFF
--- a/pkgs/development/python-modules/inequality/default.nix
+++ b/pkgs/development/python-modules/inequality/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  pythonOlder,
+
+  libpysal,
+  numpy,
+  scipy,
+  setuptools-scm,
+}:
+
+buildPythonPackage rec {
+  pname = "inequality";
+  version = "1.0.1";
+  pyproject = true;
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "pysal";
+    repo = "inequality";
+    rev = "v${version}";
+    hash = "sha256-dy1/KXnmIh5LnTxuyYfIvtt1p2CIpNQ970o5pTg6diQ=";
+  };
+
+  build-system = [ setuptools-scm ];
+
+  propagatedBuildInputs = [
+    libpysal
+    numpy
+    scipy
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "inequality" ];
+
+  meta = {
+    description = "Spatial inequality analysis";
+    homepage = "https://github.com/pysal/inequality";
+    license = lib.licenses.bsd3;
+    maintainers = lib.teams.geospatial.members;
+  };
+}

--- a/pkgs/development/python-modules/momepy/default.nix
+++ b/pkgs/development/python-modules/momepy/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  pythonOlder,
+
+  geopandas,
+  inequality,
+  libpysal,
+  mapclassify,
+  networkx,
+  packaging,
+  pandas,
+  setuptools-scm,
+  shapely,
+  tqdm,
+}:
+
+buildPythonPackage rec {
+  pname = "momepy";
+  version = "0.7.0";
+  pyproject = true;
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "pysal";
+    repo = "momepy";
+    rev = "v${version}";
+    hash = "sha256-HVp2a0z+5fbfkNSxnTfZPCgG2SJMlKX/zso14M18mCk=";
+  };
+
+  build-system = [ setuptools-scm ];
+
+  propagatedBuildInputs = [
+    geopandas
+    inequality
+    libpysal
+    mapclassify
+    networkx
+    packaging
+    pandas
+    shapely
+    tqdm
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "momepy" ];
+
+  meta = {
+    description = "Urban Morphology Measuring Toolkit";
+    homepage = "https://github.com/pysal/momepy";
+    license = lib.licenses.bsd3;
+    maintainers = lib.teams.geospatial.members;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7677,6 +7677,8 @@ self: super: with self; {
 
   molecule-plugins = callPackage ../development/python-modules/molecule/plugins.nix { };
 
+  momepy = callPackage ../development/python-modules/momepy { };
+
   monai = callPackage ../development/python-modules/monai { };
 
   monai-deploy = callPackage ../development/python-modules/monai-deploy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5787,6 +5787,8 @@ self: super: with self; {
 
   indexed-zstd = callPackage ../development/python-modules/indexed-zstd { inherit (pkgs) zstd; };
 
+  inequality = callPackage ../development/python-modules/inequality { };
+
   infinity = callPackage ../development/python-modules/infinity { };
 
   inflect = callPackage ../development/python-modules/inflect { };


### PR DESCRIPTION
## Description of changes
**[momepy](https://github.com/pysal/momepy)** - Urban Morphology Measuring Toolkit, part of [PySAL (Python Spatial Analysis Library)](http://pysal.org/).

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
