### PR TITLE
ffmpeg, ffmpeg_5: add patches for several CVEs

### DIFF
--- a/pkgs/development/libraries/ffmpeg/5.1.4-CVE-2023-49502.patch
+++ b/pkgs/development/libraries/ffmpeg/5.1.4-CVE-2023-49502.patch
@@ -1,0 +1,26 @@
+Based on upstream 737ede405b11a37fdd61d19cf25df296a0cb0b75, with cuda and
+vulkan implementations removed, bwdif adjusted to apply to 5.1.4
+
+diff --git a/libavfilter/vf_bwdif.c b/libavfilter/vf_bwdif.c
+index 65c617ebb3..35c864f71e 100644
+--- a/libavfilter/vf_bwdif.c
++++ b/libavfilter/vf_bwdif.c
+@@ -333,13 +333,14 @@ static int config_props(AVFilterLink *link)
+     if(yadif->mode&1)
+         link->frame_rate = av_mul_q(link->src->inputs[0]->frame_rate, (AVRational){2,1});
+ 
+-    if (link->w < 3 || link->h < 4) {
+-        av_log(ctx, AV_LOG_ERROR, "Video of less than 3 columns or 4 lines is not supported\n");
++    yadif->csp = av_pix_fmt_desc_get(link->format);
++    yadif->filter = filter;
++
++    if (AV_CEIL_RSHIFT(link->w, yadif->csp->log2_chroma_w) < 3 || AV_CEIL_RSHIFT(link->h, yadif->csp->log2_chroma_h) < 4) {
++        av_log(ctx, AV_LOG_ERROR, "Video with planes less than 3 columns or 4 lines is not supported\n");
+         return AVERROR(EINVAL);
+     }
+ 
+-    yadif->csp = av_pix_fmt_desc_get(link->format);
+-    yadif->filter = filter;
+     if (yadif->csp->comp[0].depth > 8) {
+         s->filter_intra = filter_intra_16bit;
+         s->filter_line  = filter_line_c_16bit;

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -395,22 +395,22 @@ stdenv.mkDerivation (finalAttrs: {
       --replace /usr/local/lib/frei0r-1 ${frei0r}/lib/frei0r-1
   '';
 
-  patches = map (patch: fetchpatch2 patch) ([ ]
+  patches = []
     ++ optionals (versionOlder version "5") [
-      {
+      (fetchpatch2 {
         name = "libsvtav1-1.5.0-compat-compressed_ten_bit_format.patch";
         url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/031f1561cd286596cdb374da32f8aa816ce3b135";
         hash = "sha256-agJgzIzrBTQBAypuCmGXXFo7vw6Iodw5Ny5O5QCKCn8=";
-      }
-      {
+      })
+      (fetchpatch2 {
         # Backport fix for binutils-2.41.
         name = "binutils-2.41.patch";
         url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/effadce6c756247ea8bae32dc13bb3e6f464f0eb";
         hash = "sha256-vLSltvZVMcQ0CnkU0A29x6fJSywE8/aU+Mp9os8DZYY=";
-      }
+      })
       # The upstream patch isn’t for ffmpeg 4, but it will apply with a few tweaks.
       # Fixes a crash when built with clang 16 due to UB in ff_seek_frame_binary.
-      {
+      (fetchpatch2 {
         name = "utils-fix_crash_in_ff_seek_frame_binary.patch";
         url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/ab792634197e364ca1bb194f9abe36836e42f12d";
         hash = "sha256-vqqVACjbCcGL9Qvmg1QArSKqVmOqr8BEr+OxTBDt6mA=";
@@ -419,60 +419,60 @@ stdenv.mkDerivation (finalAttrs: {
             --replace libavformat/seek.c libavformat/utils.c \
             --replace 'const AVInputFormat *const ' 'const AVInputFormat *'
         '';
-      }
+      })
     ]
-    ++ (lib.optionals (lib.versionAtLeast version "5" && lib.versionOlder version "6") [
-      {
+    ++ optionals (lib.versionAtLeast version "5" && lib.versionOlder version "6") [
+      (fetchpatch2 {
         name = "fix_build_failure_due_to_libjxl_version_to_new";
         url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/75b1a555a70c178a9166629e43ec2f6250219eb2";
         hash = "sha256-+2kzfPJf5piim+DqEgDuVEEX5HLwRsxq0dWONJ4ACrU=";
-      }
-      {
+      })
+      (fetchpatch2 {
         name = "5.x-CVE-2024-31585.patch";
         url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/8711cea3841fc385cccb1e7255176479e865cd4d";
         hash = "sha256-WT+ly/l04yM/tRVbhkESA3sDDjwvtd/Cg2y8tQo4ApI=";
-      }
-      {
+      })
+      (fetchpatch2 {
         name = "CVE-2024-31582.patch";
         url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/99debe5f823f45a482e1dc08de35879aa9c74bd2";
         hash = "sha256-+CQ9FXR6Vr/AmsbXFiCUXZcxKj1s8nInEdke/Oc/kUA=";
-      }
-      {
+      })
+      (fetchpatch2 {
         name = "CVE-2024-31578.patch";
         url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/3bb00c0a420c3ce83c6fafee30270d69622ccad7";
         hash = "sha256-oZMZysBA+/gwaGEM1yvI+8wCadXWE7qLRL6Emap3b8Q=";
-      }
-    ])
-    ++ (lib.optionals (lib.versionAtLeast version "6.1" && lib.versionOlder version "6.2") [
-      { # this can be removed post 6.1
+      })
+    ]
+    ++ optionals (lib.versionAtLeast version "6.1" && lib.versionOlder version "6.2") [
+      (fetchpatch2 { # this can be removed post 6.1
         name = "fix_build_failure_due_to_PropertyKey_EncoderID";
         url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/cb049d377f54f6b747667a93e4b719380c3e9475";
         hash = "sha256-sxRXKKgUak5vsQTiV7ge8vp+N22CdTIvuczNgVRP72c=";
-      }
-      {
+      })
+      (fetchpatch2 {
         name = "fix_vulkan_av1";
         url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/e06ce6d2b45edac4a2df04f304e18d4727417d24";
         hash = "sha256-73mlX1rdJrguw7OXaSItfHtI7gflDrFj+7SepVvvUIg=";
-      }
-      {
+      })
+      (fetchpatch2 {
         name = "CVE-2024-31582.patch";
         url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/99debe5f823f45a482e1dc08de35879aa9c74bd2";
         hash = "sha256-+CQ9FXR6Vr/AmsbXFiCUXZcxKj1s8nInEdke/Oc/kUA=";
-      }
-      {
+      })
+      (fetchpatch2 {
         name = "CVE-2024-31578.patch";
         url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/3bb00c0a420c3ce83c6fafee30270d69622ccad7";
         hash = "sha256-oZMZysBA+/gwaGEM1yvI+8wCadXWE7qLRL6Emap3b8Q=";
-      }
-    ])
-    ++ (lib.optionals (lib.versionAtLeast version "7.0" && lib.versionOlder version "7.0.1") [
-      {
+      })
+    ]
+    ++ optionals (lib.versionAtLeast version "7.0" && lib.versionOlder version "7.0.1") [
+      (fetchpatch2 {
         # Will likely be obsolete in >7.0
         name = "fate_avoid_dependency_on_samples";
         url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/7b7b7819bd21cc92ac07f6696b0e7f26fa8f9834";
         hash = "sha256-TKI289XqtG86Sj9s7mVYvmkjAuRXeK+2cYYEDkg6u6I=";
-      }
-    ]));
+      })
+    ];
 
   configurePlatforms = [];
   setOutputFlags = false; # Only accepts some of them

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -442,6 +442,22 @@ stdenv.mkDerivation (finalAttrs: {
         url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/3bb00c0a420c3ce83c6fafee30270d69622ccad7";
         hash = "sha256-oZMZysBA+/gwaGEM1yvI+8wCadXWE7qLRL6Emap3b8Q=";
       })
+      ./5.1.4-CVE-2023-49502.patch
+      (fetchpatch2 {
+        name = "CVE-2023-50008.patch";
+        url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/5f87a68cf70dafeab2fb89b42e41a4c29053b89b";
+        hash = "sha256-sqUUSOPTPLwu2h8GbAw4SfEf+0oWioz52BcpW1n4v3Y=";
+      })
+      (fetchpatch2 {
+        name = "CVE-2023-51793.patch";
+        url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/8b8b4bdef311f88c0075a06a25320187aff00bf2";
+        hash = "sha256-e7oGyOfUXuA8XK3vfygNtFlHpHl92O2KSLAo50sNJ5o=";
+      })
+      (fetchpatch2 {
+        name = "CVE-2023-51796.patch";
+        url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/e01a55c5283b82667dad347331816a5e20869ce9";
+        hash = "sha256-m4rq+UFG3nXdgOJ3S6XcruMZ+CPw+twmy2HFv3cnvJc=";
+      })
     ]
     ++ optionals (lib.versionAtLeast version "6.1" && lib.versionOlder version "6.2") [
       (fetchpatch2 { # this can be removed post 6.1

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -464,6 +464,26 @@ stdenv.mkDerivation (finalAttrs: {
         url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/3bb00c0a420c3ce83c6fafee30270d69622ccad7";
         hash = "sha256-oZMZysBA+/gwaGEM1yvI+8wCadXWE7qLRL6Emap3b8Q=";
       })
+      (fetchpatch2 {
+        name = "CVE-2023-49501.patch";
+        url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/4adb93dff05dd947878c67784d98c9a4e13b57a7";
+        hash = "sha256-7cwktto3fPMDGvCZCVtB01X8Q9S/4V4bDLUICSNfGgw=";
+      })
+      (fetchpatch2 {
+        name = "CVE-2023-49502.patch";
+        url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/737ede405b11a37fdd61d19cf25df296a0cb0b75";
+        hash = "sha256-mpSJwR9TX5ENjjCKvzuM/9e1Aj/AOiQW0+72oOMl9v8=";
+      })
+      (fetchpatch2 {
+        name = "CVE-2023-50007.patch";
+        url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/b1942734c7cbcdc9034034373abcc9ecb9644c47";
+        hash = "sha256-v0hNcqBtm8GCGAU9UbRUCE0slodOjZCHrkS8e4TrVcQ=";
+      })
+      (fetchpatch2 {
+        name = "CVE-2023-50008.patch";
+        url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/5f87a68cf70dafeab2fb89b42e41a4c29053b89b";
+        hash = "sha256-sqUUSOPTPLwu2h8GbAw4SfEf+0oWioz52BcpW1n4v3Y=";
+      })
     ]
     ++ optionals (lib.versionAtLeast version "7.0" && lib.versionOlder version "7.0.1") [
       (fetchpatch2 {


### PR DESCRIPTION
## Description of changes

Most of these CVEs had PoCs, so (after struggling to build an ffmpeg with asan) I tested the PoCs to see which appeared to affect 6.1 and 5.1. 7.x fixes all of these.

CVE-2023-49501: 6.1.1 affected, patched. 5.1.4 unaffected?
CVE-2023-49502: 6.1.1 affected, patched. 5.1.4 affected, needed an adjusted patch.
CVE-2023-50007: 6.1.1 affected, patched. 5.1.4 unaffected?
CVE-2023-50008: both affected, patched.
CVE-2023-50009: 6.1.1 already includes fix, 5.1.4 affected but patch won't apply... TODO?
CVE-2023-50010: 6.1.1 already includes fix, 5.1.4 unaffected?
CVE-2023-51791: 6.1.1 already includes fix, 5.1.4 unaffected?
CVE-2023-51793: 6.1.1 already includes fix, 5.1.4 affected, patched
CVE-2023-51795: 6.1.1 already includes fix, 5.1.4 unaffected?
CVE-2023-51796: 6.1.1 already includes fix, 5.1.4 affected, patched

"unaffected" have a question mark because it's hard to be definite about this. Just because the exact supplied PoC didn't happen to trip it up in this version, doesn't mean a very similar vulnerability couldn't potentially be lurking.

To be able to include the in-tree patch, I needed to refactor the patch section to remove the `fetchpatch2` mapping.. repeating `fetchpatch2` for each entry really isn't too bad and the extra flexibility it gives us is needed.

Also among this batch were CVE-2023-51797 & CVE-2023-51798 which I couldn't reproduce or find a fix for.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
