### PR TITLE
spacenavd: 0.8 -> 1.3

### DIFF
--- a/pkgs/misc/drivers/spacenavd/configure-cfgfile-path.patch
+++ b/pkgs/misc/drivers/spacenavd/configure-cfgfile-path.patch
@@ -1,5 +1,5 @@
 diff --git a/src/spnavd.c b/src/spnavd.c
-index 2d4eca6..a5227ed 100644
+index f9722ed..8cfeffc 100644
 --- a/src/spnavd.c
 +++ b/src/spnavd.c
 @@ -27,6 +27,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
@@ -11,53 +11,54 @@ index 2d4eca6..a5227ed 100644
  #include "spnavd.h"
  #include "logger.h"
  #include "dev.h"
-@@ -47,13 +49,39 @@ static void handle_events(fd_set *rset);
+@@ -48,7 +50,32 @@ static void handle_events(fd_set *rset);
  static void sig_handler(int s);
  static char *fix_path(char *str);
  
--static char *cfgfile = DEF_CFGFILE;
+-char *cfgfile = DEF_CFGFILE;
 +static char* config_path;
 +char* cfg_path()
 +{
-+	char* buf;
-+	if((buf = getenv("XDG_CONFIG_HOME"))) {
-+		if(config_path == NULL) {
-+			config_path = malloc(strlen(buf) + strlen("/spnavrc") + 1);
-+			if ( config_path != NULL) {
-+				sprintf(config_path, "%s/spnavrc", buf);
-+			}
-+		};
-+		return config_path;
-+	} else {
-+		if (!(buf = getenv("HOME"))) {
-+			struct passwd *pw = getpwuid(getuid());
-+			buf = pw->pw_dir;
-+		}
-+		config_path = malloc(strlen(buf) + strlen("/.config/spnavrc") + 1);
-+		if ( config_path != NULL) {
-+			sprintf(config_path, "%s/.config/spnavrc", buf);
-+		}
-+		return config_path;
-+	}
++ char* buf;
++ if((buf = getenv("XDG_CONFIG_HOME"))) {
++   if(config_path == NULL) {
++     config_path = malloc(strlen(buf) + strlen("/spnavrc") + 1);
++     if ( config_path != NULL) {
++       sprintf(config_path, "%s/spnavrc", buf);
++     }
++   };
++   return config_path;
++ } else {
++   if (!(buf = getenv("HOME"))) {
++     struct passwd *pw = getpwuid(getuid());
++     buf = pw->pw_dir;
++   }
++   config_path = malloc(strlen(buf) + strlen("/.config/spnavrc") + 1);
++   if ( config_path != NULL) {
++     sprintf(config_path, "%s/.config/spnavrc", buf);
++   }
++   return config_path;
++ }
 +}
 +
-+static char *cfgfile = NULL;
++char *cfgfile = NULL;
  static char *logfile = DEF_LOGFILE;
  static char *pidpath = NULL;
- 
+ static int pfd[2];
+@@ -56,6 +83,7 @@ static int pfd[2];
  int main(int argc, char **argv)
  {
  	int i, pid, ret, become_daemon = 1;
 +	cfgfile = cfg_path();
+ 	int force_logfile = 0;
  
  	for(i=1; i<argc; i++) {
- 		if(argv[i][0] == '-') {
-@@ -247,7 +275,7 @@ static void print_usage(const char *argv0)
+@@ -266,7 +294,7 @@ static void print_usage(const char *argv0)
  	printf("usage: %s [options]\n", argv0);
  	printf("options:\n");
  	printf(" -d: do not daemonize\n");
 -	printf(" -c <file>: config file path (default: " DEF_CFGFILE ")\n");
 +	printf(" -c <file>: config file path (default: %s)\n", cfg_path());
  	printf(" -l <file>|syslog: log file path or log to syslog (default: " DEF_LOGFILE ")\n");
- 	printf(" -v: verbose output\n");
+ 	printf(" -v: verbose output (use multiple times for greater effect)\n");
  	printf(" -V,-version: print version number and exit\n");

--- a/pkgs/misc/drivers/spacenavd/configure-pidfile-path.patch
+++ b/pkgs/misc/drivers/spacenavd/configure-pidfile-path.patch
@@ -1,8 +1,8 @@
 diff --git a/src/spnavd.c b/src/spnavd.c
-index 03080da..2d4eca6 100644
+index 084cd62..f9722ed 100644
 --- a/src/spnavd.c
 +++ b/src/spnavd.c
-@@ -42,12 +42,14 @@ static void cleanup(void);
+@@ -43,12 +43,14 @@ static void redir_log(int fallback_syslog);
  static void daemonize(void);
  static int write_pid_file(void);
  static int find_running_daemon(void);
@@ -11,13 +11,13 @@ index 03080da..2d4eca6 100644
  static void sig_handler(int s);
  static char *fix_path(char *str);
  
- static char *cfgfile = DEF_CFGFILE;
+ char *cfgfile = DEF_CFGFILE;
  static char *logfile = DEF_LOGFILE;
 +static char *pidpath = NULL;
+ static int pfd[2];
  
  int main(int argc, char **argv)
- {
-@@ -270,7 +272,7 @@ static void cleanup(void)
+@@ -289,7 +291,7 @@ static void cleanup(void)
  		remove_device(tmp);
  	}
  
@@ -25,8 +25,8 @@ index 03080da..2d4eca6 100644
 +	remove(pidfile_path());
  }
  
- static void daemonize(void)
-@@ -314,7 +316,7 @@ static int write_pid_file(void)
+ static void redir_log(int fallback_syslog)
+@@ -348,7 +350,7 @@ static int write_pid_file(void)
  	FILE *fp;
  	int pid = getpid();
  
@@ -35,7 +35,7 @@ index 03080da..2d4eca6 100644
  		return -1;
  	}
  	fprintf(fp, "%d\n", pid);
-@@ -329,7 +331,7 @@ static int find_running_daemon(void)
+@@ -363,7 +365,7 @@ static int find_running_daemon(void)
  	struct sockaddr_un addr;
  
  	/* try to open the pid-file */
@@ -44,39 +44,38 @@ index 03080da..2d4eca6 100644
  		return -1;
  	}
  	if(fscanf(fp, "%d\n", &pid) != 1) {
-@@ -356,6 +358,22 @@ static int find_running_daemon(void)
+@@ -390,6 +392,22 @@ static int find_running_daemon(void)
  	return pid;
  }
  
 +char *pidfile_path(void)
 +{
-+	char *xdg_runtime_dir;
-+	if((xdg_runtime_dir = getenv("XDG_RUNTIME_DIR"))) {
-+		if ( pidpath == NULL ) {
-+			pidpath = malloc(strlen(xdg_runtime_dir) + strlen("/spnavd.pid") + 1);
-+			if ( pidpath != NULL ) {
-+				sprintf(pidpath, "%s/spnavd.pid", xdg_runtime_dir);
-+			}
-+		};
-+		return pidpath;
-+	} else {
-+		return DEFAULT_PIDFILE;
-+	}
++ char *xdg_runtime_dir;
++ if((xdg_runtime_dir = getenv("XDG_RUNTIME_DIR"))) {
++   if ( pidpath == NULL ) {
++     pidpath = malloc(strlen(xdg_runtime_dir) + strlen("/spnavd.pid") + 1);
++     if ( pidpath != NULL ) {
++       sprintf(pidpath, "%s/spnavd.pid", xdg_runtime_dir);
++     }
++   };
++   return pidpath;
++ } else {
++   return DEFAULT_PIDFILE;
++ }
 +}
 +
  static void handle_events(fd_set *rset)
  {
  	int dev_fd, hotplug_fd;
 diff --git a/src/spnavd.h b/src/spnavd.h
-index 2d1c48b..17d22d3 100644
+index 084a386..77bdab9 100644
 --- a/src/spnavd.h
 +++ b/src/spnavd.h
 @@ -26,7 +26,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
- #define DEF_CFGFILE		"/etc/spnavrc"
+ #define DEF_CFGFILE		CFGDIR "/spnavrc"
  #define DEF_LOGFILE		"/var/log/spnavd.log"
  
 -#define PIDFILE		"/var/run/spnavd.pid"
 +#define DEFAULT_PIDFILE		"/run/spnavd.pid"
- #define DEFAULT_SOCK_NAME	"/run/spnav.sock"
  #define SYSLOG_ID	"spnavd"
- 
+ #define DEFAULT_SOCK_NAME  "/run/spnav.sock"

--- a/pkgs/misc/drivers/spacenavd/configure-socket-path.patch
+++ b/pkgs/misc/drivers/spacenavd/configure-socket-path.patch
@@ -1,13 +1,13 @@
 diff --git a/src/proto_unix.c b/src/proto_unix.c
-index 998f234..d38452c 100644
+index 20a3334..2b9b3a8 100644
 --- a/src/proto_unix.c
 +++ b/src/proto_unix.c
-@@ -36,11 +36,14 @@ enum {
+@@ -43,12 +43,14 @@ static int lsock = -1;
  
- static int lsock = -1;
- 
+ static int handle_request(struct client *c, struct reqresp *req);
+ static const char *reqstr(int req);
 +static char *spath = NULL;
-+
+ 
  int init_unix(void)
  {
  	int s;
@@ -17,7 +17,7 @@ index 998f234..d38452c 100644
  
  	if(lsock >= 0) return 0;
  
-@@ -49,16 +52,18 @@ int init_unix(void)
+@@ -57,16 +59,18 @@ int init_unix(void)
  		return -1;
  	}
  
@@ -39,7 +39,7 @@ index 998f234..d38452c 100644
  		close(s);
  		return -1;
  	}
-@@ -68,7 +73,7 @@ int init_unix(void)
+@@ -76,7 +80,7 @@ int init_unix(void)
  	if(listen(s, 8) == -1) {
  		logmsg(LOG_ERR, "listen failed: %s\n", strerror(errno));
  		close(s);
@@ -48,7 +48,7 @@ index 998f234..d38452c 100644
  		return -1;
  	}
  
-@@ -82,7 +87,7 @@ void close_unix(void)
+@@ -90,7 +94,7 @@ void close_unix(void)
  		close(lsock);
  		lsock = -1;
  
@@ -57,26 +57,29 @@ index 998f234..d38452c 100644
  	}
  }
  
-@@ -173,3 +178,19 @@ int handle_uevents(fd_set *rset)
- 
+@@ -653,6 +657,22 @@ static int handle_request(struct client *c, struct reqresp *req)
  	return 0;
  }
-+
+ 
 +char *socket_path(void)
 +{
-+	char *xdg_runtime_dir;
-+	if((xdg_runtime_dir = getenv("XDG_RUNTIME_DIR"))) {
-+		if ( spath == NULL ) {
-+			spath = malloc(strlen(xdg_runtime_dir) + strlen("/spnav.sock") + 1);
-+			if ( spath != NULL ) {
-+				sprintf(spath, "%s/spnav.sock", xdg_runtime_dir);
-+			}
-+		};
-+		return spath;
-+	} else {
-+		return DEFAULT_SOCK_NAME;
-+	}
++ char *xdg_runtime_dir;
++ if((xdg_runtime_dir = getenv("XDG_RUNTIME_DIR"))) {
++   if ( spath == NULL ) {
++     spath = malloc(strlen(xdg_runtime_dir) + strlen("/spnav.sock") + 1);
++     if ( spath != NULL ) {
++       sprintf(spath, "%s/spnav.sock", xdg_runtime_dir);
++     }
++   };
++   return spath;
++ } else {
++   return DEFAULT_SOCK_NAME;
++ }
 +}
++
+ static const char *reqstr(int req)
+ {
+ 	static char buf[8];
 diff --git a/src/proto_unix.h b/src/proto_unix.h
 index 045b379..ec4509c 100644
 --- a/src/proto_unix.h
@@ -90,10 +93,10 @@ index 045b379..ec4509c 100644
  void close_unix(void);
  int get_unix_socket(void);
 diff --git a/src/spnavd.c b/src/spnavd.c
-index cbea191..03080da 100644
+index b0ed791..084cd62 100644
 --- a/src/spnavd.c
 +++ b/src/spnavd.c
-@@ -344,7 +344,7 @@ static int find_running_daemon(void)
+@@ -378,7 +378,7 @@ static int find_running_daemon(void)
  	}
  	memset(&addr, 0, sizeof addr);
  	addr.sun_family = AF_UNIX;
@@ -103,16 +106,17 @@ index cbea191..03080da 100644
  	if(connect(s, (struct sockaddr*)&addr, sizeof addr) == -1) {
  		close(s);
 diff --git a/src/spnavd.h b/src/spnavd.h
-index fa0a916..2d1c48b 100644
+index 89e2c65..084a386 100644
 --- a/src/spnavd.h
 +++ b/src/spnavd.h
-@@ -26,8 +26,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
- #define DEF_CFGFILE		"/etc/spnavrc"
+@@ -26,9 +26,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ #define DEF_CFGFILE		CFGDIR "/spnavrc"
  #define DEF_LOGFILE		"/var/log/spnavd.log"
  
 -#define SOCK_NAME	"/var/run/spnav.sock"
  #define PIDFILE		"/var/run/spnavd.pid"
-+#define DEFAULT_SOCK_NAME	"/run/spnav.sock"
  #define SYSLOG_ID	"spnavd"
++#define DEFAULT_SOCK_NAME  "/run/spnav.sock"
  
  /* Multiple devices support */
+ #ifndef MAX_DEVICES

--- a/pkgs/misc/drivers/spacenavd/default.nix
+++ b/pkgs/misc/drivers/spacenavd/default.nix
@@ -1,22 +1,17 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, libX11, IOKit }:
+{ stdenv, lib, fetchFromGitHub, fetchpatch, libX11, IOKit, xorg }:
 
 stdenv.mkDerivation rec {
-  version = "0.8";
+  version = "1.3";
   pname = "spacenavd";
 
   src = fetchFromGitHub {
     owner = "FreeSpacenav";
     repo = "spacenavd";
     rev = "v${version}";
-    sha256 = "1zz0cm5cgvp9s5n4nzksl8rb11c7sw214bdafzra74smvqfjcjcf";
+    sha256 = "sha256-26geQYOXjMZZ/FpPpav7zfql0davTBwB4Ir+X1oep9Q=";
   };
 
   patches = [
-    # Fixes Darwin: https://github.com/FreeSpacenav/spacenavd/pull/38
-    (fetchpatch {
-      url = "https://github.com/FreeSpacenav/spacenavd/commit/d6a25d5c3f49b9676d039775efc8bf854737c43c.patch";
-      sha256 = "02pdgcvaqc20qf9hi3r73nb9ds7yk2ps9nnxaj0x9p50xjnhfg5c";
-    })
     # Changes the socket path from /run/spnav.sock to $XDG_RUNTIME_DIR/spnav.sock
     # to allow for a user service
     ./configure-socket-path.patch
@@ -28,7 +23,7 @@ stdenv.mkDerivation rec {
     ./configure-cfgfile-path.patch
   ];
 
-  buildInputs = [ libX11 ]
+  buildInputs = [ libX11 xorg.libXext ]
     ++ lib.optional stdenv.isDarwin IOKit;
 
   configureFlags = [ "--disable-debug" ];


### PR DESCRIPTION
## Description of changes

* Update package source from 0.8 to 1.3
* Port Nixpkgs specific fixes to allow running as a user service

## Things done

This was tested by using the daemon in my local system with FreeCAD successfully. While my SpacePilot Pro buttons were not detected using the old version, with the new version, this issue is gone.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
