### PR TITLE
{sourcery,vscode-extensions.sourcery.sourcery}: 1.16.0 -> 1.19.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/sourcery.sourcery/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/sourcery.sourcery/default.nix
@@ -3,15 +3,15 @@
   stdenv,
   vscode-utils,
   autoPatchelfHook,
-  libxcrypt-legacy,
+  zlib,
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "sourcery";
     publisher = "sourcery";
-    version = "1.16.0";
-    hash = "sha256-SHgS2C+ElTJW4v90Wg0QcsSL2FoSz+SxZQpgq2J4JiU=";
+    version = "1.19.0";
+    hash = "sha256-Wit2ozgaVwINL3PvPfmZWQ4WN7seQMWfXwXGgEKecn0=";
   };
 
   postPatch = ''
@@ -24,7 +24,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
 
   buildInputs = [
     stdenv.cc.cc.lib
-    libxcrypt-legacy
+    zlib
   ];
 
   meta = {

--- a/pkgs/by-name/so/sourcery/package.nix
+++ b/pkgs/by-name/so/sourcery/package.nix
@@ -4,25 +4,25 @@
   python3Packages,
   fetchPypi,
   autoPatchelfHook,
-  libxcrypt-legacy,
+  zlib,
 }:
 
 let
   platformInfos = {
     "x86_64-linux" = {
       platform = "manylinux1_x86_64";
-      hash = "sha256-gr5z8VYkuCqgmcnyA01/Ez6aX9NrKR4MgA0Bc6IHnfs=";
+      hash = "sha256-IJFuMtrddHciuHGeiCuv4hgco9E3GJveegL7dBmVmAw=";
     };
     "x86_64-darwin" = {
       platform = "macosx_10_9_universal2";
-      hash = "sha256-5LsxeozPgInUC1QAxDSlr8NIfmRSl5BN+g9/ZYAxiRE=";
+      hash = "sha256-eTD8NnmDTMSB0dt5skPOlWbnW6AexxEkKZ9ABc+kUas=";
     };
   };
   platformInfo = platformInfos.${stdenv.system} or (throw "Unsupported platform ${stdenv.system}");
 in
 python3Packages.buildPythonApplication rec {
   pname = "sourcery";
-  version = "1.16.0";
+  version = "1.19.0";
   format = "wheel";
 
   src = fetchPypi {
@@ -32,7 +32,7 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
 
-  buildInputs = [ libxcrypt-legacy ];
+  buildInputs = [ zlib ];
 
   meta = {
     changelog = "https://sourcery.ai/changelog/";


### PR DESCRIPTION
## Description of changes

This PR bumps the version of the `sourcery` packages

Looks like the `libxcrypt-legacy` dep was replaced by `zlib`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
