### PR TITLE
coyim: migrate to buildGoModule

### DIFF
--- a/pkgs/by-name/co/coyim/package.nix
+++ b/pkgs/by-name/co/coyim/package.nix
@@ -29,7 +29,7 @@ buildGoModule {
   buildInputs = [ glib cairo gdk-pixbuf gtk3 gnome.adwaita-icon-theme ];
 
   meta = {
-    description = "a safe and secure chat client";
+    description = "Safe and secure chat client";
     mainProgram = "coyim";
     homepage = "https://coy.im/";
     license = lib.licenses.gpl3;

--- a/pkgs/by-name/co/coyim/package.nix
+++ b/pkgs/by-name/co/coyim/package.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, buildGoPackage
+, buildGoModule
 , fetchFromGitHub
 , pkg-config
 , cairo
@@ -11,28 +11,28 @@
 , gtk3
 }:
 
-buildGoPackage rec {
+buildGoModule {
   pname = "coyim";
-  version = "0.4.1";
-
-  goPackagePath = "github.com/coyim/coyim";
+  version = "0.4.1-unstable-2023-09-21";
 
   src = fetchFromGitHub {
     owner = "coyim";
     repo = "coyim";
-    rev = "v${version}";
-    sha256 = "sha256-PmB6POaHKEXzIAaz3lAbUOhtVOzrj5oXRk90giYo6SI=";
+    rev = "3f84daa8c27277543b1b4ad4536dde5100d9df12";
+    sha256 = "sha256-lzhcUSBuAgYwcmdwnqNxKG0P6ZSjWeLS/g/gaF171D4=";
   };
+
+  vendorHash = "sha256-zG7r/Db6XiwKoHRduGj3tEh/KT1hsuBoSGLYaZ+qO0Y=";
 
   nativeBuildInputs = [ pkg-config wrapGAppsHook3 ];
 
   buildInputs = [ glib cairo gdk-pixbuf gtk3 gnome.adwaita-icon-theme ];
 
-  meta = with lib; {
-    description = "Safe and secure chat client";
+  meta = {
+    description = "a safe and secure chat client";
     mainProgram = "coyim";
     homepage = "https://coy.im/";
-    license = licenses.gpl3;
+    license = lib.licenses.gpl3;
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
     broken = stdenv.isDarwin;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30107,8 +30107,6 @@ with pkgs;
 
   coursera-dl = callPackage ../applications/misc/coursera-dl { };
 
-  coyim = callPackage ../applications/networking/instant-messengers/coyim { };
-
   cozy-drive = callPackage ../applications/networking/cozy-drive { };
 
   cplay-ng = callPackage ../applications/audio/cplay-ng { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Migrating to `buildGoModule` so `buildGoPackage` can be deprecated as per https://github.com/NixOS/nixpkgs/issues/318069. Project does use Go modules upstream now, but hasn't been tagged since.

Also moved to by-name.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
