### PR TITLE
python311Packages.gradio: disable flaky tests on darwin

### DIFF
--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -187,20 +187,70 @@ buildPythonPackage rec {
 
     # tests if pip and other tools are installed
     "test_get_executable_path"
+  ] ++ lib.optionals stdenv.isDarwin [
+    # flaky on darwin (depend on port availability)
+    "test_all_status_messages"
+    "test_async_generators"
+    "test_async_generators_interface"
+    "test_async_iterator_update_with_new_component"
+    "test_concurrency_limits"
+    "test_default_concurrency_limits"
+    "test_default_flagging_callback"
+    "test_end_to_end"
+    "test_end_to_end_cache_examples"
+    "test_event_data"
+    "test_every_does_not_block_queue"
+    "test_example_caching_relaunch"
+    "test_example_caching_relaunch"
+    "test_exit_called_at_launch"
+    "test_file_component_uploads"
+    "test_files_saved_as_file_paths"
+    "test_flagging_does_not_create_unnecessary_directories"
+    "test_flagging_no_permission_error_with_flagging_disabled"
+    "test_info_and_warning_alerts"
+    "test_info_isolation"
+    "test_launch_analytics_does_not_error_with_invalid_blocks"
+    "test_no_empty_audio_files"
+    "test_no_empty_image_files"
+    "test_no_empty_video_files"
+    "test_non_streaming_api"
+    "test_non_streaming_api_async"
+    "test_pil_images_hashed"
+    "test_progress_bar"
+    "test_progress_bar_track_tqdm"
+    "test_queue_when_using_auth"
+    "test_restart_after_close"
+    "test_set_share_in_colab"
+    "test_show_error"
+    "test_simple_csv_flagging_callback"
+    "test_single_request"
+    "test_socket_reuse"
+    "test_start_server"
+    "test_state_holder_is_used_in_postprocess"
+    "test_state_stored_up_to_capacity"
+    "test_static_files_single_app"
+    "test_streaming_api"
+    "test_streaming_api_async"
+    "test_streaming_api_with_additional_inputs"
+    "test_sync_generators"
+    "test_time_to_live_and_delete_callback_for_state"
+    "test_updates_stored_up_to_capacity"
+    "test_varying_output_forms_with_generators"
   ];
   disabledTestPaths = [
     # 100% touches network
     "test/test_networking.py"
     # makes pytest freeze 50% of the time
     "test/test_interfaces.py"
+  ] ++ lib.optionals stdenv.isDarwin [
+    # Network-related tests that are flaky on darwin (depend on port availability)
+    "test/test_routes.py"
   ];
   pytestFlagsArray = [
     "-x" # abort on first failure
     "-m 'not flaky'"
     #"-W" "ignore" # uncomment for debugging help
   ];
-
-  __darwinAllowLocalNetworking = true;
 
   # check the binary works outside the build env
   doInstallCheck = true;


### PR DESCRIPTION
## Description of changes

```
OSError: Cannot find empty port in range: 7860-7959. You can specify a different port by setting the GRADIO_SERVER_PORT environment variable or passing the `server_port` parameter to `launch()`.
```
It does sometimes pass, but often fails, especially when ran within `nixpkgs-review`.

cc @pbsds 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
