### PR TITLE
doomsday-engine: init at 2.3.1, doomsday-engine_3: init at 3.0-unstable-2024-01-23 

### DIFF
--- a/pkgs/by-name/do/doomsday-engine/package.nix
+++ b/pkgs/by-name/do/doomsday-engine/package.nix
@@ -1,0 +1,101 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  cmake,
+  ninja,
+  pkg-config,
+  python3,
+  makeBinaryWrapper,
+
+  SDL2,
+  SDL2_mixer,
+  the-foundation,
+  ncurses,
+  glbinding,
+  assimp,
+  glib,
+  qt5,
+  xorg,
+
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "doomsday-engine";
+  version = "2.3.1";
+
+  src = fetchFromGitHub {
+    owner = "skyjake";
+    repo = "Doomsday-Engine";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7jLL8ho3JL4amSTTu9ICmK1rcXIlJ9XWzh/rE6jT1zI=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    python3
+    makeBinaryWrapper
+
+    qt5.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    SDL2
+    SDL2_mixer
+    the-foundation
+    ncurses
+    glbinding
+    assimp
+    glib
+
+    qt5.qtbase
+    qt5.qtx11extras
+    xorg.libXrandr
+    xorg.libXxf86vm
+  ];
+
+  # TODO: enable FMOD support by setting FMOD_DIR
+  cmakeFlags = [
+    (lib.cmakeBool "DENG_ASSIMP_EMBEDDED" false) # Use system assimp
+    (lib.cmakeFeature "DE_PREFIX" (placeholder "out")) # Legacy output prefix
+  ];
+
+  preConfigure = ''
+    # Doomsday builds PK3 files for these games by default - PK3 files are really just ZIP files,
+    # whose contents must have a modification date not earlier than 1980.
+    find doomsday/{apps/client/data,apps/plugins/{doom,heretic,hexen,doom64}/{defs,data}} \
+      -exec touch -d '1980-01-01T00:00:00Z' {} +
+  '';
+
+  # Doomsday Engine does not like Wayland (will SIGSEGV upon launch)
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    wrapProgram $out/bin/doomsday \
+      --set "QT_QPA_PLATFORM" "xcb"
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "v([0-9.]+)$"
+    ];
+  };
+
+  meta = {
+    description = "Doom / Heretic / Hexen port with enhanced graphics";
+    homepage = "https://dengine.net/";
+    changelog = "https://manual.dengine.net/version/${finalAttrs.version}";
+    license = with lib.licenses; [
+      gpl3 # Applications
+      lgpl3 # Core libraries
+    ];
+    maintainers = with lib.maintainers; [ pluiedev ];
+    platforms = with lib.platforms; unix ++ windows;
+    # Doomsday 2 relies on QTKit which is deprecated and no longer exists on aarch64-darwin
+    # See https://github.com/NixOS/nixpkgs/pull/318552#issuecomment-2157550507
+    badPlatforms = [ "aarch64-darwin" ];
+    mainProgram = "doomsday";
+  };
+})

--- a/pkgs/by-name/do/doomsday-engine_3/package.nix
+++ b/pkgs/by-name/do/doomsday-engine_3/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  cmake,
+  ninja,
+  pkg-config,
+  python3,
+  makeBinaryWrapper,
+
+  SDL2,
+  SDL2_mixer,
+  the-foundation,
+  ncurses,
+  glbinding,
+  assimp,
+  glib,
+  zlib,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "doomsday-engine";
+  version = "3.0-unstable-2024-01-23";
+
+  src = fetchFromGitHub {
+    owner = "skyjake";
+    repo = "Doomsday-Engine";
+    rev = "aa09feba6449efe3b426013a71499bf7c310de15";
+    hash = "sha256-ZiVXaAsN8/PsdBgxyw85qxPLkl6xePm+nG2A6V269zU=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    python3
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [
+    SDL2
+    SDL2_mixer
+    the-foundation
+    ncurses
+    glbinding
+    assimp
+    glib
+    zlib
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "DE_USE_SYSTEM_ASSIMP" true)
+    (lib.cmakeBool "DE_USE_SYSTEM_GLBINDING" true)
+  ];
+
+  preConfigure = ''
+    # Doomsday builds PK3 files for these games by default - PK3 files are really just ZIP files,
+    # whose contents must have a modification date not earlier than 1980.
+    find doomsday/{apps/client/data,libs/gamekit/libs/{doom,heretic,hexen,doom64}/{defs,data}} \
+      -exec touch -d '1980-01-01T00:00:00Z' {} +
+  '';
+
+  # Doomsday Engine does not like Wayland (will SIGSEGV upon launch)
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    wrapProgram $out/bin/doomsday \
+      --set "SDL_VIDEODRIVER" "x11"
+  '';
+
+  meta = {
+    description = "Doom / Heretic / Hexen port with enhanced graphics (unstable 3.0 branch)";
+    homepage = "https://dengine.net/";
+    license = with lib.licenses; [
+      gpl3 # Applications
+      lgpl3 # Core libraries
+    ];
+    maintainers = with lib.maintainers; [ pluiedev ];
+    platforms = with lib.platforms; unix ++ windows;
+    mainProgram = "doomsday";
+  };
+})


### PR DESCRIPTION
## Description of changes

Fixes #108391

Tested with the DOOM 1 Shareware WAD and it works well!

Known issues include lack of FMOD support, and possible crash under Wayland (workaround: unset `WAYLAND_DISPLAY` for 2.x, and set `SDL_VIDEODRIVER` to `x11` for 3.x).

Neither of them have update scripts for now (much to my chagrin). See Mic92/nix-update#257

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
