### PR TITLE
nixos/fcgiwrap: refactor to fix permissions

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -51,6 +51,8 @@
   `services.fcgiwrap.*` to `services.fcgiwrap.some-instance.*`.
   The ownership and mode of the UNIX sockets created by this service are now
   configurable and private by default.
+  Processes also now run as a dynamically allocated user by default instead of
+  root.
 
 - `nvimpager` was updated to version 0.13.0, which changes the order of user and
   nvimpager settings: user commands in `-c` and `--cmd` now override the

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -44,6 +44,12 @@
   it is set, instead of the previous hardcoded default of
   `${networking.hostName}.${security.ipa.domain}`.
 
+- The fcgiwrap module now allows multiple instances running as distinct users.
+  The option `services.fgciwrap` now takes an attribute set of the
+  configuration of each individual instance.
+  This requires migrating any previous configuration keys from
+  `services.fcgiwrap.*` to `services.fcgiwrap.some-instance.*`.
+
 - `nvimpager` was updated to version 0.13.0, which changes the order of user and
   nvimpager settings: user commands in `-c` and `--cmd` now override the
   respective default settings because they are executed later.

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -54,6 +54,10 @@
   Processes also now run as a dynamically allocated user by default instead of
   root.
 
+- `services.cgit` now runs as the cgit user by default instead of root.
+  This change requires granting access to the repositories to this user or
+  setting the appropriate one through `services.cgit.some-instance.user`.
+
 - `nvimpager` was updated to version 0.13.0, which changes the order of user and
   nvimpager settings: user commands in `-c` and `--cmd` now override the
   respective default settings because they are executed later.

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -49,6 +49,8 @@
   configuration of each individual instance.
   This requires migrating any previous configuration keys from
   `services.fcgiwrap.*` to `services.fcgiwrap.some-instance.*`.
+  The ownership and mode of the UNIX sockets created by this service are now
+  configurable and private by default.
 
 - `nvimpager` was updated to version 0.13.0, which changes the order of user and
   nvimpager settings: user commands in `-c` and `--cmd` now override the

--- a/nixos/modules/services/misc/zoneminder.nix
+++ b/nixos/modules/services/misc/zoneminder.nix
@@ -203,8 +203,9 @@ in {
 
     services = {
       fcgiwrap.zoneminder = lib.mkIf useNginx {
-        preforkProcesses = cfg.cameras;
-        inherit user group;
+        process.prefork = cfg.cameras;
+        process.user = user;
+        process.group = group;
       };
 
       mysql = lib.mkIf cfg.database.createLocally {
@@ -254,7 +255,7 @@ in {
                   fastcgi_param HTTP_PROXY "";
                   fastcgi_intercept_errors on;
 
-                  fastcgi_pass unix:${config.services.fcgiwrap.zoneminder.socketAddress};
+                  fastcgi_pass unix:${config.services.fcgiwrap.zoneminder.socket.address};
                 }
 
                 location /cache/ {

--- a/nixos/modules/services/misc/zoneminder.nix
+++ b/nixos/modules/services/misc/zoneminder.nix
@@ -202,8 +202,7 @@ in {
     ];
 
     services = {
-      fcgiwrap = lib.mkIf useNginx {
-        enable = true;
+      fcgiwrap.zoneminder = lib.mkIf useNginx {
         preforkProcesses = cfg.cameras;
         inherit user group;
       };
@@ -225,9 +224,7 @@ in {
             default = true;
             root = "${pkg}/share/zoneminder/www";
             listen = [ { addr = "0.0.0.0"; inherit (cfg) port; } ];
-            extraConfig = let
-              fcgi = config.services.fcgiwrap;
-            in ''
+            extraConfig = ''
               index index.php;
 
               location / {
@@ -257,7 +254,7 @@ in {
                   fastcgi_param HTTP_PROXY "";
                   fastcgi_intercept_errors on;
 
-                  fastcgi_pass ${fcgi.socketType}:${fcgi.socketAddress};
+                  fastcgi_pass unix:${config.services.fcgiwrap.zoneminder.socketAddress};
                 }
 
                 location /cache/ {

--- a/nixos/modules/services/networking/cgit.nix
+++ b/nixos/modules/services/networking/cgit.nix
@@ -154,6 +154,18 @@ in
             type = types.lines;
             default = "";
           };
+
+          user = mkOption {
+            description = "User to run the cgit service as.";
+            type = types.str;
+            default = "cgit";
+          };
+
+          group = mkOption {
+            description = "Group to run the cgit service as.";
+            type = types.str;
+            default = "cgit";
+          };
         };
       }));
     };
@@ -165,8 +177,17 @@ in
       message = "Exactly one of services.cgit.${vhost}.scanPath or services.cgit.${vhost}.repos must be set.";
     }) cfgs;
 
+    users = mkMerge (flip mapAttrsToList cfgs (_: cfg: {
+      users.${cfg.user} = {
+        isSystemUser = true;
+        inherit (cfg) group;
+      };
+      groups.${cfg.group} = { };
+    }));
+
     services.fcgiwrap = flip mapAttrs' cfgs (name: cfg:
       nameValuePair "cgit-${name}" {
+        process = { inherit (cfg) user group; };
         socket = { inherit (config.services.nginx) user group; };
       }
     );

--- a/nixos/modules/services/networking/cgit.nix
+++ b/nixos/modules/services/networking/cgit.nix
@@ -167,6 +167,7 @@ in
 
     services.fcgiwrap = flip mapAttrs' cfgs (name: cfg:
       nameValuePair "cgit-${name}" {
+        socket = { inherit (config.services.nginx) user group; };
       }
     );
 

--- a/nixos/modules/services/networking/cgit.nix
+++ b/nixos/modules/services/networking/cgit.nix
@@ -32,7 +32,7 @@ let
       fastcgi_split_path_info ^(${regexLocation cfg})(/.+)$;
       fastcgi_param PATH_INFO $fastcgi_path_info;
     ''
-    }fastcgi_pass unix:${config.services.fcgiwrap."cgit-${name}".socketAddress};
+    }fastcgi_pass unix:${config.services.fcgiwrap."cgit-${name}".socket.address};
   '';
 
   cgitrcLine = name: value: "${name}=${

--- a/nixos/modules/services/networking/smokeping.nix
+++ b/nixos/modules/services/networking/smokeping.nix
@@ -337,7 +337,10 @@ in
     };
 
     # use nginx to serve the smokeping web service
-    services.fcgiwrap.enable = mkIf cfg.webService true;
+    services.fcgiwrap.smokeping = mkIf cfg.webService {
+      user = cfg.user;
+      group = cfg.user;
+    };
     services.nginx = mkIf cfg.webService {
       enable = true;
       virtualHosts."smokeping" = {
@@ -349,7 +352,7 @@ in
         locations."/smokeping.fcgi" = {
           extraConfig = ''
             include ${config.services.nginx.package}/conf/fastcgi_params;
-            fastcgi_pass unix:${config.services.fcgiwrap.socketAddress};
+            fastcgi_pass unix:${config.services.fcgiwrap.smokeping.socketAddress};
             fastcgi_param SCRIPT_FILENAME ${smokepingHome}/smokeping.fcgi;
             fastcgi_param DOCUMENT_ROOT ${smokepingHome};
           '';

--- a/nixos/modules/services/networking/smokeping.nix
+++ b/nixos/modules/services/networking/smokeping.nix
@@ -340,6 +340,7 @@ in
     services.fcgiwrap.smokeping = mkIf cfg.webService {
       process.user = cfg.user;
       process.group = cfg.user;
+      socket = { inherit (config.services.nginx) user group; };
     };
     services.nginx = mkIf cfg.webService {
       enable = true;

--- a/nixos/modules/services/networking/smokeping.nix
+++ b/nixos/modules/services/networking/smokeping.nix
@@ -338,8 +338,8 @@ in
 
     # use nginx to serve the smokeping web service
     services.fcgiwrap.smokeping = mkIf cfg.webService {
-      user = cfg.user;
-      group = cfg.user;
+      process.user = cfg.user;
+      process.group = cfg.user;
     };
     services.nginx = mkIf cfg.webService {
       enable = true;
@@ -352,7 +352,7 @@ in
         locations."/smokeping.fcgi" = {
           extraConfig = ''
             include ${config.services.nginx.package}/conf/fastcgi_params;
-            fastcgi_pass unix:${config.services.fcgiwrap.smokeping.socketAddress};
+            fastcgi_pass unix:${config.services.fcgiwrap.smokeping.socket.address};
             fastcgi_param SCRIPT_FILENAME ${smokepingHome}/smokeping.fcgi;
             fastcgi_param DOCUMENT_ROOT ${smokepingHome};
           '';

--- a/nixos/modules/services/web-servers/fcgiwrap.nix
+++ b/nixos/modules/services/web-servers/fcgiwrap.nix
@@ -13,7 +13,7 @@ in {
     default = { };
     type = types.attrsOf (types.submodule ({ config, ... }: { options = {
       process.prefork = mkOption {
-        type = types.int;
+        type = types.ints.positive;
         default = 1;
         description = "Number of processes to prefork.";
       };

--- a/nixos/modules/services/web-servers/fcgiwrap.nix
+++ b/nixos/modules/services/web-servers/fcgiwrap.nix
@@ -54,9 +54,13 @@ in {
       wantedBy = optional (cfg.socket.type != "unix") "multi-user.target";
 
       serviceConfig = {
-        ExecStart = "${pkgs.fcgiwrap}/sbin/fcgiwrap -c ${builtins.toString cfg.process.prefork} ${
-          optionalString (cfg.socket.type != "unix") "-s ${cfg.socket.type}:${cfg.socket.address}"
-        }";
+        ExecStart = ''
+          ${pkgs.fcgiwrap}/sbin/fcgiwrap ${cli.toGNUCommandLineShell {} ({
+            c = cfg.process.prefork;
+          } // (optionalAttrs (cfg.socket.type != "unix") {
+            s = "${cfg.socket.type}:${cfg.socket.address}";
+          }))}
+        '';
       } // (if cfg.process.user != null && cfg.process.group != null then {
         User = cfg.process.user;
         Group = cfg.process.group;

--- a/nixos/modules/services/web-servers/fcgiwrap.nix
+++ b/nixos/modules/services/web-servers/fcgiwrap.nix
@@ -21,7 +21,10 @@ in {
       process.user = mkOption {
         type = types.nullOr types.str;
         default = null;
-        description = "User as which this instance of fcgiwrap will be run.";
+        description = ''
+          User as which this instance of fcgiwrap will be run.
+          Set to `null` (the default) to use a dynamically allocated user.
+        '';
       };
 
       process.group = mkOption {
@@ -106,10 +109,12 @@ in {
             s = "${cfg.socket.type}:${cfg.socket.address}";
           }))}
         '';
-      } // (if cfg.process.user != null && cfg.process.group != null then {
+      } // (if cfg.process.user != null then {
         User = cfg.process.user;
         Group = cfg.process.group;
-      } else { } );
+      } else {
+        DynamicUser = true;
+      });
     });
 
     systemd.sockets = forEachInstance (cfg: mkIf (cfg.socket.type == "unix") {

--- a/nixos/tests/cgit.nix
+++ b/nixos/tests/cgit.nix
@@ -23,7 +23,7 @@ in {
         nginx.location = "/(c)git/";
         repos = {
           some-repo = {
-            path = "/srv/git/some-repo";
+            path = "/tmp/git/some-repo";
             desc = "some-repo description";
           };
         };
@@ -50,12 +50,12 @@ in {
 
     server.fail("curl -fsS http://localhost/robots.txt")
 
-    server.succeed("${pkgs.writeShellScript "setup-cgit-test-repo" ''
+    server.succeed("sudo -u cgit ${pkgs.writeShellScript "setup-cgit-test-repo" ''
       set -e
-      git init --bare -b master /srv/git/some-repo
+      git init --bare -b master /tmp/git/some-repo
       git init -b master reference
       cd reference
-      git remote add origin /srv/git/some-repo
+      git remote add origin /tmp/git/some-repo
       date > date.txt
       git add date.txt
       git -c user.name=test -c user.email=test@localhost commit -m 'add date'

--- a/nixos/tests/gitolite-fcgiwrap.nix
+++ b/nixos/tests/gitolite-fcgiwrap.nix
@@ -25,8 +25,8 @@ import ./make-test-python.nix (
                 networking.firewall.allowedTCPPorts = [ 80 ];
 
                 services.fcgiwrap.gitolite = {
-                  user = "gitolite";
-                  group = "gitolite";
+                  process.user = "gitolite";
+                  process.group = "gitolite";
                 };
 
                 services.gitolite = {
@@ -63,7 +63,7 @@ import ./make-test-python.nix (
                     fastcgi_param SCRIPT_FILENAME ${pkgs.gitolite}/bin/gitolite-shell;
 
                     # use Unix domain socket or inet socket
-                    fastcgi_pass unix:${config.services.fcgiwrap.gitolite.socketAddress};
+                    fastcgi_pass unix:${config.services.fcgiwrap.gitolite.socket.address};
                   '';
                 };
 

--- a/nixos/tests/gitolite-fcgiwrap.nix
+++ b/nixos/tests/gitolite-fcgiwrap.nix
@@ -27,6 +27,7 @@ import ./make-test-python.nix (
                 services.fcgiwrap.gitolite = {
                   process.user = "gitolite";
                   process.group = "gitolite";
+                  socket = { inherit (config.services.nginx) user group; };
                 };
 
                 services.gitolite = {

--- a/nixos/tests/gitolite-fcgiwrap.nix
+++ b/nixos/tests/gitolite-fcgiwrap.nix
@@ -24,7 +24,11 @@ import ./make-test-python.nix (
               {
                 networking.firewall.allowedTCPPorts = [ 80 ];
 
-                services.fcgiwrap.enable = true;
+                services.fcgiwrap.gitolite = {
+                  user = "gitolite";
+                  group = "gitolite";
+                };
+
                 services.gitolite = {
                   enable = true;
                   adminPubkey = adminPublicKey;
@@ -59,7 +63,7 @@ import ./make-test-python.nix (
                     fastcgi_param SCRIPT_FILENAME ${pkgs.gitolite}/bin/gitolite-shell;
 
                     # use Unix domain socket or inet socket
-                    fastcgi_pass unix:/run/fcgiwrap.sock;
+                    fastcgi_pass unix:${config.services.fcgiwrap.gitolite.socketAddress};
                   '';
                 };
 
@@ -82,7 +86,7 @@ import ./make-test-python.nix (
 
           server.wait_for_unit("gitolite-init.service")
           server.wait_for_unit("nginx.service")
-          server.wait_for_file("/run/fcgiwrap.sock")
+          server.wait_for_file("/run/fcgiwrap-gitolite.sock")
 
           client.wait_for_unit("multi-user.target")
           client.succeed(


### PR DESCRIPTION
## Description of changes

This PR fixes mulitple issues with the fcgiwrap module:
- It's now possible to run multiple instances of fcgiwrap,
  solving the interference issue between its consumer modules.
- The service and the spawned scripts no longer run as root by default.
- The UNIX socket is no longer exposed to everyone by default.

With the previous defaults in the module,
any local user could execute scripts as root through the socket when any of
`services.{fcgiwrap,cgit,smokeping}.enable = true` was set.
The smokeping and cgit services were indeed partially and fully running as
root. This has also been fixed in this PR.

This changes the exposed options quite a bit, making this change backward
incompatible. The security benefits might however make it worth backporting.

See indidivual commit messages and modified release notes for details.

I tested these changes by running the NixOS tests of some consumers of this
module: `nix build .#nixosTests.{smokeping,zoneminder,gitolite-fcgiwrap,cgit}`


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
