### PR TITLE
kdePackages.kio: resolve full paths to executables from the caller

### DIFF
--- a/pkgs/kde/frameworks/kio/default.nix
+++ b/pkgs/kde/frameworks/kio/default.nix
@@ -10,8 +10,10 @@ mkKdeDerivation {
 
   patches = [
     # Remove hardcoded smbd search path
-    # FIXME(later): discuss with upstream?
     ./0001-Remove-impure-smbd-search-path.patch
+    # When running a process through systemd, resolve the full path ourselves
+    ./early-resolve-executables.diff
+    # FIXME(later): discuss with upstream?
   ];
 
   extraBuildInputs = [qt5compat qttools acl attr];

--- a/pkgs/kde/frameworks/kio/early-resolve-executables.diff
+++ b/pkgs/kde/frameworks/kio/early-resolve-executables.diff
@@ -1,0 +1,13 @@
+diff --git a/src/gui/systemd/systemdprocessrunner.cpp b/src/gui/systemd/systemdprocessrunner.cpp
+index afe3e2c69..5e5ee012d 100644
+--- a/src/gui/systemd/systemdprocessrunner.cpp
++++ b/src/gui/systemd/systemdprocessrunner.cpp
+@@ -128,7 +128,7 @@ void SystemdProcessRunner::startProcess()
+                                               // so we can be notified (see https://github.com/systemd/systemd/pull/3984)
+             {QStringLiteral("Environment"), m_process->environment()},
+             {QStringLiteral("WorkingDirectory"), m_process->workingDirectory()},
+-            {QStringLiteral("ExecStart"), QVariant::fromValue(ExecCommandList{{m_process->program().first(), m_process->program(), false}})},
++            {QStringLiteral("ExecStart"), QVariant::fromValue(ExecCommandList{{QStandardPaths::findExecutable(m_process->program().first()), m_process->program(), false}})},
+         },
+         {} // aux is currently unused and should be passed as empty array.
+     );


### PR DESCRIPTION
## Description of changes

We can't rely on systemd here because it doesn't have PATH. Fixes #319184.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
