### PR TITLE
j4-dmenu-desktop: unstable-2023-09-12 -> r3.2

### DIFF
--- a/pkgs/by-name/j4/j4-dmenu-desktop/package.nix
+++ b/pkgs/by-name/j4/j4-dmenu-desktop/package.nix
@@ -1,14 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, cmake, dmenu }:
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, dmenu, fmt, spdlog }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "j4-dmenu-desktop";
-  version = "unstable-2023-09-12";
+  version = "3.2";
 
   src = fetchFromGitHub {
     owner = "enkore";
     repo = "j4-dmenu-desktop";
-    rev = "7e3fd045482a8ea70619e422975b52feabc75175";
-    hash = "sha256-8PmfzQkHlEdMbrcQO0bPruP3jaKEcr/17x0/Z7Jedh0=";
+    rev = "r${finalAttrs.version}";
+    hash = "sha256-Yrn6d2x9xOSV5FK0YP/mfD6BG9DeWlWobVafEzVYVJY=";
   };
 
   postPatch = ''
@@ -16,12 +16,22 @@ stdenv.mkDerivation (finalAttrs: {
         --replace "dmenu -i" "${lib.getExe dmenu} -i"
   '';
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
 
-  # tests are fetching an external git repository
-  cmakeFlags = [
-    "-DWITH_TESTS=OFF"
-    "-DWITH_GIT_CATCH=OFF"
+  buildInputs = [
+    fmt
+    spdlog
+  ];
+
+  mesonFlags = [
+    # Disable unit tests.
+    "-Denable-tests=false"
+    # Copy pre-generated shell completions.
+    "-Dgenerate-shell-completions=disabled"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
* Upgrade to 3.2
* Add `fmt` dependency
* Add `spdlog` dependency
* Switch to meson build system.

Upstream changelog: https://github.com/enkore/j4-dmenu-desktop/blob/r3.2/CHANGELOG
Changes since unstable revision: https://github.com/enkore/j4-dmenu-desktop/compare/7e3fd045482a8ea70619e422975b52feabc75175...r3.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
