### PR TITLE
home-assistant-custom-components.tuya_local: 2024.5.2 -> 2024.6.0

### DIFF
--- a/pkgs/development/python-modules/tinytuya/default.nix
+++ b/pkgs/development/python-modules/tinytuya/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "tinytuya";
-  version = "1.13.2";
+  version = "1.14.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jasonacox";
     repo = "tinytuya";
     rev = "refs/tags/v${version}";
-    hash = "sha256-44x5P+Ej/d6B5n53iDuLDBzkeZZvArpcgzXLJBcIJe0=";
+    hash = "sha256-ytM7S0V/hDOCb3RyzAXZEd2zV/sMVQPrah/2zRACMsQ=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/custom-components/tuya_local/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/tuya_local/default.nix
@@ -4,21 +4,25 @@
 
 # dependencies
 , tinytuya
+, tuya-device-sharing-sdk
 }:
 
 buildHomeAssistantComponent rec {
   owner = "make-all";
   domain = "tuya_local";
-  version = "2024.5.2";
+  version = "2024.6.0";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "tuya-local";
     rev = "refs/tags/${version}";
-    hash = "sha256-If5SLLizagolXF5Y43UQK5IZ9oB1lQJVjTorgmtRXtg=";
+    hash = "sha256-OLR/KFoXKqL7r7S97VpyoVHdbLfOyWU50aK6c0QhqyE=";
   };
 
-  dependencies = [ tinytuya ];
+  dependencies = [
+    tinytuya
+    tuya-device-sharing-sdk
+  ];
 
   meta = with lib; {
     description = "Local support for Tuya devices in Home Assistant";


### PR DESCRIPTION
## Description of changes

To be able to update the Home Assistant custom component tuya-local from version 2024.5.2 to version 2024.6.0, I've also updated the dependency tinytuya from version 1.13.2 to version 1.14.0, and added the new dependency tuya-device-sharing-sdk.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
