### PR TITLE
munge: Fix installation paths

### DIFF
--- a/pkgs/tools/security/munge/default.nix
+++ b/pkgs/tools/security/munge/default.nix
@@ -1,42 +1,63 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, libgcrypt, zlib, bzip2 }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  libgcrypt,
+  zlib,
+  bzip2,
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "munge";
   version = "0.5.16";
 
   src = fetchFromGitHub {
     owner = "dun";
     repo = "munge";
-    rev = "${pname}-${version}";
+    rev = "munge-${finalAttrs.version}";
     sha256 = "sha256-fv42RMUAP8Os33/iHXr70i5Pt2JWZK71DN5vFI3q7Ak=";
   };
 
-  strictDeps = true;
   nativeBuildInputs = [
     autoreconfHook
     libgcrypt # provides libgcrypt.m4
   ];
-  buildInputs = [ libgcrypt zlib bzip2 ];
+
+  buildInputs = [
+    libgcrypt
+    zlib
+    bzip2
+  ];
+
+  strictDeps = true;
+
+  configureFlags = [
+    "--localstatedir=/var"
+
+    # Cross-compilation hacks
+    "--with-libgcrypt-prefix=${lib.getDev libgcrypt}"
+    # workaround for cross compilation: https://github.com/dun/munge/issues/103
+    "ac_cv_file__dev_spx=no"
+    "x_ac_cv_check_fifo_recvfd=no"
+  ];
 
   preAutoreconf = ''
     # Remove the install-data stuff, since it tries to write to /var
     substituteInPlace src/Makefile.am --replace "etc \\" "\\"
   '';
 
-  configureFlags = [
-    "--localstatedir=/var"
-    "--with-libgcrypt-prefix=${libgcrypt.dev}"
-    # workaround for cross compilation: https://github.com/dun/munge/issues/103
-    "ac_cv_file__dev_spx=no"
-    "x_ac_cv_check_fifo_recvfd=no"
-  ];
-
   meta = with lib; {
     description = ''
       An authentication service for creating and validating credentials
     '';
-    license = licenses.lgpl3;
+    license = [
+      # MUNGE
+      licenses.gpl3Plus
+      # libmunge
+      licenses.lgpl3Plus
+    ];
     platforms = platforms.unix;
     maintainers = [ maintainers.rickynils ];
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Removing `src/etc/Makefile` is overly intrusive, as the file is responsible for installing pkg-config file.  The issue when it would try to write to the specified out-of-store paths can be easily resolved by overriding them to ones within `$out` during installation.

Also set `sysconfdir` path properly to allow configuring it with `environment.etc`. There should be no problem with missing files, as nothing was installed to `$out/etc` previously either, other than an empty `munge` directory.

`runstatedir` defaults to `$(localstatedir)/run` but that has long been deprecated in favour of `/run`, so let’s fix that as well.

`pkgconfigdir` and `sysconfigdir` (not to be confused with the standard `sysconfdir`) rely on FHS for proper detection and `systemdunitdir` tries to run `systemd --version`, let’s just hardcode them.  `sysconfigdir` is mentioned in the newly installed `munge.service` and a file within is loaded as `EnvironmentFile` when it exists so let’s override the path for installation so the file can serve as a template in `$out`. The other two are installation-only so we can directly set them to `$out` subdirectories.

Also clean up the expression.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
