### PR TITLE
nixos/locate: only set LOCATE_PATH for findutils locate

### DIFF
--- a/nixos/modules/misc/locate.nix
+++ b/nixos/modules/misc/locate.nix
@@ -1,24 +1,22 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
   cfg = config.services.locate;
-  isMLocate = hasPrefix "mlocate" cfg.package.name;
-  isPLocate = hasPrefix "plocate" cfg.package.name;
+  isMLocate = lib.hasPrefix "mlocate" cfg.package.name;
+  isPLocate = lib.hasPrefix "plocate" cfg.package.name;
   isMorPLocate = isMLocate || isPLocate;
-  isFindutils = hasPrefix "findutils" cfg.package.name;
+  isFindutils = lib.hasPrefix "findutils" cfg.package.name;
 in
 {
   imports = [
-    (mkRenamedOptionModule [ "services" "locate" "period" ] [ "services" "locate" "interval" ])
-    (mkRenamedOptionModule [ "services" "locate" "locate" ] [ "services" "locate" "package" ])
-    (mkRemovedOptionModule [ "services" "locate" "includeStore" ] "Use services.locate.prunePaths")
+    (lib.mkRenamedOptionModule [ "services" "locate" "period" ] [ "services" "locate" "interval" ])
+    (lib.mkRenamedOptionModule [ "services" "locate" "locate" ] [ "services" "locate" "package" ])
+    (lib.mkRemovedOptionModule [ "services" "locate" "includeStore" ] "Use services.locate.prunePaths")
   ];
 
-  options.services.locate = with types; {
-    enable = mkOption {
-      type = bool;
+  options.services.locate = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       description = ''
         If enabled, NixOS will periodically update the database of
@@ -26,12 +24,12 @@ in
       '';
     };
 
-    package = mkPackageOption pkgs [ "findutils" "locate" ] {
+    package = lib.mkPackageOption pkgs [ "findutils" "locate" ] {
       example = "mlocate";
     };
 
-    interval = mkOption {
-      type = str;
+    interval = lib.mkOption {
+      type = lib.types.str;
       default = "02:15";
       example = "hourly";
       description = ''
@@ -46,24 +44,24 @@ in
       '';
     };
 
-    extraFlags = mkOption {
-      type = listOf str;
+    extraFlags = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
       default = [ ];
       description = ''
         Extra flags to pass to {command}`updatedb`.
       '';
     };
 
-    output = mkOption {
-      type = path;
+    output = lib.mkOption {
+      type = lib.types.path;
       default = "/var/cache/locatedb";
       description = ''
         The database file to build.
       '';
     };
 
-    localuser = mkOption {
-      type = nullOr str;
+    localuser = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
       default = "nobody";
       description = ''
         The user to search non-network directories as, using
@@ -71,8 +69,8 @@ in
       '';
     };
 
-    pruneFS = mkOption {
-      type = listOf str;
+    pruneFS = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
       default = [
         "afs"
         "anon_inodefs"
@@ -158,8 +156,8 @@ in
       '';
     };
 
-    prunePaths = mkOption {
-      type = listOf path;
+    prunePaths = lib.mkOption {
+      type = lib.types.listOf lib.types.path;
       default = [
         "/tmp"
         "/var/tmp"
@@ -175,10 +173,10 @@ in
       '';
     };
 
-    pruneNames = mkOption {
-      type = listOf str;
+    pruneNames = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
       default = lib.optionals (!isFindutils) [ ".bzr" ".cache" ".git" ".hg" ".svn" ];
-      defaultText = literalMD ''
+      defaultText = lib.literalMD ''
         `[ ".bzr" ".cache" ".git" ".hg" ".svn" ]`, if
         supported by the locate implementation (i.e. mlocate or plocate).
       '';
@@ -187,8 +185,8 @@ in
       '';
     };
 
-    pruneBindMounts = mkOption {
-      type = bool;
+    pruneBindMounts = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       description = ''
         Whether not to index bind mounts
@@ -197,10 +195,10 @@ in
 
   };
 
-  config = mkIf cfg.enable {
-    users.groups = mkMerge [
-      (mkIf isMLocate { mlocate = { }; })
-      (mkIf isPLocate { plocate = { }; })
+  config = lib.mkIf cfg.enable {
+    users.groups = lib.mkMerge [
+      (lib.mkIf isMLocate { mlocate = { }; })
+      (lib.mkIf isPLocate { plocate = { }; })
     ];
 
     security.wrappers =
@@ -211,48 +209,46 @@ in
           setgid = true;
           setuid = false;
         };
-        mlocate = mkIf isMLocate {
+        mlocate = lib.mkIf isMLocate {
           group = "mlocate";
           source = "${cfg.package}/bin/locate";
         };
-        plocate = mkIf isPLocate {
+        plocate = lib.mkIf isPLocate {
           group = "plocate";
           source = "${cfg.package}/bin/plocate";
         };
       in
-      mkIf isMorPLocate {
-        locate = mkMerge [ common mlocate plocate ];
-        plocate = mkIf isPLocate (mkMerge [ common plocate ]);
+      lib.mkIf isMorPLocate {
+        locate = lib.mkMerge [ common mlocate plocate ];
+        plocate = lib.mkIf isPLocate (lib.mkMerge [ common plocate ]);
       };
 
-    environment.systemPackages = [ cfg.package ];
-
-    environment.variables = lib.mkIf isFindutils {
-      LOCATE_PATH = cfg.output;
-    };
-
-    environment.etc = {
+    environment = {
       # write /etc/updatedb.conf for manual calls to `updatedb`
-      "updatedb.conf" = {
-        text = ''
-          PRUNEFS="${lib.concatStringsSep " " cfg.pruneFS}"
-          PRUNENAMES="${lib.concatStringsSep " " cfg.pruneNames}"
-          PRUNEPATHS="${lib.concatStringsSep " " cfg.prunePaths}"
-          PRUNE_BIND_MOUNTS="${if cfg.pruneBindMounts then "yes" else "no"}"
-        '';
+      etc."updatedb.conf".text = ''
+        PRUNEFS="${lib.concatStringsSep " " cfg.pruneFS}"
+        PRUNENAMES="${lib.concatStringsSep " " cfg.pruneNames}"
+        PRUNEPATHS="${lib.concatStringsSep " " cfg.prunePaths}"
+        PRUNE_BIND_MOUNTS="${if cfg.pruneBindMounts then "yes" else "no"}"
+      '';
+
+      systemPackages = [ cfg.package ];
+
+      variables = lib.mkIf isFindutils {
+        LOCATE_PATH = cfg.output;
       };
     };
 
-    warnings = optional (isMorPLocate && cfg.localuser != null)
+    warnings = lib.optional (isMorPLocate && cfg.localuser != null)
       "mlocate and plocate do not support the services.locate.localuser option. updatedb will run as root. Silence this warning by setting services.locate.localuser = null."
-    ++ optional (isFindutils && cfg.pruneNames != [ ])
+    ++ lib.optional (isFindutils && cfg.pruneNames != [ ])
       "findutils locate does not support pruning by directory component"
-    ++ optional (isFindutils && cfg.pruneBindMounts)
+    ++ lib.optional (isFindutils && cfg.pruneBindMounts)
       "findutils locate does not support skipping bind mounts";
 
     systemd.services.update-locatedb = {
       description = "Update Locate Database";
-      path = mkIf (!isMorPLocate) [ pkgs.su ];
+      path = lib.mkIf (!isMorPLocate) [ pkgs.su ];
 
       # mlocate's updatedb takes flags via a configuration file or
       # on the command line, but not by environment variable.
@@ -260,42 +256,44 @@ in
         if isMorPLocate then
           let
             toFlags = x:
-              optional (cfg.${x} != [ ])
-                "--${lib.toLower x} '${concatStringsSep " " cfg.${x}}'";
-            args = concatLists (map toFlags [ "pruneFS" "pruneNames" "prunePaths" ]);
+              lib.optional (cfg.${x} != [ ])
+                "--${lib.toLower x} '${lib.concatStringsSep " " cfg.${x}}'";
+            args = lib.concatLists (map toFlags [ "pruneFS" "pruneNames" "prunePaths" ]);
           in
           ''
             exec ${cfg.package}/bin/updatedb \
-              --output ${toString cfg.output} ${concatStringsSep " " args} \
+              --output ${toString cfg.output} ${lib.concatStringsSep " " args} \
               --prune-bind-mounts ${if cfg.pruneBindMounts then "yes" else "no"} \
-              ${concatStringsSep " " cfg.extraFlags}
+              ${lib.concatStringsSep " " cfg.extraFlags}
           ''
         else ''
           exec ${cfg.package}/bin/updatedb \
-            ${optionalString (cfg.localuser != null && !isMorPLocate) "--localuser=${cfg.localuser}"} \
-            --output=${toString cfg.output} ${concatStringsSep " " cfg.extraFlags}
+            ${lib.optionalString (cfg.localuser != null && !isMorPLocate) "--localuser=${cfg.localuser}"} \
+            --output=${toString cfg.output} ${lib.concatStringsSep " " cfg.extraFlags}
         '';
-      environment = optionalAttrs (!isMorPLocate) {
-        PRUNEFS = concatStringsSep " " cfg.pruneFS;
-        PRUNEPATHS = concatStringsSep " " cfg.prunePaths;
-        PRUNENAMES = concatStringsSep " " cfg.pruneNames;
+      environment = lib.optionalAttrs (!isMorPLocate) {
+        PRUNEFS = lib.concatStringsSep " " cfg.pruneFS;
+        PRUNEPATHS = lib.concatStringsSep " " cfg.prunePaths;
+        PRUNENAMES = lib.concatStringsSep " " cfg.pruneNames;
         PRUNE_BIND_MOUNTS = if cfg.pruneBindMounts then "yes" else "no";
       };
-      serviceConfig.Nice = 19;
-      serviceConfig.IOSchedulingClass = "idle";
-      serviceConfig.PrivateTmp = "yes";
-      serviceConfig.PrivateNetwork = "yes";
-      serviceConfig.NoNewPrivileges = "yes";
-      serviceConfig.ReadOnlyPaths = "/";
-      # Use dirOf cfg.output because mlocate creates temporary files next to
-      # the actual database. We could specify and create them as well,
-      # but that would make this quite brittle when they change something.
-      # NOTE: If /var/cache does not exist, this leads to the misleading error message:
-      # update-locatedb.service: Failed at step NAMESPACE spawning …/update-locatedb-start: No such file or directory
-      serviceConfig.ReadWritePaths = dirOf cfg.output;
+      serviceConfig = {
+        Nice = 19;
+        IOSchedulingClass = "idle";
+        PrivateTmp = "yes";
+        PrivateNetwork = "yes";
+        NoNewPrivileges = "yes";
+        ReadOnlyPaths = "/";
+        # Use dirOf cfg.output because mlocate creates temporary files next to
+        # the actual database. We could specify and create them as well,
+        # but that would make this quite brittle when they change something.
+        # NOTE: If /var/cache does not exist, this leads to the misleading error message:
+        # update-locatedb.service: Failed at step NAMESPACE spawning …/update-locatedb-start: No such file or directory
+        ReadWritePaths = dirOf cfg.output;
+      };
     };
 
-    systemd.timers.update-locatedb = mkIf (cfg.interval != "never") {
+    systemd.timers.update-locatedb = lib.mkIf (cfg.interval != "never") {
       description = "Update timer for locate database";
       partOf = [ "update-locatedb.service" ];
       wantedBy = [ "timers.target" ];

--- a/nixos/modules/misc/locate.nix
+++ b/nixos/modules/misc/locate.nix
@@ -227,7 +227,9 @@ in
 
     environment.systemPackages = [ cfg.package ];
 
-    environment.variables.LOCATE_PATH = cfg.output;
+    environment.variables = lib.mkIf isFindutils {
+      LOCATE_PATH = cfg.output;
+    };
 
     environment.etc = {
       # write /etc/updatedb.conf for manual calls to `updatedb`


### PR DESCRIPTION
## Description of changes

Please review by commit.

Closes #281271

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
