### PR TITLE
python12Packages.pytest-regressions: remove unused disabledTestPathss

### DIFF
--- a/pkgs/development/python-modules/pytest-regressions/default.nix
+++ b/pkgs/development/python-modules/pytest-regressions/default.nix
@@ -47,11 +47,6 @@ buildPythonPackage rec {
     "ignore::DeprecationWarning"
   ];
 
-  disabledTestPathss = lib.optionals (pythonAtLeast "3.12") [
-    # AttributeError: partially initialized module 'pandas' has no attribute '_pandas_datetime_CAPI' (most likely due to a circular import)
-    "tests/test_num_regression.py"
-  ];
-
   pythonImportsCheck = [
     "pytest_regressions"
     "pytest_regressions.plugin"


### PR DESCRIPTION
This was added in #271586 (@mweinelt), but never used due to the spelling mistake of a double s.

`python312Packages.pytest-regressions`  builds fine, though.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
