### PR TITLE
nixos/ddclient: create RunTime directory during install

### DIFF
--- a/nixos/modules/services/networking/ddclient.nix
+++ b/nixos/modules/services/networking/ddclient.nix
@@ -30,9 +30,9 @@ let
   configFile = if (cfg.configFile != null) then cfg.configFile else configFile';
 
   preStart = ''
-    install --mode=600 --owner=$USER ${configFile} /run/${RuntimeDirectory}/ddclient.conf
+    install -D --mode=600 --owner=$USER ${configFile} /run/${RuntimeDirectory}/ddclient.conf
     ${lib.optionalString (cfg.configFile == null) (if (cfg.protocol == "nsupdate") then ''
-      install --mode=600 --owner=$USER ${cfg.passwordFile} /run/${RuntimeDirectory}/ddclient.key
+      install -D --mode=600 --owner=$USER ${cfg.passwordFile} /run/${RuntimeDirectory}/ddclient.key
     '' else if (cfg.passwordFile != null) then ''
       "${pkgs.replace-secret}/bin/replace-secret" "@password_placeholder@" "${cfg.passwordFile}" "/run/${RuntimeDirectory}/ddclient.conf"
     '' else ''


### PR DESCRIPTION
**ddclient** (`services.ddclient`) failed to find its configuration file. As reported in #149519 , this file is expected to be `/run/ddclient/ddclient.conf`. From that same issue report, a fix emerged to install the file in place using the service's `ExecStartPre`. However, this later command fails on my machine because the run time directory `/run/ddclient` does not exist.

Running the preinstall script manually leads to:
```
$ /nix/store/m7g1lz2xgjhv3x0wvgdqgi971zpskabd-ddclient-prestart
install: cannot create regular file '/run/ddclient/ddclient.conf': No such file or directory
```

I'm unsure if this change makes the situation worse by hiding an underlying problem away. I would have expected the run time directory to be created in some other manner or fashion, especially since `ddclient` is being used by more users. This is my very first PR to NixOS, kindly let me know if I should better covert it into issue, instead.

## Description of changes

Append `-D` to `install` to create leading path to files. This solves issues on instances where the configuration file can not be emplaced under `/run/ddclient/ddclient.conf` because the directory `/run/ddclient/` does not exist.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
- notes: service activated without restarting/rebooting after install. 
