### PR TITLE
igvm-tooling: 1.5.0 -> 1.5.0-unstable-2024-06-06

### DIFF
--- a/pkgs/by-name/ig/igvm-tooling/package.nix
+++ b/pkgs/by-name/ig/igvm-tooling/package.nix
@@ -8,14 +8,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "igvm-tooling";
-  version = "1.5.0";
+  version = "1.5.0-unstable-2024-06-06";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "igvm-tooling";
-    rev = "igvm-${version}";
-    hash = "sha256-13TtiJv2w9WXSW6oPMfo+rRah+Q1wHV14aBaFGfz9CE=";
+    rev = "53656ddde294bbafcae6349b5acfc5da9f7dbb92";
+    hash = "sha256-X9Gi+kTmc/ZcsgbHldEj9zPnOmd5puDD7/+J1s1CVws=";
   };
 
   patches = [
@@ -25,22 +25,6 @@ python3.pkgs.buildPythonApplication rec {
       name = "0001-setup.py-remove-unused-libclang-dependency.patch";
       url = "https://github.com/microsoft/igvm-tooling/commit/7182e925de9b5e9f5c8c3a3ce6e3942a92506064.patch";
       sha256 = "sha256-tcVxcuLxknyEdo2YjeHOqSG9xQna8US+YyvlcfX+Htw=";
-      stripLen = 1;
-    })
-    # write updated acpi files to tempdir (instead of nix store path) at runtime
-    # remove once https://github.com/microsoft/igvm-tooling/pull/54 is merged
-    (fetchpatch {
-      name = "0002-acpi-update-dsl-files-in-tempdir.patch";
-      url = "https://github.com/microsoft/igvm-tooling/commit/20f8d123ec6531d8540074b7df2ee12de60e73b8.patch";
-      sha256 = "sha256-hNfkclxaYViy66TPHqLV3mqD7wqBuBN9MnMLaDOeRNM=";
-      stripLen = 1;
-    })
-    # allow for determinist id block signing
-    # remove once https://github.com/microsoft/igvm-tooling/pull/55 is merged
-    (fetchpatch {
-      name = "0003-add-deterministic-id-block-signature-mode.patch";
-      url = "https://github.com/microsoft/igvm-tooling/commit/03ad7825ade76ac25e308bb85f92e89b732e0bf1.patch";
-      sha256 = "sha256-Y7DFr0KgGtY8KOt6fLWd32sTaig/zHFe7n83+Yb9ls8=";
       stripLen = 1;
     })
   ];


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This update allows us to drop some of the patches, which have been upstreamed since. The remaining patch is still in the air upstream. Once it's included, I'll ask them to cut a release, but for now, let's drop the patches we can already.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
