### PR TITLE
[Backport release-23.11] chromedriver,chromium: 125.0.6422.141 -> 126.0.6478.55, rebase patches, extend tarball exclude

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -226,9 +226,15 @@ let
       # (we currently package 1.26 in Nixpkgs while Chromium bundles 1.21):
       # Source: https://bugs.chromium.org/p/angleproject/issues/detail?id=7582#c1
       ./patches/angle-wayland-include-protocol.patch
-    ] ++ lib.optionals (chromiumVersionAtLeast "120") [
-      # We need to revert this patch to build M120+ with LLVM 17:
+    ] ++ lib.optionals (versionRange "120" "126") [
+      # Partial revert to build M120+ with LLVM 17:
+      # https://github.com/chromium/chromium/commit/02b6456643700771597c00741937e22068b0f956
+      # https://github.com/chromium/chromium/commit/69736ffe943ff996d4a88d15eb30103a8c854e29
       ./patches/chromium-120-llvm-17.patch
+    ] ++ lib.optionals (chromiumVersionAtLeast "126") [
+      # Rebased variant of patch right above to build M126+ with LLVM 17.
+      # staging-next will bump LLVM to 18, so we will be able to drop this soon.
+      ./patches/chromium-126-llvm-17.patch
     ] ++ lib.optionals (!chromiumVersionAtLeast "119.0.6024.0") [
       # Fix build with at-spi2-core ≥ 2.49
       # This version is still needed for electron.
@@ -243,11 +249,14 @@ let
         commit = "b9bef8e9555645fc91fab705bec697214a39dbc1";
         hash = "sha256-CJ1v/qc8+nwaHQR9xsx08EEcuVRbyBfCZCm/G7hRY+4=";
       })
-    ] ++ lib.optionals (chromiumVersionAtLeast "121") [
+    ] ++ lib.optionals (versionRange "121" "126") [
       # M121 is the first version to require the new rust toolchain.
       # Partial revert of https://github.com/chromium/chromium/commit/3687976b0c6d36cf4157419a24a39f6770098d61
       # allowing us to use our rustc and our clang.
       ./patches/chromium-121-rust.patch
+    ] ++ lib.optionals (chromiumVersionAtLeast "126") [
+      # Rebased variant of patch right above to build M126+ with our rust and our clang.
+      ./patches/chromium-126-rust.patch
     ];
 
     postPatch = ''

--- a/pkgs/applications/networking/browsers/chromium/patches/chromium-126-llvm-17.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/chromium-126-llvm-17.patch
@@ -1,0 +1,29 @@
+diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
+index 6efe967eb0a1c..590a2c274ac13 100644
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -568,24 +568,6 @@ config("compiler") {
+       }
+     }
+ 
+-    # TODO(crbug.com/40283598): This causes binary size growth and potentially
+-    # other problems.
+-    # TODO(crbug.com/40284925): This isn't supported by Cronet's mainline llvm version.
+-    if (default_toolchain != "//build/toolchain/cros:target" &&
+-        !llvm_android_mainline) {
+-      cflags += [
+-        "-mllvm",
+-        "-split-threshold-for-reg-with-hint=0",
+-      ]
+-      if (use_thin_lto && is_a_target_toolchain) {
+-        if (is_win) {
+-          ldflags += [ "-mllvm:-split-threshold-for-reg-with-hint=0" ]
+-        } else {
+-          ldflags += [ "-Wl,-mllvm,-split-threshold-for-reg-with-hint=0" ]
+-        }
+-      }
+-    }
+-
+     # TODO(crbug.com/40192287): Investigate why/if this should be needed.
+     if (is_win) {
+       cflags += [ "/clang:-ffp-contract=off" ]

--- a/pkgs/applications/networking/browsers/chromium/patches/chromium-126-rust.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/chromium-126-rust.patch
@@ -1,0 +1,21 @@
+diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
+index 6efe967eb0a1c..2ddae4efacbfa 100644
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -1653,16 +1653,6 @@ config("runtime_library") {
+     configs += [ "//build/config/c++:runtime_library" ]
+   }
+ 
+-  # Rust and C++ both provide intrinsics for LLVM to call for math operations. We
+-  # want to use the C++ intrinsics, not the ones in the Rust compiler_builtins
+-  # library. The Rust symbols are marked as weak, so that they can be replaced by
+-  # the C++ symbols. This config ensures the C++ symbols exist and are strong in
+-  # order to cause that replacement to occur by explicitly linking in clang's
+-  # compiler-rt library.
+-  if (is_clang && toolchain_has_rust) {
+-    configs += [ "//build/config/clang:compiler_builtins" ]
+-  }
+-
+   # TODO(crbug.com/40570904): Come up with a better name for is POSIX + Fuchsia
+   # configuration.
+   if (is_posix || is_fuchsia) {

--- a/pkgs/applications/networking/browsers/chromium/recompress-tarball.nix
+++ b/pkgs/applications/networking/browsers/chromium/recompress-tarball.nix
@@ -34,6 +34,7 @@ fetchurl ({
       --one-top-level=source \
       --exclude=third_party/llvm \
       --exclude=third_party/rust-src \
+      --exclude='build/linux/debian_*-sysroot' \
       --strip-components=1
 
     tar \

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -1,11 +1,11 @@
 {
   stable = {
     chromedriver = {
-      hash_darwin = "sha256-Zz2U5zQWScID7rAE6FmTADecs4zR430KZVen+hsl+KI=";
+      hash_darwin = "sha256-a1gUAyNx0gKNZRKpQrsG3neKIy+xPquKUrzmcVbfQ54=";
       hash_darwin_aarch64 =
-        "sha256-NhnJdnrzTj8gQiyp4PzmXHx6ltsxUVrz0AL9x8nGibA=";
-      hash_linux = "sha256-iyhxx7KIpGPMYgf/I1hLUK8M49kWmgTy+UOXf5WBEWY=";
-      version = "125.0.6422.141";
+        "sha256-8OzxncQs/pXIo7dVLCgOlyO5jjTKRdTMoMaQsAiJeO8=";
+      hash_linux = "sha256-lpYxCCjPacqZKiRMQrKdEaZJ8DO3jpbUK/6/j1i95a8=";
+      version = "126.0.6478.55";
     };
     deps = {
       gn = {

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -9,14 +9,14 @@
     };
     deps = {
       gn = {
-        hash = "sha256-lrVAb6La+cvuUCNI90O6M/sheOEVFTjgpfA3O/6Odp0=";
-        rev = "d823fd85da3fb83146f734377da454473b93a2b2";
+        hash = "sha256-mNoQeHSSM+rhR0UHrpbyzLJC9vFqfxK1SD0X8GiRsqw=";
+        rev = "df98b86690c83b81aedc909ded18857296406159";
         url = "https://gn.googlesource.com/gn";
-        version = "2024-04-10";
+        version = "2024-05-13";
       };
     };
-    hash = "sha256-8Qe1hgDEjvdAf2ao4CIieC7l2pTSIPLTZb+vdctUEo0=";
-    version = "125.0.6422.141";
+    hash = "sha256-nXRzISkU37TIgV8rjO0qgnhq8uM37M6IpMoGHdsOGIM=";
+    version = "126.0.6478.55";
   };
   ungoogled-chromium = {
     deps = {


### PR DESCRIPTION
## Description of changes

Manual backport of #319193, because #293251 wasn't backported to `release-23.11` which caused a cherry-pick conflict now.

https://github.com/NixOS/nixpkgs/pull/319193#issuecomment-2163943297

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).