### PR TITLE
sfwbar 1.0_beta13 -> 1.0_beta14

### DIFF
--- a/pkgs/applications/misc/sfwbar/default.nix
+++ b/pkgs/applications/misc/sfwbar/default.nix
@@ -1,18 +1,18 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, gtk3
-, meson
-, ninja
-, json_c
-, pkg-config
-, gtk-layer-shell
-, libpulseaudio
-, libmpdclient
-, libxkbcommon
-, alsa-lib
-, makeWrapper
-,
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gtk3,
+  meson,
+  ninja,
+  json_c,
+  pkg-config,
+  gtk-layer-shell,
+  libpulseaudio,
+  libmpdclient,
+  libxkbcommon,
+  alsa-lib,
+  makeWrapper,
 }:
 stdenv.mkDerivation rec {
   pname = "sfwbar";
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     owner = "LBCrion";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-7oiuTEqdXDReKdakJX6+HRaSi1XovM+MkHFkaFZtq64=";
+    hash = "sha256-4brP1SXaWq/L0D87rvlrWhLU1oFPSwNNxBSzRr4jsTM=";
   };
 
   buildInputs = [
@@ -47,12 +47,16 @@ stdenv.mkDerivation rec {
       --suffix XDG_DATA_DIRS : $out/share
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/LBCrion/sfwbar";
     description = "Flexible taskbar application for wayland compositors, designed with a stacking layout in mind";
+    changelog = "https://github.com/LBCrion/sfwbar/releases/tag/v${version}";
     mainProgram = "sfwbar";
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ NotAShelf ];
-    license = licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      luftmensch-luftmensch
+      NotAShelf
+    ];
+    license = lib.licenses.gpl3Only;
   };
 }

--- a/pkgs/by-name/sf/sfwbar/package.nix
+++ b/pkgs/by-name/sf/sfwbar/package.nix
@@ -14,13 +14,16 @@
   alsa-lib,
   makeWrapper,
 }:
-stdenv.mkDerivation rec {
+let
+  version = "1.0_beta14";
+in
+stdenv.mkDerivation {
   pname = "sfwbar";
-  version = "1.0_beta13";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "LBCrion";
-    repo = pname;
+    repo = "sfwbar";
     rev = "v${version}";
     hash = "sha256-4brP1SXaWq/L0D87rvlrWhLU1oFPSwNNxBSzRr4jsTM=";
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31647,8 +31647,6 @@ with pkgs;
     singularity-overriden-nixos
     ;
 
-  sfwbar = callPackage ../applications/misc/sfwbar { };
-
   skate = callPackage ../applications/misc/skate { };
 
   slack = callPackage ../applications/networking/instant-messengers/slack { };


### PR DESCRIPTION
## Description of changes
Closes #319278

+ [Release notes](https://github.com/LBCrion/sfwbar/releases/tag/v1.0_beta14)

Updated location of package definition to `pkgs/by-name/`
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
