### PR TITLE
Backport (the rest of) #315121 to release-23.11

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -352,7 +352,8 @@ let
       # (stable) amdgpu support for bonaire and newer chipsets
       DRM_AMDGPU_CIK = yes;
       # Allow device firmware updates
-      DRM_DP_AUX_CHARDEV = yes;
+      DRM_DP_AUX_CHARDEV = whenOlder "6.10" yes;
+      DRM_DISPLAY_DP_AUX_CHARDEV = whenAtLeast "6.10" yes;
       # amdgpu display core (DC) support
       DRM_AMD_DC_DCN1_0 = whenOlder "5.6" yes;
       DRM_AMD_DC_DCN2_0 = whenBetween "5.3" "5.6" yes;
@@ -769,8 +770,10 @@ let
       # i686 issues: https://github.com/NixOS/nixpkgs/pull/117961#issuecomment-812106375
       useZstd = stdenv.buildPlatform.is64bit && versionAtLeast version "5.9";
     in {
-      KERNEL_XZ            = mkIf (!useZstd) yes;
-      KERNEL_ZSTD          = mkIf useZstd yes;
+      # stdenv.hostPlatform.linux-kernel.target assumes uncompressed on RISC-V.
+      KERNEL_UNCOMPRESSED  = mkIf stdenv.hostPlatform.isRiscV yes;
+      KERNEL_XZ            = mkIf (!stdenv.hostPlatform.isRiscV && !useZstd) yes;
+      KERNEL_ZSTD          = mkIf (!stdenv.hostPlatform.isRiscV && useZstd) yes;
 
       HID_BATTERY_STRENGTH = yes;
       # enabled by default in x86_64 but not arm64, so we do that here

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -1,7 +1,7 @@
 {
     "testing": {
-        "version": "6.9-rc6",
-        "hash": "sha256:075l5vhk8zmwln4jks7gr5n5k67s65qvs07l2rpbc7a75fdp6c14"
+        "version": "6.10-rc1",
+        "hash": "sha256:006frl76cwi9a4mw7x6vsyazgrjfiz1gn4q4hvpykqql5mar3a05"
     },
     "6.5": {
         "version": "6.5.13",

--- a/pkgs/os-specific/linux/kernel/linux-libre.nix
+++ b/pkgs/os-specific/linux/kernel/linux-libre.nix
@@ -1,8 +1,8 @@
 { stdenv, lib, fetchsvn, linux
 , scripts ? fetchsvn {
     url = "https://www.fsfla.org/svn/fsfla/software/linux-libre/releases/branches/";
-    rev = "19569";
-    sha256 = "0nm3vzzfwx3g8scgwyszjbf7sa08kwd1xyq4v1m5py63pma7p80r";
+    rev = "19575";
+    sha256 = "1f826x8a6nmqcjcplg5x4rcqkr3p886abxhyqir8a102ymnh7wkw";
   }
 , ...
 }:

--- a/pkgs/os-specific/linux/kernel/linux-rt-5.10.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-5.10.nix
@@ -6,7 +6,7 @@
 , ... } @ args:
 
 let
-  version = "5.10.216-rt108"; # updated by ./update-rt.sh
+  version = "5.10.217-rt109"; # updated by ./update-rt.sh
   branch = lib.versions.majorMinor version;
   kversion = builtins.elemAt (lib.splitString "-" version) 0;
 in buildLinux (args // {
@@ -17,14 +17,14 @@ in buildLinux (args // {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${kversion}.tar.xz";
-    sha256 = "0lg1zfb9y4ps86q85mlnyalb3s90zix003z62jb9bw139f65h473";
+    sha256 = "0qhzqrjci45vcbzjch7vq75i6hpyap6yb7jw6g71phcnqgzw2ay5";
   };
 
   kernelPatches = let rt-patch = {
     name = "rt";
     patch = fetchurl {
       url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
-      sha256 = "0p0qmyz3g7fqlz4f638dlcp37az8lpq5yqw2fy5zqqs3qagy018j";
+      sha256 = "1cszl9414vbycswx2gjv12wdghhw5s6amd9mjmx619r2a1r0gnb7";
     };
   }; in [ rt-patch ] ++ kernelPatches;
 

--- a/pkgs/os-specific/linux/kernel/linux-rt-6.1.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-6.1.nix
@@ -6,7 +6,7 @@
 , ... } @ args:
 
 let
-  version = "6.1.91-rt31"; # updated by ./update-rt.sh
+  version = "6.1.92-rt32"; # updated by ./update-rt.sh
   branch = lib.versions.majorMinor version;
   kversion = builtins.elemAt (lib.splitString "-" version) 0;
 in buildLinux (args // {
@@ -18,14 +18,14 @@ in buildLinux (args // {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v6.x/linux-${kversion}.tar.xz";
-    sha256 = "1v2d5syxwwqlhvjzxk003qz9sr18r0n8dgg976vbi492r9iww2l8";
+    sha256 = "1j9n8gk76nn4gw42iba5zgghr360gb9n1mslr5dyv76wpwkz86ch";
   };
 
   kernelPatches = let rt-patch = {
     name = "rt";
     patch = fetchurl {
       url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
-      sha256 = "1p8i0rv4vzm1h50g08mm7a5zbxyaibqs2894nwvalhb4dfj1vas7";
+      sha256 = "00qa6l4jvkdny276jnwnra5dkagnp3qr43amf2mpqx3kdfw28g1q";
     };
   }; in [ rt-patch ] ++ kernelPatches;
 

--- a/pkgs/os-specific/linux/kernel/linux-rt-6.6.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-6.6.nix
@@ -6,7 +6,7 @@
 , ... } @ args:
 
 let
-  version = "6.6.31-rt31"; # updated by ./update-rt.sh
+  version = "6.6.32-rt32"; # updated by ./update-rt.sh
   branch = lib.versions.majorMinor version;
   kversion = builtins.elemAt (lib.splitString "-" version) 0;
 in buildLinux (args // {
@@ -18,14 +18,14 @@ in buildLinux (args // {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v6.x/linux-${kversion}.tar.xz";
-    sha256 = "080wwrc231fbf43hvvygddmdxdspyw23jc5vnd6fr5ccdybgzv6n";
+    sha256 = "1qbc8dqmk2xs1cz968rysw5xvhq3lj8g0pxp48fr2qbzy3m29a5a";
   };
 
   kernelPatches = let rt-patch = {
     name = "rt";
     patch = fetchurl {
       url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
-      sha256 = "0pj4j420ac9khw7wk6k3bcgdvcmi7p3lwycaa896q2fscz47zf01";
+      sha256 = "0hv2z6d2gw7hqfzw6dgrzxlirk4yifcxbmx71hxlvd9l2vgp72q5";
     };
   }; in [ rt-patch ] ++ kernelPatches;
 


### PR DESCRIPTION
## Description of changes

This is a manual backport of what's left of #315121 after #316231.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
