### PR TITLE
dune3d: Fix darwin build

### DIFF
--- a/pkgs/by-name/du/dune3d/package.nix
+++ b/pkgs/by-name/du/dune3d/package.nix
@@ -19,14 +19,14 @@
   wrapGAppsHook3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "dune3d";
   version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "dune3d";
     repo = "dune3d";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-Z/kdOc/MbnnEyRsel3aZGndTAy1eCdAK0Wdta0HxaE4=";
   };
 
@@ -54,12 +54,12 @@ stdenv.mkDerivation rec {
 
   env.CASROOT = opencascade-occt;
 
-  meta = with lib; {
+  meta = {
     description = "3D CAD application";
     homepage = "https://dune3d.org";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ _0x4A6F jue89 ];
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ _0x4A6F jue89 ];
     mainProgram = "dune3d";
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/du/dune3d/package.nix
+++ b/pkgs/by-name/du/dune3d/package.nix
@@ -1,5 +1,6 @@
 {
   cmake,
+  desktopToDarwinBundle,
   eigen,
   fetchFromGitHub,
   glm,
@@ -7,19 +8,26 @@
   gtkmm4,
   lib,
   libepoxy,
+  libossp_uuid,
   librsvg,
   libspnav,
   libuuid,
+  libxml2,
+  llvmPackages_17,
   meson,
   ninja,
-  opencascade-occt,
+  opencascade-occt_7_6,
   pkg-config,
   python3,
   stdenv,
   wrapGAppsHook3,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+let
+  stdenv' = if stdenv.isDarwin then llvmPackages_17.stdenv else stdenv;
+  opencascade-occt = opencascade-occt_7_6;
+in
+stdenv'.mkDerivation (finalAttrs: {
   pname = "dune3d";
   version = "1.1.0";
 
@@ -36,7 +44,9 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     wrapGAppsHook3
-  ];
+    libxml2 # for xmllints
+  ] ++ lib.optional stdenv.isDarwin desktopToDarwinBundle;
+
   buildInputs = [
     cmake
     eigen
@@ -45,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     libepoxy
     librsvg
     libspnav
-    libuuid
+    (if stdenv.isLinux then libuuid else libossp_uuid)
     opencascade-occt
     (python3.withPackages (pp: [
       pp.pygobject3
@@ -60,6 +70,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ _0x4A6F jue89 ];
     mainProgram = "dune3d";
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })


### PR DESCRIPTION
## Description of changes

* Fix darwin build
* Refactor to use `finalAttrs` instead of `rec`
* Refactor to avoid use of `meta = with lib;`

ℹ️ Pinning opencascade-occt to 7.6 helped with building on darwin immensly, are folks okay to downgrade to this version for all platforms or should this be darwin specific?

Edit: Using the latest opencascade-occt failed to build on darwin due to libraries not being found, e.g. `-lTKSTEP`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
