### PR TITLE
extlinux-conf-builder: don't emit MENU when timeout is zero

### DIFF
--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
@@ -11,18 +11,24 @@ usage() {
 }
 
 timeout=                # Timeout in centiseconds
+menu=1                  # Enable menu by default
 default=                # Default configuration
 target=/boot            # Target directory
 numGenerations=0        # Number of other generations to include in the menu
 
 while getopts "t:c:d:g:n:r" opt; do
     case "$opt" in
-        t) # U-Boot interprets '0' as infinite and negative as instant boot
+        t) # U-Boot interprets '0' as infinite
             if [ "$OPTARG" -lt 0 ]; then
+                # When negative (or null coerced to -1), disable timeout which means that we wait forever for input
                 timeout=0
             elif [ "$OPTARG" = 0 ]; then
-                timeout=-10
+                # When zero, which means disabled in Nix module, disable menu which results in instant boot of the default item
+                # .. timeout is actually ignored by u-Boot but set here for the rest of the script
+                timeout=1
+                menu=0
             else
+                # Positive results in centi-seconds of timeout, which when passed with no input results in boot of the default item
                 timeout=$((OPTARG * 10))
             fi
             ;;
@@ -126,9 +132,11 @@ cat > $tmpFile <<EOF
 # Change this to e.g. nixos-42 to temporarily boot to an older configuration.
 DEFAULT nixos-default
 
-MENU TITLE ------------------------------------------------------------
 TIMEOUT $timeout
 EOF
+
+[ "$menu" == "1" ] \
+  && echo "MENU TITLE ------------------------------------------------------------" >> $tmpFile
 
 addEntry $default default >> $tmpFile
 


### PR DESCRIPTION
## Description of changes

Fixes handling of `boot.loader.timeout = 0`. 

Before this patch, when set to `0` uBoot waits for input indefinitely. With this patch applied, it results in actual zero timeout and instant boot. This is done via not emitting `MENU` at all which is the only way to do it. The previous (`timeout=-10`) solution does wait for input indefinitely.

I've tested this many times over the years, once I've had to climb to a LoRaWAN gateway on a roof and plug in a keyboard to hit enter.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
