### PR TITLE
pahole: 1.26 -> 1.27

### DIFF
--- a/pkgs/by-name/pa/pahole/package.nix
+++ b/pkgs/by-name/pa/pahole/package.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
     musl-obstack
   ];
 
+  # https://github.com/acmel/dwarves/pull/51
   patches = [ ./threading-reproducibility.patch ];
 
   # Put libraries in "lib" subdirectory, not top level of $out

--- a/pkgs/by-name/pa/pahole/package.nix
+++ b/pkgs/by-name/pa/pahole/package.nix
@@ -13,10 +13,10 @@
 
 stdenv.mkDerivation rec {
   pname = "pahole";
-  version = "1.26";
+  version = "1.27";
   src = fetchzip {
     url = "https://git.kernel.org/pub/scm/devel/pahole/pahole.git/snapshot/pahole-${version}.tar.gz";
-    hash = "sha256-Lf9Z4vHRFplMrUf4VhJ7EDPn+S4RaS1Emm0wyEcG2HU=";
+    hash = "sha256-BwA17lc2yegmOzLfoIu8OmG/PVdc+4sOGzB8Jc4ZjGM=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];

--- a/pkgs/by-name/pa/pahole/package.nix
+++ b/pkgs/by-name/pa/pahole/package.nix
@@ -9,6 +9,7 @@
 , argp-standalone
 , musl-obstack
 , nixosTests
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
@@ -26,8 +27,16 @@ stdenv.mkDerivation rec {
     musl-obstack
   ];
 
-  # https://github.com/acmel/dwarves/pull/51
-  patches = [ ./threading-reproducibility.patch ];
+  patches = [
+    # https://github.com/acmel/dwarves/pull/51 / https://lkml.kernel.org/r/20240626032253.3406460-1-asmadeus@codewreck.org
+    ./threading-reproducibility.patch
+    # https://github.com/acmel/dwarves/issues/53
+    (fetchpatch {
+      name = "fix-clang-btf-generation-bug.patch";
+      url = "https://github.com/acmel/dwarves/commit/6a2b27c0f512619b0e7a769a18a0fb05bb3789a5.patch";
+      hash = "sha256-Le1BAew/a/QKkYNLgSQxEvZ9mEEglUw8URwz1kiheeE=";
+    })
+  ];
 
   # Put libraries in "lib" subdirectory, not top level of $out
   cmakeFlags = [ "-D__LIB=lib" "-DLIBBPF_EMBEDDED=OFF" ];

--- a/pkgs/by-name/pa/pahole/threading-reproducibility.patch
+++ b/pkgs/by-name/pa/pahole/threading-reproducibility.patch
@@ -1,18 +1,15 @@
 diff --git a/pahole.c b/pahole.c
-index 6fc4ed6..a4e306f 100644
+index 954498d2ad4f..2b010658330c 100644
 --- a/pahole.c
 +++ b/pahole.c
-@@ -1687,8 +1687,11 @@ static error_t pahole__options_parser(int key, char *arg,
- 		  class_name = arg;			break;
- 	case 'j':
- #if _ELFUTILS_PREREQ(0, 178)
--		  conf_load.nr_jobs = arg ? atoi(arg) :
--					    sysconf(_SC_NPROCESSORS_ONLN) * 1.1;
-+		  // Force single thread if reproducibility is desirable.
-+		  if (!getenv("SOURCE_DATE_EPOCH")) {
-+			  conf_load.nr_jobs = arg ? atoi(arg) :
-+						    sysconf(_SC_NPROCESSORS_ONLN) * 1.1;
-+		  }
- #else
- 		  fputs("pahole: Multithreading requires elfutils >= 0.178. Continuing with a single thread...\n", stderr);
- #endif
+@@ -3705,6 +3705,10 @@ int main(int argc, char *argv[])
+ 		goto out;
+ 	}
+ 
++	/* This being set means whoever called us tries to do a reproducible build */
++	if (getenv("SOURCE_DATE_EPOCH"))
++		conf_load.reproducible_build = true;
++
+ 	if (languages.str && parse_languages())
+ 		return rc;
+ 


### PR DESCRIPTION
## Description of changes

(Note I don't have enough cpu/disk to build a linux kernel with this, so letting ofborg do the work... Always a bit of a bet on staging. Maybe someday...)

From the release e-mail:

```
        The v1.27 release of pahole and its friends is out, supporting
parallel reproducible builds and encoding kernel kfuncs in BTF, allowing
tools such as bpftrace to enumerate the available kfuncs and obtain its
function signatures and return types.

BTF encoder:

- Inject kfunc decl tags into BTF from the BTF IDs ELF section in the Linux
  kernel vmlinux file.
  
  This allows tools such as bpftools and pfunct to enumerate the available kfuncs
  and to gets its function signature, the type of its return and of its
  arguments. See the example in the BTF loader changes description, below.

- Support parallel reproducible builds, where it doesn't matter how many
  threads are used, the end BTF encoding result is the same.

- Sanitize unsupported DWARF int type with greater-than-16 byte, as BTF doesn't
  support it.

BTF loader:

- Initial support for BTF_KIND_DECL_TAG:

  $ pfunct --prototypes -F btf vmlinux.btf.decl_tag,decl_tag_kfuncs | grep ^bpf_kfunc | head
  bpf_kfunc void cubictcp_init(struct sock * sk);
  bpf_kfunc void cubictcp_cwnd_event(struct sock * sk, enum tcp_ca_event event);
  bpf_kfunc void cubictcp_cong_avoid(struct sock * sk, u32 ack, u32 acked);
  bpf_kfunc u32 cubictcp_recalc_ssthresh(struct sock * sk);
  bpf_kfunc void cubictcp_state(struct sock * sk, u8 new_state);
  bpf_kfunc void cubictcp_acked(struct sock * sk, const struct ack_sample  * sample);
  bpf_kfunc int bpf_iter_css_new(struct bpf_iter_css * it, struct cgroup_subsys_state * start, unsigned
int flags);
  bpf_kfunc struct cgroup_subsys_state * bpf_iter_css_next(struct bpf_iter_css * it);
  bpf_kfunc void bpf_iter_css_destroy(struct bpf_iter_css * it);
  bpf_kfunc s64 bpf_map_sum_elem_count(const struct bpf_map  * map);
  $ pfunct --prototypes -F btf vmlinux.btf.decl_tag,decl_tag_kfuncs | grep ^bpf_kfunc | wc -l
  116
  $

pretty printing:

- Fix hole discovery with inheritance in C++.
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
