### PR TITLE
segger-jlink: 796b -> 796k, segger-jlink-headless: init, plus misc changes

### DIFF
--- a/pkgs/by-name/se/segger-jlink/package.nix
+++ b/pkgs/by-name/se/segger-jlink/package.nix
@@ -12,28 +12,12 @@
 }:
 
 let
-  supported = {
-    x86_64-linux = {
-      name = "x86_64";
-      hash = "sha256-UsDP+wMS7ZeWMQBObwv5RxbwuWU8nLnHes7LEXK6imE=";
-    };
-    i686-linux = {
-      name = "i386";
-      hash = "sha256-InNHXWAc6QZEWyEcTTUCRMDsKd0RtR8d7O0clWKuFo8=";
-    };
-    aarch64-linux = {
-      name = "arm64";
-      hash = "sha256-ueIGdqfuIRCuEwaPkgZMgghO9DU11IboLLMryg/mxQ8=";
-    };
-    armv7l-linux = {
-      name = "arm";
-      hash = "sha256-6nTQGQpkbqQntheQqiUAdVS4rp30nl2KRUn5Adsfeoo=";
-    };
-  };
+  source = import ./source.nix;
+  supported = removeAttrs source ["version"];
 
   platform = supported.${stdenv.system} or (throw "unsupported platform ${stdenv.system}");
 
-  version = "796b";
+  inherit (source) version;
 
   url = "https://www.segger.com/downloads/jlink/JLink_Linux_V${version}_${platform.name}.tgz";
 
@@ -217,6 +201,8 @@ in stdenv.mkDerivation {
 
     runHook postInstall
   '';
+
+  passthru.updateScript = ./update.py;
 
   meta = with lib; {
     description = "J-Link Software and Documentation pack";

--- a/pkgs/by-name/se/segger-jlink/package.nix
+++ b/pkgs/by-name/se/segger-jlink/package.nix
@@ -1,13 +1,12 @@
 { lib
 , stdenv
 , fetchurl
+, callPackage
 , autoPatchelfHook
 , udev
 , config
 , acceptLicense ? config.segger-jlink.acceptLicense or false
 , headless ? false
-, fontconfig
-, xorg
 , makeDesktopItem
 , copyDesktopItems
 }:
@@ -51,69 +50,7 @@ let
         curlOpts = "--data accept_license_agreement=accepted";
       };
 
-  qt4-bundled = stdenv.mkDerivation {
-    pname = "segger-jlink-qt4";
-    inherit src version;
-
-    nativeBuildInputs = [
-      autoPatchelfHook
-    ];
-
-    buildInputs = [
-      stdenv.cc.cc.lib
-      fontconfig
-      xorg.libXrandr
-      xorg.libXfixes
-      xorg.libXcursor
-      xorg.libSM
-      xorg.libICE
-      xorg.libX11
-    ];
-
-    dontConfigure = true;
-    dontBuild = true;
-
-    installPhase = ''
-      runHook preInstall
-
-      # Install libraries
-      mkdir -p $out/lib
-      mv libQt* $out/lib
-
-      runHook postInstall
-    '';
-
-    meta = with lib; {
-      description = "Bundled QT4 libraries for the J-Link Software and Documentation pack";
-      homepage = "https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack";
-      license = licenses.lgpl21;
-      maintainers = with maintainers; [ stargate01 ];
-      knownVulnerabilities = [
-        "This bundled version of Qt 4 has reached its end of life after 2015. See https://github.com/NixOS/nixpkgs/pull/174634"
-        "CVE-2023-43114"
-        "CVE-2023-38197"
-        "CVE-2023-37369"
-        "CVE-2023-34410"
-        "CVE-2023-32763"
-        "CVE-2023-32762"
-        "CVE-2023-32573"
-        "CVE-2022-25634"
-        "CVE-2020-17507"
-        "CVE-2020-0570"
-        "CVE-2018-21035"
-        "CVE-2018-19873"
-        "CVE-2018-19871"
-        "CVE-2018-19870"
-        "CVE-2018-19869"
-        "CVE-2015-1290"
-        "CVE-2014-0190"
-        "CVE-2013-0254"
-        "CVE-2012-6093"
-        "CVE-2012-5624"
-        "CVE-2009-2700"
-      ];
-    };
-  };
+  qt4-bundled = callPackage ./qt4-bundled.nix { inherit src version; };
 
 in stdenv.mkDerivation {
   pname = "segger-jlink";

--- a/pkgs/by-name/se/segger-jlink/package.nix
+++ b/pkgs/by-name/se/segger-jlink/package.nix
@@ -154,6 +154,10 @@ in stdenv.mkDerivation {
     changelog = "https://www.segger.com/downloads/jlink/ReleaseNotes_JLink.html";
     license = licenses.unfree;
     platforms = attrNames supported;
-    maintainers = with maintainers; [ FlorianFranzen stargate01 ];
+    maintainers = with maintainers; [
+      FlorianFranzen
+      h7x4
+      stargate01
+    ];
   };
 }

--- a/pkgs/by-name/se/segger-jlink/package.nix
+++ b/pkgs/by-name/se/segger-jlink/package.nix
@@ -151,6 +151,7 @@ in stdenv.mkDerivation {
   meta = with lib; {
     description = "J-Link Software and Documentation pack";
     homepage = "https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack";
+    changelog = "https://www.segger.com/downloads/jlink/ReleaseNotes_JLink.html";
     license = licenses.unfree;
     platforms = attrNames supported;
     maintainers = with maintainers; [ FlorianFranzen stargate01 ];

--- a/pkgs/by-name/se/segger-jlink/qt4-bundled.nix
+++ b/pkgs/by-name/se/segger-jlink/qt4-bundled.nix
@@ -1,0 +1,74 @@
+{
+  lib
+, stdenv
+, src
+, version
+, autoPatchelfHook
+, fontconfig
+, xorg
+}:
+
+stdenv.mkDerivation {
+  pname = "segger-jlink-qt4";
+  inherit src version;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    fontconfig
+    xorg.libXrandr
+    xorg.libXfixes
+    xorg.libXcursor
+    xorg.libSM
+    xorg.libICE
+    xorg.libX11
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # Install libraries
+    mkdir -p $out/lib
+    mv libQt* $out/lib
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Bundled QT4 libraries for the J-Link Software and Documentation pack";
+    homepage = "https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack";
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ stargate01 ];
+    knownVulnerabilities = [
+      "This bundled version of Qt 4 has reached its end of life after 2015. See https://github.com/NixOS/nixpkgs/pull/174634"
+      "CVE-2023-43114"
+      "CVE-2023-38197"
+      "CVE-2023-37369"
+      "CVE-2023-34410"
+      "CVE-2023-32763"
+      "CVE-2023-32762"
+      "CVE-2023-32573"
+      "CVE-2022-25634"
+      "CVE-2020-17507"
+      "CVE-2020-0570"
+      "CVE-2018-21035"
+      "CVE-2018-19873"
+      "CVE-2018-19871"
+      "CVE-2018-19870"
+      "CVE-2018-19869"
+      "CVE-2015-1290"
+      "CVE-2014-0190"
+      "CVE-2013-0254"
+      "CVE-2012-6093"
+      "CVE-2012-5624"
+      "CVE-2009-2700"
+    ];
+  };
+}
+

--- a/pkgs/by-name/se/segger-jlink/source.nix
+++ b/pkgs/by-name/se/segger-jlink/source.nix
@@ -1,19 +1,19 @@
 {
-  version = "796b";
+  version = "796k";
   x86_64-linux = {
     name = "x86_64";
-    hash = "sha256-UsDP+wMS7ZeWMQBObwv5RxbwuWU8nLnHes7LEXK6imE=";
+    hash = "sha256-GDmdKjMD9nJLPl4Qaxgrb5+b9CsUdyNqNak1JG4ERjo=";
   };
   i686-linux = {
     name = "i386";
-    hash = "sha256-InNHXWAc6QZEWyEcTTUCRMDsKd0RtR8d7O0clWKuFo8=";
+    hash = "sha256-8j2UkPtDyIA+mfXl4jIVp89CpGA+T4eU5IQ0GwROgwU=";
   };
   aarch64-linux = {
     name = "arm64";
-    hash = "sha256-ueIGdqfuIRCuEwaPkgZMgghO9DU11IboLLMryg/mxQ8=";
+    hash = "sha256-FIzg7vAPlhnjuKEm5uGa7a37srp1U0e4eqlG9C6q26s=";
   };
   armv7l-linux = {
     name = "arm";
-    hash = "sha256-6nTQGQpkbqQntheQqiUAdVS4rp30nl2KRUn5Adsfeoo=";
+    hash = "sha256-NceqkV54QVXEJr4pJ3nvY3zxSYb9Er0uQWQ4vaojkv8=";
   };
 }

--- a/pkgs/by-name/se/segger-jlink/source.nix
+++ b/pkgs/by-name/se/segger-jlink/source.nix
@@ -1,0 +1,19 @@
+{
+  version = "796b";
+  x86_64-linux = {
+    name = "x86_64";
+    hash = "sha256-UsDP+wMS7ZeWMQBObwv5RxbwuWU8nLnHes7LEXK6imE=";
+  };
+  i686-linux = {
+    name = "i386";
+    hash = "sha256-InNHXWAc6QZEWyEcTTUCRMDsKd0RtR8d7O0clWKuFo8=";
+  };
+  aarch64-linux = {
+    name = "arm64";
+    hash = "sha256-ueIGdqfuIRCuEwaPkgZMgghO9DU11IboLLMryg/mxQ8=";
+  };
+  armv7l-linux = {
+    name = "arm";
+    hash = "sha256-6nTQGQpkbqQntheQqiUAdVS4rp30nl2KRUn5Adsfeoo=";
+  };
+}

--- a/pkgs/by-name/se/segger-jlink/update.py
+++ b/pkgs/by-name/se/segger-jlink/update.py
@@ -1,0 +1,87 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i python3 -p python3 python3Packages.beautifulsoup4 python3Packages.requests
+
+import requests
+import subprocess
+
+from bs4 import BeautifulSoup
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from textwrap import indent, dedent
+
+
+ARCH_MAP = {
+    'x86_64-linux': 'x86_64',
+    'i686-linux': 'i386',
+    'aarch64-linux': 'arm64',
+    'armv7l-linux': 'arm',
+}
+
+
+def find_latest_jlink_version() -> str:
+    try:
+        response = requests.get('https://www.segger.com/downloads/jlink/')
+        response.raise_for_status()
+    except requests.RequestException as e:
+        raise RuntimeError(f"Error fetching J-Link version: {e}")
+
+    soup = BeautifulSoup(response.text, 'html.parser')
+
+    jlink_download_tile = soup.find(lambda tag: tag.name == 'tbody' and "J-Link Software and Documentation pack" in tag.text)
+    version_select = jlink_download_tile.find('select')
+    version = next(o.text for o in version_select.find_all('option'))
+
+    if version is None:
+        raise RuntimeError("Could not find the J-Link version on the download page.")
+
+    return version.removeprefix('V').replace('.', '')
+
+
+def nar_hash(url: str) -> str:
+    try:
+        response = requests.post(url, data={'accept_license_agreement': 'accepted'})
+        response.raise_for_status()
+    except requests.RequestException as e:
+        raise RuntimeError(f"Error downloading file from {url}: {e}")
+
+    with NamedTemporaryFile() as tmpfile:
+        tmpfile.write(response.content)
+        tmpfile.flush()
+        output = subprocess.check_output([
+            "nix",
+            "--extra-experimental-features", "nix-command",
+            "hash", "file", "--sri", tmpfile.name
+        ]).decode("utf8")
+
+    return output.strip()
+
+
+def calculate_package_hashes(version: str) -> list[tuple[str, str, str]]:
+    result = []
+    for (arch_nix, arch_web) in ARCH_MAP.items():
+        url = f"https://www.segger.com/downloads/jlink/JLink_Linux_V{version}_{arch_web}.tgz";
+        nhash = nar_hash(url)
+        result.append((arch_nix, arch_web, nhash))
+    return result
+
+
+def update_source(version: str, package_hashes: list[tuple[str, str, str]]):
+    content = f'version = "{version}";\n'
+    for arch_nix, arch_web, nhash in package_hashes:
+        content += dedent(f'''
+        {arch_nix} = {{
+          name = "{arch_web}";
+          hash = "{nhash}";
+        }};''').strip() + '\n'
+
+    content = '{\n' + indent(content, '  ') + '}\n'
+
+    with open(Path(__file__).parent / 'source.nix', 'w') as file:
+        file.write(content)
+
+
+if __name__ == '__main__':
+    version = find_latest_jlink_version()
+    package_hashes = calculate_package_hashes(version)
+    update_source(version, package_hashes)
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12758,6 +12758,8 @@ with pkgs;
 
   seehecht = callPackage ../tools/text/seehecht { };
 
+  segger-jlink-headless = callPackage ../by-name/se/segger-jlink/package.nix { headless = true; };
+
   selectdefaultapplication = libsForQt5.callPackage ../applications/misc/selectdefaultapplication { };
 
   semantic-release = callPackage ../development/tools/semantic-release {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Miscellaneous fixes to `segger-jlink`. I have added a headless variant of the package that excludes the qt4 bundle, removing the need for adding it to the list of insecure packages. The headless variant is exposed as a toplevel attribute with the `-headless` suffix.

As for other changes, I've added a changelog link, added myself to maintainers, added an update script and bumped the package version

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
