### PR TITLE
Revert "python12Packages.pytest-regressions: remove unused disabledTestPathss"

### DIFF
--- a/pkgs/development/python-modules/pytest-regressions/default.nix
+++ b/pkgs/development/python-modules/pytest-regressions/default.nix
@@ -47,6 +47,11 @@ buildPythonPackage rec {
     "ignore::DeprecationWarning"
   ];
 
+  disabledTestPathss = lib.optionals (pythonAtLeast "3.12") [
+    # AttributeError: partially initialized module 'pandas' has no attribute '_pandas_datetime_CAPI' (most likely due to a circular import)
+    "tests/test_num_regression.py"
+  ];
+
   pythonImportsCheck = [
     "pytest_regressions"
     "pytest_regressions.plugin"


### PR DESCRIPTION
Reverts NixOS/nixpkgs#319351

Mass-rebuild, I'm sorry.