### PR TITLE
haskell.compiler.*: calculate tool path using common function

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -131,23 +131,44 @@ let
 
   targetCC = builtins.head toolsForTarget;
 
-  # Sometimes we have to dispatch between the bintools wrapper and the unwrapped
-  # derivation for certain tools depending on the platform.
-  bintoolsFor = {
-    # GHC needs install_name_tool on all darwin platforms. On aarch64-darwin it is
-    # part of the bintools wrapper (due to codesigning requirements), but not on
-    # x86_64-darwin.
-    install_name_tool =
-      if stdenv.targetPlatform.isAarch64
-      then targetCC.bintools
-      else targetCC.bintools.bintools;
-    # Same goes for strip.
-    strip =
-      # TODO(@sternenseemann): also use wrapper if linker == "bfd" or "gold"
-      if stdenv.targetPlatform.isAarch64 && stdenv.targetPlatform.isDarwin
-      then targetCC.bintools
-      else targetCC.bintools.bintools;
-  };
+  # toolPath calculates the absolute path to the name tool associated with a
+  # given `stdenv.cc` derivation, i.e. it picks the correct derivation to take
+  # the tool from (cc, cc.bintools, cc.bintools.bintools) and adds the correct
+  # subpath of the tool.
+  toolPath = name: cc:
+    let
+      tools = {
+        "cc" = cc;
+        "c++" = cc;
+        as = cc.bintools.bintools;
+
+        ar = cc.bintools.bintools;
+        ranlib = cc.bintools.bintools;
+        nm = cc.bintools.bintools;
+        readelf = cc.bintools.bintools;
+
+        ld = cc.bintools;
+        "ld.gold" = cc.bintools;
+
+        otool = cc.bintools.bintools;
+
+        # GHC needs install_name_tool on all darwin platforms. On aarch64-darwin it is
+        # part of the bintools wrapper (due to codesigning requirements), but not on
+        # x86_64-darwin. We decide based on target platform to have consistent tools
+        # across all GHC stages.
+        install_name_tool =
+          if stdenv.targetPlatform.isAarch64
+          then cc.bintools
+          else cc.bintools.bintools;
+        # Same goes for strip.
+        strip =
+          # TODO(@sternenseemann): also use wrapper if linker == "bfd" or "gold"
+          if stdenv.targetPlatform.isAarch64 && stdenv.targetPlatform.isDarwin
+          then cc.bintools
+          else cc.bintools.bintools;
+      }.${name};
+    in
+    "${tools}/bin/${tools.targetPrefix}${name}";
 
   # Use gold either following the default, or to avoid the BFD linker due to some bugs / perf issues.
   # But we cannot avoid BFD when using musl libc due to https://sourceware.org/bugzilla/show_bug.cgi?id=23856
@@ -255,19 +276,19 @@ stdenv.mkDerivation (rec {
     done
     # GHC is a bit confused on its cross terminology, as these would normally be
     # the *host* tools.
-    export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
-    export CXX="${targetCC}/bin/${targetCC.targetPrefix}c++"
+    export CC="${toolPath "cc" targetCC}"
+    export CXX="${toolPath "c++" targetCC}"
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
-    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${lib.optionalString useLdGold ".gold"}"
-    export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
-    export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
-    export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
-    export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
-    export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
-    export STRIP="${bintoolsFor.strip}/bin/${bintoolsFor.strip.targetPrefix}strip"
+    export LD="${toolPath "ld${lib.optionalString useLdGold ".gold"}" targetCC}"
+    export AS="${toolPath "as" targetCC}"
+    export AR="${toolPath "ar" targetCC}"
+    export NM="${toolPath "nm" targetCC}"
+    export RANLIB="${toolPath "ranlib" targetCC}"
+    export READELF="${toolPath "readelf" targetCC}"
+    export STRIP="${toolPath "strip" targetCC}"
   '' + lib.optionalString (stdenv.targetPlatform.linker == "cctools") ''
-    export OTOOL="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}otool"
-    export INSTALL_NAME_TOOL="${bintoolsFor.install_name_tool}/bin/${bintoolsFor.install_name_tool.targetPrefix}install_name_tool"
+    export OTOOL="${toolPath "otool" targetCC}"
+    export INSTALL_NAME_TOOL="${toolPath "install_name_tool" targetCC}"
   '' + lib.optionalString useLLVM ''
     export LLC="${lib.getBin buildTargetLlvmPackages.llvm}/bin/llc"
     export OPT="${lib.getBin buildTargetLlvmPackages.llvm}/bin/opt"

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -267,23 +267,44 @@ let
 
   targetCC = builtins.head toolsForTarget;
 
-  # Sometimes we have to dispatch between the bintools wrapper and the unwrapped
-  # derivation for certain tools depending on the platform.
-  bintoolsFor = {
-    # GHC needs install_name_tool on all darwin platforms. On aarch64-darwin it is
-    # part of the bintools wrapper (due to codesigning requirements), but not on
-    # x86_64-darwin.
-    install_name_tool =
-      if stdenv.targetPlatform.isAarch64
-      then targetCC.bintools
-      else targetCC.bintools.bintools;
-    # Same goes for strip.
-    strip =
-      # TODO(@sternenseemann): also use wrapper if linker == "bfd" or "gold"
-      if stdenv.targetPlatform.isAarch64 && stdenv.targetPlatform.isDarwin
-      then targetCC.bintools
-      else targetCC.bintools.bintools;
-  };
+  # toolPath calculates the absolute path to the name tool associated with a
+  # given `stdenv.cc` derivation, i.e. it picks the correct derivation to take
+  # the tool from (cc, cc.bintools, cc.bintools.bintools) and adds the correct
+  # subpath of the tool.
+  toolPath = name: cc:
+    let
+      tools = {
+        "cc" = cc;
+        "c++" = cc;
+        as = cc.bintools.bintools;
+
+        ar = cc.bintools.bintools;
+        ranlib = cc.bintools.bintools;
+        nm = cc.bintools.bintools;
+        readelf = cc.bintools.bintools;
+
+        ld = cc.bintools;
+        "ld.gold" = cc.bintools;
+
+        otool = cc.bintools.bintools;
+
+        # GHC needs install_name_tool on all darwin platforms. On aarch64-darwin it is
+        # part of the bintools wrapper (due to codesigning requirements), but not on
+        # x86_64-darwin. We decide based on target platform to have consistent tools
+        # across all GHC stages.
+        install_name_tool =
+          if stdenv.targetPlatform.isAarch64
+          then cc.bintools
+          else cc.bintools.bintools;
+        # Same goes for strip.
+        strip =
+          # TODO(@sternenseemann): also use wrapper if linker == "bfd" or "gold"
+          if stdenv.targetPlatform.isAarch64 && stdenv.targetPlatform.isDarwin
+          then cc.bintools
+          else cc.bintools.bintools;
+      }.${name};
+    in
+    "${tools}/bin/${tools.targetPrefix}${name}";
 
   # Use gold either following the default, or to avoid the BFD linker due to some bugs / perf issues.
   # But we cannot avoid BFD when using musl libc due to https://sourceware.org/bugzilla/show_bug.cgi?id=23856
@@ -329,19 +350,19 @@ stdenv.mkDerivation ({
     done
     # GHC is a bit confused on its cross terminology, as these would normally be
     # the *host* tools.
-    export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
-    export CXX="${targetCC}/bin/${targetCC.targetPrefix}c++"
+    export CC="${toolPath "cc" targetCC}"
+    export CXX="${toolPath "c++" targetCC}"
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
-    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${lib.optionalString useLdGold ".gold"}"
-    export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
-    export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
-    export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
-    export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
-    export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
-    export STRIP="${bintoolsFor.strip}/bin/${bintoolsFor.strip.targetPrefix}strip"
+    export LD="${toolPath "ld${lib.optionalString useLdGold ".gold"}" targetCC}"
+    export AS="${toolPath "as" targetCC}"
+    export AR="${toolPath "ar" targetCC}"
+    export NM="${toolPath "nm" targetCC}"
+    export RANLIB="${toolPath "ranlib" targetCC}"
+    export READELF="${toolPath "readelf" targetCC}"
+    export STRIP="${toolPath "strip" targetCC}"
   '' + lib.optionalString (stdenv.targetPlatform.linker == "cctools") ''
-    export OTOOL="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}otool"
-    export INSTALL_NAME_TOOL="${bintoolsFor.install_name_tool}/bin/${bintoolsFor.install_name_tool.targetPrefix}install_name_tool"
+    export OTOOL="${toolPath "otool" targetCC}"
+    export INSTALL_NAME_TOOL="${toolPath "install_name_tool" targetCC}"
   '' + lib.optionalString useLLVM ''
     export LLC="${lib.getBin buildTargetLlvmPackages.llvm}/bin/llc"
     export OPT="${lib.getBin buildTargetLlvmPackages.llvm}/bin/opt"

--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -136,23 +136,44 @@ let
 
   targetCC = builtins.head toolsForTarget;
 
-  # Sometimes we have to dispatch between the bintools wrapper and the unwrapped
-  # derivation for certain tools depending on the platform.
-  bintoolsFor = {
-    # GHC needs install_name_tool on all darwin platforms. On aarch64-darwin it is
-    # part of the bintools wrapper (due to codesigning requirements), but not on
-    # x86_64-darwin.
-    install_name_tool =
-      if stdenv.targetPlatform.isAarch64
-      then targetCC.bintools
-      else targetCC.bintools.bintools;
-    # Same goes for strip.
-    strip =
-      # TODO(@sternenseemann): also use wrapper if linker == "bfd" or "gold"
-      if stdenv.targetPlatform.isAarch64 && stdenv.targetPlatform.isDarwin
-      then targetCC.bintools
-      else targetCC.bintools.bintools;
-  };
+  # toolPath calculates the absolute path to the name tool associated with a
+  # given `stdenv.cc` derivation, i.e. it picks the correct derivation to take
+  # the tool from (cc, cc.bintools, cc.bintools.bintools) and adds the correct
+  # subpath of the tool.
+  toolPath = name: cc:
+    let
+      tools = {
+        "cc" = cc;
+        "c++" = cc;
+        as = cc.bintools.bintools;
+
+        ar = cc.bintools.bintools;
+        ranlib = cc.bintools.bintools;
+        nm = cc.bintools.bintools;
+        readelf = cc.bintools.bintools;
+
+        ld = cc.bintools;
+        "ld.gold" = cc.bintools;
+
+        otool = cc.bintools.bintools;
+
+        # GHC needs install_name_tool on all darwin platforms. On aarch64-darwin it is
+        # part of the bintools wrapper (due to codesigning requirements), but not on
+        # x86_64-darwin. We decide based on target platform to have consistent tools
+        # across all GHC stages.
+        install_name_tool =
+          if stdenv.targetPlatform.isAarch64
+          then cc.bintools
+          else cc.bintools.bintools;
+        # Same goes for strip.
+        strip =
+          # TODO(@sternenseemann): also use wrapper if linker == "bfd" or "gold"
+          if stdenv.targetPlatform.isAarch64 && stdenv.targetPlatform.isDarwin
+          then cc.bintools
+          else cc.bintools.bintools;
+      }.${name};
+    in
+    "${tools}/bin/${tools.targetPrefix}${name}";
 
   # Use gold either following the default, or to avoid the BFD linker due to some bugs / perf issues.
   # But we cannot avoid BFD when using musl libc due to https://sourceware.org/bugzilla/show_bug.cgi?id=23856
@@ -265,19 +286,19 @@ stdenv.mkDerivation (rec {
     done
     # GHC is a bit confused on its cross terminology, as these would normally be
     # the *host* tools.
-    export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
-    export CXX="${targetCC}/bin/${targetCC.targetPrefix}c++"
+    export CC="${toolPath "cc" targetCC}"
+    export CXX="${toolPath "c++" targetCC}"
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
-    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${lib.optionalString useLdGold ".gold"}"
-    export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
-    export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
-    export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
-    export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
-    export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
-    export STRIP="${bintoolsFor.strip}/bin/${bintoolsFor.strip.targetPrefix}strip"
+    export LD="${toolPath "ld${lib.optionalString useLdGold ".gold"}" targetCC}"
+    export AS="${toolPath "as" targetCC}"
+    export AR="${toolPath "ar" targetCC}"
+    export NM="${toolPath "nm" targetCC}"
+    export RANLIB="${toolPath "ranlib" targetCC}"
+    export READELF="${toolPath "readelf" targetCC}"
+    export STRIP="${toolPath "strip" targetCC}"
   '' + lib.optionalString (stdenv.targetPlatform.linker == "cctools") ''
-    export OTOOL="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}otool"
-    export INSTALL_NAME_TOOL="${bintoolsFor.install_name_tool}/bin/${bintoolsFor.install_name_tool.targetPrefix}install_name_tool"
+    export OTOOL="${toolPath "otool" targetCC}"
+    export INSTALL_NAME_TOOL="${toolPath "install_name_tool" targetCC}"
   '' + lib.optionalString useLLVM ''
     export LLC="${lib.getBin buildTargetLlvmPackages.llvm}/bin/llc"
     export OPT="${lib.getBin buildTargetLlvmPackages.llvm}/bin/opt"


### PR DESCRIPTION
This refactor should simplify the code a little bit and make future changes easier. I. e. for cross compiling GHC we'll have to update the tools in the GHC settings file and calculate the host->target tool paths for later use. Having a ready function for this will make this a lot easier.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
