### PR TITLE
lix: various improvements to the packaging for release automation

### DIFF
--- a/pkgs/tools/package-management/lix/common.nix
+++ b/pkgs/tools/package-management/lix/common.nix
@@ -65,6 +65,11 @@ assert (hash == null) -> (src != null);
   util-linuxMinimal,
   xz,
   nixosTests,
+  lix-doc ? callPackage ./doc {
+    inherit src;
+    version = "${version}${suffix}";
+    cargoHash = docCargoHash;
+  },
 
   enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
   enableStatic ? stdenv.hostPlatform.isStatic,
@@ -79,11 +84,6 @@ assert (hash == null) -> (src != null);
   storeDir,
 }:
 let
-  lix-doc = callPackage ./doc {
-    inherit src;
-    version = "${version}${suffix}";
-    cargoHash = docCargoHash;
-  };
   self = stdenv.mkDerivation {
     pname = "lix";
 

--- a/pkgs/tools/package-management/lix/common.nix
+++ b/pkgs/tools/package-management/lix/common.nix
@@ -83,207 +83,204 @@ assert (hash == null) -> (src != null);
   stateDir,
   storeDir,
 }:
-let
-  self = stdenv.mkDerivation {
-    pname = "lix";
+stdenv.mkDerivation {
+  pname = "lix";
 
-    version = "${version}${suffix}";
-    VERSION_SUFFIX = suffix;
+  version = "${version}${suffix}";
+  VERSION_SUFFIX = suffix;
 
-    inherit src patches;
+  inherit src patches;
 
-    outputs =
-      [
-        "out"
-        "dev"
-      ]
-      ++ lib.optionals enableDocumentation [
-        "man"
-        "doc"
-      ];
-
-    strictDeps = true;
-
-    nativeBuildInputs =
-      [
-        pkg-config
-        bison
-        flex
-        jq
-        meson
-        ninja
-        cmake
-        python3
-        doxygen
-
-        # Tests
-        git
-        mercurial
-        jq
-        lsof
-      ]
-      ++ lib.optionals (enableDocumentation) [
-        (lib.getBin lowdown)
-        mdbook
-        mdbook-linkcheck
-      ]
-      ++ lib.optionals stdenv.isLinux [ util-linuxMinimal ];
-
-    buildInputs =
-      [
-        boost
-        brotli
-        bzip2
-        curl
-        editline
-        libsodium
-        openssl
-        sqlite
-        xz
-        gtest
-        libarchive
-        lowdown
-        rapidcheck
-        toml11
-        lix-doc
-      ]
-      ++ lib.optionals stdenv.isDarwin [ Security ]
-      ++ lib.optionals (stdenv.isx86_64) [ libcpuid ]
-      ++ lib.optionals withLibseccomp [ libseccomp ]
-      ++ lib.optionals withAWS [ aws-sdk-cpp ];
-
-    propagatedBuildInputs = [
-      boehmgc
-      nlohmann_json
+  outputs =
+    [
+      "out"
+      "dev"
+    ]
+    ++ lib.optionals enableDocumentation [
+      "man"
+      "doc"
     ];
 
-    postPatch = ''
-      patchShebangs --build tests
-    '';
+  strictDeps = true;
 
-    preConfigure =
-      # Copy libboost_context so we don't get all of Boost in our closure.
-      # https://github.com/NixOS/nixpkgs/issues/45462
-      lib.optionalString (!enableStatic) ''
-        mkdir -p $out/lib
-        cp -pd ${boost}/lib/{libboost_context*,libboost_thread*,libboost_system*} $out/lib
-        rm -f $out/lib/*.a
-        ${lib.optionalString stdenv.isLinux ''
-          chmod u+w $out/lib/*.so.*
-          patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib $out/lib/libboost_thread.so.*
-        ''}
-        ${lib.optionalString stdenv.hostPlatform.isDarwin ''
-          for LIB in $out/lib/*.dylib; do
-            chmod u+w $LIB
-            install_name_tool -id $LIB $LIB
-            install_name_tool -delete_rpath ${boost}/lib/ $LIB || true
-          done
-          install_name_tool -change ${boost}/lib/libboost_system.dylib $out/lib/libboost_system.dylib $out/lib/libboost_thread.dylib
-        ''}
-      '';
+  nativeBuildInputs =
+    [
+      pkg-config
+      bison
+      flex
+      jq
+      meson
+      ninja
+      cmake
+      python3
+      doxygen
 
-    mesonBuildType = "release";
-    mesonFlags =
-      [
-        # LTO optimization
-        (lib.mesonBool "b_lto" (!stdenv.isDarwin))
-        (lib.mesonEnable "gc" true)
-        (lib.mesonBool "enable-tests" true)
-        (lib.mesonBool "enable-docs" enableDocumentation)
-        (lib.mesonBool "enable-embedded-sandbox-shell" (stdenv.isLinux && stdenv.hostPlatform.isStatic))
-        (lib.mesonEnable "seccomp-sandboxing" withLibseccomp)
+      # Tests
+      git
+      mercurial
+      jq
+      lsof
+    ]
+    ++ lib.optionals (enableDocumentation) [
+      (lib.getBin lowdown)
+      mdbook
+      mdbook-linkcheck
+    ]
+    ++ lib.optionals stdenv.isLinux [ util-linuxMinimal ];
 
-        (lib.mesonOption "store-dir" storeDir)
-        (lib.mesonOption "state-dir" stateDir)
-        (lib.mesonOption "sysconfdir" confDir)
-      ]
-      ++ lib.optionals stdenv.isLinux [
-        (lib.mesonOption "sandbox-shell" "${busybox-sandbox-shell}/bin/busybox")
-      ];
-
-    # Needed for Meson to find Boost.
-    # https://github.com/NixOS/nixpkgs/issues/86131.
-    env = {
-      BOOST_INCLUDEDIR = "${lib.getDev boost}/include";
-      BOOST_LIBRARYDIR = "${lib.getLib boost}/lib";
-    };
-
-    postInstall =
-      ''
-        mkdir -p $doc/nix-support
-        echo "doc manual $doc/share/doc/nix/manual" >> $doc/nix-support/hydra-build-products
-      ''
-      + lib.optionalString stdenv.hostPlatform.isStatic ''
-        mkdir -p $out/nix-support
-        echo "file binary-dist $out/bin/nix" >> $out/nix-support/hydra-build-products
-      ''
-      + lib.optionalString stdenv.isDarwin ''
-        for lib in libnixutil.dylib libnixexpr.dylib; do
-          install_name_tool \
-            -change "${lib.getLib boost}/lib/libboost_context.dylib" \
-            "$out/lib/libboost_context.dylib" \
-            "$out/lib/$lib"
-        done
-      '';
-
-    doCheck = true;
-    mesonCheckFlags = [ "--suite=check" ];
-    checkInputs = [
+  buildInputs =
+    [
+      boost
+      brotli
+      bzip2
+      curl
+      editline
+      libsodium
+      openssl
+      sqlite
+      xz
       gtest
+      libarchive
+      lowdown
       rapidcheck
+      toml11
+      lix-doc
+    ]
+    ++ lib.optionals stdenv.isDarwin [ Security ]
+    ++ lib.optionals (stdenv.isx86_64) [ libcpuid ]
+    ++ lib.optionals withLibseccomp [ libseccomp ]
+    ++ lib.optionals withAWS [ aws-sdk-cpp ];
+
+  propagatedBuildInputs = [
+    boehmgc
+    nlohmann_json
+  ];
+
+  postPatch = ''
+    patchShebangs --build tests
+  '';
+
+  preConfigure =
+    # Copy libboost_context so we don't get all of Boost in our closure.
+    # https://github.com/NixOS/nixpkgs/issues/45462
+    lib.optionalString (!enableStatic) ''
+      mkdir -p $out/lib
+      cp -pd ${boost}/lib/{libboost_context*,libboost_thread*,libboost_system*} $out/lib
+      rm -f $out/lib/*.a
+      ${lib.optionalString stdenv.isLinux ''
+        chmod u+w $out/lib/*.so.*
+        patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib $out/lib/libboost_thread.so.*
+      ''}
+      ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+        for LIB in $out/lib/*.dylib; do
+          chmod u+w $LIB
+          install_name_tool -id $LIB $LIB
+          install_name_tool -delete_rpath ${boost}/lib/ $LIB || true
+        done
+        install_name_tool -change ${boost}/lib/libboost_system.dylib $out/lib/libboost_system.dylib $out/lib/libboost_thread.dylib
+      ''}
+    '';
+
+  mesonBuildType = "release";
+  mesonFlags =
+    [
+      # LTO optimization
+      (lib.mesonBool "b_lto" (!stdenv.isDarwin))
+      (lib.mesonEnable "gc" true)
+      (lib.mesonBool "enable-tests" true)
+      (lib.mesonBool "enable-docs" enableDocumentation)
+      (lib.mesonBool "enable-embedded-sandbox-shell" (stdenv.isLinux && stdenv.hostPlatform.isStatic))
+      (lib.mesonEnable "seccomp-sandboxing" withLibseccomp)
+
+      (lib.mesonOption "store-dir" storeDir)
+      (lib.mesonOption "state-dir" stateDir)
+      (lib.mesonOption "sysconfdir" confDir)
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      (lib.mesonOption "sandbox-shell" "${busybox-sandbox-shell}/bin/busybox")
     ];
 
-    doInstallCheck = true;
-    mesonInstallCheckFlags = [ "--suite=installcheck" ];
+  # Needed for Meson to find Boost.
+  # https://github.com/NixOS/nixpkgs/issues/86131.
+  env = {
+    BOOST_INCLUDEDIR = "${lib.getDev boost}/include";
+    BOOST_LIBRARYDIR = "${lib.getLib boost}/lib";
+  };
 
-    preInstallCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      # socket path becomes too long otherwise
-      export TMPDIR=$NIX_BUILD_TOP
-      # Prevent crashes in libcurl due to invoking Objective-C `+initialize` methods after `fork`.
-      # See http://sealiesoftware.com/blog/archive/2017/6/5/Objective-C_and_fork_in_macOS_1013.html.
-      export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+  postInstall =
+    ''
+      mkdir -p $doc/nix-support
+      echo "doc manual $doc/share/doc/nix/manual" >> $doc/nix-support/hydra-build-products
+    ''
+    + lib.optionalString stdenv.hostPlatform.isStatic ''
+      mkdir -p $out/nix-support
+      echo "file binary-dist $out/bin/nix" >> $out/nix-support/hydra-build-products
+    ''
+    + lib.optionalString stdenv.isDarwin ''
+      for lib in libnixutil.dylib libnixexpr.dylib; do
+        install_name_tool \
+          -change "${lib.getLib boost}/lib/libboost_context.dylib" \
+          "$out/lib/libboost_context.dylib" \
+          "$out/lib/$lib"
+      done
     '';
 
-    installCheckPhase = ''
-      runHook preInstallCheck
-      flagsArray=($mesonInstallCheckFlags "''${mesonInstallCheckFlagsArray[@]}")
-      meson test --no-rebuild "''${flagsArray[@]}"
-      runHook postInstallCheck
-    '';
-    # strictoverflow is disabled because we trap on signed overflow instead
-    hardeningDisable = [ "strictoverflow" ] ++ lib.optional stdenv.hostPlatform.isStatic "pie";
-    # hardeningEnable = lib.optionals (!stdenv.isDarwin) [ "pie" ];
-    # hardeningDisable = lib.optional stdenv.hostPlatform.isMusl "fortify";
-    separateDebugInfo = stdenv.isLinux && !enableStatic;
-    enableParallelBuilding = true;
+  doCheck = true;
+  mesonCheckFlags = [ "--suite=check" ];
+  checkInputs = [
+    gtest
+    rapidcheck
+  ];
 
-    passthru = {
-      inherit aws-sdk-cpp boehmgc;
-      tests = {
-        misc = nixosTests.nix-misc.lix;
-      };
-    };
+  doInstallCheck = true;
+  mesonInstallCheckFlags = [ "--suite=installcheck" ];
 
-    # point 'nix edit' and ofborg at the file that defines the attribute,
-    # not this common file.
-    pos = builtins.unsafeGetAttrPos "version" args;
-    meta = with lib; {
-      description = "Powerful package manager that makes package management reliable and reproducible";
-      longDescription = ''
-        Lix (a fork of Nix) is a powerful package manager for Linux and other Unix systems that
-        makes package management reliable and reproducible. It provides atomic
-        upgrades and rollbacks, side-by-side installation of multiple versions of
-        a package, multi-user package management and easy setup of build
-        environments.
-      '';
-      homepage = "https://lix.systems";
-      license = licenses.lgpl21Plus;
-      inherit maintainers;
-      platforms = platforms.unix;
-      outputsToInstall = [ "out" ] ++ optional enableDocumentation "man";
-      mainProgram = "nix";
-      broken = enableStatic;
+  preInstallCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # socket path becomes too long otherwise
+    export TMPDIR=$NIX_BUILD_TOP
+    # Prevent crashes in libcurl due to invoking Objective-C `+initialize` methods after `fork`.
+    # See http://sealiesoftware.com/blog/archive/2017/6/5/Objective-C_and_fork_in_macOS_1013.html.
+    export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+  '';
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+    flagsArray=($mesonInstallCheckFlags "''${mesonInstallCheckFlagsArray[@]}")
+    meson test --no-rebuild "''${flagsArray[@]}"
+    runHook postInstallCheck
+  '';
+  # strictoverflow is disabled because we trap on signed overflow instead
+  hardeningDisable = [ "strictoverflow" ] ++ lib.optional stdenv.hostPlatform.isStatic "pie";
+  # hardeningEnable = lib.optionals (!stdenv.isDarwin) [ "pie" ];
+  # hardeningDisable = lib.optional stdenv.hostPlatform.isMusl "fortify";
+  separateDebugInfo = stdenv.isLinux && !enableStatic;
+  enableParallelBuilding = true;
+
+  passthru = {
+    inherit aws-sdk-cpp boehmgc;
+    tests = {
+      misc = nixosTests.nix-misc.lix;
     };
   };
-in
-self
+
+  # point 'nix edit' and ofborg at the file that defines the attribute,
+  # not this common file.
+  pos = builtins.unsafeGetAttrPos "version" args;
+  meta = with lib; {
+    description = "Powerful package manager that makes package management reliable and reproducible";
+    longDescription = ''
+      Lix (a fork of Nix) is a powerful package manager for Linux and other Unix systems that
+      makes package management reliable and reproducible. It provides atomic
+      upgrades and rollbacks, side-by-side installation of multiple versions of
+      a package, multi-user package management and easy setup of build
+      environments.
+    '';
+    homepage = "https://lix.systems";
+    license = licenses.lgpl21Plus;
+    inherit maintainers;
+    platforms = platforms.unix;
+    outputsToInstall = [ "out" ] ++ optional enableDocumentation "man";
+    mainProgram = "nix";
+    broken = enableStatic;
+  };
+}

--- a/pkgs/tools/package-management/lix/common.nix
+++ b/pkgs/tools/package-management/lix/common.nix
@@ -11,6 +11,7 @@
     inherit hash;
   },
   docCargoHash ? null,
+  docCargoLock ? null,
   patches ? [ ],
   maintainers ? lib.teams.lix.members,
 }@args:
@@ -69,6 +70,7 @@ assert (hash == null) -> (src != null);
     inherit src;
     version = "${version}${suffix}";
     cargoHash = docCargoHash;
+    cargoLock = docCargoLock;
   },
 
   enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
@@ -83,6 +85,7 @@ assert (hash == null) -> (src != null);
   stateDir,
   storeDir,
 }:
+assert lib.assertMsg (docCargoHash != null || docCargoLock != null) "Either `lix-doc`'s cargoHash using `docCargoHash` or `lix-doc`'s `cargoLock.lockFile` using `docCargoLock` must be set!";
 stdenv.mkDerivation {
   pname = "lix";
 

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -47,6 +47,8 @@ let
     };
 in
 lib.makeExtensible (self: ({
+  buildLix = common;
+
   lix_2_90 = (
     common {
       version = "2.90-beta.1";

--- a/pkgs/tools/package-management/lix/doc/default.nix
+++ b/pkgs/tools/package-management/lix/doc/default.nix
@@ -2,11 +2,12 @@
   src,
   rustPlatform,
   version,
-  cargoHash,
+  cargoHash ? null,
+  cargoLock ? null
 }:
 
 rustPlatform.buildRustPackage {
   pname = "lix-doc";
   sourceRoot = "${src.name}/lix-doc";
-  inherit version src cargoHash;
+  inherit version src cargoHash cargoLock;
 }

--- a/pkgs/tools/package-management/lix/doc/default.nix
+++ b/pkgs/tools/package-management/lix/doc/default.nix
@@ -8,6 +8,6 @@
 
 rustPlatform.buildRustPackage {
   pname = "lix-doc";
-  sourceRoot = "${src.name}/lix-doc";
+  sourceRoot = "${src.name or src}/lix-doc";
   inherit version src cargoHash cargoLock;
 }


### PR DESCRIPTION
## Description of changes

In preparations for Lix release, we are making some improvements to make the interoperability between the Lix repository and a Nixpkgs repository easier.

The idea is that it should be easy to:

- extract a given worktree from a nixpkgs checkout
- Run `nix-build -E 'let pkgs = (import <nixpkgs> {}); lib = pkgs.lib; in pkgs.lixVersions.buildLix { version = "lix-next"; src = ./.; docCargoLock.lockFile = ./lix-doc/Cargo.lock; }'` from a Lix specific revision.

And do more complicated operations on the top of this idea.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
