### PR TITLE
openssh-password: add tests for ssh login with password

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -683,6 +683,7 @@ in {
   opensmtpd-rspamd = handleTest ./opensmtpd-rspamd.nix {};
   opensnitch = handleTest ./opensnitch.nix {};
   openssh = handleTest ./openssh.nix {};
+  openssh-password = handleTest ./openssh-password.nix {};
   octoprint = handleTest ./octoprint.nix {};
   openstack-image-metadata = (handleTestOn ["x86_64-linux"] ./openstack-image.nix {}).metadata or {};
   openstack-image-userdata = (handleTestOn ["x86_64-linux"] ./openstack-image.nix {}).userdata or {};

--- a/nixos/tests/openssh-password.nix
+++ b/nixos/tests/openssh-password.nix
@@ -1,0 +1,117 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+{
+  name = "openssh";
+
+  nodes = {
+    server = {
+      services.openssh = {
+        enable = true;
+        settings.PasswordAuthentication = true;
+      };
+    };
+
+    server-allowed-users = {
+      services.openssh = {
+        enable = true;
+        settings = {
+          AllowUsers = [ "alice" "bob" ];
+          PasswordAuthentication = true;
+        };
+      };
+      users.groups = { alice = { }; bob = { }; carol = { }; };
+      users.users = {
+        alice = { isNormalUser = true; group = "alice"; password = "alice"; };
+        bob = { isSystemUser = true; group = "bob"; password = "bob"; };
+        carol = { isNormalUser = true; group = "carol"; password = "carol"; };
+      };
+    };
+
+    server-root-login = {
+      services.openssh = {
+        enable = true;
+        settings = {
+          PermitRootLogin = "yes";
+          PermitEmptyPasswords = "yes";
+          PasswordAuthentication = true;
+        };
+      };
+      security.pam.services.sshd.allowNullPassword = true;
+      users.groups = { alice = { }; };
+      users.users = {
+        # root.hashedPasswordFile = "${pkgs.writeText "hashed-password.root" ""}";
+        alice = { isNormalUser = true; group = "alice"; password = "alice"; };
+      };
+      users.mutableUsers = false;
+    };
+
+    server-permit-empty = {
+      services.openssh = {
+        enable = true;
+        settings = {
+          AllowUsers = [ "alice" "bob" ];
+          PermitEmptyPasswords = "yes";
+          PasswordAuthentication = true;
+        };
+      };
+      security.pam.services.sshd.allowNullPassword = true;
+      users.groups = { alice = { }; bob = { }; carol = { }; };
+      users.users = {
+        alice = { isNormalUser = true; group = "alice"; password = ""; };
+        bob = { isNormalUser = true; group = "bob"; password = "bob"; };
+      };
+    };
+
+    client = {
+      environment.systemPackages = with pkgs; [
+        sshpass
+      ];
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    server.wait_for_unit("sshd", timeout=30)
+    server_allowed_users.wait_for_unit("sshd", timeout=30)
+    server_root_login.wait_for_unit("sshd", timeout=30)
+    server_permit_empty.wait_for_unit("sshd", timeout=30)
+
+    with subtest("allowed-users"):
+        client.succeed(
+            "sshpass -p alice ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no alice@server-allowed-users true",
+            timeout=30
+        )
+        client.fail(
+            "sshpass -p bob ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no bob@server-allowed-users true",
+            timeout=30
+        )
+        client.fail(
+            "sshpass -p carol ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no carol@server-allowed-users true",
+            timeout=30
+        )
+
+    with subtest("server-root-login"):
+        client.succeed(
+            "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@server-root-login true",
+            timeout=30
+        )
+
+        ### BUG! DOES NOT WORK
+        # client.succeed(
+        #     "sshpass -p alice ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no alice@server-root-login true",
+        #     timeout=30
+        # )
+
+    with subtest("server-permit-empty"):
+        client.succeed(
+            "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no alice@server-permit-empty true",
+            timeout=30
+        )
+
+        ### BUG! DOES NOT WORK
+        # client.succeed(
+        #     "sshpass -p bob ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no bob@server-permit-empty true",
+        #     timeout=30
+        # )
+  '';
+})


### PR DESCRIPTION
## Description of changes

New regression tests for openssh. Tests to log-in with password.
Sadly some openssh nixpkgs features seem to be broken and therefore some tests are commented out - please fix the features to enable the corresponding tests afterwards.

`PermitEmptyPasswords = "yes"` seems to be bad.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
