### PR TITLE
pantheon.elementary-shortcut-overlay: 2.0.1 -> 8.0.0

### DIFF
--- a/pkgs/desktops/pantheon/desktop/elementary-shortcut-overlay/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-shortcut-overlay/default.nix
@@ -7,22 +7,26 @@
 , ninja
 , vala
 , desktop-file-utils
+, gala
+, gsettings-desktop-schemas
 , gtk4
 , glib
+, gnome-settings-daemon
 , granite7
 , libgee
+, mutter
 , wrapGAppsHook4
 }:
 
 stdenv.mkDerivation rec {
   pname = "elementary-shortcut-overlay";
-  version = "2.0.1";
+  version = "8.0.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = "shortcut-overlay";
     rev = version;
-    sha256 = "sha256-YVeCO7mZmf+FEY4d8tvC76lW/HkOwQ6kw7nvmzAFEtw=";
+    sha256 = "sha256-HqF2eSNwAzgzwyfNQIeumaGkPYiSc+2OfaD3JRQp4/4=";
   };
 
   nativeBuildInputs = [
@@ -35,10 +39,14 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    gala # org.pantheon.desktop.gala.keybindings
+    gsettings-desktop-schemas # org.gnome.desktop.wm.keybindings
     glib
+    gnome-settings-daemon # org.gnome.settings-daemon.plugins.media-keys
     granite7
     gtk4
     libgee
+    mutter # org.gnome.mutter.keybindings
   ];
 
   passthru = {


### PR DESCRIPTION
https://github.com/elementary/shortcut-overlay/compare/2.0.1...8.0.0

https://github.com/NixOS/nixpkgs/pull/312449

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

