### PR TITLE
wine64Packages.{stable,unstable,staging}: support GPTK on Darwin

### DIFF
--- a/pkgs/applications/emulators/wine/base.nix
+++ b/pkgs/applications/emulators/wine/base.nix
@@ -117,6 +117,7 @@ lib.optionalAttrs (buildScript != null) { builder = buildScript; }
     (substituteAll {
       src = ./gptk/0001-winemac.drv-changes-for-GPTK-compatibility.patch;
       usePre910API = if lib.versionOlder finalAttrs.version "9.10" then 1 else 0;
+      usePre912API = if lib.versionOlder finalAttrs.version "9.12" then 1 else 0;
     })
     (substituteAll {
       src =

--- a/pkgs/applications/emulators/wine/default.nix
+++ b/pkgs/applications/emulators/wine/default.nix
@@ -38,8 +38,11 @@
   mingwSupport ? false,
   waylandSupport ? false,
   x11Support ? false,
+  d3dmetalSupport ? false, # Disabled by default because it’s non-free and requires manually downloading GPTK.
   embedInstallers ? false, # The Mono and Gecko MSI installers
-  moltenvk ? darwin.moltenvk # Allow users to override MoltenVK easily
+  # Allow users to override these easily since they may need a specific version for their system.
+  d3dmetal,
+  moltenvk ? darwin.moltenvk,
 }:
 
 let wine-build = build: release:
@@ -47,7 +50,7 @@ let wine-build = build: release:
         wineRelease = release;
         supportFlags = {
           inherit
-            alsaSupport cairoSupport cupsSupport cursesSupport dbusSupport
+            alsaSupport cairoSupport cupsSupport cursesSupport d3dmetalSupport dbusSupport
             embedInstallers fontconfigSupport gettextSupport gphoto2Support
             gstreamerSupport gtkSupport krb5Support mingwSupport netapiSupport
             odbcSupport openclSupport openglSupport pcapSupport
@@ -56,7 +59,7 @@ let wine-build = build: release:
             x11Support xineramaSupport
           ;
         };
-        inherit moltenvk;
+        inherit d3dmetal moltenvk;
       });
 
 in if wineRelease == "staging" then

--- a/pkgs/applications/emulators/wine/gptk/0001-winemac.drv-changes-for-GPTK-compatibility.patch
+++ b/pkgs/applications/emulators/wine/gptk/0001-winemac.drv-changes-for-GPTK-compatibility.patch
@@ -1,14 +1,14 @@
-From b784fad5792ac7b47b9a3353435083e7d8c19039 Mon Sep 17 00:00:00 2001
+From 4c3d6688545cc768c56a30c22b76120a753708fc Mon Sep 17 00:00:00 2001
 From: Randy Eckenrode <randy@largeandhighquality.com>
 Date: Fri, 7 Jun 2024 21:43:16 -0400
 Subject: [PATCH 1/3] winemac.drv changes for GPTK compatibility
 
 ---
  dlls/winemac.drv/Makefile.in |   3 +-
- dlls/winemac.drv/dllmain.c   |  75 ++++++++
- dlls/winemac.drv/gpt.c       | 340 +++++++++++++++++++++++++++++++++++
- dlls/winemac.drv/unixlib.h   |  45 +++++
- 4 files changed, 462 insertions(+), 1 deletion(-)
+ dlls/winemac.drv/dllmain.c   |  81 ++++++++
+ dlls/winemac.drv/gpt.c       | 358 +++++++++++++++++++++++++++++++++++
+ dlls/winemac.drv/unixlib.h   |  46 +++++
+ 4 files changed, 487 insertions(+), 1 deletion(-)
  create mode 100644 dlls/winemac.drv/gpt.c
 
 diff --git a/dlls/winemac.drv/Makefile.in b/dlls/winemac.drv/Makefile.in
@@ -33,14 +33,19 @@ index e3e71c5f4cc..0690cc71008 100644
  	keyboard.c \
  	macdrv_main.c \
 diff --git a/dlls/winemac.drv/dllmain.c b/dlls/winemac.drv/dllmain.c
-index bd381bc9fc2..8f3af0c272a 100644
+index bd381bc9fc2..940b549e082 100644
 --- a/dlls/winemac.drv/dllmain.c
 +++ b/dlls/winemac.drv/dllmain.c
-@@ -40,6 +40,76 @@ struct quit_info {
+@@ -40,6 +40,81 @@ struct quit_info {
      BOOL                replied;
  };
  
 +#if defined(__x86_64__)
++
++static DPI_AWARENESS_CONTEXT WINAPI macdrv_getthreaddpiawarenesscontext(void)
++{
++    return GetThreadDpiAwarenessContext();
++}
 +
 +static NTSTATUS WINAPI macdrv_regcreateopenkeyexa(void *arg, ULONG size)
 +{
@@ -113,11 +118,12 @@ index bd381bc9fc2..8f3af0c272a 100644
  
  static BOOL CALLBACK get_process_windows(HWND hwnd, LPARAM lp)
  {
-@@ -375,6 +445,11 @@ static const KERNEL_CALLBACK_PROC kernel_callbacks[] =
+@@ -375,6 +450,12 @@ static const KERNEL_CALLBACK_PROC kernel_callbacks[] =
      macdrv_dnd_query_drag,
      macdrv_dnd_query_drop,
      macdrv_dnd_query_exited,
 +#if defined(__x86_64__)
++    macdrv_getthreaddpiawarenesscontext,
 +    macdrv_regcreateopenkeyexa,
 +    macdrv_regqueryvalueexa,
 +    macdrv_regsetvalueexa,
@@ -127,10 +133,10 @@ index bd381bc9fc2..8f3af0c272a 100644
  C_ASSERT(NtUserDriverCallbackFirst + ARRAYSIZE(kernel_callbacks) == client_func_last);
 diff --git a/dlls/winemac.drv/gpt.c b/dlls/winemac.drv/gpt.c
 new file mode 100644
-index 00000000000..7017a274cde
+index 00000000000..55045831c5a
 --- /dev/null
 +++ b/dlls/winemac.drv/gpt.c
-@@ -0,0 +1,340 @@
+@@ -0,0 +1,358 @@
 +/*
 + * Mac graphics driver hooks for Apple Game Porting Toolkit D3D layer
 + *
@@ -206,9 +212,13 @@ index 00000000000..7017a274cde
 +    TRACE("macdrv_init_display_devices %d\n", p1);
 +#if @usePre910API@
 +    macdrv_init_display_devices(p1);
-+#else
++#elif @usePre912API@
 +    if (p1) {
 +        NtUserCallNoParam(NtUserCallNoParam_UpdateDisplayCache);
++    }
++#else
++    if (p1) {
++        NtUserCallNoParam(NtUserCallNoParam_DisplayModeChanged);
 +    }
 +#endif
 +}
@@ -402,7 +412,14 @@ index 00000000000..7017a274cde
 +static BOOL WINAPI my_AdjustWindowRectEx(LPRECT p1,DWORD p2,BOOL p3,DWORD p4)
 +{
 +    TRACE("AdjustWindowRectEx %p %u %d %u\n", p1, p2, p3, p4);
++#if @usePre912API@
 +    return AdjustWindowRectEx(p1, p2, p3, p4);
++#else
++    UINT dpi = NTUSER_DPI_CONTEXT_GET_DPI(
++        (UINT_PTR) macdrv_client_func(client_func_getthreaddpiawarenesscontext, NULL, 0)
++    );
++    return NtUserAdjustWindowRect( p1, p2, p3, p4, dpi );
++#endif
 +}
 +
 +static LONG_PTR WINAPI my_GetWindowLongPtrW(HWND h,int nIndex)
@@ -415,7 +432,14 @@ index 00000000000..7017a274cde
 +static BOOL WINAPI my_GetWindowRect(HWND h, LPRECT rect)
 +{
 +    TRACE("GetWindowRect %p %p\n", h, rect);
++#if @usePre912API@
 +    return NtUserGetWindowRect(h, rect);
++#else
++    UINT dpi = NTUSER_DPI_CONTEXT_GET_DPI(
++        (UINT_PTR) macdrv_client_func(client_func_getthreaddpiawarenesscontext, NULL, 0)
++    );
++    return NtUserGetWindowRect(h, rect, dpi);
++#endif
 +}
 +
 +static BOOL WINAPI my_MoveWindow(HWND h, int X,int Y,int nWidth,int nHeight,BOOL bRepaint)
@@ -472,14 +496,15 @@ index 00000000000..7017a274cde
 +
 +#endif
 diff --git a/dlls/winemac.drv/unixlib.h b/dlls/winemac.drv/unixlib.h
-index e77a31a86c1..365faf66a34 100644
+index e77a31a86c1..0d86152afbe 100644
 --- a/dlls/winemac.drv/unixlib.h
 +++ b/dlls/winemac.drv/unixlib.h
-@@ -83,6 +83,11 @@
+@@ -83,6 +83,12 @@
      client_func_dnd_query_drag,
      client_func_dnd_query_drop,
      client_func_dnd_query_exited,
 +#if defined(__x86_64__)
++    client_func_getthreaddpiawarenesscontext,
 +    client_func_regcreateopenkeyexa,
 +    client_func_regqueryvalueexa,
 +    client_func_regsetvalueexa,
@@ -487,7 +512,7 @@ index e77a31a86c1..365faf66a34 100644
      client_func_last
  };
  
-@@ -128,6 +133,46 @@
+@@ -128,6 +134,46 @@
      UINT32 hwnd;
  };
  
@@ -535,5 +560,5 @@ index e77a31a86c1..365faf66a34 100644
  {
      return (void *)(UINT_PTR)param;
 -- 
-2.45.1
+2.45.2
 

--- a/pkgs/applications/emulators/wine/gptk/0001-winemac.drv-changes-for-GPTK-compatibility.patch
+++ b/pkgs/applications/emulators/wine/gptk/0001-winemac.drv-changes-for-GPTK-compatibility.patch
@@ -1,0 +1,539 @@
+From b784fad5792ac7b47b9a3353435083e7d8c19039 Mon Sep 17 00:00:00 2001
+From: Randy Eckenrode <randy@largeandhighquality.com>
+Date: Fri, 7 Jun 2024 21:43:16 -0400
+Subject: [PATCH 1/3] winemac.drv changes for GPTK compatibility
+
+---
+ dlls/winemac.drv/Makefile.in |   3 +-
+ dlls/winemac.drv/dllmain.c   |  75 ++++++++
+ dlls/winemac.drv/gpt.c       | 340 +++++++++++++++++++++++++++++++++++
+ dlls/winemac.drv/unixlib.h   |  45 +++++
+ 4 files changed, 462 insertions(+), 1 deletion(-)
+ create mode 100644 dlls/winemac.drv/gpt.c
+
+diff --git a/dlls/winemac.drv/Makefile.in b/dlls/winemac.drv/Makefile.in
+index e3e71c5f4cc..0690cc71008 100644
+--- a/dlls/winemac.drv/Makefile.in
++++ b/dlls/winemac.drv/Makefile.in
+@@ -1,7 +1,7 @@
+ MODULE    = winemac.drv
+ UNIXLIB   = winemac.so
+ IMPORTS   = uuid rpcrt4 user32 gdi32 win32u
+-DELAYIMPORTS = ole32 shell32 imm32
++DELAYIMPORTS = advapi32 ole32 shell32 imm32
+ UNIX_LIBS    = \
+ 	-lwin32u \
+ 	-framework AppKit \
+@@ -30,6 +30,7 @@ SOURCES = \
+ 	dragdrop.c \
+ 	event.c \
+ 	gdi.c \
++	gpt.c \
+ 	image.c \
+ 	keyboard.c \
+ 	macdrv_main.c \
+diff --git a/dlls/winemac.drv/dllmain.c b/dlls/winemac.drv/dllmain.c
+index bd381bc9fc2..8f3af0c272a 100644
+--- a/dlls/winemac.drv/dllmain.c
++++ b/dlls/winemac.drv/dllmain.c
+@@ -40,6 +40,76 @@ struct quit_info {
+     BOOL                replied;
+ };
+ 
++#if defined(__x86_64__)
++
++static NTSTATUS WINAPI macdrv_regcreateopenkeyexa(void *arg, ULONG size)
++{
++    struct regcreateopenkeyexa_params *params = arg;
++    LONG result;
++
++    TRACE("()\n");
++
++    if (params->create)
++    {
++        result = RegCreateKeyExA(UlongToHandle(params->hkey),
++                                 param_ptr(params->name),
++                                 params->reserved,
++                                 param_ptr(params->class),
++                                 params->options,
++                                 params->access,
++                                 param_ptr(params->security),
++                                 param_ptr(params->retkey),
++                                 param_ptr(params->disposition));
++    }
++    else
++    {
++        result = RegOpenKeyExA(UlongToHandle(params->hkey),
++                               param_ptr(params->name),
++                               params->options,
++                               params->access,
++                               param_ptr(params->retkey));
++    }
++    *(LONG *)param_ptr(params->result) = result;
++    return 0;
++}
++
++static NTSTATUS WINAPI macdrv_regqueryvalueexa(void *arg, ULONG size)
++{
++    struct regqueryvalueexa_params *params = arg;
++    LONG result;
++
++    TRACE("()\n");
++
++    result = RegQueryValueExA(UlongToHandle(params->hkey),
++                              param_ptr(params->name),
++                              param_ptr(params->reserved),
++                              param_ptr(params->type),
++                              param_ptr(params->data),
++                              param_ptr(params->count));
++
++    *(LONG *)param_ptr(params->result) = result;
++    return 0;
++}
++
++static NTSTATUS WINAPI macdrv_regsetvalueexa(void *arg, ULONG size)
++{
++    struct regsetvalueexa_params *params = arg;
++    LONG result;
++
++    TRACE("()\n");
++
++    result = RegSetValueExA(UlongToHandle(params->hkey),
++                            param_ptr(params->name),
++                            params->reserved,
++                            params->type,
++                            param_ptr(params->data),
++                            params->count);
++
++    *(LONG *)param_ptr(params->result) = result;
++    return 0;
++}
++
++#endif
+ 
+ static BOOL CALLBACK get_process_windows(HWND hwnd, LPARAM lp)
+ {
+@@ -375,6 +445,11 @@ static const KERNEL_CALLBACK_PROC kernel_callbacks[] =
+     macdrv_dnd_query_drag,
+     macdrv_dnd_query_drop,
+     macdrv_dnd_query_exited,
++#if defined(__x86_64__)
++    macdrv_regcreateopenkeyexa,
++    macdrv_regqueryvalueexa,
++    macdrv_regsetvalueexa,
++#endif
+ };
+ 
+ C_ASSERT(NtUserDriverCallbackFirst + ARRAYSIZE(kernel_callbacks) == client_func_last);
+diff --git a/dlls/winemac.drv/gpt.c b/dlls/winemac.drv/gpt.c
+new file mode 100644
+index 00000000000..7017a274cde
+--- /dev/null
++++ b/dlls/winemac.drv/gpt.c
+@@ -0,0 +1,340 @@
++/*
++ * Mac graphics driver hooks for Apple Game Porting Toolkit D3D layer
++ *
++ * Copyright 2023 Brendan Shanks for CodeWeavers, Inc.
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with this library; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
++ */
++
++#if 0
++#pragma makedep unix
++#endif
++
++#if defined(__x86_64__)
++
++#include "config.h"
++
++#include "ntstatus.h"
++#define WIN32_NO_STATUS
++#include "macdrv.h"
++#include "shellapi.h"
++#include "wine/server.h"
++
++WINE_DEFAULT_DEBUG_CHANNEL(macdrv_gpt);
++
++typedef LONG LSTATUS;
++
++struct macdrv_functions_t
++{
++    void (*macdrv_init_display_devices)(BOOL);
++    struct macdrv_win_data*(*get_win_data)(HWND hwnd);
++    void (*release_win_data)(struct macdrv_win_data *data);
++    macdrv_window(*macdrv_get_cocoa_window)(HWND hwnd, BOOL require_on_screen);
++    macdrv_metal_device (*macdrv_create_metal_device)(void);
++    void (*macdrv_release_metal_device)(macdrv_metal_device d);
++    macdrv_metal_view (*macdrv_view_create_metal_view)(macdrv_view v, macdrv_metal_device d);
++    macdrv_metal_layer (*macdrv_view_get_metal_layer)(macdrv_metal_view v);
++    void (*macdrv_view_release_metal_view)(macdrv_metal_view v);
++    void (*on_main_thread)(dispatch_block_t b);
++    LSTATUS(WINAPI*RegQueryValueExA)(HKEY, LPCSTR, LPDWORD, LPDWORD, BYTE*, LPDWORD);
++    LSTATUS(WINAPI*RegSetValueExA)(HKEY, LPCSTR, DWORD, DWORD, const BYTE*, DWORD);
++    LSTATUS(WINAPI*RegOpenKeyExA)(HKEY, LPCSTR, DWORD, DWORD, HKEY*);
++    LSTATUS(WINAPI*RegCreateKeyExA)(HKEY, LPCSTR, DWORD, LPSTR, DWORD, DWORD, LPSECURITY_ATTRIBUTES, HKEY*, LPDWORD);
++    LSTATUS(WINAPI*RegCloseKey)(HKEY);
++    BOOL(WINAPI*EnumDisplayMonitors)(HDC,LPRECT,MONITORENUMPROC,LPARAM);
++    BOOL(WINAPI*GetMonitorInfoA)(HMONITOR,LPMONITORINFO);
++    BOOL(WINAPI*AdjustWindowRectEx)(LPRECT,DWORD,BOOL,DWORD);
++    LONG_PTR(WINAPI*GetWindowLongPtrW)(HWND,int);
++    BOOL(WINAPI*GetWindowRect)(HWND,LPRECT);
++    BOOL(WINAPI*MoveWindow)(HWND,int,int,int,int,BOOL);
++    BOOL(WINAPI*SetWindowPos)(HWND,HWND,int,int,int,int,UINT);
++    INT(WINAPI*GetSystemMetrics)(INT);
++    LONG_PTR(WINAPI*SetWindowLongPtrW)(HWND,INT,LONG_PTR);
++};
++C_ASSERT(sizeof(struct macdrv_functions_t) == 192);
++C_ASSERT(sizeof(struct macdrv_win_data) == 120);
++
++void OnMainThread(dispatch_block_t block);
++
++static void my_macdrv_init_display_devices(BOOL p1)
++{
++    TRACE("macdrv_init_display_devices %d\n", p1);
++#if @usePre910API@
++    macdrv_init_display_devices(p1);
++#else
++    if (p1) {
++        NtUserCallNoParam(NtUserCallNoParam_UpdateDisplayCache);
++    }
++#endif
++}
++
++static struct macdrv_win_data *my_get_win_data(HWND hwnd)
++{
++    TRACE("get_win_data %p\n", hwnd);
++    return get_win_data(hwnd);
++}
++
++static void my_release_win_data(struct macdrv_win_data *data)
++{
++    TRACE("release_win_data %p\n", data);
++    release_win_data(data);
++}
++
++static macdrv_window my_macdrv_get_cocoa_window(HWND hwnd, BOOL require_on_screen)
++{
++    TRACE("macdrv_get_cocoa_window %p %d\n", hwnd, require_on_screen);
++    return macdrv_get_cocoa_window(hwnd, require_on_screen);
++}
++
++static macdrv_metal_device my_macdrv_create_metal_device(void)
++{
++    TRACE("macdrv_create_metal_device\n");
++    return macdrv_create_metal_device();
++}
++
++static void my_macdrv_release_metal_device(macdrv_metal_device d)
++{
++    TRACE("macdrv_release_metal_device %p\n", d);
++    macdrv_release_metal_device(d);
++}
++
++static macdrv_metal_view my_macdrv_view_create_metal_view(macdrv_view v, macdrv_metal_device d)
++{
++    TRACE("macdrv_view_create_metal_view %p %p\n", v, d);
++    return macdrv_view_create_metal_view(v, d);
++}
++
++static macdrv_metal_layer my_macdrv_view_get_metal_layer(macdrv_metal_view v)
++{
++    TRACE("macdrv_view_get_metal_layer %p\n", v);
++    return macdrv_view_get_metal_layer(v);
++}
++
++static void my_macdrv_view_release_metal_view(macdrv_metal_view v)
++{
++    TRACE("macdrv_view_release_metal_view %p\n", v);
++    return macdrv_view_release_metal_view(v);
++}
++
++static void my_OnMainThread(dispatch_block_t b)
++{
++    TRACE("OnMainThread %p\n", b);
++    OnMainThread(b);
++}
++
++
++static LSTATUS WINAPI my_RegQueryValueExA(HKEY p1, LPCSTR p2, LPDWORD p3, LPDWORD p4, BYTE* p5, LPDWORD p6)
++{
++    LSTATUS result;
++    struct regqueryvalueexa_params params =
++    {
++        .hkey = HandleToUlong(p1),
++        .name = (UINT_PTR)p2,
++        .reserved = (UINT_PTR)p3,
++        .type = (UINT_PTR)p4,
++        .data = (UINT_PTR)p5,
++        .count = (UINT_PTR)p6,
++        .result = (UINT_PTR)&result,
++    };
++
++    TRACE("RegQueryValueExA %p %s %p %p %p %p\n", p1, p2, p3, p4, p5, p6);
++
++    macdrv_client_func(client_func_regqueryvalueexa, &params, sizeof(params));
++
++    return result;
++}
++
++static LSTATUS WINAPI my_RegSetValueExA(HKEY p1, LPCSTR p2, DWORD p3, DWORD p4, const BYTE* p5, DWORD p6)
++{
++    LSTATUS result;
++    struct regsetvalueexa_params params =
++    {
++        .hkey = HandleToUlong(p1),
++        .name = (UINT_PTR)p2,
++        .reserved = p3,
++        .type = p4,
++        .data = (UINT_PTR)p5,
++        .count = p6,
++        .result = (UINT_PTR)&result,
++    };
++
++    TRACE("RegSetValueExA %p %s(%p) %d %p %d\n", p1, p2, p2, p4, p5, p6);
++
++    macdrv_client_func(client_func_regsetvalueexa, &params, sizeof(params));
++
++    return result;
++}
++
++static LSTATUS WINAPI my_RegOpenKeyExA(HKEY p1, LPCSTR p2, DWORD p3, DWORD p4, HKEY* p5)
++{
++    LSTATUS result;
++    struct regcreateopenkeyexa_params params =
++    {
++        .create = 0,
++        .hkey = HandleToUlong(p1),
++        .name = (UINT_PTR)p2,
++        .options = p3,
++        .access = p4,
++        .retkey = (UINT_PTR)p5,
++        .result = (UINT_PTR)&result,
++    };
++
++    TRACE("RegOpenKeyExA %p %s\n", p1, p2);
++
++    macdrv_client_func(client_func_regcreateopenkeyexa, &params, sizeof(params));
++
++    return result;
++}
++
++static LSTATUS WINAPI my_RegCreateKeyExA(HKEY p1, LPCSTR p2, DWORD p3, LPSTR p4, DWORD p5, DWORD p6, LPSECURITY_ATTRIBUTES p7, HKEY* p8, LPDWORD p9)
++{
++    LSTATUS result;
++    struct regcreateopenkeyexa_params params =
++    {
++        .create = 1,
++        .hkey = HandleToUlong(p1),
++        .name = (UINT_PTR)p2,
++        .reserved = p3,
++        .class = (UINT_PTR)p4,
++        .options = p5,
++        .access = p6,
++        .security = (UINT_PTR)p7,
++        .retkey = (UINT_PTR)p8,
++        .disposition = (UINT_PTR)p9,
++        .result = (UINT_PTR)&result,
++    };
++
++    TRACE("RegCreateKeyExA %p %s\n", p1, p2);
++
++    macdrv_client_func(client_func_regcreateopenkeyexa, &params, sizeof(params));
++
++    return result;
++}
++
++static LSTATUS WINAPI DECLSPEC_HOTPATCH RegCloseKey( HKEY hkey )
++{
++    if (!hkey) return ERROR_INVALID_HANDLE;
++    if (hkey >= (HKEY)0x80000000) return ERROR_SUCCESS;
++    return RtlNtStatusToDosError( NtClose( hkey ) );
++}
++
++static LSTATUS WINAPI my_RegCloseKey(HKEY hkey)
++{
++    TRACE("RegCloseKey %p\n", hkey);
++    return RegCloseKey(hkey);
++}
++
++static BOOL WINAPI my_EnumDisplayMonitors(HDC h, LPRECT p2, MONITORENUMPROC p3, LPARAM p4)
++{
++    TRACE("EnumDisplayMonitors %p %p %p %ld\n", h, p2, p3, p4);
++    return NtUserEnumDisplayMonitors(h, p2, p3, p4);
++}
++
++static BOOL WINAPI my_GetMonitorInfoA(HMONITOR monitor, LPMONITORINFO info)
++{
++    MONITORINFOEXW miW;
++    BOOL ret;
++
++    TRACE("GetMonitorInfoA %p %p\n", monitor, info);
++
++    if (info->cbSize == sizeof(MONITORINFO)) return NtUserGetMonitorInfo( monitor, info );
++    if (info->cbSize != sizeof(MONITORINFOEXA)) return FALSE;
++
++    miW.cbSize = sizeof(miW);
++    ret = NtUserGetMonitorInfo( monitor, (MONITORINFO *)&miW );
++    if (ret)
++    {
++        MONITORINFOEXA *miA = (MONITORINFOEXA *)info;
++        ULONG size;
++        miA->rcMonitor = miW.rcMonitor;
++        miA->rcWork = miW.rcWork;
++        miA->dwFlags = miW.dwFlags;
++        RtlUnicodeToUTF8N(miA->szDevice, sizeof(miA->szDevice), &size, miW.szDevice, lstrlenW(miW.szDevice) * sizeof(WCHAR));
++    }
++    return ret;
++}
++
++static BOOL WINAPI my_AdjustWindowRectEx(LPRECT p1,DWORD p2,BOOL p3,DWORD p4)
++{
++    TRACE("AdjustWindowRectEx %p %u %d %u\n", p1, p2, p3, p4);
++    return AdjustWindowRectEx(p1, p2, p3, p4);
++}
++
++static LONG_PTR WINAPI my_GetWindowLongPtrW(HWND h,int nIndex)
++{
++    TRACE("GetWindowLongPtrW %p\n", h);
++    /* ignore possibility of DWLP_DLGPROC */
++    return NtUserGetWindowLongPtrW(h, nIndex);
++}
++
++static BOOL WINAPI my_GetWindowRect(HWND h, LPRECT rect)
++{
++    TRACE("GetWindowRect %p %p\n", h, rect);
++    return NtUserGetWindowRect(h, rect);
++}
++
++static BOOL WINAPI my_MoveWindow(HWND h, int X,int Y,int nWidth,int nHeight,BOOL bRepaint)
++{
++    TRACE("MoveWindow %p %d %d %d %d %d\n", h, X, Y, nWidth, nHeight, bRepaint);
++    return NtUserMoveWindow(h, X, Y, nWidth, nHeight, bRepaint);
++}
++
++static BOOL WINAPI my_SetWindowPos(HWND h,HWND h2,int x,int y,int cx,int cy,UINT flags)
++{
++    TRACE("SetWindowPos %p %p %d %d %d %d %u\n", h, h2, x, y, cx, cy, flags);
++    return NtUserSetWindowPos(h, h2, x, y, cx, cy, flags);
++}
++
++static INT WINAPI my_GetSystemMetrics(INT index)
++{
++    TRACE("GetSystemMetrics %d\n", index);
++    return NtUserGetSystemMetrics( index );
++}
++
++static LONG_PTR WINAPI my_SetWindowLongPtrW(HWND hwnd, INT offset, LONG_PTR newval)
++{
++    TRACE("SetWindowLongPtrW %p %d %ld\n", hwnd, offset, newval);
++    /* ignore possibility of DWLP_DLGPROC */
++    return NtUserSetWindowLongPtr( hwnd, offset, newval, FALSE );
++}
++
++DECLSPEC_EXPORT struct macdrv_functions_t macdrv_functions = {
++    &my_macdrv_init_display_devices,
++    &my_get_win_data,
++    &my_release_win_data,
++    &my_macdrv_get_cocoa_window,
++    &my_macdrv_create_metal_device,
++    &my_macdrv_release_metal_device,
++    &my_macdrv_view_create_metal_view,
++    &my_macdrv_view_get_metal_layer,
++    &my_macdrv_view_release_metal_view,
++    &my_OnMainThread,
++    &my_RegQueryValueExA,
++    &my_RegSetValueExA,
++    &my_RegOpenKeyExA,
++    &my_RegCreateKeyExA,
++    &my_RegCloseKey,
++    &my_EnumDisplayMonitors,
++    &my_GetMonitorInfoA,
++    &my_AdjustWindowRectEx,
++    &my_GetWindowLongPtrW,
++    &my_GetWindowRect,
++    &my_MoveWindow,
++    &my_SetWindowPos,
++    &my_GetSystemMetrics,
++    &my_SetWindowLongPtrW,
++};
++
++#endif
+diff --git a/dlls/winemac.drv/unixlib.h b/dlls/winemac.drv/unixlib.h
+index e77a31a86c1..365faf66a34 100644
+--- a/dlls/winemac.drv/unixlib.h
++++ b/dlls/winemac.drv/unixlib.h
+@@ -83,6 +83,11 @@
+     client_func_dnd_query_drag,
+     client_func_dnd_query_drop,
+     client_func_dnd_query_exited,
++#if defined(__x86_64__)
++    client_func_regcreateopenkeyexa,
++    client_func_regqueryvalueexa,
++    client_func_regsetvalueexa,
++#endif
+     client_func_last
+ };
+ 
+@@ -128,6 +133,46 @@
+     UINT32 hwnd;
+ };
+ 
++/* macdrv_regcreateopenkeyexa params */
++struct regcreateopenkeyexa_params
++{
++    UINT32 create;
++    UINT32 hkey;
++    UINT64 name;
++    UINT32 reserved;
++    UINT64 class;
++    UINT32 options;
++    UINT32 access;
++    UINT64 security;
++    UINT64 retkey;
++    UINT64 disposition;
++    UINT32 result;
++};
++
++/* macdrv_regqueryvalueexa params */
++struct regqueryvalueexa_params
++{
++    UINT32 hkey;
++    UINT64 name;
++    UINT64 reserved;
++    UINT64 type;
++    UINT64 data;
++    UINT64 count;
++    UINT32 result;
++};
++
++/* macdrv_regsetvalueexa params */
++struct regsetvalueexa_params
++{
++    UINT32 hkey;
++    UINT64 name;
++    UINT32 reserved;
++    UINT32 type;
++    UINT64 data;
++    UINT32 count;
++    UINT32 result;
++};
++
+ static inline void *param_ptr(UINT64 param)
+ {
+     return (void *)(UINT_PTR)param;
+-- 
+2.45.1
+

--- a/pkgs/applications/emulators/wine/gptk/0002-ntdll-changes-for-GPTK-compatibility-staging.patch
+++ b/pkgs/applications/emulators/wine/gptk/0002-ntdll-changes-for-GPTK-compatibility-staging.patch
@@ -1,0 +1,265 @@
+From 7e4247cc8485eeb3560eb27d8928dd98138f6eef Mon Sep 17 00:00:00 2001
+From: Randy Eckenrode <randy@largeandhighquality.com>
+Date: Sat, 8 Jun 2024 02:16:35 -0400
+Subject: [PATCH 3/4] ntdll changes for GPTK compatibility
+
+---
+ dlls/ntdll/loader.c             |   8 +++
+ dlls/ntdll/unix/loader.c        | 100 +++++++++++++++++++++++++++++++-
+ dlls/ntdll/unix/signal_x86_64.c |  31 ++++++++++
+ dlls/ntdll/unixlib.h            |   9 +++
+ 4 files changed, 147 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/ntdll/loader.c b/dlls/ntdll/loader.c
+index 5c59d102dd9..6d22a255e0a 100644
+--- a/dlls/ntdll/loader.c
++++ b/dlls/ntdll/loader.c
+@@ -2271,6 +2271,14 @@ static NTSTATUS build_module( LPCWSTR load_path, const UNICODE_STRING *nt_name,
+     TRACE_(loaddll)( "Loaded %s at %p: %s\n", debugstr_w(wm->ldr.FullDllName.Buffer), *module,
+                      is_builtin ? "builtin" : "native" );
+ 
++#if defined(__x86_64__)
++    if (is_builtin == FALSE)
++    {
++        struct pe_module_loaded_params params = { *module, (void*)((BYTE*)*module + map_size) };
++        WINE_UNIX_CALL( unix_pe_module_loaded, &params );
++    }
++#endif
++
+     wm->ldr.LoadCount = 1;
+     *pwm = wm;
+     *module = NULL;
+diff --git a/dlls/ntdll/unix/loader.c b/dlls/ntdll/unix/loader.c
+index 9d866fa70f5..bd9ce36c30b 100644
+--- a/dlls/ntdll/unix/loader.c
++++ b/dlls/ntdll/unix/loader.c
+@@ -37,6 +37,7 @@
+ #include <sys/stat.h>
+ #include <sys/mman.h>
+ #include <sys/wait.h>
++#include <sys/utsname.h>
+ #include <unistd.h>
+ #include <dlfcn.h>
+ #ifdef HAVE_PWD_H
+@@ -343,9 +344,11 @@ static void set_dll_path(void)
+ 
+     if (path) for (p = path, count = 1; *p; p++) if (*p == ':') count++;
+ 
+-    dll_paths = malloc( (count + 2) * sizeof(*dll_paths) );
++    dll_paths = malloc( (count + 2 + 1 /* For the D3DMetal store path */) * sizeof(*dll_paths) );
+     count = 0;
+ 
++    dll_paths[count++] = "@nixD3dMetal@/lib/wine";
++
+     if (!build_dir) dll_paths[count++] = dll_dir;
+ 
+     if (path)
+@@ -356,6 +359,7 @@ static void set_dll_path(void)
+     }
+ 
+     for (i = 0; i < count; i++) dll_path_maxlen = max( dll_path_maxlen, strlen(dll_paths[i]) );
++
+     dll_paths[count] = NULL;
+ }
+ 
+@@ -973,6 +977,93 @@ static NTSTATUS load_so_dll( void *args )
+     return status;
+ }
+ 
++#if defined(__APPLE__) && defined(__x86_64__)
++static pthread_once_t non_native_init_once = PTHREAD_ONCE_INIT;
++static void* non_native_support_lib;
++static void (*register_non_native_code_region) (void*, void*);
++static bool (*supports_non_native_code_regions) (void);
++
++/* libd3dshared.dylib requires Ventura or later, don't bother loading on earlier OSes */
++static BOOL ventura_or_later(void)
++{
++    int result;
++    struct utsname name;
++    unsigned major, minor;
++
++    result = (uname( &name ) == 0 &&
++              sscanf( name.release, "%u.%u", &major, &minor ) == 2 &&
++              major >= 22 /* macOS 13 Ventura */);
++
++    return (result == 1) ? TRUE : FALSE;
++}
++
++/* Only load libd3dshared under Rosetta/Apple Silicon.
++ * On Intel, supports_non_native_code_regions() returns TRUE, but of course
++ * it actually doesn't.
++ * register_non_native_code_region() then does a syscall() which triggers a
++ * SIGSYS and crashes.
++ */
++static BOOL is_apple_silicon(void)
++{
++    /* returns 0 for native process or on error, 1 for translated */
++    int ret = 0;
++    size_t size = sizeof(ret);
++    if (sysctlbyname( "sysctl.proc_translated", &ret, &size, NULL, 0 ) == -1)
++        return FALSE;
++    else
++        return (ret == 1) ? TRUE : FALSE;
++}
++
++static void init_non_native_support(void)
++{
++    size_t idx = 0;
++
++    register_non_native_code_region = NULL;
++    supports_non_native_code_regions = NULL;
++
++    non_native_support_lib = NULL;
++
++    if (!ventura_or_later() || !is_apple_silicon())
++    {
++        return;
++    }
++
++    const char* libd3dshared_path = "@nixD3dMetal@/lib/external/libd3dshared.dylib";
++    non_native_support_lib = dlopen( libd3dshared_path, RTLD_LOCAL );
++    if (non_native_support_lib)
++    {
++        TRACE( "Found libd3dshared.dylib at %s\n", libd3dshared_path );
++    }
++
++    if (non_native_support_lib)
++    {
++        register_non_native_code_region = dlsym( non_native_support_lib, "register_non_native_code_region" );
++        supports_non_native_code_regions = dlsym( non_native_support_lib, "supports_non_native_code_regions" );
++        TRACE( "Loaded libd3dshared.dylib, does%s support non-native code regions\n",
++               supports_non_native_code_regions ? (supports_non_native_code_regions() ? "" : " not") : " not" );
++    }
++    else
++    {
++        TRACE( "Loading libd3dshared.dylib failed: %s\n", dlerror() );
++    }
++}
++
++static NTSTATUS pe_module_loaded( void *args )
++{
++    struct pe_module_loaded_params *params = args;
++
++    pthread_once( &non_native_init_once, &init_non_native_support );
++    if ((supports_non_native_code_regions && supports_non_native_code_regions()))
++    {
++        TRACE("Marking non_native_code_region: %p, %p\n", params->start, params->end);
++        register_non_native_code_region(params->start, params->end);
++    }
++    return STATUS_SUCCESS;
++}
++#elif defined(__x86_64__)
++static NTSTATUS pe_module_loaded( void *args ) { return STATUS_NOT_IMPLEMENTED; }
++#endif
++
+ 
+ static const unixlib_entry_t unix_call_funcs[] =
+ {
+@@ -984,6 +1075,9 @@ static const unixlib_entry_t unix_call_funcs[] =
+     unixcall_wine_server_handle_to_fd,
+     unixcall_wine_spawnvp,
+     system_time_precise,
++#if defined(__x86_64__)
++    pe_module_loaded,
++#endif
+ };
+ 
+ 
+@@ -991,6 +1085,7 @@ static const unixlib_entry_t unix_call_funcs[] =
+ 
+ static NTSTATUS wow64_load_so_dll( void *args ) { return STATUS_INVALID_IMAGE_FORMAT; }
+ static NTSTATUS wow64_unwind_builtin_dll( void *args ) { return STATUS_UNSUCCESSFUL; }
++static NTSTATUS wow64_pe_module_loaded( void *args ) { return STATUS_NOT_IMPLEMENTED; }
+ 
+ const unixlib_entry_t unix_call_wow64_funcs[] =
+ {
+@@ -1002,6 +1097,9 @@ const unixlib_entry_t unix_call_wow64_funcs[] =
+     wow64_wine_server_handle_to_fd,
+     wow64_wine_spawnvp,
+     system_time_precise,
++#if defined(__x86_64__)
++    wow64_pe_module_loaded,
++#endif
+ };
+ 
+ #endif  /* _WIN64 */
+diff --git a/dlls/ntdll/unix/signal_x86_64.c b/dlls/ntdll/unix/signal_x86_64.c
+index e6b53003257..91043d7289f 100644
+--- a/dlls/ntdll/unix/signal_x86_64.c
++++ b/dlls/ntdll/unix/signal_x86_64.c
+@@ -2203,6 +2203,33 @@ static void usr1_handler( int signal, siginfo_t *siginfo, void *sigcontext )
+ }
+ 
+ 
++#ifdef __APPLE__
++/**********************************************************************
++ *		sigsys_handler
++ *
++ * Handler for SIGSYS, signals that a non-existent system call was invoked.
++ * Only called on macOS 14 Sonoma and later.
++ */
++static void sigsys_handler( int signal, siginfo_t *siginfo, void *sigcontext )
++{
++    extern const void *__wine_syscall_dispatcher_prolog_end_ptr;
++    struct syscall_frame *frame = amd64_thread_data()->syscall_frame;
++    ucontext_t *ctx = sigcontext;
++
++    TRACE_(seh)("SIGSYS, rax %#llx, rip %#llx.\n", RAX_sig(ctx), RIP_sig(ctx));
++
++    frame->rip = RIP_sig(ctx) + 0xb;
++    frame->rcx = RIP_sig(ctx);
++    frame->eflags = EFL_sig(ctx);
++    frame->restore_flags = 0;
++    RCX_sig(ctx) = (ULONG_PTR)frame;
++    R11_sig(ctx) = frame->eflags;
++    EFL_sig(ctx) &= ~0x100;  /* clear single-step flag */
++    RIP_sig(ctx) = (ULONG64)__wine_syscall_dispatcher_prolog_end_ptr;
++}
++#endif
++
++
+ /***********************************************************************
+  *           LDT support
+  */
+@@ -2496,6 +2523,10 @@ void signal_init_process(void)
+     if (sigaction( SIGSEGV, &sig_act, NULL ) == -1) goto error;
+     if (sigaction( SIGILL, &sig_act, NULL ) == -1) goto error;
+     if (sigaction( SIGBUS, &sig_act, NULL ) == -1) goto error;
++#ifdef __APPLE__
++    sig_act.sa_sigaction = sigsys_handler;
++    if (sigaction( SIGSYS, &sig_act, NULL ) == -1) goto error;
++#endif
+     install_bpf(&sig_act);
+     return;
+ 
+diff --git a/dlls/ntdll/unixlib.h b/dlls/ntdll/unixlib.h
+index 9cb444342fe..3a4a3700e03 100644
+--- a/dlls/ntdll/unixlib.h
++++ b/dlls/ntdll/unixlib.h
+@@ -66,6 +66,12 @@ struct unwind_builtin_dll_params
+     CONTEXT                    *context;
+ };
+ 
++struct pe_module_loaded_params
++{
++    void *start;
++    void *end;
++};
++
+ enum ntdll_unix_funcs
+ {
+     unix_load_so_dll,
+@@ -76,6 +82,9 @@ enum ntdll_unix_funcs
+     unix_wine_server_handle_to_fd,
+     unix_wine_spawnvp,
+     unix_system_time_precise,
++#if defined(__x86_64__)
++    unix_pe_module_loaded,
++#endif
+ };
+ 
+ extern unixlib_handle_t __wine_unixlib_handle;
+-- 
+2.45.1
+

--- a/pkgs/applications/emulators/wine/gptk/0002-ntdll-changes-for-GPTK-compatibility.patch
+++ b/pkgs/applications/emulators/wine/gptk/0002-ntdll-changes-for-GPTK-compatibility.patch
@@ -1,0 +1,265 @@
+From 887c812755e626fbc688dfa3f380173bcc978edf Mon Sep 17 00:00:00 2001
+From: Randy Eckenrode <randy@largeandhighquality.com>
+Date: Sat, 8 Jun 2024 02:16:35 -0400
+Subject: [PATCH 2/3] ntdll changes for GPTK compatibility
+
+---
+ dlls/ntdll/loader.c             |   8 +++
+ dlls/ntdll/unix/loader.c        | 100 +++++++++++++++++++++++++++++++-
+ dlls/ntdll/unix/signal_x86_64.c |  31 ++++++++++
+ dlls/ntdll/unixlib.h            |   9 +++
+ 4 files changed, 147 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/ntdll/loader.c b/dlls/ntdll/loader.c
+index 5c59d102dd9..6d22a255e0a 100644
+--- a/dlls/ntdll/loader.c
++++ b/dlls/ntdll/loader.c
+@@ -2271,6 +2271,14 @@ static NTSTATUS build_module( LPCWSTR load_path, const UNICODE_STRING *nt_name,
+     TRACE_(loaddll)( "Loaded %s at %p: %s\n", debugstr_w(wm->ldr.FullDllName.Buffer), *module,
+                      is_builtin ? "builtin" : "native" );
+ 
++#if defined(__x86_64__)
++    if (is_builtin == FALSE)
++    {
++        struct pe_module_loaded_params params = { *module, (void*)((BYTE*)*module + map_size) };
++        WINE_UNIX_CALL( unix_pe_module_loaded, &params );
++    }
++#endif
++
+     wm->ldr.LoadCount = 1;
+     *pwm = wm;
+     *module = NULL;
+diff --git a/dlls/ntdll/unix/loader.c b/dlls/ntdll/unix/loader.c
+index 9d866fa70f5..bd9ce36c30b 100644
+--- a/dlls/ntdll/unix/loader.c
++++ b/dlls/ntdll/unix/loader.c
+@@ -37,6 +37,7 @@
+ #include <sys/stat.h>
+ #include <sys/mman.h>
+ #include <sys/wait.h>
++#include <sys/utsname.h>
+ #include <unistd.h>
+ #include <dlfcn.h>
+ #ifdef HAVE_PWD_H
+@@ -343,9 +344,11 @@ static void set_dll_path(void)
+ 
+     if (path) for (p = path, count = 1; *p; p++) if (*p == ':') count++;
+ 
+-    dll_paths = malloc( (count + 2) * sizeof(*dll_paths) );
++    dll_paths = malloc( (count + 2 + 1 /* For the D3DMetal store path */) * sizeof(*dll_paths) );
+     count = 0;
+ 
++    dll_paths[count++] = "@nixD3dMetal@/lib/wine";
++
+     if (!build_dir) dll_paths[count++] = dll_dir;
+ 
+     if (path)
+@@ -356,6 +359,7 @@ static void set_dll_path(void)
+     }
+ 
+     for (i = 0; i < count; i++) dll_path_maxlen = max( dll_path_maxlen, strlen(dll_paths[i]) );
++
+     dll_paths[count] = NULL;
+ }
+ 
+@@ -973,6 +977,93 @@ static NTSTATUS load_so_dll( void *args )
+     return status;
+ }
+ 
++#if defined(__APPLE__) && defined(__x86_64__)
++static pthread_once_t non_native_init_once = PTHREAD_ONCE_INIT;
++static void* non_native_support_lib;
++static void (*register_non_native_code_region) (void*, void*);
++static bool (*supports_non_native_code_regions) (void);
++
++/* libd3dshared.dylib requires Ventura or later, don't bother loading on earlier OSes */
++static BOOL ventura_or_later(void)
++{
++    int result;
++    struct utsname name;
++    unsigned major, minor;
++
++    result = (uname( &name ) == 0 &&
++              sscanf( name.release, "%u.%u", &major, &minor ) == 2 &&
++              major >= 22 /* macOS 13 Ventura */);
++
++    return (result == 1) ? TRUE : FALSE;
++}
++
++/* Only load libd3dshared under Rosetta/Apple Silicon.
++ * On Intel, supports_non_native_code_regions() returns TRUE, but of course
++ * it actually doesn't.
++ * register_non_native_code_region() then does a syscall() which triggers a
++ * SIGSYS and crashes.
++ */
++static BOOL is_apple_silicon(void)
++{
++    /* returns 0 for native process or on error, 1 for translated */
++    int ret = 0;
++    size_t size = sizeof(ret);
++    if (sysctlbyname( "sysctl.proc_translated", &ret, &size, NULL, 0 ) == -1)
++        return FALSE;
++    else
++        return (ret == 1) ? TRUE : FALSE;
++}
++
++static void init_non_native_support(void)
++{
++    size_t idx = 0;
++
++    register_non_native_code_region = NULL;
++    supports_non_native_code_regions = NULL;
++
++    non_native_support_lib = NULL;
++
++    if (!ventura_or_later() || !is_apple_silicon())
++    {
++        return;
++    }
++
++    const char* libd3dshared_path = "@nixD3dMetal@/lib/external/libd3dshared.dylib";
++    non_native_support_lib = dlopen( libd3dshared_path, RTLD_LOCAL );
++    if (non_native_support_lib)
++    {
++        TRACE( "Found libd3dshared.dylib at %s\n", libd3dshared_path );
++    }
++
++    if (non_native_support_lib)
++    {
++        register_non_native_code_region = dlsym( non_native_support_lib, "register_non_native_code_region" );
++        supports_non_native_code_regions = dlsym( non_native_support_lib, "supports_non_native_code_regions" );
++        TRACE( "Loaded libd3dshared.dylib, does%s support non-native code regions\n",
++               supports_non_native_code_regions ? (supports_non_native_code_regions() ? "" : " not") : " not" );
++    }
++    else
++    {
++        TRACE( "Loading libd3dshared.dylib failed: %s\n", dlerror() );
++    }
++}
++
++static NTSTATUS pe_module_loaded( void *args )
++{
++    struct pe_module_loaded_params *params = args;
++
++    pthread_once( &non_native_init_once, &init_non_native_support );
++    if ((supports_non_native_code_regions && supports_non_native_code_regions()))
++    {
++        TRACE("Marking non_native_code_region: %p, %p\n", params->start, params->end);
++        register_non_native_code_region(params->start, params->end);
++    }
++    return STATUS_SUCCESS;
++}
++#elif defined(__x86_64__)
++static NTSTATUS pe_module_loaded( void *args ) { return STATUS_NOT_IMPLEMENTED; }
++#endif
++
+ 
+ static const unixlib_entry_t unix_call_funcs[] =
+ {
+@@ -984,6 +1075,9 @@ static const unixlib_entry_t unix_call_funcs[] =
+     unixcall_wine_server_handle_to_fd,
+     unixcall_wine_spawnvp,
+     system_time_precise,
++#if defined(__x86_64__)
++    pe_module_loaded,
++#endif
+ };
+ 
+ 
+@@ -991,6 +1085,7 @@ static const unixlib_entry_t unix_call_funcs[] =
+ 
+ static NTSTATUS wow64_load_so_dll( void *args ) { return STATUS_INVALID_IMAGE_FORMAT; }
+ static NTSTATUS wow64_unwind_builtin_dll( void *args ) { return STATUS_UNSUCCESSFUL; }
++static NTSTATUS wow64_pe_module_loaded( void *args ) { return STATUS_NOT_IMPLEMENTED; }
+ 
+ const unixlib_entry_t unix_call_wow64_funcs[] =
+ {
+@@ -1002,6 +1097,9 @@ const unixlib_entry_t unix_call_wow64_funcs[] =
+     wow64_wine_server_handle_to_fd,
+     wow64_wine_spawnvp,
+     system_time_precise,
++#if defined(__x86_64__)
++    wow64_pe_module_loaded,
++#endif
+ };
+ 
+ #endif  /* _WIN64 */
+diff --git a/dlls/ntdll/unix/signal_x86_64.c b/dlls/ntdll/unix/signal_x86_64.c
+index a163d5d0b33..fe9595798ba 100644
+--- a/dlls/ntdll/unix/signal_x86_64.c
++++ b/dlls/ntdll/unix/signal_x86_64.c
+@@ -2203,6 +2203,33 @@ static void usr1_handler( int signal, siginfo_t *siginfo, void *sigcontext )
+ }
+ 
+ 
++#ifdef __APPLE__
++/**********************************************************************
++ *		sigsys_handler
++ *
++ * Handler for SIGSYS, signals that a non-existent system call was invoked.
++ * Only called on macOS 14 Sonoma and later.
++ */
++static void sigsys_handler( int signal, siginfo_t *siginfo, void *sigcontext )
++{
++    extern const void *__wine_syscall_dispatcher_prolog_end_ptr;
++    struct syscall_frame *frame = amd64_thread_data()->syscall_frame;
++    ucontext_t *ctx = sigcontext;
++
++    TRACE_(seh)("SIGSYS, rax %#llx, rip %#llx.\n", RAX_sig(ctx), RIP_sig(ctx));
++
++    frame->rip = RIP_sig(ctx) + 0xb;
++    frame->rcx = RIP_sig(ctx);
++    frame->eflags = EFL_sig(ctx);
++    frame->restore_flags = 0;
++    RCX_sig(ctx) = (ULONG_PTR)frame;
++    R11_sig(ctx) = frame->eflags;
++    EFL_sig(ctx) &= ~0x100;  /* clear single-step flag */
++    RIP_sig(ctx) = (ULONG64)__wine_syscall_dispatcher_prolog_end_ptr;
++}
++#endif
++
++
+ /***********************************************************************
+  *           LDT support
+  */
+@@ -2496,6 +2523,10 @@ void signal_init_process(void)
+     if (sigaction( SIGSEGV, &sig_act, NULL ) == -1) goto error;
+     if (sigaction( SIGILL, &sig_act, NULL ) == -1) goto error;
+     if (sigaction( SIGBUS, &sig_act, NULL ) == -1) goto error;
++#ifdef __APPLE__
++    sig_act.sa_sigaction = sigsys_handler;
++    if (sigaction( SIGSYS, &sig_act, NULL ) == -1) goto error;
++#endif
+     return;
+ 
+  error:
+diff --git a/dlls/ntdll/unixlib.h b/dlls/ntdll/unixlib.h
+index 9cb444342fe..3a4a3700e03 100644
+--- a/dlls/ntdll/unixlib.h
++++ b/dlls/ntdll/unixlib.h
+@@ -66,6 +66,12 @@ struct unwind_builtin_dll_params
+     CONTEXT                    *context;
+ };
+ 
++struct pe_module_loaded_params
++{
++    void *start;
++    void *end;
++};
++
+ enum ntdll_unix_funcs
+ {
+     unix_load_so_dll,
+@@ -76,6 +82,9 @@ enum ntdll_unix_funcs
+     unix_wine_server_handle_to_fd,
+     unix_wine_spawnvp,
+     unix_system_time_precise,
++#if defined(__x86_64__)
++    unix_pe_module_loaded,
++#endif
+ };
+ 
+ extern unixlib_handle_t __wine_unixlib_handle;
+-- 
+2.45.1
+

--- a/pkgs/applications/emulators/wine/gptk/0003-Revert-ntdll-Make-__wine_unix_call-an-inline-functio.patch
+++ b/pkgs/applications/emulators/wine/gptk/0003-Revert-ntdll-Make-__wine_unix_call-an-inline-functio.patch
@@ -1,0 +1,111 @@
+From 5abdd5c6c01c64c0e7d9ed0c8eb8d12ca2f5abee Mon Sep 17 00:00:00 2001
+From: Randy Eckenrode <randy@largeandhighquality.com>
+Date: Tue, 11 Jun 2024 00:21:05 -0400
+Subject: [PATCH 3/3] Revert "ntdll: Make __wine_unix_call() an inline
+ function."
+
+This reverts commit 127650c293b5716c6a1f2028185c3f3fe8c6598c.
+---
+ dlls/ntdll/loader.c    | 11 ++++++++++-
+ dlls/ntdll/ntdll.spec  |  1 +
+ dlls/win32u/main.c     |  8 +++++---
+ include/wine/unixlib.h |  7 ++-----
+ 4 files changed, 18 insertions(+), 9 deletions(-)
+
+diff --git a/dlls/ntdll/loader.c b/dlls/ntdll/loader.c
+index 6d22a255e0a..6b2de559965 100644
+--- a/dlls/ntdll/loader.c
++++ b/dlls/ntdll/loader.c
+@@ -70,7 +70,7 @@ typedef DWORD (CALLBACK *DLLENTRYPROC)(HMODULE,DWORD,LPVOID);
+ typedef void  (CALLBACK *LDRENUMPROC)(LDR_DATA_TABLE_ENTRY *, void *, BOOLEAN *);
+ 
+ void (FASTCALL *pBaseThreadInitThunk)(DWORD,LPTHREAD_START_ROUTINE,void *) = NULL;
+-NTSTATUS (WINAPI *__wine_unix_call_dispatcher)( unixlib_handle_t, unsigned int, void * ) = NULL;
++NTSTATUS (WINAPI *__wine_unix_call_dispatcher)( unixlib_handle_t, unsigned int, void * ) = __wine_unix_call;
+ 
+ static DWORD (WINAPI *pCtrlRoutine)(void *);
+ 
+@@ -3331,6 +3331,15 @@ NTSTATUS WINAPI __wine_ctrl_routine( void *arg )
+ }
+ 
+ 
++/***********************************************************************
++ *              __wine_unix_call
++ */
++NTSTATUS WINAPI __wine_unix_call( unixlib_handle_t handle, unsigned int code, void *args )
++{
++    return __wine_unix_call_dispatcher( handle, code, args );
++}
++
++
+ /***********************************************************************
+  *           __wine_unix_spawnvp
+  */
+diff --git a/dlls/ntdll/ntdll.spec b/dlls/ntdll/ntdll.spec
+index 3471905c762..5070d1c4b40 100644
+--- a/dlls/ntdll/ntdll.spec
++++ b/dlls/ntdll/ntdll.spec
+@@ -1719,6 +1719,7 @@
+ @ cdecl wine_server_handle_to_fd(long long ptr ptr)
+ 
+ # Unix interface
++@ stdcall __wine_unix_call(int64 long ptr)
+ @ stdcall __wine_unix_spawnvp(long ptr)
+ @ stdcall __wine_ctrl_routine(ptr)
+ @ extern -private __wine_syscall_dispatcher
+diff --git a/dlls/win32u/main.c b/dlls/win32u/main.c
+index 8e32fc63556..28383161b6f 100644
+--- a/dlls/win32u/main.c
++++ b/dlls/win32u/main.c
+@@ -33,6 +33,8 @@
+ 
+ void *__wine_syscall_dispatcher = NULL;
+ 
++static unixlib_handle_t win32u_handle;
++
+ /*******************************************************************
+  *         syscalls
+  */
+@@ -2190,8 +2192,6 @@ void __cdecl __wine_spec_unimplemented_stub( const char *module, const char *fun
+     for (;;) RtlRaiseException( &record );
+ }
+ 
+-void *dummy = NtQueryVirtualMemory;  /* forced import to avoid link error with winecrt0 */
+-
+ BOOL WINAPI DllMain( HINSTANCE inst, DWORD reason, void *reserved )
+ {
+     HMODULE ntdll;
+@@ -2206,7 +2206,9 @@ BOOL WINAPI DllMain( HINSTANCE inst, DWORD reason, void *reserved )
+         LdrGetDllHandle( NULL, 0, &ntdll_name, &ntdll );
+         dispatcher_ptr = RtlFindExportedRoutineByName( ntdll, "__wine_syscall_dispatcher" );
+         __wine_syscall_dispatcher = *dispatcher_ptr;
+-        if (!__wine_init_unix_call()) WINE_UNIX_CALL( 0, NULL );
++        if (!NtQueryVirtualMemory( GetCurrentProcess(), inst, MemoryWineUnixFuncs,
++                                   &win32u_handle, sizeof(win32u_handle), NULL ))
++            __wine_unix_call( win32u_handle, 0, NULL );
+         break;
+     }
+     return TRUE;
+diff --git a/include/wine/unixlib.h b/include/wine/unixlib.h
+index 9a342fada73..90c16ff1f07 100644
+--- a/include/wine/unixlib.h
++++ b/include/wine/unixlib.h
+@@ -269,13 +269,10 @@ static inline NTSTATUS __wine_unix_call( unixlib_handle_t handle, unsigned int c
+     return __wine_unix_call_arm64ec( handle, code, args );
+ }
+ #else
+-static inline NTSTATUS __wine_unix_call( unixlib_handle_t handle, unsigned int code, void *args )
+-{
+-    return __wine_unix_call_dispatcher( handle, code, args );
+-}
++NTSYSAPI NTSTATUS WINAPI __wine_unix_call( unixlib_handle_t handle, unsigned int code, void *args );
+ #endif
+ 
+-#define WINE_UNIX_CALL(code,args) __wine_unix_call( __wine_unixlib_handle, (code), (args) )
++#define WINE_UNIX_CALL(code,args) __wine_unix_call_dispatcher( __wine_unixlib_handle, (code), (args) )
+ 
+ #endif /* WINE_UNIX_LIB */
+ 
+-- 
+2.45.1
+

--- a/pkgs/applications/emulators/wine/packages.nix
+++ b/pkgs/applications/emulators/wine/packages.nix
@@ -1,4 +1,4 @@
-{ stdenv_32bit, lib, pkgs, pkgsi686Linux, pkgsCross, callPackage, substituteAll, moltenvk,
+{ stdenv_32bit, lib, pkgs, pkgsi686Linux, pkgsCross, callPackage, substituteAll, d3dmetal, moltenvk,
   wineRelease ? "stable",
   supportFlags
 }:
@@ -8,7 +8,7 @@ let
 in with src; {
   wine32 = pkgsi686Linux.callPackage ./base.nix {
     pname = "wine";
-    inherit src version supportFlags patches moltenvk wineRelease;
+    inherit src version supportFlags patches d3dmetal moltenvk wineRelease;
     pkgArches = [ pkgsi686Linux ];
     geckos = [ gecko32 ];
     mingwGccs = with pkgsCross; [ mingw32.buildPackages.gcc ];
@@ -17,7 +17,7 @@ in with src; {
   };
   wine64 = callPackage ./base.nix {
     pname = "wine64";
-    inherit src version supportFlags patches moltenvk wineRelease;
+    inherit src version supportFlags patches d3dmetal moltenvk wineRelease;
     pkgArches = [ pkgs ];
     mingwGccs = with pkgsCross; [ mingwW64.buildPackages.gcc ];
     geckos = [ gecko64 ];
@@ -28,7 +28,7 @@ in with src; {
   };
   wineWow = callPackage ./base.nix {
     pname = "wine-wow";
-    inherit src version supportFlags patches moltenvk wineRelease;
+    inherit src version supportFlags patches d3dmetal moltenvk wineRelease;
     stdenv = stdenv_32bit;
     pkgArches = [ pkgs pkgsi686Linux ];
     geckos = [ gecko32 gecko64 ];
@@ -44,7 +44,7 @@ in with src; {
   };
   wineWow64 = callPackage ./base.nix {
     pname = "wine-wow64";
-    inherit src version patches moltenvk wineRelease;
+    inherit src version patches d3dmetal moltenvk wineRelease;
     supportFlags = supportFlags // { mingwSupport = true; };  # Required because we request "--enable-archs=x86_64"
     pkgArches = [ pkgs ];
     mingwGccs = with pkgsCross; [ mingw32.buildPackages.gcc mingwW64.buildPackages.gcc ];

--- a/pkgs/by-name/d3/d3dmetal/package.nix
+++ b/pkgs/by-name/d3/d3dmetal/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenvNoCC,
+  requireFile,
+  undmg,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "d3dmetal";
+  version = "1.1";
+
+  src = requireFile {
+    name = "Game_Porting_Toolkit_${finalAttrs.version}.dmg";
+    hash = "sha256-KoZRjX/OicMEJmZUp2EH05Wpp1VyJQlrc6g0iTSCt/E=";
+    url = "https://developer.apple.com/download/all/?q=game%20porting%20toolkit";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ undmg ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p "$out/lib/wine/x86_64-"{unix,windows}
+    cp -r lib/external "$out/lib"
+    for dll_so in atidxx64 d3d9 d3d10 d3d11 d3d12 dxgi; do
+      ln -s "$out/lib/external/libd3dshared.dylib" "$out/lib/wine/x86_64-unix/$dll_so.so"
+    done
+    cp -r lib/wine/x86_64-windows "$out/lib/wine"
+  '';
+
+  meta = with lib; {
+    description = "The D3D Metal component of Apple’s Gaming Porting Toolkit for use with Wine.";
+    license = licenses.unfree;
+    maintainers = [ maintainers.reckenrode ];
+    platforms = [ "x86_64-darwin" ];
+  };
+})


### PR DESCRIPTION
## Description of changes

All GPTK patches apply to Wine stable, unstable, and staging. D3DMetal 2.0b1 also works, but it won’t updated until a final release is available.

- Port winemac.drv and ntdll changes from CrossOver; and
- Revert Wine 9.10 commit that breaks GPTK.

Tested with https://gpuopen.com/learn/mlaa11-directx-11-sdk-sample/ and _Bloodstained: Ritual of the Night_.

Closes #236414.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
