### PR TITLE
mesa: split out the Darwin build into a separate expression

### DIFF
--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -341,10 +341,10 @@ stdenv.mkDerivation (finalAttrs: {
       };
 
     tests = {
-      render = runCommand "${finalAttrs.pname}-test" { } ''
+      render = runCommand "${finalAttrs.pname}-test" {
+        nativeBuildInputs = [ mesa.llvmpipeHook ];
+      } ''
         set -euo pipefail
-        export LIBGL_DRIVERS_PATH=${mesa.drivers}/lib/dri
-        export __EGL_VENDOR_LIBRARY_FILENAMES=${mesa.drivers}/share/glvnd/egl_vendor.d/50_mesa.json
         cat <<'PYTHON' > scene-config.py
         import bpy
         bpy.context.scene.eevee.taa_render_samples = 32

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -199,7 +199,7 @@ let
       pciutils protobuf speechd libXdamage at-spi2-core
       pipewire
       libva
-      libdrm wayland mesa.drivers libxkbcommon
+      libdrm wayland libxkbcommon
       curl
       libepoxy
       libffi
@@ -227,7 +227,7 @@ let
       pciutils protobuf speechd libXdamage at-spi2-core
       pipewire
       libva
-      libdrm wayland mesa.drivers libxkbcommon
+      libdrm wayland libxkbcommon
       curl
       libepoxy
       libffi

--- a/pkgs/applications/networking/instant-messengers/teamspeak/client5.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/client5.nix
@@ -52,7 +52,6 @@ stdenv.mkDerivation rec {
     libnotify
     libpulseaudio
     libxkbcommon
-    mesa.drivers
     nss
     xorg.libX11
     xorg.libXScrnSaver

--- a/pkgs/by-name/co/cosmic-edit/package.nix
+++ b/pkgs/by-name/co/cosmic-edit/package.nix
@@ -97,7 +97,7 @@ rustPlatform.buildRustPackage rec {
     wrapProgram "$out/bin/${pname}" \
       --suffix XDG_DATA_DIRS : "${cosmic-icons}/share" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
-        xorg.libX11 xorg.libXcursor xorg.libXi xorg.libXrandr vulkan-loader libxkbcommon mesa.drivers wayland
+        xorg.libX11 xorg.libXcursor xorg.libXi xorg.libXrandr vulkan-loader libxkbcommon wayland
       ]}
   '';
 

--- a/pkgs/by-name/co/cosmic-store/package.nix
+++ b/pkgs/by-name/co/cosmic-store/package.nix
@@ -86,7 +86,6 @@ rustPlatform.buildRustPackage rec {
           xorg.libXrandr
           libxkbcommon
           vulkan-loader
-          mesa.drivers
         ]
       }
   '';

--- a/pkgs/by-name/co/cosmic-term/package.nix
+++ b/pkgs/by-name/co/cosmic-term/package.nix
@@ -99,7 +99,6 @@ rustPlatform.buildRustPackage rec {
       --suffix XDG_DATA_DIRS : "${cosmic-icons}/share" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
         libxkbcommon
-        mesa.drivers
         vulkan-loader
         xorg.libX11
         xorg.libXcursor

--- a/pkgs/by-name/op/openscad-unstable/package.nix
+++ b/pkgs/by-name/op/openscad-unstable/package.nix
@@ -152,10 +152,11 @@ clangStdenv.mkDerivation rec {
 
   doCheck = true;
 
+  nativeCheckInputs = [
+    mesa.llvmpipeHook
+  ];
+
   checkPhase = ''
-    # for running mesa llvmpipe
-    export LIBGL_DRIVERS_PATH=${mesa.drivers}/lib/dri
-    export __EGL_VENDOR_LIBRARY_FILENAMES=${mesa.drivers}/share/glvnd/egl_vendor.d/50_mesa.json
     # some fontconfig issues cause pdf output to have wrong font
     ctest -j$NIX_BUILD_CORES -E pdfexporttest.\*
   '';

--- a/pkgs/by-name/op/openscad-unstable/package.nix
+++ b/pkgs/by-name/op/openscad-unstable/package.nix
@@ -149,11 +149,13 @@ clangStdenv.mkDerivation rec {
     "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld"
     "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON"
   ];
+
   doCheck = true;
+
   checkPhase = ''
     # for running mesa llvmpipe
+    export LIBGL_DRIVERS_PATH=${mesa.drivers}/lib/dri
     export __EGL_VENDOR_LIBRARY_FILENAMES=${mesa.drivers}/share/glvnd/egl_vendor.d/50_mesa.json
-    export LIBGL_DRIVERS_PATH=${mesa.drivers}/lib:${mesa.drivers}/lib/dri
     # some fontconfig issues cause pdf output to have wrong font
     ctest -j$NIX_BUILD_CORES -E pdfexporttest.\*
   '';

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -313,7 +313,7 @@ stdenv.mkDerivation (rec {
     )
   '';
 
-  # E.g. mesa.drivers use the build-id as a cache key (see #93946):
+  # E.g. Mesa uses the build-id as a cache key (see #93946):
   LDFLAGS = optionalString (enableSharedLibraries && !stdenv.isDarwin) "-Wl,--build-id=sha1";
 
   cmakeBuildType = if debugVersion then "Debug" else "Release";

--- a/pkgs/development/libraries/libva/1.nix
+++ b/pkgs/development/libraries/libva/1.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   # TODO: share libs between minimal and !minimal - perhaps just symlink them
 
   # Add FHS paths for non-NixOS applications.
-  configureFlags = [ "--with-drivers-path=${mesa.drivers.driverLink}/lib/dri:/usr/lib/dri:/usr/lib32/dri" ]
+  configureFlags = lib.optionals stdenv.isLinux [ "--with-drivers-path=${mesa.driverLink}/lib/dri:/usr/lib/dri:/usr/lib32/dri" ]
     ++ lib.optionals (!minimal) [ "--enable-glx" ];
 
   installFlags = [ "dummy_drv_video_ladir=$(out)/lib/dri" ];

--- a/pkgs/development/libraries/libva/default.nix
+++ b/pkgs/development/libraries/libva/default.nix
@@ -33,9 +33,9 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [ libdrm ]
     ++ lib.optionals (!minimal) [ libX11 libXext libXfixes wayland libffi libGL ];
 
-  mesonFlags = [
+  mesonFlags = lib.optionals stdenv.isLinux [
     # Add FHS and Debian paths for non-NixOS applications
-    "-Ddriverdir=${mesa.drivers.driverLink}/lib/dri:/usr/lib/dri:/usr/lib32/dri:/usr/lib/x86_64-linux-gnu/dri:/usr/lib/i386-linux-gnu/dri"
+    "-Ddriverdir=${mesa.driverLink}/lib/dri:/usr/lib/dri:/usr/lib32/dri:/usr/lib/x86_64-linux-gnu/dri:/usr/lib/i386-linux-gnu/dri"
   ];
 
   passthru.tests = {

--- a/pkgs/development/libraries/libvdpau/default.nix
+++ b/pkgs/development/libraries/libvdpau/default.nix
@@ -17,8 +17,7 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ xorg.libX11 ];
 
-  mesonFlags = lib.optionals stdenv.isLinux
-    [ "-Dmoduledir=${mesa.drivers.driverLink}/lib/vdpau" ];
+  mesonFlags = lib.optionals stdenv.isLinux [ "-Dmoduledir=${mesa.driverLink}/lib/vdpau" ];
 
   NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-lX11";
 

--- a/pkgs/development/libraries/mesa/common.nix
+++ b/pkgs/development/libraries/mesa/common.nix
@@ -1,0 +1,32 @@
+{ lib, fetchurl }:
+rec {
+  pname = "mesa";
+  version = "24.1.1";
+
+  src = fetchurl {
+    urls = [
+      "https://archive.mesa3d.org/mesa-${version}.tar.xz"
+      "https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz"
+    ];
+    hash = "sha256-ADiCbG9+iNkLTOb3GRkvpYyn3t9O3KoRdM972SDvieo=";
+  };
+
+  meta = {
+    description = "Open source 3D graphics library";
+    longDescription = ''
+      The Mesa project began as an open-source implementation of the OpenGL
+      specification - a system for rendering interactive 3D graphics. Over the
+      years the project has grown to implement more graphics APIs, including
+      OpenGL ES (versions 1, 2, 3), OpenCL, OpenMAX, VDPAU, VA API, XvMC, and
+      Vulkan.  A variety of device drivers allows the Mesa libraries to be used
+      in many different environments ranging from software emulation to
+      complete hardware acceleration for modern GPUs.
+    '';
+    homepage = "https://www.mesa3d.org/";
+    changelog = "https://www.mesa3d.org/relnotes/${version}.html";
+    license = with lib.licenses; [ mit ]; # X11 variant, in most files
+    platforms = lib.platforms.mesaPlatforms;
+    badPlatforms = []; # Load bearing for libGL meta on Darwin.
+    maintainers = with lib.maintainers; [ primeos vcunat ]; # Help is welcome :)
+  };
+}

--- a/pkgs/development/libraries/mesa/darwin.nix
+++ b/pkgs/development/libraries/mesa/darwin.nix
@@ -1,0 +1,56 @@
+# The Darwin build of Mesa is different enough that we just give it an entire separate expression.
+{
+  lib,
+  stdenv,
+  fetchurl,
+  bison,
+  flex,
+  meson,
+  ninja,
+  pkg-config,
+  python3Packages,
+  Xplugin,
+  xorg,
+  zlib,
+}:
+let
+  common = import ./common.nix { inherit lib fetchurl; };
+in stdenv.mkDerivation {
+  inherit (common) pname version src meta;
+
+  patches = [
+    # Reorder things to make it build on Darwin again
+    # Submitted upstream: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/29592
+    # FIXME: remove when merged or otherwise addressed
+    ./darwin.patch
+  ];
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [
+    bison
+    flex
+    meson
+    ninja
+    pkg-config
+    python3Packages.python
+    python3Packages.mako
+  ];
+
+  buildInputs = [
+    Xplugin
+    xorg.libX11
+    xorg.libXext
+    xorg.libXfixes
+    zlib
+  ];
+
+  mesonAutoFeatures = "disabled";
+
+  mesonFlags = [
+    "--sysconfdir=/etc"
+    "--datadir=${placeholder "out"}/share"
+    (lib.mesonEnable "glvnd" false)
+    (lib.mesonEnable "shared-glapi" true)
+  ];
+}

--- a/pkgs/development/libraries/mesa/darwin.nix
+++ b/pkgs/development/libraries/mesa/darwin.nix
@@ -53,4 +53,7 @@ in stdenv.mkDerivation {
     (lib.mesonEnable "glvnd" false)
     (lib.mesonEnable "shared-glapi" true)
   ];
+
+  # Don't need this on Darwin.
+  passthru.llvmpipeHook = null;
 }

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -92,6 +92,7 @@
     "intel-nullhw"
   ]
 , mesa
+, makeSetupHook
 }:
 
 # When updating this package, please verify at least these build (assuming x86_64-linux):
@@ -394,5 +395,10 @@ in stdenv.mkDerivation {
       '';
       disallowedRequisites = [ llvmPackages.llvm mesa.drivers ];
     };
+
+    llvmpipeHook = makeSetupHook {
+      name = "llvmpipe-hook";
+      substitutions.drivers = mesa.drivers;
+    } ./llvmpipe-hook.sh;
   };
 }

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -1,6 +1,4 @@
 { lib
-, OpenGL
-, Xplugin
 , bison
 , buildPackages
 , directx-headers
@@ -42,19 +40,9 @@
 , xcbutilkeysyms
 , xorg
 , zstd
-, withValgrind ?
-  lib.meta.availableOn stdenv.hostPlatform valgrind-light
-  && !valgrind-light.meta.broken
-, withLibunwind ? lib.meta.availableOn stdenv.hostPlatform libunwind
-, enableGalliumNine ? stdenv.isLinux
-, enableOSMesa ? stdenv.isLinux
-, enableOpenCL ? stdenv.isLinux && stdenv.isx86_64
-, enableTeflon ? stdenv.isLinux && stdenv.isAarch64  # currently only supports aarch64 SoCs, may change in the future
 , enablePatentEncumberedCodecs ? true
 
-, galliumDrivers ?
-  if stdenv.isLinux
-  then [
+, galliumDrivers ? [
     "d3d12" # WSL emulated GPU (aka Dozen)
     "iris" # new Intel (Broadwell+)
     "kmsro" # special "render only" driver for GPUs without a display controller
@@ -79,10 +67,7 @@
     "crocus" # Intel legacy, x86 only
     "i915" # Intel extra legacy, x86 only
   ]
-  else [ "auto" ]
-, vulkanDrivers ?
-  if stdenv.isLinux
-  then [
+, vulkanDrivers ? [
     "amd" # AMD (aka RADV)
     "intel" # new Intel (aka ANV)
     "microsoft-experimental" # WSL virtualized GPU (aka DZN/Dozen)
@@ -100,32 +85,19 @@
   ] ++ lib.optionals stdenv.hostPlatform.isx86 [
     "intel_hasvk" # Intel Haswell/Broadwell, "legacy" Vulkan driver (https://www.phoronix.com/news/Intel-HasVK-Drop-Dead-Code)
   ]
-  else [ "auto" ]
-, eglPlatforms ? [ "x11" ] ++ lib.optionals stdenv.isLinux [ "wayland" ]
-, vulkanLayers ? lib.optionals (!stdenv.isDarwin) [ # No Vulkan support on Darwin
-  "device-select"
-  "overlay"
-  "intel-nullhw"
-]
+, eglPlatforms ? [ "x11" "wayland" ]
+, vulkanLayers ? [
+    "device-select"
+    "overlay"
+    "intel-nullhw"
+  ]
+, mesa
 }:
 
 # When updating this package, please verify at least these build (assuming x86_64-linux):
 # nix build .#mesa .#pkgsi686Linux.mesa .#pkgsCross.aarch64-multiplatform.mesa .#pkgsMusl.mesa
 
 let
-  version = "24.1.1";
-  hash = "sha256-ADiCbG9+iNkLTOb3GRkvpYyn3t9O3KoRdM972SDvieo=";
-
-  # Release calendar: https://www.mesa3d.org/release-calendar.html
-  # Release frequency: https://www.mesa3d.org/releasing.html#schedule
-  branch = lib.versions.major version;
-
-  withLibdrm = lib.meta.availableOn stdenv.hostPlatform libdrm;
-
-  haveWayland = lib.elem "wayland" eglPlatforms;
-  haveZink = lib.elem "zink" galliumDrivers;
-  haveDozen = (lib.elem "d3d12" galliumDrivers) || (lib.elem "microsoft-experimental" vulkanDrivers);
-
   rustDeps = [
     {
       pname = "paste";
@@ -162,28 +134,13 @@ let
   copyRustDeps = lib.concatStringsSep "\n" (builtins.map copyRustDep rustDeps);
 
   needNativeCLC = !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
-self = stdenv.mkDerivation {
-  pname = "mesa";
-  inherit version;
 
-  src = fetchurl {
-    urls = [
-      "https://archive.mesa3d.org/mesa-${version}.tar.xz"
-      "https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz"
-      "ftp://ftp.freedesktop.org/pub/mesa/mesa-${version}.tar.xz"
-      "ftp://ftp.freedesktop.org/pub/mesa/${version}/mesa-${version}.tar.xz"
-      "ftp://ftp.freedesktop.org/pub/mesa/older-versions/${branch}.x/${version}/mesa-${version}.tar.xz"
-    ];
-    inherit hash;
-  };
+  common = import ./common.nix { inherit lib fetchurl; };
+in stdenv.mkDerivation {
+  inherit (common) pname version src meta;
 
   patches = [
     ./opencl.patch
-  ] ++ lib.optionals stdenv.isDarwin [
-    # Reorder things to make it build on Darwin again
-    # Submitted upstream: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/29592
-    # FIXME: remove when merged or otherwise addressed
-    ./darwin.patch
   ];
 
   postPatch = ''
@@ -201,16 +158,7 @@ self = stdenv.mkDerivation {
   '';
 
   outputs = [
-    "out" "dev" "drivers"
-  ] ++ lib.optionals enableOSMesa [
-    "osmesa"
-  ] ++ lib.optionals stdenv.isLinux [
-    "driversdev"
-  ] ++ lib.optionals enableTeflon [
-    "teflon"
-  ] ++ lib.optionals enableOpenCL [
-    "opencl"
-  ] ++ lib.optionals haveDozen [
+    "out" "dev" "drivers" "driversdev" "opencl" "teflon" "osmesa"
     # the Dozen drivers depend on libspirv2dxil, but link it statically, and
     # libspirv2dxil itself is pretty chonky, so relocate it to its own output in
     # case anything wants to use it at some point
@@ -228,69 +176,49 @@ self = stdenv.mkDerivation {
 
   mesonFlags = [
     "--sysconfdir=/etc"
-    "--datadir=${placeholder "drivers"}/share" # Vendor files
+    "--datadir=${placeholder "drivers"}/share"
 
-    # Don't build in debug mode
-    # https://gitlab.freedesktop.org/mesa/mesa/blob/master/docs/meson.html#L327
-    (lib.mesonBool "b_ndebug" true)
-
-    (lib.mesonOption "dri-search-path" "${libglvnd.driverLink}/lib/dri")
-
+    # What to build
     (lib.mesonOption "platforms" (lib.concatStringsSep "," eglPlatforms))
     (lib.mesonOption "gallium-drivers" (lib.concatStringsSep "," galliumDrivers))
     (lib.mesonOption "vulkan-drivers" (lib.concatStringsSep "," vulkanDrivers))
+    (lib.mesonOption "vulkan-layers" (builtins.concatStringsSep "," vulkanLayers))
 
+    # Make sure we know where to find all the drivers
     (lib.mesonOption "dri-drivers-path" "${placeholder "drivers"}/lib/dri")
     (lib.mesonOption "vdpau-libs-path" "${placeholder "drivers"}/lib/vdpau")
     (lib.mesonOption "omx-libs-path" "${placeholder "drivers"}/lib/bellagio")
     (lib.mesonOption "va-libs-path" "${placeholder "drivers"}/lib/dri")
     (lib.mesonOption "d3d-drivers-path" "${placeholder "drivers"}/lib/d3d")
 
-    (lib.mesonBool "gallium-nine" enableGalliumNine) # Direct3D in Wine
-    (lib.mesonBool "osmesa" enableOSMesa) # used by wine
-    (lib.mesonBool "teflon" enableTeflon) # TensorFlow frontend
-    (lib.mesonEnable "microsoft-clc" false) # Only relevant on Windows (OpenCL 1.2 API on top of D3D12)
-
-    # To enable non-mesa gbm backends to be found (e.g. Nvidia)
+    # Set search paths for non-Mesa drivers (e.g. Nvidia)
+    (lib.mesonOption "dri-search-path" "${libglvnd.driverLink}/lib/dri")
     (lib.mesonOption "gbm-backends-path" "${libglvnd.driverLink}/lib/gbm:${placeholder "out"}/lib/gbm")
 
-    # meson auto_features enables these features, but we do not want them
-    (lib.mesonEnable "android-libbacktrace" false)
-  ] ++ lib.optionals stdenv.isLinux [
+    # Enable glvnd for dynamic libGL dispatch
     (lib.mesonEnable "glvnd" true)
+
+    (lib.mesonBool "gallium-nine" true) # Direct3D in Wine
+    (lib.mesonBool "osmesa" true) # used by wine
+    (lib.mesonBool "teflon" true) # TensorFlow frontend
+
+    # Enable Intel RT stuff when available
     (lib.mesonBool "install-intel-clc" true)
     (lib.mesonEnable "intel-rt" stdenv.isx86_64)
     (lib.mesonOption "clang-libdir" "${llvmPackages.clang-unwrapped.lib}/lib")
-  ] ++ lib.optionals stdenv.isDarwin [
-    # Disable features that are explicitly unsupported on the platform
-    (lib.mesonEnable "gbm" false)
-    (lib.mesonEnable "xlib-lease" false)
-    (lib.mesonEnable "egl" false)
-    (lib.mesonEnable "gallium-vdpau" false)
-    (lib.mesonEnable "gallium-va" false)
-    (lib.mesonEnable "gallium-xa" false)
-    (lib.mesonEnable "lmsensors" false)
-    # Don’t build with glvnd support to make sure Mesa builds libGL on Darwin
-    (lib.mesonEnable "glvnd" false)
-    # This gets enabled by mesonAutoFeatures and fails on aarch64-darwin,
-    # which makes no sense because Darwin has neither Intel nor RT, but OK
-    (lib.mesonEnable "intel-rt" false)
-  ] ++ lib.optionals enableOpenCL [
+
     # Clover, old OpenCL frontend
     (lib.mesonOption "gallium-opencl" "icd")
     (lib.mesonBool "opencl-spirv" true)
 
     # Rusticl, new OpenCL frontend
     (lib.mesonBool "gallium-rusticl" true)
-  ] ++ lib.optionals (!withValgrind) [
-    (lib.mesonEnable "valgrind" false)
-  ] ++ lib.optionals (!withLibunwind) [
-    (lib.mesonEnable "libunwind" false)
-  ]
-  ++ lib.optionals enablePatentEncumberedCodecs [
+
+    # meson auto_features enables this, but we do not want it
+    (lib.mesonEnable "android-libbacktrace" false)
+    (lib.mesonEnable "microsoft-clc" false) # Only relevant on Windows (OpenCL 1.2 API on top of D3D12)
+  ] ++ lib.optionals enablePatentEncumberedCodecs [
     (lib.mesonOption "video-codecs" "all")
-  ] ++ lib.optionals (vulkanLayers != []) [
-    (lib.mesonOption "vulkan-layers" (builtins.concatStringsSep "," vulkanLayers))
   ] ++ lib.optionals needNativeCLC [
     (lib.mesonOption "intel-clc" "system")
   ];
@@ -298,61 +226,45 @@ self = stdenv.mkDerivation {
   strictDeps = true;
 
   buildInputs = with xorg; [
+    directx-headers
+    elfutils
     expat
     glslang
     libffi
     libglvnd
+    libomxil-bellagio
+    libpthreadstubs
+    libunwind
+    libva-minimal
     libvdpau
-    llvmPackages.libllvm
-    openssl
-    zstd
-  ] ++ (with xorg; [
     libX11
+    libxcb
     libXext
     libXfixes
     libXrandr
+    libxshmfence
     libXt
     libXvMC
-    libpthreadstubs
-    libxcb
-    libxshmfence
-    xcbutilkeysyms
-    xorgproto
-  ]) ++ lib.optionals withLibunwind [
-    libunwind
-  ] ++ [
-    python3Packages.python # for shebang
-  ] ++ lib.optionals haveWayland [
-    wayland
-    wayland-protocols
-  ] ++ lib.optionals stdenv.isLinux [
-    libomxil-bellagio
-    libva-minimal
+    llvmPackages.clang
     llvmPackages.clang-unwrapped
     llvmPackages.libclc
+    llvmPackages.libllvm
     lm_sensors
+    openssl
+    python3Packages.python # for shebang
     spirv-llvm-translator
     udev
-  ] ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform elfutils) [
-    elfutils
-  ] ++ lib.optionals enableOpenCL [
-    llvmPackages.clang
-  ] ++ lib.optionals withValgrind [
     valgrind-light
-  ] ++ lib.optionals haveZink [
     vulkan-loader
-  ] ++ lib.optionals haveDozen [
-    directx-headers
+    wayland
+    wayland-protocols
+    xcbutilkeysyms
+    xorgproto
+    zstd
   ];
 
   depsBuildBuild = [
     pkg-config
-  ] ++ lib.optionals (!stdenv.isDarwin) [
-    # Adding this unconditionally makes x86_64-darwin pick up an older
-    # toolchain, as we explicitly call Mesa with 11.0 stdenv, but buildPackages
-    # is still 10.something, and Mesa can't build with that.
-    # FIXME: figure this out, or figure out how to get rid of Mesa on Darwin,
-    # whichever is easier.
     buildPackages.stdenv.cc
   ];
 
@@ -374,7 +286,6 @@ self = stdenv.mkDerivation {
     rust-bindgen
     rust-cbindgen
     rustPlatform.bindgenHook
-  ] ++ lib.optionals haveWayland [
     wayland-scanner
   ] ++ lib.optionals needNativeCLC [
     buildPackages.mesa.driversdev
@@ -384,74 +295,52 @@ self = stdenv.mkDerivation {
     buildPackages.mesa.driversdev
   ];
 
-  propagatedBuildInputs = (with xorg; [
+  propagatedBuildInputs = with xorg; [
     libXdamage
     libXxf86vm
-  ]) ++ lib.optionals withLibdrm [
     libdrm
-  ] ++ lib.optionals stdenv.isDarwin [
-    OpenGL
-    Xplugin
   ];
 
   doCheck = false;
 
   postInstall = ''
-    # Some installs don't have any drivers so this directory is never created.
-    mkdir -p $drivers $osmesa
-  '' + lib.optionalString stdenv.isLinux ''
-    mkdir -p $drivers/lib
+    # Move driver-related bits to $drivers
+    moveToOutput "lib/lib*_mesa*" $drivers
+    moveToOutput "lib/libpowervr_rogue*" $drivers
+    moveToOutput "lib/libxatracker*" $drivers
+    moveToOutput "lib/libvulkan_*" $drivers
 
-    if [ -n "$(shopt -s nullglob; echo "$out/lib/libxatracker"*)" -o -n "$(shopt -s nullglob; echo "$out/lib/libvulkan_"*)" ]; then
-      # move gallium-related stuff to $drivers, so $out doesn't depend on LLVM
-      mv -t $drivers/lib       \
-        $out/lib/libpowervr_rogue* \
-        $out/lib/libxatracker* \
-        $out/lib/libvulkan_*
-    fi
-
-    if [ -n "$(shopt -s nullglob; echo "$out"/lib/lib*_mesa*)" ]; then
-      # Move other drivers to a separate output
-      mv -t $drivers/lib $out/lib/lib*_mesa*
-    fi
-
-    # Update search path used by glvnd
+    # Update search path used by glvnd (it's pointing to $out but drivers are in $drivers)
     for js in $drivers/share/glvnd/egl_vendor.d/*.json; do
-      substituteInPlace "$js" --replace '"libEGL_' '"'"$drivers/lib/libEGL_"
+      substituteInPlace "$js" --replace-fail '"libEGL_' '"'"$drivers/lib/libEGL_"
     done
 
-    # Update search path used by Vulkan (it's pointing to $out but
-    # drivers are in $drivers)
+    # And same for Vulkan
     for js in $drivers/share/vulkan/icd.d/*.json; do
-      substituteInPlace "$js" --replace "$out" "$drivers"
+      substituteInPlace "$js" --replace-fail "$out" "$drivers"
     done
-  '' + lib.optionalString enableOpenCL ''
-    # Move OpenCL stuff
-    mkdir -p $opencl/lib
-    mv -t "$opencl/lib/"     \
-      $out/lib/gallium-pipe   \
-      $out/lib/lib*OpenCL*
 
-    # We construct our own .icd files that contain absolute paths.
-    mkdir -p $opencl/etc/OpenCL/vendors/
-    echo $opencl/lib/libMesaOpenCL.so > $opencl/etc/OpenCL/vendors/mesa.icd
-    echo $opencl/lib/libRusticlOpenCL.so > $opencl/etc/OpenCL/vendors/rusticl.icd
-  '' + lib.optionalString enableOSMesa ''
-    # move libOSMesa to $osmesa, as it's relatively big
-    mkdir -p $osmesa/lib
-    mv -t $osmesa/lib/ $out/lib/libOSMesa*
-  '' + lib.optionalString (vulkanLayers != []) ''
-    mv -t $drivers/lib $out/lib/libVkLayer*
+    # Move Vulkan layers to $drivers and update manifests
+    moveToOutput "lib/libVkLayer*" $drivers
     for js in $drivers/share/vulkan/{im,ex}plicit_layer.d/*.json; do
       substituteInPlace "$js" --replace '"libVkLayer_' '"'"$drivers/lib/libVkLayer_"
     done
-  '' + lib.optionalString haveDozen ''
-    mkdir -p $spirv2dxil/{bin,lib}
-    mv -t $spirv2dxil/lib $out/lib/libspirv_to_dxil*
-    mv -t $spirv2dxil/bin $out/bin/spirv2dxil
+
+    # Construct our own .icd files that contain absolute paths.
+    mkdir -p $opencl/etc/OpenCL/vendors/
+    echo $opencl/lib/libMesaOpenCL.so > $opencl/etc/OpenCL/vendors/mesa.icd
+    echo $opencl/lib/libRusticlOpenCL.so > $opencl/etc/OpenCL/vendors/rusticl.icd
+
+    moveToOutput bin/intel_clc $driversdev
+    moveToOutput lib/gallium-pipe $opencl
+    moveToOutput "lib/lib*OpenCL*" $opencl
+    moveToOutput "lib/libOSMesa*" $osmesa
+    moveToOutput bin/spirv2dxil $spirv2dxil
+    moveToOutput "lib/libspirv_to_dxil*" $spirv2dxil
+    moveToOutput lib/libteflon.so $teflon
   '';
 
-  postFixup = lib.optionalString stdenv.isLinux ''
+  postFixup = ''
     # set the default search path for DRI drivers; used e.g. by X server
     for pc in lib/pkgconfig/{dri,d3d}.pc; do
       [ -f "$dev/$pc" ] && substituteInPlace "$dev/$pc" --replace "$drivers" "${libglvnd.driverLink}"
@@ -471,8 +360,6 @@ self = stdenv.mkDerivation {
       fi
     done
 
-    moveToOutput bin/intel_clc $driversdev
-
     # Don't depend on build python
     patchShebangs --host --update $out/bin/*
 
@@ -486,59 +373,26 @@ self = stdenv.mkDerivation {
         patchelf --set-rpath "$(patchelf --print-rpath $lib):$drivers/lib" "$lib"
       fi
     done
-    # add RPATH here so Zink can find libvulkan.so
-    ${lib.optionalString haveZink ''
-      patchelf --add-rpath ${vulkan-loader}/lib $drivers/lib/dri/zink_dri.so
-    ''}
 
-    ${lib.optionalString enableTeflon ''
-      moveToOutput lib/libteflon.so $teflon
-    ''}
+    # add RPATH here so Zink can find libvulkan.so
+    patchelf --add-rpath ${vulkan-loader}/lib $drivers/lib/dri/zink_dri.so
   '';
 
-  env.NIX_CFLAGS_COMPILE = toString (
-    lib.optionals stdenv.isDarwin [
-      "-fno-common"
-    ] ++ lib.optionals enableOpenCL [
-      "-UPIPE_SEARCH_DIR"
-      "-DPIPE_SEARCH_DIR=\"${placeholder "opencl"}/lib/gallium-pipe\""
+  env.NIX_CFLAGS_COMPILE = toString ([
+    "-UPIPE_SEARCH_DIR"
+    "-DPIPE_SEARCH_DIR=\"${placeholder "opencl"}/lib/gallium-pipe\""
   ]);
 
   passthru = {
     inherit (libglvnd) driverLink;
     inherit llvmPackages;
 
-    libdrm = if withLibdrm then libdrm else null;
-
-    tests = lib.optionalAttrs stdenv.isLinux {
-      devDoesNotDependOnLLVM = stdenv.mkDerivation {
-        name = "mesa-dev-does-not-depend-on-llvm";
-        buildCommand = ''
-          echo ${self.dev} >>$out
-        '';
-        disallowedRequisites = [ llvmPackages.llvm self.drivers ];
-      };
+    tests.devDoesNotDependOnLLVM = stdenv.mkDerivation {
+      name = "mesa-dev-does-not-depend-on-llvm";
+      buildCommand = ''
+        echo ${mesa.dev} >>$out
+      '';
+      disallowedRequisites = [ llvmPackages.llvm mesa.drivers ];
     };
   };
-
-  meta = {
-    description = "Open source 3D graphics library";
-    longDescription = ''
-      The Mesa project began as an open-source implementation of the OpenGL
-      specification - a system for rendering interactive 3D graphics. Over the
-      years the project has grown to implement more graphics APIs, including
-      OpenGL ES (versions 1, 2, 3), OpenCL, OpenMAX, VDPAU, VA API, XvMC, and
-      Vulkan.  A variety of device drivers allows the Mesa libraries to be used
-      in many different environments ranging from software emulation to
-      complete hardware acceleration for modern GPUs.
-    '';
-    homepage = "https://www.mesa3d.org/";
-    changelog = "https://www.mesa3d.org/relnotes/${version}.html";
-    license = with lib.licenses; [ mit ]; # X11 variant, in most files
-    platforms = lib.platforms.mesaPlatforms;
-    badPlatforms = []; # Load bearing for libGL meta on Darwin.
-    maintainers = with lib.maintainers; [ primeos vcunat ]; # Help is welcome :)
-  };
-};
-
-in self
+}

--- a/pkgs/development/libraries/mesa/llvmpipe-hook.sh
+++ b/pkgs/development/libraries/mesa/llvmpipe-hook.sh
@@ -1,0 +1,14 @@
+# shellcheck shell=bash
+
+# https://docs.mesa3d.org/envvars.html
+export LIBGL_ALWAYS_SOFTWARE=true
+export LIBGL_DRIVERS_PATH=@drivers@/lib/dri
+
+# https://github.com/NVIDIA/libglvnd/blob/master/src/EGL/icd_enumeration.md
+export __EGL_VENDOR_LIBRARY_FILENAMES=@drivers@/share/glvnd/egl_vendor.d/50_mesa.json
+
+# https://github.com/KhronosGroup/Vulkan-Loader/blob/main/docs/LoaderInterfaceArchitecture.md
+# glob because the filenames contain an architecture suffix
+# echo is needed to force-expand the glob
+VK_DRIVER_FILES="$(echo @drivers@/share/vulkan/icd.d/lvp_icd.*.json)"
+export VK_DRIVER_FILES

--- a/pkgs/development/python-modules/pyopencl/default.nix
+++ b/pkgs/development/python-modules/pyopencl/default.nix
@@ -5,9 +5,9 @@
   buildPythonPackage,
   appdirs,
   cffi,
+  darwin,
   decorator,
   mako,
-  mesa_drivers,
   numpy,
   ocl-icd,
   oldest-supported-numpy,
@@ -22,7 +22,7 @@
 }:
 
 let
-  os-specific-buildInputs = if stdenv.isDarwin then [ mesa_drivers.dev ] else [ ocl-icd ];
+  os-specific-buildInputs = if stdenv.isDarwin then [ darwin.apple_sdk.frameworks.OpenCL ] else [ ocl-icd ];
 in
 buildPythonPackage rec {
   pname = "pyopencl";

--- a/pkgs/games/katago/default.nix
+++ b/pkgs/games/katago/default.nix
@@ -53,11 +53,9 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (backend == "cuda") [
     cudaPackages.cudnn
     cudaPackages.cudatoolkit
-    mesa.drivers
   ] ++ lib.optionals (backend == "tensorrt") [
       cudaPackages.cudatoolkit
       cudaPackages.tensorrt
-      mesa.drivers
   ] ++ lib.optionals (backend == "opencl") [
     opencl-headers
     ocl-icd

--- a/pkgs/tools/admin/turbovnc/default.nix
+++ b/pkgs/tools/admin/turbovnc/default.nix
@@ -94,7 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
     # to the swrast dri driver in Mesa.
     # Can also be given at runtime to its `Xvnc` as:
     #   -dridir /nix/store/...-mesa-20.1.10-drivers/lib/dri/
-    "-DXORG_DRI_DRIVER_PATH=${mesa.drivers}/lib/dri"
+    "-DXORG_DRI_DRIVER_PATH=${mesa.driverLink}/lib/dri"
     # The build system doesn't find these files automatically.
     "-DTJPEG_JAR=${libjpeg_turbo.out}/share/java/turbojpeg.jar"
     "-DTJPEG_JNILIBRARY=${libjpeg_turbo.out}/lib/libturbojpeg.so"

--- a/pkgs/tools/graphics/asymptote/default.nix
+++ b/pkgs/tools/graphics/asymptote/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl
 , autoreconfHook, bison, glm, flex, wrapQtAppsHook, cmake, pkg-config
 , freeglut, ghostscriptX, imagemagick, fftw, eigen, libtirpc
-, boehmgc, libGLU, libGL, mesa, ncurses, readline, gsl, libsigsegv
+, boehmgc, libGLU, libGL, ncurses, readline, gsl, libsigsegv
 , python3, qtbase, qtsvg, boost
 , zlib, perl, curl
 , texinfo
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   propagatedBuildInputs = [
     glm
   ] ++ lib.optionals stdenv.isLinux [
-    freeglut libGLU libGL mesa.osmesa
+    freeglut libGLU libGL
   ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
     OpenGL GLUT Cocoa
   ]);

--- a/pkgs/tools/graphics/mesa-demos/default.nix
+++ b/pkgs/tools/graphics/mesa-demos/default.nix
@@ -54,14 +54,12 @@ stdenv.mkDerivation rec {
     vulkan-loader
     libxkbcommon
     libdecor
-  ] ++ lib.optional (mesa ? osmesa) mesa.osmesa;
+  ];
 
   mesonFlags = [
-    "-Degl=${if stdenv.isDarwin then "disabled" else "auto"}"
-    "-Dlibdrm=${if mesa.libdrm == null then "disabled" else "enabled"}"
-    "-Dosmesa=${if mesa ? osmesa then "enabled" else "disabled"}"
-    "-Dwayland=${if wayland.withLibraries then "enabled" else "disabled"}"
     "-Dwith-system-data-files=true"
+    "-Dgles1=disabled"
+    "-Dosmesa=disabled"
   ];
 
   meta = with lib; {

--- a/pkgs/tools/graphics/vulkan-cts/default.nix
+++ b/pkgs/tools/graphics/vulkan-cts/default.nix
@@ -106,9 +106,9 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru.updateScript = ./update.sh;
-  passthru.tests.lavapipe = runCommand "vulkan-cts-tests-lavapipe" { nativeBuildInputs = [ finalAttrs.finalPackage ]; } ''
-    # Expand the wildcard to pick the existing architecture
-    export VK_ICD_FILENAMES=$(echo ${mesa.drivers}/share/vulkan/icd.d/lvp_icd.*.json)
+  passthru.tests.lavapipe = runCommand "vulkan-cts-tests-lavapipe" {
+    nativeBuildInputs = [ finalAttrs.finalPackage mesa.llvmpipeHook ];
+  } ''
     deqp-vk -n dEQP-VK.api.smoke.triangle
     touch $out
   '';

--- a/pkgs/tools/networking/burpsuite/default.nix
+++ b/pkgs/tools/networking/burpsuite/default.nix
@@ -52,7 +52,6 @@ buildFHSEnv {
     libdrm
     libudev0-shim
     libxkbcommon
-    mesa.drivers
     nspr
     nss
     pango

--- a/pkgs/tools/security/enpass/default.nix
+++ b/pkgs/tools/security/enpass/default.nix
@@ -18,7 +18,6 @@ let
 
   # used of both wrappers and libpath
   libPath = lib.makeLibraryPath (with xorg; [
-    mesa.drivers
     libGLU libGL
     fontconfig
     freetype

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23264,10 +23264,12 @@ with pkgs;
   # Default libGLU
   libGLU = mesa_glu;
 
-  mesa = darwin.apple_sdk_11_0.callPackage ../development/libraries/mesa {
-    inherit (darwin.apple_sdk_11_0.frameworks) OpenGL;
-    inherit (darwin.apple_sdk_11_0.libs) Xplugin;
-  };
+  mesa = if stdenv.isDarwin
+    then darwin.apple_sdk_11_0.callPackage ../development/libraries/mesa/darwin.nix {
+      inherit (darwin.apple_sdk_11_0.libs) Xplugin;
+    }
+    else callPackage ../development/libraries/mesa {};
+
   mesa_i686 = pkgsi686Linux.mesa; # make it build on Hydra
 
   mesa_glu =  callPackage ../development/libraries/mesa-glu {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11554,9 +11554,7 @@ self: super: with self; {
 
   phonemizer = callPackage ../development/python-modules/phonemizer { };
 
-  pyopencl = callPackage ../development/python-modules/pyopencl {
-    mesa_drivers = pkgs.mesa.drivers;
-  };
+  pyopencl = callPackage ../development/python-modules/pyopencl { };
 
   pyopengl = callPackage ../development/python-modules/pyopengl { };
 


### PR DESCRIPTION
The way we build Mesa for Linux (and potentially others) is very, very different from the way we build Mesa on Darwin. In short, on Linux we generally want to build as much of it as possible, while on Darwin we want to build just enough of it to get GLX for legacy X applications.

So, split out the Darwin build into its own expression entirely, and give it just enough inputs and just enough feature flags to actually do the one thing we want it to do, and nothing else.

Then use the newly gained flexibility to remove most of the platform conditionals from the Linux expression.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
