### PR TITLE
rmw: 0.9.1 -> 0.9.4, canfigger: init at 0.3.0

### DIFF
--- a/pkgs/by-name/ca/canfigger/package.nix
+++ b/pkgs/by-name/ca/canfigger/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "canfigger";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "andy5995";
+    repo = "canfigger";
+    rev = "v${version}";
+    hash = "sha256-S2rEQT8wKSjJ7LFF6vcigqb9r5QR/nNUCzNdhuBNjTo=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
+
+  # canfigger has asan and ubsan enabled by default, disable it here
+  mesonFlags = [
+    "-Dcanfigger:b_sanitize=none"
+  ];
+
+  meta = {
+    description = "Lightweight library designed to parse configuration files";
+    homepage = "https://github.com/andy5995/canfigger";
+    changelog = "https://github.com/andy5995/canfigger/blob/${src.rev}/ChangeLog.txt";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ iynaix ];
+    mainProgram = "canfigger";
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/rm/rmw/package.nix
+++ b/pkgs/by-name/rm/rmw/package.nix
@@ -5,19 +5,20 @@
   meson,
   ninja,
   pkg-config,
+  canfigger,
   ncurses,
   gettext,
 }:
 
 stdenv.mkDerivation rec {
   pname = "rmw";
-  version = "0.9.1";
+  version = "0.9.4";
 
   src = fetchFromGitHub {
     owner = "theimpossibleastronaut";
     repo = "rmw";
     tag = "v${version}";
-    hash = "sha256-rfJdJHSkusZj/PN74KgV5i36YC0YRZmIfRdvkUNoKEM=";
+    hash = "sha256-/bE9fFjn3mPfUbtsB6bXfQAxUtbtuZiT4pevi5RCQA4=";
     fetchSubmodules = true;
   };
 
@@ -28,14 +29,10 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    canfigger
     ncurses
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin gettext;
-
-  # The subproject "canfigger" has asan and ubsan enabled by default, disable it here
-  mesonFlags = [
-    "-Dcanfigger:b_sanitize=none"
-  ];
 
   meta = {
     description = "Trashcan/ recycle bin utility for the command line";


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/theimpossibleastronaut/rmw/releases/tag/v0.9.3

Added canfigger as a separate package as "Automatic wrap-based subproject downloading is disabled".
Note: The previous v0.9.1 errors during build.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
