### PR TITLE
debase: init at 2

### DIFF
--- a/pkgs/by-name/de/debase/ignore-vendored-libgit2.patch
+++ b/pkgs/by-name/de/debase/ignore-vendored-libgit2.patch
@@ -1,0 +1,31 @@
+diff --git a/Makefile b/Makefile
+index b0b682cb..513822d9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -58,17 +58,14 @@ endif
+ 
+ INCDIRS =										\
+ 	-isystem ./lib/ncurses/include				\
+-	-iquote ./lib/libgit2/include				\
+ 	-iquote ./src								\
+ 	-iquote .
+ 
+ LIBDIRS =										\
+-	-L./lib/libgit2/build-$(PLATFORM)			\
+ 	-L./lib/ncurses/build-$(PLATFORM)
+ 
+ LIBS =											\
+ 	-lgit2										\
+-	-lz											\
+ 	-lpthread									\
+ 	-lformw										\
+ 	-lmenuw										\
+@@ -102,7 +99,7 @@ $(OBJS): | lib $(GITHASHHEADER)
+ # Libs: execute make from `lib` directory
+ .PHONY: lib
+ lib:
+-	$(MAKE) -C $@
++	$(MAKE) -C $@ ncurses/$(BUILDROOT)
+ 
+ # C rule
+ $(BUILDDIR)/%.o: %.c

--- a/pkgs/by-name/de/debase/package.nix
+++ b/pkgs/by-name/de/debase/package.nix
@@ -1,0 +1,96 @@
+{
+  darwin,
+  fetchFromGitHub,
+  fetchpatch, # Delete at next version bump.
+  lib,
+  libgit2,
+  stdenv,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "debase";
+  # NOTE: When updating version, also update commit hash in prePatch.
+  version = "2";
+
+  src =
+    (fetchFromGitHub {
+      owner = "toasterllc";
+      repo = "debase";
+      rev = "refs/tags/v${version}";
+      hash = "sha256-6AavH8Ag+879ntcxJDbVgsg8V6U4cxwPQYPKvq2PpoQ=";
+      fetchSubmodules = true;
+    }).overrideAttrs
+      {
+        # Workaround to fetch git@github.com submodules.
+        # See https://github.com/NixOS/nixpkgs/issues/195117
+        #
+        # Already fixed in latest upstream, so delete at next version bump.
+        GIT_CONFIG_COUNT = 1;
+        GIT_CONFIG_KEY_0 = "url.https://github.com/.insteadOf";
+        GIT_CONFIG_VALUE_0 = "git@github.com:";
+      };
+
+  prePatch = ''
+    # xcrun is not available in the Darwin stdenv, but we don't need it anyway.
+    substituteInPlace Makefile \
+      --replace-fail 'xcrun dsymutil' dsymutil
+
+    # NOTE: Update this when updating version.
+    substituteInPlace Makefile \
+      --replace-fail 'git rev-parse HEAD' 'echo bbe9f1737ab229dd370640a4b5d5e742a051c13b' \
+      --replace-fail '$(GITHASHHEADER): .git/HEAD .git/index' '$(GITHASHHEADER):'
+  '';
+
+  patches = [
+    # Ignore debase's vendored copy of libgit2 in favor of the nixpkgs version.
+    ./ignore-vendored-libgit2.patch
+    # Already fixed in latest upstream, so delete at next version bump.
+    (fetchpatch {
+      url = "https://github.com/toasterllc/debase/commit/d483c5ac016ac2ef3600e93ae4022cd9d7781c83.patch";
+      hash = "sha256-vVQMOEiLTd46+UknZm8Y197sjyK/kTK/M+9sRX9AssY=";
+    })
+  ];
+
+  buildInputs = [
+    libgit2
+  ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk_11_0.frameworks.Foundation ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 build-${if stdenv.isDarwin then "mac" else "linux"}/release/debase $out/bin/debase
+    runHook postInstall
+  '';
+
+  enableParallelBuilding = true;
+
+  makeFlags = [
+    "ARCHS=${
+      if stdenv.isx86_64 then
+        "x86_64"
+      else if stdenv.isAarch64 then
+        "arm64"
+      else
+        abort "unsupported system: ${stdenv.system}"
+    }"
+  ];
+
+  meta = {
+    description = "TUI for drag-and-drop manipulation of git commits";
+    homepage = "https://toaster.llc/debase";
+    # The author has not yet specified a license.
+    # See https://github.com/toasterllc/debase/pull/4
+    license = lib.licenses.publicDomain;
+    mainProgram = "debase";
+    maintainers = with lib.maintainers; [
+      jeremyschlatter
+      aleksana
+    ];
+    platforms = [
+      # Only these systems are supported by Makefile
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2217,6 +2217,10 @@ with pkgs;
 
   delta = darwin.apple_sdk_11_0.callPackage ../applications/version-management/delta { };
 
+  debase = callPackage ../by-name/de/debase/package.nix {
+    stdenv = if stdenv.isDarwin then darwin.apple_sdk_11_0.stdenv else stdenv;
+  };
+
   diff-so-fancy = callPackage ../applications/version-management/diff-so-fancy { };
 
   gex = callPackage ../applications/version-management/gex {


### PR DESCRIPTION
## Description of changes

debase is a TUI for drag-and-drop manipulation of Git commits:

![screenshot](https://raw.githubusercontent.com/toasterllc/debase/8d45caff9e716172224903eb5717b13638220f18/readme-copy.gif)

Resolves #317240

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
