### PR TITLE
Skaware 2024 06

### DIFF
--- a/pkgs/development/skaware-packages/execline/default.nix
+++ b/pkgs/development/skaware-packages/execline/default.nix
@@ -1,14 +1,14 @@
 { lib, skawarePackages, skalibs }:
 
 let
-  version = "2.9.5.1";
+  version = "2.9.6.0";
 
 in skawarePackages.buildPackage {
   inherit version;
 
   pname = "execline";
   # ATTN: also check whether there is a new manpages version
-  sha256 = "33UANdD7IccmW/+37X4bZh3h6EKUSiJSvc3cMtDZchc=";
+  sha256 = "uion6Xxetr18pqCYeokl5ERlpb6ZbaoNGPj+yjfXVxo=";
 
   # Maintainer of manpages uses following versioning scheme: for every
   # upstream $version he tags manpages release as ${version}.1, and,
@@ -16,8 +16,8 @@ in skawarePackages.buildPackage {
   # ${version}.3 and so on are created.
   manpages = skawarePackages.buildManPages {
     pname = "execline-man-pages";
-    version = "2.9.5.1.1";
-    sha256 = "hLo0TJJ4F2UQ+NkyO9DvVHO0ec86Eps1z99HthBzoIc=";
+    version = "2.9.6.0.1";
+    sha256 = "0lyX3rIUZ2JqWioRSm22uDS+q9ONkwIZxfR5E2pSDC4=";
     description = "Port of the documentation for the execline suite to mdoc";
     maintainers = [ lib.maintainers.sternenseemann ];
   };

--- a/pkgs/development/skaware-packages/mdevd/default.nix
+++ b/pkgs/development/skaware-packages/mdevd/default.nix
@@ -2,8 +2,8 @@
 
 skawarePackages.buildPackage {
   pname = "mdevd";
-  version = "0.1.6.3";
-  sha256 = "9uzw73zUjQTvx1rLLa2WfYULyIFb2wCY8cnvBDOU1DA=";
+  version = "0.1.6.4";
+  sha256 = "c1jOUwtrm++3FeSBkJgem2mhLMqFhRnm0uS0bqt+JHA=";
 
   description = "mdev-compatible Linux hotplug manager daemon";
   platforms = lib.platforms.linux;

--- a/pkgs/development/skaware-packages/s6-dns/default.nix
+++ b/pkgs/development/skaware-packages/s6-dns/default.nix
@@ -2,8 +2,8 @@
 
 skawarePackages.buildPackage {
   pname = "s6-dns";
-  version = "2.3.7.1";
-  sha256 = "zwJYV07H1itlTgwq14r0x9Z6xMnLN/eBSA9ZflSzD20=";
+  version = "2.3.7.2";
+  sha256 = "au4yu2jQH1EJ9x4xooMhPGaM08Dnn7nkaebKu1gHnys=";
 
   description = "A suite of DNS client programs and libraries for Unix systems";
 

--- a/pkgs/development/skaware-packages/s6-networking/default.nix
+++ b/pkgs/development/skaware-packages/s6-networking/default.nix
@@ -18,13 +18,13 @@ assert sslSupportEnabled -> sslLibs ? ${sslSupport};
 
 skawarePackages.buildPackage {
   pname = "s6-networking";
-  version = "2.7.0.2";
-  sha256 = "wzxvGyvhb4miGvlGz9BiQqEvmBhMiYt1XdskM4ZxzrE=";
+  version = "2.7.0.3";
+  sha256 = "20EcVDcaF+19RUPdhs+VMM4l/PYkvvg64rV5Ug5ecL8=";
 
   manpages = skawarePackages.buildManPages {
     pname = "s6-networking-man-pages";
-    version = "2.5.1.3.3";
-    sha256 = "02ba5jyfpbib402mfl42pbbdxyjy2vhpiz1b2qdg4ax58yr4jzqk";
+    version = "2.7.0.3.1";
+    sha256 = "9u2C1TF9vma+7Qo+00uZ6eOCn/9eMgKALgHDVgMcrfg=";
     description = "Port of the documentation for the s6-networking suite to mdoc";
     maintainers = [ lib.maintainers.sternenseemann ];
   };

--- a/pkgs/development/skaware-packages/s6-rc/default.nix
+++ b/pkgs/development/skaware-packages/s6-rc/default.nix
@@ -2,12 +2,12 @@
 
 skawarePackages.buildPackage {
   pname = "s6-rc";
-  version = "0.5.4.2";
-  sha256 = "AL36WW+nFhUS6XLskoKiq9j9DjHwkXe616K8PY8oOYI=";
+  version = "0.5.4.3";
+  sha256 = "4ycnlqlHkE3jerNOwQQw4mEHuO8FIQ2BBZyLNiA+ap8=";
 
   manpages = skawarePackages.buildManPages {
     pname = "s6-rc-man-pages";
-    version = "0.5.4.2.1";
+    version = "0.5.4.3.1";
     sha256 = "Ywke3FG/xhhUd934auDB+iFRDCvy8IJs6IkirP6O/As=";
     description = "mdoc(7) versions of the documentation for the s6-rc service manager";
     maintainers = [ lib.maintainers.qyliss ];

--- a/pkgs/development/skaware-packages/s6/default.nix
+++ b/pkgs/development/skaware-packages/s6/default.nix
@@ -2,13 +2,13 @@
 
 skawarePackages.buildPackage {
   pname = "s6";
-  version = "2.12.0.4";
-  sha256 = "yV1ReHYC4MjI5PkqcQy9qk7nl+6IbnE0Jyfil0+VwGs=";
+  version = "2.13.0.0";
+  sha256 = "fkb49V2Auw4gJaZNXWSa9KSsIeNIAgyqrd4wul5bSDA=";
 
   manpages = skawarePackages.buildManPages {
     pname = "s6-man-pages";
-    version = "2.12.0.4.1";
-    sha256 = "9n4oIGfgcu+Q/UcY1Edr3n09Ecrbg77AI8TRBQoFzs0=";
+    version = "2.13.0.0.1";
+    sha256 = "oZgyJ2mPxpgsV2Le29XM+NsjMhqvDQ70SUZ2gjYg5U8=";
     description = "Port of the documentation for the s6 supervision suite to mdoc";
     maintainers = [ lib.maintainers.sternenseemann ];
   };

--- a/pkgs/development/skaware-packages/skalibs/default.nix
+++ b/pkgs/development/skaware-packages/skalibs/default.nix
@@ -6,8 +6,8 @@
 
 skawarePackages.buildPackage {
   pname = "skalibs";
-  version = "2.14.1.1";
-  sha256 = "trebgW9LoLaAFnaw7UF5tZyMeAnu/+JttnLkBGNr78M=";
+  version = "2.14.2.0";
+  sha256 = "sha256-3f7Fcw5bLxnQOB7Pf3lrOabkcyNr2grY03dqP+ewfkM=";
 
   description = "A set of general-purpose C programming libraries";
 

--- a/pkgs/development/skaware-packages/tipidee/default.nix
+++ b/pkgs/development/skaware-packages/tipidee/default.nix
@@ -2,8 +2,8 @@
 
 skawarePackages.buildPackage {
   pname = "tipidee";
-  version = "0.0.4.0";
-  sha256 = "sha256-FzZRGg8IBTkzXINb9WCdVukej9KyPFQIUuXfdcLz1RQ=";
+  version = "0.0.5.0";
+  sha256 = "2ekfxxmHmkPVQym5mwLGZJxU5Cjne8lqBXNQa1K/FCI=";
 
   description = "A HTTP 1.1 webserver, serving static files and CGI/NPH";
 


### PR DESCRIPTION
## Description of changes

https://list.skarnet.org/lists/skaware/2058.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
