### PR TITLE
sympow: 2.023.6 → 2.023.7

### DIFF
--- a/pkgs/development/libraries/science/math/sympow/clean-extra-logfile-output-from-pari.patch
+++ b/pkgs/development/libraries/science/math/sympow/clean-extra-logfile-output-from-pari.patch
@@ -13,18 +13,18 @@ Date:   Tue Mar 2 22:07:11 2021 -0300
     mechanism already in sympow to trim this new message.
 
 diff --git a/Configure b/Configure
-index 1ef9756..776bec2 100755
+index 53b556e..53999ae 100755
 --- a/Configure
 +++ b/Configure
 @@ -322,7 +322,7 @@ echo "datafiles/param_data: \$(OTHERb)" >> $FILE
  echo "	\$(MKDIR) -p datafiles" >> $FILE
  echo "	\$(TOUCH) datafiles/param_data" >> $FILE
  echo "	\$(SH) armd.sh" >> $FILE
--echo "	\$(SED) -i -e '/logfile =/d' datafiles/*.txt" >> $FILE
+-echo "	\$(SED) -i -e '/logfile =/d'  datafiles/*.txt" >> $FILE
 +echo "	\$(SED) -i -e '/logfile /d' datafiles/*.txt" >> $FILE
+ echo "	\$(SED) -i -e '/logfile is/d' datafiles/*.txt" >> $FILE
  echo "sympow.1: sympow" >> $FILE
  echo "	\$(HELP2MAN) \$(H2MFLAGS) -s 1 -n \"SYMPOW program\" -I sympow.h2m -o \$@ ./\$<" >> $FILE
- echo "clean:" >> $FILE
 diff --git a/generate.c b/generate.c
 index dbb811f..783320c 100644
 --- a/generate.c

--- a/pkgs/development/libraries/science/math/sympow/default.nix
+++ b/pkgs/development/libraries/science/math/sympow/default.nix
@@ -1,16 +1,17 @@
-{ lib, stdenv
-, fetchFromGitLab
-, fetchpatch
-, makeWrapper
-, which
-, autoconf
-, help2man
-, file
-, pari
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  makeWrapper,
+  which,
+  autoconf,
+  help2man,
+  file,
+  pari,
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.023.6";
+  version = "2.023.7";
   pname = "sympow";
 
   src = fetchFromGitLab {
@@ -18,17 +19,10 @@ stdenv.mkDerivation rec {
     owner = "forks";
     repo = "sympow";
     rev = "v${version}";
-    sha256 = "132l0xv00ld1svvv9wh99wfra4zzjv2885h2sq0dsl98wiyvi5zl";
+    hash = "sha256-sex8gRiBdTcVMV3nSeiTYamAjPoXQdiiZwjRmeKA+mc=";
   };
 
-  patches = [
-    ./clean-extra-logfile-output-from-pari.patch
-    (fetchpatch {
-      name = "null-terminate-dupdirname.patch";
-      url = "https://gitlab.com/rezozer/forks/sympow/-/merge_requests/5.diff";
-      sha256 = "sha256-yKjio+qN9teL8L+mb7WOBN/iv545vRIxW20FJU37oO4=";
-    })
-  ];
+  patches = [ ./clean-extra-logfile-output-from-pari.patch ];
 
   postUnpack = ''
     patchShebangs .
@@ -66,12 +60,11 @@ stdenv.mkDerivation rec {
   # Example from the README as a sanity check.
   doInstallCheck = true;
   installCheckPhase = ''
-    export HOME="$TMP/home"
-    mkdir -p "$HOME"
+    export HOME=$TMPDIR
     "$out/bin/sympow" -sp 2p16 -curve "[1,2,3,4,5]" | grep '8.3705'
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Compute special values of symmetric power elliptic curve L-functions";
     mainProgram = "sympow";
     license = {
@@ -79,7 +72,7 @@ stdenv.mkDerivation rec {
       fullName = "Custom, BSD-like. See COPYING file.";
       free = true;
     };
-    maintainers = teams.sage.members;
-    platforms = platforms.linux;
+    maintainers = lib.teams.sage.members;
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
## Description of changes
https://gitlab.com/rezozer/forks/sympow/-/blob/master/HISTORY

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
