### PR TITLE
box86: init at 0.3.6

### DIFF
--- a/pkgs/applications/emulators/box86/default.nix
+++ b/pkgs/applications/emulators/box86/default.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  cmake,
+  python3,
+  withDynarec ? stdenv.hostPlatform.isAarch32,
+  runCommand,
+  hello-x86_32,
+}:
+
+# Currently only supported on specific archs
+assert withDynarec -> stdenv.hostPlatform.isAarch32;
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "box86";
+  version = "0.3.6";
+
+  src = fetchFromGitHub {
+    owner = "ptitSeb";
+    repo = "box86";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Ywsf+q7tWcAbrwbE/KvM6AJFNMJvqHKWD6tuANxrUt8=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    python3
+  ];
+
+  cmakeFlags =
+    [
+      (lib.cmakeBool "NOGIT" true)
+
+      # Arch mega-option
+      (lib.cmakeBool "POWERPCLE" (stdenv.hostPlatform.isPower && stdenv.hostPlatform.isLittleEndian))
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isi686 [
+      # x86 has no arch-specific mega-option, manually enable the options that apply to it
+      (lib.cmakeBool "LD80BITS" true)
+      (lib.cmakeBool "NOALIGN" true)
+    ]
+    ++ [
+      # Arch dynarec
+      (lib.cmakeBool "ARM_DYNAREC" (withDynarec && stdenv.hostPlatform.isAarch))
+    ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm 0755 box86 "$out/bin/box86"
+
+    runHook postInstall
+  '';
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    echo Checking if it works
+    $out/bin/box86 -v
+
+    echo Checking if Dynarec option was respected
+    $out/bin/box86 -v | grep ${lib.optionalString (!withDynarec) "-v"} Dynarec
+
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    updateScript = gitUpdater { rev-prefix = "v"; };
+    tests.hello =
+      runCommand "box86-test-hello" { nativeBuildInputs = [ finalAttrs.finalPackage ]; }
+        # There is no actual "Hello, world!" with any of the logging enabled, and with all logging disabled it's hard to
+        # tell what problems the emulator has run into.
+        ''
+          BOX86_NOBANNER=0 BOX86_LOG=1 box86 ${lib.getExe hello-x86_32} --version | tee $out
+        '';
+  };
+
+  meta = {
+    homepage = "https://box86.org/";
+    description = "Lets you run x86 Linux programs on non-x86 Linux systems";
+    changelog = "https://github.com/ptitSeb/box86/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      gador
+      OPNA2608
+    ];
+    mainProgram = "box86";
+    platforms = [
+      "i686-linux"
+      "armv7l-linux"
+      "powerpcle-linux"
+      "loongarch64-linux"
+      "mipsel-linux"
+    ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2585,6 +2585,13 @@ with pkgs;
       pkgsCross.gnu64.hello;
   };
 
+  box86 = callPackage ../applications/emulators/box86 {
+    hello-x86_32 = if stdenv.hostPlatform.isx86_32 then
+      hello
+    else
+      pkgsCross.gnu32.hello;
+  };
+
   caprice32 = callPackage ../applications/emulators/caprice32 { };
 
   ccemux = callPackage ../applications/emulators/ccemux { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2585,12 +2585,23 @@ with pkgs;
       pkgsCross.gnu64.hello;
   };
 
-  box86 = callPackage ../applications/emulators/box86 {
-    hello-x86_32 = if stdenv.hostPlatform.isx86_32 then
-      hello
+  box86 =
+    let
+      args = {
+        hello-x86_32 = if stdenv.hostPlatform.isx86_32 then
+          hello
+        else
+          pkgsCross.gnu32.hello;
+      };
+    in
+    if stdenv.hostPlatform.is32bit then
+      callPackage ../applications/emulators/box86 args
+    else if stdenv.hostPlatform.isx86_64 then
+      pkgsCross.gnu32.callPackage ../applications/emulators/box86 args
+    else if stdenv.hostPlatform.isAarch64 then
+      pkgsCross.armv7l-hf-multiplatform.callPackage ../applications/emulators/box86 args
     else
-      pkgsCross.gnu32.hello;
-  };
+      throw "Don't know 32-bit platform for cross from: ${stdenv.hostPlatform.stdenv}";
 
   caprice32 = callPackage ../applications/emulators/caprice32 { };
 


### PR DESCRIPTION
## Description of changes

Closes #174113 (stale)

CC @Yeshey since you seem interested in box86

Heavily based on our box64 expression.

Second commit is maybe abit sketchy, so it's separate in case we don't want it.

Since box86 is only supported on 32-bit userland, its supported platforms can also only be 32-bit. But one may want to use it to run 32-bit x86 software on 64-bit non-x86 hardware as well. It's trivial to tell nix to cross-compile the package, but then the user would need to compile this on their own hardware since (AFAIU) the cache doesn't serve many 32-bit packages (especially on ARM I imagine?). This should work around this by mapping x86_64 -> i686 & aarch64 -> armv7l, which should hopefully let the cache be able to substitute this for ppl.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (i686-linux cross)
  - [x] aarch64-linux (armv7l-linux cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
