### PR TITLE
roddhjav-apparmor-rules: init at 0-unstable-2024-06-11

### DIFF
--- a/pkgs/by-name/ro/roddhjav-apparmor-rules/package.nix
+++ b/pkgs/by-name/ro/roddhjav-apparmor-rules/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  unstableGitUpdater,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "roddhjav-apparmor-rules";
+  version = "0-unstable-2024-06-11";
+
+  src = fetchFromGitHub {
+    owner = "roddhjav";
+    repo = "apparmor.d";
+    rev = "6d549b7c70415e884586c23a8a5d2448d89e543d";
+    hash = "sha256-iHBIBOKOsagDwQRD8SjymEeM3xTQhtTDeL8YvqhHtPQ=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/etc/apparmor.d
+    cp -r apparmor.d/* $out/etc/apparmor.d
+    runHook postInstall
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    homepage = "https://github.com/roddhjav/apparmor.d";
+    description = "Over 1500 AppArmor profiles aiming to confine most linux processes";
+    longDescription = ''
+      AppArmor.d is a set of over 1500 AppArmor profiles whose aim is to confine
+      most Linux based applications and processes. Confines all system services, user services
+      and most desktop environments. Currently supported DEs are GNOME, KDE and XFCE (partial).
+      If your DE is not listed in https://github.com/roddhjav/apparmor.d
+      Do not use this, else it may break your system.
+    '';
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      johnrtitor
+    ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This is a set of over 1500 AppArmor profiles whose aim is to confine most Linux based applications and processes. Currently GNOME, KDE, and XFCE (partial) are supported.

This is meant to be used with AppArmor module.
```nix
security.apparmor.packages = with pkgs; [ roddhjav-apparmor-rules ];
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
