### PR TITLE
python: automate pythonRelaxDepsHook

### DIFF
--- a/pkgs/development/python-modules/aio-geojson-generic-client/default.nix
+++ b/pkgs/development/python-modules/aio-geojson-generic-client/default.nix
@@ -31,7 +31,6 @@ buildPythonPackage rec {
   __darwinAllowLocalNetworking = true;
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/django-two-factor-auth/default.nix
+++ b/pkgs/development/python-modules/django-two-factor-auth/default.nix
@@ -31,7 +31,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools-scm
   ];
 

--- a/pkgs/development/python-modules/libretranslate/default.nix
+++ b/pkgs/development/python-modules/libretranslate/default.nix
@@ -43,7 +43,6 @@ buildPythonPackage rec {
 
   build-system = [
     hatchling
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = true;

--- a/pkgs/development/python-modules/robomachine/default.nix
+++ b/pkgs/development/python-modules/robomachine/default.nix
@@ -22,7 +22,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/tools/admin/gimme-aws-creds/default.nix
+++ b/pkgs/tools/admin/gimme-aws-creds/default.nix
@@ -37,7 +37,6 @@ python.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python.pkgs; [
     installShellFiles
-    pythonRelaxDepsHook
   ];
 
   pythonRemoveDeps = [


### PR DESCRIPTION
python: automate pythonRelaxDepsHook

As a test, removed `pythonRelaxDepsHook` from:
* libretranslate
* aio-geojson-generic-client
* gimme-aws-creds
* robomachine
* django-two-factor-auth

Seems to work fine.

Pending work unplanned for this PR (because this has to be accepted first):

- Remove `pythonRelaxDepsHook` globally.
- Update documentation.

CC @thiagokokada @mweinelt @fabaff @marsam @tjni @jonringer 

Considering `stable`, a back-port is important because any package not including `pythonRelaxDepsHook` will break. I've tested back-port to `release-24.05` and merges cleanly. But then, if this causes a mass rebuild. What should be done?