### PR TITLE
rPackages.vegan: removed from `packagesRequiringX` list

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -934,7 +934,6 @@ let
     "uHMM"
     "vcdExtra"
     "VecStatGraphs3D"
-    "vegan"
     "vegan3d"
     "vegclust"
     "x12GUI"


### PR DESCRIPTION
Dear @jbedo,

It seems that this `vegan` package do not actually require X.

As mentioned in https://github.com/NixOS/nixpkgs/issues/319189, R-packages requiring X are broken on darwin platform. It is therefore good to keep this list up-to-date to let MacOS users being able to install them if they do not actually require X. 

Best regards,
@juliendiot42 


## Description of changes

`vegan` have been removed from `packagesRequiringX`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
  
 This package builds successfully without X with the command:
 
 ```
 nix build .\#pkgs.rPackages.vegan
 ```
 
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)

It seems so:

<details><summary>Console log, click to expand</summary>


```console
❯ nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
these 2 paths will be fetched (0.11 MiB download, 0.63 MiB unpacked):
  /nix/store/rx6laqr63fhb15sysy8z4magbijb8g0i-nixpkgs-review-2.10.4
  /nix/store/abnch2ab1jfh3kvlrf1fshnx4i2p7kdf-python3.11-argcomplete-3.3.0
copying path '/nix/store/abnch2ab1jfh3kvlrf1fshnx4i2p7kdf-python3.11-argcomplete-3.3.0' from 'https://cache.nixos.org'...
copying path '/nix/store/rx6laqr63fhb15sysy8z4magbijb8g0i-nixpkgs-review-2.10.4' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 47280, done.
remote: Counting objects: 100% (16339/16339), done.
remote: Compressing objects: 100% (622/622), done.
remote: Total 47280 (delta 15901), reused 15984 (delta 15674), pack-reused 30941
Receiving objects: 100% (47280/47280), 23.03 MiB | 3.43 MiB/s, done.
Resolving deltas: 100% (24784/24784), completed with 5450 local objects.
From https://github.com/NixOS/nixpkgs
 * [new branch]                master     -> refs/nixpkgs-review/0
$ git worktree add /home/julien/.cache/nixpkgs-review/rev-149f81c8d00e5053308b5f225cf6bbabaeee79e7/nixpkgs 698c1d1aeb6a1dc2d86f2fc1e9c418379e90a2e8
Preparing worktree (detached HEAD 698c1d1aeb6a)
Updating files: 100% (41584/41584), done.
HEAD is now at 698c1d1aeb6a Merge pull request #319039 from 0x4A6F/master-atuin
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f <nixpkgs> --nix-path nixpkgs=/home/julien/.cache/nixpkgs-review/rev-149f81c8d00e5053308b5f225cf6bbabaeee79e7/nixpkgs nixpkgs-overlays=/run/user/1000/tmppu_kgl_o -qaP --xml --out-path --show-trace --no-allow-import-from-derivation
$ git merge --no-commit --no-ff 149f81c8d00e5053308b5f225cf6bbabaeee79e7
Automatic merge went well; stopped before committing as requested
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f <nixpkgs> --nix-path nixpkgs=/home/julien/.cache/nixpkgs-review/rev-149f81c8d00e5053308b5f225cf6bbabaeee79e7/nixpkgs nixpkgs-overlays=/run/user/1000/tmppu_kgl_o -qaP --xml --out-path --show-trace --no-allow-import-from-derivation --meta
Nothing to be built.
$ /nix/store/j7rp0y3ii1w3dlbflbxlv4g7hbaaz3bs-nix-2.18.2/bin/nix-shell --argstr system x86_64-linux --argstr nixpkgs-path /home/julien/.cache/nixpkgs-review/rev-149f81c8d00e5053308b5f225cf6bbabaeee79e7/nixpkgs --argstr nixpkgs-config-path /run/user/1000/tmpbkjqupmg.nix --argstr attrs-path /home/julien/.cache/nixpkgs-review/rev-149f81c8d00e5053308b5f225cf6bbabaeee79e7/attrs.nix --nix-path nixpkgs=/home/julien/.cache/nixpkgs-review/rev-149f81c8d00e5053308b5f225cf6bbabaeee79e7/nixpkgs nixpkgs-overlays=/run/user/1000/tmppu_kgl_o /nix/store/rx6laqr63fhb15sysy8z4magbijb8g0i-nixpkgs-review-2.10.4/lib/python3.11/site-packages/nixpkgs_review/nix/review-shell.nix

[nix-shell:~/.cache/nixpkgs-review/rev-149f81c8d00e5053308b5f225cf6bbabaeee79e7]$

```

</details>

But I am not sure this apply for r-packages.

- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)

```r
library('vegan')
```
Works.

I used this flake to test it:

<details><summary>`flake.nix`, click to expand</summary>

```nix
{
  description = "Flake for a R environment";
  inputs = {
    nixpkgs.url = "github:juliendiot42/nixpkgs?ref=rpackages-vegan_doesnt_requireX";
    flake-utils.url = "github:numtide/flake-utils";
  };

  outputs = {
    self,
    nixpkgs,
    flake-utils,
  }:
    flake-utils.lib.eachDefaultSystem (
      system: let
        pkgs = import nixpkgs {inherit system;};
        R-with-my-packages = pkgs.rWrapper.override {
          packages = with pkgs.rPackages; [
            vegan
          ];
        };
      in rec {
        devShells.default = pkgs.mkShell {
          LOCALE_ARCHIVE =
            if "${system}" == "x86_64-linux"
            then "${pkgs.glibcLocalesUtf8}/lib/locale/locale-archive"
            else "";
          R_LIBS_USER = "''"; # to no use users' installed R packages
          R_PROFILE_USER = "''"; # to disable`.Rprofile` files (eg. when the project already use `renv`)
          nativeBuildInputs = [pkgs.bashInteractive];
          buildInputs = [
            R-with-my-packages
          ];
        };
        apps = {
          simpleTest = let
            simpleTest = pkgs.writeShellApplication {
              name = "simpleTest";
              text = ''
                Rscript --vanilla -e "library('vegan'); q()"
              '';
            };
          in {
            type = "app";
            program = "${simpleTest}/bin/simpleTest";
          };
        };
      }
    );
}
```

and

```sh
nix run .\#simpleTest
```

Output:

```console
nix-shell-env ❯ nix run .\#simpleTest
Loading required package: permute
Loading required package: lattice
This is vegan 2.6-4
```

</details>

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
