### PR TITLE
pympress: fix gstreamer support

### DIFF
--- a/pkgs/applications/office/pympress/default.nix
+++ b/pkgs/applications/office/pympress/default.nix
@@ -8,6 +8,7 @@
 , libcanberra-gtk3
 , poppler_gi
 , withGstreamer ? stdenv.isLinux
+, gst_all_1
 , withVLC ? stdenv.isLinux
 }:
 
@@ -29,7 +30,16 @@ python3Packages.buildPythonApplication rec {
   buildInputs = [
     gtk3
     poppler_gi
-  ] ++ lib.optional withGstreamer libcanberra-gtk3;
+  ] ++ lib.optionals withGstreamer [
+    libcanberra-gtk3
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+    (gst_all_1.gst-plugins-good.override {gtkSupport = true;})
+    gst_all_1.gst-libav
+    gst_all_1.gst-vaapi
+  ];
 
   propagatedBuildInputs = with python3Packages; [
     pycairo


### PR DESCRIPTION
## Description of changes

In the current version of this package playback support with gstreamer is broken because dependencies are missing.
I stumbled across this when I tried to embed a video in my presentation and running pympress on wayland. As it turns out VLC does not support embedded videos on wayland and opens the video in a new window (see https://github.com/Cimbali/pympress/issues/320). When turning off vlc in the pympress config file videos cannot be played at all because gstreamer does not work.
This PR adds the missing dependencies.
The minimal additional dependencies I need to be able to play an embedded `.mp4` video with gstreamer are:
```
gst_all_1.gst-plugins-base
gst_all_1.gst-plugins-bad
gst_all_1.gst-plugins-good.override {gtkSupport = true;}
```
but I think adding full gstreamer support (video/audio hardware acceleration, additional codecs) can't be a bad idea. Let me know what you think!

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

@tbenst @jtojnar @drupol 

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
