### PR TITLE
nixosTest: Introduce IPv6

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -224,6 +224,8 @@
 
 - [`lib.options.mkPackageOptionMD`](https://nixos.org/manual/nixpkgs/unstable#function-library-lib.options.mkPackageOptionMD) is now obsolete; use the identical [`lib.options.mkPackageOption`](https://nixos.org/manual/nixpkgs/unstable#function-library-lib.options.mkPackageOption) instead.
 
+- `nixosTests` now provide a working IPv6 setup for VLAN 1 by default.
+
 - To facilitate dependency injection, the `imgui` package now builds a static archive using vcpkg' CMake rules.
   The derivation now installs "impl" headers selectively instead of by a wildcard.
   Use `imgui.src` if you just want to access the unpacked sources.

--- a/nixos/lib/testing/network.nix
+++ b/nixos/lib/testing/network.nix
@@ -32,10 +32,19 @@ let
       # Automatically assign IP addresses to requested interfaces.
       assignIPs = lib.filter (i: i.assignIP) interfaces;
       ipInterfaces = forEach assignIPs (i:
-        nameValuePair i.name { ipv4.addresses =
-          [ { address = "192.168.${toString i.vlan}.${toString config.virtualisation.test.nodeNumber}";
+        nameValuePair i.name {
+          ipv4.addresses = [
+            {
+              address = "192.168.${toString i.vlan}.${toString config.virtualisation.test.nodeNumber}";
               prefixLength = 24;
-            }];
+            }
+          ];
+          ipv6.addresses = [
+            {
+              address = "2001:db8:${toString i.vlan}::${toString config.virtualisation.test.nodeNumber}";
+              prefixLength = 64;
+            }
+          ];
         });
 
       qemuOptions = lib.flatten (forEach interfacesNumbered ({ fst, snd }:
@@ -53,6 +62,9 @@ let
           networking.primaryIPAddress =
             optionalString (ipInterfaces != [ ]) (head (head ipInterfaces).value.ipv4.addresses).address;
 
+          networking.primaryIPv6Address =
+            optionalString (ipInterfaces != [ ]) (head (head ipInterfaces).value.ipv6.addresses).address;
+
           # Put the IP addresses of all VMs in this machine's
           # /etc/hosts file.  If a machine has multiple
           # interfaces, use the IP address corresponding to
@@ -60,12 +72,16 @@ let
           # virtualisation.vlans option).
           networking.extraHosts = flip concatMapStrings (attrNames nodes)
             (m':
-              let config = nodes.${m'}; in
+              let
+                config = nodes.${m'};
+                hostnames =
+                  optionalString (config.networking.domain != null) "${config.networking.hostName}.${config.networking.domain} " +
+                  "${config.networking.hostName}\n";
+              in
               optionalString (config.networking.primaryIPAddress != "")
-                ("${config.networking.primaryIPAddress} " +
-                  optionalString (config.networking.domain != null)
-                    "${config.networking.hostName}.${config.networking.domain} " +
-                  "${config.networking.hostName}\n"));
+                "${config.networking.primaryIPAddress} ${hostnames}" +
+              optionalString (config.networking.primaryIPv6Address != "")
+                ("${config.networking.primaryIPv6Address} ${hostnames}"));
 
           virtualisation.qemu.options = qemuOptions;
           boot.initrd.services.udev.rules = concatMapStrings (x: x + "\n") udevRules;

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -665,6 +665,14 @@ in
         description = "Primary IP address used in /etc/hosts.";
       };
 
+    networking.primaryIPv6Address =
+      mkOption {
+        type = types.str;
+        default = "";
+        internal = true;
+        description = "Primary IPv6 address used in /etc/hosts.";
+      };
+
     virtualisation.host.pkgs = mkOption {
       type = options.nixpkgs.pkgs.type;
       default = pkgs;

--- a/nixos/tests/firewall.nix
+++ b/nixos/tests/firewall.nix
@@ -36,7 +36,7 @@ import ./make-test-python.nix ( { pkgs, nftables, ... } : {
     };
 
   testScript = { nodes, ... }: let
-    newSystem = nodes.walled2.config.system.build.toplevel;
+    newSystem = nodes.walled2.system.build.toplevel;
     unit = if nftables then "nftables" else "firewall";
   in ''
     start_all()

--- a/nixos/tests/ipv6.nix
+++ b/nixos/tests/ipv6.nix
@@ -39,6 +39,8 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : {
         { services.httpd.enable = true;
           services.httpd.adminAddr = "foo@example.org";
           networking.firewall.allowedTCPPorts = [ 80 ];
+          # disable testing driver's default IPv6 address.
+          networking.interfaces.eth1.ipv6.addresses = lib.mkForce [ ];
         };
 
       router =

--- a/nixos/tests/iscsi-root.nix
+++ b/nixos/tests/iscsi-root.nix
@@ -59,7 +59,7 @@ import ./make-test-python.nix (
                         ];
                         portals = [
                           {
-                            ip_address = "0.0.0.0";
+                            ip_address = "[::]";
                             iser = false;
                             offload = false;
                             port = 3260;
@@ -93,7 +93,7 @@ import ./make-test-python.nix (
               xfsprogs
             ];
 
-            system.extraDependencies = [ nodes.initiatorRootDisk.config.system.build.toplevel ];
+            system.extraDependencies = [ nodes.initiatorRootDisk.system.build.toplevel ];
 
             nix.settings = {
               substituters = lib.mkForce [];
@@ -108,7 +108,7 @@ import ./make-test-python.nix (
               [
                 "boot.shell_on_fail"
                 "console=tty1"
-                "ip=${config.networking.primaryIPAddress}:::255.255.255.0::ens9:none"
+                "ip=${config.networking.primaryIPAddress}:::255.255.255.0::eth1:none"
               ]
             );
 

--- a/nixos/tests/jool.nix
+++ b/nixos/tests/jool.nix
@@ -165,9 +165,12 @@ in
       virtualisation.vlans = [ 1 ];
 
       networking.interfaces.eth1.ipv6 = {
-        addresses = [ { address = "2001:db8::8"; prefixLength = 96; } ];
-        routes    = [ { address = "64:ff9b::";   prefixLength = 96;
-                        via = "2001:db8::1"; } ];
+        addresses = lib.mkForce [ { address = "2001:db8::8"; prefixLength = 96; } ];
+        routes = lib.mkForce [ {
+          address = "64:ff9b::";
+          prefixLength = 96;
+          via = "2001:db8::1";
+        } ];
       };
     };
 
@@ -177,9 +180,12 @@ in
 
       virtualisation.vlans = [ 1 ];
       networking.interfaces.eth1.ipv6 = {
-        addresses = [ { address = "2001:db8::9"; prefixLength = 96; } ];
-        routes    = [ { address = "64:ff9b::";   prefixLength = 96;
-                        via = "2001:db8::1"; } ];
+        addresses = lib.mkForce [ { address = "2001:db8::9"; prefixLength = 96; } ];
+        routes    = lib.mkForce [ {
+          address = "64:ff9b::";
+          prefixLength = 96;
+          via = "2001:db8::1";
+        } ];
       };
     };
 

--- a/nixos/tests/mediatomb.nix
+++ b/nixos/tests/mediatomb.nix
@@ -30,15 +30,22 @@ import ./make-test-python.nix {
     client = {};
   };
 
-  testScript = ''
-    start_all()
+  testScript = { nodes, ... }:
+    let
+      serverIP = nodes.server.networking.primaryIPAddress;
+      serverIPv6 = nodes.server.networking.primaryIPv6Address;
+    in
+    ''
+      start_all()
 
-    server.wait_for_unit("mediatomb")
-    server.wait_until_succeeds("nc -z 192.168.1.2 49152")
-    server.succeed("curl -v --fail http://server:49152/")
+      server.wait_for_unit("mediatomb")
+      server.wait_until_succeeds("nc -z ${serverIP} 49152")
+      server.succeed("curl -v --fail http://${serverIP}:49152/")
+      server.succeed("curl -v --fail http://[${serverIPv6}]:49152/")
 
-    client.wait_for_unit("multi-user.target")
-    page = client.succeed("curl -v --fail http://server:49152/")
-    assert "Gerbera" in page and "MediaTomb" not in page
-  '';
+      client.wait_for_unit("multi-user.target")
+      page = client.succeed("curl -v --fail http://${serverIP}:49152/")
+      page = client.succeed("curl -v --fail http://[${serverIPv6}]:49152/")
+      assert "Gerbera" in page and "MediaTomb" not in page
+    '';
 }

--- a/nixos/tests/nvmetcfg.nix
+++ b/nixos/tests/nvmetcfg.nix
@@ -27,7 +27,7 @@ import ./make-test-python.nix ({ lib, ... }: {
 
     with subtest("Bind subsystem to port"):
       server.wait_for_unit("network-online.target")
-      server.succeed("nvmet port add 1 tcp 0.0.0.0:4420")
+      server.succeed("nvmet port add 1 tcp [::]:4420")
       server.succeed("nvmet port add-subsystem 1 ${subsystem}")
 
     with subtest("Discover and connect to available subsystems"):

--- a/nixos/tests/step-ca.nix
+++ b/nixos/tests/step-ca.nix
@@ -16,7 +16,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
           { config, pkgs, ... }: {
             services.step-ca = {
               enable = true;
-              address = "0.0.0.0";
+              address = "[::]";
               port = 8443;
               openFirewall = true;
               intermediatePasswordFile = "${test-certificates}/intermediate-password-file";

--- a/nixos/tests/vaultwarden.nix
+++ b/nixos/tests/vaultwarden.nix
@@ -133,7 +133,7 @@ let
             enable = true;
             dbBackend = backend;
             config = {
-              rocketAddress = "0.0.0.0";
+              rocketAddress = "::";
               rocketPort = 8080;
             };
           };

--- a/nixos/tests/vector/dnstap.nix
+++ b/nixos/tests/vector/dnstap.nix
@@ -49,7 +49,7 @@ in
         settings = {
           server = {
             interface = [ "0.0.0.0" "::" ];
-            access-control = [ "192.168.1.0/24 allow" ];
+            access-control = [ "192.168.0.0/24 allow" "::/0 allow" ];
 
             domain-insecure = "local";
             private-domain = "local";


### PR DESCRIPTION
## Description of changes

This contribution enables a working IPv6 setup by default. This works analog to the current automatic IPv4 setup.
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [X] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
