### PR TITLE
_7zz: 24.05 → 24.06

### DIFF
--- a/pkgs/tools/archivers/7zz/default.nix
+++ b/pkgs/tools/archivers/7zz/default.nix
@@ -25,13 +25,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "7zz";
-  version = "24.05";
+  version = "24.06";
 
   src = fetchurl {
     url = "https://7-zip.org/a/7z${lib.replaceStrings [ "." ] [ "" ] finalAttrs.version}-src.tar.xz";
     hash = {
-      free = "sha256-yYq3IEV2GeDWwW6KrdpgK2/QOsmDcBpIZvbk6VKZETY=";
-      unfree = "sha256-Y/NBz4C40ofG6UVRmz2g+nVVPIVXKkcbf6bmj5qQt5A=";
+      free = "sha256-X3uqGnJGQpW5MOaTtgWYwwrhS84e+piX7Gc+e8Pll00=";
+      unfree = "sha256-KqFmDHc1JbLthNbNf/BoDHhuwIk7h+TbRGVNy39ayLU=";
     }.${if enableUnfree then "unfree" else "free"};
     downloadToTemp = (!enableUnfree);
     # remove the unRAR related code from the src drv

--- a/pkgs/tools/archivers/7zz/update.sh
+++ b/pkgs/tools/archivers/7zz/update.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p curl xq-xml nix-prefetch
+#! nix-shell -I nixpkgs=./. -i bash -p curl xq-xml nix-prefetch
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/pkgs/tools/archivers/7zz/update.sh
+++ b/pkgs/tools/archivers/7zz/update.sh
@@ -1,11 +1,8 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -I nixpkgs=./. -i bash -p curl xq-xml nix-prefetch
+#! nix-shell -I nixpkgs=./. -i bash -p curl xq-xml common-updater-scripts
 set -euo pipefail
-cd "$(dirname "${BASH_SOURCE[0]}")"
 
-DRV_DIR="$PWD"
-
-OLD_VERSION="$(sed -nE 's/\s*version = "(.*)".*/\1/p' ./default.nix)"
+OLD_VERSION="$(nix-instantiate --eval --json --expr 'let pkgs = import ./. {}; in pkgs._7zz.version' | sed 's/"//g')"
 NEW_VERSION="$(curl -H 'Accept: application/rss+xml' 'https://sourceforge.net/projects/sevenzip/rss?path=/7-Zip' | xq -x "substring((/rss/channel/item[link[contains(., 'src.tar.xz')]])[1]/title, 8, 5)")"
 
 echo "comparing versions $OLD_VERSION => $NEW_VERSION"
@@ -14,37 +11,5 @@ if [[ "$OLD_VERSION" == "$NEW_VERSION" ]]; then
     exit 0
 fi
 
-NIXPKGS_ROOT="$(realpath "$DRV_DIR/../../../..")"
-
-echo "getting free source hash"
-OLD_FREE_HASH="$(nix-instantiate --eval --strict -E "with import $NIXPKGS_ROOT {}; _7zz.src.drvAttrs.outputHash" | tr -d '"')"
-echo "getting unfree source hash"
-OLD_UNFREE_HASH="$(nix-instantiate --eval --strict -E "with import $NIXPKGS_ROOT {}; (_7zz.override { enableUnfree = true; }).src.drvAttrs.outputHash" | tr -d '"')"
-
-NEW_VERSION_FORMATTED="$(echo "$NEW_VERSION" | tr -d '.')"
-URL="https://7-zip.org/a/7z${NEW_VERSION_FORMATTED}-src.tar.xz"
-
-# `nix-prefetch` is broken without flakes
-# see https://github.com/msteen/nix-prefetch/issues/51
-NEW_FREE_HASH=$(nix-prefetch -f "$NIXPKGS_ROOT" -E "_7zz.src" --url "$URL" --option extra-experimental-features flakes)
-
-NEW_UNFREE_OUT=$(nix-prefetch -f "$NIXPKGS_ROOT" -E "(_7zz.override { enableUnfree = true; }).src" --url "$URL" --output raw --print-path --option extra-experimental-features flakes)
-# first line of raw output is the hash
-NEW_UNFREE_HASH="$(echo "$NEW_UNFREE_OUT" | sed -n 1p)"
-# second line of raw output is the src path
-NEW_UNFREE_SRC="$(echo "$NEW_UNFREE_OUT" | sed -n 2p)"
-# make sure to nuke the unfree src from the updater's machine
-# > the license requires that you agree to these use restrictions, or you must remove the software (source and binary) from your hard disks
-# https://fedoraproject.org/wiki/Licensing:Unrar
-nix-store --delete "$NEW_UNFREE_SRC"
-
-
-echo "updating version"
-sed -i "s/version = \"$OLD_VERSION\";/version = \"$NEW_VERSION\";/" "$DRV_DIR/default.nix"
-
-echo "updating free hash"
-sed -i "s@free = \"$OLD_FREE_HASH\";@free = \"$NEW_FREE_HASH\";@" "$DRV_DIR/default.nix"
-echo "updating unfree hash"
-sed -i "s@unfree = \"$OLD_UNFREE_HASH\";@unfree = \"$NEW_UNFREE_HASH\";@" "$DRV_DIR/default.nix"
-
-echo "done"
+update-source-version _7zz "$NEW_VERSION"
+update-source-version _7zz-rar "$NEW_VERSION" --ignore-same-version

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1473,6 +1473,7 @@ with pkgs;
   _6tunnel = callPackage ../tools/networking/6tunnel { };
 
   _7zz = darwin.apple_sdk_11_0.callPackage ../tools/archivers/7zz { };
+  _7zz-rar = _7zz.override { enableUnfree = true; };
 
   _9pfs = callPackage ../tools/filesystems/9pfs { };
 
@@ -11498,6 +11499,7 @@ with pkgs;
   };
 
   p7zip = callPackage ../tools/archivers/p7zip { };
+  p7zip-rar = p7zip.override { enableUnfree = true; };
 
   packagekit = callPackage ../tools/package-management/packagekit { };
 


### PR DESCRIPTION
## Description of changes

https://sourceforge.net/p/sevenzip/discussion/45797/thread/bbe6861abe/

Depends on https://github.com/NixOS/nixpkgs/pull/318589


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
