### PR TITLE
d2vm: init at 0.2.0; sparsecat: init at 1.0.1

### DIFF
--- a/pkgs/by-name/d2/d2vm/package.nix
+++ b/pkgs/by-name/d2/d2vm/package.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  docker,
+  util-linux,
+  udev,
+  parted,
+  e2fsprogs,
+  dosfstools,
+  mount,
+  gnutar,
+  syslinux,
+  qemu-utils,
+  multipath-tools,
+  sparsecat,
+  qemu,
+  virtualbox,
+  qemuSupport ? false,
+  virtualboxSupport ? false,
+}:
+
+buildGoModule rec {
+  pname = "d2vm";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "linka-cloud";
+    repo = "d2vm";
+    rev = "v${version}";
+    hash = "sha256-cSl9WfJIbnl3WyUTQjgCukhQ91uIyGB2xFPr5VF8E/U=";
+  };
+
+  subPackages = [ "cmd/d2vm" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  vendorHash = "sha256-pzO1qCRWR6+Htv+RZT8ZI+MUYkMumODushp/iUIc114=";
+
+  preBuild = ''
+    cp ${sparsecat}/bin/sparsecat cmd/d2vm/run/sparsecat-linux-amd64
+    cp ${sparsecat}/bin/sparsecat cmd/d2vm/run/sparsecat-linux-arm64
+  '';
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ];
+
+  postPatch = ''
+    substituteInPlace builder.go \
+      --replace /usr/lib/syslinux/mbr/mbr.bin ${syslinux}/share/syslinux/mbr.bin
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/d2vm \
+      --suffix PATH : ${
+        lib.makeBinPath (
+          [
+            docker
+            util-linux
+            udev
+            parted
+            e2fsprogs
+            dosfstools
+            mount
+            gnutar
+            syslinux
+            qemu-utils
+            multipath-tools
+          ]
+          ++ lib.optionals qemuSupport [ qemu ]
+          ++ lib.optionals virtualboxSupport [ virtualbox ]
+        )
+      }
+  '';
+
+  meta = {
+    description = "Build Virtual Machine Image from Dockerfile or Docker image";
+    homepage = "https://github.com/linka-cloud/d2vm";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kilimnik ];
+  };
+}

--- a/pkgs/by-name/sp/sparsecat/package.nix
+++ b/pkgs/by-name/sp/sparsecat/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "sparsecat";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "svenwiltink";
+    repo = "sparsecat";
+    rev = "v${version}";
+    hash = "sha256-2E5yPlLg/XtosiR//be7usDjOKWEWcAzgWFQc0nYYF0=";
+  };
+
+  vendorHash = "sha256-vxLqSmM6iSbWNlu0jz7CR9mqf9MMq3qAt26tOWwQRSc=";
+
+  subPackages = [ "cmd/sparsecat" ];
+
+  meta = {
+    description = "CLI tool that reduces bandwidth usage when transmitting sparse files";
+    homepage = "https://github.com/svenwiltink/sparsecat";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kilimnik ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Package d2vm which is a way to build vm images out of docker containers. As well as the sparsecat which is
 a dependency designed to transmitting sparse files.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
