### PR TITLE
24.11 rename codeName to Vicuna

### DIFF
--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -403,7 +403,7 @@ in {
     On each release the first letter is bumped and a new animal is chosen
     starting with that new letter.
   */
-  codeName = "Vicuña";
+  codeName = "Vicuna";
 
   /**
     Returns the current nixpkgs version suffix as string.

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -1,4 +1,4 @@
-# Release 24.11 (“Vicuna”, 2024.11/??) {#sec-release-24.11}
+# Release 24.11 (“Vicuña”, 2024.11/??) {#sec-release-24.11}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -1,4 +1,4 @@
-# Release 24.11 (“Vicuña”, 2024.11/??) {#sec-release-24.11}
+# Release 24.11 (“Vicuna”, 2024.11/??) {#sec-release-24.11}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 


### PR DESCRIPTION
1. We need to keep code name simple and universal, not every culture know how to type ñ on their keyboard
2. Avoid unnecessary and potential trouble caused by unicode 
https://github.com/NixOS/nixpkgs/issues/315574  
3. According to wiki, vicuña is same as vicuna

>  The vicuña or vicuna is one of the two wild South American camelids, which live in the high alpine areas of the Andes, the other being the guanaco, which lives at lower elevations. [Wikipedia](https://en.wikipedia.org/wiki/Vicu%C3%B1a)