### PR TITLE
duktape: use fixDarwinDylibNames to fix install_name

### DIFF
--- a/pkgs/development/interpreters/duktape/default.nix
+++ b/pkgs/development/interpreters/duktape/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, validatePkgConfig }:
+{ lib, stdenv, fetchurl, fixDarwinDylibNames, validatePkgConfig }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "duktape";
@@ -11,7 +11,8 @@ stdenv.mkDerivation (finalAttrs: {
   # https://github.com/svaarala/duktape/issues/2464
   LDFLAGS = [ "-lm" ];
 
-  nativeBuildInputs = [ validatePkgConfig ];
+  nativeBuildInputs = [ validatePkgConfig ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ fixDarwinDylibNames ];
 
   buildPhase = ''
     make -f Makefile.sharedlibrary


### PR DESCRIPTION
## Description of changes

The duktape libraries are not using full path when linking which prevents darwin consumers from locating the library at load time. Add fixDarwinDylibNames to patch LC_ID_DYLIB with the full path to the library.

testing: 
before:
```
dlopen(/nix/store/yg6c7wcvfs984fc1xphmkwq2y0p5albk-glib-networking-2.80.0/lib/gio/modules/libgiolibproxy.so, 5): Library not loaded: libduktape.207.so
  Referenced from: /nix/store/rxzwm0za8ikl3jzbk7n24k1zsxhkgsi4-libproxy-0.5.6/lib/libproxy/libpxbackend-1.0.dylib
  Reason: image not found
Failed to load module: /nix/store/yg6c7wcvfs984fc1xphmkwq2y0p5albk-glib-networking-2.80.0/lib/gio/modules/libgiolibproxy.so

$ otool -L /nix/store/rxzwm0za8ikl3jzbk7n24k1zsxhkgsi4-libproxy-0.5.6/lib/libproxy/libpxbackend-1.0.dylib
/nix/store/rxzwm0za8ikl3jzbk7n24k1zsxhkgsi4-libproxy-0.5.6/lib/libproxy/libpxbackend-1.0.dylib:
     [...]
        libduktape.207.so (compatibility version 0.0.0, current version 0.0.0)
```
after:
`ibgiolibproxy.so, 5` loads fine and can see that `libpxbackend` contains the 9path to libduktape
```
$ otool -L /nix/store/jlrnjfwdsq2a1r081vkv9nb7qjv7zncv-libproxy-0.5.6/lib/libproxy/libpxbackend-1.0.dylib
  [...]
  /nix/store/vsjzj639y444wmrpk70smcrcych8b473-duktape-2.7.0/lib/libduktape.207.20700.so (compatibility version 0.0.0, current version 0.0.0)
```




<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
