### PR TITLE
python311Packages.finetuning-scheduler: init at 2.3.3

### DIFF
--- a/pkgs/development/python-modules/finetuning-scheduler/default.nix
+++ b/pkgs/development/python-modules/finetuning-scheduler/default.nix
@@ -1,0 +1,55 @@
+{
+  stdenv,
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pythonOlder,
+  pytestCheckHook,
+  torch,
+  pytorch-lightning,
+}:
+
+buildPythonPackage rec {
+  pname = "finetuning-scheduler";
+  version = "2.3.3";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "speediedan";
+    repo = "finetuning-scheduler";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-Nci+NcfcaZV3NH3MTCyr8PwPdDykJTdq8+CmtngWdiM=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    pytorch-lightning
+    torch
+  ];
+
+  # needed while lightning is installed as package `pytorch-lightning` rather than`lightning`:
+  env.PACKAGE_NAME = "pytorch";
+
+  nativeCheckInputs = [ pytestCheckHook ];
+  pytestFlagsArray = [ "tests" ];
+  disabledTests = lib.optionals (stdenv.isAarch64 && stdenv.isLinux) [
+    # slightly exceeds numerical tolerance on aarch64-linux:
+    "test_fts_frozen_bn_track_running_stats"
+  ];
+
+  pythonImportsCheck = [ "finetuning_scheduler" ];
+
+  meta = {
+    description = "PyTorch Lightning extension for foundation model experimentation with flexible fine-tuning schedules";
+    homepage = "https://finetuning-scheduler.readthedocs.io";
+    changelog = "https://github.com/speediedan/finetuning-scheduler/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+    # "No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package" at import time:
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4290,6 +4290,8 @@ self: super: with self; {
 
   findpython = callPackage ../development/python-modules/findpython { };
 
+  finetuning-scheduler = callPackage ../development/python-modules/finetuning-scheduler { };
+
   fingerprints = callPackage ../development/python-modules/fingerprints { };
 
   finitude = callPackage ../development/python-modules/finitude { };


### PR DESCRIPTION
## Description of changes

Add `finetuning-scheduler`, a package for generating Pytorch/Lightning learning rate schedules.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
