### PR TITLE
nixosTests.taskchampion-sync-server: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -27,6 +27,8 @@
 
 ## New Services {#sec-release-24.11-new-services}
 
+- [TaskChampion Sync-Server](https://github.com/GothenburgBitFactory/taskchampion-sync-server), a [Taskwariror 3](https://taskwarrior.org/docs/upgrade-3/) sync server, replacing Taskwarrior 2's sync server named [`taskserver`](https://github.com/GothenburgBitFactory/taskserver).
+
 - [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr), proxy server to bypass Cloudflare protection. Available as [services.flaresolverr](#opt-services.flaresolverr.enable) service.
 
 - [Goatcounter](https://www.goatcounter.com/), Easy web analytics. No tracking of personal data. Available as [services.goatcounter](options.html#opt-services.goatcocunter.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -844,6 +844,7 @@
   ./services/misc/tabby.nix
   ./services/misc/tandoor-recipes.nix
   ./services/misc/taskserver
+  ./services/misc/taskchampion-sync-server.nix
   ./services/misc/tautulli.nix
   ./services/misc/tiddlywiki.nix
   ./services/misc/tp-auto-kbbl.nix

--- a/nixos/modules/services/misc/taskchampion-sync-server.nix
+++ b/nixos/modules/services/misc/taskchampion-sync-server.nix
@@ -1,0 +1,85 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  inherit (lib) types;
+  cfg = config.services.taskchampion-sync-server;
+in
+{
+  options.services.taskchampion-sync-server = {
+    enable = lib.mkEnableOption "TaskChampion Sync Server for Taskwarrior 3";
+    package = lib.mkPackageOption pkgs "taskchampion-sync-server" { };
+    user = lib.mkOption {
+      description = "Unix User to run the server under";
+      type = types.str;
+      default = "taskchampion";
+    };
+    group = lib.mkOption {
+      description = "Unix Group to run the server under";
+      type = types.str;
+      default = "taskchampion";
+    };
+    port = lib.mkOption {
+      description = "Port on which to serve";
+      type = types.port;
+      default = 10222;
+    };
+    openFirewall = lib.mkEnableOption "Open firewall port for taskchampion-sync-server";
+    dataDir = lib.mkOption {
+      description = "Directory in which to store data";
+      type = types.path;
+      default = "/var/lib/taskchampion-sync-server";
+    };
+    snapshot = {
+      versions = lib.mkOption {
+        description = "Target number of versions between snapshots";
+        type = types.ints.positive;
+        default = 100;
+      };
+      days = lib.mkOption {
+        description = "Target number of days between snapshots";
+        type = types.ints.positive;
+        default = 14;
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      inherit (cfg) group;
+    };
+    users.groups.${cfg.group} = { };
+    networking.firewall.allowedTCPPorts = lib.mkIf (cfg.openFirewall) [ cfg.port ];
+    systemd.tmpfiles.settings = {
+      "10-taskchampion-sync-server" = {
+        "${cfg.dataDir}" = {
+          d = {
+            inherit (cfg) group user;
+            mode = "0750";
+          };
+        };
+      };
+    };
+
+    systemd.services.taskchampion-sync-server = {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        DynamicUser = false;
+        ExecStart = ''
+          ${lib.getExe cfg.package} \
+            --port ${builtins.toString cfg.port} \
+            --data-dir ${cfg.dataDir} \
+            --snapshot-versions ${builtins.toString cfg.snapshot.versions} \
+            --snapshot-days ${builtins.toString cfg.snapshot.days}
+        '';
+      };
+    };
+  };
+}

--- a/nixos/modules/services/misc/taskserver/default.md
+++ b/nixos/modules/services/misc/taskserver/default.md
@@ -1,10 +1,8 @@
 # Taskserver {#module-services-taskserver}
 
-Taskserver is the server component of
+Taskserver is the server component of the now deprecated version 2 of
 [Taskwarrior](https://taskwarrior.org/), a free and
 open source todo list application.
-
-*Upstream documentation:* <https://taskwarrior.org/docs/#taskd>
 
 ## Configuration {#module-services-taskserver-configuration}
 
@@ -23,7 +21,7 @@ entity.
 
 With {command}`nixos-taskserver` the client certificate is created
 along with the UUID of the user, so it handles all of the credentials needed
-in order to setup the Taskwarrior client to work with a Taskserver.
+in order to setup the Taskwarrior 2 client to work with a Taskserver.
 
 ## The nixos-taskserver tool {#module-services-taskserver-nixos-taskserver-tool}
 
@@ -49,7 +47,7 @@ command, documentation for each subcommand can be shown by using the
 ## Declarative/automatic CA management {#module-services-taskserver-declarative-ca-management}
 
 Everything is done according to what you specify in the module options,
-however in order to set up a Taskwarrior client for synchronisation with a
+however in order to set up a Taskwarrior 2 client for synchronisation with a
 Taskserver instance, you have to transfer the keys and certificates to the
 client machine.
 

--- a/nixos/modules/services/misc/taskserver/default.md
+++ b/nixos/modules/services/misc/taskserver/default.md
@@ -4,6 +4,16 @@ Taskserver is the server component of the now deprecated version 2 of
 [Taskwarrior](https://taskwarrior.org/), a free and
 open source todo list application.
 
+[Taskwarrior 3.0.0 was released in March
+2024](https://github.com/GothenburgBitFactory/taskwarrior/releases/tag/v3.0.0),
+and the sync functionality was rewritten entirely. With it, a NixOS module
+named
+[`taskchampion-sync-server`](options.html#opt-services.taskchampion-sync-server.enable)
+was added to Nixpkgs. Many people still want to use the old [Taskwarrior
+2.6.x](https://github.com/GothenburgBitFactory/taskwarrior/releases/tag/v2.6.2),
+and Taskserver along with it. Hence this module and this documentation will
+stay here for the near future.
+
 ## Configuration {#module-services-taskserver-configuration}
 
 Taskserver does all of its authentication via TLS using client certificates,

--- a/nixos/modules/services/misc/taskserver/default.nix
+++ b/nixos/modules/services/misc/taskserver/default.nix
@@ -143,7 +143,7 @@ in {
         description = let
           url = "https://nixos.org/manual/nixos/stable/index.html#module-services-taskserver";
         in ''
-          Whether to enable the Taskwarrior server.
+          Whether to enable the Taskwarrior 2 server.
 
           More instructions about NixOS in conjunction with Taskserver can be
           found [in the NixOS manual](${url}).
@@ -327,7 +327,7 @@ in {
           Configuration options to pass to Taskserver.
 
           The options here are the same as described in
-          {manpage}`taskdrc(5)`, but with one difference:
+          {manpage}`taskdrc(5)` from the `taskwarrior2` package, but with one difference:
 
           The `server` option is
           `server.listen` here, because the
@@ -449,7 +449,7 @@ in {
       };
 
       systemd.services.taskserver = {
-        description = "Taskwarrior Server";
+        description = "Taskwarrior 2 Server";
 
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" ];

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -993,6 +993,7 @@ in {
   tandoor-recipes-script-name = handleTest ./tandoor-recipes-script-name.nix {};
   tang = handleTest ./tang.nix {};
   taskserver = handleTest ./taskserver.nix {};
+  taskchampion-sync-server = handleTest ./taskchampion-sync-server.nix {};
   tayga = handleTest ./tayga.nix {};
   technitium-dns-server = handleTest ./technitium-dns-server.nix {};
   teeworlds = handleTest ./teeworlds.nix {};

--- a/nixos/tests/taskchampion-sync-server.nix
+++ b/nixos/tests/taskchampion-sync-server.nix
@@ -1,0 +1,48 @@
+import ./make-test-python.nix (
+  { ... }:
+  {
+    name = "taskchampion-sync-server";
+
+    nodes = {
+      server = {
+        services.taskchampion-sync-server.enable = true;
+        services.taskchampion-sync-server.openFirewall = true;
+      };
+      client =
+        { pkgs, ... }:
+        {
+          environment.systemPackages = [ pkgs.taskwarrior3 ];
+        };
+    };
+    testScript =
+      { nodes, ... }:
+      let
+        cfg = nodes.server.services.taskchampion-sync-server;
+        port = builtins.toString cfg.port;
+        # Generated with uuidgen
+        uuid = "bf01376e-04a4-435a-9263-608567531af3";
+        password = "nixos-test";
+      in
+      ''
+        # Explicitly start the VMs so that we don't accidentally start newServer
+        server.start()
+        client.start()
+
+        server.wait_for_unit("taskchampion-sync-server.service")
+        server.wait_for_open_port(${port})
+
+        # See man task-sync(5)
+        client.succeed("mkdir ~/.task")
+        client.succeed("touch ~/.taskrc")
+        client.succeed("echo sync.server.origin=http://server:${port} >> ~/.taskrc")
+        client.succeed("echo sync.server.client_id=${uuid} >> ~/.taskrc")
+        client.succeed("echo sync.encryption_secret=${password} >> ~/.taskrc")
+        client.succeed("task add hello world")
+        client.succeed("task sync")
+
+        # Useful for debugging
+        client.copy_from_vm("/root/.task", "client")
+        server.copy_from_vm("${cfg.dataDir}", "server")
+      '';
+  }
+)

--- a/nixos/tests/taskserver.nix
+++ b/nixos/tests/taskserver.nix
@@ -81,7 +81,7 @@ in {
     };
 
     client1 = { pkgs, ... }: {
-      environment.systemPackages = [ pkgs.taskwarrior pkgs.gnutls ];
+      environment.systemPackages = [ pkgs.taskwarrior2 pkgs.gnutls ];
       users.users.alice.isNormalUser = true;
       users.users.bob.isNormalUser = true;
       users.users.foo.isNormalUser = true;

--- a/pkgs/applications/editors/vim/plugins/deprecated.json
+++ b/pkgs/applications/editors/vim/plugins/deprecated.json
@@ -7,6 +7,10 @@
         "date": "2021-12-21",
         "new": "cmp-tmux"
     },
+    "taskwarrior": {
+        "date": "2024-08-13",
+        "new": "taskwarrior3 or taskwarrior2"
+    },
     "fern-vim": {
         "date": "2024-05-28",
         "new": "vim-fern"

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -46,7 +46,8 @@
 , statix
 , stylish-haskell
 , tabnine
-, taskwarrior
+, taskwarrior2
+, taskwarrior3
 , tmux
 , tup
 , vim
@@ -1581,9 +1582,14 @@
       };
     };
 
-  taskwarrior = buildVimPlugin {
-    inherit (taskwarrior) version pname;
-    src = "${taskwarrior.src}/scripts/vim";
+  taskwarrior3 = buildVimPlugin {
+    inherit (taskwarrior3) version pname;
+    src = "${taskwarrior3.src}/scripts/vim";
+  };
+
+  taskwarrior2 = buildVimPlugin {
+    inherit (taskwarrior2) version pname;
+    src = "${taskwarrior2.src}/scripts/vim";
   };
 
   telescope-cheat-nvim = super.telescope-cheat-nvim.overrideAttrs {

--- a/pkgs/applications/misc/ptask/default.nix
+++ b/pkgs/applications/misc/ptask/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkg-config, makeWrapper, gtk3, json_c, taskwarrior }:
+{ lib, stdenv, fetchurl, pkg-config, makeWrapper, gtk3, json_c, taskwarrior2 }:
 
 stdenv.mkDerivation rec {
   pname = "ptask";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   preFixup = ''
     wrapProgram "$out/bin/ptask" \
       --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
-      --prefix PATH : "${taskwarrior}/bin"
+      --prefix PATH : "${taskwarrior2}/bin"
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/tasknc/default.nix
+++ b/pkgs/applications/misc/tasknc/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, makeWrapper, perl, ncurses5, taskwarrior }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, makeWrapper, perl, ncurses5, taskwarrior2 }:
 
 stdenv.mkDerivation rec {
   version = "2020-12-17";
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
     DESTDIR=$out PREFIX= MANPREFIX=/share/man make install
 
-    wrapProgram $out/bin/tasknc --prefix PATH : ${taskwarrior}/bin
+    wrapProgram $out/bin/tasknc --prefix PATH : ${taskwarrior2}/bin
   '';
 
 

--- a/pkgs/applications/misc/vit/default.nix
+++ b/pkgs/applications/misc/vit/default.nix
@@ -1,7 +1,7 @@
 { lib
 , python3Packages
 , fetchPypi
-, taskwarrior
+, taskwarrior2
 , glibcLocales
 }:
 
@@ -24,7 +24,7 @@ buildPythonApplication rec {
 
   nativeCheckInputs = [ glibcLocales ];
 
-  makeWrapperArgs = [ "--suffix" "PATH" ":" "${taskwarrior}/bin" ];
+  makeWrapperArgs = [ "--suffix" "PATH" ":" "${taskwarrior2}/bin" ];
 
   preCheck = ''
     export TERM=''${TERM-linux}

--- a/pkgs/by-name/ta/taskwarrior2/package.nix
+++ b/pkgs/by-name/ta/taskwarrior2/package.nix
@@ -1,4 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, cmake, libuuid, gnutls, python3, xdg-utils, installShellFiles }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  libuuid,
+  gnutls,
+  python3,
+  xdg-utils,
+  installShellFiles,
+}:
 
 stdenv.mkDerivation rec {
   pname = "taskwarrior";
@@ -17,7 +27,13 @@ stdenv.mkDerivation rec {
       --replace "xdg-open" "${lib.getBin xdg-utils}/bin/xdg-open"
   '';
 
-  nativeBuildInputs = [ cmake libuuid gnutls python3 installShellFiles ];
+  nativeBuildInputs = [
+    cmake
+    libuuid
+    gnutls
+    python3
+    installShellFiles
+  ];
 
   doCheck = true;
   preCheck = ''
@@ -44,7 +60,10 @@ stdenv.mkDerivation rec {
     description = "Highly flexible command-line tool to manage TODO lists";
     homepage = "https://taskwarrior.org";
     license = licenses.mit;
-    maintainers = with maintainers; [ marcweber oxalica ];
+    maintainers = with maintainers; [
+      marcweber
+      oxalica
+    ];
     mainProgram = "task";
     platforms = platforms.unix;
   };

--- a/pkgs/by-name/ta/taskwarrior3/package.nix
+++ b/pkgs/by-name/ta/taskwarrior3/package.nix
@@ -8,6 +8,7 @@
   fetchFromGitHub,
   cmake,
   libuuid,
+  nixosTests,
   python3,
   xdg-utils,
   installShellFiles,
@@ -74,6 +75,8 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/nvim
     ln -s $out/share/vim-plugins/task $out/share/nvim/site
   '';
+
+  passthru.tests.nixos = nixosTests.taskchampion-sync-server;
 
   meta = {
     changelog = "https://github.com/GothenburgBitFactory/taskwarrior/blob/${src.rev}/ChangeLog";

--- a/pkgs/by-name/ta/taskwarrior3/package.nix
+++ b/pkgs/by-name/ta/taskwarrior3/package.nix
@@ -29,20 +29,22 @@ stdenv.mkDerivation rec {
       --replace "xdg-open" "${lib.getBin xdg-utils}/bin/xdg-open"
   '';
 
-  nativeBuildInputs = [
-    cmake
-    libuuid
-    python3
-    installShellFiles
-    corrosion
-    cargo
-    rustc
-    rustPlatform.cargoSetupHook
-  ] ++ lib.optionals stdenv.isDarwin [
-    # darwin dependencies
-    darwin.apple_sdk.frameworks.Security
-    darwin.apple_sdk.frameworks.SystemConfiguration
-  ];
+  nativeBuildInputs =
+    [
+      cmake
+      libuuid
+      python3
+      installShellFiles
+      corrosion
+      cargo
+      rustc
+      rustPlatform.cargoSetupHook
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      # darwin dependencies
+      darwin.apple_sdk.frameworks.Security
+      darwin.apple_sdk.frameworks.SystemConfiguration
+    ];
 
   doCheck = true;
   checkTarget = "build_tests";
@@ -73,13 +75,18 @@ stdenv.mkDerivation rec {
     ln -s $out/share/vim-plugins/task $out/share/nvim/site
   '';
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/GothenburgBitFactory/taskwarrior/blob/${src.rev}/ChangeLog";
     description = "Highly flexible command-line tool to manage TODO lists";
     homepage = "https://taskwarrior.org";
-    license = licenses.mit;
-    maintainers = with maintainers; [marcweber oxalica mlaradji];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      marcweber
+      oxalica
+      mlaradji
+      doronbehar
+    ];
     mainProgram = "task";
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/desktops/gnome/extensions/taskwhisperer/default.nix
+++ b/pkgs/desktops/gnome/extensions/taskwhisperer/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, substituteAll, fetchFromGitHub, taskwarrior, gettext, runtimeShell }:
+{ lib, stdenv, substituteAll, fetchFromGitHub, taskwarrior2, gettext, runtimeShell }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-taskwhisperer";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    taskwarrior
+    taskwarrior2
   ];
 
   passthru = {
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      task = "${taskwarrior}/bin/task";
+      task = "${taskwarrior2}/bin/task";
       shell = runtimeShell;
     })
   ];

--- a/pkgs/development/python-modules/tasklib/default.nix
+++ b/pkgs/development/python-modules/tasklib/default.nix
@@ -1,17 +1,14 @@
 {
   lib,
-  pythonPackages,
+  buildPythonPackage,
+  six,
+  pytz,
+  tzlocal,
   fetchPypi,
   taskwarrior2,
   writeShellScriptBin,
 }:
 
-with pythonPackages;
-
-let
-
-  wsl_stub = writeShellScriptBin "wsl" "true";
-in
 buildPythonPackage rec {
   pname = "tasklib";
   version = "2.5.1";
@@ -30,15 +27,16 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     taskwarrior2
-    wsl_stub
+    # stub
+    (writeShellScriptBin "wsl" "true")
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/robgolding/tasklib";
     description = "Library for interacting with taskwarrior databases";
     changelog = "https://github.com/GothenburgBitFactory/tasklib/releases/tag/${version}";
-    maintainers = with maintainers; [ arcnmx ];
-    platforms = platforms.all;
-    license = licenses.bsd3;
+    maintainers = with lib.maintainers; [ arcnmx ];
+    platforms = lib.platforms.all;
+    license = lib.licenses.bsd3;
   };
 }

--- a/pkgs/development/python-modules/tasklib/default.nix
+++ b/pkgs/development/python-modules/tasklib/default.nix
@@ -2,7 +2,7 @@
   lib,
   pythonPackages,
   fetchPypi,
-  taskwarrior,
+  taskwarrior2,
   writeShellScriptBin,
 }:
 
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    taskwarrior
+    taskwarrior2
     wsl_stub
   ];
 

--- a/pkgs/development/python-modules/taskw-ng/default.nix
+++ b/pkgs/development/python-modules/taskw-ng/default.nix
@@ -9,7 +9,7 @@
   python-dateutil,
   pythonOlder,
   pytz,
-  taskwarrior,
+  taskwarrior2,
 }:
 
 buildPythonPackage rec {
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     pytz
   ];
 
-  checkInputs = [ taskwarrior ];
+  checkInputs = [ taskwarrior2 ];
 
   # TODO: doesn't pass because `can_use` fails and `task --version` seems not to be answering.
   # pythonImportsCheck = [ "taskw_ng" ];

--- a/pkgs/development/python-modules/taskw/default.nix
+++ b/pkgs/development/python-modules/taskw/default.nix
@@ -8,7 +8,7 @@
   setuptools,
 
   # native dependencies
-  pkgs,
+  taskwarrior2,
 
   # dependencies
   kitchen,
@@ -39,12 +39,12 @@ buildPythonPackage rec {
   ];
   postPatch = ''
     substituteInPlace taskw/warrior.py \
-      --replace '@@taskwarrior@@' '${pkgs.taskwarrior}'
+      --replace '@@taskwarrior@@' '${taskwarrior2}'
   '';
 
   build-system = [ setuptools ];
 
-  buildInputs = [ pkgs.taskwarrior ];
+  buildInputs = [ taskwarrior2 ];
 
   dependencies = [
     kitchen

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1427,6 +1427,7 @@ mapAliases ({
 
   tabula = throw "tabula has been removed from nixpkgs, as it was broken"; # Added 2024-07-15
   tangogps = foxtrotgps; # Added 2020-01-26
+  taskwarrior = lib.warn "taskwarrior was replaced by taskwarrior3, which requires manual transition from taskwarrior 2.6, read upstram's docs: https://taskwarrior.org/docs/upgrade-3/" taskwarrior2;
   taplo-cli = taplo; # Added 2022-07-30
   taplo-lsp = taplo; # Added 2022-07-30
   taro = taproot-assets; # Added 2023-07-04

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33866,8 +33866,6 @@ with pkgs;
 
   tasktimer = callPackage ../applications/misc/tasktimer { };
 
-  taskwarrior = callPackage ../applications/misc/taskwarrior { };
-
   taskwarrior-tui = callPackage ../applications/misc/taskwarrior-tui { };
 
   dstask = callPackage ../applications/misc/dstask { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
