### PR TITLE
obs: add vpl-gpu-rt

### DIFF
--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -52,6 +52,7 @@
 , blackmagic-desktop-video
 , libdatachannel
 , libvpl
+, vpl-gpu-rt
 , qrcodegencpp
 , nix-update-script
 }:
@@ -167,7 +168,11 @@ stdenv.mkDerivation (finalAttrs: {
       xorg.libX11
       libvlc
       libGL
-    ] ++ optionals decklinkSupport [
+    ]
+    ++ optionals (!vpl-gpu-rt.meta.broken) [
+      vpl-gpu-rt
+    ]
+    ++ optionals decklinkSupport [
       blackmagic-desktop-video
     ];
   in ''


### PR DESCRIPTION
## Description of changes

Needed for [Intel Quick Sync hardware encoding](https://obsproject.com/kb/hardware-encoding#qsv). Without it, trying to stream with the QuickSync Video Encoder, you get an error:

    Starting the output failed. Please check the log for details.

    02:37:16.446: Failed to initialize MFX
    02:37:16.447: [qsv encoder: 'msdk_impl'] Specified object/item/sync point not found. (MFX_ERR_NOT_FOUND)

Ping @evanrichter @PJungkamp 

## Things done

- [x] Built on `x86_64-linux`
  - `vpl-gpu-rt` is [broken on other architectures](https://github.com/intel/vpl-gpu-rt/issues/303). Since obs builds on those, only conditionally adding it
- [x] Checked that the error disappears and that hardware encoding is used (using `intel_gpu_top`)

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
