### PR TITLE
fluent-bit: fix darwin build

### DIFF
--- a/pkgs/tools/misc/fluent-bit/default.nix
+++ b/pkgs/tools/misc/fluent-bit/default.nix
@@ -8,6 +8,7 @@
 , postgresql
 , openssl
 , libyaml
+, darwin
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -21,17 +22,22 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-o48qnyYAiV2gt81hC8/ja+/JWNFlMb47QsBt6BD7VjA=";
   };
 
+  # optional only to avoid linux rebuild
+  patches = lib.optionals stdenv.isDarwin [ ./macos-11-sdk-compat.patch ];
+
   nativeBuildInputs = [ cmake flex bison ];
 
   buildInputs = [ openssl libyaml postgresql ]
-    ++ lib.optionals stdenv.isLinux [ systemd ];
+    ++ lib.optionals stdenv.isLinux [ systemd ]
+    ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk_11_0.frameworks.IOKit darwin.apple_sdk_11_0.frameworks.Foundation ];
 
   cmakeFlags = [
     "-DFLB_RELEASE=ON"
     "-DFLB_METRICS=ON"
     "-DFLB_HTTP_SERVER=ON"
     "-DFLB_OUT_PGSQL=ON"
-  ];
+  ]
+  ++ lib.optionals stdenv.isDarwin [ "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13" ];
 
   env.NIX_CFLAGS_COMPILE = toString (
     # Used by the embedded luajit, but is not predefined on older mac SDKs.

--- a/pkgs/tools/misc/fluent-bit/macos-11-sdk-compat.patch
+++ b/pkgs/tools/misc/fluent-bit/macos-11-sdk-compat.patch
@@ -1,0 +1,17 @@
+diff --git i/src/flb_utils.c w/src/flb_utils.c
+index 87637f1331d7..7a0036566438 100644
+--- i/src/flb_utils.c
++++ w/src/flb_utils.c
+@@ -1424,11 +1424,11 @@ int flb_utils_get_machine_id(char **out_id, size_t *out_size)
+         return 0;
+     }
+ #elif defined (FLB_SYSTEM_MACOS)
+     bool bret;
+     CFStringRef serialNumber;
+-    io_service_t platformExpert = IOServiceGetMatchingService(kIOMainPortDefault,
++    io_service_t platformExpert = IOServiceGetMatchingService(kIOMasterPortDefault,
+         IOServiceMatching("IOPlatformExpertDevice"));
+
+     if (platformExpert) {
+         CFTypeRef serialNumberAsCFString =
+             IORegistryEntryCreateCFProperty(platformExpert,


### PR DESCRIPTION
## Description of changes

This fixes the fluent-bit build for macOS.

- The embedded luajit build defaults the `CMAKE_OSX_DEPLOYMENT_TARGET` to `10.10`, which is too old for fluent-bit. `lib/wasm-micro-runtime-WAMR-1.3.0/core/shared/platform/common/posix/posix_file.c` uses `futimens` and `utimensat` which are only available since macOS 10.13.
- The [`kIOMainPortDefault`](https://developer.apple.com/documentation/iokit/kiomainportdefault?language=objc) name was introduced in the macOS 12 SDK, deprecating [`kIOMasterPortDefault`](https://developer.apple.com/documentation/iokit/kiomasterportdefault?language=objc). Since the new name is unavailable in the macOS 11 SDK, patch to use the old name instead.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
