### PR TITLE
klassy: init at 6.4.breeze6.4.0

### DIFF
--- a/pkgs/by-name/kl/klassy/package.nix
+++ b/pkgs/by-name/kl/klassy/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  kdePackages,
+  gitUpdater,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "klassy";
+  version = "6.4.breeze6.4.0";
+
+  src = fetchFromGitHub {
+    owner = "paulmcauley";
+    repo = "klassy";
+    tag = finalAttrs.version;
+    hash = "sha256-+bYS2Upr84BS0IdA0HlCK0FF05yIMVbRvB8jlN5EOUM=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    kdePackages.extra-cmake-modules
+    kdePackages.wrapQtAppsHook
+  ];
+
+  buildInputs = with kdePackages; [
+    qtbase
+    qtdeclarative
+    qttools
+    qtsvg
+
+    frameworkintegration
+    kcmutils
+    kcolorscheme
+    kconfig
+    kcoreaddons
+    kdecoration
+    kguiaddons
+    ki18n
+    kiconthemes
+    kirigami
+    kwidgetsaddons
+    kwindowsystem
+  ];
+
+  # Klassy tries to build for both Qt 5 and 6 at the same time by default
+  # but that is impossible given how Qt setup hooks are currently designed
+  # in Nixpkgs. Given that KDE Plasma 5 has already been removed as of the
+  # time of writing, I figure it's fine to only build the Qt 6 version.
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_QT6" true)
+    (lib.cmakeBool "BUILD_QT5" false)
+  ];
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "Highly customizable binary Window Decoration, Application Style and Global Theme plugin for recent versions of the KDE Plasma desktop";
+    homepage = "https://github.com/paulmcauley/klassy";
+    platforms = lib.platforms.linux;
+    license = with lib.licenses; [
+      bsd3
+      cc0
+      gpl2Only
+      gpl2Plus
+      gpl3Only
+      gpl3Plus # KDE-Accepted-GPL
+      mit
+    ];
+    maintainers = with lib.maintainers; [ pluiedev ];
+    mainProgram = "klassy-settings";
+  };
+})


### PR DESCRIPTION
## Description of changes

Fixes #272566

Unlike the solution proposed in [this comment](https://github.com/NixOS/nixpkgs/issues/272566#issuecomment-2157880152), this doesn't attempt to build Qt 5 and Qt 6 versions at once, which makes the derivation logic much simpler.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
