### PR TITLE
dep-tree: init at 0.20.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2718,6 +2718,11 @@
     githubId = 30630233;
     name = "Timo Triebensky";
   };
+  birdee = {
+    name = "birdee";
+    github = "BirdeeHub";
+    githubId = 85372418;
+  };
   birkb = {
     email = "birk@batchworks.de";
     github = "birkb";

--- a/pkgs/by-name/de/dep-tree/package.nix
+++ b/pkgs/by-name/de/dep-tree/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  linkFarm,
+}:
+let
+  testDeps = {
+    react-stl-viewer = fetchFromGitHub {
+      owner = "gabotechs";
+      repo = "react-stl-viewer";
+      rev = "2.2.4";
+      sha256 = "sha256-0u9q0UgOn43PE1Y6BUhl1l6RnVjpPraFqZWB+HhQ0s8=";
+    };
+    react-gcode-viewer = fetchFromGitHub {
+      owner = "gabotechs";
+      repo = "react-gcode-viewer";
+      rev = "2.2.4";
+      sha256 = "sha256-FHBICLdy0k4j3pPKStg+nkIktMpKS1ADa4m1vYHJ+AQ=";
+    };
+    graphql-js = fetchFromGitHub {
+      owner = "graphql";
+      repo = "graphql-js";
+      rev = "v17.0.0-alpha.2";
+      sha256 = "sha256-y55SNiMivL7bRsjLEIpsKKyaluI4sXhREpiB6A5jfDU=";
+    };
+    warp = fetchFromGitHub {
+      owner = "seanmonstar";
+      repo = "warp";
+      rev = "v0.3.3";
+      sha256 = "sha256-76ib8KMjTS2iUOwkQYCsoeL3GwBaA/MRQU2eGjJEpOo=";
+    };
+  };
+  pname = "dep-tree";
+  version = "0.20.3";
+in
+buildGoModule {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "gabotechs";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-w0t6SF0Kqr+XAKPNJpDJGDTm2Tc6J9OzbXtRUNkqp2k=";
+  };
+
+  vendorHash = "sha256-ZDADo1takCemPGYySLwPAODUF+mEJXsaxZn4WWmaUR8=";
+
+  preCheck = ''
+    substituteInPlace internal/tui/tui_test.go \
+      --replace-fail /tmp/dep-tree-tests ${linkFarm "dep-tree_testDeps-farm" testDeps}
+  '';
+
+  meta = {
+    description = "Tool for visualizing interconnectedness of codebases in multiple languages";
+    longDescription = ''
+      dep-tree is a tool for interactively visualizing the complexity of a code base.
+      It helps analyze the interconnectedness of the codebase and create goals to improve maintainability.
+    '';
+    homepage = "https://github.com/gabotechs/dep-tree";
+    changelog = "https://github.com/gabotechs/dep-tree/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ birdee ];
+    mainProgram = "dep-tree";
+  };
+}


### PR DESCRIPTION
## Description of changes

[added dep-tree](https://github.com/gabotechs/dep-tree)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
