### PR TITLE
refind: make the build reproducible

### DIFF
--- a/pkgs/tools/bootloaders/refind/default.nix
+++ b/pkgs/tools/bootloaders/refind/default.nix
@@ -34,6 +34,9 @@ stdenv.mkDerivation rec {
   patches = [
     # Removes hardcoded toolchain for aarch64, allowing successful aarch64 builds.
     ./0001-toolchain.patch
+    # Avoid leaking the build timestamp
+    # https://sourceforge.net/p/refind/code/merge-requests/53/
+    ./reproducible.patch
   ];
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/bootloaders/refind/reproducible.patch
+++ b/pkgs/tools/bootloaders/refind/reproducible.patch
@@ -1,0 +1,67 @@
+diff --git a/Makefile b/Makefile
+index 4d07160..4ae2a7d 100644
+--- a/Makefile
++++ b/Makefile
+@@ -150,9 +150,11 @@ edk2: build_edk2
+ 	cp $(EDK2_BUILDLOC)/refind.efi ./refind/refind_$(FILENAME_CODE).efi
+ 	cp $(EDK2_BUILDLOC)/gptsync.efi ./gptsync/gptsync_$(FILENAME_CODE).efi
+ ifneq ($(OMIT_SBAT), 1)
+-	$(OBJCOPY) --set-section-alignment '.sbat=512' --add-section .sbat=$(REFIND_SBAT_CSV) \
++	$(OBJCOPY) --preserve-dates --set-section-alignment '.sbat=512' \
++		--add-section .sbat=$(REFIND_SBAT_CSV) \
+ 		--adjust-section-vma .sbat+10000000 ./refind/refind_$(FILENAME_CODE).efi
+-	$(OBJCOPY) --set-section-alignment '.sbat=512' --add-section .sbat=$(REFIND_SBAT_CSV) \
++	$(OBJCOPY) --preserve-dates --set-section-alignment '.sbat=512' \
++		--add-section .sbat=$(REFIND_SBAT_CSV) \
+ 		--adjust-section-vma .sbat+10000000 ./gptsync/gptsync_$(FILENAME_CODE).efi
+ endif
+ 
+@@ -173,7 +175,8 @@ else
+ 	for BASENAME in $(EDK2_DRIVER_BASENAMES) ; do \
+ 		echo "Copying $$BASENAME""_$(FILENAME_CODE).efi" ; \
+ 		cp "$(EDK2_BUILDLOC)/$$BASENAME.efi" ./drivers_$(FILENAME_CODE)/$$BASENAME\_$(FILENAME_CODE).efi ; \
+-		$(OBJCOPY) --set-section-alignment '.sbat=512' --add-section .sbat=$(REFIND_SBAT_CSV) \
++		$(OBJCOPY) --preserve-dates --set-section-alignment '.sbat=512' \
++		    --add-section .sbat=$(REFIND_SBAT_CSV) \
+ 		    --adjust-section-vma .sbat+10000000 ./drivers_$(FILENAME_CODE)/$$BASENAME\_$(FILENAME_CODE).efi ; \
+ 	done
+ endif
+diff --git a/filesystems/Make.gnuefi b/filesystems/Make.gnuefi
+index 70e4ad6..2329659 100644
+--- a/filesystems/Make.gnuefi
++++ b/filesystems/Make.gnuefi
+@@ -38,7 +38,7 @@ $(TARGET): $(SHLIB_TARGET)
+ 	           -j .rel -j .rela -j .rel.* -j .rela.* -j .rel* -j .rela* \
+ 		   -j .reloc --strip-unneeded $(FORMAT_DRIVER) $< $@
+ ifneq ($(OMIT_SBAT), 1)
+-		   $(OBJCOPY) --add-section .sbat=$(SRCDIR)/../$(REFIND_SBAT_CSV) \
++		   $(OBJCOPY) --preserve-dates --add-section .sbat=$(SRCDIR)/../$(REFIND_SBAT_CSV) \
+ 		   --adjust-section-vma .sbat+10000000 $@
+ endif
+ 	chmod a-x $(TARGET)
+diff --git a/gptsync/Make.gnuefi b/gptsync/Make.gnuefi
+index b6c0763..49aff13 100644
+--- a/gptsync/Make.gnuefi
++++ b/gptsync/Make.gnuefi
+@@ -35,7 +35,7 @@ $(TARGET): $(SHLIB_TARGET)
+ 	           -j .rel -j .rela -j .rel.* -j .rela.* -j .rel* -j .rela* \
+ 		   -j .reloc --strip-unneeded  $(FORMAT) $< $@
+ ifneq ($(OMIT_SBAT), 1)
+-	$(OBJCOPY) --add-section .sbat=../$(REFIND_SBAT_CSV) \
++	$(OBJCOPY) --preserve-dates --add-section .sbat=../$(REFIND_SBAT_CSV) \
+ 		   --adjust-section-vma .sbat+10000000 $@
+ endif
+ 	chmod a-x $(TARGET)
+diff --git a/refind/Makefile b/refind/Makefile
+index 73be8e5..880bd22 100644
+--- a/refind/Makefile
++++ b/refind/Makefile
+@@ -54,7 +54,7 @@ $(TARGET): $(SHLIB_TARGET)
+ 		   -j .rel -j .rela -j .rel.* -j .rela.* -j .rel* -j .rela* \
+ 		   -j .reloc --strip-unneeded $(FORMAT) $< $@
+ ifneq ($(OMIT_SBAT), 1)
+-	    $(OBJCOPY) --add-section .sbat=$(SRCDIR)/../$(REFIND_SBAT_CSV) \
++	    $(OBJCOPY) --preserve-dates --add-section .sbat=$(SRCDIR)/../$(REFIND_SBAT_CSV) \
+ 		       --adjust-section-vma .sbat+10000000 $@
+ endif
+ 	chmod a-x $(TARGET)


### PR DESCRIPTION
## Description of changes

Avoid leaking build timestamps into the output.

/cc @AndersonTorres @samueldr @chewblacka 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
