### PR TITLE
cargo-bolero: 0.9.0 → 0.11.2

### DIFF
--- a/pkgs/development/tools/rust/cargo-bolero/default.nix
+++ b/pkgs/development/tools/rust/cargo-bolero/default.nix
@@ -1,17 +1,21 @@
-{ lib, rustPlatform, fetchCrate, libbfd, libopcodes, libunwind }:
+{ lib, rustPlatform, fetchCrate, libbfd, libopcodes, libunwind, nix-update-script }:
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-bolero";
-  version = "0.9.0";
+  version = "0.11.2";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-BuqbM55P/st+4XUSCwrqILUUCfwvSlxhKQFO+IZLa8U=";
+    sha256 = "sha256-Xcu91CbIDBLSojWQJjvdFWJiqjMteAxF105lemCAipk=";
   };
 
-  cargoSha256 = "sha256-+TxMOKoId13meXqmr1QjDZMNqBnPEDQF1VSPheq8Ji0=";
+  cargoSha256 = "sha256-QLtf42Il+XHWeaUdh8jNNWU1sXaVe82sYOKiHLoXw2M=";
 
   buildInputs = [ libbfd libopcodes libunwind ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = with lib; {
     description = "Fuzzing and property testing front-end framework for Rust";


### PR DESCRIPTION
## Description of changes

~~Currently broken by https://github.com/camshaft/bolero/issues/232~~

Thanks to newly introduced `random` engine, it is possible to use it on rustc from Nixpkgs with `--sanitizer NONE --engine random`. Other engines do not work because of https://github.com/camshaft/bolero/issues/79, honggfuzz is still disabled by default, and it got broken by binutils bump anyway (https://github.com/camshaft/bolero/issues/233).

- 0.10.0:
  https://github.com/camshaft/bolero/compare/v0.9.0...36d41b8fea358b30afbc63f2c189ca608470c1fb
- 0.11.0:
  https://github.com/camshaft/bolero/compare/36d41b8fea358b30afbc63f2c189ca608470c1fb...be95281871ef6ba4bc95f10947af554dfe1aa1a4
- 0.11.1:
  https://www.github.com/camshaft/bolero/pull/230
  https://github.com/camshaft/bolero/compare/be95281871ef6ba4bc95f10947af554dfe1aa1a4...004acbf825a14c02e70da9811ce99e5514d68c4f
- 0.11.2:
  https://github.com/camshaft/bolero/compare/004acbf825a14c02e70da9811ce99e5514d68c4f...b2f578f843714824b51e814e0dcecb71766ca314

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc @ghpzin

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
