### PR TITLE
android-ndks: add 25, 26 ndks, update default ndk and sdk

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -60,23 +60,23 @@ rec {
   armv7a-android-prebuilt = {
     config = "armv7a-unknown-linux-androideabi";
     rust.rustcTarget = "armv7-linux-androideabi";
-    sdkVer = "28";
-    ndkVer = "24";
+    sdkVer = "33";
+    ndkVer = "26";
     useAndroidPrebuilt = true;
   } // platforms.armv7a-android;
 
   aarch64-android-prebuilt = {
     config = "aarch64-unknown-linux-android";
     rust.rustcTarget = "aarch64-linux-android";
-    sdkVer = "28";
-    ndkVer = "24";
+    sdkVer = "33";
+    ndkVer = "26";
     useAndroidPrebuilt = true;
   };
 
   aarch64-android = {
     config = "aarch64-unknown-linux-android";
-    sdkVer = "30";
-    ndkVer = "24";
+    sdkVer = "33";
+    ndkVer = "26";
     libc = "bionic";
     useAndroidPrebuilt = false;
     useLLVM = true;

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -49,6 +49,10 @@
   before changing the package to `pkgs.stalwart-mail` in
   [`services.stalwart-mail.package`](#opt-services.stalwart-mail.package).
 
+- `androidndkPkgs` has been updated to `androidndkPkgs_26`.
+
+- Android NDK version 26 and SDK version 33 are now the default versions used for cross compilation to android.
+
 - `haskell.lib.compose.justStaticExecutables` now disallows references to GHC in the
   output by default, to alert users to closure size issues caused by
   [#164630](https://github.com/NixOS/nixpkgs/issues/164630). See ["Packaging

--- a/pkgs/development/androidndk-pkgs/default.nix
+++ b/pkgs/development/androidndk-pkgs/default.nix
@@ -37,4 +37,5 @@ in
   "23b" = makeNdkPkgs "23.1.7779620";
   "24" = makeNdkPkgs "24.0.8215888";
   "25" = makeNdkPkgs "25.2.9519653";
+  "26" = makeNdkPkgs "26.3.11579264";
 }

--- a/pkgs/development/androidndk-pkgs/default.nix
+++ b/pkgs/development/androidndk-pkgs/default.nix
@@ -36,4 +36,5 @@ in
   "21" = makeNdkPkgs "21.0.6113669";
   "23b" = makeNdkPkgs "23.1.7779620";
   "24" = makeNdkPkgs "24.0.8215888";
+  "25" = makeNdkPkgs "25.2.9519653";
 }

--- a/pkgs/development/androidndk-pkgs/default.nix
+++ b/pkgs/development/androidndk-pkgs/default.nix
@@ -1,95 +1,39 @@
 { lib, androidenv, buildPackages, pkgs, targetPackages
 }:
 
+let
+  makeNdkPkgs = ndkVersion:
+    let
+      buildAndroidComposition = buildPackages.buildPackages.androidenv.composeAndroidPackages {
+        includeNDK = true;
+        inherit ndkVersion;
+      };
+
+      androidComposition = androidenv.composeAndroidPackages {
+        includeNDK = true;
+        inherit ndkVersion;
+      };
+      majorVersion = lib.versions.major ndkVersion;
+    in
+    import ./androidndk-pkgs.nix {
+      inherit lib;
+      inherit (buildPackages)
+        makeWrapper autoPatchelfHook;
+      inherit (pkgs)
+        stdenv
+        runCommand wrapBintoolsWith wrapCCWith;
+      # buildPackages.foo rather than buildPackages.buildPackages.foo would work,
+      # but for splicing messing up on infinite recursion for the variants we
+      # *dont't* use. Using this workaround, but also making a test to ensure
+      # these two really are the same.
+      buildAndroidndk = buildAndroidComposition.ndk-bundle;
+      androidndk = androidComposition.ndk-bundle;
+      targetAndroidndkPkgs = if targetPackages ? "androidndkPkgs_${majorVersion}" then targetPackages."androidndkPkgs_${majorVersion}" else throw "androidndkPkgs_${majorVersion}: no targetPackages, use `buildPackages.androidndkPkgs_${majorVersion}";
+    };
+in
+
 {
-  "21" =
-    let
-      ndkVersion = "21.0.6113669";
-
-      buildAndroidComposition = buildPackages.buildPackages.androidenv.composeAndroidPackages {
-        includeNDK = true;
-        inherit ndkVersion;
-      };
-
-      androidComposition = androidenv.composeAndroidPackages {
-        includeNDK = true;
-        inherit ndkVersion;
-      };
-    in
-    import ./androidndk-pkgs.nix {
-      inherit lib;
-      inherit (buildPackages)
-        makeWrapper autoPatchelfHook;
-      inherit (pkgs)
-        stdenv
-        runCommand wrapBintoolsWith wrapCCWith;
-      # buildPackages.foo rather than buildPackages.buildPackages.foo would work,
-      # but for splicing messing up on infinite recursion for the variants we
-      # *dont't* use. Using this workaround, but also making a test to ensure
-      # these two really are the same.
-      buildAndroidndk = buildAndroidComposition.ndk-bundle;
-      androidndk = androidComposition.ndk-bundle;
-      targetAndroidndkPkgs = if targetPackages ? androidndkPkgs_21 then targetPackages.androidndkPkgs_21 else throw "androidndkPkgs_21: no targetPackages, use `buildPackages.androidndkPkgs_21";
-    };
-
-  "23b" =
-    let
-      ndkVersion = "23.1.7779620";
-
-      buildAndroidComposition = buildPackages.buildPackages.androidenv.composeAndroidPackages {
-        includeNDK = true;
-        inherit ndkVersion;
-      };
-
-      androidComposition = androidenv.composeAndroidPackages {
-        includeNDK = true;
-        inherit ndkVersion;
-      };
-    in
-    import ./androidndk-pkgs.nix {
-      inherit lib;
-      inherit (buildPackages)
-        makeWrapper autoPatchelfHook;
-      inherit (pkgs)
-        stdenv
-        runCommand wrapBintoolsWith wrapCCWith;
-      # buildPackages.foo rather than buildPackages.buildPackages.foo would work,
-      # but for splicing messing up on infinite recursion for the variants we
-      # *dont't* use. Using this workaround, but also making a test to ensure
-      # these two really are the same.
-      buildAndroidndk = buildAndroidComposition.ndk-bundle;
-      androidndk = androidComposition.ndk-bundle;
-      targetAndroidndkPkgs = if targetPackages ? androidndkPkgs_23b then targetPackages.androidndkPkgs_23b else throw "androidndkPkgs_23b: no targetPackages, use `buildPackages.androidndkPkgs_23b";
-    };
-
-  "24" =
-    let
-      ndkVersion = "24.0.8215888";
-
-      buildAndroidComposition = buildPackages.buildPackages.androidenv.composeAndroidPackages {
-        includeNDK = true;
-        inherit ndkVersion;
-      };
-
-      androidComposition = androidenv.composeAndroidPackages {
-        includeNDK = true;
-        inherit ndkVersion;
-      };
-    in
-    import ./androidndk-pkgs.nix {
-      inherit lib;
-      inherit (buildPackages)
-        makeWrapper autoPatchelfHook;
-      inherit (pkgs)
-        stdenv
-        runCommand wrapBintoolsWith wrapCCWith;
-      # buildPackages.foo rather than buildPackages.buildPackages.foo would work,
-      # but for splicing messing up on infinite recursion for the variants we
-      # *dont't* use. Using this workaround, but also making a test to ensure
-      # these two really are the same.
-      buildAndroidndk = buildAndroidComposition.ndk-bundle;
-      androidndk = androidComposition.ndk-bundle;
-      targetAndroidndkPkgs = if targetPackages ? androidndkPkgs_24 then targetPackages.androidndkPkgs_24 else throw "androidndkPkgs_24: no targetPackages, use `buildPackages.androidndkPkgs_24";
-    };
-
+  "21" = makeNdkPkgs "21.0.6113669";
+  "23b" = makeNdkPkgs "23.1.7779620";
+  "24" = makeNdkPkgs "24.0.8215888";
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4084,6 +4084,7 @@ with pkgs;
   androidndkPkgs_23b = (callPackage ../development/androidndk-pkgs {})."23b";
   androidndkPkgs_24 = (callPackage ../development/androidndk-pkgs {})."24";
   androidndkPkgs_25 = (callPackage ../development/androidndk-pkgs {})."25";
+  androidndkPkgs_26 = (callPackage ../development/androidndk-pkgs {})."26";
 
   androidsdk = androidenv.androidPkgs.androidsdk;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4079,7 +4079,7 @@ with pkgs;
 
   androidenv = callPackage ../development/mobile/androidenv { };
 
-  androidndkPkgs = androidndkPkgs_21;
+  androidndkPkgs = androidndkPkgs_26;
   androidndkPkgs_21 = (callPackage ../development/androidndk-pkgs {})."21";
   androidndkPkgs_23b = (callPackage ../development/androidndk-pkgs {})."23b";
   androidndkPkgs_24 = (callPackage ../development/androidndk-pkgs {})."24";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4083,6 +4083,7 @@ with pkgs;
   androidndkPkgs_21 = (callPackage ../development/androidndk-pkgs {})."21";
   androidndkPkgs_23b = (callPackage ../development/androidndk-pkgs {})."23b";
   androidndkPkgs_24 = (callPackage ../development/androidndk-pkgs {})."24";
+  androidndkPkgs_25 = (callPackage ../development/androidndk-pkgs {})."25";
 
   androidsdk = androidenv.androidPkgs.androidsdk;
 


### PR DESCRIPTION
## Description of changes

- refactor androidndkPkgs to remove code duplication
- adds ndk 25 and 26
- sets default ndk to 26
- sets default android sdk to 33

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
