### PR TITLE
v2raya: add cliPackage option

### DIFF
--- a/.github/workflows/check-cherry-picks.yml
+++ b/.github/workflows/check-cherry-picks.yml
@@ -4,6 +4,7 @@ on:
     branches:
      - 'release-**'
      - 'staging-**'
+     - '!staging-next'
 
 permissions: {}
 

--- a/nixos/modules/services/networking/v2raya.nix
+++ b/nixos/modules/services/networking/v2raya.nix
@@ -2,15 +2,31 @@
 
 with lib;
 
+let
+  cfg = config.services.v2raya;
+in
+
 {
   options = {
     services.v2raya = {
       enable = options.mkEnableOption "the v2rayA service";
+
+      package = options.mkPackageOption pkgs "v2raya" { };
+      cliPackage = options.mkOption {
+        type = types.package;
+        default = pkgs.v2ray;
+        defaultText = literalExpression "pkgs.v2ray";
+        example = literalExpression "pkgs.xray";
+        description = ''
+          The package used for the cli binary.
+        '';
+        relatedPackages = [ "xray" "v2ray" ];
+      };
     };
   };
 
   config = mkIf config.services.v2raya.enable {
-    environment.systemPackages = [ pkgs.v2raya ];
+    environment.systemPackages = [ (pkgs.v2raya.override { v2ray = cfg.cliPackage; }) ];
 
     systemd.services.v2raya =
       let
@@ -33,7 +49,7 @@ with lib;
 
         serviceConfig = {
           User = "root";
-          ExecStart = "${getExe pkgs.v2raya} --log-disable-timestamp";
+          ExecStart = "${getExe (pkgs.v2raya.override { v2ray = cfg.cliPackage; })} --log-disable-timestamp";
           Environment = [ "V2RAYA_LOG_FILE=/var/log/v2raya/v2raya.log" ];
           LimitNPROC = 500;
           LimitNOFILE = 1000000;
@@ -48,3 +64,4 @@ with lib;
 
   meta.maintainers = with maintainers; [ elliot ];
 }
+


### PR DESCRIPTION
v2raya can now be run using the xray cli package as well

## Description of changes

fixes #271818

## Things done

added a cliPackage option

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
