### PR TITLE
Release 24.05: update hercules ci packages

### DIFF
--- a/pkgs/development/haskell-modules/non-hackage-packages.nix
+++ b/pkgs/development/haskell-modules/non-hackage-packages.nix
@@ -1,5 +1,19 @@
 { pkgs, haskellLib }:
 
+let
+  inherit (pkgs) lib;
+  inherit (lib.strings) hasSuffix removeSuffix;
+
+  pathsByName =
+    lib.concatMapAttrs
+      (name: type:
+        lib.optionalAttrs (type == "regular" && hasSuffix ".nix" name) {
+          ${removeSuffix ".nix" name} = ./replacements-by-name + "/${name}";
+        }
+      )
+      (builtins.readDir ./replacements-by-name);
+in
+
 # EXTRA HASKELL PACKAGES NOT ON HACKAGE
 #
 # This file should only contain packages that are not in ./hackage-packages.nix.
@@ -42,3 +56,4 @@ self: super: {
   hercules-ci-optparse-applicative = self.callPackage ../misc/haskell/hercules-ci-optparse-applicative.nix {};
 
 }
+// lib.mapAttrs (_name: path: self.callPackage path {}) pathsByName

--- a/pkgs/development/haskell-modules/replacements-by-name/README.md
+++ b/pkgs/development/haskell-modules/replacements-by-name/README.md
@@ -1,0 +1,7 @@
+# haskell-modules/replacements-by-name
+
+This directory is scanned, and all `.nix` files are called in order to replace their respective packages in the `haskellPackages` set.
+They're loaded after `hackage-packages.nix` but before any overrides are applied.
+See [non-hackage-packages.nix](../non-hackage-packages.nix) for the implementation.
+
+This is used for selective backports of updates, as the hackage package set won't be updated in its entirety.

--- a/pkgs/development/haskell-modules/replacements-by-name/hercules-ci-agent.nix
+++ b/pkgs/development/haskell-modules/replacements-by-name/hercules-ci-agent.nix
@@ -1,0 +1,66 @@
+{ mkDerivation, aeson, async, attoparsec, base, base64-bytestring
+, bifunctors, binary, binary-conduit, boost, bytestring, Cabal
+, cabal-pkg-config-version-hook, cachix, cachix-api, conduit
+, conduit-extra, containers, directory, dlist, exceptions
+, file-embed, filepath, hercules-ci-api, hercules-ci-api-agent
+, hercules-ci-api-core, hercules-ci-cnix-expr
+, hercules-ci-cnix-store, hostname, hspec, hspec-discover
+, http-client, http-client-tls, http-conduit, HUnit, inline-c
+, inline-c-cpp, katip, lens, lens-aeson, lib, lifted-async
+, lifted-base, monad-control, mtl, network, network-uri, nix
+, optparse-applicative, process, process-extras, profunctors
+, protolude, QuickCheck, safe-exceptions, scientific, servant
+, servant-auth-client, servant-client, servant-client-core, stm
+, tagged, temporary, text, time, tls, tomland, transformers
+, transformers-base, unbounded-delays, unix, unliftio
+, unliftio-core, unordered-containers, uuid, vector, websockets
+, wuss
+}:
+mkDerivation {
+  pname = "hercules-ci-agent";
+  version = "0.10.4";
+  sha256 = "8daf98cb6817bc08cc1bcde0275fb9c4dc1727449b3d797a99e64ed009be54af";
+  isLibrary = true;
+  isExecutable = true;
+  setupHaskellDepends = [ base Cabal cabal-pkg-config-version-hook ];
+  libraryHaskellDepends = [
+    aeson async base binary binary-conduit bytestring conduit
+    containers directory dlist exceptions file-embed filepath
+    hercules-ci-api-agent hercules-ci-api-core hercules-ci-cnix-expr
+    hercules-ci-cnix-store katip lens lens-aeson lifted-async
+    lifted-base monad-control mtl network network-uri process
+    process-extras protolude safe-exceptions stm tagged temporary text
+    time tls transformers transformers-base unbounded-delays unix
+    unliftio unliftio-core uuid vector websockets wuss
+  ];
+  executableHaskellDepends = [
+    aeson async attoparsec base base64-bytestring bifunctors binary
+    binary-conduit bytestring cachix cachix-api conduit conduit-extra
+    containers directory dlist exceptions filepath hercules-ci-api
+    hercules-ci-api-agent hercules-ci-api-core hercules-ci-cnix-expr
+    hercules-ci-cnix-store hostname http-client http-client-tls
+    http-conduit inline-c inline-c-cpp katip lens lens-aeson
+    lifted-async lifted-base monad-control mtl network network-uri
+    optparse-applicative process process-extras profunctors protolude
+    safe-exceptions scientific servant servant-auth-client
+    servant-client servant-client-core stm temporary text time tomland
+    transformers transformers-base unix unliftio unliftio-core
+    unordered-containers uuid vector websockets wuss
+  ];
+  executableSystemDepends = [ boost ];
+  executablePkgconfigDepends = [ nix ];
+  testHaskellDepends = [
+    aeson async attoparsec base bifunctors binary binary-conduit
+    bytestring conduit containers exceptions filepath
+    hercules-ci-api-agent hercules-ci-api-core hercules-ci-cnix-store
+    hspec HUnit katip lens lens-aeson lifted-async lifted-base
+    monad-control mtl process profunctors protolude QuickCheck
+    safe-exceptions scientific stm tagged temporary text tomland
+    transformers transformers-base unliftio-core unordered-containers
+    uuid vector
+  ];
+  testToolDepends = [ hspec-discover ];
+  homepage = "https://docs.hercules-ci.com";
+  description = "Runs Continuous Integration tasks on your machines";
+  license = lib.licenses.asl20;
+}

--- a/pkgs/development/haskell-modules/replacements-by-name/hercules-ci-api.nix
+++ b/pkgs/development/haskell-modules/replacements-by-name/hercules-ci-api.nix
@@ -1,0 +1,39 @@
+{ mkDerivation, aeson, base, bytestring, containers, cookie
+, exceptions, hashable, hercules-ci-api-core, hspec, http-api-data
+, http-media, insert-ordered-containers, lens, lens-aeson, lib
+, memory, network-uri, openapi3, profunctors, protolude, QuickCheck
+, quickcheck-classes, servant, servant-auth, servant-auth-swagger
+, servant-openapi3, servant-swagger, servant-swagger-ui-core
+, string-conv, swagger2, text, time, uuid, vector
+}:
+mkDerivation {
+  pname = "hercules-ci-api";
+  version = "0.8.4.0";
+  sha256 = "6e7701d374ba9c3fc0491985f67e1d4a1ac477cc1eff6e37e1dcdc00e29a45dc";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson base bytestring containers cookie exceptions hashable
+    hercules-ci-api-core http-api-data http-media lens lens-aeson
+    memory network-uri openapi3 profunctors servant servant-auth
+    servant-auth-swagger servant-openapi3 servant-swagger
+    servant-swagger-ui-core string-conv swagger2 text time uuid
+  ];
+  executableHaskellDepends = [
+    aeson base bytestring containers cookie exceptions hashable
+    http-api-data http-media insert-ordered-containers lens memory
+    network-uri openapi3 profunctors servant servant-auth
+    servant-auth-swagger servant-openapi3 servant-swagger
+    servant-swagger-ui-core string-conv swagger2 text time uuid
+  ];
+  testHaskellDepends = [
+    aeson base bytestring containers exceptions hashable
+    hercules-ci-api-core hspec http-api-data http-media protolude
+    QuickCheck quickcheck-classes servant servant-auth string-conv text
+    time uuid vector
+  ];
+  homepage = "https://github.com/hercules-ci/hercules-ci-agent#readme";
+  description = "Hercules CI API definition with Servant";
+  license = lib.licenses.asl20;
+  mainProgram = "hercules-gen-swagger";
+}

--- a/pkgs/development/haskell-modules/replacements-by-name/hercules-ci-cnix-expr.nix
+++ b/pkgs/development/haskell-modules/replacements-by-name/hercules-ci-cnix-expr.nix
@@ -1,0 +1,29 @@
+{ mkDerivation, aeson, base, boost, bytestring, Cabal
+, cabal-pkg-config-version-hook, conduit, containers, directory
+, exceptions, filepath, hercules-ci-cnix-store, hspec
+, hspec-discover, inline-c, inline-c-cpp, lib, nix, process
+, protolude, QuickCheck, scientific, temporary, text, unliftio
+, unordered-containers, vector
+}:
+mkDerivation {
+  pname = "hercules-ci-cnix-expr";
+  version = "0.3.6.4";
+  sha256 = "6cc5cc25bd5a246ac81bd1d7903951c01ba21eff025705b71e0421976325ad50";
+  setupHaskellDepends = [ base Cabal cabal-pkg-config-version-hook ];
+  libraryHaskellDepends = [
+    aeson base bytestring conduit containers directory exceptions
+    filepath hercules-ci-cnix-store inline-c inline-c-cpp protolude
+    scientific text unliftio unordered-containers vector
+  ];
+  librarySystemDepends = [ boost ];
+  libraryPkgconfigDepends = [ nix ];
+  testHaskellDepends = [
+    aeson base bytestring containers filepath hercules-ci-cnix-store
+    hspec process protolude QuickCheck scientific temporary text
+    unordered-containers vector
+  ];
+  testToolDepends = [ hspec-discover ];
+  homepage = "https://docs.hercules-ci.com";
+  description = "Bindings for the Nix evaluator";
+  license = lib.licenses.asl20;
+}

--- a/pkgs/development/haskell-modules/replacements-by-name/hercules-ci-cnix-store.nix
+++ b/pkgs/development/haskell-modules/replacements-by-name/hercules-ci-cnix-store.nix
@@ -1,0 +1,26 @@
+{ mkDerivation, base, boost, bytestring, Cabal
+, cabal-pkg-config-version-hook, conduit, containers, exceptions
+, hspec, hspec-discover, inline-c, inline-c-cpp, lib, nix
+, protolude, template-haskell, temporary, text, unix, unliftio-core
+, vector
+}:
+mkDerivation {
+  pname = "hercules-ci-cnix-store";
+  version = "0.3.6.0";
+  sha256 = "07aa51577193274d71e1fa8c794d9b70780bf3b2c9d851d517ec95df715b850a";
+  setupHaskellDepends = [ base Cabal cabal-pkg-config-version-hook ];
+  libraryHaskellDepends = [
+    base bytestring conduit containers inline-c inline-c-cpp protolude
+    template-haskell unix unliftio-core vector
+  ];
+  librarySystemDepends = [ boost ];
+  libraryPkgconfigDepends = [ nix ];
+  testHaskellDepends = [
+    base bytestring containers exceptions hspec inline-c inline-c-cpp
+    protolude temporary text
+  ];
+  testToolDepends = [ hspec-discover ];
+  homepage = "https://docs.hercules-ci.com";
+  description = "Haskell bindings for Nix's libstore";
+  license = lib.licenses.asl20;
+}


### PR DESCRIPTION
## Description of changes


- Deliver stability improvements to 24.05.

- Haskell package sets weren't normally updated on stable, so this is a bit new-ish. I've added a bit of code to replace packages. Previously (year ago?) I'd just used `non-hackage-packages.nix` directly, but I figured the following is a nicer solution:

> ### haskell-modules/replacements-by-name

> This directory is scanned, and all `.nix` files are called in order to replace their respective packages in the `haskellPackages` set.
> They're loaded after `hackage-packages.nix` but before any overrides are applied.
> See [non-hackage-packages.nix](../non-hackage-packages.nix) for the implementation.
>
> This is used for selective backports of updates, as the hackage package set won't be updated in its entirety.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
     - `hci`
     - `hercules-ci-agent`
     - `cachix`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
     - `hci`
     - `hercules-ci-agent`
     - `cachix`
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
