### PR TITLE
Revert "neomutt: 20231221 -> 20240425"

### DIFF
--- a/pkgs/applications/networking/mailreaders/neomutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/neomutt/default.nix
@@ -5,15 +5,15 @@
 , withContrib ? true
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation rec {
+  version = "20231221";
   pname = "neomutt";
-  version = "20240425";
 
   src = fetchFromGitHub {
     owner  = "neomutt";
     repo   = "neomutt";
-    rev    = finalAttrs.version;
-    hash   = "sha256-QBqPFteoAm3AdQN0XTWpho8DEW2BFCCzBcHUZIiSxyQ=";
+    rev    = version;
+    sha256 = "sha256-IXly2N/DD2+XBXVIXJw1sE/0eJwbUaONDNRMi7n1T44=";
   };
 
   buildInputs = [
@@ -73,35 +73,30 @@ stdenv.mkDerivation (finalAttrs: {
   ''
   # https://github.com/neomutt/neomutt-contrib
   # Contains vim-keys, keybindings presets and more.
-  + lib.optionalString withContrib "${lib.getExe lndir} ${finalAttrs.passthru.contrib} $out/share/doc/neomutt";
+  + lib.optionalString withContrib "${lib.getExe lndir} ${passthru.contrib} $out/share/doc/neomutt";
 
   doCheck = true;
 
   preCheck = ''
-    cp -r ${finalAttrs.passthru.test-files} $(pwd)/test-files
-
+    cp -r ${passthru.test-files} $(pwd)/test-files
     chmod -R +w test-files
     (cd test-files && ./setup.sh)
 
     export NEOMUTT_TEST_DIR=$(pwd)/test-files
-
-    # The test fails with: node_padding.c:135: Check rc == 15... failed
-    substituteInPlace test/main.c \
-      --replace-fail "NEOMUTT_TEST_ITEM(test_expando_node_padding)" ""
   '';
 
   passthru = {
     test-files = fetchFromGitHub {
       owner = "neomutt";
       repo = "neomutt-test-files";
-      rev = "00efc8388110208e77e6ed9d8294dfc333753d54";
-      hash = "sha256-/ELowuMq67v56MAJBtO73g6OqV0DVwW4+x+0u4P5mB0=";
+      rev = "1569b826a56c39fd09f7c6dd5fc1163ff5a356a2";
+      sha256 = "sha256-MaH2zEH1Wq3C0lFxpEJ+b/A+k2aKY/sr1EtSPAuRPp8=";
     };
     contrib = fetchFromGitHub {
       owner = "neomutt";
       repo = "neomutt-contrib";
       rev = "8e97688693ca47ea1055f3d15055a4f4ecc5c832";
-      hash = "sha256-tx5Y819rNDxOpjg3B/Y2lPcqJDArAxVwjbYarVmJ79k=";
+      sha256 = "sha256-tx5Y819rNDxOpjg3B/Y2lPcqJDArAxVwjbYarVmJ79k=";
     };
   };
 
@@ -109,11 +104,11 @@ stdenv.mkDerivation (finalAttrs: {
   postCheck = "unset NEOMUTT_TEST_DIR";
 
   meta = {
-    description = "Small but very powerful text-based mail client";
+    description = "A small but very powerful text-based mail client";
     mainProgram = "neomutt";
     homepage    = "https://www.neomutt.org";
     license     = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ erikryb vrthra raitobezarius ];
     platforms   = lib.platforms.unix;
   };
-})
+}


### PR DESCRIPTION
```
=================================================================
==1321651==ERROR: AddressSanitizer: heap-use-after-free on address 0x60200000fd50 at pc 0x7ff2cfcd522b bp 0x7ffe69a43820 sp 0x7ffe69a42fe0
READ of size 3 at 0x60200000fd50 thread T0
    #0 0x7ff2cfcd522a in __interceptor_regexec.part.0 (/nix/store/xvzz97yk73hw03v5dhhz3j47ggwf1yq1-gcc-13.2.0-lib/lib/libasan.so.8+0x9222a)
    #1 0x8d40b0 in mutt_regex_capture mutt/regex.c:603
    #2 0x8d5deb in mutt_regex_match mutt/regex.c:616
    #3 0x45fccb in mutt_folder_hook /build/source/hook.c:644
    #4 0x474420 in main /build/source/main.c:1404
    #5 0x7ff2ce9b310d in __libc_start_call_main (/nix/store/k7zgvzp2r31zkg9xqgjim7mbknryv6bs-glibc-2.39-52/lib/libc.so.6+0x2a10d) (BuildId: bc8ec5f3ac2561de8f08b232685038c7167bf4b7)
    #6 0x7ff2ce9b31c8 in __libc_start_main_alias_1 (/nix/store/k7zgvzp2r31zkg9xqgjim7mbknryv6bs-glibc-2.39-52/lib/libc.so.6+0x2a1c8) (BuildId: bc8ec5f3ac2561de8f08b232685038c7167bf4b7)
    #7 0x40e3f4 in _start (/nix/store/4viqafxjc9dq6n9aixwq9cff8vl8pg40-neomutt-20240425/bin/.neomutt-wrapped+0x40e3f4)

0x60200000fd50 is located 0 bytes inside of 10-byte region [0x60200000fd50,0x60200000fd5a)
freed by thread T0 here:
    #0 0x7ff2cfd1dd08 in __interceptor_free.part.0 (/nix/store/xvzz97yk73hw03v5dhhz3j47ggwf1yq1-gcc-13.2.0-lib/lib/libasan.so.8+0xdad08)
    #1 0x8ca5c9 in mutt_mem_free mutt/memory.c:75
    #2 0x8d9dfa in mutt_str_replace mutt/string.c:280
    #3 0x413753 in mailbox_add /build/source/commands.c:667
    #4 0x414a17 in parse_mailboxes /build/source/commands.c:814
    #5 0x835ce7 in parse_rc_buffer parse/rc.c:79
    #6 0x41882e in source_rc /build/source/commands.c:281
    #7 0x41900f in parse_source /build/source/commands.c:1085
    #8 0x835ce7 in parse_rc_buffer parse/rc.c:79
    #9 0x836138 in parse_rc_line parse/rc.c:114
    #10 0x4179d5 in parse_rc_line_cwd /build/source/commands.c:168
    #11 0x460024 in mutt_folder_hook /build/source/hook.c:651
    #12 0x474420 in main /build/source/main.c:1404
    #13 0x7ff2ce9b310d in __libc_start_call_main (/nix/store/k7zgvzp2r31zkg9xqgjim7mbknryv6bs-glibc-2.39-52/lib/libc.so.6+0x2a10d) (BuildId: bc8ec5f3ac2561de8f08b232685038c7167bf4b7)

previously allocated by thread T0 here:
    #0 0x7ff2cfcc71f8 in strdup (/nix/store/xvzz97yk73hw03v5dhhz3j47ggwf1yq1-gcc-13.2.0-lib/lib/libasan.so.8+0x841f8)
    #1 0x8d9cb5 in mutt_str_dup mutt/string.c:258
    #2 0x8d9dba in mutt_str_replace mutt/string.c:279
    #3 0x413753 in mailbox_add /build/source/commands.c:667
    #4 0x414a17 in parse_mailboxes /build/source/commands.c:814
    #5 0x835ce7 in parse_rc_buffer parse/rc.c:79
    #6 0x41882e in source_rc /build/source/commands.c:281
    #7 0x41900f in parse_source /build/source/commands.c:1085
    #8 0x835ce7 in parse_rc_buffer parse/rc.c:79
    #9 0x41882e in source_rc /build/source/commands.c:281
    #10 0x465746 in mutt_init /build/source/init.c:537
    #11 0x46ec4b in main /build/source/main.c:851
    #12 0x7ff2ce9b310d in __libc_start_call_main (/nix/store/k7zgvzp2r31zkg9xqgjim7mbknryv6bs-glibc-2.39-52/lib/libc.so.6+0x2a10d) (BuildId: bc8ec5f3ac2561de8f08b232685038c7167bf4b7)

SUMMARY: AddressSanitizer: heap-use-after-free (/nix/store/xvzz97yk73hw03v5dhhz3j47ggwf1yq1-gcc-13.2.0-lib/lib/libasan.so.8+0x9222a) in __interceptor_regexec.part.0
Shadow bytes around the buggy address:
  0x60200000fa80: fa fa 00 00 fa fa 00 00 fa fa 00 00 fa fa 00 00
  0x60200000fb00: fa fa 00 00 fa fa 00 00 fa fa 00 00 fa fa 00 00
  0x60200000fb80: fa fa 00 00 fa fa 00 00 fa fa 00 00 fa fa 00 00
  0x60200000fc00: fa fa 00 00 fa fa 00 00 fa fa 00 00 fa fa 00 00
  0x60200000fc80: fa fa 00 00 fa fa 00 00 fa fa 00 00 fa fa 00 00
=>0x60200000fd00: fa fa 00 00 fa fa 00 00 fa fa[fd]fd fa fa fd fa
  0x60200000fd80: fa fa 00 fa fa fa fd fa fa fa fd fa fa fa 04 fa
  0x60200000fe00: fa fa 04 fa fa fa fd fa fa fa 04 fa fa fa 04 fa
  0x60200000fe80: fa fa 00 00 fa fa 02 fa fa fa fd fa fa fa 04 fa
  0x60200000ff00: fa fa 04 fa fa fa 04 fa fa fa 04 fa fa fa 04 fa
  0x60200000ff80: fa fa 04 fa fa fa 04 fa fa fa 04 fa fa fa 04 fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==1321651==ABORTING
```

Reverts NixOS/nixpkgs#305817 as it was unfortunately insufficiently tested.