### PR TITLE
pantalaimon: add glib typelib to GI_TYPELIB_PATH

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pantalaimon/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pantalaimon/default.nix
@@ -4,6 +4,8 @@
 , fetchFromGitHub
 , installShellFiles
 , nixosTests
+, gobject-introspection
+, wrapGAppsNoGuiHook
 , enableDbusUi ? true
 }:
 
@@ -52,6 +54,17 @@ python3Packages.buildPythonApplication rec {
     notify2
     pygobject3
     pydbus
+  ];
+
+  nativeBuildInputs = [
+    wrapGAppsNoGuiHook
+    gobject-introspection
+  ];
+
+  # Prevent double wrapping from wrapGApps and wrapPythonProgram
+  dontWrapGApps = true;
+  makeWrapperArgs = [
+    "\${gappsWrapperArgs[@]}"
   ];
 
   nativeCheckInputs = with python3Packages; [


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

After upgrading from 23.11 to 24.05 my pantalaimon and pantalaimon-headless would fail to start

```
pantalaimon[520124]: Traceback (most recent call last):
pantalaimon[520124]:   File "/nix/store/696z8j4sh013k1zv0nmv7w989rksjfzc-pantalaimon-0.10.5/bin/.pantalaimon-wrapped", line 6, in <module>
pantalaimon[520124]:     from pantalaimon.main import main
pantalaimon[520124]:   File "/nix/store/696z8j4sh013k1zv0nmv7w989rksjfzc-pantalaimon-0.10.5/lib/python3.11/site-packages/pantalaimon/main.py", line 34, in <module>
ppantalaimon[520124]:   File "/nix/store/696z8j4sh013k1zv0nmv7w989rksjfzc-pantalaimon-0.10.5/lib/python3.11/site-packages/pantalaimon/ui.py", line 30, in <module>
pantalaimon[520124]:     from gi.repository import GLib
pantalaimon[520124]:   File "/nix/store/0x1rkqvaiddldc1si8wjwphz7wbny269-python3.11-pygobject-3.48.2/lib/python3.11/site-packages/gi/importer.py", line 133, in create_module
pantalaimon[520124]:     raise ImportError('cannot import name %s, '
pantalaimon[520124]: ImportError: cannot import name GLib, introspection typelib not found
systemd[1988]: pantalaimon.service: Main process exited, code=exited, status=1/FAILURE
```

This is usually managed by `wrapGAppsHook` but we only need glib typelib to make this work, so I set up a GI_TYPELIB_PATH wrapper modeled on wrappers in other nixpkgs.

This change allows pantalaimon to start and sync and have a working dbus interface.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
