### PR TITLE
gupax: init at 1.3.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17783,6 +17783,12 @@
     githubId = 69053978;
     name = "rogarb";
   };
+  RoGreat = {
+    email = "roguegreat@gmail.com";
+    github = "RoGreat";
+    githubId = 64620440;
+    name = "Justin";
+  };
   rohanssrao = {
     email = "rohanssrao@gmail.com";
     github = "rohanssrao";

--- a/pkgs/by-name/gu/gupax/package.nix
+++ b/pkgs/by-name/gu/gupax/package.nix
@@ -1,0 +1,98 @@
+{
+  autoPatchelfHook,
+  darwin,
+  fetchFromGitHub,
+  git,
+  lib,
+  libglvnd,
+  libxkbcommon,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  stdenv,
+  vulkan-loader,
+  wayland,
+  xorg,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "gupax";
+  version = "1.3.8";
+
+  src = fetchFromGitHub {
+    owner = "hinto-janai";
+    repo = "gupax";
+    rev = "v${version}";
+    hash = "sha256-duDqlCUAMYXM+M3Ifzwshlkr80PcqqXE/G4zih/uwA0=";
+    leaveDotGit = true; # git command in build.rs
+  };
+
+  cargoHash = "sha256-a9Q0/AA/kJCcZl3maROuwUH9/tBGDZdxqBYSEIXr6EA=";
+
+  cargoBuildFlags = [
+    # disables updates but also uses /usr/bin paths
+    # p2pool and xmrig will need to be symlinked anyways
+    "--features distro"
+  ];
+
+  checkFlags = [
+    # requires filesystem write
+    "--skip disk::test::create_and_serde_gupax_p2pool_api"
+  ];
+
+  nativeBuildInputs =
+    [
+      git
+      pkg-config
+    ]
+    ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ]
+    ++ lib.optionals stdenv.isDarwin [ rustPlatform.bindgenHook ];
+
+  buildInputs =
+    [
+      openssl
+      stdenv.cc.cc.libgcc or null # libgcc_s.so
+    ]
+    ++ lib.optionals stdenv.isDarwin (
+      with darwin.apple_sdk_11_0.frameworks;
+      [
+        AppKit
+        ApplicationServices
+        Carbon
+        CoreData
+        CoreFoundation
+        CoreGraphics
+        CoreServices
+        CoreVideo
+        Foundation
+        IOKit
+        Metal
+        OpenGL
+        QuartzCore
+        Security
+      ]
+    );
+
+  runtimeDependencies = lib.optionals stdenv.isLinux [
+    libglvnd # libEGL.so
+    libxkbcommon
+    vulkan-loader # libvulkan.so
+    wayland # libwayland-client.so
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXi
+  ];
+
+  # Needed to get openssl-sys to use pkg-config.
+  OPENSSL_NO_VENDOR = 1;
+
+  meta = with lib; {
+    description = "GUI Uniting P2Pool And XMRig";
+    homepage = "https://gupax.io";
+    changelog = "https://github.com/hinto-janai/gupax/releases/tag/v${version}";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ RoGreat ];
+    mainProgram = "gupax";
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A Monero GUI for launching P2Pool and XMRig: https://gupax.io/

Configure advanced mode and define symlink paths for P2Pool and XMRig with proper user permissions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
