### PR TITLE
 misskey: init at 2024.5.0 & nixos/misskey: init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6515,6 +6515,11 @@
     githubId = 541748;
     name = "Felipe Espinoza";
   };
+  feathecutie = {
+    name = "feathecutie";
+    github = "feathecutie";
+    githubId = 53912746;
+  };
   fedx-sudo = {
     email = "fedx-sudo@pm.me";
     github = "FedX-sudo";

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -56,6 +56,8 @@
 
 - [Apache Tika](https://github.com/apache/tika), a toolkit that detects and extracts metadata and text from over a thousand different file types. Available as [services.tika](option.html#opt-services.tika).
 
+- [Misskey](https://misskey-hub.net/en/), an interplanetary microblogging platform. Available as [services.misskey](options.html#opt-services.misskey).
+
 - [Improved File Manager](https://github.com/misterunknown/ifm), or IFM, a single-file web-based file manager.
 
 ## Backward Incompatibilities {#sec-release-24.11-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1427,6 +1427,7 @@
   ./services/web-apps/meme-bingo-web.nix
   ./services/web-apps/microbin.nix
   ./services/web-apps/miniflux.nix
+  ./services/web-apps/misskey.nix
   ./services/web-apps/monica.nix
   ./services/web-apps/moodle.nix
   ./services/web-apps/movim.nix

--- a/nixos/modules/services/web-apps/misskey.nix
+++ b/nixos/modules/services/web-apps/misskey.nix
@@ -1,0 +1,418 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.misskey;
+  settingsFormat = pkgs.formats.yaml { };
+  redisType = lib.types.submodule {
+    freeformType = lib.types.attrsOf settingsFormat.type;
+    options = {
+      host = lib.mkOption {
+        type = lib.types.str;
+        default = "localhost";
+        description = "The Redis host.";
+      };
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 6379;
+        description = "The Redis port.";
+      };
+    };
+  };
+  settings = lib.mkOption {
+    description = ''
+      Configuration for Misskey, see
+      [`example.yml`](https://github.com/misskey-dev/misskey/blob/develop/.config/example.yml)
+      for all supported options.
+    '';
+    type = lib.types.submodule {
+      freeformType = lib.types.attrsOf settingsFormat.type;
+      options = {
+        url = lib.mkOption {
+          type = lib.types.str;
+          example = "https://example.tld/";
+          description = ''
+            The final user-facing URL. Do not change after running Misskey for the first time.
+
+            This needs to match up with the configured reverse proxy and is automatically configured when using `services.misskey.reverseProxy`.
+          '';
+        };
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = 3000;
+          description = "The port your Misskey server should listen on.";
+        };
+        socket = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          example = "/path/to/misskey.sock";
+          description = "The UNIX socket your Misskey server should listen on.";
+        };
+        chmodSocket = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = "777";
+          description = "The file access mode of the UNIX socket.";
+        };
+        db = lib.mkOption {
+          description = "Database settings.";
+          type = lib.types.submodule {
+            options = {
+              host = lib.mkOption {
+                type = lib.types.str;
+                default = "/var/run/postgresql";
+                example = "localhost";
+                description = "The PostgreSQL host.";
+              };
+              port = lib.mkOption {
+                type = lib.types.port;
+                default = 5432;
+                description = "The PostgreSQL port.";
+              };
+              db = lib.mkOption {
+                type = lib.types.str;
+                default = "misskey";
+                description = "The database name.";
+              };
+              user = lib.mkOption {
+                type = lib.types.str;
+                default = "misskey";
+                description = "The user used for database authentication.";
+              };
+              pass = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                description = "The password used for database authentication.";
+              };
+              disableCache = lib.mkOption {
+                type = lib.types.bool;
+                default = false;
+                description = "Whether to disable caching queries.";
+              };
+              extra = lib.mkOption {
+                type = lib.types.nullOr (lib.types.attrsOf settingsFormat.type);
+                default = null;
+                example = {
+                  ssl = true;
+                };
+                description = "Extra connection options.";
+              };
+            };
+          };
+          default = { };
+        };
+        redis = lib.mkOption {
+          type = redisType;
+          default = { };
+          description = "`ioredis` options. See [`README`](https://github.com/redis/ioredis?tab=readme-ov-file#connect-to-redis) for reference.";
+        };
+        redisForPubsub = lib.mkOption {
+          type = lib.types.nullOr redisType;
+          default = null;
+          description = "`ioredis` options for pubsub. See [`README`](https://github.com/redis/ioredis?tab=readme-ov-file#connect-to-redis) for reference.";
+        };
+        redisForJobQueue = lib.mkOption {
+          type = lib.types.nullOr redisType;
+          default = null;
+          description = "`ioredis` options for the job queue. See [`README`](https://github.com/redis/ioredis?tab=readme-ov-file#connect-to-redis) for reference.";
+        };
+        redisForTimelines = lib.mkOption {
+          type = lib.types.nullOr redisType;
+          default = null;
+          description = "`ioredis` options for timelines. See [`README`](https://github.com/redis/ioredis?tab=readme-ov-file#connect-to-redis) for reference.";
+        };
+        meilisearch = lib.mkOption {
+          description = "Meilisearch connection options.";
+          type = lib.types.nullOr (
+            lib.types.submodule {
+              options = {
+                host = lib.mkOption {
+                  type = lib.types.str;
+                  default = "localhost";
+                  description = "The Meilisearch host.";
+                };
+                port = lib.mkOption {
+                  type = lib.types.port;
+                  default = 7700;
+                  description = "The Meilisearch port.";
+                };
+                apiKey = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  default = null;
+                  description = "The Meilisearch API key.";
+                };
+                ssl = lib.mkOption {
+                  type = lib.types.bool;
+                  default = false;
+                  description = "Whether to connect via SSL.";
+                };
+                index = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  default = null;
+                  description = "Meilisearch index to use.";
+                };
+                scope = lib.mkOption {
+                  type = lib.types.enum [
+                    "local"
+                    "global"
+                  ];
+                  default = "local";
+                  description = "The search scope.";
+                };
+              };
+            }
+          );
+          default = null;
+        };
+        id = lib.mkOption {
+          type = lib.types.enum [
+            "aid"
+            "aidx"
+            "meid"
+            "ulid"
+            "objectid"
+          ];
+          default = "aidx";
+          description = "The ID generation method to use. Do not change after starting Misskey for the first time.";
+        };
+      };
+    };
+  };
+in
+
+{
+  options = {
+    services.misskey = {
+      enable = lib.mkEnableOption "misskey";
+      package = lib.mkPackageOption pkgs "misskey" { };
+      inherit settings;
+      database = {
+        createLocally = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Create the PostgreSQL database locally. Sets `services.misskey.settings.db.{db,host,port,user,pass}`.";
+        };
+        passwordFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          description = "The path to a file containing the database password. Sets `services.misskey.settings.db.pass`.";
+        };
+      };
+      redis = {
+        createLocally = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Create and use a local Redis instance. Sets `services.misskey.settings.redis.host`.";
+        };
+        passwordFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          description = "The path to a file containing the Redis password. Sets `services.misskey.settings.redis.pass`.";
+        };
+      };
+      meilisearch = {
+        createLocally = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Create and use a local Meilisearch instance. Sets `services.misskey.settings.meilisearch.{host,port,ssl}`.";
+        };
+        keyFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          description = "The path to a file containing the Meilisearch API key. Sets `services.misskey.settings.meilisearch.apiKey`.";
+        };
+      };
+      reverseProxy = {
+        enable = lib.mkEnableOption "a HTTP reverse proxy for Misskey";
+        webserver = lib.mkOption {
+          type = lib.types.attrTag {
+            nginx = lib.mkOption {
+              type = lib.types.submodule (import ../web-servers/nginx/vhost-options.nix);
+              default = { };
+              description = ''
+                Extra configuration for the nginx virtual host of Misskey.
+                Set to `{ }` to use the default configuration.
+              '';
+            };
+            caddy = lib.mkOption {
+              type = lib.types.submodule (
+                import ../web-servers/caddy/vhost-options.nix { cfg = config.services.caddy; }
+              );
+              default = { };
+              description = ''
+                Extra configuration for the caddy virtual host of Misskey.
+                Set to `{ }` to use the default configuration.
+              '';
+            };
+          };
+          description = "The webserver to use as the reverse proxy.";
+        };
+        host = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          description = ''
+            The fully qualified domain name to bind to. Sets `services.misskey.settings.url`.
+
+            This is required when using `services.misskey.reverseProxy.enable = true`.
+          '';
+          example = "misskey.example.com";
+          default = null;
+        };
+        ssl = lib.mkOption {
+          type = lib.types.nullOr lib.types.bool;
+          description = ''
+            Whether to enable SSL for the reverse proxy. Sets `services.misskey.settings.url`.
+
+            This is required when using `services.misskey.reverseProxy.enable = true`.
+          '';
+          example = true;
+          default = null;
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion =
+          cfg.reverseProxy.enable -> ((cfg.reverseProxy.host != null) && (cfg.reverseProxy.ssl != null));
+        message = "`services.misskey.reverseProxy.enable` requires `services.misskey.reverseProxy.host` and `services.misskey.reverseProxy.ssl` to be set.";
+      }
+    ];
+
+    services.misskey.settings = lib.mkMerge [
+      (lib.mkIf cfg.database.createLocally {
+        db = {
+          db = lib.mkDefault "misskey";
+          # Use unix socket instead of localhost to allow PostgreSQL peer authentication,
+          # required for `services.postgresql.ensureUsers`
+          host = lib.mkDefault "/var/run/postgresql";
+          port = lib.mkDefault config.services.postgresql.settings.port;
+          user = lib.mkDefault "misskey";
+          pass = lib.mkDefault null;
+        };
+      })
+      (lib.mkIf (cfg.database.passwordFile != null) { db.pass = lib.mkDefault "@DATABASE_PASSWORD@"; })
+      (lib.mkIf cfg.redis.createLocally { redis.host = lib.mkDefault "localhost"; })
+      (lib.mkIf (cfg.redis.passwordFile != null) { redis.pass = lib.mkDefault "@REDIS_PASSWORD@"; })
+      (lib.mkIf cfg.meilisearch.createLocally {
+        meilisearch = {
+          host = lib.mkDefault "localhost";
+          port = lib.mkDefault config.services.meilisearch.listenPort;
+          ssl = lib.mkDefault false;
+        };
+      })
+      (lib.mkIf (cfg.meilisearch.keyFile != null) {
+        meilisearch.apiKey = lib.mkDefault "@MEILISEARCH_KEY@";
+      })
+      (lib.mkIf cfg.reverseProxy.enable {
+        url = lib.mkDefault "${
+          if cfg.reverseProxy.ssl then "https" else "http"
+        }://${cfg.reverseProxy.host}";
+      })
+    ];
+
+    systemd.services.misskey = {
+      after = [
+        "network-online.target"
+        "postgresql.service"
+      ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+      environment = {
+        MISSKEY_CONFIG_YML = "/run/misskey/default.yml";
+      };
+      preStart =
+        ''
+          install -m 700 ${settingsFormat.generate "misskey-config.yml" cfg.settings} /run/misskey/default.yml
+        ''
+        + (lib.optionalString (cfg.database.passwordFile != null) ''
+          ${pkgs.replace-secret}/bin/replace-secret '@DATABASE_PASSWORD@' "${cfg.database.passwordFile}" /run/misskey/default.yml
+        '')
+        + (lib.optionalString (cfg.redis.passwordFile != null) ''
+          ${pkgs.replace-secret}/bin/replace-secret '@REDIS_PASSWORD@' "${cfg.redis.passwordFile}" /run/misskey/default.yml
+        '')
+        + (lib.optionalString (cfg.meilisearch.keyFile != null) ''
+          ${pkgs.replace-secret}/bin/replace-secret '@MEILISEARCH_KEY@' "${cfg.meilisearch.keyFile}" /run/misskey/default.yml
+        '');
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/misskey migrateandstart";
+        RuntimeDirectory = "misskey";
+        RuntimeDirectoryMode = "700";
+        StateDirectory = "misskey";
+        StateDirectoryMode = "700";
+        TimeoutSec = 60;
+        DynamicUser = true;
+        User = "misskey";
+        LockPersonality = true;
+        PrivateDevices = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectProc = "invisible";
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        RestrictAddressFamilies = "AF_INET AF_INET6 AF_UNIX AF_NETLINK";
+      };
+    };
+
+    services.postgresql = lib.mkIf cfg.database.createLocally {
+      enable = true;
+      ensureDatabases = [ "misskey" ];
+      ensureUsers = [
+        {
+          name = "misskey";
+          ensureDBOwnership = true;
+        }
+      ];
+    };
+
+    services.redis.servers = lib.mkIf cfg.redis.createLocally {
+      misskey = {
+        enable = true;
+        port = cfg.settings.redis.port;
+      };
+    };
+
+    services.meilisearch = lib.mkIf cfg.meilisearch.createLocally { enable = true; };
+
+    services.caddy = lib.mkIf (cfg.reverseProxy.enable && cfg.reverseProxy.webserver ? caddy) {
+      enable = true;
+      virtualHosts.${cfg.settings.url} = lib.mkMerge [
+        cfg.reverseProxy.webserver.caddy
+        {
+          hostName = lib.mkDefault cfg.settings.url;
+          extraConfig = ''
+            reverse_proxy localhost:${toString cfg.settings.port}
+          '';
+        }
+      ];
+    };
+
+    services.nginx = lib.mkIf (cfg.reverseProxy.enable && cfg.reverseProxy.webserver ? nginx) {
+      enable = true;
+      virtualHosts.${cfg.reverseProxy.host} = lib.mkMerge [
+        cfg.reverseProxy.webserver.nginx
+        {
+          locations."/" = {
+            proxyPass = lib.mkDefault "http://localhost:${toString cfg.settings.port}";
+            proxyWebsockets = lib.mkDefault true;
+            recommendedProxySettings = lib.mkDefault true;
+          };
+        }
+        (lib.mkIf (cfg.reverseProxy.ssl != null) { forceSSL = lib.mkDefault cfg.reverseProxy.ssl; })
+      ];
+    };
+  };
+
+  meta = {
+    maintainers = [ lib.maintainers.feathecutie ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -576,6 +576,7 @@ in {
   minio = handleTest ./minio.nix {};
   miriway = handleTest ./miriway.nix {};
   misc = handleTest ./misc.nix {};
+  misskey = handleTest ./misskey.nix {};
   mjolnir = handleTest ./matrix/mjolnir.nix {};
   mobilizon = handleTest ./mobilizon.nix {};
   mod_perl = handleTest ./mod_perl.nix {};

--- a/nixos/tests/misskey.nix
+++ b/nixos/tests/misskey.nix
@@ -1,0 +1,29 @@
+import ./make-test-python.nix (
+  { lib, ... }:
+  let
+    port = 61812;
+  in
+  {
+    name = "misskey";
+
+    meta.maintainers = [ lib.maintainers.feathecutie ];
+
+    nodes.machine = {
+      services.misskey = {
+        enable = true;
+        settings = {
+          url = "http://misskey.local";
+          inherit port;
+        };
+        database.createLocally = true;
+        redis.createLocally = true;
+      };
+    };
+
+    testScript = ''
+      machine.wait_for_unit("misskey.service")
+      machine.wait_for_open_port(${toString port})
+      machine.succeed("curl --fail http://localhost:${toString port}/")
+    '';
+  }
+)

--- a/pkgs/by-name/mi/misskey/package.nix
+++ b/pkgs/by-name/mi/misskey/package.nix
@@ -111,6 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     inherit (finalAttrs) pnpmDeps;
+    tests.misskey = nixosTests.misskey;
   };
 
   meta = {

--- a/pkgs/by-name/mi/misskey/package.nix
+++ b/pkgs/by-name/mi/misskey/package.nix
@@ -1,0 +1,124 @@
+{
+  stdenv,
+  lib,
+  nixosTests,
+  fetchFromGitHub,
+  nodejs,
+  pnpm,
+  makeWrapper,
+  python3,
+  bash,
+  jemalloc,
+  ffmpeg-headless,
+  writeShellScript,
+  ...
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "misskey";
+
+  version = "2024.5.0";
+
+  src = fetchFromGitHub {
+    owner = "misskey-dev";
+    repo = finalAttrs.pname;
+    rev = finalAttrs.version;
+    hash = "sha256-nKf+SfuF6MQtNO53E6vN9CMDvQzKMv3PrD6gs9Qa86w=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm.configHook
+    makeWrapper
+    python3
+  ];
+
+  # https://nixos.org/manual/nixpkgs/unstable/#javascript-pnpm
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-A1JBLa6lIw5tXFuD2L3vvkH6pHS5rlwt8vU2+UUQYdg=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    # https://github.com/NixOS/nixpkgs/pull/296697/files#r1617546739
+    (
+      cd node_modules/.pnpm/node_modules/v-code-diff
+      pnpm run postinstall
+    )
+
+    # https://github.com/NixOS/nixpkgs/pull/296697/files#r1617595593
+    export npm_config_nodedir=${nodejs}
+    (
+      cd node_modules/.pnpm/node_modules/re2
+      pnpm run rebuild
+    )
+    (
+      cd node_modules/.pnpm/node_modules/sharp
+      pnpm run install
+    )
+
+    pnpm build
+
+    runHook postBuild
+  '';
+
+  installPhase =
+    let
+      checkEnvVarScript = writeShellScript "misskey-check-env-var" ''
+        if [[ -z $MISSKEY_CONFIG_YML ]]; then
+          echo "MISSKEY_CONFIG_YML must be set to the location of the Misskey config file."
+          exit 1
+        fi
+      '';
+    in
+    ''
+      runHook preInstall
+
+      mkdir -p $out/data
+      cp -r . $out/data
+
+      # Set up symlink for use at runtime
+      # TODO: Find a better solution for this (potentially patch Misskey to make this configurable?)
+      # Line that would need to be patched: https://github.com/misskey-dev/misskey/blob/9849aab40283cbde2184e74d4795aec8ef8ccba3/packages/backend/src/core/InternalStorageService.ts#L18
+      # Otherwise, maybe somehow bindmount a writable directory into <package>/data/files.
+      ln -s /var/lib/misskey $out/data/files
+
+      makeWrapper ${pnpm}/bin/pnpm $out/bin/misskey \
+        --run "${checkEnvVarScript} || exit" \
+        --chdir $out/data \
+        --add-flags run \
+        --set-default NODE_ENV production \
+        --prefix PATH : ${
+          lib.makeBinPath [
+            nodejs
+            pnpm
+            bash
+          ]
+        } \
+        --prefix LD_LIBRARY_PATH : ${
+          lib.makeLibraryPath [
+            jemalloc
+            ffmpeg-headless
+            stdenv.cc.cc.lib
+          ]
+        }
+
+      runHook postInstall
+    '';
+
+  passthru = {
+    inherit (finalAttrs) pnpmDeps;
+  };
+
+  meta = {
+    description = "🌎 An interplanetary microblogging platform 🚀";
+    homepage = "https://misskey-hub.net/";
+    license = lib.licenses.agpl3Only;
+    maintainers = [ lib.maintainers.feathecutie ];
+    platforms = lib.platforms.unix;
+    mainProgram = "misskey";
+  };
+})


### PR DESCRIPTION
## Description of changes

This adds the Misskey blogging platform by providing a package and accompanying NixOS module.

Source code: https://github.com/misskey-dev/misskey
Homepage: https://misskey-hub.net/en/

This PR is largely inspired by https://github.com/NixOS/nixpkgs/pull/296697.

### TODO / Nice to have:

- [x] Add the ability to pass secrets via files that are read at runtime.
  - Currently only for `settings.{db.pass,redis.pass,meilisearch.apiKey}`. 
- [x] Correctly type all config options in the NixOS module, as there aren't that many.
  - Created typed options with defaults for the most important options, while leaving the rest freeform. 
- [x] Split out the config options that affect PostgreSQL/Redis/Nginx/Caddy instead of reading them from the untyped `settings` field.
  - Not split out from settings, but all relevant fields are properly typed now.
- [x] Assert the `settings` to be in a state where Misskey doesn't crash at runtime, e.g. when certain options are `null`.
  - All relevant fields have proper types and defaults and can't be null.
- [x] Automatically configure SSL for Nginx (I never used Nginx before).
  - [ ] Potentially detect if SSL is even necessary by checking if `settings.url` starts with `https://` or `http://`. This seems quite error prone, so a seperate toggle for SSL in nginx might make sense. Luckily, Caddy handles this automatically based on the URL type.
  - [ ] Alternative: Remove the option for auto-configuring a Nginx reverse proxy and let the user set it up completely themselves. This seems less ergonomic, but would leave the specifics of setting up SSL (among other things) to the user.

Feedback is welcome for any of the remaining (or even completed) TODOs.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
