### PR TITLE
enzyme: init at 0.0.165

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11636,6 +11636,12 @@
     github = "kira-bruneau";
     githubId = 382041;
   };
+  kiranshila = {
+    email = "me@kiranshila.com";
+    name = "Kiran Shila";
+    github = "kiranshila";
+    githubId = 6305359;
+  };
   kirelagin = {
     email = "kirelagin@gmail.com";
     matrix = "@kirelagin:matrix.org";

--- a/pkgs/by-name/en/enzyme/package.nix
+++ b/pkgs/by-name/en/enzyme/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  llvmPackages,
+  git,
+}:
+stdenv.mkDerivation rec {
+  pname = "enzyme";
+  version = "0.0.165";
+
+  src = fetchFromGitHub {
+    owner = "EnzymeAD";
+    repo = "Enzyme";
+    rev = "v${version}";
+    hash = "sha256-EyIpbcCJHj09Aa/NMr9BqOHvaWvaRqetCQRy2oxiJKE=";
+  };
+
+  postPatch = ''
+    patchShebangs enzyme
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    git
+  ];
+
+  buildInputs = with llvmPackages; [
+    llvm
+    libclang
+  ];
+
+  cmakeFlags = [
+    "-S../enzyme"
+    "-DLLVM_DIR=${llvmPackages.llvm.dev}"
+    "-DClang_DIR=${llvmPackages.libclang.dev}"
+  ];
+
+  meta = with lib; {
+    homepage = "https://enzyme.mit.edu/";
+    description = "High-performance automatic differentiation of LLVM and MLIR.";
+    maintainers = with maintainers; [ kiranshila ];
+    platforms = platforms.all;
+    license = licenses.asl20-llvm;
+  };
+}

--- a/pkgs/by-name/en/enzyme/package.nix
+++ b/pkgs/by-name/en/enzyme/package.nix
@@ -1,12 +1,11 @@
 {
   lib,
-  stdenv,
   fetchFromGitHub,
   cmake,
   llvmPackages,
   git,
 }:
-stdenv.mkDerivation rec {
+llvmPackages.stdenv.mkDerivation rec {
   pname = "enzyme";
   version = "0.0.165";
 
@@ -24,24 +23,20 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     git
+    llvmPackages.llvm
   ];
 
-  buildInputs = with llvmPackages; [
-    llvm
-    libclang
-  ];
+  cmakeDir = "../enzyme";
 
-  cmakeFlags = [
-    "-S../enzyme"
-    "-DLLVM_DIR=${llvmPackages.llvm.dev}"
-    "-DClang_DIR=${llvmPackages.libclang.dev}"
-  ];
+  cmakeFlags = [ "-DLLVM_DIR=${llvmPackages.llvm.dev}" ];
 
-  meta = with lib; {
+  enableParallelBuilding = true;
+
+  meta = {
     homepage = "https://enzyme.mit.edu/";
-    description = "High-performance automatic differentiation of LLVM and MLIR.";
-    maintainers = with maintainers; [ kiranshila ];
-    platforms = platforms.all;
-    license = licenses.asl20-llvm;
+    description = "High-performance automatic differentiation of LLVM and MLIR";
+    maintainers = with lib.maintainers; [ kiranshila ];
+    platforms = lib.platforms.all;
+    license = lib.licenses.asl20-llvm;
   };
 }


### PR DESCRIPTION
## Description of changes

Adds the package [Enzyme](https://enzyme.mit.edu/), which provides compiler plugins for Clang and LLD for state-of-the-art automatic differentiation.

I'm not sure if I rigged `buildInputs` correctly, as technically these plugins require their respective components at runtime. For example, `ClangEnzyme` needs clang, etc. I have a test repo [here](https://github.com/kiranshila/enzyme_test) that seems to work with `pkgs.mkShell.override {stdenv = pkgs.clangStdenv;}` and adding `lld` as a package, but if there's a better way to make that work here, suggestions are appreciated.

Also, `git` is not *really* required as a native build input, it's just wonky because it tries to git clone a dependency before it checks to see if that dependency was actually called for. I'll see if I can come up with a patch, otherwise we can leave it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
