### PR TITLE
nixos/ngrok: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -14,6 +14,8 @@
 
 - [Quickwit](https://quickwit.io), sub-second search & analytics engine on cloud storage. Available as [services.quickwit](options.html#opt-services.quickwit).
 
+- [Ngrok](https://ngrok.com/), a globally distributed reverse proxy. Available as [services.ngrok](#opt-services.ngrok.enable).
+
 ## Backward Incompatibilities {#sec-release-24.11-incompatibilities}
 
 - `nginx` package no longer includes `gd` and `geoip` dependencies. For enabling it, override `nginx` package with the optionals `withImageFilter` and `withGeoIP`.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1097,6 +1097,7 @@
   ./services/networking/nftables.nix
   ./services/networking/nghttpx/default.nix
   ./services/networking/ngircd.nix
+  ./services/networking/ngrok.nix
   ./services/networking/nix-serve.nix
   ./services/networking/nix-store-gcs-proxy.nix
   ./services/networking/nixops-dns.nix

--- a/nixos/modules/services/networking/ngrok.nix
+++ b/nixos/modules/services/networking/ngrok.nix
@@ -1,0 +1,144 @@
+{ config, lib, pkgs, ... }:
+let
+  inherit (lib) options types mkIf optional optionalAttrs getExe;
+
+  name = "ngrok";
+  cfg = config.services.ngrok;
+
+  configFormat = pkgs.formats.yaml { };
+
+  configFileGenerated = configFormat.generate "ngrok-config.yml" cfg.config;
+
+  configFiles = builtins.concatStringsSep "," ((optional (cfg.config != { }) configFileGenerated) ++ cfg.extraConfigFiles);
+in
+{
+  ###### interface
+  options.services.ngrok = {
+    enable = options.mkEnableOption "Ngrok";
+
+    package = options.mkPackageOption pkgs name { };
+
+    user = options.mkOption {
+      type = types.str;
+      default = name;
+      description = "User account under which ngrok agent runs.";
+    };
+
+    group = options.mkOption {
+      type = types.str;
+      default = name;
+      description = "Group account under which ngrok agent runs.";
+    };
+
+    config = options.mkOption {
+      type = types.submodule {
+        freeformType = configFormat.type;
+      };
+
+      default = { };
+      description = ''
+        Config to pass to Ngrok agent.
+
+        See [documentation](https://ngrok.com/docs/agent/config/) for details.
+      '';
+
+      example = {
+        log = "stdout";
+        log_level = "info";
+        tunnels = {
+          website = {
+            addr = "localhost:8080";
+            schemes = [ "https" ];
+            proto = "http";
+            domain = "myapp.ngrok.dev";
+          };
+        };
+      };
+    };
+
+    extraConfigFiles = options.mkOption {
+      type = with types; listOf path;
+      default = [ ];
+      description = ''
+        Extra config files to inject **after** the declarative config.
+
+        See [documentation](https://ngrok.com/docs/agent/config/#config-file-merging) for details.
+      '';
+    };
+
+    startArguments = options.mkOption {
+      type = types.str;
+      default = "--all";
+      example = "web dev";
+      description = ''
+        Arguments & flags to pass to `ngrok start` command.
+        Can be used to start only specific tunnel(s), for example.
+
+        See [documentation](https://ngrok.com/docs/agent/cli/#ngrok-start) for details.
+      '';
+    };
+  };
+
+  ###### implementation
+  config = mkIf cfg.enable {
+    assertions = [{
+      assertion = cfg.config != { } || cfg.extraConfigFiles != [ ];
+      message = "At least one of `config`, `extraConfigFiles` must be specified.";
+    }];
+
+    users = {
+      users = optionalAttrs (cfg.user == name) {
+        ${name} = {
+          description = "Ngrok Agent User";
+          group = cfg.group;
+          home = "/var/lib/${name}";
+          isSystemUser = true;
+        };
+      };
+
+      groups = optionalAttrs (cfg.group == name) {
+        ${name} = { };
+      };
+    };
+
+    systemd.services.ngrok = {
+      description = "Ngrok reverse proxy";
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+
+      serviceConfig = {
+        ExecStart = "${getExe cfg.package} --config ${configFiles} start ${cfg.startArguments}";
+        User = cfg.user;
+        Group = cfg.group;
+        Restart = "always";
+        RestartSec = 15;
+        StateDirectory = name;
+        Type = "simple";
+
+        # Hardening
+        CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+      };
+
+    };
+  };
+}


### PR DESCRIPTION
## Description of changes

Adding a [ngrok](https://ngrok.com/docs/what-is-ngrok/) systemd service.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
