### PR TITLE
lomiri.qtmir: 0.7.2-unstable-2024-01-08 -> 0.8.0-unstable-2024-03-06, switch to debian-upstream branch

### DIFF
--- a/pkgs/desktops/lomiri/development/qtmir/default.nix
+++ b/pkgs/desktops/lomiri/development/qtmir/default.nix
@@ -34,15 +34,15 @@
 
 stdenv.mkDerivation (finalAttrs: {
   # Not regular qtmir, experimental support for Mir 2.x
-  # Currently following https://gitlab.com/ubports/development/core/qtmir/-/tree/personal/mariogrip/desktop-development
-  pname = "qtmir-mir2";
-  version = "0.7.2-unstable-2024-01-08";
+  # Currently following https://gitlab.com/ubports/development/core/qtmir/-/tree/personal/sunweaver/debian-upstream
+  pname = "qtmir-debian-upstream";
+  version = "0.8.0-unstable-2024-03-06";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/qtmir";
-    rev = "ae0d87415d5c9ed2c4fd2284ba0807d23d564bb0";
-    hash = "sha256-fE8ttCC0FNavs91pASGGG7k7nKVg2lD3JK0WTmCA3gM=";
+    rev = "de639c3a482ac6c59b9be02abb839a8c96158041";
+    hash = "sha256-AKSzkGl6bAoR4I2lolNRUp67VS/PiZnrPpCYtTlKWKc=";
   };
 
   outputs = [
@@ -83,11 +83,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
-      --replace "\''${CMAKE_INSTALL_FULL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}" \
-      --replace "\''${CMAKE_INSTALL_FULL_LIBDIR}/qt5/plugins/platforms" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtPluginPrefix}/platforms" \
+      --replace-fail "\''${CMAKE_INSTALL_FULL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}" \
+      --replace-fail "\''${CMAKE_INSTALL_FULL_LIBDIR}/qt5/plugins/platforms" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtPluginPrefix}/platforms" \
 
     substituteInPlace data/xwayland.qtmir.desktop \
-      --replace '/usr/bin/Xwayland' 'Xwayland'
+      --replace-fail '/usr/bin/Xwayland' 'Xwayland'
   '';
 
   strictDeps = true;

--- a/pkgs/desktops/lomiri/development/qtmir/default.nix
+++ b/pkgs/desktops/lomiri/development/qtmir/default.nix
@@ -1,35 +1,36 @@
-{ stdenv
-, lib
-, fetchFromGitLab
-, fetchpatch
-, testers
-, cmake
-, cmake-extras
-, pkg-config
-, wrapQtAppsHook
-, gsettings-qt
-, gtest
-, libqtdbustest
-, libqtdbusmock
-, libuuid
-, lomiri-api
-, lomiri-app-launch
-, lomiri-url-dispatcher
-, lttng-ust
-, mir_2_15
-, process-cpp
-, qtbase
-, qtdeclarative
-, qtsensors
-, valgrind
-, protobuf
-, glm
-, boost
-, properties-cpp
-, glib
-, validatePkgConfig
-, wayland
-, xwayland
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  fetchpatch,
+  testers,
+  cmake,
+  cmake-extras,
+  pkg-config,
+  wrapQtAppsHook,
+  gsettings-qt,
+  gtest,
+  libqtdbustest,
+  libqtdbusmock,
+  libuuid,
+  lomiri-api,
+  lomiri-app-launch,
+  lomiri-url-dispatcher,
+  lttng-ust,
+  mir_2_15,
+  process-cpp,
+  qtbase,
+  qtdeclarative,
+  qtsensors,
+  valgrind,
+  protobuf,
+  glm,
+  boost,
+  properties-cpp,
+  glib,
+  validatePkgConfig,
+  wayland,
+  xwayland,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -153,8 +154,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.lgpl3Only;
     maintainers = teams.lomiri.members;
     platforms = platforms.linux;
-    pkgConfigModules = [
-      "qtmirserver"
-    ];
+    pkgConfigModules = [ "qtmirserver" ];
   };
 })


### PR DESCRIPTION
## Description of changes

Fixes launching Firefox under Lomiri, https://github.com/NixOS/nixpkgs/issues/260859#issuecomment-2156421790

![Bildschirmfoto_2024-06-12_14-47-47](https://github.com/NixOS/nixpkgs/assets/23431373/e061d35b-ef50-4433-bab9-71df264f7291)

CC @ilya-fedin

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
