### PR TITLE
unl0kr: 2.0.0 -> 3.2.0

### DIFF
--- a/pkgs/by-name/un/unl0kr/package.nix
+++ b/pkgs/by-name/un/unl0kr/package.nix
@@ -14,16 +14,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "unl0kr";
-  version = "2.0.0";
+  version = "3.2.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.com";
-    owner = "cherrypicker";
-    repo = "unl0kr";
+    owner = "postmarketOS";
+    repo = "buffybox";
     rev = finalAttrs.version;
-    fetchSubmodules = true;
-    hash = "sha256-KPP4Ol1GCAWqdQYlNtKQD/jx8A/xuHdvKjcocPMqWa0=";
+    fetchSubmodules = true;  # to use its vendored lvgl
+    hash = "sha256-nZX7mSY9IBIhVNmOD6mXI1IF2TgyKLc00a8ADAvVLB0=";
   };
+
+  sourceRoot = "source/unl0kr";
 
   nativeBuildInputs = [
     meson
@@ -43,6 +45,8 @@ stdenv.mkDerivation (finalAttrs: {
     libxkbcommon
   ];
 
+  strictDeps = false;  # upstream incorrectly specifies `scdoc` as a runtime dependency
+
   passthru = {
     tests.unl0kr = nixosTests.systemd-initrd-luks-unl0kr;
   };
@@ -50,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     description = "Framebuffer-based disk unlocker for the initramfs based on LVGL";
     mainProgram = "unl0kr";
-    homepage = "https://gitlab.com/cherrypicker/unl0kr";
+    homepage = "https://gitlab.com/postmarketOS/buffybox";
     license = licenses.gpl3Plus;
     maintainers = [];
     platforms = platforms.linux;


### PR DESCRIPTION
## Description of changes

- changelogs: <https://gitlab.com/postmarketOS/buffybox/-/releases>
  - new themes
  - UI fixes for the shutdown button
  - update vendored lvgl to 2023-06-03
- unl0kr has been moved to the buffybox umbrella project, [as announced in the old repo](https://gitlab.com/cherrypicker/unl0kr/-/commit/323629cfec302559b9c080a5a2c2eb0565fe7534)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux  (and `pkgCross.aarch64-multiplatform`, `pkgsCross.armv7l-hf-multiplatform`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
