### PR TITLE
prometheus-folder-size-exporter: init at 0.5.1

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -36,6 +36,7 @@ let
     "dovecot"
     "fastly"
     "flow"
+    "folder-size"
     "fritz"
     "fritzbox"
     "graphite"

--- a/nixos/modules/services/monitoring/prometheus/exporters/folder-size.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/folder-size.nix
@@ -1,0 +1,84 @@
+{ config, lib, pkgs, options, utils }:
+let
+  cfg = config.services.prometheus.exporters.folder-size;
+
+  settingsFormat = pkgs.formats.json { };
+  settingsFile = settingsFormat.generate "config.json" (builtins.filter (folder: builtins.hasAttr "path" folder) cfg.folders);
+in
+{
+  port = 9974;
+  extraOpts = {
+    folders = lib.mkOption {
+      description = "Folders to Scan";
+      type = lib.types.listOf (lib.types.submodule {
+        options = {
+          path = lib.mkOption {
+            description = "The starting analysis path.";
+            type = lib.types.str;
+          };
+          explode_depth = lib.mkOption {
+            description = ''
+              This setting controls how deep the folder explosion will go.
+              -1 means no limit.
+              0 means no explosion.
+            '';
+            type = lib.types.int;
+            default = 0;
+          };
+          sum_remaining_subfolders = lib.mkOption {
+            description = ''This setting specifies if the last exploded folder size should include the subfolders.'';
+            type = lib.types.bool;
+            default = false;
+          };
+          user = lib.mkOption {
+            description = "Folders belonging to this user you want to specifically label.";
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+          };
+        };
+      });
+    };
+
+    background = lib.mkOption {
+      type = lib.types.int;
+      default = 0;
+      description = ''
+        Enables the async storage calculation.
+        The value specifies how often (in seconds) the calculation will be done.
+        If not specified, the values will be calculated synchronously at each HTTP Get.
+      '';
+    };
+
+    verbose = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''Enable verbose logging of service.'';
+    };
+
+    directory = {
+      root = lib.mkOption {
+        type = lib.types.str;
+        default = "/var/lib";
+        description = "Parent path of working directory";
+      };
+      folder = lib.mkOption {
+        type = lib.types.str;
+        default = "prometheus-folder-size-exporter";
+        description = "Working Directory name";
+      };
+    };
+  };
+
+  serviceOpts = {
+    serviceConfig = {
+      StateDirectory = cfg.directory.folder;
+      WorkingDirectory = "${cfg.directory.root}/${cfg.directory.folder}";
+      ExecStart = "${pkgs.writeShellScript "setup-cfg" ''
+        ${pkgs.prometheus-folder-size-exporter}/bin/prometheus_folder_size_exporter \
+          -p ${toString cfg.port} \
+          -i ${settingsFile} \
+          ${lib.optionalString (cfg.background > 0) "-b ${toString cfg.background}"} ${lib.optionalString cfg.verbose "-v"}
+      ''}";
+    };
+  };
+}

--- a/pkgs/by-name/pr/prometheus-folder-size-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-folder-size-exporter/package.nix
@@ -1,0 +1,41 @@
+{
+  cargo,
+  rustc,
+  fetchFromGitHub,
+  rustPlatform,
+  lib,
+}:
+rustPlatform.buildRustPackage {
+  pname = "prometheus_folder_size_exporter";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "MindFlavor";
+    repo = "prometheus_folder_size_exporter";
+    rev = "5800b20e86855f407d9c5db48ad6f966a5bd2df2";
+    hash = "sha256-lvn24NAKv4YU1iU0U7NBBQVr2BQM1wi5M6czj/7gUSk=";
+  };
+
+  cargoHash = "sha256-FuXlFQBcVGJkUqkJdiX37a9d4QpHYES04XVYusWrAJo=";
+
+  nativeBuildInputs = [
+    cargo
+    rustc
+    rustPlatform.cargoSetupHook
+  ];
+
+  buildInputs = [
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/MindFlavor/prometheus_folder_size_exporter";
+    description = ''
+      A Rust Prometheus exporter for folder size.
+      This tool exports the folder size information (optionally including every subdir) in a format that Prometheus can understand.
+    '';
+    maintainers = with maintainers; [Silver-Golden];
+    license = licenses.mit;
+    platforms = platforms.linux;
+    mainProgram = "prometheus_folder_size_exporter";
+  };
+}


### PR DESCRIPTION
## Description of changes
Added the Prometheus Folder Size exporter.  
https://github.com/MindFlavor/prometheus_folder_size_exporter/tree/master

This patch includes both the package and the nixos module for the above exporter.

Ive built and deployed it on my local server to test and debug issues.  
There are no passwords or secret info so the ``config.json`` is free to go into the ``/nix/store``.  

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### From the READMEs
#### Package
##### Reviewed points

- [x] package name fits guidelines
- [x] package version fits guidelines
- [x] package builds on ARCHITECTURE
- [x] executables tested on ARCHITECTURE
- [ ] all depending packages build
- [ ] patches have a comment describing either the upstream URL or a reason why the patch wasn't upstreamed
- [ ] patches that are remotely available are fetched rather than vendored

##### Possible improvements

##### Comments



#### Module
##### Reviewed points

- [x] module path fits the guidelines
- [x] module tests succeed on ARCHITECTURE
- [x] options have appropriate types
- [x] options have default
- [x] options have example
- [x] options have descriptions
- [x] No unneeded package is added to `environment.systemPackages`
- [x] `meta.maintainers` is set
- [ ] module documentation is declared in `meta.doc`

##### Possible improvements

##### Comments

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
