### PR TITLE
molbar: init at 1.1.1

### DIFF
--- a/pkgs/development/python-modules/dscribe/default.nix
+++ b/pkgs/development/python-modules/dscribe/default.nix
@@ -1,0 +1,47 @@
+{ buildPythonPackage
+, lib
+, fetchFromGitHub
+, numpy
+, scipy
+, ase
+, joblib
+, sparse
+, pybind11
+, scikit-learn
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  name = "dscribe";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = "singroup";
+    repo = "dscribe";
+    rev = "v${version}";
+    fetchSubmodules = true; # Bundles a specific version of Eigen
+    hash = "sha256-2JY24cR2ie4+4svVWC4rm3Iy6Wfg0n2vkINz032kPWc=";
+  };
+
+  pyproject = true;
+
+  build-system = [
+    pybind11
+  ];
+
+  dependencies = [
+    numpy
+    scipy
+    ase
+    joblib
+    sparse
+    scikit-learn
+  ];
+
+  meta = with lib; {
+    description = "Machine learning descriptors for atomistic systems";
+    homepage = "https://github.com/SINGROUP/dscribe";
+    license = licenses.asl20;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/development/python-modules/molbar/default.nix
+++ b/pkgs/development/python-modules/molbar/default.nix
@@ -1,0 +1,73 @@
+{ buildPythonPackage
+, python
+, pythonRelaxDepsHook
+, lib
+, gfortran
+, fetchgit
+, cmake
+, ninja
+, networkx
+, numpy
+, pandas
+, scipy
+, tqdm
+, joblib
+, numba
+, ase
+, scikit-build
+, dscribe
+, pyyaml
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  name = "MolBar";
+  version = "1.1.1";
+
+  src = fetchgit {
+    url = "https://git.rwth-aachen.de/bannwarthlab/molbar";
+    rev = "release_v${version}";
+    hash = "sha256-AFp2x8gil6nbZbgTZmuv+QAMImUMryyCc1by9U/ukYE=";
+  };
+
+  pyproject = true;
+
+  nativeBuildInputs = [
+    gfortran
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [ "networkx" ];
+
+  build-system = [
+    cmake
+    scikit-build
+    ninja
+  ];
+
+  dependencies = [
+    networkx
+    numpy
+    pandas
+    scipy
+    tqdm
+    joblib
+    numba
+    ase
+    dscribe
+    pyyaml
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  dontUseCmakeConfigure = true;
+
+  doCheck = false; # Doesn't find the fortran libs before installation
+
+  meta = with lib; {
+    description = "Unique molecular identifiers for molecular barcoding";
+    homepage = "https://git.rwth-aachen.de/bannwarthlab/molbar";
+    license = licenses.mit;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37679,6 +37679,8 @@ with pkgs;
 
   marvin = callPackage ../applications/science/chemistry/marvin { };
 
+  molbar = with python3Packages; toPythonApplication molbar;
+
   molden = callPackage ../applications/science/chemistry/molden { };
 
   mopac = callPackage ../applications/science/chemistry/mopac { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7679,6 +7679,8 @@ self: super: with self; {
 
   mohawk = callPackage ../development/python-modules/mohawk { };
 
+  molbar = callPackage ../development/python-modules/molbar { };
+
   molecule = callPackage ../development/python-modules/molecule { };
 
   molecule-plugins = callPackage ../development/python-modules/molecule/plugins.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3592,6 +3592,8 @@ self: super: with self; {
 
   dropmqttapi = callPackage ../development/python-modules/dropmqttapi { };
 
+  dscribe  = callPackage ../development/python-modules/dscribe { };
+
   ds-store = callPackage ../development/python-modules/ds-store { };
 
   ds4drv = callPackage ../development/python-modules/ds4drv { };


### PR DESCRIPTION
## Description of changes

This PR adds MolBar, a code to generate unique identifiers for molecular structures for machine learning and databases, and its dependency dscribe, a machine learning descriptor generator for molecules.

https://github.com/SINGROUP/dscribe
https://git.rwth-aachen.de/bannwarthlab/molbar

The pytest checkphases require the C++ and Fortran libraries to be already installed. I couldn't convince pytest to find them in the checkPhase.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
