### PR TITLE
treewide: support structuredAttrs in setup hooks

### DIFF
--- a/pkgs/build-support/setup-hooks/autoreconf.sh
+++ b/pkgs/build-support/setup-hooks/autoreconf.sh
@@ -2,6 +2,11 @@ preConfigurePhases="${preConfigurePhases:-} autoreconfPhase"
 
 autoreconfPhase() {
     runHook preAutoreconf
-    autoreconf ${autoreconfFlags:---install --force --verbose}
+
+    local flagsArray=()
+    : "${autoreconfFlags:=--install --force --verbose}"
+    concatTo flagsArray autoreconfFlags
+
+    autoreconf "${flagsArray[@]}"
     runHook postAutoreconf
 }

--- a/pkgs/by-name/cm/cmake/setup-hook.sh
+++ b/pkgs/by-name/cm/cmake/setup-hook.sh
@@ -38,7 +38,7 @@ cmakeConfigurePhase() {
     fi
 
     if [ -z "${dontAddPrefix-}" ]; then
-        cmakeFlags="-DCMAKE_INSTALL_PREFIX=$prefix $cmakeFlags"
+        prependToVar cmakeFlags "-DCMAKE_INSTALL_PREFIX=$prefix"
     fi
 
     # We should set the proper `CMAKE_SYSTEM_NAME`.
@@ -47,21 +47,21 @@ cmakeConfigurePhase() {
     # Unfortunately cmake seems to expect absolute paths for ar, ranlib, and
     # strip. Otherwise they are taken to be relative to the source root of the
     # package being built.
-    cmakeFlags="-DCMAKE_CXX_COMPILER=$CXX $cmakeFlags"
-    cmakeFlags="-DCMAKE_C_COMPILER=$CC $cmakeFlags"
-    cmakeFlags="-DCMAKE_AR=$(command -v $AR) $cmakeFlags"
-    cmakeFlags="-DCMAKE_RANLIB=$(command -v $RANLIB) $cmakeFlags"
-    cmakeFlags="-DCMAKE_STRIP=$(command -v $STRIP) $cmakeFlags"
+    prependToVar cmakeFlags "-DCMAKE_CXX_COMPILER=$CXX"
+    prependToVar cmakeFlags "-DCMAKE_C_COMPILER=$CC"
+    prependToVar cmakeFlags "-DCMAKE_AR=$(command -v $AR)"
+    prependToVar cmakeFlags "-DCMAKE_RANLIB=$(command -v $RANLIB)"
+    prependToVar cmakeFlags "-DCMAKE_STRIP=$(command -v $STRIP)"
 
     # on macOS we want to prefer Unix-style headers to Frameworks
     # because we usually do not package the framework
-    cmakeFlags="-DCMAKE_FIND_FRAMEWORK=LAST $cmakeFlags"
+    prependToVar cmakeFlags "-DCMAKE_FIND_FRAMEWORK=LAST"
 
     # we never want to use the global macOS SDK
-    cmakeFlags="-DCMAKE_OSX_SYSROOT= $cmakeFlags"
+    prependToVar cmakeFlags "-DCMAKE_OSX_SYSROOT="
 
     # correctly detect our clang compiler
-    cmakeFlags="-DCMAKE_POLICY_DEFAULT_CMP0025=NEW $cmakeFlags"
+    prependToVar cmakeFlags "-DCMAKE_POLICY_DEFAULT_CMP0025=NEW"
 
     # This installs shared libraries with a fully-specified install
     # name. By default, cmake installs shared libraries with just the
@@ -70,7 +70,7 @@ cmakeConfigurePhase() {
     # libraries are in a system path or in the same directory as the
     # executable. This flag makes the shared library accessible from its
     # nix/store directory.
-    cmakeFlags="-DCMAKE_INSTALL_NAME_DIR=${!outputLib}/lib $cmakeFlags"
+    prependToVar cmakeFlags "-DCMAKE_INSTALL_NAME_DIR=${!outputLib}/lib"
 
     # The docdir flag needs to include PROJECT_NAME as per GNU guidelines,
     # try to extract it from CMakeLists.txt.
@@ -93,39 +93,42 @@ cmakeConfigurePhase() {
     # This ensures correct paths with multiple output derivations
     # It requires the project to use variables from GNUInstallDirs module
     # https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
-    cmakeFlags="-DCMAKE_INSTALL_BINDIR=${!outputBin}/bin $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_SBINDIR=${!outputBin}/sbin $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_INCLUDEDIR=${!outputInclude}/include $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_OLDINCLUDEDIR=${!outputInclude}/include $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_MANDIR=${!outputMan}/share/man $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_INFODIR=${!outputInfo}/share/info $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_DOCDIR=${!outputDoc}/share/doc/${shareDocName} $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_LIBDIR=${!outputLib}/lib $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_LIBEXECDIR=${!outputLib}/libexec $cmakeFlags"
-    cmakeFlags="-DCMAKE_INSTALL_LOCALEDIR=${!outputLib}/share/locale $cmakeFlags"
+    prependToVar cmakeFlags "-DCMAKE_INSTALL_BINDIR=${!outputBin}/bin"
+    prependToVar cmakeFlags "-DCMAKE_INSTALL_SBINDIR=${!outputBin}/sbin"
+    prependToVar cmakeFlags "-DCMAKE_INSTALL_INCLUDEDIR=${!outputInclude}/include"
+    prependToVar cmakeFlags "-DCMAKE_INSTALL_OLDINCLUDEDIR=${!outputInclude}/include"
+    prependToVar cmakeFlags "-DCMAKE_INSTALL_MANDIR=${!outputMan}/share/man"
+    prependToVar cmakeFlags "-DCMAKE_INSTALL_INFODIR=${!outputInfo}/share/info"
+    prependToVar cmakeFlags "-DCMAKE_INSTALL_DOCDIR=${!outputDoc}/share/doc/${shareDocName}"
+    prependToVar cmakeFlags "-DCMAKE_INSTALL_LIBDIR=${!outputLib}/lib"
+    prependToVar cmakeFlags "-DCMAKE_INSTALL_LIBEXECDIR=${!outputLib}/libexec"
+    prependToVar cmakeFlags "-DCMAKE_INSTALL_LOCALEDIR=${!outputLib}/share/locale"
 
     # Don’t build tests when doCheck = false
     if [ -z "${doCheck-}" ]; then
-        cmakeFlags="-DBUILD_TESTING=OFF $cmakeFlags"
+        prependToVar cmakeFlags "-DBUILD_TESTING=OFF"
     fi
 
     # Always build Release, to ensure optimisation flags
-    cmakeFlags="-DCMAKE_BUILD_TYPE=${cmakeBuildType:-Release} $cmakeFlags"
+    prependToVar cmakeFlags "-DCMAKE_BUILD_TYPE=${cmakeBuildType:-Release}"
 
     # Disable user package registry to avoid potential side effects
     # and unecessary attempts to access non-existent home folder
     # https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#disabling-the-package-registry
-    cmakeFlags="-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON $cmakeFlags"
-    cmakeFlags="-DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF $cmakeFlags"
-    cmakeFlags="-DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF $cmakeFlags"
+    prependToVar cmakeFlags "-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON"
+    prependToVar cmakeFlags "-DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF"
+    prependToVar cmakeFlags "-DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF"
 
     if [ "${buildPhase-}" = ninjaBuildPhase ]; then
-        cmakeFlags="-GNinja $cmakeFlags"
+        prependToVar cmakeFlags "-GNinja"
     fi
 
-    echo "cmake flags: $cmakeFlags ${cmakeFlagsArray[@]}"
+    local flagsArray=()
+    concatTo flagsArray cmakeFlags cmakeFlagsArray
 
-    cmake "$cmakeDir" $cmakeFlags "${cmakeFlagsArray[@]}"
+    echoCmd 'cmake flags' "${flagsArray[@]}"
+
+    cmake "$cmakeDir" "${flagsArray[@]}"
 
     if ! [[ -v enableParallelBuilding ]]; then
         enableParallelBuilding=1

--- a/pkgs/by-name/lo/local-ai/package.nix
+++ b/pkgs/by-name/lo/local-ai/package.nix
@@ -488,7 +488,7 @@ let
         ''${enableParallelBuilding:+-j''${NIX_BUILD_CORES}}
         SHELL=$SHELL
       )
-      _accumFlagsArray makeFlags makeFlagsArray buildFlags buildFlagsArray
+      concatTo flagsArray makeFlags makeFlagsArray buildFlags buildFlagsArray
       echoCmd 'build flags' "''${flagsArray[@]}"
       make build "''${flagsArray[@]}"
       unset flagsArray

--- a/pkgs/by-name/me/meson/setup-hook.sh
+++ b/pkgs/by-name/me/meson/setup-hook.sh
@@ -21,7 +21,6 @@ mesonConfigurePhase() {
         "--localedir=${!outputLib}/share/locale"
         "-Dauto_features=${mesonAutoFeatures:-enabled}"
         "-Dwrap_mode=${mesonWrapMode:-nodownload}"
-        ${crossMesonFlags}
         "--buildtype=${mesonBuildType:-plain}"
     )
 

--- a/pkgs/by-name/me/meson/setup-hook.sh
+++ b/pkgs/by-name/me/meson/setup-hook.sh
@@ -25,7 +25,7 @@ mesonConfigurePhase() {
         "--buildtype=${mesonBuildType:-plain}"
     )
 
-    _accumFlagsArray mesonFlags mesonFlagsArray
+    concatTo flagsArray mesonFlags mesonFlagsArray
 
     echoCmd 'mesonConfigurePhase flags' "${flagsArray[@]}"
 

--- a/pkgs/by-name/me/meson/setup-hook.sh
+++ b/pkgs/by-name/me/meson/setup-hook.sh
@@ -50,7 +50,8 @@ mesonConfigurePhase() {
 mesonCheckPhase() {
     runHook preCheck
 
-    local flagsArray=($mesonCheckFlags "${mesonCheckFlagsArray[@]}")
+    local flagsArray=()
+    concatTo flagsArray mesonCheckFlags mesonCheckFlagsArray
 
     echoCmd 'mesonCheckPhase flags' "${flagsArray[@]}"
     meson test --no-rebuild --print-errorlogs "${flagsArray[@]}"
@@ -64,12 +65,9 @@ mesonInstallPhase() {
     local flagsArray=()
 
     if [[ -n "$mesonInstallTags" ]]; then
-        flagsArray+=("--tags" "${mesonInstallTags// /,}")
+        flagsArray+=("--tags" "$(concatStringsSep "," mesonInstallTags)")
     fi
-    flagsArray+=(
-        $mesonInstallFlags
-        "${mesonInstallFlagsArray[@]}"
-    )
+    concatTo flagsArray mesonInstallFlags mesonInstallFlagsArray
 
     echoCmd 'mesonInstallPhase flags' "${flagsArray[@]}"
     meson install --no-rebuild "${flagsArray[@]}"

--- a/pkgs/by-name/ni/ninja/setup-hook.sh
+++ b/pkgs/by-name/ni/ninja/setup-hook.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 ninjaBuildPhase() {
     runHook preBuild
 
@@ -9,7 +11,7 @@ ninjaBuildPhase() {
     fi
 
     local flagsArray=(
-        -j$buildCores
+        "-j$buildCores"
     )
     concatTo flagsArray ninjaFlags ninjaFlagsArray
 
@@ -24,7 +26,7 @@ ninjaCheckPhase() {
 
     if [ -z "${checkTarget:-}" ]; then
         if ninja -t query test >/dev/null 2>&1; then
-            checkTarget=test
+            checkTarget="test"
         fi
     fi
 
@@ -38,7 +40,7 @@ ninjaCheckPhase() {
         fi
 
         local flagsArray=(
-            -j$buildCores
+            "-j$buildCores"
         )
         concatTo flagsArray ninjaFlags ninjaFlagsArray checkTarget
 
@@ -61,9 +63,9 @@ ninjaInstallPhase() {
 
     # shellcheck disable=SC2086
     local flagsArray=(
-        -j$buildCores
+        "-j$buildCores"
     )
-    : ${installTargets:=install}
+    : "${installTargets:=install}"
     concatTo flagsArray ninjaFlags ninjaFlagsArray installTargets
 
     echoCmd 'install flags' "${flagsArray[@]}"
@@ -72,14 +74,14 @@ ninjaInstallPhase() {
     runHook postInstall
 }
 
-if [ -z "${dontUseNinjaBuild-}" -a -z "${buildPhase-}" ]; then
+if [ -z "${dontUseNinjaBuild-}" ] && [ -z "${buildPhase-}" ]; then
     buildPhase=ninjaBuildPhase
 fi
 
-if [ -z "${dontUseNinjaCheck-}" -a -z "${checkPhase-}" ]; then
+if [ -z "${dontUseNinjaCheck-}" ] && [ -z "${checkPhase-}" ]; then
     checkPhase=ninjaCheckPhase
 fi
 
-if [ -z "${dontUseNinjaInstall-}" -a -z "${installPhase-}" ]; then
+if [ -z "${dontUseNinjaInstall-}" ] && [ -z "${installPhase-}" ]; then
     installPhase=ninjaInstallPhase
 fi

--- a/pkgs/by-name/ni/ninja/setup-hook.sh
+++ b/pkgs/by-name/ni/ninja/setup-hook.sh
@@ -10,8 +10,8 @@ ninjaBuildPhase() {
 
     local flagsArray=(
         -j$buildCores
-        $ninjaFlags "${ninjaFlagsArray[@]}"
     )
+    concatTo flagsArray ninjaFlags ninjaFlagsArray
 
     echoCmd 'build flags' "${flagsArray[@]}"
     TERM=dumb ninja "${flagsArray[@]}"
@@ -39,9 +39,8 @@ ninjaCheckPhase() {
 
         local flagsArray=(
             -j$buildCores
-            $ninjaFlags "${ninjaFlagsArray[@]}"
-            $checkTarget
         )
+        concatTo flagsArray ninjaFlags ninjaFlagsArray checkTarget
 
         echoCmd 'check flags' "${flagsArray[@]}"
         TERM=dumb ninja "${flagsArray[@]}"
@@ -63,9 +62,9 @@ ninjaInstallPhase() {
     # shellcheck disable=SC2086
     local flagsArray=(
         -j$buildCores
-        $ninjaFlags "${ninjaFlagsArray[@]}"
-        ${installTargets:-install}
     )
+    : ${installTargets:=install}
+    concatTo flagsArray ninjaFlags ninjaFlagsArray installTargets
 
     echoCmd 'install flags' "${flagsArray[@]}"
     TERM=dumb ninja "${flagsArray[@]}"

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -357,6 +357,36 @@ concatTo() {
     done
 }
 
+# Concatenate a list of strings ($2) with a separator ($1) between each element.
+# The list can be an indexed array of strings or a single string. A single string
+# is split on spaces and then concatenated with the separator.
+#
+# $ flags="lorem ipsum dolor sit amet"
+# $ concatStringsSep ";" flags
+# lorem;ipsum;dolor;sit;amet
+#
+# $ flags=("lorem ipsum" "dolor" "sit amet")
+# $ concatStringsSep ";" flags
+# lorem ipsum;dolor;sit amet
+concatStringsSep() {
+    local sep="$1"
+    local name="$2"
+    local type oldifs
+    if type=$(declare -p "$name" 2> /dev/null); then
+        local -n nameref="$name"
+        case "${type#* }" in
+            -A*)
+                echo "concatStringsSep(): ERROR: trying to use concatStringsSep on an associative array." >&2
+                return 1 ;;
+            -a*)
+                local IFS="$sep"
+                echo -n "${nameref[*]}" ;;
+            *)
+                echo -n "${nameref// /${sep}}" ;;
+        esac
+    fi
+}
+
 # Add $1/lib* into rpaths.
 # The function is used in multiple-outputs.sh hook,
 # so it is defined here but tried after the hook.

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -280,16 +280,16 @@ prependToVar() {
     fi
 
     # check if variable already exist and if it does then do extra checks
-    if declare -p "$1" 2> /dev/null | grep -q '^'; then
-        type="$(declare -p "$1")"
-        if [[ "$type" =~ "declare -A" ]]; then
-            echo "prependToVar(): ERROR: trying to use prependToVar on an associative array." >&2
-            return 1
-        elif [[ "$type" =~ "declare -a" ]]; then
-            useArray=true
-        else
-            useArray=false
-        fi
+    if type=$(declare -p "$1" 2> /dev/null); then
+        case "${type#* }" in
+            -A*)
+                echo "prependToVar(): ERROR: trying to use prependToVar on an associative array." >&2
+                return 1 ;;
+            -a*)
+                useArray=true ;;
+            *)
+                useArray=false ;;
+        esac
     fi
 
     shift
@@ -313,16 +313,16 @@ appendToVar() {
     fi
 
     # check if variable already exist and if it does then do extra checks
-    if declare -p "$1" 2> /dev/null | grep -q '^'; then
-        type="$(declare -p "$1")"
-        if [[ "$type" =~ "declare -A" ]]; then
-            echo "appendToVar(): ERROR: trying to use appendToVar on an associative array, use variable+=([\"X\"]=\"Y\") instead." >&2
-            return 1
-        elif [[ "$type" =~ "declare -a" ]]; then
-            useArray=true
-        else
-            useArray=false
-        fi
+    if type=$(declare -p "$1" 2> /dev/null); then
+        case "${type#* }" in
+            -A*)
+                echo "appendToVar(): ERROR: trying to use appendToVar on an associative array, use variable+=([\"X\"]=\"Y\") instead." >&2
+                return 1 ;;
+            -a*)
+                useArray=true ;;
+            *)
+                useArray=false ;;
+        esac
     fi
 
     shift

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1254,12 +1254,8 @@ patchPhase() {
         esac
 
         local -a flagsArray
-        if [ -n "$__structuredAttrs" ]; then
-            flagsArray=( "${patchFlags[@]:--p1}" )
-        else
-            # shellcheck disable=SC2086,SC2206
-            flagsArray=( ${patchFlags:--p1} )
-        fi
+        : "${patchFlags:=-p1}"
+        concatTo flagsArray patchFlags
         # "2>&1" is a hack to make patch fail if the decompressor fails (nonexistent patch, etc.)
         # shellcheck disable=SC2086
         $uncompress < "$i" 2>&1 | patch "${flagsArray[@]}"
@@ -1411,16 +1407,8 @@ checkPhase() {
             SHELL="$SHELL"
         )
 
-        concatTo flagsArray makeFlags makeFlagsArray
-        if [ -n "$__structuredAttrs" ]; then
-            flagsArray+=( "${checkFlags[@]:-VERBOSE=y}" )
-        else
-            # shellcheck disable=SC2206
-            flagsArray+=( ${checkFlags:-VERBOSE=y} )
-        fi
-        concatTo flagsArray checkFlagsArray
-        # shellcheck disable=SC2206
-        flagsArray+=( ${checkTarget} )
+        : "${checkFlags:=VERBOSE=y}"
+        concatTo flagsArray makeFlags makeFlagsArray checkFlags checkFlagsArray checkTarget
 
         echoCmd 'check flags' "${flagsArray[@]}"
         make ${makefile:+-f $makefile} "${flagsArray[@]}"
@@ -1453,13 +1441,9 @@ installPhase() {
         ${enableParallelInstalling:+-j${NIX_BUILD_CORES}}
         SHELL="$SHELL"
     )
-    concatTo flagsArray makeFlags makeFlagsArray installFlags installFlagsArray
-    if [ -n "$__structuredAttrs" ]; then
-        flagsArray+=( "${installTargets[@]:-install}" )
-    else
-        # shellcheck disable=SC2206
-        flagsArray+=( ${installTargets:-install} )
-    fi
+
+    : "${installTargets:=install}"
+    concatTo flagsArray makeFlags makeFlagsArray installFlags installFlagsArray installTargets
 
     echoCmd 'install flags' "${flagsArray[@]}"
     make ${makefile:+-f $makefile} "${flagsArray[@]}"
@@ -1542,10 +1526,9 @@ installCheckPhase() {
             SHELL="$SHELL"
         )
 
+        : "${installCheckTarget:=installcheck}"
         concatTo flagsArray makeFlags makeFlagsArray \
-          installCheckFlags installCheckFlagsArray
-        # shellcheck disable=SC2206
-        flagsArray+=( ${installCheckTarget:-installcheck} )
+          installCheckFlags installCheckFlagsArray installCheckTarget
 
         echoCmd 'installcheck flags' "${flagsArray[@]}"
         make ${makefile:+-f $makefile} "${flagsArray[@]}"
@@ -1560,9 +1543,8 @@ distPhase() {
     runHook preDist
 
     local flagsArray=()
-    concatTo flagsArray distFlags distFlagsArray
-    # shellcheck disable=SC2206
-    flagsArray+=( ${distTarget:-dist} )
+    : "${distTarget:=dist}"
+    concatTo flagsArray distFlags distFlagsArray distTarget
 
     echo 'dist flags: %q' "${flagsArray[@]}"
     make ${makefile:+-f $makefile} "${flagsArray[@]}"

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -382,7 +382,7 @@ concatStringsSep() {
                 local IFS="$sep"
                 echo -n "${nameref[*]}" ;;
             *)
-                echo -n "${nameref// /${sep}}" ;;
+                echo -n "${nameref// /"${sep}"}" ;;
         esac
     fi
 }

--- a/pkgs/test/stdenv/default.nix
+++ b/pkgs/test/stdenv/default.nix
@@ -131,6 +131,27 @@ let
         '';
       } // extraAttrs);
 
+  testConcatStringsSep = { name, stdenv' }:
+    stdenv'.mkDerivation
+      {
+        inherit name;
+
+        passAsFile = [ "buildCommand" ];
+        buildCommand = ''
+          declare -A associativeArray=(["X"]="Y")
+          [[ $(concatStringsSep ";" associativeArray 2>&1) =~ "trying to use" ]] || (echo "concatStringsSep did not throw concatenating associativeArray" && false)
+
+          string="lorem ipsum dolor sit amet"
+          stringWithSep="$(concatStringsSep ";" string)"
+          [[ "$stringWithSep" == "lorem;ipsum;dolor;sit;amet" ]] || (echo "'\$stringWithSep' was not 'lorem;ipsum;dolor;sit;amet'" && false)
+
+          array=("lorem ipsum" "dolor" "sit amet")
+          arrayWithSep="$(concatStringsSep ";" array)"
+          [[ "$arrayWithSep" == "lorem ipsum;dolor;sit amet" ]] || (echo "'\$arrayWithSep' was not 'lorem ipsum;dolor;sit amet'" && false)
+
+          touch $out
+        '';
+      };
 in
 
 {
@@ -236,6 +257,11 @@ in
     stdenv' = bootStdenv;
   };
 
+  test-concat-strings-sep = testConcatStringsSep {
+    name = "test-concat-strings-sep";
+    stdenv' = bootStdenv;
+  };
+
   test-structured-env-attrset = testEnvAttrset {
     name = "test-structured-env-attrset";
     stdenv' = bootStdenv;
@@ -311,6 +337,11 @@ in
           [[ "''${flagsWithSpaces[3]}" == "d d" ]] || (echo "'\$flagsWithSpaces[3]' was not 'd d'" && false)
         '';
       };
+    };
+
+    test-concat-strings-sep = testConcatStringsSep {
+      name = "test-concat-strings-sep-structuredAttrsByDefault";
+      stdenv' = bootStdenvStructuredAttrsByDefault;
     };
 
     test-golden-example-structuredAttrs =

--- a/pkgs/test/stdenv/default.nix
+++ b/pkgs/test/stdenv/default.nix
@@ -74,19 +74,19 @@ let
           declare -p string
 
           declare -A associativeArray=(["X"]="Y")
-          [[ $(appendToVar associativeArray "fail" 2>&1) =~ "trying to use" ]] || (echo "prependToVar did not catch prepending associativeArray" && false)
-          [[ $(prependToVar associativeArray "fail" 2>&1) =~ "trying to use" ]] || (echo "prependToVar did not catch prepending associativeArray" && false)
+          [[ $(appendToVar associativeArray "fail" 2>&1) =~ "trying to use" ]] || (echo "appendToVar did not throw appending to associativeArray" && false)
+          [[ $(prependToVar associativeArray "fail" 2>&1) =~ "trying to use" ]] || (echo "prependToVar did not throw prepending associativeArray" && false)
 
           [[ $string == "world testing-string hello" ]] || (echo "'\$string' was not 'world testing-string hello'" && false)
 
           # test appending to a unset variable
           appendToVar nonExistant created hello
-          typeset -p nonExistant
+          declare -p nonExistant
           if [[ -n $__structuredAttrs ]]; then
             [[ "''${nonExistant[@]}" == "created hello" ]]
           else
             # there's a extra " " in front here and a extra " " in the end of prependToVar
-            # shouldn't matter because these functions will mostly be used for $*Flags and the Flag variable will in most cases already exit
+            # shouldn't matter because these functions will mostly be used for $*Flags and the Flag variable will in most cases already exist
             [[ "$nonExistant" == " created hello" ]]
           fi
 

--- a/pkgs/test/stdenv/default.nix
+++ b/pkgs/test/stdenv/default.nix
@@ -136,18 +136,21 @@ let
       {
         inherit name;
 
+        # NOTE: Testing with "&" as separator is intentional, because unquoted
+        # "&" has a special meaning in the "${var//pattern/replacement}" syntax.
+        # Cf. https://github.com/NixOS/nixpkgs/pull/318614#discussion_r1706191919
         passAsFile = [ "buildCommand" ];
         buildCommand = ''
           declare -A associativeArray=(["X"]="Y")
           [[ $(concatStringsSep ";" associativeArray 2>&1) =~ "trying to use" ]] || (echo "concatStringsSep did not throw concatenating associativeArray" && false)
 
           string="lorem ipsum dolor sit amet"
-          stringWithSep="$(concatStringsSep ";" string)"
-          [[ "$stringWithSep" == "lorem;ipsum;dolor;sit;amet" ]] || (echo "'\$stringWithSep' was not 'lorem;ipsum;dolor;sit;amet'" && false)
+          stringWithSep="$(concatStringsSep "&" string)"
+          [[ "$stringWithSep" == "lorem&ipsum&dolor&sit&amet" ]] || (echo "'\$stringWithSep' was not 'lorem&ipsum&dolor&sit&amet'" && false)
 
           array=("lorem ipsum" "dolor" "sit amet")
-          arrayWithSep="$(concatStringsSep ";" array)"
-          [[ "$arrayWithSep" == "lorem ipsum;dolor;sit amet" ]] || (echo "'\$arrayWithSep' was not 'lorem ipsum;dolor;sit amet'" && false)
+          arrayWithSep="$(concatStringsSep "&" array)"
+          [[ "$arrayWithSep" == "lorem ipsum&dolor&sit amet" ]] || (echo "'\$arrayWithSep' was not 'lorem ipsum&dolor&sit amet'" && false)
 
           touch $out
         '';


### PR DESCRIPTION
## Description of changes

I tried to build a package with `__structuredAttrs` which uses meson, realized that meson setup hooks don't support structuredAttrs, yet, and then... this happened.

The first 5 commits make the helpers in `stdenv` related to structuredAttrs a bit better re-usable. The remaining commits are using the "new" `concatTo` and `prependToVar` / `appendToVar` to fix many setup hooks.

The main goal here is to support structuredAttrs in those setup hooks *without* having any "if structuredAttrs then ..." conditionals except for a few in `stdenv`. I think this works pretty well.

There's a lot of changes in here, but many of them should be very easy to review. Most of them were tested by building a package using the related hooks: Once with `structuredAttrs` on master, which would fail, then with and without `structuredAttrs` on this branch - both would pass.

In any case, I pushed all those commits mostly to show how those helpers in `stdenv` would be used across the different hooks. I am happy to split up the PR into smaller pieces later and would welcome feedback especially on the first 5 commits.

The problem in 99% of those hooks is that `$xxxFlags` is used without `[@]`, which will always just return the first array item when using `structuredAttrs`. However a simple change to `$xxxFlags[@]` isn't going to fly, if whitespace should be treated properly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
