### PR TITLE
init: trunk-recorder at 4.7.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13149,6 +13149,12 @@
       fingerprint = "D709 03C8 0BE9 ACDC 14F0  3BFB 77BF E531 397E DE94";
     }];
   };
+  mcdonc = {
+    email = "chrism@plope.com";
+    github = "mcdonc";
+    githubId = 125174;
+    name = "Chris McDonough";
+  };
   mcmtroffaes = {
     email = "matthias.troffaes@gmail.com";
     github = "mcmtroffaes";

--- a/pkgs/by-name/tr/trunk-recorder/package.nix
+++ b/pkgs/by-name/tr/trunk-recorder/package.nix
@@ -31,7 +31,6 @@
 , sox
 , fdk-aac-encoder
 }:
-
 stdenv.mkDerivation rec {
   pname = "trunk-recorder";
   version = "4.7.1";

--- a/pkgs/by-name/tr/trunk-recorder/package.nix
+++ b/pkgs/by-name/tr/trunk-recorder/package.nix
@@ -1,0 +1,88 @@
+{ lib
+, stdenv
+, fetchurl
+, readline
+, termcap
+, gnucap
+, callPackage
+, writeScript
+, fetchFromGitHub
+, cmake
+, pkg-config
+, makeWrapper
+, gnuradio
+, gnupg
+, libsndfile
+, fftw
+, cacert
+, gnuradioPackages
+, uhd
+, boost
+, curl
+, gmp
+, hackrf
+, orc
+, xorg
+, openssl
+, libusb1
+, git
+, spdlog
+, volk
+, sox
+, fdk-aac-encoder
+}:
+
+stdenv.mkDerivation rec {
+  pname = "trunk-recorder";
+  version = "4.7.1";
+  src = fetchFromGitHub {
+    owner = "robotastic";
+    repo = "trunk-recorder";
+    rev = "v${version}";
+    sha256 = "sha256-nL59+BAL5zKoAZs+i947Zzmj7U0UNsbmMCLnpTLaMQA=";
+  };
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    makeWrapper
+  ];
+  cmakeFlags = [
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
+    "-DSPDLOG_FMT_EXTERNAL=ON"
+  ];
+  buildInputs = [
+    gnuradio
+    gnupg
+    libsndfile
+    fftw
+    cacert
+    gnuradioPackages.osmosdr
+    uhd
+    boost
+    curl
+    gmp
+    hackrf
+    orc
+    xorg.libpthreadstubs
+    openssl
+    libusb1
+    git
+    spdlog
+    volk
+  ];
+  postInstall = ''
+    wrapProgram $out/bin/trunk-recorder \
+       --prefix PATH : ${lib.makeBinPath [ sox fdk-aac-encoder ]}
+  '';
+  meta = with lib; {
+    description = "Record calls on trunked and conventional radio systems";
+    longDescription = ''
+      Radio call recording supporting trunked P25 & SmartNet systems, conventional P25 & analog systems, and P25 Phase 1, P25 Phase 2 & analog voice channels'';
+    homepage = "https://github.com/robotastic/trunk-recorder";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ mcdonc ];
+    platforms = platforms.linux;
+    mainProgram = "trunk-recorder";
+  };
+
+}


### PR DESCRIPTION
## Description of changes

New package: trunk-recorder; Radio call recording supporting trunked P25 & SmartNet systems, conventional P25 & analog systems, and P25 Phase 1, P25 Phase 2 & analog voice channels.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
