### PR TITLE
nixos/nextcloud: add objectstore test, refactor testing structure

### DIFF
--- a/nixos/tests/nextcloud/default.nix
+++ b/nixos/tests/nextcloud/default.nix
@@ -20,6 +20,10 @@ foldl
       inherit system pkgs;
       nextcloudVersion = ver;
     };
+    "with-objectstore${toString ver}" = import ./with-objectstore.nix {
+      inherit system pkgs;
+      nextcloudVersion = ver;
+    };
   })
 { }
   [ 27 28 29 ]

--- a/nixos/tests/nextcloud/default.nix
+++ b/nixos/tests/nextcloud/default.nix
@@ -5,25 +5,108 @@
 
 with pkgs.lib;
 
-foldl
-  (matrix: ver: matrix // {
-    "basic${toString ver}" = import ./basic.nix { inherit system pkgs; nextcloudVersion = ver; };
-    "with-postgresql-and-redis${toString ver}" = import ./with-postgresql-and-redis.nix {
-      inherit system pkgs;
-      nextcloudVersion = ver;
+let
+  baseModule = { config, ... }: {
+    imports = [
+      {
+        options.test-helpers = {
+          rclone = mkOption { type = types.str; };
+          upload-sample = mkOption { type = types.str; };
+          check-sample = mkOption { type = types.str; };
+          init = mkOption { type = types.str; default = ""; };
+          extraTests = mkOption { type = types.either types.str (types.functionTo types.str); default = ""; };
+        };
+        options.adminuser = mkOption { type = types.str; };
+        options.adminpass = mkOption { type = types.str; };
+      }
+    ];
+
+    adminuser = "root";
+    adminpass = "hunter2";
+
+    test-helpers.rclone = "${pkgs.writeShellScript "rclone" ''
+      set -euo pipefail
+      export PATH="${pkgs.rclone}/bin:$PATH"
+      export RCLONE_CONFIG_NEXTCLOUD_TYPE=webdav
+      export RCLONE_CONFIG_NEXTCLOUD_URL="http://nextcloud/remote.php/dav/files/${config.adminuser}"
+      export RCLONE_CONFIG_NEXTCLOUD_VENDOR="nextcloud"
+      export RCLONE_CONFIG_NEXTCLOUD_USER="${config.adminuser}"
+      export RCLONE_CONFIG_NEXTCLOUD_PASS="$(rclone obscure ${config.adminpass})"
+      exec "$@"
+    ''}";
+    test-helpers.upload-sample = "${pkgs.writeShellScript "rclone-upload" ''
+      <<<'hi' rclone rcat nextcloud:test-shared-file
+    ''}";
+    test-helpers.check-sample = "${pkgs.writeShellScript "check-sample" ''
+      set -e
+      diff <(echo 'hi') <(rclone cat nextcloud:test-shared-file)
+    ''}";
+
+    nodes = {
+      client = { ... }: {};
+      nextcloud = {
+        networking.firewall.allowedTCPPorts = [ 80 ];
+        services.nextcloud = {
+          enable = true;
+          hostName = "nextcloud";
+          https = false;
+          database.createLocally = true;
+          config = {
+            adminpassFile = "${pkgs.writeText "adminpass" config.adminpass}"; # Don't try this at home!
+          };
+        };
+      };
     };
-    "with-mysql-and-memcached${toString ver}" = import ./with-mysql-and-memcached.nix {
-      inherit system pkgs;
-      nextcloudVersion = ver;
-    };
-    "with-declarative-redis-and-secrets${toString ver}" = import ./with-declarative-redis-and-secrets.nix {
-      inherit system pkgs;
-      nextcloudVersion = ver;
-    };
-    "with-objectstore${toString ver}" = import ./with-objectstore.nix {
-      inherit system pkgs;
-      nextcloudVersion = ver;
-    };
-  })
-{ }
-  [ 27 28 29 ]
+
+    testScript = args@{ nodes, ... }: let
+      inherit (config) test-helpers;
+    in mkBefore ''
+      nextcloud.start()
+      client.start()
+      nextcloud.wait_for_unit("multi-user.target")
+
+      ${test-helpers.init}
+
+      with subtest("Ensure nextcloud-occ is working"):
+          nextcloud.succeed("nextcloud-occ status")
+          nextcloud.succeed("curl -sSf http://nextcloud/login")
+
+      with subtest("Upload/Download test"):
+          nextcloud.succeed(
+              "${test-helpers.rclone} ${test-helpers.upload-sample}"
+          )
+          client.wait_for_unit("multi-user.target")
+          client.succeed(
+              "${test-helpers.rclone} ${test-helpers.check-sample}"
+          )
+
+      ${if builtins.isFunction test-helpers.extraTests then test-helpers.extraTests args else test-helpers.extraTests}
+    '';
+  };
+
+  genTests = version:
+    let
+      testBase.imports = [
+        baseModule
+        {
+          nodes.nextcloud = { pkgs, ... }: {
+            services.nextcloud.package = pkgs.${"nextcloud${toString version}"};
+          };
+        }
+      ];
+
+      callNextcloudTest = path:
+        let
+          name = "${removeSuffix ".nix" (baseNameOf path)}${toString version}";
+        in nameValuePair name (import path {
+          inherit system pkgs testBase;
+          name = "nextcloud-${name}";
+        });
+    in map callNextcloudTest [
+      ./basic.nix
+      ./with-mysql-and-memcached.nix
+      ./with-postgresql-and-redis.nix
+      ./with-objectstore.nix
+    ];
+in
+listToAttrs (concatMap genTests [ 27 28 29 ])

--- a/nixos/tests/nextcloud/with-mysql-and-memcached.nix
+++ b/nixos/tests/nextcloud/with-mysql-and-memcached.nix
@@ -1,79 +1,37 @@
-args@{ pkgs, nextcloudVersion ? 22, ... }:
+{ pkgs, testBase, system, ... }:
 
-(import ../make-test-python.nix ({ pkgs, ...}: let
-  adminpass = "hunter2";
-  adminuser = "root";
-in {
+with import ../../lib/testing-python.nix { inherit system pkgs; };
+runTest ({ config, ... }: {
   name = "nextcloud-with-mysql-and-memcached";
   meta = with pkgs.lib.maintainers; {
     maintainers = [ eqyiel ];
   };
 
+  imports = [ testBase ];
+
   nodes = {
-    # The only thing the client needs to do is download a file.
-    client = { ... }: {};
-
     nextcloud = { config, pkgs, ... }: {
-      networking.firewall.allowedTCPPorts = [ 80 ];
-
       services.nextcloud = {
-        enable = true;
-        hostName = "nextcloud";
-        https = true;
-        package = pkgs.${"nextcloud" + (toString nextcloudVersion)};
         caching = {
           apcu = true;
           redis = false;
           memcached = true;
         };
-        database.createLocally = true;
-        config = {
-          dbtype = "mysql";
-          # Don't inherit adminuser since "root" is supposed to be the default
-          adminpassFile = "${pkgs.writeText "adminpass" adminpass}"; # Don't try this at home!
-        };
+        config.dbtype = "mysql";
       };
 
       services.memcached.enable = true;
     };
   };
 
-  testScript = let
+  test-helpers.init = let
     configureMemcached = pkgs.writeScript "configure-memcached" ''
-      #!${pkgs.runtimeShell}
       nextcloud-occ config:system:set memcached_servers 0 0 --value 127.0.0.1 --type string
       nextcloud-occ config:system:set memcached_servers 0 1 --value 11211 --type integer
       nextcloud-occ config:system:set memcache.local --value '\OC\Memcache\APCu' --type string
       nextcloud-occ config:system:set memcache.distributed --value '\OC\Memcache\Memcached' --type string
     '';
-    withRcloneEnv = pkgs.writeScript "with-rclone-env" ''
-      #!${pkgs.runtimeShell}
-      export RCLONE_CONFIG_NEXTCLOUD_TYPE=webdav
-      export RCLONE_CONFIG_NEXTCLOUD_URL="http://nextcloud/remote.php/dav/files/${adminuser}"
-      export RCLONE_CONFIG_NEXTCLOUD_VENDOR="nextcloud"
-      export RCLONE_CONFIG_NEXTCLOUD_USER="${adminuser}"
-      export RCLONE_CONFIG_NEXTCLOUD_PASS="$(${pkgs.rclone}/bin/rclone obscure ${adminpass})"
-    '';
-    copySharedFile = pkgs.writeScript "copy-shared-file" ''
-      #!${pkgs.runtimeShell}
-      echo 'hi' | ${pkgs.rclone}/bin/rclone rcat nextcloud:test-shared-file
-    '';
-
-    diffSharedFile = pkgs.writeScript "diff-shared-file" ''
-      #!${pkgs.runtimeShell}
-      diff <(echo 'hi') <(${pkgs.rclone}/bin/rclone cat nextcloud:test-shared-file)
-    '';
   in ''
-    start_all()
-    nextcloud.wait_for_unit("multi-user.target")
     nextcloud.succeed("${configureMemcached}")
-    nextcloud.succeed("curl -sSf http://nextcloud/login")
-    nextcloud.succeed(
-        "${withRcloneEnv} ${copySharedFile}"
-    )
-    client.wait_for_unit("multi-user.target")
-    client.succeed(
-        "${withRcloneEnv} ${diffSharedFile}"
-    )
   '';
-})) args
+})

--- a/nixos/tests/nextcloud/with-objectstore.nix
+++ b/nixos/tests/nextcloud/with-objectstore.nix
@@ -1,0 +1,94 @@
+args@{ pkgs, nextcloudVersion ? 28, ... }:
+
+(import ../make-test-python.nix ({ pkgs, ...}: let
+  adminpass = "hunter2";
+  adminuser = "root";
+
+  accessKey = "nextcloud";
+  secretKey = "test12345";
+
+  rootCredentialsFile = pkgs.writeText "minio-credentials-full" ''
+    MINIO_ROOT_USER=${accessKey}
+    MINIO_ROOT_PASSWORD=${secretKey}
+  '';
+
+in {
+  name = "nextcloud-with-objectstore";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ onny ];
+  };
+
+  nodes = {
+    # The only thing the client needs to do is download a file.
+    client = { ... }: {};
+
+    nextcloud = { config, pkgs, ... }: {
+      networking.firewall.allowedTCPPorts = [ 9000 ];
+
+      services.nextcloud = {
+        enable = true;
+        hostName = "nextcloud";
+        package = pkgs.${"nextcloud" + (toString nextcloudVersion)};
+        database.createLocally = true;
+        # Don't try this at home!
+        config.adminpassFile = "${pkgs.writeText "adminpass" adminpass}";
+        config.objectstore.s3 = {
+          enable = true;
+          bucket = "nextcloud";
+          autocreate = true;
+          key = "nextcloud";
+          secretFile = "${pkgs.writeText "secretKey" secretKey}";
+          hostname = "nextcloud";
+          useSsl = false;
+          port = 9000;
+          usePathStyle = true;
+          region = "us-east-1";
+        };
+      };
+
+      services.minio = {
+        enable = true;
+        listenAddress = "0.0.0.0:9000";
+        consoleAddress = "0.0.0.0:9001";
+        inherit rootCredentialsFile;
+      };
+
+    };
+  };
+
+  testScript = let
+    withRcloneEnv = pkgs.writeScript "with-rclone-env" ''
+      #!${pkgs.runtimeShell}
+      export RCLONE_CONFIG_NEXTCLOUD_TYPE=webdav
+      export RCLONE_CONFIG_NEXTCLOUD_URL="http://nextcloud/remote.php/dav/files/${adminuser}"
+      export RCLONE_CONFIG_NEXTCLOUD_VENDOR="nextcloud"
+      export RCLONE_CONFIG_NEXTCLOUD_USER="${adminuser}"
+      export RCLONE_CONFIG_NEXTCLOUD_PASS="$(${pkgs.rclone}/bin/rclone obscure ${adminpass})"
+    '';
+    copySharedFile = pkgs.writeScript "copy-shared-file" ''
+      #!${pkgs.runtimeShell}
+      echo 'hello world' | ${pkgs.rclone}/bin/rclone rcat nextcloud:test-shared-file
+    '';
+
+    diffSharedFile = pkgs.writeScript "diff-shared-file" ''
+      #!${pkgs.runtimeShell}
+      export AWS_ACCESS_KEY_ID=${accessKey}
+      export AWS_SECRET_ACCESS_KEY=${secretKey}
+      ${pkgs.awscli2}/bin/aws s3 cp s3://nextcloud /tmp/. --recursive --endpoint-url http://nextcloud:9000 --region us-east-1
+      grep -r "hello world" /tmp
+    '';
+  in ''
+    start_all()
+    nextcloud.wait_for_unit("multi-user.target")
+    nextcloud.wait_for_unit("minio.service")
+    nextcloud.wait_for_open_port(9000)
+    nextcloud.succeed("curl -sSf http://nextcloud/login")
+    nextcloud.succeed(
+        "${withRcloneEnv} ${copySharedFile}"
+    )
+    client.wait_for_unit("multi-user.target")
+    client.wait_until_succeeds(
+        "${diffSharedFile}"
+    )
+  '';
+})) args

--- a/nixos/tests/nextcloud/with-objectstore.nix
+++ b/nixos/tests/nextcloud/with-objectstore.nix
@@ -1,9 +1,7 @@
-args@{ pkgs, nextcloudVersion ? 28, ... }:
+{ name, pkgs, testBase, system, ... }:
 
-(import ../make-test-python.nix ({ pkgs, ...}: let
-  adminpass = "hunter2";
-  adminuser = "root";
-
+with import ../../lib/testing-python.nix { inherit system pkgs; };
+runTest ({ config, lib, ... }: let
   accessKey = "BKIKJAA5BMMU2RHO6IBB";
   secretKey = "V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12";
 
@@ -11,40 +9,30 @@ args@{ pkgs, nextcloudVersion ? 28, ... }:
     MINIO_ROOT_USER=${accessKey}
     MINIO_ROOT_PASSWORD=${secretKey}
   '';
-
 in {
-  name = "nextcloud-with-objectstore";
+  inherit name;
   meta = with pkgs.lib.maintainers; {
     maintainers = [ onny ma27 ];
   };
 
-  nodes = {
-    # The only thing the client needs to do is download a file.
-    client = { ... }: {};
+  imports = [ testBase ];
 
+  nodes = {
     nextcloud = { config, pkgs, ... }: {
-      networking.firewall.allowedTCPPorts = [ 80 9000 ];
+      networking.firewall.allowedTCPPorts = [ 9000 ];
       environment.systemPackages = [ pkgs.minio-client ];
 
-      services.nextcloud = {
+      services.nextcloud.config.objectstore.s3 = {
         enable = true;
-        hostName = "nextcloud";
-        package = pkgs.${"nextcloud" + (toString nextcloudVersion)};
-        database.createLocally = true;
-        # Don't try this at home!
-        config.adminpassFile = "${pkgs.writeText "adminpass" adminpass}";
-        config.objectstore.s3 = {
-          enable = true;
-          bucket = "nextcloud";
-          autocreate = false;
-          key = accessKey;
-          secretFile = "${pkgs.writeText "secretKey" secretKey}";
-          hostname = "nextcloud";
-          useSsl = false;
-          port = 9000;
-          usePathStyle = true;
-          region = "us-east-1";
-        };
+        bucket = "nextcloud";
+        autocreate = true;
+        key = accessKey;
+        secretFile = "${pkgs.writeText "secretKey" secretKey}";
+        hostname = "nextcloud";
+        useSsl = false;
+        port = 9000;
+        usePathStyle = true;
+        region = "us-east-1";
       };
 
       services.minio = {
@@ -53,51 +41,56 @@ in {
         consoleAddress = "0.0.0.0:9001";
         inherit rootCredentialsFile;
       };
-
     };
   };
 
-  testScript = let
-    withRcloneEnv = pkgs.writeScript "with-rclone-env" ''
-      #!${pkgs.runtimeShell}
-      export RCLONE_CONFIG_NEXTCLOUD_TYPE=webdav
-      export RCLONE_CONFIG_NEXTCLOUD_URL="http://nextcloud/remote.php/dav/files/${adminuser}"
-      export RCLONE_CONFIG_NEXTCLOUD_VENDOR="nextcloud"
-      export RCLONE_CONFIG_NEXTCLOUD_USER="${adminuser}"
-      export RCLONE_CONFIG_NEXTCLOUD_PASS="$(${pkgs.rclone}/bin/rclone obscure ${adminpass})"
-      "''${@}"
-    '';
-    copySharedFile = pkgs.writeScript "copy-shared-file" ''
-      #!${pkgs.runtimeShell}
-      set -euxo pipefail
-      echo 'hello world' | ${pkgs.rclone}/bin/rclone rcat nextcloud:test-shared-file
-    '';
-
-    diffSharedFile = pkgs.writeScript "diff-shared-file" ''
-      #!${pkgs.runtimeShell}
-      set -euxo pipefail
-      diff <(echo 'hello world') <(${pkgs.rclone}/bin/rclone cat nextcloud:test-shared-file)
-    '';
-  in ''
-    start_all()
-    nextcloud.wait_for_unit("multi-user.target")
-    nextcloud.wait_for_unit("minio.service")
+  test-helpers.init = ''
     nextcloud.wait_for_open_port(9000)
-    nextcloud.succeed(
-        "mc config host add minio http://localhost:9000 ${accessKey} ${secretKey} --api s3v4"
-    )
-    nextcloud.succeed("mc mb minio/nextcloud")
-    nextcloud.succeed("curl -sSf http://nextcloud/login")
-
-    client.wait_for_unit("multi-user.target")
-    client.succeed(
-        "${withRcloneEnv} ${copySharedFile}"
-    )
-    nextcloud.succeed("${withRcloneEnv} ${diffSharedFile}")
-    client.wait_until_succeeds(
-        "${withRcloneEnv} ${diffSharedFile}"
-    )
-
-    nextcloud.succeed("mc ls --recursive minio >&2")
   '';
-})) args
+
+  test-helpers.extraTests = { nodes, ... }: ''
+    with subtest("File is not on the filesystem"):
+        nextcloud.succeed("test ! -e ${nodes.nextcloud.services.nextcloud.home}/data/root/files/test-shared-file")
+
+    with subtest("Check if file is in S3"):
+        nextcloud.succeed(
+            "mc config host add minio http://localhost:9000 ${accessKey} ${secretKey} --api s3v4"
+        )
+        files = nextcloud.succeed('mc ls minio/nextcloud|sort').strip().split('\n')
+
+        # Cannot assert an exact number here, nc27 writes more stuff initially into S3.
+        # For now let's assume it's always the most recently added file.
+        assert len(files) > 0, f"""
+          Expected to have at least one object in minio/nextcloud. But `mc ls` gave output:
+
+          '{files}'
+        """
+
+        import re
+        ptrn = re.compile("^\[[A-Z0-9 :-]+\] +(?P<details>[A-Za-z0-9 :]+)$")
+        match = ptrn.match(files[-1].strip())
+        assert match, "Cannot match mc client output!"
+        size, type_, file = tuple(match.group('details').split(' '))
+
+        assert size == "3B", f"""
+          Expected size of uploaded file to be 3 bytes, got {size}
+        """
+
+        assert type_ == 'STANDARD', f"""
+          Expected type of bucket entry to be a file, i.e. 'STANDARD'. Got {type_}
+        """
+
+        assert file.startswith('urn:oid'), """
+          Expected filename to start with 'urn:oid', instead got '{file}.
+        """
+
+    with subtest("Test download from S3"):
+        client.succeed(
+            "env AWS_ACCESS_KEY_ID=${accessKey} AWS_SECRET_ACCESS_KEY=${secretKey} "
+            + f"${lib.getExe pkgs.awscli2} s3 cp s3://nextcloud/{file} test --endpoint-url http://nextcloud:9000 "
+            + "--region us-east-1"
+        )
+
+        client.succeed("test hi = $(cat test)")
+  '';
+})

--- a/nixos/tests/nextcloud/with-postgresql-and-redis.nix
+++ b/nixos/tests/nextcloud/with-postgresql-and-redis.nix
@@ -1,45 +1,30 @@
-args@{ pkgs, nextcloudVersion ? 22, ... }:
+{ name, pkgs, testBase, system, ... }:
 
-(import ../make-test-python.nix ({ pkgs, ...}: let
-  adminpass = "hunter2";
-  adminuser = "custom-admin-username";
-in {
-  name = "nextcloud-with-postgresql-and-redis";
+with import ../../lib/testing-python.nix { inherit system pkgs; };
+runTest ({ config, ... }: {
+  inherit name;
   meta = with pkgs.lib.maintainers; {
-    maintainers = [ eqyiel ];
+    maintainers = [ eqyiel ma27 ];
   };
 
+  imports = [ testBase ];
+
   nodes = {
-    # The only thing the client needs to do is download a file.
-    client = { ... }: {};
-
     nextcloud = { config, pkgs, lib, ... }: {
-      networking.firewall.allowedTCPPorts = [ 80 ];
-
       services.nextcloud = {
-        enable = true;
-        hostName = "nextcloud";
-        package = pkgs.${"nextcloud" + (toString nextcloudVersion)};
         caching = {
           apcu = false;
           redis = true;
           memcached = false;
         };
-        database.createLocally = true;
-        config = {
-          dbtype = "pgsql";
-          inherit adminuser;
-          adminpassFile = toString (pkgs.writeText "admin-pass-file" ''
-            ${adminpass}
-          '');
-        };
+        config.dbtype = "pgsql";
         notify_push = {
           enable = true;
           logLevel = "debug";
         };
         extraAppsEnable = true;
-        extraApps = {
-          inherit (pkgs."nextcloud${lib.versions.major config.services.nextcloud.package.version}Packages".apps) notify_push notes;
+        extraApps = with config.services.nextcloud.package.packages.apps; {
+          inherit notify_push notes;
         };
         settings.trusted_proxies = [ "::1" ];
       };
@@ -49,50 +34,27 @@ in {
     };
   };
 
-  testScript = let
+  test-helpers.init = let
     configureRedis = pkgs.writeScript "configure-redis" ''
-      #!${pkgs.runtimeShell}
       nextcloud-occ config:system:set redis 'host' --value 'localhost' --type string
       nextcloud-occ config:system:set redis 'port' --value 6379 --type integer
       nextcloud-occ config:system:set memcache.local --value '\OC\Memcache\Redis' --type string
       nextcloud-occ config:system:set memcache.locking --value '\OC\Memcache\Redis' --type string
     '';
-    withRcloneEnv = pkgs.writeScript "with-rclone-env" ''
-      #!${pkgs.runtimeShell}
-      export RCLONE_CONFIG_NEXTCLOUD_TYPE=webdav
-      export RCLONE_CONFIG_NEXTCLOUD_URL="http://nextcloud/remote.php/dav/files/${adminuser}"
-      export RCLONE_CONFIG_NEXTCLOUD_VENDOR="nextcloud"
-      export RCLONE_CONFIG_NEXTCLOUD_USER="${adminuser}"
-      export RCLONE_CONFIG_NEXTCLOUD_PASS="$(${pkgs.rclone}/bin/rclone obscure ${adminpass})"
-      "''${@}"
-    '';
-    copySharedFile = pkgs.writeScript "copy-shared-file" ''
-      #!${pkgs.runtimeShell}
-      echo 'hi' | ${pkgs.rclone}/bin/rclone rcat nextcloud:test-shared-file
-    '';
-
-    diffSharedFile = pkgs.writeScript "diff-shared-file" ''
-      #!${pkgs.runtimeShell}
-      diff <(echo 'hi') <(${pkgs.rclone}/bin/rclone cat nextcloud:test-shared-file)
-    '';
   in ''
-    start_all()
-    nextcloud.wait_for_unit("multi-user.target")
     nextcloud.succeed("${configureRedis}")
-    nextcloud.succeed("curl -sSf http://nextcloud/login")
-    nextcloud.succeed(
-        "${withRcloneEnv} ${copySharedFile}"
-    )
-    client.wait_for_unit("multi-user.target")
-    client.execute("${pkgs.lib.getExe pkgs.nextcloud-notify_push.passthru.test_client} http://nextcloud ${adminuser} ${adminpass} >&2 &")
-    client.succeed(
-        "${withRcloneEnv} ${diffSharedFile}"
-    )
-    nextcloud.wait_until_succeeds("journalctl -u nextcloud-notify_push | grep -q \"Sending ping to ${adminuser}\"")
-
-    # redis cache should not be empty
-    nextcloud.fail('test "[]" = "$(redis-cli --json KEYS "*")"')
-
-    nextcloud.fail("curl -f http://nextcloud/nix-apps/notes/lib/AppInfo/Application.php")
   '';
-})) args
+
+  test-helpers.extraTests = ''
+    with subtest("notify-push"):
+        client.execute("${pkgs.lib.getExe pkgs.nextcloud-notify_push.passthru.test_client} http://nextcloud ${config.adminuser} ${config.adminpass} >&2 &")
+        nextcloud.wait_until_succeeds("journalctl -u nextcloud-notify_push | grep -q \"Sending ping to ${config.adminuser}\"")
+
+    with subtest("Redis is used for caching"):
+        # redis cache should not be empty
+        nextcloud.fail('test "[]" = "$(redis-cli --json KEYS "*")"')
+
+    with subtest("No code is returned when requesting PHP files (regression test)"):
+        nextcloud.fail("curl -f http://nextcloud/nix-apps/notes/lib/AppInfo/Application.php")
+  '';
+})


### PR DESCRIPTION
## Description of changes

Closes #288323

__Note:__ even though these are two separate changes, I recommend to review the full diff and not commit-by-commit.

---

Add testcase for the objectstore/s3 integration

---

The tests had very much duplication and some if it was even wrong! For
instance, `withRcloneEnv` in the MySQL test didn't have the `"$@"` at
the bottom to execute commands passed to it. Because of that, the MySQL
testcase never checked whether files can be uploaded.

Since tests are just another module-system I decided to abstract away
common things by using it:

* Define a base module with
  * an empty `client` node and a `nextcloud` node with defaults
    shared among all tests.
  * rclone scripts that are used by all tests.
  * a `testScript` checking upload/download. Additional checks can be
    added via `test-helpers.extraTests`.

* Make common information such as admin user & password shared via
  options.

Also, changed the following things:

* The `name` of the final derivation also includes the Nextcloud major
  it was tested against.

* Improved the objecstore test by making sure the file was actually
  uploaded into the bucket.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
