### PR TITLE
corsix-th: darwin build, add maintainer

### DIFF
--- a/pkgs/games/corsix-th/darwin-cmake-no-fixup-bundle.patch
+++ b/pkgs/games/corsix-th/darwin-cmake-no-fixup-bundle.patch
@@ -1,0 +1,12 @@
+diff --git a/CorsixTH/CMakeLists.txt b/CorsixTH/CMakeLists.txt
+index 85856df3..f0f08277 100644
+--- a/CorsixTH/CMakeLists.txt
++++ b/CorsixTH/CMakeLists.txt
+@@ -293,7 +293,6 @@ if(NOT USE_SOURCE_DATADIRS)
+     install(CODE "
+       INCLUDE(BundleUtilities)
+       SET(BU_CHMOD_BUNDLE_ITEMS ON)
+-      FIXUP_BUNDLE(\"${CMAKE_INSTALL_PREFIX}/CorsixTH.app\" \"\" \"\")
+       ")
+     if(WITH_LUAROCKS)
+       install(CODE "execute_process(

--- a/pkgs/games/corsix-th/default.nix
+++ b/pkgs/games/corsix-th/default.nix
@@ -10,9 +10,15 @@
 , SDL2
 , SDL2_mixer
 , timidity
+# Darwin dependencies
+, libiconv
+, Cocoa
+, CoreVideo
+# Update
+, nix-update-script
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation(finalAttrs: {
   pname = "corsix-th";
   version = "0.67";
 
@@ -23,23 +29,50 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-WA/VJqHXzBfVUBNtxCVsGBRzSRQ0pvDvAy03ntc0KZE=";
   };
 
-  luaEnv = lua.withPackages(p: with p; [ luafilesystem lpeg luasec luasocket ]);
+  patches = [
+    ./darwin-cmake-no-fixup-bundle.patch
+  ];
+
   nativeBuildInputs = [ cmake doxygen makeWrapper ];
-  buildInputs = [ ffmpeg freetype lua finalAttrs.luaEnv SDL2 SDL2_mixer timidity ];
+
+  buildInputs = let
+    luaEnv = lua.withPackages(p: with p; [ luafilesystem lpeg luasec luasocket ]);
+  in [
+    ffmpeg
+    freetype
+    lua
+    luaEnv
+    SDL2
+    SDL2_mixer
+    timidity
+  ] ++ lib.optionals stdenv.isDarwin [
+    libiconv
+    Cocoa
+    CoreVideo
+  ];
+
   cmakeFlags = [ "-Wno-dev" ];
 
-  postInstall = ''
+  postInstall = lib.optionalString stdenv.isLinux ''
     wrapProgram $out/bin/corsix-th \
     --set LUA_PATH "$LUA_PATH" \
     --set LUA_CPATH "$LUA_CPATH"
+  '' + lib.optionalString stdenv.isDarwin ''
+    mkdir -p $out/Applications
+    mv $out/CorsixTH.app $out/Applications
+    wrapProgram $out/Applications/CorsixTH.app/Contents/MacOS/CorsixTH \
+      --set LUA_PATH "$LUA_PATH" \
+      --set LUA_CPATH "$LUA_CPATH"
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "A reimplementation of the 1997 Bullfrog business sim Theme Hospital";
     mainProgram = "corsix-th";
     homepage = "https://corsixth.com/";
     license = licenses.mit;
-    maintainers = with maintainers; [ hughobrien ];
-    platforms = platforms.linux;
+    maintainers = with maintainers; [ hughobrien matteopacini ];
+    platforms = platforms.linux ++ platforms.darwin;
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36219,7 +36219,9 @@ with pkgs;
 
   colobot = callPackage ../games/colobot { };
 
-  corsix-th = callPackage ../games/corsix-th { };
+  corsix-th = callPackage ../games/corsix-th {
+    inherit (darwin.apple_sdk.frameworks) Cocoa CoreVideo;
+  };
 
   enigma = callPackage ../games/enigma { };
 


### PR DESCRIPTION
## Description of changes

- Added darwin build to `corsix-th`.
- Added myself as second maintainer for Darwin.
- Added `nix-update-script` as `passthru.updateScript`

Tested on `aarch64-darwin`. Also rebuilt on `aarch64-linux` to ensure that my changes did not break stuff.

![Screenshot 2024-06-09 at 15 15 14](https://github.com/NixOS/nixpkgs/assets/3139724/75f3d0fc-f054-428e-adce-610c4299c0a6)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
