### PR TITLE
vimPlugins.nvim-treesitter: collate grammars

### DIFF
--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
@@ -36,8 +36,22 @@ let
   # pkgs.vimPlugins.nvim-treesitter.withAllGrammars
   withPlugins =
     f: self.nvim-treesitter.overrideAttrs {
-      passthru.dependencies = map grammarToPlugin
-        (f (tree-sitter.builtGrammars // builtGrammars));
+      passthru.dependencies =
+        let
+          grammars = map grammarToPlugin
+            (f (tree-sitter.builtGrammars // builtGrammars));
+          copyGrammar = grammar:
+            let name = lib.last (lib.splitString "-" grammar.name); in
+            "ln -s ${grammar}/parser/${name}.so $out/parser/${name}.so";
+        in
+        [
+          (runCommand "vimplugin-treesitter-grammars"
+            { meta.platforms = lib.platforms.all; }
+            ''
+              mkdir -p $out/parser
+              ${lib.concatMapStringsSep "\n" copyGrammar grammars}
+            '')
+        ];
     };
 
   withAllGrammars = withPlugins (_: allGrammars);


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Currently `pkgs.vimPlugins.nvim-treesitter.withAllGrammars` adds 279 directories to `'runtimepath'`, significantly slowing down startup time. See `:help nvim-treesitter-performance`.

> `nvim-treesitter` checks the 'runtimepath' on startup in order to discover
> available parsers and queries and index them. As a consequence, a very long
> 'runtimepath' might result in delayed startup times.

This PR changes the directory structure from `vimplugin-treesitter-${grammar}/parser/${name}.so` for each grammar to a single directory of the form `vimplugin-treesitter-grammars/parser/*.so` containing all specified grammars.

In my configuration, this saves about 100 ms. I use `vim.loader.enable()` and the contents of `test.py` are
```python
print("hello")
```

- `pkgs.vimPlugins.nvim-treesitter.withPlugins (_: [ ])` (0 additional grammars)
  - `nvim --startuptime time.txt` -> ~110 ms
  - `nvim --startuptime time.txt test.py` -> ~200 ms
- with these [56 treesitter grammars](https://github.com/stephen-huan/nixos-config/blob/8e4cddb60aff356e22ea45aa1d4e1f2af2686d21/home/neovim/plugins.nix#L107-L162)
  - `nvim --startuptime time.txt` -> ~130 ms
  - `nvim --startuptime time.txt test.py` -> ~220 ms
- `pkgs.vimPlugins.nvim-treesitter.withAllGrammars` (279 grammars)
  - `nvim --startuptime time.txt` -> ~200 ms
  - `nvim --startuptime time.txt test.py` -> ~300 ms
- after collating (this PR)
  - with 56 treesitter grammars
    - `nvim --startuptime time.txt` -> ~115 ms
    - `nvim --startuptime time.txt test.py` -> ~200 ms
  - `pkgs.vimPlugins.nvim-treesitter.withAllGrammars` 
    - `nvim --startuptime time.txt` -> ~115 ms
    - `nvim --startuptime time.txt test.py` -> ~200 ms
  
We can conclude the cost of adding each grammar to `'runtimepath'` is linear and roughly 0.36 ms per grammar. After collating, the startup cost is negligible even with all grammars added. 

Ran `nix build .#vimPlugins.nvim-treesitter.tests.check-queries` and `nixpkgs-review rev HEAD`. 

Also (a variant of this PR in my [personal configuration](https://github.com/stephen-huan/nixos-config/commit/452b8693046ecebf9807a8ebef54f044d5cf27b1)) passes `:checkhealth`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
