### PR TITLE
rocmPackages.composable_kernel: compress `composable_kernel` using extra derivation

### DIFF
--- a/pkgs/development/rocm-modules/6/composable_kernel/default.nix
+++ b/pkgs/development/rocm-modules/6/composable_kernel/default.nix
@@ -9,6 +9,7 @@
 , clang-tools-extra
 , git
 , gtest
+, zstd
 , buildTests ? false
 , buildExamples ? false
 , gpuTargets ? [ ] # gpuTargets = [ "gfx803" "gfx900" "gfx1030" ... ]
@@ -39,6 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     rocm-cmake
     clr
     clang-tools-extra
+    zstd
   ];
 
   buildInputs = [ openmp ];
@@ -66,7 +68,9 @@ stdenv.mkDerivation (finalAttrs: {
   ''
   ;
 
-  postInstall = lib.optionalString buildTests ''
+  postInstall = ''
+    zstd --rm $out/lib/libdevice_operations.a
+  '' + lib.optionalString buildTests ''
     mkdir -p $test/bin
     mv $out/bin/test_* $test/bin
   '' + lib.optionalString buildExamples ''

--- a/pkgs/development/rocm-modules/6/composable_kernel/unpack.nix
+++ b/pkgs/development/rocm-modules/6/composable_kernel/unpack.nix
@@ -1,0 +1,16 @@
+{ runCommandLocal,
+  composable_kernel_build,
+  zstd
+}:
+let
+  ck = composable_kernel_build;
+in runCommandLocal "unpack-${ck.name}" {
+    nativeBuildInputs = [ zstd ];
+    meta = ck.meta;
+  } ''
+    mkdir -p $out
+    cp -r --no-preserve=mode ${ck}/* $out
+    zstd -dv --rm $out/lib/libdevice_operations.a.zst -o $out/lib/libdevice_operations.a
+    substituteInPlace $out/lib/cmake/composable_kernel/*.cmake \
+      --replace "${ck}" "$out"
+  ''

--- a/pkgs/development/rocm-modules/6/default.nix
+++ b/pkgs/development/rocm-modules/6/default.nix
@@ -240,10 +240,12 @@ in rec {
     It is still available for some time as part of rocmPackages_5.
   ''; # Added 2024-3-3;
 
-  composable_kernel = callPackage ./composable_kernel {
-    inherit rocmUpdateScript rocm-cmake clr;
-    inherit (llvm) openmp clang-tools-extra;
-    stdenv = llvm.rocmClangStdenv;
+  composable_kernel = callPackage ./composable_kernel/unpack.nix {
+    composable_kernel_build = callPackage ./composable_kernel {
+      inherit rocmUpdateScript rocm-cmake clr;
+      inherit (llvm) openmp clang-tools-extra;
+      stdenv = llvm.rocmClangStdenv;
+    };
   };
 
   half = callPackage ./half {


### PR DESCRIPTION
This compresses part of the output of the original derivation that builds `composable_kernel`, so that the output of that  derivation is small enough that it can be cached by Hydra.
It also adds another derivation which decompresses the output of the first one again. The output of that second derivation will of course be too large for the cache and run locally on user's systems, but that's OK.

Without this change ROCm is really annoying to use, because people have to build `composable_kernel` themselves, which takes ages.
Because of that, this change should probably be back-ported to 24.05, either right away or after some time.

This is the exact same commit I originally wrote for https://github.com/NixOS/nixpkgs/pull/299589, but I then changed that PR to implement a more complicated solution, which tries to use use the support for compressed device binaries which will be built into upstream ROCm in a future version.
Unfortunately how I implemented that in nixpkgs was totally broken, because there were several things still missing.
https://github.com/NixOS/nixpkgs/pull/305920 is an ongoing effort to make that actually work, but there is still a lot of effort involved in getting that to work.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
