### PR TITLE
linuxPackages: bring back GNU build ID for kernels

### DIFF
--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -170,12 +170,6 @@ let
         # Ensure that depmod gets resolved through PATH
         sed -i Makefile -e 's|= /sbin/depmod|= depmod|'
 
-        # Don't include a (random) NT_GNU_BUILD_ID, to make the build more deterministic.
-        # This way kernels can be bit-by-bit reproducible depending on settings
-        # (e.g. MODULE_SIG and SECURITY_LOCKDOWN_LSM need to be disabled).
-        # See also https://kernelnewbies.org/BuildId
-        sed -i Makefile -e 's|--build-id=[^ ]*|--build-id=none|'
-
         # Some linux-hardened patches now remove certain files in the scripts directory, so the file may not exist.
         [[ -f scripts/ld-version.sh ]] && patchShebangs scripts/ld-version.sh
 


### PR DESCRIPTION
## Description of changes

https://github.com/NixOS/nixpkgs/pull/106648 added a `sed` invocation that prevents build IDs from being generated for the kernels and their modules. Other than stated in the PR and the comment on the removed code, build IDs do not necessarily negatively affect reproducibility. 

The IDs are very useful for all sorts of application that wish to symbolize kernel stack traces. Without build IDs, it can be very difficult to retrieve debug information for the correct kernel, and essentially all other major Linux distributions (including Alpine, which otherwise doesn't use build IDs) ship with them enabled.

The code to disable the build IDs further didn't actually work for a lot of older kernels, because the regexp accidentally didn't apply: [older kernels use `--build-id` instead of `--build-id=sha1`](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/Makefile?h=v5.4.277#n945).

You can confirm this by running:

```
nix build nixpkgs#linuxPackages_5_4.kernel
wget https://raw.githubusercontent.com/torvalds/linux/v5.4/scripts/extract-vmlinux
chmod a+x ./extract-vmlinux
./extract-vmlinux result/bzImage > kernel.elf
readelf --notes ./kernel.elf
```

which will print (among other things):

```
  GNU                  0x00000014       NT_GNU_BUILD_ID (unique build ID bitstring)
    Build ID: 73bb7ff00772ff054e711ab7058d8c1df438c778
```

So the current situation is that on newer kernels that have `--build-id=sha1` in their Makefile (which is meant to be perfectly reproducible), we disable the build ID, whereas for older kernels where the exact build ID schema is unspecified and the default depends on the linker, we keep it.

In this PR I just remove the patch entirely. It seems that the linker-chosen default worked well enough in the past -- at least I can't find any issues complaining about the reproducibility of older kernels. If people would prefer it, I'd however also be happy to rework the PR to instead patch older kernels to explicitly request SHA1 build IDs: I'm not aware of any, but there **may** be some linkers that use random build IDs (`--build-id=uuid`) as their default.

I validated reproducibility of these changes by running `nix build .#linuxPackages_6_6.kernel --rebuild` multiple times and consistently ended up with a `bzImage` with the same shasum and hence also same build ID in the kernel ELF.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
