### PR TITLE
code-oss: init at 1.89.1

### DIFF
--- a/pkgs/applications/editors/vscode/binary-generic.nix
+++ b/pkgs/applications/editors/vscode/binary-generic.nix
@@ -38,8 +38,7 @@
 , executableName
 , longName
 , shortName
-, desktopItem
-, urlHandlerDesktopItem
+, common
 , pname
 , updateScript
 , dontFixup ? false
@@ -124,7 +123,7 @@ in
     inherit rev vscodeServer;
   };
 
-  inherit desktopItem urlHandlerDesktopItem;
+  inherit (common) desktopItem urlHandlerDesktopItem;
 
   buildInputs = [ libsecret libXScrnSaver libxshmfence ]
     ++ lib.optionals (!stdenv.isDarwin) [ alsa-lib at-spi2-atk libkrb5 mesa nss nspr systemd xorg.libxkbfile ];

--- a/pkgs/applications/editors/vscode/binary-generic.nix
+++ b/pkgs/applications/editors/vscode/binary-generic.nix
@@ -38,6 +38,8 @@
 , executableName
 , longName
 , shortName
+, desktopItem
+, urlHandlerDesktopItem
 , pname
 , updateScript
 , dontFixup ? false
@@ -122,38 +124,7 @@ in
     inherit rev vscodeServer;
   };
 
-  desktopItem = makeDesktopItem {
-    name = executableName;
-    desktopName = longName;
-    comment = "Code Editing. Redefined.";
-    genericName = "Text Editor";
-    exec = "${executableName} %F";
-    icon = "vs${executableName}";
-    startupNotify = true;
-    startupWMClass = shortName;
-    categories = [ "Utility" "TextEditor" "Development" "IDE" ];
-    mimeTypes = [ "text/plain" "inode/directory" ];
-    keywords = [ "vscode" ];
-    actions.new-empty-window = {
-      name = "New Empty Window";
-      exec = "${executableName} --new-window %F";
-      icon = "vs${executableName}";
-    };
-  };
-
-  urlHandlerDesktopItem = makeDesktopItem {
-    name = executableName + "-url-handler";
-    desktopName = longName + " - URL Handler";
-    comment = "Code Editing. Redefined.";
-    genericName = "Text Editor";
-    exec = executableName + " --open-url %U";
-    icon = "vs${executableName}";
-    startupNotify = true;
-    categories = [ "Utility" "TextEditor" "Development" "IDE" ];
-    mimeTypes = [ "x-scheme-handler/vs${executableName}" ];
-    keywords = [ "vscode" ];
-    noDisplay = true;
-  };
+  inherit desktopItem urlHandlerDesktopItem;
 
   buildInputs = [ libsecret libXScrnSaver libxshmfence ]
     ++ lib.optionals (!stdenv.isDarwin) [ alsa-lib at-spi2-atk libkrb5 mesa nss nspr systemd xorg.libxkbfile ];

--- a/pkgs/applications/editors/vscode/common.nix
+++ b/pkgs/applications/editors/vscode/common.nix
@@ -1,0 +1,78 @@
+# Define some common items among all vscode variants.
+{
+  lib,
+  makeDesktopItem,
+  executableName,
+  longName,
+  shortName,
+}:
+{
+  desktopItem = makeDesktopItem {
+    name = executableName;
+    desktopName = longName;
+    comment = "Code Editing. Redefined.";
+    genericName = "Text Editor";
+    exec = "${executableName} %F";
+    icon = "vs${executableName}";
+    startupNotify = true;
+    startupWMClass = shortName;
+    categories = [
+      "Utility"
+      "TextEditor"
+      "Development"
+      "IDE"
+    ];
+    mimeTypes = [
+      "text/plain"
+      "inode/directory"
+    ];
+    keywords = [ "vscode" ];
+    actions.new-empty-window = {
+      name = "New Empty Window";
+      exec = "${executableName} --new-window %F";
+      icon = "vs${executableName}";
+    };
+  };
+
+  urlHandlerDesktopItem = makeDesktopItem {
+    name = executableName + "-url-handler";
+    desktopName = longName + " - URL Handler";
+    comment = "Code Editing. Redefined.";
+    genericName = "Text Editor";
+    exec = executableName + " --open-url %U";
+    icon = "vs${executableName}";
+    startupNotify = true;
+    categories = [
+      "Utility"
+      "TextEditor"
+      "Development"
+      "IDE"
+    ];
+    mimeTypes = [ "x-scheme-handler/vs${executableName}" ];
+    keywords = [ "vscode" ];
+    noDisplay = true;
+  };
+
+  meta = {
+    description = ''
+      Open source source code editor developed by Microsoft for Windows,
+      Linux and macOS
+    '';
+    longDescription = ''
+      Open source source code editor developed by Microsoft for Windows,
+      Linux and macOS. It includes support for debugging, embedded Git
+      control, syntax highlighting, intelligent code completion, snippets,
+      and code refactoring. It is also customizable, so users can change the
+      editor's theme, keyboard shortcuts, and preferences
+    '';
+    license = lib.licenses.mit;
+    mainProgram = executableName;
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-linux"
+      "aarch64-darwin"
+      "armv7l-linux"
+    ];
+  };
+}

--- a/pkgs/applications/editors/vscode/vscode-oss.nix
+++ b/pkgs/applications/editors/vscode/vscode-oss.nix
@@ -11,8 +11,8 @@
   makeDesktopItem,
   makeWrapper,
   moreutils,
-  nodejs_18,
-  electron_28,
+  nodejs_20,
+  electron_29,
   nodePackages,
   pkg-config,
   python3,
@@ -54,9 +54,9 @@ let
 
   inherit (common) desktopItem urlHandlerDesktopItem;
 
-  nodejs = nodejs_18;
+  nodejs = nodejs_20;
 
-  electron = electron_28;
+  electron = electron_29;
 
   yarn' = yarn.override { inherit nodejs; };
 
@@ -113,14 +113,14 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = executableName;
-  version = "1.89.1";
-  commit = "dc96b837cf6bb4af9cd736aa3af08cf8279f7685";
+  version = "1.90.0";
+  commit = "89de5a8d4d6205e5b11647eb6a74844ca23d2573";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "vscode";
     rev = finalAttrs.version;
-    sha256 = "sha256-z4VA1pv+RPAzUOH/yK6EB84h4DOFG5TcRH443N7EIL0=";
+    sha256 = "sha256-Y+tmIZLayW+M3IuNNGufZJSlHD90nakL/WP9ACCiES0=";
   };
 
   passthru.product =
@@ -163,7 +163,7 @@ stdenv.mkDerivation (finalAttrs: {
 
       outputHashMode = "recursive";
       outputHashAlgo = "sha256";
-      outputHash = "sha256-7Qy0xMLcvmZ43EcNbsy7lko0nsXlbVYSMiq6aa4LuoQ=";
+      outputHash = "sha256-GogYDiEwx+IzJi11kPY55QnXSxI1zFsQXx9FJQxDbiU=";
     }
   );
 

--- a/pkgs/applications/editors/vscode/vscode-oss.nix
+++ b/pkgs/applications/editors/vscode/vscode-oss.nix
@@ -1,0 +1,311 @@
+# Variant built microsoft/vscode from source
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  buildGoModule,
+  cacert,
+  esbuild,
+  jq,
+  krb5,
+  libsecret,
+  makeDesktopItem,
+  makeWrapper,
+  moreutils,
+  nodejs_18,
+  electron_28,
+  nodePackages,
+  pkg-config,
+  python3,
+  ripgrep,
+  xorg,
+  yarn,
+  darwin,
+
+  # Customize product.json, with some reasonable defaults
+  product ? (import ./vscode-oss/product.nix { inherit lib; }),
+
+  # Override product.json
+  productOverrides ? { },
+}:
+
+let
+  inherit (nodePackages) node-gyp;
+  inherit (darwin) autoSignDarwinBinariesHook;
+
+  shortName = productOverrides.nameShort or "Code - OSS";
+  longName = productOverrides.nameLong or "Code - OSS";
+  executableName = productOverrides.applicationName or "code-oss";
+
+  common = import ./common.nix {
+    inherit
+      lib
+      makeDesktopItem
+      shortName
+      longName
+      executableName
+      ;
+  };
+
+  inherit (common) desktopItem urlHandlerDesktopItem;
+
+  pname = executableName;
+  version = "1.89.1";
+  commit = "dc96b837cf6bb4af9cd736aa3af08cf8279f7685";
+
+  product' = product // { inherit version; } // productOverrides;
+
+  nodejs = nodejs_18;
+
+  electron = electron_28;
+
+  yarn' = yarn.override { inherit nodejs; };
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "vscode";
+    rev = version;
+    sha256 = "sha256-z4VA1pv+RPAzUOH/yK6EB84h4DOFG5TcRH443N7EIL0=";
+  };
+
+  # Give all platform related information in this lambda.
+  vscodePlatforms =
+    hostPlatform:
+    let
+      select = attrs: name: attrs.${name} or name;
+    in
+    {
+      ms = rec {
+        # Map Microsoft system names.
+        os = select {
+          Darwin = "darwin";
+          Linux = "linux";
+        } hostPlatform.uname.system;
+        arch = select {
+          x86_64 = "x64";
+          aarch64 = "arm64";
+        } hostPlatform.uname.processor;
+        # The name, interpolate it in gulp build tasks
+        name = "${os}-${arch}";
+      };
+    };
+
+  platform = vscodePlatforms stdenv.hostPlatform;
+
+  yarnCache = stdenv.mkDerivation {
+    name = "${pname}-${version}-yarn-cache";
+    inherit src;
+    GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+    NODE_EXTRA_CA_CERTS = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+    nativeBuildInputs = [ yarn ];
+    buildPhase = ''
+      export HOME=$PWD
+      yarn config set yarn-offline-mirror $out
+      find "$PWD" -name "yarn.lock" -printf "%h\n" | \
+        xargs -I {}                                                            \
+          yarn --cwd {}                                                        \
+          --frozen-lockfile                                                    \
+          --ignore-scripts                                                     \
+          --ignore-platform                                                    \
+          --ignore-engines                                                     \
+          --no-progress                                                        \
+          --non-interactive
+    '';
+
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = "sha256-7Qy0xMLcvmZ43EcNbsy7lko0nsXlbVYSMiq6aa4LuoQ=";
+  };
+
+  esbuild' = esbuild.override {
+    buildGoModule =
+      args:
+      buildGoModule (
+        args
+        // rec {
+          version = "0.17.14";
+          src = fetchFromGitHub {
+            owner = "evanw";
+            repo = "esbuild";
+            rev = "v${version}";
+            hash = "sha256-4TC1d5FOZHUMuEMTcTOBLZZM+sFUswhyblI5HVWyvPA=";
+          };
+          vendorHash = "sha256-+BfxCyg0KkDQpHt/wycy/8CTG6YBA/VJvJFhhzUnSiQ=";
+        }
+      );
+  };
+
+  # replaces esbuild's download script with a binary from nixpkgs
+  patchEsbuild = path: version: ''
+    mkdir -p ${path}/node_modules/esbuild/bin
+    jq "del(.scripts.postinstall)" ${path}/node_modules/esbuild/package.json | sponge ${path}/node_modules/esbuild/package.json
+    sed -i 's/${version}/${esbuild'.version}/g' ${path}/node_modules/esbuild/lib/main.js
+    ln -s -f ${esbuild'}/bin/esbuild ${path}/node_modules/esbuild/bin/esbuild
+  '';
+in
+
+stdenv.mkDerivation {
+  inherit pname version src;
+
+  outputs = [
+    # Desktop version.
+    "out"
+
+    # Remote extension host, for vscode remote development
+    "reh"
+
+    # Web extension host, run extension host in CLI, client in browser
+    "rehweb"
+  ];
+
+  nativeBuildInputs =
+    [
+      yarn'
+      python3
+      nodejs
+      jq
+      moreutils
+      pkg-config
+      makeWrapper
+    ]
+    ++ lib.optionals stdenv.isDarwin [ darwin.cctools ]
+    ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [ autoSignDarwinBinariesHook ];
+
+  buildInputs = [
+    krb5
+    libsecret
+    xorg.libX11
+    xorg.libxkbfile
+  ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Cocoa ];
+
+  patches = map (name: ./vscode-oss/patches/${name}) (
+    builtins.attrNames (builtins.readDir ./vscode-oss/patches)
+  );
+
+  env = {
+    # Disable NAPI_EXPERIMENTAL to allow to build with Node.js≥18.20.0.
+    NIX_CFLAGS_COMPILE = "-DNODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT";
+
+    # Commit version embeded in vscode
+    BUILD_SOURCEVERSION = commit;
+  };
+
+  postPatch = ''
+    export HOME=$PWD
+  '';
+
+  configurePhase = ''
+    runHook preConfigure
+
+    # Generate product.json
+    cp ${builtins.toFile "product.json" (builtins.toJSON product')} product.json
+
+    # set offline mirror to yarn cache we created in previous steps
+    yarn --offline config set yarn-offline-mirror "${yarnCache}"
+    # set nodedir to prevent node-gyp from downloading headers
+    # taken from https://nixos.org/manual/nixpkgs/stable/#javascript-tool-specific
+    mkdir -p $HOME/.node-gyp/${nodejs.version}
+    echo 9 > $HOME/.node-gyp/${nodejs.version}/installVersion
+    ln -sfv ${nodejs}/include $HOME/.node-gyp/${nodejs.version}
+    export npm_config_nodedir=${nodejs}
+    # use updated node-gyp. fixes the following error on Darwin:
+    # PermissionError: [Errno 1] Operation not permitted: '/usr/sbin/pkgutil'
+    export npm_config_node_gyp=${node-gyp}/lib/node_modules/node-gyp/bin/node-gyp.js
+    runHook postConfigure
+  '';
+
+  preBuild = ''
+    export ELECTRON_SKIP_BINARY_DOWNLOAD=1
+    export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+    export SKIP_SUBMODULE_DEPS=1
+    export NODE_OPTIONS=--openssl-legacy-provider
+  '';
+
+  buildPhase =
+    ''
+      runHook preBuild
+
+      # install dependencies
+      yarn --offline                                                           \
+           --ignore-scripts                                                    \
+           --no-progress                                                       \
+           --non-interactive                                                   \
+           --frozen-lockfile
+
+      # run yarn install everywhere, skipping postinstall so we can patch esbuild
+      find . -path "*node_modules" -prune -o \
+        -path "./*/*" -name "yarn.lock" -printf "%h\n" |                       \
+          xargs -I {}                                                          \
+            yarn --cwd {}                                                      \
+                 --frozen-lockfile                                             \
+                 --offline                                                     \
+                 --ignore-scripts                                              \
+                 --ignore-engines
+
+      ${patchEsbuild "./build" "0.12.6"}
+      ${patchEsbuild "./extensions" "0.11.23"}
+      # patch shebangs of node_modules to allow binary packages to build
+      patchShebangs .
+      # put ripgrep binary into bin so postinstall does not try to download it
+      find -path "*@vscode/ripgrep" -type d                                    \
+        -execdir mkdir -p {}/bin \;                                            \
+        -execdir ln -s ${ripgrep}/bin/rg {}/bin/rg \;
+    ''
+    + lib.optionalString stdenv.isDarwin ''
+      # use prebuilt binary for @parcel/watcher, which requires macOS SDK 10.13+
+      # (see issue #101229)
+      pushd ./remote/node_modules/@parcel/watcher
+      mkdir -p ./build/Release
+      mv ./prebuilds/darwin-x64/node.napi.glibc.node ./build/Release/watcher.node
+      jq "del(.scripts) | .gypfile = false" ./package.json | sponge ./package.json
+      popd
+    ''
+    + ''
+      npm rebuild --build-from-source
+      npm rebuild --prefix remote/ --build-from-source
+      # run postinstall scripts after patching
+      find . -path "*node_modules" -prune -o \
+        -path "./*/*" -name "yarn.lock" -printf "%h\n" | \
+          xargs -I {} sh -c 'jq -e ".scripts.postinstall" {}/package.json >/dev/null && yarn --cwd {} postinstall --frozen-lockfile --offline || true'
+      yarn --offline gulp core-ci
+      yarn --offline gulp compile-extensions-build
+      yarn --offline gulp compile-extension-media-build
+      yarn --offline gulp vscode-reh-${platform.ms.name}-min-ci
+      yarn --offline gulp vscode-reh-web-${platform.ms.name}-min-ci
+      yarn --offline gulp vscode-${platform.ms.name}-min-ci
+      runHook postBuild
+    '';
+
+  installPhase =
+    let
+      binName = if stdenv.isDarwin then "resources/app/bin/code" else "bin/code-oss";
+    in
+    ''
+      runHook preInstall
+      mkdir -p $out/lib $out/bin
+      mv ../VSCode-${platform.ms.name} $out/lib/vscode
+      mv -T ../vscode-reh-${platform.ms.name} $reh
+      mv -T ../vscode-reh-web-${platform.ms.name} $rehweb
+
+      ln -s ${nodejs}/bin/node $reh/
+      ln -s ${nodejs}/bin/node $rehweb/
+    ''
+    + lib.optionalString stdenv.isLinux ''
+      mkdir -p $out/share/applications
+      ln -s ${desktopItem}/share/applications/${executableName}.desktop $out/share/applications/${executableName}.desktop
+      ln -s ${urlHandlerDesktopItem}/share/applications/${executableName}-url-handler.desktop $out/share/applications/${executableName}-url-handler.desktop
+      install -D $out/lib/vscode/resources/app/resources/linux/code.png $out/share/pixmaps/${executableName}.png
+    ''
+    + ''
+      # Make a wrapper script, setting the electron path, and vscode path
+      makeWrapper "$out/lib/vscode/${binName}" "$out/bin/code-oss"             \
+        --set ELECTRON '${lib.getExe electron}'                                \
+        --set VSCODE_PATH "$out/lib/vscode"
+      runHook postInstall
+    '';
+
+  meta = common.meta // {
+    homepage = "https://github.com/microsoft/vscode";
+    maintainers = with lib.maintainers; [ inclyc ];
+  };
+}

--- a/pkgs/applications/editors/vscode/vscode-oss.nix
+++ b/pkgs/applications/editors/vscode/vscode-oss.nix
@@ -11,8 +11,8 @@
   makeDesktopItem,
   makeWrapper,
   moreutils,
-  nodejs_20,
-  electron_29,
+  nodejs_18,
+  electron_28,
   nodePackages,
   pkg-config,
   python3,
@@ -54,9 +54,9 @@ let
 
   inherit (common) desktopItem urlHandlerDesktopItem;
 
-  nodejs = nodejs_20;
+  nodejs = nodejs_18;
 
-  electron = electron_29;
+  electron = electron_28;
 
   yarn' = yarn.override { inherit nodejs; };
 
@@ -113,14 +113,14 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = executableName;
-  version = "1.90.0";
-  commit = "89de5a8d4d6205e5b11647eb6a74844ca23d2573";
+  version = "1.89.1";
+  commit = "dc96b837cf6bb4af9cd736aa3af08cf8279f7685";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "vscode";
     rev = finalAttrs.version;
-    sha256 = "sha256-Y+tmIZLayW+M3IuNNGufZJSlHD90nakL/WP9ACCiES0=";
+    sha256 = "sha256-z4VA1pv+RPAzUOH/yK6EB84h4DOFG5TcRH443N7EIL0=";
   };
 
   passthru.product =
@@ -163,7 +163,7 @@ stdenv.mkDerivation (finalAttrs: {
 
       outputHashMode = "recursive";
       outputHashAlgo = "sha256";
-      outputHash = "sha256-GogYDiEwx+IzJi11kPY55QnXSxI1zFsQXx9FJQxDbiU=";
+      outputHash = "sha256-7Qy0xMLcvmZ43EcNbsy7lko0nsXlbVYSMiq6aa4LuoQ=";
     }
   );
 

--- a/pkgs/applications/editors/vscode/vscode-oss/patches/build-npm-allow-npm-for-rebuilding-binaries.patch
+++ b/pkgs/applications/editors/vscode/vscode-oss/patches/build-npm-allow-npm-for-rebuilding-binaries.patch
@@ -1,0 +1,26 @@
+From e65885dcce66e77bd8ec738cf3dc59160d32d507 Mon Sep 17 00:00:00 2001
+From: Yingchi Long <i@lyc.dev>
+Date: Mon, 3 Jun 2024 23:25:08 +0800
+Subject: [PATCH] build/npm: allow npm for rebuilding binaries
+
+---
+ build/npm/preinstall.js | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/build/npm/preinstall.js b/build/npm/preinstall.js
+index edf0d98c3d5..2c814494279 100644
+--- a/build/npm/preinstall.js
++++ b/build/npm/preinstall.js
+@@ -39,10 +39,6 @@ if (
+ 	err = true;
+ }
+
+-if (!/yarn[\w-.]*\.c?js$|yarnpkg$/.test(process.env['npm_execpath'])) {
+-	console.error('\x1b[1;31m*** Please use yarn to install dependencies.\x1b[0;0m');
+-	err = true;
+-}
+
+ if (process.platform === 'win32') {
+ 	if (!hasSupportedVisualStudioVersion()) {
+--
+2.44.0

--- a/pkgs/applications/editors/vscode/vscode-oss/patches/build-npm-postinstall-remove-git-config.patch
+++ b/pkgs/applications/editors/vscode/vscode-oss/patches/build-npm-postinstall-remove-git-config.patch
@@ -1,0 +1,21 @@
+From c833c4a3d41b96b2b382d8750388806e25d1bdc5 Mon Sep 17 00:00:00 2001
+From: Yingchi Long <i@lyc.dev>
+Date: Mon, 3 Jun 2024 22:29:45 +0800
+Subject: [PATCH] build/npm/postinstall: remove git config
+
+---
+ build/npm/postinstall.js | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/build/npm/postinstall.js b/build/npm/postinstall.js
+index 72dd74f8986..f72ce6d6e23 100644
+--- a/build/npm/postinstall.js
++++ b/build/npm/postinstall.js
+@@ -131,5 +131,3 @@ for (let dir of dirs) {
+ 	yarnInstall(dir, opts);
+ }
+
+-cp.execSync('git config pull.rebase merges');
+-cp.execSync('git config blame.ignoreRevsFile .git-blame-ignore-revs');
+--
+2.44.0

--- a/pkgs/applications/editors/vscode/vscode-oss/patches/build-omit-electron-download.patch
+++ b/pkgs/applications/editors/vscode/vscode-oss/patches/build-omit-electron-download.patch
@@ -1,0 +1,32 @@
+From 2f3fe75948f1cada5c67da46c51a03443d7e38e0 Mon Sep 17 00:00:00 2001
+From: Yingchi Long <i@lyc.dev>
+Date: Mon, 3 Jun 2024 22:32:04 +0800
+Subject: [PATCH] build: omit electron download
+
+---
+ build/gulpfile.vscode.js | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/build/gulpfile.vscode.js b/build/gulpfile.vscode.js
+index e1507e0424f..50f38dccedc 100644
+--- a/build/gulpfile.vscode.js
++++ b/build/gulpfile.vscode.js
+@@ -199,7 +199,6 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
+ 	platform = platform || process.platform;
+
+ 	return () => {
+-		const electron = require('@vscode/gulp-electron');
+ 		const json = require('gulp-json-editor');
+
+ 		const out = sourceFolderName;
+@@ -340,7 +339,7 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
+ 			.pipe(util.skipDirectories())
+ 			.pipe(util.fixWin32DirectoryPermissions())
+ 			.pipe(filter(['**', '!**/.github/**'], { dot: true })) // https://github.com/microsoft/vscode/issues/116523
+-			.pipe(electron({ ...config, platform, arch: arch === 'armhf' ? 'arm' : arch, ffmpegChromium: false }))
++			.pipe(rename(path => { path.dirname = "resources/app" + (path.dirname === "." ? "" : "/" + path.dirname); }))
+ 			.pipe(filter(['**', '!LICENSE', '!version'], { dot: true }));
+
+ 		if (platform === 'linux') {
+--
+2.44.0

--- a/pkgs/applications/editors/vscode/vscode-oss/patches/build-omit-nodejs-download.patch
+++ b/pkgs/applications/editors/vscode/vscode-oss/patches/build-omit-nodejs-download.patch
@@ -1,0 +1,41 @@
+From cc179ad383409558e171318ddfeeceabb53674bf Mon Sep 17 00:00:00 2001
+From: Yingchi Long <i@lyc.dev>
+Date: Mon, 3 Jun 2024 22:30:26 +0800
+Subject: [PATCH] build: omit nodejs download
+
+---
+ build/gulpfile.reh.js | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/build/gulpfile.reh.js b/build/gulpfile.reh.js
+index c2b81d0cf7c..b5a08c7fc53 100644
+--- a/build/gulpfile.reh.js
++++ b/build/gulpfile.reh.js
+@@ -311,9 +311,6 @@ function packageTask(type, platform, arch, sourceFolderName, destinationFolderNa
+ 			.pipe(util.stripSourceMappingURL())
+ 			.pipe(jsFilter.restore);
+
+-		const nodePath = `.build/node/v${nodeVersion}/${platform}-${arch}`;
+-		const node = gulp.src(`${nodePath}/**`, { base: nodePath, dot: true });
+-
+ 		let web = [];
+ 		if (type === 'reh-web') {
+ 			web = [
+@@ -330,7 +327,6 @@ function packageTask(type, platform, arch, sourceFolderName, destinationFolderNa
+ 			license,
+ 			sources,
+ 			deps,
+-			node,
+ 			...web
+ 		);
+
+@@ -453,7 +449,6 @@ function tweakProductForServerWeb(product) {
+ 			const destinationFolderName = `vscode-${type}${dashed(platform)}${dashed(arch)}`;
+
+ 			const serverTaskCI = task.define(`vscode-${type}${dashed(platform)}${dashed(arch)}${dashed(minified)}-ci`, task.series(
+-				gulp.task(`node-${platform}-${arch}`),
+ 				util.rimraf(path.join(BUILD_ROOT, destinationFolderName)),
+ 				packageTask(type, platform, arch, sourceFolderName, destinationFolderName)
+ 			));
+--
+2.44.0

--- a/pkgs/applications/editors/vscode/vscode-oss/patches/resources-darwin-remove-darwin-bundled-electron.patch
+++ b/pkgs/applications/editors/vscode/vscode-oss/patches/resources-darwin-remove-darwin-bundled-electron.patch
@@ -1,0 +1,48 @@
+From 69b8cda3e935aba348e656be52ec5b6813c50162 Mon Sep 17 00:00:00 2001
+From: Yingchi Long <i@lyc.dev>
+Date: Sat, 8 Jun 2024 18:01:22 +0800
+Subject: [PATCH] resources/darwin: remove darwin-bundled electron
+
+---
+ resources/darwin/bin/code.sh | 24 ++++--------------------
+ 1 file changed, 4 insertions(+), 20 deletions(-)
+
+diff --git a/resources/darwin/bin/code.sh b/resources/darwin/bin/code.sh
+index de5c3bfcab0..1d85b9c55d3 100755
+--- a/resources/darwin/bin/code.sh
++++ b/resources/darwin/bin/code.sh
+@@ -12,28 +12,12 @@ if [ -n "$VSCODE_IPC_HOOK_CLI" ]; then
+ 	fi
+ fi
+
+-function app_realpath() {
+-	SOURCE=$1
+-	while [ -h "$SOURCE" ]; do
+-		DIR=$(dirname "$SOURCE")
+-		SOURCE=$(readlink "$SOURCE")
+-		[[ $SOURCE != /* ]] && SOURCE=$DIR/$SOURCE
+-	done
+-	SOURCE_DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+-	echo "${SOURCE_DIR%%${SOURCE_DIR#*.app}}"
+-}
+-
+-APP_PATH="$(app_realpath "${BASH_SOURCE[0]}")"
+-if [ -z "$APP_PATH" ]; then
+-	echo "Unable to determine app path from symlink : ${BASH_SOURCE[0]}"
+-	exit 1
+-fi
+-CONTENTS="$APP_PATH/Contents"
+-ELECTRON="$CONTENTS/MacOS/Electron"
+-CLI="$CONTENTS/Resources/app/out/cli.js"
+ export VSCODE_NODE_OPTIONS=$NODE_OPTIONS
+ export VSCODE_NODE_REPL_EXTERNAL_MODULE=$NODE_REPL_EXTERNAL_MODULE
+ unset NODE_OPTIONS
+ unset NODE_REPL_EXTERNAL_MODULE
+-ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"
++
++CLI="$VSCODE_PATH/resources/app/out/cli.js"
++ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$VSCODE_PATH/resources/app" "$@"
++
+ exit $?
+--
+2.44.1

--- a/pkgs/applications/editors/vscode/vscode-oss/patches/resources-linux-remove-VSCODE_PATH-and-ELECTRON-path.patch
+++ b/pkgs/applications/editors/vscode/vscode-oss/patches/resources-linux-remove-VSCODE_PATH-and-ELECTRON-path.patch
@@ -1,0 +1,75 @@
+From 5ed1ff4f02a4eab620622a477345a6ee22013434 Mon Sep 17 00:00:00 2001
+From: Yingchi Long <i@lyc.dev>
+Date: Mon, 3 Jun 2024 23:10:08 +0800
+Subject: [PATCH] resources/linux: remove VSCODE_PATH and ELECTRON path
+ setting
+
+These values will be given from nix.
+---
+ resources/linux/bin/code.sh                    | 17 ++---------------
+ src/vs/platform/environment/node/argvHelper.ts |  9 +++++++--
+ 2 files changed, 9 insertions(+), 17 deletions(-)
+
+diff --git a/resources/linux/bin/code.sh b/resources/linux/bin/code.sh
+index 4f11f5b82e0..d695f60bde4 100755
+--- a/resources/linux/bin/code.sh
++++ b/resources/linux/bin/code.sh
+@@ -44,20 +44,7 @@ if [ "$(id -u)" = "0" ]; then
+ 	fi
+ fi
+
+-if [ ! -L "$0" ]; then
+-	# if path is not a symlink, find relatively
+-	VSCODE_PATH="$(dirname "$0")/.."
+-else
+-	if command -v readlink >/dev/null; then
+-		# if readlink exists, follow the symlink and find relatively
+-		VSCODE_PATH="$(dirname "$(readlink -f "$0")")/.."
+-	else
+-		# else use the standard install location
+-		VSCODE_PATH="/usr/share/@@APPNAME@@"
+-	fi
+-fi
+-
+-ELECTRON="$VSCODE_PATH/@@APPNAME@@"
++export VSCODE_STRIP_APP_PATH=1
+ CLI="$VSCODE_PATH/resources/app/out/cli.js"
+-ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"
++ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$VSCODE_PATH/resources/app" "$@"
+ exit $?
+diff --git a/src/vs/platform/environment/node/argvHelper.ts b/src/vs/platform/environment/node/argvHelper.ts
+index d8cefb6df67..dc2fb1de090 100644
+--- a/src/vs/platform/environment/node/argvHelper.ts
++++ b/src/vs/platform/environment/node/argvHelper.ts
+@@ -57,6 +57,11 @@ function stripAppPath(argv: string[]): string[] | undefined {
+ 	return undefined;
+ }
+
++/**
++ * Returns true if app path should be stripped in program args
++ */
++const shouldStripAppPath = (): boolean => !process.env['VSCODE_DEV'] || !process.env['VSCODE_STRIP_APP_PATH'];
++
+ /**
+  * Use this to parse raw code process.argv such as: `Electron . --verbose --wait`
+  */
+@@ -64,7 +69,7 @@ export function parseMainProcessArgv(processArgv: string[]): NativeParsedArgs {
+ 	let [, ...args] = processArgv;
+
+ 	// If dev, remove the first non-option argument: it's the app location
+-	if (process.env['VSCODE_DEV']) {
++	if (shouldStripAppPath()) {
+ 		args = stripAppPath(args) || [];
+ 	}
+
+@@ -80,7 +85,7 @@ export function parseCLIProcessArgv(processArgv: string[]): NativeParsedArgs {
+ 	let [, , ...args] = processArgv; // remove the first non-option argument: it's always the app location
+
+ 	// If dev, remove the first non-option argument: it's the app location
+-	if (process.env['VSCODE_DEV']) {
++	if (shouldStripAppPath()) {
+ 		args = stripAppPath(args) || [];
+ 	}
+
+--
+2.44.0

--- a/pkgs/applications/editors/vscode/vscode-oss/product.nix
+++ b/pkgs/applications/editors/vscode/vscode-oss/product.nix
@@ -1,0 +1,408 @@
+{ lib }:
+{
+  nameShort = "Code - OSS";
+  nameLong = "Code - OSS";
+  applicationName = "code-oss";
+  dataFolderName = ".vscode-oss";
+  win32MutexName = "vscodeoss";
+  licenseName = "MIT";
+  licenseUrl = "https://github.com/microsoft/vscode/blob/main/LICENSE.txt";
+  serverLicenseUrl = "https://github.com/microsoft/vscode/blob/main/LICENSE.txt";
+  serverGreeting = [ ];
+  serverLicense = [ ];
+  serverLicensePrompt = "";
+  serverApplicationName = "code-server-oss";
+  serverDataFolderName = ".vscode-server-oss";
+  tunnelApplicationName = "code-tunnel-oss";
+  win32DirName = "Microsoft Code OSS";
+  win32NameVersion = "Microsoft Code OSS";
+  win32RegValueName = "CodeOSS";
+  win32x64AppId = "{{D77B7E06-80BA-4137-BCF4-654B95CCEBC5}";
+  win32arm64AppId = "{{D1ACE434-89C5-48D1-88D3-E2991DF85475}";
+  win32x64UserAppId = "{{CC6B787D-37A0-49E8-AE24-8559A032BE0C}";
+  win32arm64UserAppId = "{{3AEBF0C8-F733-4AD4-BADE-FDB816D53D7B}";
+  win32AppUserModelId = "Microsoft.CodeOSS";
+  win32ShellNameShort = "C&ode - OSS";
+  win32TunnelServiceMutex = "vscodeoss-tunnelservice";
+  win32TunnelMutex = "vscodeoss-tunnel";
+  darwinBundleIdentifier = "com.visualstudio.code.oss";
+  linuxIconName = "code-oss";
+  licenseFileName = "LICENSE.txt";
+  reportIssueUrl = "https://github.com/microsoft/vscode/issues/new";
+  nodejsRepository = "https://nodejs.org";
+  urlProtocol = "code-oss";
+  webviewContentExternalBaseUrlTemplate = "https://{{uuid}}.vscode-cdn.net/insider/ef65ac1ba57f57f2a3961bfe94aa20481caca4c6/out/vs/workbench/contrib/webview/browser/pre/";
+
+  extensionAllowedBadgeProviders = [
+    "api.bintray.com"
+    "api.travis-ci.com"
+    "api.travis-ci.org"
+    "app.fossa.io"
+    "badge.buildkite.com"
+    "badge.fury.io"
+    "badge.waffle.io"
+    "badgen.net"
+    "badges.frapsoft.com"
+    "badges.gitter.im"
+    "badges.greenkeeper.io"
+    "cdn.travis-ci.com"
+    "cdn.travis-ci.org"
+    "ci.appveyor.com"
+    "circleci.com"
+    "cla.opensource.microsoft.com"
+    "codacy.com"
+    "codeclimate.com"
+    "codecov.io"
+    "coveralls.io"
+    "david-dm.org"
+    "deepscan.io"
+    "dev.azure.com"
+    "docs.rs"
+    "flat.badgen.net"
+    "gemnasium.com"
+    "githost.io"
+    "gitlab.com"
+    "godoc.org"
+    "goreportcard.com"
+    "img.shields.io"
+    "isitmaintained.com"
+    "marketplace.visualstudio.com"
+    "nodesecurity.io"
+    "opencollective.com"
+    "snyk.io"
+    "travis-ci.com"
+    "travis-ci.org"
+    "visualstudio.com"
+    "vsmarketplacebadge.apphb.com"
+    "www.bithound.io"
+    "www.versioneye.com"
+  ];
+  extensionAllowedBadgeProvidersRegex = [
+    "^https:\\/\\/github\\.com\\/[^/]+\\/[^/]+\\/(actions\\/)?workflows\\/.*badge\\.svg"
+  ];
+  extensionEnabledApiProposals = {
+    "ms-vscode.vscode-selfhost-test-provider" = [ "testObserver" ];
+    "VisualStudioExptTeam.vscodeintellicode-completions" = [ "inlineCompletionsAdditions" ];
+    "ms-toolsai.datawrangler" = [ "debugFocus" ];
+    "ms-vsliveshare.vsliveshare" = [
+      "contribMenuBarHome"
+      "contribShareMenu"
+      "contribStatusBarItems"
+      "diffCommand"
+      "documentFiltersExclusive"
+      "fileSearchProvider"
+      "findTextInFiles"
+      "notebookCellExecutionState"
+      "notebookLiveShare"
+      "terminalDimensions"
+      "terminalDataWriteEvent"
+      "textSearchProvider"
+    ];
+    "ms-vscode.js-debug" = [
+      "portsAttributes"
+      "findTextInFiles"
+      "workspaceTrust"
+      "tunnels"
+    ];
+    "ms-toolsai.vscode-ai-remote" = [ "resolvers" ];
+    "ms-python.python" = [
+      "contribEditorContentMenu"
+      "quickPickSortByLabel"
+      "portsAttributes"
+      "testObserver"
+      "quickPickItemTooltip"
+      "terminalDataWriteEvent"
+      "terminalExecuteCommandEvent"
+      "contribIssueReporter"
+      "terminalShellIntegration"
+    ];
+    "ms-dotnettools.dotnet-interactive-vscode" = [ "notebookMessaging" ];
+    "GitHub.codespaces" = [
+      "contribEditSessions"
+      "contribMenuBarHome"
+      "contribRemoteHelp"
+      "contribViewsRemote"
+      "resolvers"
+      "tunnels"
+      "terminalDataWriteEvent"
+      "treeViewReveal"
+      "notebookKernelSource"
+    ];
+    "ms-vscode.azure-repos" = [
+      "extensionRuntime"
+      "fileSearchProvider"
+      "textSearchProvider"
+    ];
+    "ms-vscode.remote-repositories" = [
+      "canonicalUriProvider"
+      "contribEditSessions"
+      "contribRemoteHelp"
+      "contribMenuBarHome"
+      "contribViewsRemote"
+      "contribViewsWelcome"
+      "contribShareMenu"
+      "documentFiltersExclusive"
+      "editSessionIdentityProvider"
+      "extensionRuntime"
+      "fileSearchProvider"
+      "quickPickSortByLabel"
+      "workspaceTrust"
+      "shareProvider"
+      "scmActionButton"
+      "scmSelectedProvider"
+      "scmValidation"
+      "textSearchProvider"
+      "timeline"
+    ];
+    "ms-vscode-remote.remote-wsl" = [
+      "resolvers"
+      "contribRemoteHelp"
+      "contribViewsRemote"
+      "telemetry"
+    ];
+    "ms-vscode-remote.remote-ssh" = [
+      "resolvers"
+      "tunnels"
+      "terminalDataWriteEvent"
+      "contribRemoteHelp"
+      "contribViewsRemote"
+      "telemetry"
+    ];
+    "ms-vscode.remote-server" = [
+      "resolvers"
+      "tunnels"
+      "contribViewsWelcome"
+    ];
+    "ms-vscode.remote-explorer" = [
+      "contribRemoteHelp"
+      "contribViewsRemote"
+      "extensionsAny"
+    ];
+    "ms-vscode-remote.remote-containers" = [
+      "contribEditSessions"
+      "resolvers"
+      "portsAttributes"
+      "tunnels"
+      "workspaceTrust"
+      "terminalDimensions"
+      "contribRemoteHelp"
+      "contribViewsRemote"
+    ];
+    "ms-vscode.js-debug-nightly" = [
+      "portsAttributes"
+      "findTextInFiles"
+      "workspaceTrust"
+      "tunnels"
+    ];
+    "ms-vscode.lsif-browser" = [ "documentFiltersExclusive" ];
+    "ms-vscode.vscode-speech" = [ "speech" ];
+    "GitHub.vscode-pull-request-github" = [
+      "activeComment"
+      "codiconDecoration"
+      "codeActionRanges"
+      "commentingRangeHint"
+      "commentReactor"
+      "commentThreadApplicability"
+      "contribAccessibilityHelpContent"
+      "contribCommentEditorActionsMenu"
+      "contribCommentPeekContext"
+      "contribCommentThreadAdditionalMenu"
+      "contribCommentsViewThreadMenus"
+      "contribEditorContentMenu"
+      "contribShareMenu"
+      "diffCommand"
+      "fileComments"
+      "quickDiffProvider"
+      "shareProvider"
+      "tabInputTextMerge"
+      "tokenInformation"
+      "treeViewMarkdownMessage"
+    ];
+    "GitHub.copilot" = [ "inlineCompletionsAdditions" ];
+    "GitHub.copilot-nightly" = [ "inlineCompletionsAdditions" ];
+    "GitHub.copilot-chat" = [
+      "interactive"
+      "terminalDataWriteEvent"
+      "terminalExecuteCommandEvent"
+      "terminalSelection"
+      "terminalQuickFixProvider"
+      "chatParticipant"
+      "chatParticipantAdditions"
+      "defaultChatParticipant"
+      "chatVariableResolver"
+      "chatProvider"
+      "mappedEditsProvider"
+      "aiRelatedInformation"
+      "codeActionAI"
+      "findTextInFiles"
+      "textSearchProvider"
+      "contribSourceControlInputBoxMenu"
+      "newSymbolNamesProvider"
+      "findFiles2"
+      "extensionsAny"
+      "authLearnMore"
+      "testObserver"
+    ];
+    "GitHub.remotehub" = [
+      "contribRemoteHelp"
+      "contribMenuBarHome"
+      "contribViewsRemote"
+      "contribViewsWelcome"
+      "documentFiltersExclusive"
+      "extensionRuntime"
+      "fileSearchProvider"
+      "quickPickSortByLabel"
+      "workspaceTrust"
+      "scmSelectedProvider"
+      "scmValidation"
+      "textSearchProvider"
+      "timeline"
+    ];
+    "ms-python.gather" = [ "notebookCellExecutionState" ];
+    "ms-python.vscode-pylance" = [ "notebookCellExecutionState" ];
+    "ms-python.debugpy" = [
+      "portsAttributes"
+      "contribIssueReporter"
+      "debugVisualization"
+    ];
+    "ms-toolsai.jupyter-renderers" = [ "contribNotebookStaticPreloads" ];
+    "ms-toolsai.jupyter" = [
+      "notebookDeprecated"
+      "notebookMessaging"
+      "notebookMime"
+      "notebookCellExecutionState"
+      "portsAttributes"
+      "quickPickSortByLabel"
+      "notebookKernelSource"
+      "interactiveWindow"
+      "notebookControllerAffinityHidden"
+      "contribNotebookStaticPreloads"
+      "quickPickItemTooltip"
+      "notebookExecution"
+      "notebookCellExecution"
+      "notebookVariableProvider"
+    ];
+    "dbaeumer.vscode-eslint" = [ "notebookCellExecutionState" ];
+    "ms-vscode.azure-sphere-tools-ui" = [ "tunnels" ];
+    "ms-azuretools.vscode-azureappservice" = [ "terminalDataWriteEvent" ];
+    "ms-azuretools.vscode-azureresourcegroups" = [ "authGetSessions" ];
+    "ms-vscode.anycode" = [ "extensionsAny" ];
+    "ms-vscode.cpptools" = [ "terminalDataWriteEvent" ];
+    "redhat.java" = [ "documentPaste" ];
+    "ms-dotnettools.csdevkit" = [ "inlineCompletionsAdditions" ];
+    "ms-dotnettools.vscodeintellicode-csharp" = [ "inlineCompletionsAdditions" ];
+    "microsoft-IsvExpTools.powerplatform-vscode" = [
+      "fileSearchProvider"
+      "textSearchProvider"
+    ];
+    "microsoft-IsvExpTools.powerplatform-vscode-preview" = [
+      "fileSearchProvider"
+      "textSearchProvider"
+    ];
+    "apidev.azure-api-center" = [
+      "chatParticipant"
+      "languageModels"
+    ];
+    "jeanp413.open-remote-ssh" = [
+      "resolvers"
+      "tunnels"
+      "terminalDataWriteEvent"
+      "contribRemoteHelp"
+      "contribViewsRemote"
+    ];
+    "jeanp413.open-remote-wsl" = [
+      "resolvers"
+      "contribRemoteHelp"
+      "contribViewsRemote"
+    ];
+  };
+  extensionKind = {
+    "Shan.code-settings-sync" = [ "ui" ];
+    "shalldie.background" = [ "ui" ];
+    "techer.open-in-browser" = [ "ui" ];
+    "CoenraadS.bracket-pair-colorizer-2" = [ "ui" ];
+    "CoenraadS.bracket-pair-colorizer" = [
+      "ui"
+      "workspace"
+    ];
+    "hiro-sun.vscode-emacs" = [
+      "ui"
+      "workspace"
+    ];
+    "hnw.vscode-auto-open-markdown-preview" = [
+      "ui"
+      "workspace"
+    ];
+    "wayou.vscode-todo-highlight" = [
+      "ui"
+      "workspace"
+    ];
+    "aaron-bond.better-comments" = [
+      "ui"
+      "workspace"
+    ];
+    "vscodevim.vim" = [ "ui" ];
+    "ollyhayes.colmak-vim" = [ "ui" ];
+  };
+  extensionPointExtensionKind = {
+    typescriptServerPlugins = [ "workspace" ];
+  };
+  extensionSyncedKeys = {
+    "ritwickdey.liveserver" = [ "liveServer.setup.version" ];
+  };
+  # Make a list of extensions with special virtual workspace defaults.
+  extensionVirtualWorkspacesSupport =
+    let
+      defaultDefault = [
+        "esbenp.prettier-vscode"
+        "msjsdiag.debugger-for-chrome"
+        "redhat.java"
+        "HookyQR.beautify"
+        "ritwickdey.LiveServer"
+        "VisualStudioExptTeam.vscodeintellicode"
+        "octref.vetur"
+        "formulahendry.code-runner"
+        "xdebug.php-debug"
+        "ms-mssql.mssql"
+        "christian-kohler.path-intellisense"
+        "eg2.tslint"
+        "eg2.vscode-npm-script"
+        "donjayamanne.githistory"
+        "Zignd.html-css-class-completion"
+        "christian-kohler.npm-intellisense"
+        "EditorConfig.EditorConfig"
+        "austin.code-gnu-global"
+        "johnpapa.Angular2"
+        "ms-vscode.vscode-typescript-tslint-plugin"
+        "DotJoshJohnson.xml"
+        "techer.open-in-browser"
+        "tht13.python"
+        "bmewburn.vscode-intelephense-client"
+        "Angular.ng-template"
+        "xdebug.php-pack"
+        "dbaeumer.jshint"
+        "yzhang.markdown-all-in-one"
+        "Dart-Code.flutter"
+        "streetsidesoftware.code-spell-checker"
+        "rebornix.Ruby"
+        "ms-vscode.sublime-keybindings"
+        "mitaki28.vscode-clang"
+        "steoates.autoimport"
+        "donjayamanne.python-extension-pack"
+        "shd101wyy.markdown-preview-enhanced"
+        "mikestead.dotenv"
+        "pranaygp.vscode-css-peek"
+        "ikappas.phpcs"
+        "platformio.platformio-ide"
+        "jchannon.csharpextensions"
+        "gruntfuggly.todo-tree"
+      ];
+    in
+    lib.genAttrs defaultDefault (name: {
+      default = false;
+    });
+
+  builtInExtensions = [ ];
+
+  # Commit, Version Info
+}

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -37,7 +37,7 @@ let
     armv7l-linux = "0a0iy109qjwj1ri23xmmfa3j3mngz72ljw2m0czaf8rkcaglxa1v";
   }.${system} or throwSystem;
 in
-  callPackage ./generic.nix rec {
+  callPackage ./binary-generic.nix rec {
     # Please backport all compatible updates to the stable release.
     # This is important for the extension ecosystem.
     version = "1.90.0";
@@ -50,6 +50,18 @@ in
     longName = "Visual Studio Code" + lib.optionalString isInsiders " - Insiders";
     shortName = "Code" + lib.optionalString isInsiders " - Insiders";
     inherit commandLineArgs useVSCodeRipgrep sourceExecutableName;
+
+
+    common = import ./common.nix {
+      inherit
+        lib
+        executableName
+        longName
+        shortName
+        ;
+    };
+
+    inherit (common) desktopItem urlHandlerDesktopItem;
 
     src = fetchurl {
       name = "VSCode_${version}_${plat}.${archive_fmt}";
@@ -81,23 +93,15 @@ in
     # See https://eclecticlight.co/2022/06/17/app-security-changes-coming-in-ventura/ for more information.
     dontFixup = stdenv.isDarwin;
 
-    meta = with lib; {
-      description = ''
-        Open source source code editor developed by Microsoft for Windows,
-        Linux and macOS
-      '';
-      mainProgram = "code";
-      longDescription = ''
-        Open source source code editor developed by Microsoft for Windows,
-        Linux and macOS. It includes support for debugging, embedded Git
-        control, syntax highlighting, intelligent code completion, snippets,
-        and code refactoring. It is also customizable, so users can change the
-        editor's theme, keyboard shortcuts, and preferences
-      '';
+    meta = common.meta // {
       homepage = "https://code.visualstudio.com/";
       downloadPage = "https://code.visualstudio.com/Updates";
-      license = licenses.unfree;
-      maintainers = with maintainers; [ eadwu synthetica bobby285271 Enzime ];
-      platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" "aarch64-linux" "armv7l-linux" ];
+      license = lib.licenses.unfree;
+      maintainers = with lib.maintainers; [
+        eadwu
+        synthetica
+        bobby285271
+        Enzime
+      ];
     };
-  }
+}

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -2,6 +2,7 @@
 , lib
 , callPackage
 , fetchurl
+, makeDesktopItem
 , nixosTests
 , srcOnly
 , isInsiders ? false
@@ -58,10 +59,9 @@ in
         executableName
         longName
         shortName
+        makeDesktopItem
         ;
     };
-
-    inherit (common) desktopItem urlHandlerDesktopItem;
 
     src = fetchurl {
       name = "VSCode_${version}_${plat}.${archive_fmt}";

--- a/pkgs/applications/editors/vscode/vscodium.nix
+++ b/pkgs/applications/editors/vscode/vscodium.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, callPackage, fetchurl, nixosTests, commandLineArgs ? "", useVSCodeRipgrep ? stdenv.isDarwin }:
+{ lib, stdenv, makeDesktopItem, callPackage, fetchurl, nixosTests, commandLineArgs ? "", useVSCodeRipgrep ? stdenv.isDarwin }:
 
 let
   inherit (stdenv.hostPlatform) system;
@@ -43,10 +43,9 @@ in
         executableName
         longName
         shortName
+        makeDesktopItem
         ;
     };
-
-    inherit (common) desktopItem urlHandlerDesktopItem;
 
     src = fetchurl {
       url = "https://github.com/VSCodium/vscodium/releases/download/${version}/VSCodium-${plat}-${version}.${archive_fmt}";

--- a/pkgs/applications/editors/vscode/vscodium.nix
+++ b/pkgs/applications/editors/vscode/vscodium.nix
@@ -24,7 +24,7 @@ let
 
   sourceRoot = lib.optionalString (!stdenv.isDarwin) ".";
 in
-  callPackage ./generic.nix rec {
+  callPackage ./binary-generic.nix rec {
     inherit sourceRoot commandLineArgs useVSCodeRipgrep;
 
     # Please backport all compatible updates to the stable release.
@@ -36,6 +36,18 @@ in
     longName = "VSCodium";
     shortName = "vscodium";
 
+
+    common = import ./common.nix {
+      inherit
+        lib
+        executableName
+        longName
+        shortName
+        ;
+    };
+
+    inherit (common) desktopItem urlHandlerDesktopItem;
+
     src = fetchurl {
       url = "https://github.com/VSCodium/vscodium/releases/download/${version}/VSCodium-${plat}-${version}.${archive_fmt}";
       inherit sha256;
@@ -45,24 +57,11 @@ in
 
     updateScript = ./update-vscodium.sh;
 
-    meta = with lib; {
-      description = ''
-        Open source source code editor developed by Microsoft for Windows,
-        Linux and macOS (VS Code without MS branding/telemetry/licensing)
-      '';
-      longDescription = ''
-        Open source source code editor developed by Microsoft for Windows,
-        Linux and macOS. It includes support for debugging, embedded Git
-        control, syntax highlighting, intelligent code completion, snippets,
-        and code refactoring. It is also customizable, so users can change the
-        editor's theme, keyboard shortcuts, and preferences
-      '';
+    meta = common.meta // {
       homepage = "https://github.com/VSCodium/vscodium";
       downloadPage = "https://github.com/VSCodium/vscodium/releases";
-      license = licenses.mit;
-      sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-      maintainers = with maintainers; [ synthetica bobby285271 ludovicopiero ];
-      mainProgram = "codium";
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+      maintainers = with lib.maintainers; [ synthetica bobby285271 ludovicopiero ];
       platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" "armv7l-linux" ];
     };
   }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35257,6 +35257,7 @@ with pkgs;
   vscode-extensions = recurseIntoAttrs (callPackage ../applications/editors/vscode/extensions { });
 
   vscodium = callPackage ../applications/editors/vscode/vscodium.nix { };
+  vscode-oss = callPackage ../applications/editors/vscode/vscode-oss.nix { };
   vscodium-fhs = vscodium.fhs;
   vscodium-fhsWithPackages = vscodium.fhsWithPackages;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35262,7 +35262,7 @@ with pkgs;
     vscodium-fhs = vscodium.fhs;
     vscodium-fhsWithPackages = vscodium.fhsWithPackages;
   })
-  vscode vschde-fhs vscode-fhsWithPackages vscode-with-extensions
+  vscode vscode-fhs vscode-fhsWithPackages vscode-with-extensions
   vscode-utils
   vscode-extensions
   vscodium vscodium-fhs vscodium-fhsWithPackages

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35246,20 +35246,27 @@ with pkgs;
 
   vsce = callPackage ../development/tools/vsce { };
 
-  vscode = callPackage ../applications/editors/vscode/vscode.nix { };
-  vscode-fhs = vscode.fhs;
-  vscode-fhsWithPackages = vscode.fhsWithPackages;
+  inherit ({
+    vscode = callPackage ../applications/editors/vscode/vscode.nix { };
+    vscode-fhs = vscode.fhs;
+    vscode-fhsWithPackages = vscode.fhsWithPackages;
 
-  vscode-with-extensions = callPackage ../applications/editors/vscode/with-extensions.nix { };
+    vscode-with-extensions = callPackage ../applications/editors/vscode/with-extensions.nix { };
 
-  vscode-utils = callPackage ../applications/editors/vscode/extensions/vscode-utils.nix { };
+    vscode-utils = callPackage ../applications/editors/vscode/extensions/vscode-utils.nix { };
 
-  vscode-extensions = recurseIntoAttrs (callPackage ../applications/editors/vscode/extensions { });
+    vscode-extensions = recurseIntoAttrs (callPackage ../applications/editors/vscode/extensions { });
 
-  vscodium = callPackage ../applications/editors/vscode/vscodium.nix { };
-  vscode-oss = callPackage ../applications/editors/vscode/vscode-oss.nix { };
-  vscodium-fhs = vscodium.fhs;
-  vscodium-fhsWithPackages = vscodium.fhsWithPackages;
+    vscodium = callPackage ../applications/editors/vscode/vscodium.nix { };
+    vscode-oss = callPackage ../applications/editors/vscode/vscode-oss.nix { };
+    vscodium-fhs = vscodium.fhs;
+    vscodium-fhsWithPackages = vscodium.fhsWithPackages;
+  })
+  vscode vschde-fhs vscode-fhsWithPackages vscode-with-extensions
+  vscode-utils
+  vscode-extensions
+  vscodium vscodium-fhs vscodium-fhsWithPackages
+  vscode-oss;
 
   openvscode-server = callPackage ../servers/openvscode-server {
     nodejs = nodejs_18;


### PR DESCRIPTION
## Description of changes

This PR adds a package named `vscode-oss` that build https://github.com/microsoft/vscode from source. (Currently we have vscode + vscodium but they are not built by nix). 

Not only does this provide vscode desktop, but also remote-ssh server and web server in separated outputs. That is, users of this package can use `vscode-oss.reh` for their remote-ssh extension host, instead of downloading a large unknown binary from microsoft.

Electron, nodejs, are reused from nixpkgs.

The package also allows user changing the product.json, to customize their own vscode variant.

I don't know how to use by-name technology as well as reusing vscode directory, sorry ;)

Initially when I wrote these expressions, vscode is on 1.89.1 and I tested it. Automatic version bump, ~1.90.0,~ I think I can file another subsequent PRs.

Fixes: #26698
Closes: #86122

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
