### PR TITLE
utterly-round-plasma-style: update, utterly-nord-plasma: fix installation

### DIFF
--- a/pkgs/data/themes/utterly-nord-plasma/default.nix
+++ b/pkgs/data/themes/utterly-nord-plasma/default.nix
@@ -33,9 +33,9 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/{color-schemes,Kvantum,plasma/look-and-feel,sddm/themes,wallpapers,konsole}
 
     cp -a look-and-feel $out/share/plasma/look-and-feel/Utterly-Nord
-    cp -a look-and-feel-solid $out/share/plasma/look-and-feel/Utterly-Nord-solid
-    cp -a look-and-feel-light $out/share/plasma/look-and-feel/Utterly-Nord-light
-    cp -a look-and-feel-light-solid $out/share/plasma/look-and-feel/Utterly-Nord-light-solid
+    cp -a look-and-feel-solid $out/share/plasma/look-and-feel/Utterly-Nord-Solid
+    cp -a look-and-feel-light $out/share/plasma/look-and-feel/Utterly-Nord-Light
+    cp -a look-and-feel-light-solid $out/share/plasma/look-and-feel/Utterly-Nord-Light-Solid
 
     cp -a *.colors $out/share/color-schemes/
 

--- a/pkgs/data/themes/utterly-round-plasma-style/default.nix
+++ b/pkgs/data/themes/utterly-round-plasma-style/default.nix
@@ -10,8 +10,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "HimDek";
     repo = pname;
-    rev = "c3677d5223286f69871f6745cdb3b71367229d40";
-    hash = "sha256-mlqRMz0cAZnnM4xE6p7fMzhGlqCQcM4FxmDlVnbGUgQ=";
+    rev = "6280f69781b7fa9613b7a9c502d8d61e11fefca5";
+    hash = "sha256-b0vah/rkcJH01bnDOGXQ04vrRR1c1Ijgc2HPBmToLuc=";
   };
 
   installPhase = ''


### PR DESCRIPTION
## Description of changes

`utterly-round-plasma-style` was updated to support plasma 6.

The name of the install directory of `utterly-nord-plasma` was modified to be in line with `Id` in themes' `metadata.json`, otherwise the theme will not shown in plasma config.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
