### PR TITLE
ocaml: remove left-over builder.sh

### DIFF
--- a/pkgs/development/compilers/ocaml/builder.sh
+++ b/pkgs/development/compilers/ocaml/builder.sh
@@ -1,9 +1,0 @@
-if [ -e "$NIX_ATTRS_SH_FILE" ]; then . "$NIX_ATTRS_SH_FILE"; elif [ -f .attrs.sh ]; then . .attrs.sh; fi
-source $stdenv/setup
-
-configureFlags="-prefix $out $configureFlags"
-genericBuild
-
-#cd emacs/
-#mkdir -p $out/share/ocaml/emacs
-#make EMACSDIR=$out/share/ocaml/emacs install


### PR DESCRIPTION
## Description of changes

This file was last used in 3.08.0.nix removed in #114848 3 years ago.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
