### PR TITLE
Add usrBinEnv setup hook for running scripts with `#!/usr/bin/env` shebang during build without patching them

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1448,6 +1448,12 @@ with pkgs;
   #package writers
   writers = callPackage ../build-support/writers { };
 
+  # Useful for creating /usr/bin/env in a build environment to run build scripts with #!/usr/bin/env shebang
+  usrBinEnv = makeSetupHook { name = "create-usr-bin-env"; } (pkgs.writeText "create-usr-bin-env.sh" ''
+    mkdir -m 0755 -p /usr/bin
+    ln -sfn "${pkgs.coreutils}/bin/env" /usr/bin/env
+  '');
+
   # lib functions depending on pkgs
   inherit (import ../pkgs-lib {
     # The `lib` variable in this scope doesn't include any applied lib overlays,


### PR DESCRIPTION
## Description of changes
Adds `pkgs.usrBinEnv` (setup hook) for providing `/usr/bin/env` in build environments.

Related issues:
- https://github.com/NixOS/nixpkgs/issues/6227
- https://github.com/NixOS/nix/issues/1205

## Motivation
Consider that you want to build a third party project with build-scripts written in bash, and you see the following line at the top:
```sh
#!/usr/bin/env bash
...
```
Now, if you want to run this script in your build sandbox, you have a problem, since `/usr/bin/env` doesn't exist in your build sandbox. You will typically find advice telling you that you need to patch the shebang line of the scripts.

There is an alternative approach that doesn't require patching the third party source code though. You can create /usr/bin/env in your build sandbox before running the script as part of your build. This can be done with a setup hook.

```nix
{ pkgs ? import <nixpkgs> {}
}:
let
  usrBinEnv = pkgs.makeSetupHook { name = "create-usr-bin-env"; } (pkgs.writeText "create-usr-bin-env.sh" ''
    mkdir -m 0755 -p /usr/bin
    ln -sfn "${pkgs.coreutils}/bin/env" /usr/bin/env
  '');
in
pkgs.runCommand "example" { buildInputs = [ usrBinEnv ]; } ''
  mkdir -p $out && cd $out
  ${./some-script-that-uses-usr-bin-env.sh}
''
```

This feels like something "common enough" that it maybe should be part of nixpkgs. Then the above example could be written as
```nix
{ pkgs ? import <nixpkgs> {}
}:
pkgs.runCommand "example" { buildInputs = [ pkgs.usrBinEnv ]; } ''
  mkdir -p $out && cd $out
  ${./some-script-that-uses-usr-bin-env.sh}
''
```


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
