### PR TITLE
shipwright: darwin build, add maintainer

### DIFF
--- a/pkgs/games/shipwright/darwin-fixes.patch
+++ b/pkgs/games/shipwright/darwin-fixes.patch
@@ -1,0 +1,37 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2c8644af..157758c9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -166,17 +166,13 @@ endif()
+ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+ add_custom_target(CreateOSXIcons
+     COMMAND mkdir -p ${CMAKE_BINARY_DIR}/macosx/soh.iconset
+-    COMMAND sips -z 16 16     soh/macosx/sohIcon.png --out ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_16x16.png
+-    COMMAND sips -z 32 32     soh/macosx/sohIcon.png --out ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_16x16@2x.png
+-    COMMAND sips -z 32 32     soh/macosx/sohIcon.png --out ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_32x32.png
+-    COMMAND sips -z 64 64     soh/macosx/sohIcon.png --out ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_32x32@2x.png
+-    COMMAND sips -z 128 128   soh/macosx/sohIcon.png --out ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_128x128.png
+-    COMMAND sips -z 256 256   soh/macosx/sohIcon.png --out ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_128x128@2x.png
+-    COMMAND sips -z 256 256   soh/macosx/sohIcon.png --out ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_256x256.png
+-    COMMAND sips -z 512 512   soh/macosx/sohIcon.png --out ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_256x256@2x.png
+-    COMMAND sips -z 512 512   soh/macosx/sohIcon.png --out ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_512x512.png
+-    COMMAND cp                soh/macosx/sohIcon.png ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_512x512@2x.png
+-    COMMAND iconutil -c icns -o ${CMAKE_BINARY_DIR}/macosx/soh.icns ${CMAKE_BINARY_DIR}/macosx/soh.iconset
++    COMMAND convert soh/macosx/sohIcon.png -resize 16x16 ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_16.png
++    COMMAND convert soh/macosx/sohIcon.png -resize 32x32 ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_32.png
++    COMMAND convert soh/macosx/sohIcon.png -resize 64x64 ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_64.png
++    COMMAND convert soh/macosx/sohIcon.png -resize 128x128 ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_128.png
++    COMMAND convert soh/macosx/sohIcon.png -resize 256x256 ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_256.png
++    COMMAND convert soh/macosx/sohIcon.png -resize 512x512 ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_512.png
++    COMMAND png2icns ${CMAKE_BINARY_DIR}/macosx/soh.icns ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_{16,32,64,128,256,512}.png
+     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+     COMMENT "Creating OSX icons ..."
+     )
+@@ -201,7 +197,6 @@ install(DIRECTORY ${CMAKE_BINARY_DIR}/assets
+ 
+ install(CODE "
+     include(BundleUtilities)
+-    fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/soh-macos\" \"\" \"${dirs}\")
+     ")
+ 
+ endif()

--- a/pkgs/games/shipwright/default.nix
+++ b/pkgs/games/shipwright/default.nix
@@ -24,8 +24,13 @@
 , imagemagick
 , gnome
 , makeWrapper
+, darwin
+, libicns
 }:
-
+let
+  inherit (darwin.apple_sdk_11_0.frameworks)
+    IOSurface Metal QuartzCore Cocoa AVFoundation;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "shipwright";
   version = "8.0.5";
@@ -37,6 +42,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-o2VwOF46Iq4pwpumOau3bDXJ/CArx6NWBi00s3E4PnE=";
     fetchSubmodules = true;
   };
+
+  patches = [
+    ./darwin-fixes.patch
+  ];
 
   # This would get fetched at build time otherwise, see:
   # https://github.com/HarbourMasters/Shipwright/blob/e46c60a7a1396374e23f7a1f7122ddf9efcadff7/soh/CMakeLists.txt#L736
@@ -50,33 +59,48 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     ninja
     pkg-config
-    lsb-release
     python3
     imagemagick
-    copyDesktopItems
     makeWrapper
+  ] ++ lib.optionals stdenv.isLinux [
+    lsb-release
+    copyDesktopItems
+  ] ++ lib.optionals stdenv.isDarwin [
+    libicns
+    darwin.sigtool
   ];
 
   buildInputs = [
     boost
+    glew
+    SDL2
+    SDL2_net
+    libpng
+  ] ++ lib.optionals stdenv.isLinux [
     libX11
     libXrandr
     libXinerama
     libXcursor
     libXi
     libXext
-    glew
-    SDL2
-    SDL2_net
     libpulseaudio
-    libpng
     gnome.zenity
+  ] ++ lib.optionals stdenv.isDarwin [
+    IOSurface
+    Metal
+    QuartzCore
+    Cocoa
+    AVFoundation
+    darwin.apple_sdk_11_0.libs.simd
   ];
 
   cmakeFlags = [
     "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}/lib"
     (lib.cmakeBool "NON_PORTABLE" true)
   ];
+
+  env.NIX_CFLAGS_COMPILE =
+    lib.optionalString stdenv.isDarwin "-Wno-int-conversion -Wno-implicit-int";
 
   dontAddPrefix = true;
 
@@ -90,18 +114,60 @@ stdenv.mkDerivation (finalAttrs: {
     popd
   '';
 
-  preInstall = ''
+  preInstall = lib.optionalString stdenv.isLinux ''
     # Cmake likes it here for its install paths
     cp ../OTRExporter/soh.otr ..
+  '' + lib.optionalString stdenv.isDarwin ''
+    cp ../OTRExporter/soh.otr soh/soh.otr
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString stdenv.isLinux ''
     mkdir -p $out/bin
     ln -s $out/lib/soh.elf $out/bin/soh
     install -Dm644 ../soh/macosx/sohIcon.png $out/share/pixmaps/soh.png
+  '' + lib.optionalString stdenv.isDarwin ''
+    # Recreate the macOS bundle (without using cpack)
+    # We mirror the structure of the bundle distributed by the project
+
+    mkdir -p $out/Applications/soh.app/Contents
+    cp $src/soh/macosx/Info.plist.in $out/Applications/soh.app/Contents/Info.plist
+    substituteInPlace $out/Applications/soh.app/Contents/Info.plist \
+      --replace-fail "@CMAKE_PROJECT_VERSION@" "${finalAttrs.version}"
+
+    mv $out/MacOS $out/Applications/soh.app/Contents/MacOS
+
+    # Wrapper
+    cp $src/soh/macosx/soh-macos.sh.in $out/Applications/soh.app/Contents/MacOS/soh
+    chmod +x $out/Applications/soh.app/Contents/MacOS/soh
+    patchShebangs $out/Applications/soh.app/Contents/MacOS/soh
+
+    # "lib" contains all resources that are in "Resources" in the official bundle.
+    # We move them to the right place and symlink them back to $out/lib,
+    # as that's where the game expects them.
+    mv $out/Resources $out/Applications/soh.app/Contents/Resources
+    mv $out/lib/** $out/Applications/soh.app/Contents/Resources
+    rm -rf $out/lib
+    ln -s $out/Applications/soh.app/Contents/Resources $out/lib
+
+    # Copy icons
+    cp -r ../build/macosx/soh.icns $out/Applications/soh.app/Contents/Resources/soh.icns
+
+    # Fix executable
+    install_name_tool -change @executable_path/../Frameworks/libSDL2-2.0.0.dylib \
+                      ${SDL2}/lib/libSDL2-2.0.0.dylib \
+                      $out/Applications/soh.app/Contents/Resources/soh-macos
+    install_name_tool -change @executable_path/../Frameworks/libGLEW.2.2.0.dylib \
+                      ${glew}/lib/libGLEW.2.2.0.dylib \
+                      $out/Applications/soh.app/Contents/Resources/soh-macos
+    install_name_tool -change @executable_path/../Frameworks/libpng16.16.dylib \
+                      ${libpng}/lib/libpng16.16.dylib \
+                      $out/Applications/soh.app/Contents/Resources/soh-macos
+
+    # Codesign (ad-hoc)
+    codesign -f -s - $out/Applications/soh.app/Contents/Resources/soh-macos
   '';
 
-  fixupPhase = ''
+  fixupPhase = lib.optionalString stdenv.isLinux ''
     wrapProgram $out/lib/soh.elf --prefix PATH ":" ${lib.makeBinPath [ gnome.zenity ]}
   '';
 
@@ -121,8 +187,8 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/HarbourMasters/Shipwright";
     description = "A PC port of Ocarina of Time with modern controls, widescreen, high-resolution, and more";
     mainProgram = "soh";
-    platforms = [ "x86_64-linux" ];
-    maintainers = with lib.maintainers; [ ivar j0lol ];
+    platforms = [ "x86_64-linux" ] ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ ivar j0lol matteopacini ];
     license = with lib.licenses; [
       # OTRExporter, OTRGui, ZAPDTR, libultraship
       mit

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36251,7 +36251,9 @@ with pkgs;
 
   keeperrl = callPackage ../games/keeperrl { };
 
-  shipwright = callPackage ../games/shipwright { };
+  shipwright = callPackage ../games/shipwright {
+    stdenv = if stdenv.isDarwin then overrideSDK stdenv "11.0" else stdenv;
+  };
 
   wipeout-rewrite = callPackage ../games/wipeout-rewrite {
     inherit (darwin.apple_sdk.frameworks) Foundation;


### PR DESCRIPTION
## Description of changes

- Added support for Darwin (with 11.0 SDK, as Metal is needed)
- Added myself as a maintainer for Darwin

Changes needed to make it work on macOS:
- `-Wno-int-conversion -Wno-implicit-int` CFLAGS (Clang is unhappy about a few pieces of code)
- Recreate the app bundle from scratch - as we cannot use `cpack` directly because it needs `hdiutil`

Note: on `aarch64-darwin` Rosetta is required to start the app, to install it run:

`/usr/sbin/softwareupdate --install-rosetta --agree-to-license`

![Screenshot 2024-06-12 at 12 54 10](https://github.com/NixOS/nixpkgs/assets/3139724/83562ad3-a7fd-4e88-9048-b4310887d7d7)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
