### PR TITLE
decibels: init at 46.0

### DIFF
--- a/pkgs/by-name/de/decibels/package.nix
+++ b/pkgs/by-name/de/decibels/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  appstream,
+  blueprint-compiler,
+  desktop-file-utils,
+  gjs,
+  gst_all_1,
+  libadwaita,
+  meson,
+  ninja,
+  pkg-config,
+  typescript,
+  wrapGAppsHook4,
+  nix-update-script,
+}:
+stdenv.mkDerivation rec {
+  pname = "decibels";
+  version = "46.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    group = "GNOME";
+    owner = "Incubator";
+    repo = "decibels";
+    rev = version;
+    hash = "sha256-3LQQcrpmWrTfk8A8GR+KnxJEB1HGozgEsM+j5ECK8kc=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    appstream
+    blueprint-compiler
+    desktop-file-utils
+    meson
+    ninja
+    pkg-config
+    typescript
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gjs
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base # for GstVideo
+    gst_all_1.gst-plugins-bad # for GstPlay
+    gst_all_1.gst-plugins-good # for scaletempo
+    libadwaita
+  ];
+
+  # NOTE: this is applied after install to ensure `tsc` doesn't
+  # mess with us
+  #
+  # gjs uses the invocation name to add gresource files
+  # to get around this, we set the entry point name manually
+  preFixup = ''
+    sed -i "1 a imports.package._findEffectiveEntryPointName = () => 'org.gnome.Decibels';" $out/bin/org.gnome.Decibels
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Play audio files";
+    homepage = "https://gitlab.gnome.org/GNOME/Incubator/decibels";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ getchoo ];
+    mainProgram = "org.gnome.Decibels";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

[Decibels](https://apps.gnome.org/Decibels/) is a small Libadwaita application that plays audio files

A part of #195280

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
