### PR TITLE
fishPlugins.fish-you-should-use: init at 0-unstable-2022-02-13

### DIFF
--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -26,6 +26,8 @@ lib.makeScope newScope (self: with self; {
   fishtape = callPackage ./fishtape.nix { };
   fishtape_3 = callPackage ./fishtape_3.nix { };
 
+  fish-you-should-use = callPackage ./fish-you-should-use.nix { };
+
   foreign-env = callPackage ./foreign-env { };
 
   forgit = callPackage ./forgit.nix { };

--- a/pkgs/shells/fish/plugins/fish-you-should-use.nix
+++ b/pkgs/shells/fish/plugins/fish-you-should-use.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  buildFishPlugin,
+  fetchFromGitHub,
+  unstableGitUpdater,
+}:
+buildFishPlugin {
+  pname = "fish-you-should-use";
+  version = "0-unstable-2022-02-13";
+
+  src = fetchFromGitHub {
+    owner = "paysonwallach";
+    repo = "fish-you-should-use";
+    rev = "a332823512c0b51e71516ebb8341db0528c87926";
+    hash = "sha256-MmGDFTgxEFgHdX95OjH3jKsVG1hdwo6bRht+Lvvqe5Y=";
+  };
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Fish plugin that reminds you to use your aliases";
+    homepage = "https://github.com/paysonwallach/fish-you-should-use";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ anomalocaris ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Adds [`fish-you-should-use`](https://github.com/paysonwallach/fish-you-should-use), a `fish` plugin that reminds users of set aliases when running equivalent commands.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
