### PR TITLE
iperf2 2.2.0 update

### DIFF
--- a/pkgs/tools/networking/iperf/2.nix
+++ b/pkgs/tools/networking/iperf/2.nix
@@ -2,15 +2,15 @@
 
 stdenv.mkDerivation rec {
   pname = "iperf";
-  version = "2.1.4";
+  version = "2.2.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/iperf2/files/${pname}-${version}.tar.gz";
-    sha256 = "1yflnj2ni988nm0p158q8lnkiq2gn2chmvsglyn2gqmqhwp3jaq6";
+    sha256 = "16810a9575e4c6dd65e4a18ab5df3cdac6730b3c832cf080a8990f132f68364a";
   };
 
   hardeningDisable = [ "format" ];
-  configureFlags = [ "--enable-fastsampling" ];
+  #configureFlags = [ "--enable-fastsampling" ];
 
   makeFlags = [ "AR:=$(AR)" ];
 
@@ -20,12 +20,11 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "https://sourceforge.net/projects/iperf/";
+    homepage = "https://sourceforge.net/projects/iperf2/";
     description = "Tool to measure IP bandwidth using UDP or TCP";
     platforms = platforms.unix;
-    license = licenses.mit;
-
-    # prioritize iperf3
-    priority = 10;
+    # broadcom license
+    # https://sourceforge.net/p/iperf2/code/ci/master/tree/LICENSE
+    #license = licenses.mit;
   };
 }

--- a/pkgs/tools/networking/iperf/3.nix
+++ b/pkgs/tools/networking/iperf/3.nix
@@ -35,5 +35,9 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     license = licenses.bsd3;
     maintainers = with maintainers; [ fpletz ];
+
+    # prioritize iperf2
+    # https://iperf2.sourceforge.io/IperfCompare.html
+    priority = 10;
   };
 }


### PR DESCRIPTION
## Description of changes

- Update iperf2 2.1.4 (18 August 2021) to latest 2.2.0 version
-- Please note the existing version of iperf2 crashes for me on Linux x86
- Prefer iperf2 over iper3, which is potentially slightly controversial, so here's the reasons why:
-- https://iperf2.sourceforge.io/IperfCompare.html

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

This is my first nixpkgs pull request, so I tried to follow the instructions.  I cloned the repo into a folder and did the rebuild, and it looks good.
```
sudo nixos-rebuild switch -I nixpkgs=/home/das/nixpkgs

[das@nixos:~]$ iperf2 --version
iperf version 2.2.0 (10 April 2024) pthreads

[das@nixos:~]$ which iperf2
/run/current-system/sw/bin/iperf2

[das@nixos:~]$ iperf --version
iperf version 2.2.0 (10 April 2024) pthreads

[das@nixos:~]$ uname -a
Linux nixos 6.6.32 #1-NixOS SMP PREEMPT_DYNAMIC Sat May 25 14:22:56 UTC 2024 x86_64 GNU/Linux

[das@nixos:~]$ date
Sun Jun  9 12:58:29 PM PDT 2024

[das@nixos:~]$ cd nixpkgs/

[das@nixos:~/nixpkgs]$ git rev-parse HEAD
1b8293b45bf9064bf871e24ae6aebbb2b7eb1793

```

- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))

Test on linux only

I have been testing iperf2 2.20 on linux for several weeks now, doing a manual install.
```
#!/usr/bin/bash

wget https://sourceforge.net/projects/iperf2/files/iperf-2.2.0.tar.gz/download
mv ./download ./iperf-2.2.0.tar.gz

tar zxf ./iperf-2.2.0.tar.gz
cd iperf-2.2.0 || exit

# git clone https://git.code.sf.net/p/iperf2/code iperf2-code
# cd iperf2-code || exit
./configure
make
echo "sudo make install"       <--- manual install
```

Thanks in advance
Dave