### PR TITLE
raze: init at 1.10.2

### DIFF
--- a/pkgs/by-name/ra/raze/package.nix
+++ b/pkgs/by-name/ra/raze/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  SDL2,
+  zmusic,
+  libvpx,
+  pkg-config,
+  makeWrapper,
+  bzip2,
+  gtk3,
+  fluidsynth,
+  openal,
+  libGL,
+  vulkan-loader,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "raze";
+  version = "1.10.2";
+
+  src = fetchFromGitHub {
+    owner = "ZDoom";
+    repo = "Raze";
+    rev = finalAttrs.version;
+    hash = "sha256-R3Sm/cibg+D2QPS4UisRp91xvz3Ine2BUR8jF5Rbj1g=";
+    leaveDotGit = true;
+    postFetch = ''
+      cd $out
+      git rev-parse HEAD > COMMIT
+      rm -rf .git
+    '';
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    SDL2
+    zmusic
+    libvpx
+    bzip2
+    gtk3
+    fluidsynth
+    openal
+    libGL
+    vulkan-loader
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
+    (lib.cmakeBool "DYN_GTK" false)
+    (lib.cmakeBool "DYN_OPENAL" false)
+  ];
+
+  postPatch = ''
+    substituteInPlace tools/updaterevision/gitinfo.h.in \
+      --replace-fail "@Tag@" "${finalAttrs.version}" \
+      --replace-fail "@Hash@" "$(cat COMMIT)" \
+      --replace-fail "@Timestamp@" "1970-01-01 00:00:01 +0000"
+  '';
+
+  postInstall = ''
+    mv $out/bin/raze $out/share/raze
+    makeWrapper $out/share/raze/raze $out/bin/raze
+    install -Dm644 ../source/platform/posix/org.zdoom.Raze.256.png $out/share/pixmaps/org.zdoom.Raze.png
+    install -Dm644 ../source/platform/posix/org.zdoom.Raze.desktop $out/share/applications/org.zdoom.Raze.desktop
+    install -Dm644 ../soundfont/raze.sf2 $out/share/raze/soundfonts/raze.sf2
+  '';
+
+  meta = {
+    description = "Build engine port backed by GZDoom tech";
+    longDescription = ''
+      Raze is a fork of Build engine games backed by GZDoom tech and combines
+      Duke Nukem 3D, Blood, Redneck Rampage, Shadow Warrior and Exhumed/Powerslave
+      in a single package. It is also capable of playing Nam and WW2 GI.
+    '';
+    homepage = "https://github.com/ZDoom/Raze";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ qubitnano ];
+    mainProgram = "raze";
+    platforms = [ "x86_64-linux" ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/189163

Raze is a fork of Build engine games backed by GZDoom tech and combines Duke Nukem 3D, Blood, Redneck Rampage, Shadow Warrior and Exhumed/Powerslave in a single package. It is also capable of playing Nam and WW2 GI.

Tested with Duke Nukem 3D and Shadow Warrior.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
