### PR TITLE
treewide: use lib.systems.equals when comparing elaborated systems

### DIFF
--- a/pkgs/applications/audio/csound/default.nix
+++ b/pkgs/applications/audio/csound/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [ "-DBUILD_CSOUND_AC=0" ] # fails to find Score.hpp
     ++ lib.optional stdenv.isDarwin "-DCS_FRAMEWORK_DEST=${placeholder "out"}/lib"
     # Ignore gettext in CMAKE_PREFIX_PATH on cross to prevent find_program picking up the wrong gettext
-    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "-DCMAKE_IGNORE_PATH=${lib.getBin gettext}/bin";
+    ++ lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) "-DCMAKE_IGNORE_PATH=${lib.getBin gettext}/bin";
 
   nativeBuildInputs = [ cmake flex bison gettext ];
   buildInputs = [ libsndfile libsamplerate boost ]

--- a/pkgs/applications/audio/vcv-rack/default.nix
+++ b/pkgs/applications/audio/vcv-rack/default.nix
@@ -204,7 +204,7 @@ stdenv.mkDerivation rec {
     zstd
   ];
 
-  makeFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  makeFlags = lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ] ++ [
     "all"

--- a/pkgs/applications/editors/mg/default.nix
+++ b/pkgs/applications/editors/mg/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-88FrXN7h5uRLY8YMKSzUjBF4n18DEiiiDyoYr+7qXdQ=";
   };
 
-  postPatch = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  postPatch = lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
     substituteInPlace configure --replace "./conftest" "echo"
   '';
 

--- a/pkgs/applications/editors/oed/default.nix
+++ b/pkgs/applications/editors/oed/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-bbV89YhrmL7tOgKly5OfQDRz4QE0UzZrVsmoXiJ7ZZw=";
   };
 
-  postPatch = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  postPatch = lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
     substituteInPlace configure --replace "./conftest" "echo"
   '';
 

--- a/pkgs/applications/editors/poke/default.nix
+++ b/pkgs/applications/editors/poke/default.nix
@@ -15,7 +15,7 @@
 }:
 
 let
-  isCross = stdenv.hostPlatform != stdenv.buildPlatform;
+  isCross = (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "poke";

--- a/pkgs/applications/editors/vim/default.nix
+++ b/pkgs/applications/editors/vim/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
   configureFlags = [
     "--enable-multibyte"
     "--enable-nls"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) ([
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ([
     "vim_cv_toupper_broken=no"
     "--with-tlib=ncurses"
     "vim_cv_terminfo=yes"

--- a/pkgs/applications/editors/vim/full.nix
+++ b/pkgs/applications/editors/vim/full.nix
@@ -93,7 +93,7 @@ in stdenv.mkDerivation {
     "--disable-nextaf_check"
     "--disable-carbon_check"
     "--disable-gtktest"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "vim_cv_toupper_broken=no"
     "--with-tlib=ncurses"
     "vim_cv_terminfo=yes"

--- a/pkgs/applications/editors/zile/default.nix
+++ b/pkgs/applications/editors/zile/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   ]
   # `help2man' wants to run Zile, which won't work when the
   # newly-produced binary can't be run at build-time.
-  ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) help2man;
+  ++ lib.optional (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) help2man;
 
   # Tests can't be run because most of them rely on the ability to
   # fiddle with the terminal.

--- a/pkgs/applications/graphics/sane/backends/default.nix
+++ b/pkgs/applications/graphics/sane/backends/default.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation {
 
   # autoconf check for HAVE_MMAP is never set on cross compilation.
   # The pieusb backend fails compilation if HAVE_MMAP is not set.
-  buildFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [ "CFLAGS=-DHAVE_MMAP=${if stdenv.hostPlatform.isLinux then "1" else "0"}" ];
+  buildFlags = lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [ "CFLAGS=-DHAVE_MMAP=${if stdenv.hostPlatform.isLinux then "1" else "0"}" ];
 
   postInstall = let
 

--- a/pkgs/applications/misc/comodoro/default.nix
+++ b/pkgs/applications/misc/comodoro/default.nix
@@ -3,8 +3,8 @@
 , fetchFromGitHub
 , stdenv
 , installShellFiles
-, installShellCompletions ? stdenv.hostPlatform == stdenv.buildPlatform
-, installManPages ? stdenv.hostPlatform == stdenv.buildPlatform
+, installShellCompletions ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
+, installManPages ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
 , withTcp ? true
 }:
 

--- a/pkgs/applications/misc/mangal/default.nix
+++ b/pkgs/applications/misc/mangal/default.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     # Mangal creates a config file in the folder ~/.config/mangal and fails if not possible
     export MANGAL_CONFIG_PATH=`mktemp -d`
     installShellCompletion --cmd mangal \

--- a/pkgs/applications/misc/visidata/default.nix
+++ b/pkgs/applications/misc/visidata/default.nix
@@ -111,7 +111,7 @@ buildPythonApplication rec {
   ];
 
   # check phase uses the output bin, which is not possible when cross-compiling
-  doCheck = stdenv.buildPlatform == stdenv.hostPlatform;
+  doCheck = (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
 
   checkPhase = ''
     runHook preCheck

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -415,7 +415,7 @@ let
       host_toolchain = "//build/toolchain/linux/unbundle:default";
       # We only build those specific toolchains when we cross-compile, as native non-cross-compilations would otherwise
       # end up building much more things than they need to (roughtly double the build steps and time/compute):
-    } // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+    } // lib.optionalAttrs (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) {
       host_toolchain = "//build/toolchain/linux/unbundle:host";
       v8_snapshot_toolchain = "//build/toolchain/linux/unbundle:host";
     } // {

--- a/pkgs/applications/networking/browsers/elinks/default.nix
+++ b/pkgs/applications/networking/browsers/elinks/default.nix
@@ -4,7 +4,7 @@
 , # Incompatible licenses, LGPLv3 - GPLv2
   enableGuile        ? false,                                         guile ? null
 , enablePython       ? false,                                         python ? null
-, enablePerl         ? (!stdenv.isDarwin) && (stdenv.hostPlatform == stdenv.buildPlatform), perl ? null
+, enablePerl         ? (!stdenv.isDarwin) && (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform), perl ? null
 # re-add javascript support when upstream supports modern spidermonkey
 }:
 

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -104,7 +104,7 @@ in
 , jackSupport ? stdenv.isLinux, libjack2
 , jemallocSupport ? !stdenv.hostPlatform.isMusl, jemalloc
 , ltoSupport ? (stdenv.isLinux && stdenv.is64bit && !stdenv.hostPlatform.isRiscV), overrideCC, buildPackages
-, pgoSupport ? (stdenv.isLinux && stdenv.hostPlatform == stdenv.buildPlatform), xvfb-run
+, pgoSupport ? (stdenv.isLinux && (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)), xvfb-run
 , pipewireSupport ? waylandSupport && webrtcSupport
 , pulseaudioSupport ? stdenv.isLinux, libpulseaudio
 , sndioSupport ? stdenv.isLinux, sndio

--- a/pkgs/applications/networking/browsers/w3m/default.nix
+++ b/pkgs/applications/networking/browsers/w3m/default.nix
@@ -47,7 +47,7 @@ in stdenv.mkDerivation rec {
     })
   ];
 
-  postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  postPatch = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     ln -s ${mktable}/bin/mktable mktable
     # stop make from recompiling mktable
     sed -ie 's!mktable.*:.*!mktable:!' Makefile.in
@@ -68,7 +68,7 @@ in stdenv.mkDerivation rec {
 
   configureFlags =
     [ "--with-ssl=${openssl.dev}" "--with-gc=${boehmgc.dev}" ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
       "ac_cv_func_setpgrp_void=yes"
     ]
     ++ lib.optional graphicsSupport "--enable-image=${lib.optionalString x11Support "x11,"}fb"

--- a/pkgs/applications/networking/cluster/argo/default.nix
+++ b/pkgs/applications/networking/cluster/argo/default.nix
@@ -74,7 +74,7 @@ buildGoModule rec {
 
   postInstall = ''
     for shell in bash zsh; do
-      ${if (stdenv.buildPlatform == stdenv.hostPlatform)
+      ${if (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
         then "$out/bin/argo"
         else "${pkgsBuildBuild.argo}/bin/argo"
       } completion $shell > argo.$shell

--- a/pkgs/applications/networking/cluster/fluxcd/default.nix
+++ b/pkgs/applications/networking/cluster/fluxcd/default.nix
@@ -53,7 +53,7 @@ in buildGoModule rec {
     $out/bin/flux --version | grep ${version} > /dev/null
   '';
 
-  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     for shell in bash fish zsh; do
       $out/bin/flux completion $shell > flux.$shell
       installShellCompletion flux.$shell

--- a/pkgs/applications/networking/cluster/kaniko/default.nix
+++ b/pkgs/applications/networking/cluster/kaniko/default.nix
@@ -29,7 +29,7 @@ buildGoModule rec {
 
   doCheck = false; # requires docker, container-diff (unpackaged yet)
 
-  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     for shell in bash fish zsh; do
       $out/bin/executor completion $shell > executor.$shell
       installShellCompletion executor.$shell

--- a/pkgs/applications/networking/cluster/kubeshark/default.nix
+++ b/pkgs/applications/networking/cluster/kubeshark/default.nix
@@ -29,7 +29,7 @@ buildGoModule rec {
   '';
   doCheck = true;
 
-  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     installShellCompletion --cmd kubeshark \
       --bash <($out/bin/kubeshark completion bash) \
       --fish <($out/bin/kubeshark completion fish) \

--- a/pkgs/applications/networking/cluster/kubevela/default.nix
+++ b/pkgs/applications/networking/cluster/kubevela/default.nix
@@ -40,7 +40,7 @@ buildGoModule rec {
   '';
 
   nativeBuildInputs = [ installShellFiles ];
-  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     installShellCompletion --cmd vela \
       --bash <($out/bin/vela completion bash) \
       --zsh <($out/bin/vela completion zsh)

--- a/pkgs/applications/networking/cluster/velero/default.nix
+++ b/pkgs/applications/networking/cluster/velero/default.nix
@@ -31,7 +31,7 @@ buildGoModule rec {
   '';
 
   nativeBuildInputs = [ installShellFiles ];
-  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     $out/bin/velero completion bash > velero.bash
     $out/bin/velero completion zsh > velero.zsh
     installShellCompletion velero.{bash,zsh}

--- a/pkgs/applications/networking/instant-messengers/element/keytar/default.nix
+++ b/pkgs/applications/networking/instant-messengers/element/keytar/default.nix
@@ -31,7 +31,7 @@ in stdenv.mkDerivation rec {
 
   doCheck = false;
 
-  postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  postPatch = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     pkg-config() { "''${PKG_CONFIG}" "$@"; }
     export -f pkg-config
   '';

--- a/pkgs/applications/networking/instant-messengers/pidgin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/default.nix
@@ -117,7 +117,7 @@ let
         --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
     '';
 
-    doInstallCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+    doInstallCheck = (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
     # In particular, this detects missing python imports in some of the tools.
     postFixup = let
       # TODO: python is a script, so it doesn't work as interpreter on darwin

--- a/pkgs/applications/networking/instant-messengers/utox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/utox/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     "-DENABLE_TESTS=${if doCheck then "ON" else "OFF"}"
   ];
 
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
   nativeCheckInputs = [ check ];
 
   meta = with lib; {

--- a/pkgs/applications/networking/offrss/default.nix
+++ b/pkgs/applications/networking/offrss/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ curl libmrss ]
-    ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) podofo
+    ++ lib.optional (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) podofo
     ++ lib.optional (!stdenv.isLinux) libiconv;
 
   # Workaround build failure on -fno-common toolchains:
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
       --replace '$(CC) $(CFLAGS) $(LDFLAGS)' '$(CXX) $(CFLAGS) $(LDFLAGS)'
   '' + lib.optionalString (!stdenv.isLinux) ''
     sed 's/#EXTRA/EXTRA/' -i Makefile
-  '' + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  '' + lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     sed 's/^PDF/#PDF/' -i Makefile
   '';
 

--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
     ./patches/lookup-dumpcap-in-path.patch
   ];
 
-  depsBuildBuild = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  depsBuildBuild = lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     buildPackages.stdenv.cc
   ];
 
@@ -141,7 +141,7 @@ stdenv.mkDerivation rec {
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DENABLE_APPLICATION_BUNDLE=${if withQt && stdenv.isDarwin then "ON" else "OFF"}"
     "-DLEMON_C_COMPILER=cc"
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "-DHAVE_C99_VSNPRINTF_EXITCODE__TRYRUN_OUTPUT="
     "-DHAVE_C99_VSNPRINTF_EXITCODE=0"
   ];

--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
       "kmymoney/plugins/woob/interface/kmymoneywoob.py"
   '';
 
-  doInstallCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doInstallCheck = (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
   nativeInstallCheckInputs = [ xvfb-run ];
   installCheckPhase =
     lib.optionalString doInstallCheck ''

--- a/pkgs/applications/science/misc/openmodelica/omcompiler/default.nix
+++ b/pkgs/applications/science/misc/openmodelica/omcompiler/default.nix
@@ -17,7 +17,7 @@
 , mkOpenModelicaDerivation
 }:
 let
-  isCross = stdenv.buildPlatform != stdenv.hostPlatform;
+  isCross = (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
   nativeOMCompiler = buildPackages.openmodelica.omcompiler;
 in
 mkOpenModelicaDerivation ({

--- a/pkgs/applications/terminal-emulators/foot/default.nix
+++ b/pkgs/applications/terminal-emulators/foot/default.nix
@@ -84,7 +84,7 @@ let
 
   # PGO only makes sense if we are not cross compiling and
   # using a compiler which foot's PGO build supports (clang or gcc)
-  doPgo = allowPgo && (stdenv.hostPlatform == stdenv.buildPlatform)
+  doPgo = allowPgo && (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
     && compilerName != "unknown";
 
   terminfoDir = "${placeholder "terminfo"}/share/terminfo";

--- a/pkgs/applications/version-management/fossil/default.nix
+++ b/pkgs/applications/version-management/fossil/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 
   configureFlags =
     lib.optional (!withInternalSqlite) "--disable-internal-sqlite"

--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -5,7 +5,7 @@
 , asciidoc, texinfo, xmlto, docbook2x, docbook_xsl, docbook_xml_dtd_45
 , libxslt, tcl, tk, makeWrapper, libiconv
 , svnSupport ? false, subversionClient, perlLibs, smtpPerlLibs
-, perlSupport ? stdenv.buildPlatform == stdenv.hostPlatform
+, perlSupport ? (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
 , nlsSupport ? true
 , osxkeychainSupport ? stdenv.isDarwin
 , guiSupport ? false
@@ -91,7 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags = [
     "ac_cv_prog_CURL_CONFIG=${lib.getDev curl}/bin/curl-config"
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "ac_cv_fread_reads_directories=yes"
     "ac_cv_snprintf_returns_bogus=no"
     "ac_cv_iconv_omits_bom=no"
@@ -106,7 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   # Git does not allow setting a shell separately for building and run-time.
   # Therefore lets leave it at the default /bin/sh when cross-compiling
-  ++ lib.optional (stdenv.buildPlatform == stdenv.hostPlatform) "SHELL_PATH=${stdenv.shell}"
+  ++ lib.optional (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) "SHELL_PATH=${stdenv.shell}"
   ++ (if perlSupport then ["PERL_PATH=${perlPackages.perl}/bin/perl"] else ["NO_PERL=1"])
   ++ (if pythonSupport then ["PYTHON_PATH=${python3}/bin/python"] else ["NO_PYTHON=1"])
   ++ lib.optionals stdenv.isSunOS ["INSTALL=install" "NO_INET_NTOP=" "NO_INET_PTON="]
@@ -122,9 +122,9 @@ stdenv.mkDerivation (finalAttrs: {
   #
   # See https://github.com/Homebrew/homebrew-core/commit/dfa3ccf1e7d3901e371b5140b935839ba9d8b706
   ++ lib.optional stdenv.isDarwin "TKFRAMEWORK=/nonexistent"
-  ++ lib.optional (stdenv.hostPlatform.isFreeBSD && stdenv.hostPlatform != stdenv.buildPlatform) "uname_S=FreeBSD";
+  ++ lib.optional (stdenv.hostPlatform.isFreeBSD && (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)) "uname_S=FreeBSD";
 
-  disallowedReferences = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  disallowedReferences = lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     stdenv.shellPackage
   ];
 

--- a/pkgs/applications/version-management/glab/default.nix
+++ b/pkgs/applications/version-management/glab/default.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     make manpage
     installManPage share/man/man1/*
     installShellCompletion --cmd glab \

--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -133,7 +133,7 @@ let
     requiredSystemFeatures = [ "big-parallel" ];
 
     # Don't run tests if not-Linux or if cross-compiling.
-    meta.broken = !stdenv.hostPlatform.isLinux || stdenv.buildPlatform != stdenv.hostPlatform;
+    meta.broken = !stdenv.hostPlatform.isLinux || (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
   } ''
     addToSearchPathWithCustomDelimiter : PYTHONPATH "${mercurial}/${python.sitePackages}"
 

--- a/pkgs/applications/version-management/rcs/default.nix
+++ b/pkgs/applications/version-management/rcs/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   DIFF3 = "${diffutils}/bin/diff3";
 
   disallowedReferences =
-    lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform)
+    lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
       [ buildPackages.diffutils buildPackages.ed ];
 
   env.NIX_CFLAGS_COMPILE = "-std=c99";

--- a/pkgs/applications/video/kodi/unwrapped.nix
+++ b/pkgs/applications/video/kodi/unwrapped.nix
@@ -205,7 +205,7 @@ in stdenv.mkDerivation (finalAttrs: {
 
     preConfigure = ''
       cmakeFlagsArray+=("-DCORE_PLATFORM_NAME=${lib.concatStringsSep " " kodi_platforms}")
-    '' + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    '' + lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
       # Need these tools on the build system when cross compiling,
       # hacky, but have found no other way.
       CXX=$CXX_FOR_BUILD LD=ld make -C tools/depends/native/JsonSchemaBuilder

--- a/pkgs/applications/video/mplayer/default.nix
+++ b/pkgs/applications/video/mplayer/default.nix
@@ -64,7 +64,7 @@ let
     meta.license = lib.licenses.unfree;
   } else null;
 
-  crossBuild = stdenv.hostPlatform != stdenv.buildPlatform;
+  crossBuild = (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 
 in
 

--- a/pkgs/applications/video/omxplayer/default.nix
+++ b/pkgs/applications/video/omxplayer/default.nix
@@ -55,7 +55,7 @@ let
       "--disable-debug"
       "--arch=${stdenv.hostPlatform.parsed.cpu.name}"
       "--target_os=${stdenv.hostPlatform.parsed.kernel.name}"
-    ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
       "--cross-prefix=${stdenv.cc.targetPrefix}"
       "--enable-cross-compile"
     ];

--- a/pkgs/applications/virtualization/kvmtool/default.nix
+++ b/pkgs/applications/virtualization/kvmtool/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
     "prefix=${placeholder "out"}"
   ] ++ lib.optionals stdenv.hostPlatform.isAarch64 ([
     "LIBFDT_DIR=${dtc}/lib"
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "CROSS_COMPILE=aarch64-unknown-linux-gnu-"
     "ARCH=arm64"
   ]);

--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -270,7 +270,7 @@ let
         echo "Building subPackage $pkg"
         buildGoDir install "$pkg"
       done
-    '' + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    '' + lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
       # normalize cross-compiled builds w.r.t. native builds
       (
         dir=$GOPATH/bin/${go.GOOS}_${go.GOARCH}

--- a/pkgs/build-support/go/package.nix
+++ b/pkgs/build-support/go/package.nix
@@ -221,7 +221,7 @@ let
         echo "Building subPackage $pkg"
         buildGoDir install "$pkg"
       done
-    '' + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    '' + lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
       # normalize cross-compiled builds w.r.t. native builds
       (
         dir=$NIX_BUILD_TOP/go/bin/${go.GOOS}_${go.GOARCH}

--- a/pkgs/build-support/lib/cmake.nix
+++ b/pkgs/build-support/lib/cmake.nix
@@ -4,7 +4,7 @@ let
   inherit (lib) findFirst isString optional optionals;
 
   cmakeFlags' =
-    optionals (stdenv.hostPlatform != stdenv.buildPlatform) ([
+    optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ([
       "-DCMAKE_SYSTEM_NAME=${findFirst isString "Generic" (optional (!stdenv.hostPlatform.isRedox) stdenv.hostPlatform.uname.system)}"
     ] ++ optionals (stdenv.hostPlatform.uname.processor != null) [
       "-DCMAKE_SYSTEM_PROCESSOR=${stdenv.hostPlatform.uname.processor}"

--- a/pkgs/build-support/lib/meson.nix
+++ b/pkgs/build-support/lib/meson.nix
@@ -29,7 +29,7 @@ let
     cmake = 'cmake'
   '';
 
-  crossFlags = optionals (stdenv.hostPlatform != stdenv.buildPlatform) [ "--cross-file=${crossFile}" ];
+  crossFlags = optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [ "--cross-file=${crossFile}" ];
 
   makeMesonFlags = { mesonFlags ? [], ... }: crossFlags ++ mesonFlags;
 

--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -19,7 +19,7 @@
         "--remap-path-prefix=$NIX_BUILD_TOP=/"
         (mkRustcDepArgs dependencies crateRenames)
         (mkRustcFeatureArgs crateFeatures)
-      ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
         "--target" stdenv.hostPlatform.rust.rustcTargetSpec
       ] ++ lib.optionals (needUnstableCLI dependencies) [
         "-Z" "unstable-options"

--- a/pkgs/build-support/rust/build-rust-crate/test/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/default.nix
@@ -93,15 +93,15 @@ let
       } (if !hasTests then ''
           ${lib.concatMapStringsSep "\n" (binary:
             # Can't actually run the binary when cross-compiling
-            (lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) "type ") + binary
+            (lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) "type ") + binary
           ) binaries}
           ${lib.optionalString isLib ''
               test -e ${crate}/lib/*.rlib || exit 1
-              ${lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) "test -x "} \
+              ${lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) "test -x "} \
                 ${libTestBinary}/bin/run-test-${crateName}
           ''}
           touch $out
-        '' else if stdenv.hostPlatform == stdenv.buildPlatform then ''
+        '' else if (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) then ''
           for file in ${crate}/tests/*; do
             $file 2>&1 >> $out
           done
@@ -630,7 +630,7 @@ let
       pkg = brotliCrates.brotli_2_5_0 {};
     in runCommand "run-brotli-test-cmd" {
       nativeBuildInputs = [ pkg ];
-    } (if stdenv.hostPlatform == stdenv.buildPlatform then ''
+    } (if (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) then ''
       ${pkg}/bin/brotli -c ${pkg}/bin/brotli > /dev/null && touch $out
     '' else ''
       test -x '${pkg}/bin/brotli' && touch $out
@@ -654,7 +654,7 @@ let
       pkg = rcgenCrates.rootCrate.build;
     in runCommand "run-rcgen-test-cmd" {
       nativeBuildInputs = [ pkg ];
-    } (if stdenv.hostPlatform == stdenv.buildPlatform then ''
+    } (if (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) then ''
       ${pkg}/bin/rcgen && touch $out
     '' else ''
       test -x '${pkg}/bin/rcgen' && touch $out

--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -133,7 +133,7 @@ stdenv.mkDerivation ((removeAttrs args [ "depsExtraArgs" "cargoUpdateHook" "carg
   patches = cargoPatches ++ patches;
 
   PKG_CONFIG_ALLOW_CROSS =
-    if stdenv.buildPlatform != stdenv.hostPlatform then 1 else 0;
+    if (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) then 1 else 0;
 
   postUnpack = ''
     eval "$cargoDepsHook"

--- a/pkgs/by-name/at/attic-client/package.nix
+++ b/pkgs/by-name/at/attic-client/package.nix
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage {
   # to nix-daemon to import NARs, which is not possible in the build sandbox.
   doCheck = false;
 
-  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     if [[ -f $out/bin/attic ]]; then
       installShellCompletion --cmd attic \
         --bash <($out/bin/attic gen-completions bash) \

--- a/pkgs/by-name/cm/cmake/package.nix
+++ b/pkgs/by-name/cm/cmake/package.nix
@@ -174,7 +174,7 @@ stdenv.mkDerivation (finalAttrs: {
   env.NIX_CFLAGS_COMPILE = "-Wno-unused-command-line-argument";
 
   # make install attempts to use the just-built cmake
-  preInstall = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  preInstall = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     sed -i 's|bin/cmake|${buildPackages.cmakeMinimal}/bin/cmake|g' Makefile
   '';
 

--- a/pkgs/by-name/cz/czkawka/package.nix
+++ b/pkgs/by-name/cz/czkawka/package.nix
@@ -63,7 +63,7 @@ rustPlatform.buildRustPackage {
   '';
 
   doCheck = stdenv.hostPlatform.isLinux
-          && (stdenv.hostPlatform == stdenv.buildPlatform);
+          && (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 
   passthru.tests.version = testers.testVersion {
     package = czkawka;

--- a/pkgs/by-name/ei/eiwd/package.nix
+++ b/pkgs/by-name/ei/eiwd/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
 
   # override this to false if you don't want to build python3
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 
   # prevent the `install-data-local` Makefile rule from running;
   # all it does is attempt to `mkdir` the `localstatedir`.

--- a/pkgs/by-name/hi/himalaya/package.nix
+++ b/pkgs/by-name/hi/himalaya/package.nix
@@ -5,8 +5,8 @@
 , pkg-config
 , darwin
 , installShellFiles
-, installShellCompletions ? stdenv.hostPlatform == stdenv.buildPlatform
-, installManPages ? stdenv.hostPlatform == stdenv.buildPlatform
+, installShellCompletions ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
+, installManPages ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
 , notmuch
 , gpgme
 , buildNoDefaultFeatures ? false

--- a/pkgs/by-name/ja/jasper/package.nix
+++ b/pkgs/by-name/ja/jasper/package.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.unix;
     # The value of __STDC_VERSION__ cannot be automatically determined when
     # cross-compiling.
-    broken = stdenv.buildPlatform != stdenv.hostPlatform;
+    broken = (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
   };
 })
 # TODO: investigate opengl support

--- a/pkgs/by-name/ne/neverest/package.nix
+++ b/pkgs/by-name/ne/neverest/package.nix
@@ -5,8 +5,8 @@
 , pkg-config
 , darwin
 , installShellFiles
-, installShellCompletions ? stdenv.hostPlatform == stdenv.buildPlatform
-, installManPages ? stdenv.hostPlatform == stdenv.buildPlatform
+, installShellCompletions ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
+, installManPages ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
 , notmuch
 , buildNoDefaultFeatures ? false
 , buildFeatures ? []

--- a/pkgs/by-name/op/openai-triton-llvm/package.nix
+++ b/pkgs/by-name/op/openai-triton-llvm/package.nix
@@ -42,7 +42,7 @@ let
     then python3Packages.python.withPackages (p: with p; [ psutil pygments pyyaml ])
     else python3Packages.python;
 
-  isNative = stdenv.hostPlatform == stdenv.buildPlatform;
+  isNative = (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 in stdenv.mkDerivation (finalAttrs: {
   pname = "openai-triton-llvm";
   version = "17.0.0-c5dede880d17";

--- a/pkgs/by-name/re/redict/package.nix
+++ b/pkgs/by-name/re/redict/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # More cross-compiling fixes.
   makeFlags = [ "PREFIX=${placeholder "out"}" ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ "AR=${stdenv.cc.targetPrefix}ar" "RANLIB=${stdenv.cc.targetPrefix}ranlib" ]
+    ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [ "AR=${stdenv.cc.targetPrefix}ar" "RANLIB=${stdenv.cc.targetPrefix}ranlib" ]
     ++ lib.optionals withSystemd [ "USE_SYSTEMD=yes" ]
     ++ lib.optionals tlsSupport [ "BUILD_TLS=yes" ];
 

--- a/pkgs/by-name/ti/tilemaker/package.nix
+++ b/pkgs/by-name/ti/tilemaker/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ boost lua protobuf_21 rapidjson shapelib sqlite zlib ];
 
-  cmakeFlags = lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
+  cmakeFlags = lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
     (lib.cmakeFeature "PROTOBUF_PROTOC_EXECUTABLE" "${buildPackages.protobuf}/bin/protoc");
 
   env.NIX_CFLAGS_COMPILE = toString [ "-DTM_VERSION=${finalAttrs.version}" ];

--- a/pkgs/by-name/uc/uclibc-ng/package.nix
+++ b/pkgs/by-name/uc/uclibc-ng/package.nix
@@ -9,7 +9,7 @@
 }:
 
 let
-  isCross = (stdenv.buildPlatform != stdenv.hostPlatform);
+  isCross = (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
   configParser = ''
     function parseconfig {
         set -x

--- a/pkgs/by-name/va/valkey/package.nix
+++ b/pkgs/by-name/va/valkey/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # More cross-compiling fixes.
   makeFlags = [ "PREFIX=${placeholder "out"}" ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ "AR=${stdenv.cc.targetPrefix}ar" "RANLIB=${stdenv.cc.targetPrefix}ranlib" ]
+    ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [ "AR=${stdenv.cc.targetPrefix}ar" "RANLIB=${stdenv.cc.targetPrefix}ranlib" ]
     ++ lib.optionals withSystemd [ "USE_SYSTEMD=yes" ]
     ++ lib.optionals tlsSupport [ "BUILD_TLS=yes" ];
 

--- a/pkgs/by-name/wl/wlogout/package.nix
+++ b/pkgs/by-name/wl/wlogout/package.nix
@@ -15,7 +15,7 @@
 # on gobject-introspection.
 # Disable it when cross-compiling since it's an optional dependency.
 # This disables transparency support.
-, withGtkLayerShell ? (stdenv.buildPlatform == stdenv.hostPlatform)
+, withGtkLayerShell ? (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/data/misc/shared-mime-info/default.nix
+++ b/pkgs/data/misc/shared-mime-info/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     pkg-config
     gettext
     libxml2
-  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) shared-mime-info;
+  ] ++ lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) shared-mime-info;
 
   buildInputs = [
     libxml2

--- a/pkgs/data/misc/tzdata/default.nix
+++ b/pkgs/data/misc/tzdata/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
   # - check_now, because that depends on the current time
   checkTarget = "check_back check_character_set check_white_space check_links check_name_lengths check_slashed_abbrs check_sorted check_tables check_ziguard check_zishrink check_tzs";
 
-  installFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  installFlags = lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "zic=${buildPackages.tzdata.bin}/bin/zic"
   ];
 

--- a/pkgs/desktops/gnome-2/platform/ORBit2/default.nix
+++ b/pkgs/desktops/gnome-2/platform/ORBit2/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  configureFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  configureFlags = lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "--with-idl-compiler=${lib.getExe' buildPackages.gnome2.ORBit2 "orbit-idl-2"}"
     # https://github.com/void-linux/void-packages/blob/e5856e02aa6ef7e4f2725afbff2915f89d39024b/srcpkgs/ORBit2/template#L17-L35
     "ac_cv_alignof_CORBA_boolean=1"

--- a/pkgs/desktops/gnome-2/platform/libIDL/default.nix
+++ b/pkgs/desktops/gnome-2/platform/libIDL/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ flex bison pkg-config ];
 
-  configureFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  configureFlags = lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     # before openembedded removed libIDL
     # the result was always ll https://lists.openembedded.org/g/openembedded-core/topic/85775262?p=%2C%2C%2C20%2C0%2C0%2C0%3A%3A%2C%2C%2C0%2C0%2C0%2C85775262
     "libIDL_cv_long_long_format=ll"

--- a/pkgs/desktops/lomiri/development/geonames/default.nix
+++ b/pkgs/desktops/lomiri/development/geonames/default.nix
@@ -107,7 +107,7 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = platforms.all;
     # Cross requires hostPlatform emulation during build
     # https://gitlab.com/ubports/development/core/geonames/-/issues/1
-    broken = stdenv.buildPlatform != stdenv.hostPlatform && !stdenv.hostPlatform.emulatorAvailable buildPackages;
+    broken = (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) && !stdenv.hostPlatform.emulatorAvailable buildPackages;
     pkgConfigModules = [
       "geonames"
     ];

--- a/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
+++ b/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
@@ -50,7 +50,7 @@ let
   # targetInfo.triple is what Google thinks the toolchain should be, this is a little
   # different from what we use. We make it four parts to conform with the existing
   # standard more properly.
-  targetPrefix = lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform) (stdenv.targetPlatform.config + "-");
+  targetPrefix = lib.optionalString (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform) (stdenv.targetPlatform.config + "-");
 in
 
 rec {

--- a/pkgs/development/compilers/chicken/5/chicken.nix
+++ b/pkgs/development/compilers/chicken/5/chicken.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     "XCODE_TOOL_PATH=${darwin.binutils.bintools}/bin"
     "LINKER_OPTIONS=-headerpad_max_install_names"
     "POSTINSTALL_PROGRAM=install_name_tool"
-  ]) ++ (lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ]) ++ (lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "HOSTSYSTEM=${stdenv.hostPlatform.config}"
     "TARGET_C_COMPILER=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc"
     "TARGET_CXX_COMPILER=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}c++"

--- a/pkgs/development/compilers/fbc/default.nix
+++ b/pkgs/development/compilers/fbc/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     "format"
   ];
 
-  makeFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  makeFlags = lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "TARGET=${stdenv.hostPlatform.config}"
   ];
 
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
       BUILD_PREFIX=${buildPackages.stdenv.cc.targetPrefix} LD=${buildPackages.stdenv.cc.targetPrefix}ld
     make rtlib -j$buildJobs \
       "FBC=$PWD/bin/fbc${stdenv.buildPlatform.extensions.executable} -i $PWD/inc" \
-      ${if (stdenv.buildPlatform == stdenv.hostPlatform) then
+      ${if (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) then
         "BUILD_PREFIX=${buildPackages.stdenv.cc.targetPrefix} LD=${buildPackages.stdenv.cc.targetPrefix}ld"
       else
         "TARGET=${stdenv.hostPlatform.config}"
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
 
     echo Install patched build compiler and host rtlib to local directory
     make install-compiler prefix=$PWD/patched-fbc
-    make install-rtlib prefix=$PWD/patched-fbc ${lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) "TARGET=${stdenv.hostPlatform.config}"}
+    make install-rtlib prefix=$PWD/patched-fbc ${lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) "TARGET=${stdenv.hostPlatform.config}"}
     make clean
 
     echo Compile patched host everything with previous patched stage
@@ -93,7 +93,7 @@ stdenv.mkDerivation rec {
 
   # Tests do not work when cross-compiling even if build platform can execute
   # host binaries, compiler struggles to find the cross compiler's libgcc_s
-  doCheck = stdenv.buildPlatform == stdenv.hostPlatform;
+  doCheck = (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
 
   checkTarget = "unit-tests warning-tests log-tests";
 

--- a/pkgs/development/compilers/gcc/all.nix
+++ b/pkgs/development/compilers/gcc/all.nix
@@ -24,8 +24,8 @@ let
         inherit majorMinorVersion;
         reproducibleBuild = true;
         profiledCompiler = false;
-        libcCross = if stdenv.targetPlatform != stdenv.buildPlatform then args.libcCross else null;
-        threadsCross = if stdenv.targetPlatform != stdenv.buildPlatform then threadsCross else { };
+        libcCross = if (!lib.systems.equals stdenv.targetPlatform stdenv.buildPlatform) then args.libcCross else null;
+        threadsCross = if (!lib.systems.equals stdenv.targetPlatform stdenv.buildPlatform) then threadsCross else { };
         isl = if       stdenv.isDarwin then null
               else if    atLeast "9"   then isl_0_20
               else if    atLeast "7"   then isl_0_17
@@ -41,7 +41,7 @@ let
                 else          /* 4.8 */    cloog;
       } // lib.optionalAttrs (atLeast "6" && !(atLeast "9")) {
         # gcc 10 is too strict to cross compile gcc <= 8
-        stdenv = if (stdenv.targetPlatform != stdenv.buildPlatform) && stdenv.cc.isGNU then gcc7Stdenv else stdenv;
+        stdenv = if (!lib.systems.equals stdenv.targetPlatform stdenv.buildPlatform) && stdenv.cc.isGNU then gcc7Stdenv else stdenv;
       })));
     in
       lib.nameValuePair attrName pkg;

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -24,7 +24,7 @@
 , langObjC
 , langObjCpp
 , langJit
-, disableBootstrap ? stdenv.targetPlatform != stdenv.hostPlatform
+, disableBootstrap ? (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform)
 }:
 
 assert !enablePlugin -> disableGdbPlugin;
@@ -50,7 +50,7 @@ let
   crossMingw = targetPlatform != hostPlatform && targetPlatform.isMinGW;
   crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
 
-  targetPrefix = lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform)
+  targetPrefix = lib.optionalString (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform)
                   "${stdenv.targetPlatform.config}-";
 
   crossConfigureFlags =

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -19,7 +19,7 @@
 , libucontext ? null
 , gnat-bootstrap ? null
 , enableMultilib ? false
-, enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
+, enablePlugin ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) # Whether to support user-supplied plug-ins
 , name ? "gcc"
 , libcCross ? null
 , threadsCross ? null # for MinGW

--- a/pkgs/development/compilers/ghc/8.10.7-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.7-binary.nix
@@ -14,7 +14,7 @@
 }:
 
 # Prebuilt only does native
-assert stdenv.targetPlatform == stdenv.hostPlatform;
+assert (lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform);
 
 let
   downloadsUrl = "https://downloads.haskell.org/ghc";

--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -26,7 +26,7 @@
 , gmp
 
 , # If enabled, use -fPIC when compiling static libs.
-  enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
+  enableRelocatedStaticLibs ? (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform)
 
 , enableProfiledLibs ? true
 
@@ -39,7 +39,7 @@
 
 , # What flavour to build. An empty string indicates no
   # specific flavour and falls back to ghc default values.
-  ghcFlavour ? lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform)
+  ghcFlavour ? lib.optionalString (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform)
     (if useLLVM then "perf-cross" else "perf-cross-ncg")
 
 , #  Whether to build sphinx documentation.
@@ -51,7 +51,7 @@
 
 , enableHaddockProgram ?
     # Disabled for cross; see note [HADDOCK_DOCS].
-    (stdenv.targetPlatform == stdenv.hostPlatform)
+    (lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform)
 
 , # Whether to disable the large address space allocator
   # necessary fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
@@ -62,7 +62,7 @@ assert !enableIntegerSimple -> gmp != null;
 
 # Cross cannot currently build the `haddock` program for silly reasons,
 # see note [HADDOCK_DOCS].
-assert (stdenv.targetPlatform != stdenv.hostPlatform) -> !enableHaddockProgram;
+assert (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform) -> !enableHaddockProgram;
 
 let
   inherit (stdenv) buildPlatform hostPlatform targetPlatform;

--- a/pkgs/development/compilers/ghc/8.6.5-binary.nix
+++ b/pkgs/development/compilers/ghc/8.6.5-binary.nix
@@ -7,7 +7,7 @@
 }:
 
 # Prebuilt only does native
-assert stdenv.targetPlatform == stdenv.hostPlatform;
+assert (lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform);
 
 let
   useLLVM = !(stdenv.targetPlatform.isx86

--- a/pkgs/development/compilers/ghc/9.2.4-binary.nix
+++ b/pkgs/development/compilers/ghc/9.2.4-binary.nix
@@ -14,7 +14,7 @@
 }:
 
 # Prebuilt only does native
-assert stdenv.targetPlatform == stdenv.hostPlatform;
+assert (lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform);
 
 let
   downloadsUrl = "https://downloads.haskell.org/ghc";

--- a/pkgs/development/compilers/ghc/9.6.3-binary.nix
+++ b/pkgs/development/compilers/ghc/9.6.3-binary.nix
@@ -14,7 +14,7 @@
 }:
 
 # Prebuilt only does native
-assert stdenv.targetPlatform == stdenv.hostPlatform;
+assert (lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform);
 
 let
   downloadsUrl = "https://downloads.haskell.org/ghc";

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -55,7 +55,7 @@
 , gmp
 
 , # If enabled, use -fPIC when compiling static libs.
-  enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
+  enableRelocatedStaticLibs ? (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform)
 
 , enableProfiledLibs ? true
 
@@ -544,7 +544,7 @@ stdenv.mkDerivation ({
 
     # TODO(@sternenseemann): there's no stage0:exe:haddock target by default,
     # so haddock isn't available for GHC cross-compilers. Can we fix that?
-    hasHaddock = stdenv.hostPlatform == stdenv.targetPlatform;
+    hasHaddock = (lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform);
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -33,7 +33,7 @@
 , gmp
 
 , # If enabled, use -fPIC when compiling static libs.
-  enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
+  enableRelocatedStaticLibs ? (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform)
 
 , enableProfiledLibs ? true
 
@@ -46,7 +46,7 @@
 
 , # What flavour to build. An empty string indicates no
   # specific flavour and falls back to ghc default values.
-  ghcFlavour ? lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform)
+  ghcFlavour ? lib.optionalString (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform)
     (if useLLVM then "perf-cross" else "perf-cross-ncg")
 
 , #  Whether to build sphinx documentation.
@@ -58,7 +58,7 @@
 
 , enableHaddockProgram ?
     # Disabled for cross; see note [HADDOCK_DOCS].
-    (stdenv.targetPlatform == stdenv.hostPlatform)
+    (lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform)
 
 , # Whether to disable the large address space allocator
   # necessary fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
@@ -69,7 +69,7 @@ assert !enableNativeBignum -> gmp != null;
 
 # Cross cannot currently build the `haddock` program for silly reasons,
 # see note [HADDOCK_DOCS].
-assert (stdenv.targetPlatform != stdenv.hostPlatform) -> !enableHaddockProgram;
+assert (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform) -> !enableHaddockProgram;
 
 let
   inherit (stdenv) buildPlatform hostPlatform targetPlatform;

--- a/pkgs/development/compilers/go/1.21.nix
+++ b/pkgs/development/compilers/go/1.21.nix
@@ -43,7 +43,7 @@ let
   # to handle the cross-building case where build != host == target
   targetCC = pkgsBuildTarget.targetPackages.stdenv.cc;
 
-  isCross = stdenv.buildPlatform != stdenv.targetPlatform;
+  isCross = (!lib.systems.equals stdenv.buildPlatform stdenv.targetPlatform);
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "go";

--- a/pkgs/development/compilers/go/1.22.nix
+++ b/pkgs/development/compilers/go/1.22.nix
@@ -44,7 +44,7 @@ let
   # to handle the cross-building case where build != host == target
   targetCC = pkgsBuildTarget.targetPackages.stdenv.cc;
 
-  isCross = stdenv.buildPlatform != stdenv.targetPlatform;
+  isCross = (!lib.systems.equals stdenv.buildPlatform stdenv.targetPlatform);
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "go";

--- a/pkgs/development/compilers/llvm/common/bintools.nix
+++ b/pkgs/development/compilers/llvm/common/bintools.nix
@@ -1,7 +1,7 @@
 { lib, runCommand, stdenv, llvm, lld, version, release_version }:
 
 let
-  targetPrefix = lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) "${stdenv.targetPlatform.config}-";
+  targetPrefix = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform) "${stdenv.targetPlatform.config}-";
 in
 runCommand "llvm-binutils-${version}"
 {

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -60,7 +60,7 @@ let
       "-DSPHINX_OUTPUT_MAN=ON"
       "-DSPHINX_OUTPUT_HTML=OFF"
       "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
-    ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) ([
+    ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ([
       "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
       "-DCLANG_TABLEGEN=${buildLlvmTools.libclang.dev}/bin/clang-tblgen"
     ] ++ lib.optionals (lib.versionAtLeast release_version "15") [
@@ -196,7 +196,7 @@ let
       '';
     })
   // (lib.optionalAttrs (lib.versionAtLeast release_version "15") {
-    env = lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+    env = lib.optionalAttrs (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) {
       # The following warning is triggered with (at least) gcc >=
       # 12, but appears to occur only for cross compiles.
       NIX_CFLAGS_COMPILE = "-Wno-maybe-uninitialized";

--- a/pkgs/development/compilers/llvm/common/libclc.nix
+++ b/pkgs/development/compilers/llvm/common/libclc.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
                 'find_program( LLVM_OPT opt PATHS "${buildLlvmTools.llvm}/bin" NO_DEFAULT_PATH )' \
       --replace 'find_program( LLVM_SPIRV llvm-spirv PATHS ''${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )' \
                 'find_program( LLVM_SPIRV llvm-spirv PATHS "${buildPackages.spirv-llvm-translator.override { inherit (buildLlvmTools) llvm; }}/bin" NO_DEFAULT_PATH )'
-  '' + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  '' + lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     substituteInPlace CMakeLists.txt \
       --replace 'COMMAND prepare_builtins' 'COMMAND ${buildLlvmTools.libclc.dev}/bin/prepare_builtins'
   '';

--- a/pkgs/development/compilers/llvm/common/lld/default.nix
+++ b/pkgs/development/compilers/llvm/common/lld/default.nix
@@ -50,10 +50,10 @@ stdenv.mkDerivation (rec {
   buildInputs = [ libllvm libxml2 ];
 
   cmakeFlags = lib.optionals (lib.versionOlder release_version "14") [
-    "-DLLVM_CONFIG_PATH=${libllvm.dev}/bin/llvm-config${lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) "-native"}"
+    "-DLLVM_CONFIG_PATH=${libllvm.dev}/bin/llvm-config${lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) "-native"}"
   ] ++ lib.optionals (lib.versionAtLeast release_version "15") [
     "-DLLD_INSTALL_PACKAGE_DIR=${placeholder "dev"}/lib/cmake/lld"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
 

--- a/pkgs/development/compilers/llvm/common/mlir/default.nix
+++ b/pkgs/development/compilers/llvm/common/mlir/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
     "-DLLVM_ENABLE_PIC=OFF"
     "-DLLVM_BUILD_STATIC=ON"
     "-DLLVM_LINK_LLVM_DYLIB=OFF"
-  ] ++ lib.optionals ((stdenv.hostPlatform != stdenv.buildPlatform) && !(stdenv.buildPlatform.canExecute stdenv.hostPlatform)) [
+  ] ++ lib.optionals ((!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) && !(stdenv.buildPlatform.canExecute stdenv.hostPlatform)) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
     "-DMLIR_TABLEGEN_EXE=${buildLlvmTools.mlir}/bin/mlir-tblgen"
   ];

--- a/pkgs/development/compilers/llvm/common/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/common/openmp/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (rec {
   ];
 
   buildInputs = [
-    (if stdenv.buildPlatform == stdenv.hostPlatform then llvm else targetLlvm)
+    (if (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) then llvm else targetLlvm)
   ];
 
   cmakeFlags = lib.optionals (lib.versions.major release_version == "13") [

--- a/pkgs/development/compilers/rust/cargo-auditable.nix
+++ b/pkgs/development/compilers/rust/cargo-auditable.nix
@@ -29,7 +29,7 @@ let
       changelog = "https://github.com/rust-secure-code/cargo-auditable/blob/v${version}/cargo-auditable/CHANGELOG.md";
       license = with licenses; [ mit /* or */ asl20 ];
       maintainers = with maintainers; [ figsoda ];
-      broken = stdenv.hostPlatform != stdenv.buildPlatform;
+      broken = (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
     };
   };
 

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -77,7 +77,7 @@ rustPlatform.buildRustPackage.override {
     license = [ licenses.mit licenses.asl20 ];
     platforms = platforms.unix;
     # https://github.com/alexcrichton/nghttp2-rs/issues/2
-    broken = stdenv.hostPlatform.isx86 && stdenv.buildPlatform != stdenv.hostPlatform;
+    broken = stdenv.hostPlatform.isx86 && (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
   };
 }
 // lib.optionalAttrs (stdenv.buildPlatform.rust.rustcTarget != stdenv.hostPlatform.rust.rustcTarget) {

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -28,7 +28,7 @@ let
     inherit lib stdenv pkgsBuildHost pkgsBuildTarget pkgsTargetTarget;
   };
   # Allow faster cross compiler generation by reusing Build artifacts
-  fastCross = (stdenv.buildPlatform == stdenv.hostPlatform) && (stdenv.hostPlatform != stdenv.targetPlatform);
+  fastCross = (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) && (!lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform);
 in
 {
   lib = lib';
@@ -60,7 +60,7 @@ in
       then pkgsBuildBuild.rustPackages
       else
         self.buildRustPackages.overrideScope (_: _:
-        lib.optionalAttrs (stdenv.buildPlatform == stdenv.hostPlatform)
+        lib.optionalAttrs (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
           (selectRustPackage pkgsBuildHost).packages.prebuilt);
       bootRustPlatform = makeRustPlatform bootstrapRustPackages;
     in {

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -44,7 +44,7 @@ let
     configureFlags = lib.optional  disableGraphviz "--disable-graphviz";
     # when cross-compiling ./compiler/valac is valac for host
     # so add the build vala in nativeBuildInputs
-    preBuild       = lib.optionalString (disableGraphviz && (stdenv.buildPlatform == stdenv.hostPlatform)) "buildFlagsArray+=(\"VALAC=$(pwd)/compiler/valac\")";
+    preBuild       = lib.optionalString (disableGraphviz && (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)) "buildFlagsArray+=(\"VALAC=$(pwd)/compiler/valac\")";
 
     outputs = [ "out" "devdoc" ];
 
@@ -52,7 +52,7 @@ let
       pkg-config flex bison libxslt gobject-introspection
     ] ++ lib.optional (stdenv.isDarwin) expat
       ++ lib.optional disableGraphviz autoreconfHook # if we changed our ./configure script, need to reconfigure
-      ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ vala ]
+      ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [ vala ]
       ++ extraNativeBuildInputs;
 
     buildInputs = [

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  isCross = stdenv.buildPlatform != stdenv.hostPlatform;
+  isCross = (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
 
   # Pass the "wrong" C compiler rather than none at all so packages that just
   # use the C preproccessor still work, see

--- a/pkgs/development/interpreters/guile/1.8.nix
+++ b/pkgs/development/interpreters/guile/1.8.nix
@@ -29,13 +29,13 @@ stdenv.mkDerivation rec {
   ]
   # Guile needs patching to preset results for the configure tests about
   # pthreads, which work only in native builds.
-  ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
+  ++ lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
     "--with-threads=no";
 
   depsBuildBuild = [
     buildPackages.stdenv.cc
   ]
-  ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
+  ++ lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
     pkgsBuildBuild.guile_1_8;
   nativeBuildInputs = [
     makeWrapper

--- a/pkgs/development/interpreters/guile/2.0.nix
+++ b/pkgs/development/interpreters/guile/2.0.nix
@@ -37,7 +37,7 @@ builder rec {
   depsBuildBuild = [
     buildPackages.stdenv.cc
   ]
-  ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
+  ++ lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
     pkgsBuildBuild.guile_2_0;
 
   nativeBuildInputs = [

--- a/pkgs/development/interpreters/guile/2.2.nix
+++ b/pkgs/development/interpreters/guile/2.2.nix
@@ -37,7 +37,7 @@ builder rec {
   depsBuildBuild = [
     buildPackages.stdenv.cc
   ]
-  ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
+  ++ lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
     pkgsBuildBuild.guile_2_2;
   nativeBuildInputs = [
     makeWrapper

--- a/pkgs/development/interpreters/guile/3.0.nix
+++ b/pkgs/development/interpreters/guile/3.0.nix
@@ -38,7 +38,7 @@ builder rec {
 
   depsBuildBuild = [
     buildPackages.stdenv.cc
-  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
+  ] ++ lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
     pkgsBuildBuild.guile_3_0;
   nativeBuildInputs = [
     makeWrapper
@@ -70,7 +70,7 @@ builder rec {
   # https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/packages/guile.scm?h=a39207f7afd977e4e4299c6f0bb34bcb6d153818#n405
   # starting with Guile 3.0.8, parallel builds can be done
   # bit-reproducibly as long as we're not cross-compiling
-  enableParallelBuilding = stdenv.buildPlatform == stdenv.hostPlatform;
+  enableParallelBuilding = (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
 
   patches = [
     ./eai_system.patch

--- a/pkgs/development/interpreters/lua-5/interpreter.nix
+++ b/pkgs/development/interpreters/lua-5/interpreter.nix
@@ -96,7 +96,7 @@ stdenv.mkDerivation (finalAttrs:
 
     makeFlagsArray+=(CFLAGS='-O2 -fPIC${lib.optionalString compat compatFlags} $(${
       if lib.versionAtLeast luaversion "5.2" then "SYSCFLAGS" else "MYCFLAGS"})' )
-    makeFlagsArray+=(${lib.optionalString stdenv.isDarwin "CC=\"$CC\""}${lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) " 'AR=${stdenv.cc.targetPrefix}ar rcu'"})
+    makeFlagsArray+=(${lib.optionalString stdenv.isDarwin "CC=\"$CC\""}${lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) " 'AR=${stdenv.cc.targetPrefix}ar rcu'"})
 
     installFlagsArray=( TO_BIN="lua luac" INSTALL_DATA='cp -d' \
       TO_LIB="${if stdenv.isDarwin then "liblua.${finalAttrs.version}.dylib"

--- a/pkgs/development/interpreters/ngn-k/default.nix
+++ b/pkgs/development/interpreters/ngn-k/default.nix
@@ -3,7 +3,7 @@
 , stdenvNoLibs
 , fetchFromGitea
 , runtimeShell
-, doCheck ? withLibc && stdenv.hostPlatform == stdenv.buildPlatform
+, doCheck ? withLibc && (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
 , withLibc ? true
 }:
 

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -1,4 +1,4 @@
-{ callPackage }:
+{ callPackage, lib }:
 
 let
   # Common passthru for all perl interpreters.
@@ -22,7 +22,7 @@ let
             # allow 'perlPackages.override { pkgs = pkgs // { imagemagick = imagemagickBig; }; }' like in python3Packages
             # most perl packages aren't called with callPackage so it's not possible to override their arguments individually
             # the conditional is because the // above won't be applied to __splicedPackages and hopefully no one is doing that when cross-compiling
-            pkgs = if stdenv.buildPlatform != stdenv.hostPlatform then pkgs.__splicedPackages else pkgs;
+            pkgs = if (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) then pkgs.__splicedPackages else pkgs;
             inherit stdenv;
             perl = self;
           };

--- a/pkgs/development/interpreters/perl/interpreter.nix
+++ b/pkgs/development/interpreters/perl/interpreter.nix
@@ -28,7 +28,7 @@
 assert (enableCrypt -> (libxcrypt != null));
 
 let
-  crossCompiling = stdenv.buildPlatform != stdenv.hostPlatform;
+  crossCompiling = (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
   libc = if stdenv.cc.libc or null != null then stdenv.cc.libc else "/usr";
   libcInc = lib.getDev libc;
   libcLib = lib.getLib libc;
@@ -235,7 +235,7 @@ stdenv.mkDerivation (rec {
     priority = 6; # in `buildEnv' (including the one inside `perl.withPackages') the library files will have priority over files in `perl`
     mainProgram = "perl";
   };
-} // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) rec {
+} // lib.optionalAttrs (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) rec {
   crossVersion = "84db4c71ae3d3b01fb2966cd15a060a7be334710"; # Nov 29, 2023
 
   perl-cross-src = fetchFromGitHub {

--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -58,7 +58,7 @@ let
   buildPackages = pkgsBuildHost;
   inherit (passthru) pythonOnBuildForHost;
 
-  pythonOnBuildForHostInterpreter = if stdenv.hostPlatform == stdenv.buildPlatform then
+  pythonOnBuildForHostInterpreter = if (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) then
     "$out/bin/python"
   else pythonOnBuildForHost.interpreter;
 
@@ -175,7 +175,7 @@ let
       # only works for GCC and Apple Clang. This makes distutils to call C++
       # compiler when needed.
       ./python-2.7-distutils-C++.patch
-    ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
       ./cross-compile.patch
     ];
 
@@ -207,7 +207,7 @@ let
     "ac_cv_func_bind_textdomain_codeset=yes"
   ] ++ lib.optionals stdenv.isDarwin [
     "--disable-toolbox-glue"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "PYTHON_FOR_BUILD=${lib.getBin buildPackages.python}/bin/python"
     "ac_cv_buggy_getaddrinfo=no"
     # Assume little-endian IEEE 754 floating point when cross compiling
@@ -243,7 +243,7 @@ let
     ++ lib.optional (stdenv.isDarwin && configd != null) configd;
   nativeBuildInputs =
     [ autoreconfHook ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform)
+    ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
       [ buildPackages.stdenv.cc buildPackages.python ];
 
   mkPaths = paths: {
@@ -252,7 +252,7 @@ let
   };
 
   # Python 2.7 needs this
-  crossCompileEnv = lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform)
+  crossCompileEnv = lib.optionalAttrs (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
                       { _PYTHON_HOST_PLATFORM = stdenv.hostPlatform.config; };
 
   # Build the basic Python interpreter without modules that have

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -156,7 +156,7 @@ let
     autoconf-archive # needed for AX_CHECK_COMPILE_FLAG
     autoreconfHook
     pkg-config
-  ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     buildPackages.stdenv.cc
     pythonOnBuildForHost
   ] ++ optionals (stdenv.cc.isClang && (!stdenv.hostPlatform.useAndroidPrebuilt or false) && (enableLTO || enableOptimizations)) [
@@ -198,7 +198,7 @@ let
 
   hasDistutilsCxxPatch = !(stdenv.cc.isGNU or false);
 
-  pythonOnBuildForHostInterpreter = if stdenv.hostPlatform == stdenv.buildPlatform then
+  pythonOnBuildForHostInterpreter = if (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) then
     "$out/bin/python"
   else pythonOnBuildForHost.interpreter;
 
@@ -422,7 +422,7 @@ in with passthru; stdenv.mkDerivation (finalAttrs: {
   ] ++ optionals (libxcrypt != null) [
     "CFLAGS=-I${libxcrypt}/include"
     "LIBS=-L${libxcrypt}/lib"
-  ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "ac_cv_buggy_getaddrinfo=no"
     # Assume little-endian IEEE 754 floating point when cross compiling
     "ac_cv_little_endian_double=yes"
@@ -596,7 +596,7 @@ in with passthru; stdenv.mkDerivation (finalAttrs: {
     linkDLLsInfolder $out/lib/python*/lib-dynload/
   '';
 
-  preFixup = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  preFixup = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     # Ensure patch-shebangs uses shebangs of host interpreter.
     export PATH=${lib.makeBinPath [ "$out" ]}:$PATH
   '';
@@ -613,7 +613,7 @@ in with passthru; stdenv.mkDerivation (finalAttrs: {
   # explicitly specify in our configure flags above.
   disallowedReferences = lib.optionals (openssl != null && !static && !enableFramework) [
     openssl.dev
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     # Ensure we don't have references to build-time packages.
     # These typically end up in shebangs.
     pythonOnBuildForHost buildPackages.bash

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -284,7 +284,7 @@ let
         }
       else
         pypaInstallHook
-    )] ++ optionals (stdenv.buildPlatform == stdenv.hostPlatform) [
+    )] ++ optionals (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
       # This is a test, however, it should be ran independent of the checkPhase and checkInputs
       pythonImportsCheckHook
     ] ++ optionals (python.pythonAtLeast "3.3") [

--- a/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
@@ -187,7 +187,7 @@ let
       eggUnpackHook eggBuildHook eggInstallHook
     ] ++ lib.optionals (format != "other") [(
       pipInstallHook
-    )] ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [
+    )] ++ lib.optionals (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
       # This is a test, however, it should be ran independent of the checkPhase and checkInputs
       pythonImportsCheckHook
     ] ++ lib.optionals withDistOutput [

--- a/pkgs/development/interpreters/python/tests.nix
+++ b/pkgs/development/interpreters/python/tests.nix
@@ -192,4 +192,4 @@ let
       '';
     };
 
-in lib.optionalAttrs (stdenv.hostPlatform == stdenv.buildPlatform ) (environmentTests // integrationTests // overrideTests // condaTests)
+in lib.optionalAttrs (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) (environmentTests // integrationTests // overrideTests // condaTests)

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -56,7 +56,7 @@ let
           docSupport = false;
           rubygemsSupport = false;
         }
-      , useBaseRuby ? stdenv.hostPlatform != stdenv.buildPlatform
+      , useBaseRuby ? (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
       }:
       stdenv.mkDerivation ( finalAttrs: {
         pname = "ruby";

--- a/pkgs/development/interpreters/s9fes/default.nix
+++ b/pkgs/development/interpreters/s9fes/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, ncurses, buildPackages }:
 
 let
-  isCrossCompiling = stdenv.hostPlatform != stdenv.buildPlatform;
+  isCrossCompiling = (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/apr-util/default.nix
+++ b/pkgs/development/libraries/apr-util/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     # For some reason, db version 6.9 is selected when cross-compiling.
     # It's unclear as to why, it requires someone with more autotools / configure knowledge to go deeper into that.
     # Always replacing the link flag with a generic link flag seems to help though, so let's do that for now.
-    lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
       substituteInPlace Makefile \
         --replace "-ldb-6.9" "-ldb"
       substituteInPlace apu-1-config \

--- a/pkgs/development/libraries/apr/default.nix
+++ b/pkgs/development/libraries/apr/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
       configureFlagsArray+=("--with-installbuilddir=$dev/share/build")
     '';
 
-  configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  configureFlags = lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     # For cross builds, provide answers to the configure time tests.
     # These answers are valid on x86_64-linux and aarch64-linux.
     "ac_cv_file__dev_zero=yes"

--- a/pkgs/development/libraries/aubio/default.nix
+++ b/pkgs/development/libraries/aubio/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ alsa-lib fftw libjack2 libsamplerate libsndfile ];
 
   strictDeps = true;
-  wafFlags = lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "--disable-tests";
+  wafFlags = lib.optional (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) "--disable-tests";
 
   postPatch = ''
     # U was removed in python 3.11 because it had no effect

--- a/pkgs/development/libraries/audio/vamp-plugin-sdk/default.nix
+++ b/pkgs/development/libraries/audio/vamp-plugin-sdk/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   makeFlags = [
     "AR:=$(AR)"
     "RANLIB:=$(RANLIB)"
-  ] ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "-o test";
+  ] ++ lib.optional (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) "-o test";
 
   meta = with lib; {
     description = "Audio processing plugin system for plugins that extract descriptive information from audio data";

--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DBUILD_DEPS=OFF"
   ] ++ lib.optional (!customMemoryManagement) "-DCUSTOM_MEMORY_MANAGEMENT=0"
-  ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "-DENABLE_TESTING=OFF"
     "-DCURL_HAS_H2=1"
     "-DCURL_HAS_TLS_PROXY=1"

--- a/pkgs/development/libraries/bencodetools/default.nix
+++ b/pkgs/development/libraries/bencodetools/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   ];
 
   # installCheck instead of check due to -install_name'd library on Darwin
-  doInstallCheck = stdenv.buildPlatform == stdenv.hostPlatform;
+  doInstallCheck = (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
   installCheckTarget = "check";
 
   meta = with lib; {

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -13,7 +13,7 @@
 , enableStatic ? !enableShared
 , enablePython ? false
 , enableNumpy ? false
-, enableIcu ? stdenv.hostPlatform == stdenv.buildPlatform
+, enableIcu ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
 , taggedLayout ? ((enableRelease && enableDebug) || (enableSingleThreaded && enableMultiThreaded) || (enableShared && enableStatic))
 , patches ? []
 , boostBuildPatches ? []
@@ -50,7 +50,7 @@ let
   # To avoid library name collisions
   layout = if taggedLayout then "tagged" else "system";
 
-  needUserConfig = stdenv.hostPlatform != stdenv.buildPlatform || useMpi || (stdenv.isDarwin && enableShared);
+  needUserConfig = (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) || useMpi || (stdenv.isDarwin && enableShared);
 
   b2Args = lib.concatStringsSep " " ([
     "--includedir=$dev/include"
@@ -187,7 +187,7 @@ stdenv.mkDerivation {
   # uniform way for clang and gcc (which works thanks to our cc-wrapper).
   # We pass toolset later which will make b2 invoke everything in the right
   # way -- the other toolset in user-config.jam will be ignored.
-  + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  + lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     cat << EOF >> user-config.jam
     using gcc : cross : ${stdenv.cc.targetPrefix}c++
       : <archiver>$AR

--- a/pkgs/development/libraries/boringssl/default.nix
+++ b/pkgs/development/libraries/boringssl/default.nix
@@ -27,7 +27,7 @@ buildGoModule {
   # (if we use postConfigure then cmake will loop runHook postConfigure)
   preBuild = ''
     cmakeConfigurePhase
-  '' + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  '' + lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
     export GOARCH=$(go env GOHOSTARCH)
   '';
 

--- a/pkgs/development/libraries/check/default.nix
+++ b/pkgs/development/libraries/check/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   # fortify breaks the libcompat vsnprintf implementation
-  hardeningDisable = lib.optionals (stdenv.hostPlatform.isMusl && (stdenv.hostPlatform != stdenv.buildPlatform)) [ "fortify" ];
+  hardeningDisable = lib.optionals (stdenv.hostPlatform.isMusl && (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)) [ "fortify" ];
 
   # Test can randomly fail: https://hydra.nixos.org/build/7243912
   doCheck = false;

--- a/pkgs/development/libraries/clucene-core/2.x.nix
+++ b/pkgs/development/libraries/clucene-core/2.x.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     "-DBUILD_CONTRIBS=ON"
     "-DBUILD_CONTRIBS_LIB=ON"
     "-DCMAKE_BUILD_WITH_INSTALL_NAME_DIR=ON"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "-D_CL_HAVE_GCC_ATOMIC_FUNCTIONS=0"
     "-D_CL_HAVE_NAMESPACES_EXITCODE=0"
     "-D_CL_HAVE_NAMESPACES_EXITCODE__TRYRUN_OUTPUT="

--- a/pkgs/development/libraries/cracklib/default.nix
+++ b/pkgs/development/libraries/cracklib/default.nix
@@ -15,10 +15,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-yosEmjwtOyIloejRXWE3mOvHSOOVA4jtomlN5Qe6YCA=";
   };
 
-  nativeBuildInputs = lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) buildPackages.cracklib;
+  nativeBuildInputs = lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) buildPackages.cracklib;
   buildInputs = [ zlib gettext ];
 
-  postPatch = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postPatch = lib.optionalString (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     chmod +x util/cracklib-format
     patchShebangs util
 

--- a/pkgs/development/libraries/dbus-glib/default.nix
+++ b/pkgs/development/libraries/dbus-glib/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ dbus glib ];
 
   configureFlags = [ "--exec-prefix=${placeholder "dev"}" ] ++
-    lib.optional (stdenv.buildPlatform != stdenv.hostPlatform)
+    lib.optional (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
       "--with-dbus-binding-tool=${buildPackages.dbus-glib.dev}/bin/dbus-binding-tool";
 
   doCheck = false;

--- a/pkgs/development/libraries/drogon/default.nix
+++ b/pkgs/development/libraries/drogon/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # this excludes you, pkgsStatic (cmake wants to run built binaries
   # in the buildPhase)
-  doInstallCheck = stdenv.buildPlatform == stdenv.hostPlatform;
+  doInstallCheck = (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
 
   meta = with lib; {
     homepage = "https://github.com/drogonframework/drogon";

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -37,7 +37,7 @@
 , withAom ? withFullDeps # AV1 reference encoder
 , withAppKit ? withHeadlessDeps && stdenv.isDarwin # Apple AppKit framework
 , withAribcaption ? withFullDeps && lib.versionAtLeast version "6.1" # ARIB STD-B24 Caption Decoder/Renderer
-, withAss ? withHeadlessDeps && stdenv.hostPlatform == stdenv.buildPlatform # (Advanced) SubStation Alpha subtitle rendering
+, withAss ? withHeadlessDeps && (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) # (Advanced) SubStation Alpha subtitle rendering
 , withAudioToolbox ? withHeadlessDeps && stdenv.isDarwin # Apple AudioToolbox
 , withAvFoundation ? withHeadlessDeps && stdenv.isDarwin # Apple AVFoundation framework
 , withAvisynth ? withFullDeps # AviSynth script files reading
@@ -116,7 +116,7 @@
 , withVoAmrwbenc ? withFullDeps && withVersion3 # AMR-WB encoder
 , withVorbis ? withHeadlessDeps # Vorbis de/encoding, native encoder exists
 , withVpl ? false # Hardware acceleration via intel libvpl
-, withVpx ? withHeadlessDeps && stdenv.buildPlatform == stdenv.hostPlatform # VP8 & VP9 de/encoding
+, withVpx ? withHeadlessDeps && (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) # VP8 & VP9 de/encoding
 , withVulkan ? withSmallDeps && !stdenv.isDarwin
 , withWebp ? withFullDeps # WebP encoder
 , withX264 ? withHeadlessDeps && withGPL # H.264/AVC encoder
@@ -682,7 +682,7 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withOptimisations "optimizations")
     (enableFeature withExtraWarnings "extra-warnings")
     (enableFeature withStripping "stripping")
-  ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "--cross-prefix=${stdenv.cc.targetPrefix}"
     "--enable-cross-compile"
     "--host-cc=${buildPackages.stdenv.cc}/bin/cc"
@@ -697,7 +697,7 @@ stdenv.mkDerivation (finalAttrs: {
   # such references except for data.
   postConfigure = let
     toStrip = map placeholder (lib.remove "data" finalAttrs.outputs) # We want to keep references to the data dir.
-      ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) buildPackages.stdenv.cc;
+      ++ lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) buildPackages.stdenv.cc;
   in
     "remove-references-to ${lib.concatStringsSep " " (map (o: "-t ${o}") toStrip)} config.h";
 
@@ -803,7 +803,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildFlags = [ "all" ]
     ++ optional buildQtFaststart "tools/qt-faststart"; # Build qt-faststart executable
 
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 
   # Fails with SIGABRT otherwise FIXME: Why?
   checkPhase = let

--- a/pkgs/development/libraries/flatbuffers/default.nix
+++ b/pkgs/development/libraries/flatbuffers/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     "-DFLATBUFFERS_OSX_BUILD_UNIVERSAL=OFF"
   ];
 
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
   checkTarget = "test";
 
   meta = with lib; {

--- a/pkgs/development/libraries/fltk/common.nix
+++ b/pkgs/development/libraries/fltk/common.nix
@@ -37,7 +37,7 @@
 , doxygen
 , graphviz
 
-, withExamples ? (stdenv.buildPlatform == stdenv.hostPlatform)
+, withExamples ? (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
 , withShared ? true
 }:
 

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-cache-dir=/var/cache/fontconfig" # otherwise the fallback is in $out/
     # just <1MB; this is what you get when loading config fails for some reason
     "--with-default-fonts=${dejavu_fonts.minimal}"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "--with-arch=${stdenv.hostPlatform.parsed.cpu.name}"
   ];
 

--- a/pkgs/development/libraries/gamin/default.nix
+++ b/pkgs/development/libraries/gamin/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
       name = "fix-pthread-mutex.patch";
       url = "https://git.alpinelinux.org/aports/plain/main/gamin/fix-pthread-mutex.patch?h=3.4-stable&id=a1a836b089573752c1b0da7d144c0948b04e8ea8";
       sha256 = "13igdbqsxb3sz0h417k6ifmq2n4siwqspj6slhc7fdl5wd1fxmdz";
-    }) ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) ./abstract-socket-namespace.patch;
+    }) ++ lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ./abstract-socket-namespace.patch;
 
 
   meta = with lib; {

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [ "out" "dev" "man" ]
     ++ lib.optional withIntrospection "devdoc"
-    ++ lib.optional (stdenv.buildPlatform == stdenv.hostPlatform) "installedTests";
+    ++ lib.optional (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) "installedTests";
 
   src = let
     inherit (finalAttrs) pname version;

--- a/pkgs/development/libraries/geoip/default.nix
+++ b/pkgs/development/libraries/geoip/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook ];
 
   # Cross compilation shenanigans
-  configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  configureFlags = lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"
     "ac_cv_func_realloc_0_nonnull=yes"
   ];

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
      "--disable-csharp"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     # On cross building, gettext supposes that the wchar.h from libc
     # does not fulfill gettext needs, so it tries to work with its
     # own wchar.h file, which does not cope well with the system's

--- a/pkgs/development/libraries/glew/1.10.nix
+++ b/pkgs/development/libraries/glew/1.10.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patchPhase = ''
     sed -i 's|lib64|lib|' config/Makefile.linux
-    ${lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    ${lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     sed -i -e 's/\(INSTALL.*\)-s/\1/' Makefile
     ''}
   '';

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -132,7 +132,7 @@ stdenv.mkDerivation ({
     ''
     # FIXME: find a solution for infinite recursion in cross builds.
     # For now it's hopefully acceptable that IDN from libc doesn't reliably work.
-    + lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+    + lib.optionalString (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
 
       # Ensure that libidn2 is found.
       patch -p 1 <<EOF
@@ -164,7 +164,7 @@ stdenv.mkDerivation ({
       "--enable-cet${if builtins.isString enableCET then "=${enableCET}"  else ""}"
     ] ++ lib.optionals withLinuxHeaders [
       "--enable-kernel=3.10.0" # RHEL 7 and derivatives, seems oldest still supported kernel
-    ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
       (lib.flip lib.withFeature "fp"
          (stdenv.hostPlatform.gcc.float or (stdenv.hostPlatform.parsed.abi.float or "hard") == "soft"))
       "--with-__thread"
@@ -240,7 +240,7 @@ stdenv.mkDerivation ({
     }
 
 
-  '' + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  '' + lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     sed -i s/-lgcc_eh//g "../$sourceRoot/Makeconfig"
 
     cat > config.cache << "EOF"

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -58,7 +58,7 @@ in
           # Fix -Werror build failure when building glibc with musl with GCC >= 8, see:
           # https://github.com/NixOS/nixpkgs/pull/68244#issuecomment-544307798
           (lib.optional stdenv.hostPlatform.isMusl "-Wno-error=attribute-alias")
-          (lib.optionals ((stdenv.hostPlatform != stdenv.buildPlatform) || stdenv.hostPlatform.isMusl) [
+          (lib.optionals ((!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) || stdenv.hostPlatform.isMusl) [
             # Ignore "error: '__EI___errno_location' specifies less restrictive attributes than its target '__errno_location'"
             # New warning as of GCC 9
             # Same for musl: https://github.com/NixOS/nixpkgs/issues/78805

--- a/pkgs/development/libraries/gmime/2.nix
+++ b/pkgs/development/libraries/gmime/2.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ glib zlib libgpg-error ];
   configureFlags = [
     "--enable-introspection=yes"
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ "ac_cv_have_iconv_detect_h=yes" ];
+  ] ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [ "ac_cv_have_iconv_detect_h=yes" ];
 
   postPatch = ''
     substituteInPlace tests/testsuite.c \
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
       --replace /bin/mkdir mkdir
   '';
 
-  preConfigure = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  preConfigure = lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
     cp ${if stdenv.hostPlatform.isMusl then ./musl-iconv-detect.h else ./iconv-detect.h} ./iconv-detect.h
   '';
 

--- a/pkgs/development/libraries/gmime/3.nix
+++ b/pkgs/development/libraries/gmime/3.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
       "--enable-introspection=yes"
       "--enable-vala=yes"
     ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ "ac_cv_have_iconv_detect_h=yes" ];
+    ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [ "ac_cv_have_iconv_detect_h=yes" ];
 
   postPatch =
     ''
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
       PKG_CONFIG_VAPIGEN_VAPIGEN="$(type -p vapigen)"
       export PKG_CONFIG_VAPIGEN_VAPIGEN
     ''
-    + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    + lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
       cp ${
         if stdenv.hostPlatform.isMusl then ./musl-iconv-detect.h else ./iconv-detect.h
       } ./iconv-detect.h

--- a/pkgs/development/libraries/gnutls/default.nix
+++ b/pkgs/development/libraries/gnutls/default.nix
@@ -53,7 +53,7 @@ let
   # XXX: Gnulib's `test-select' fails on FreeBSD:
   # https://hydra.nixos.org/build/2962084/nixlog/1/raw .
   doCheck = !stdenv.isFreeBSD && !stdenv.isDarwin
-    && stdenv.buildPlatform == stdenv.hostPlatform;
+    && (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
 
   inherit (stdenv.hostPlatform) isDarwin;
 in

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
     (buildPackages.python3.withPackages pythonModules)
     finalAttrs.setupHook # move .gir files
     # can't use canExecute, we need prebuilt when cross
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ gobject-introspection-unwrapped ];
+  ] ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [ gobject-introspection-unwrapped ];
 
   buildInputs = [
     (python3.withPackages pythonModules)
@@ -102,7 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
   mesonFlags = [
     "--datadir=${placeholder "dev"}/share"
     "-Dcairo=disabled"
-    "-Dgtk_doc=${lib.boolToString (stdenv.hostPlatform == stdenv.buildPlatform)}"
+    "-Dgtk_doc=${lib.boolToString (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)}"
   ] ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
     "-Dgi_cross_ldd_wrapper=${substituteAll {
       name = "g-ir-scanner-lddwrapper";
@@ -113,7 +113,7 @@ stdenv.mkDerivation (finalAttrs: {
     }}"
     "-Dgi_cross_binary_wrapper=${stdenv.hostPlatform.emulator buildPackages}"
     # can't use canExecute, we need prebuilt when cross
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "-Dgi_cross_use_prebuilt_gi=true"
   ];
 
@@ -125,7 +125,7 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs tools/*
   '';
 
-  postInstall = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     cp -r ${buildPackages.gobject-introspection-unwrapped.devdoc} $devdoc
     # these are uncompiled c and header files which aren't installed when cross-compiling because
     # code that installs them is in tests/meson.build which is only run when not cross-compiling

--- a/pkgs/development/libraries/graphene/default.nix
+++ b/pkgs/development/libraries/graphene/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [ "out" "dev" ]
     ++ lib.optionals withDocumentation [ "devdoc" ]
-    ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [ "installedTests" ];
+    ++ lib.optionals (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [ "installedTests" ];
 
   src = fetchFromGitHub {
     owner = "ebassi";

--- a/pkgs/development/libraries/grpc/default.nix
+++ b/pkgs/development/libraries/grpc/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ cmake pkg-config ]
-    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) grpc;
+    ++ lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) grpc;
   propagatedBuildInputs = [ c-ares re2 zlib abseil-cpp ];
   buildInputs = [ openssl protobuf ]
     ++ lib.optionals stdenv.isLinux [ libnsl ];
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
     "-DgRPC_PROTOBUF_PROVIDER=package"
     "-DgRPC_ABSL_PROVIDER=package"
     "-DBUILD_SHARED_LIBS=ON"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "-D_gRPC_PROTOBUF_PROTOC_EXECUTABLE=${buildPackages.protobuf}/bin/protoc"
     "-D_gRPC_CPP_PLUGIN=${buildPackages.grpc}/bin/grpc_cpp_plugin"
   ]
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
   # LD_LIBRARY_PATH to enable this. When cross compiling we need to avoid this,
   # since it can cause the grpc_cpp_plugin executable from buildPackages to
   # crash if build and host architecture are compatible (e. g. pkgsLLVM).
-  preBuild = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  preBuild = lib.optionalString (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     export LD_LIBRARY_PATH=$(pwd)''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH
   '';
 

--- a/pkgs/development/libraries/gssdp/default.nix
+++ b/pkgs/development/libraries/gssdp/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   version = "1.4.1";
 
   outputs = [ "out" "dev" ]
-    ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ "devdoc" ];
+    ++ lib.optionals (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [ "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gssdp/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
@@ -51,14 +51,14 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Dgtk_doc=${lib.boolToString (stdenv.buildPlatform == stdenv.hostPlatform)}"
+    "-Dgtk_doc=${lib.boolToString (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)}"
     "-Dsniffer=false"
   ];
 
   # Bail out! GLib-GIO-FATAL-CRITICAL: g_inet_address_to_string: assertion 'G_IS_INET_ADDRESS (address)' failed
   doCheck = !stdenv.isDarwin;
 
-  postFixup = lib.optionalString (stdenv.buildPlatform == stdenv.hostPlatform) ''
+  postFixup = lib.optionalString (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
     # Move developer documentation to devdoc output.
     # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
     find -L "$out/share/doc" -type f -regex '.*\.devhelp2?' -print0 \

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -106,7 +106,7 @@
 # Causes every application using GstDeviceMonitor to send mDNS queries every 2 seconds
 , microdnsSupport ? false
 # Checks meson.is_cross_build(), so even canExecute isn't enough.
-, enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform, hotdoc
+, enableDocumentation ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform), hotdoc
 , guiSupport ? true, directfb
 }:
 

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -40,7 +40,7 @@
 , glib
 , testers
 # Checks meson.is_cross_build(), so even canExecute isn't enough.
-, enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform
+, enableDocumentation ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
 , hotdoc
 }:
 
@@ -117,7 +117,7 @@ stdenv.mkDerivation (finalAttrs: {
     # See https://github.com/GStreamer/gst-plugins-base/blob/d64a4b7a69c3462851ff4dcfa97cc6f94cd64aef/meson_options.txt#L15 for a list of choices
     "-Dgl_winsys=${lib.concatStringsSep "," (lib.optional enableX11 "x11" ++ lib.optional enableWayland "wayland" ++ lib.optional enableCocoa "cocoa")}"
     (lib.mesonEnable "doc" enableDocumentation)
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "-Dtests=disabled"
   ]
   ++ lib.optional (!enableX11) "-Dx11=disabled"

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -20,7 +20,7 @@
 , rustc
 , testers
 # Checks meson.is_cross_build(), so even canExecute isn't enough.
-, enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform, hotdoc
+, enableDocumentation ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform), hotdoc
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/development/libraries/gstreamer/devtools/default.nix
+++ b/pkgs/development/libraries/gstreamer/devtools/default.nix
@@ -12,7 +12,7 @@
 , gobject-introspection
 , json-glib
 # Checks meson.is_cross_build(), so even canExecute isn't enough.
-, enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform, hotdoc
+, enableDocumentation ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform), hotdoc
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/gstreamer/ges/default.nix
+++ b/pkgs/development/libraries/gstreamer/ges/default.nix
@@ -13,7 +13,7 @@
 , gettext
 , gobject-introspection
 # Checks meson.is_cross_build(), so even canExecute isn't enough.
-, enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform, hotdoc
+, enableDocumentation ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform), hotdoc
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -49,7 +49,7 @@
 , glib
 , openssl
 # Checks meson.is_cross_build(), so even canExecute isn't enough.
-, enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform, hotdoc
+, enableDocumentation ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform), hotdoc
 }:
 
 # MMAL is not supported on aarch64, see:

--- a/pkgs/development/libraries/gstreamer/libav/default.nix
+++ b/pkgs/development/libraries/gstreamer/libav/default.nix
@@ -10,7 +10,7 @@
 , gettext
 , libav
 # Checks meson.is_cross_build(), so even canExecute isn't enough.
-, enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform, hotdoc
+, enableDocumentation ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform), hotdoc
 }:
 
 # Note that since gst-libav-1.6, libav is actually ffmpeg. See

--- a/pkgs/development/libraries/gstreamer/rs/default.nix
+++ b/pkgs/development/libraries/gstreamer/rs/default.nix
@@ -31,7 +31,7 @@
 , plugins ? null
 , withGtkPlugins ? true
 # Checks meson.is_cross_build(), so even canExecute isn't enough.
-, enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform && plugins == null
+, enableDocumentation ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) && plugins == null
 , hotdoc
 }:
 

--- a/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
+++ b/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
@@ -10,7 +10,7 @@
 , gst-plugins-base
 , gst-plugins-bad
 # Checks meson.is_cross_build(), so even canExecute isn't enough.
-, enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform, hotdoc
+, enableDocumentation ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform), hotdoc
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/gstreamer/ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/ugly/default.nix
@@ -20,7 +20,7 @@
 , DiskArbitration
 , enableGplPlugins ? true
 # Checks meson.is_cross_build(), so even canExecute isn't enough.
-, enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform, hotdoc
+, enableDocumentation ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform), hotdoc
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/gstreamer/vaapi/default.nix
+++ b/pkgs/development/libraries/gstreamer/vaapi/default.nix
@@ -19,7 +19,7 @@
 , libvpx
 , python3
 # Checks meson.is_cross_build(), so even canExecute isn't enough.
-, enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform, hotdoc
+, enableDocumentation ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform), hotdoc
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/gtk/2.x.nix
+++ b/pkgs/development/libraries/gtk/2.x.nix
@@ -104,7 +104,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--disable-glibtest"
     "--disable-introspection"
     "--disable-visibility"
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "ac_cv_path_GTK_UPDATE_ICON_CACHE=${buildPackages.gtk2}/bin/gtk-update-icon-cache"
     "ac_cv_path_GDK_PIXBUF_CSOURCE=${buildPackages.gdk-pixbuf.dev}/bin/gdk-pixbuf-csource"
   ];

--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -34,7 +34,7 @@
 , gnome
 , gsettings-desktop-schemas
 , sassc
-, trackerSupport ? stdenv.isLinux && (stdenv.buildPlatform == stdenv.hostPlatform)
+, trackerSupport ? stdenv.isLinux && (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
 , tracker
 , x11Support ? stdenv.isLinux
 , waylandSupport ? stdenv.isLinux
@@ -215,7 +215,7 @@ stdenv.mkDerivation (finalAttrs: {
     for f in $dev/bin/gtk-encode-symbolic-svg; do
       wrapProgram $f --prefix XDG_DATA_DIRS : "${shared-mime-info}/share"
     done
-  '' + lib.optionalString (stdenv.buildPlatform == stdenv.hostPlatform) ''
+  '' + lib.optionalString (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
     GTK_PATH="''${out:?}/lib/gtk-3.0/3.0.0/immodules/" ''${dev:?}/bin/gtk-query-immodules-3.0 > "''${out:?}/lib/gtk-3.0/3.0.0/immodules.cache"
   '';
 

--- a/pkgs/development/libraries/gts/default.nix
+++ b/pkgs/development/libraries/gts/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   doCheck = false; # fails with "permission denied"
 
-  preBuild = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  preBuild = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     pushd src
     make CC=${buildPackages.stdenv.cc}/bin/cc predicates_init
     mv predicates_init predicates_init_build

--- a/pkgs/development/libraries/gupnp-igd/default.nix
+++ b/pkgs/development/libraries/gupnp-igd/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   version = "1.2.0";
 
   outputs = [ "out" "dev" ]
-    ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ "devdoc" ];
+    ++ lib.optionals (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [ "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
@@ -46,8 +46,8 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Dgtk_doc=${lib.boolToString (stdenv.buildPlatform == stdenv.hostPlatform)}"
-    "-Dintrospection=${lib.boolToString (stdenv.buildPlatform == stdenv.hostPlatform)}"
+    "-Dgtk_doc=${lib.boolToString (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)}"
+    "-Dintrospection=${lib.boolToString (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)}"
   ];
 
   # Seems to get stuck sometimes.

--- a/pkgs/development/libraries/gupnp/default.nix
+++ b/pkgs/development/libraries/gupnp/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   version = "1.4.4";
 
   outputs = [ "out" "dev" ]
-    ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ "devdoc" ];
+    ++ lib.optionals (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [ "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gupnp/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Dgtk_doc=${lib.boolToString (stdenv.buildPlatform == stdenv.hostPlatform)}"
+    "-Dgtk_doc=${lib.boolToString (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)}"
   ];
 
   # Bail out! ERROR:../tests/test-bugs.c:168:test_on_timeout: code should not be reached

--- a/pkgs/development/libraries/hamlib/default.nix
+++ b/pkgs/development/libraries/hamlib/default.nix
@@ -15,7 +15,7 @@
 , perlPackages
 , pythonBindings ? true
 , tclBindings ? true
-, perlBindings ? stdenv.buildPlatform == stdenv.hostPlatform
+, perlBindings ? (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
 , buildPackages
 }:
 

--- a/pkgs/development/libraries/hspell/default.nix
+++ b/pkgs/development/libraries/hspell/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   patches = [./remove-shared-library-checks.patch];
   postPatch = "patchShebangs .";
-  preBuild = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  preBuild = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     make CC=${buildPackages.stdenv.cc}/bin/cc find_sizes
     mv find_sizes find_sizes_build
     make clean

--- a/pkgs/development/libraries/icu/make-icu.nix
+++ b/pkgs/development/libraries/icu/make-icu.nix
@@ -40,7 +40,7 @@ let
 
     configureFlags = [ "--disable-debug" ]
       ++ lib.optional (stdenv.isFreeBSD || stdenv.isDarwin) "--enable-rpath"
-      ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "--with-cross-build=${nativeBuildRoot}"
+      ++ lib.optional (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) "--with-cross-build=${nativeBuildRoot}"
       ++ lib.optional withStatic "--enable-static";
 
     enableParallelBuilding = true;

--- a/pkgs/development/libraries/jsoncpp/default.nix
+++ b/pkgs/development/libraries/jsoncpp/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     # comparison operators and conversion functions between
     # std::basic_string<..., Json::SecureAllocator<char>> vs.
     # std::basic_string<..., [default allocator]>
-    ++ lib.optional ((stdenv.buildPlatform != stdenv.hostPlatform) || secureMemory) "-DJSONCPP_WITH_TESTS=OFF";
+    ++ lib.optional ((!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) || secureMemory) "-DJSONCPP_WITH_TESTS=OFF";
 
   meta = with lib; {
     homepage = "https://github.com/open-source-parsers/jsoncpp";

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional withLdap "--with-ldap"
     ++ lib.optional withVerto "--with-system-verto"
     ++ lib.optional stdenv.isFreeBSD ''WARN_CFLAGS=''
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform)
+    ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
        [ "krb5_cv_attr_constructor_destructor=yes,yes"
          "ac_cv_func_regcomp=yes"
          "ac_cv_printf_positional=yes"

--- a/pkgs/development/libraries/ldb/default.nix
+++ b/pkgs/development/libraries/ldb/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--bundled-libraries=NONE"
     "--builtin-libraries=replace"
     "--without-ldb-lmdb"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "--cross-compile"
     "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
   ];

--- a/pkgs/development/libraries/ldns/default.nix
+++ b/pkgs/development/libraries/ldns/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     "--with-drill"
     "--disable-gost"
     "--with-examples"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"
     "ac_cv_func_realloc_0_nonnull=yes"
   ];

--- a/pkgs/development/libraries/libaom/default.nix
+++ b/pkgs/development/libraries/libaom/default.nix
@@ -9,7 +9,7 @@
 }:
 
 let
-  isCross = stdenv.buildPlatform != stdenv.hostPlatform;
+  isCross = (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
 in
 stdenv.mkDerivation rec {
   pname = "libaom";

--- a/pkgs/development/libraries/libasyncns/default.nix
+++ b/pkgs/development/libraries/libasyncns/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
       --replace '<arpa/nameser.h>' '<arpa/nameser_compat.h>'
   '';
 
-  configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  configureFlags = lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"
     "ac_cv_func_realloc_0_nonnull=yes"
   ];

--- a/pkgs/development/libraries/libav/default.nix
+++ b/pkgs/development/libraries/libav/default.nix
@@ -77,7 +77,7 @@ let
       (enableFeature vaapiSupport "vaapi")
       (enableFeature vdpauSupport "vdpau")
       (enableFeature freetypeSupport "libfreetype")
-    ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ] ++ optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
       "--cross-prefix=${stdenv.cc.targetPrefix}"
       "--enable-cross-compile"
     ];

--- a/pkgs/development/libraries/libavif/default.nix
+++ b/pkgs/development/libraries/libavif/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
 
   ''
   # Cross-compiled gdk-pixbuf doesn't support thumbnailers
-  + lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  + lib.optionalString (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     mkdir -p "$out/bin"
     makeWrapper ${gdk-pixbuf}/bin/gdk-pixbuf-thumbnailer "$out/libexec/gdk-pixbuf-thumbnailer-avif" \
       --set GDK_PIXBUF_MODULE_FILE ${gdkPixbufModuleFile}

--- a/pkgs/development/libraries/libb64/default.nix
+++ b/pkgs/development/libraries/libb64/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
       url = "https://github.com/libb64/libb64/commit/98eaf510f40e384b32c01ad4bd5c3a697fdd8560.patch";
       hash = "sha256-CGslJUw0og/bBBirLm0J5Q7cf2WW/vniVAkXHlb6lbQ=";
     })
-  ] ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) (fetchpatch {
+  ] ++ lib.optional (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) (fetchpatch {
     name = "0001-example-Do-not-run-the-tests.patch";
     url = "https://cgit.openembedded.org/meta-openembedded/plain/meta-oe/recipes-support/libb64/libb64/0001-example-Do-not-run-the-tests.patch?id=484e0de1e4ee107f21ae2a5c5f976ed987978baf";
     sha256 = "sha256-KTsiIWJe66BKlu/A43FWfW0XAu4E7lWX/RY4NITRrm4=";

--- a/pkgs/development/libraries/libcbor/default.nix
+++ b/pkgs/development/libraries/libcbor/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Tests are restricted while pkgsStatic.cmocka is broken. Tracked at:
   # https://github.com/NixOS/nixpkgs/issues/213623
   doCheck = !stdenv.hostPlatform.isStatic
-    && stdenv.hostPlatform == stdenv.buildPlatform;
+    && (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 
   nativeCheckInputs = [ cmocka ];
 

--- a/pkgs/development/libraries/libcddb/default.nix
+++ b/pkgs/development/libraries/libcddb/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libiconv ];
 
-  configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  configureFlags = lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"
     "ac_cv_func_realloc_0_nonnull=yes"
   ];

--- a/pkgs/development/libraries/libchamplain/default.nix
+++ b/pkgs/development/libraries/libchamplain/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   version = "0.12.21";
 
   outputs = [ "out" "dev" ]
-    ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ "devdoc" ];
+    ++ lib.optionals (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [ "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     pkg-config
     gobject-introspection
     vala
-  ] ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [
+  ] ++ lib.optionals (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     gtk-doc
     docbook_xsl
     docbook_xml_dtd_412
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    (lib.mesonBool "gtk_doc" (stdenv.buildPlatform == stdenv.hostPlatform))
+    (lib.mesonBool "gtk_doc" (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform))
     "-Dvapi=true"
     (lib.mesonBool "libsoup3" withLibsoup3)
   ];

--- a/pkgs/development/libraries/libdaemon/default.nix
+++ b/pkgs/development/libraries/libdaemon/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   patches = [ ./fix-includes.patch ];
 
   configureFlags = [ "--disable-lynx" ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform)
+    ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
     [ # Can't run this test while cross-compiling
       "ac_cv_func_setpgrp_void=yes"
     ];

--- a/pkgs/development/libraries/libelf/default.nix
+++ b/pkgs/development/libraries/libelf/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   configureFlags = []
        # Configure check for dynamic lib support is broken, see
        # http://lists.uclibc.org/pipermail/uclibc-cvs/2005-August/019383.html
-    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "mr_cv_target_elf=yes"
+    ++ lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) "mr_cv_target_elf=yes"
        # Libelf's custom NLS macros fail to determine the catalog file extension
        # on Darwin, so disable NLS for now.
     ++ lib.optional stdenv.hostPlatform.isDarwin "--disable-nls";

--- a/pkgs/development/libraries/libffi/3.3.nix
+++ b/pkgs/development/libraries/libffi/3.3.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     NIX_HARDENING_ENABLE=''${NIX_HARDENING_ENABLE/fortify/}
   '';
 
-  dontStrip = stdenv.hostPlatform != stdenv.buildPlatform; # Don't run the native `strip' when cross-compiling.
+  dontStrip = (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform); # Don't run the native `strip' when cross-compiling.
 
   inherit doCheck;
 

--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     NIX_HARDENING_ENABLE=''${NIX_HARDENING_ENABLE/fortify/}
   '';
 
-  dontStrip = stdenv.hostPlatform != stdenv.buildPlatform; # Don't run the native `strip' when cross-compiling.
+  dontStrip = (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform); # Don't run the native `strip' when cross-compiling.
 
   inherit doCheck;
 

--- a/pkgs/development/libraries/libgphoto2/default.nix
+++ b/pkgs/development/libraries/libgphoto2/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
   postInstall =
     let
       executablePrefix =
-        if stdenv.buildPlatform == stdenv.hostPlatform then
+        if (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) then
           "$out"
         else
           buildPackages.libgphoto2;

--- a/pkgs/development/libraries/libgrss/default.nix
+++ b/pkgs/development/libraries/libgrss/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "PKG_CONFIG=${buildPackages.pkg-config}/bin/${buildPackages.pkg-config.targetPrefix}pkg-config"
-  ] ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [
+  ] ++ lib.optionals (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "--enable-gtk-doc"
   ];
 

--- a/pkgs/development/libraries/libgweather/default.nix
+++ b/pkgs/development/libraries/libgweather/default.nix
@@ -16,7 +16,7 @@
 , geocode-glib_2
 , vala
 , gnome
-, withIntrospection ? stdenv.buildPlatform == stdenv.hostPlatform
+, withIntrospection ? (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/libgxps/default.nix
+++ b/pkgs/development/libraries/libgxps/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Denable-test=false"
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "-Ddisable-introspection=true"
   ];
 

--- a/pkgs/development/libraries/libical/default.nix
+++ b/pkgs/development/libraries/libical/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
-  depsBuildBuild = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  depsBuildBuild = lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     # provides ical-glib-src-generator that runs during build
     libical
   ];
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
     "-DENABLE_GTK_DOC=False"
     "-DGOBJECT_INTROSPECTION=${if withIntrospection then "True" else "False"}"
     "-DICAL_GLIB_VAPI=${if withIntrospection then "True" else "False"}"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "-DIMPORT_ICAL_GLIB_SRC_GENERATOR=${lib.getDev pkgsBuildBuild.libical}/lib/cmake/LibIcal/IcalGlibSrcGenerator.cmake"
   ];
 

--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -4,7 +4,7 @@
 , enableDarwinABICompat ? false
 }:
 
-# assert !stdenv.hostPlatform.isLinux || stdenv.hostPlatform != stdenv.buildPlatform; # TODO: improve on cross
+# assert !stdenv.hostPlatform.isLinux || (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform); # TODO: improve on cross
 
 stdenv.mkDerivation rec {
   pname = "libiconv";

--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation rec {
     "--libexecdir=${placeholder "bin"}/libexec"
   ];
 
-  doCheck = testsSupport && stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = testsSupport && (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 
   postPatch = ''
     patchShebangs \

--- a/pkgs/development/libraries/liblouis/default.nix
+++ b/pkgs/development/libraries/liblouis/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [ "out" "dev" "info" "doc" ]
     # configure: WARNING: cannot generate manual pages while cross compiling
-    ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [ "man" ];
+    ++ lib.optionals (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [ "man" ];
 
   src = fetchFromGitHub {
     owner = "liblouis";

--- a/pkgs/development/libraries/libmbim/default.nix
+++ b/pkgs/development/libraries/libmbim/default.nix
@@ -11,7 +11,7 @@
 , bash
 , buildPackages
 , withIntrospection ? lib.meta.availableOn stdenv.hostPlatform gobject-introspection && stdenv.hostPlatform.emulatorAvailable buildPackages
-, withDocs ? stdenv.hostPlatform == stdenv.buildPlatform
+, withDocs ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
 , gobject-introspection
 }:
 

--- a/pkgs/development/libraries/libmcrypt/default.nix
+++ b/pkgs/development/libraries/libmcrypt/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   buildInputs = lib.optional stdenv.isDarwin darwin.cctools;
 
   configureFlags = lib.optionals disablePosixThreads [ "--disable-posix-threads" ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
       # AC_FUNC_MALLOC is broken on cross builds.
       "ac_cv_func_malloc_0_nonnull=yes"
       "ac_cv_func_realloc_0_nonnull=yes"

--- a/pkgs/development/libraries/libndp/default.nix
+++ b/pkgs/development/libraries/libndp/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  configureFlags = lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"
   ];
 

--- a/pkgs/development/libraries/libnice/default.nix
+++ b/pkgs/development/libraries/libnice/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   version = "0.1.22";
 
   outputs = [ "bin" "out" "dev" ]
-    ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ "devdoc" ];
+    ++ lib.optionals (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [ "devdoc" ];
 
   src = fetchurl {
     url = "https://libnice.freedesktop.org/releases/${pname}-${version}.tar.gz";
@@ -64,8 +64,8 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Dgtk_doc=${if (stdenv.buildPlatform == stdenv.hostPlatform) then "enabled" else "disabled"}"
-    "-Dintrospection=${if (stdenv.buildPlatform == stdenv.hostPlatform) then "enabled" else "disabled"}"
+    "-Dgtk_doc=${if (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) then "enabled" else "disabled"}"
+    "-Dintrospection=${if (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) then "enabled" else "disabled"}"
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
   ];
 

--- a/pkgs/development/libraries/libomxil-bellagio/default.nix
+++ b/pkgs/development/libraries/libomxil-bellagio/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   configureFlags =
-    lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [ "ac_cv_func_malloc_0_nonnull=yes" ];
+    lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [ "ac_cv_func_malloc_0_nonnull=yes" ];
 
   patches = [
     ./fedora-fixes.patch

--- a/pkgs/development/libraries/libosinfo/default.nix
+++ b/pkgs/development/libraries/libosinfo/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   };
 
   outputs = [ "out" "dev" ]
-    ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) "devdoc";
+    ++ lib.optional (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) "devdoc";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/development/libraries/libpcap/default.nix
+++ b/pkgs/development/libraries/libpcap/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     "--disable-universal"
   ] ++ lib.optionals withRemote [
     "--enable-remote"
-  ] ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform)
+  ] ++ lib.optionals (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
     [ "ac_cv_linux_vers=2" ];
 
   postInstall = ''

--- a/pkgs/development/libraries/libpng/12.nix
+++ b/pkgs/development/libraries/libpng/12.nix
@@ -2,7 +2,7 @@
 , testers
 }:
 
-assert stdenv.hostPlatform == stdenv.buildPlatform -> zlib != null;
+assert (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) -> zlib != null;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libpng";

--- a/pkgs/development/libraries/librest/default.nix
+++ b/pkgs/development/libraries/librest/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     gobject-introspection
-  ] ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [
+  ] ++ lib.optionals (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     gtk-doc
     docbook-xsl-nons
     docbook_xml_dtd_412
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [
-    (lib.enableFeature (stdenv.hostPlatform == stdenv.buildPlatform) "gtk-doc")
+    (lib.enableFeature (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) "gtk-doc")
     # Remove when https://gitlab.gnome.org/GNOME/librest/merge_requests/2 is merged.
     "--with-ca-certificates=/etc/ssl/certs/ca-certificates.crt"
   ];

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     "--enable-always-build-tests"
   ] ++ lib.optional stdenv.isDarwin "--disable-Bsymbolic"
-    ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "RUST_TARGET=${stdenv.hostPlatform.rust.rustcTarget}";
+    ++ lib.optional (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) "RUST_TARGET=${stdenv.hostPlatform.rust.rustcTarget}";
 
   doCheck = false; # all tests fail on libtool-generated rsvg-convert not being able to find coreutils
 
@@ -143,7 +143,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # 'error: linker `cc` not found' when cross-compiling
     export RUSTFLAGS="-Clinker=$CC"
-  '' + lib.optionalString ((stdenv.buildPlatform != stdenv.hostPlatform) && (stdenv.hostPlatform.emulatorAvailable buildPackages)) ''
+  '' + lib.optionalString ((!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) && (stdenv.hostPlatform.emulatorAvailable buildPackages)) ''
     # the replacement is the native conditional
     substituteInPlace gdk-pixbuf-loader/Makefile \
       --replace 'RUN_QUERY_LOADER_TEST = false' 'RUN_QUERY_LOADER_TEST = test -z "$(DESTDIR)"' \

--- a/pkgs/development/libraries/librsync/default.nix
+++ b/pkgs/development/libraries/librsync/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ perl zlib bzip2 popt ];
 
-  dontStrip = stdenv.hostPlatform != stdenv.buildPlatform;
+  dontStrip = (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 
   meta = with lib; {
     description = "Implementation of the rsync remote-delta algorithm";

--- a/pkgs/development/libraries/libvirt-glib/default.nix
+++ b/pkgs/development/libraries/libvirt-glib/default.nix
@@ -12,7 +12,7 @@
 , buildPackages
 , withIntrospection ? lib.meta.availableOn stdenv.hostPlatform gobject-introspection && stdenv.hostPlatform.emulatorAvailable buildPackages
 , gobject-introspection
-, withDocs ? stdenv.hostPlatform == stdenv.buildPlatform
+, withDocs ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
 , gtk-doc
 , docbook-xsl-nons
 }:

--- a/pkgs/development/libraries/libvisual/default.nix
+++ b/pkgs/development/libraries/libvisual/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ SDL glib ];
 
-  configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  configureFlags = lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     # Remove once "sdl-cross-prereq.patch" patch above is removed.
     "--disable-lv-tool"
   ] ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [

--- a/pkgs/development/libraries/libvpx/1_8.nix
+++ b/pkgs/development/libraries/libvpx/1_8.nix
@@ -141,7 +141,7 @@ stdenv.mkDerivation rec {
     (enableFeature (experimentalSpatialSvcSupport ||
                     experimentalFpMbStatsSupport ||
                     experimentalEmulateHardwareSupport) "experimental")
-  ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "--enable-external-build"
     # libvpx darwin targets include darwin version (ie. ARCH-darwinXX-gcc, XX being the darwin version)
     # See all_platforms: https://github.com/webmproject/libvpx/blob/master/configure

--- a/pkgs/development/libraries/libvpx/default.nix
+++ b/pkgs/development/libraries/libvpx/default.nix
@@ -163,7 +163,7 @@ stdenv.mkDerivation rec {
     (enableFeature (experimentalSpatialSvcSupport ||
                     experimentalFpMbStatsSupport ||
                     experimentalEmulateHardwareSupport) "experimental")
-  ] ++ optionals (stdenv.isBSD || stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ optionals (stdenv.isBSD || (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)) [
     "--force-target=${stdenv.hostPlatform.parsed.cpu.name}-${kernel}-gcc"
     (lib.optionalString stdenv.hostPlatform.isCygwin "--enable-static-msvcrt")
   ] # Experimental features

--- a/pkgs/development/libraries/libwacom/default.nix
+++ b/pkgs/development/libraries/libwacom/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     libgudev
   ];
 
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform
+  doCheck = (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
             && lib.meta.availableOn stdenv.hostPlatform valgrind
             && !stdenv.hostPlatform.isPower  # one test times out
   ;

--- a/pkgs/development/libraries/libwebsockets/default.nix
+++ b/pkgs/development/libraries/libwebsockets/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     "-DLWS_WITH_SOCKS5=ON"
     "-DDISABLE_WERROR=ON"
     "-DLWS_BUILD_HASH=no_hash"
-  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "-DLWS_WITHOUT_TESTAPPS=ON"
+  ] ++ lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) "-DLWS_WITHOUT_TESTAPPS=ON"
   ++ lib.optional withExternalPoll "-DLWS_WITH_EXTERNAL_POLL=ON"
   ++ (
     if stdenv.hostPlatform.isStatic then

--- a/pkgs/development/libraries/libxklavier/default.nix
+++ b/pkgs/development/libraries/libxklavier/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchgit, fetchpatch, autoreconfHook, pkg-config, gtk-doc, xkeyboard_config, libxml2, xorg, docbook_xsl
 , glib, isocodes, gobject-introspection
-, withDoc ? (stdenv.buildPlatform == stdenv.hostPlatform)
+, withDoc ? (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation (finalAttrs: rec {
   enableParallelBuilding = true;
 
   doCheck =
-    (stdenv.hostPlatform == stdenv.buildPlatform) &&
+    (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) &&
     stdenv.hostPlatform.libc != "musl";
   preCheck = lib.optional stdenv.isDarwin ''
     export DYLD_LIBRARY_PATH="$PWD/.libs:$DYLD_LIBRARY_PATH"

--- a/pkgs/development/libraries/minizip-ng/default.nix
+++ b/pkgs/development/libraries/minizip-ng/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     fi
   '';
 
-  doCheck = stdenv.buildPlatform == stdenv.hostPlatform;
+  doCheck = (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
   nativeCheckInputs = [ gtest ];
   enableParallelChecking = false;
 

--- a/pkgs/development/libraries/msgpack/generic.nix
+++ b/pkgs/development/libraries/msgpack/generic.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "-DMSGPACK_BUILD_EXAMPLES=OFF";
+  cmakeFlags = lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) "-DMSGPACK_BUILD_EXAMPLES=OFF";
 
   meta = with lib; {
     description = "MessagePack implementation for C and C++";

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
         "/usr/share/terminfo" # upstream default, probably all FHS-based distros
         "/run/current-system/sw/share/terminfo" # NixOS
       ]}"
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "--with-build-cc=${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc"
   ] ++ (lib.optionals (stdenv.cc.bintools.isLLVM && lib.versionAtLeast stdenv.cc.bintools.version "17") [
       # lld17+ passes `--no-undefined-version` by default and makes this a hard
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     updateAutotoolsGnuConfigScriptsHook
     pkg-config
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
    # for `tic`, build already depends on for build `cc` so it's weird the build doesn't just build `tic`.
     ncurses
   ];

--- a/pkgs/development/libraries/newt/default.nix
+++ b/pkgs/development/libraries/newt/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     "--disable-nls"
   ];
 
-  makeFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  makeFlags = lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ];
 

--- a/pkgs/development/libraries/nlohmann_json/default.nix
+++ b/pkgs/development/libraries/nlohmann_json/default.nix
@@ -29,7 +29,7 @@ in stdenv.mkDerivation (finalAttrs: {
     "-DJSON_MultipleHeaders=ON"
   ] ++ lib.optional finalAttrs.finalPackage.doCheck "-DJSON_TestDataDirectory=${testData}";
 
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 
   # skip tests that require git or modify “installed files”
   preCheck = ''

--- a/pkgs/development/libraries/nss/generic.nix
+++ b/pkgs/development/libraries/nss/generic.nix
@@ -98,7 +98,7 @@ stdenv.mkDerivation rec {
         -j $NIX_BUILD_CORES \
         ${lib.optionalString enableFIPS "--enable-fips"} \
         ${lib.optionalString stdenv.isDarwin "--clang"} \
-        ${lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) "--disable-tests"}
+        ${lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) "--disable-tests"}
 
       runHook postBuild
     '';
@@ -153,7 +153,7 @@ stdenv.mkDerivation rec {
 
   postFixup =
     let
-      isCross = stdenv.hostPlatform != stdenv.buildPlatform;
+      isCross = (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
       nss = if isCross then buildPackages.nss.tools else "$out";
     in
     (lib.optionalString enableFIPS (''

--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     "--enable-crypt"
     "--enable-modules"
     "--enable-overlays"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "--with-yielding_select=yes"
     "ac_cv_func_memcmp_working=yes"
   ] ++ lib.optional stdenv.isFreeBSD "--with-pic";

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -89,7 +89,7 @@ let
         powerpc64-linux = "./Configure linux-ppc64";
         riscv64-linux = "./Configure linux64-riscv64";
       }.${stdenv.hostPlatform.system} or (
-        if stdenv.hostPlatform == stdenv.buildPlatform
+        if (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
           then "./config"
         else if stdenv.hostPlatform.isBSD
           then if stdenv.hostPlatform.isx86_64 then "./Configure BSD-x86_64"

--- a/pkgs/development/libraries/pcre/default.nix
+++ b/pkgs/development/libraries/pcre/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     patchShebangs RunGrepTest
   '';
 
-  doCheck = !(with stdenv.hostPlatform; isCygwin || isFreeBSD) && stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = !(with stdenv.hostPlatform; isCygwin || isFreeBSD) && (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
     # XXX: test failure on Cygwin
     # we are running out of stack on both freeBSDs on Hydra
 

--- a/pkgs/development/libraries/protobuf/generic-v3.nix
+++ b/pkgs/development/libraries/protobuf/generic-v3.nix
@@ -54,6 +54,6 @@ mkProtobufDerivation = buildProtobuf: stdenv: stdenv.mkDerivation {
     platforms = lib.platforms.unix;
   };
 };
-in mkProtobufDerivation(if (stdenv.buildPlatform != stdenv.hostPlatform)
+in mkProtobufDerivation(if (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
                         then (mkProtobufDerivation null buildPackages.stdenv)
                         else null) stdenv

--- a/pkgs/development/libraries/protobuf/generic.nix
+++ b/pkgs/development/libraries/protobuf/generic.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     # protoc of the same version must be available for build. For non-cross builds, it's able to
     # re-use the executable generated as part of the build
     buildPackages."protobuf_${lib.versions.major version}"

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -350,7 +350,7 @@ let
 
       qmake = callPackage ({ qtbase }: makeSetupHook {
         name = "qmake-hook";
-        ${if stdenv.buildPlatform == stdenv.hostPlatform
+        ${if (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
           then "propagatedBuildInputs"
           else "depsTargetTargetPropagated"} = [ qtbase.dev ];
         substitutions = {
@@ -380,7 +380,7 @@ let
     # qttranslations causes eval-time infinite recursion when
     # cross-compiling; disabled for now.
     qttranslations =
-      if stdenv.buildPlatform == stdenv.hostPlatform
+      if (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
       then bootstrapScope.qttranslations
       else null;
   });

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -21,7 +21,7 @@
 , libGLSupported ? !stdenv.isDarwin
 , libGL
   # qmake detection for libmysqlclient does not seem to work when cross compiling
-, mysqlSupport ? stdenv.hostPlatform == stdenv.buildPlatform
+, mysqlSupport ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
 , libmysqlclient
 , buildExamples ? false
 , buildTests ? false
@@ -88,7 +88,7 @@ stdenv.mkDerivation (finalAttrs: ({
   nativeBuildInputs = [ bison flex gperf lndir perl pkg-config which ]
     ++ lib.optionals stdenv.isDarwin [ xcbuild ];
 
-  } // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+  } // lib.optionalAttrs (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) {
     # `qtbase` expects to find `cc` (with no prefix) in the
     # `$PATH`, so the following is needed even if
     # `stdenv.buildPlatform.canExecute stdenv.hostPlatform`
@@ -208,7 +208,7 @@ stdenv.mkDerivation (finalAttrs: ({
   env = {
     NIX_CFLAGS_COMPILE = toString ([
       "-Wno-error=sign-compare" # freetype-2.5.4 changed signedness of some struct fields
-    ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ] ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
       "-Wno-warn=free-nonheap-object"
       "-Wno-free-nonheap-object"
       "-w"
@@ -226,7 +226,7 @@ stdenv.mkDerivation (finalAttrs: ({
       ''-DNIXPKGS_QGTK3_XDG_DATA_DIRS="${gtk3}/share/gsettings-schemas/${gtk3.name}"''
       ''-DNIXPKGS_QGTK3_GIO_EXTRA_MODULES="${dconf.lib}/lib/gio/modules"''
     ] ++ lib.optional decryptSslTraffic "-DQT_DECRYPT_SSL_TRAFFIC");
-  } // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+  } // lib.optionalAttrs (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) {
     NIX_CFLAGS_COMPILE_FOR_BUILD = toString ([
       "-Wno-warn=free-nonheap-object"
       "-Wno-free-nonheap-object"
@@ -241,7 +241,7 @@ stdenv.mkDerivation (finalAttrs: ({
   # To prevent these failures, we need to override PostgreSQL detection.
   PSQL_LIBS = lib.optionalString (postgresql != null) "-L${postgresql.lib}/lib -lpq";
 
-  } // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+  } // lib.optionalAttrs (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) {
   configurePlatforms = [ ];
   } // {
   # TODO Remove obsolete and useless flags once the build will be totally mastered
@@ -270,7 +270,7 @@ stdenv.mkDerivation (finalAttrs: ({
     "-L" "${icu.out}/lib"
     "-I" "${icu.dev}/include"
     "-pch"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "-device ${qtPlatformCross stdenv.hostPlatform}"
     "-device-option CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ]
@@ -278,7 +278,7 @@ stdenv.mkDerivation (finalAttrs: ({
   ++ lib.optionals developerBuild [
     "-developer-build"
     "-no-warnings-are-errors"
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "-no-warnings-are-errors"
   ] ++ (if (!stdenv.hostPlatform.isx86_64) then [
     "-no-sse2"

--- a/pkgs/development/libraries/qt-5/modules/qtwebchannel.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebchannel.nix
@@ -8,5 +8,5 @@
 qtModule {
   pname = "qtwebchannel";
   propagatedBuildInputs = [ qtbase qtdeclarative ];
-  outputs = [ "out" "dev" ] ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [ "bin" ];
+  outputs = [ "out" "dev" ] ++ lib.optionals (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [ "bin" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -57,7 +57,7 @@ qtModule ({
   pname = "qtwebengine";
   nativeBuildInputs = [
     bison flex git gperf ninja pkg-config (python.withPackages(ps: [ ps.html5lib ])) which gn nodejs
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     perl
     lndir (lib.getDev pkgsBuildTarget.targetPackages.qt5.qtbase)
     pkgsBuildBuild.pkg-config
@@ -135,7 +135,7 @@ qtModule ({
   env = {
     NIX_CFLAGS_COMPILE =
       toString (
-        lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+        lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
           "-w "
         ] ++ lib.optionals stdenv.cc.isGNU [
           # with gcc8, -Wclass-memaccess became part of -Wall and this exceeds the logging limit
@@ -147,7 +147,7 @@ qtModule ({
         ] ++ lib.optionals stdenv.cc.isClang [
           "-Wno-elaborated-enum-base"
         ]);
-  } // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+  } // lib.optionalAttrs (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) {
     NIX_CFLAGS_LINK = "-Wl,--no-warn-search-mismatch";
     "NIX_CFLAGS_LINK_${buildPackages.stdenv.cc.suffixSalt}" = "-Wl,--no-warn-search-mismatch";
   };
@@ -158,7 +158,7 @@ qtModule ({
     if [ -d "$PWD/tools/qmake" ]; then
         QMAKEPATH="$PWD/tools/qmake''${QMAKEPATH:+:}$QMAKEPATH"
     fi
-  '' + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  '' + lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     export QMAKE_CC=$CC
     export QMAKE_CXX=$CXX
     export QMAKE_LINK=$CXX
@@ -166,7 +166,7 @@ qtModule ({
   '';
 
   qmakeFlags = [ "--" "-system-ffmpeg" ]
-    ++ lib.optional (pipewireSupport && stdenv.buildPlatform == stdenv.hostPlatform) "-webengine-webrtc-pipewire"
+    ++ lib.optional (pipewireSupport && (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)) "-webengine-webrtc-pipewire"
     ++ lib.optional enableProprietaryCodecs "-proprietary-codecs";
 
   propagatedBuildInputs = [
@@ -264,7 +264,7 @@ qtModule ({
   dontUseNinjaBuild = true;
   dontUseNinjaInstall = true;
 
-  postInstall = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  postInstall = lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
     mkdir -p $out/libexec
   '' + lib.optionalString stdenv.isLinux ''
     cat > $out/libexec/qt.conf <<EOF
@@ -300,7 +300,7 @@ qtModule ({
     timeout = 24 * 3600;
   };
 
-} // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+} // lib.optionalAttrs (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) {
   configurePlatforms = [ ];
   # to get progress output in `nix-build` and `nix build -L`
   preBuild = ''

--- a/pkgs/development/libraries/qt-5/qtModule.nix
+++ b/pkgs/development/libraries/qt-5/qtModule.nix
@@ -26,13 +26,13 @@ mkDerivation (args // {
   nativeBuildInputs =
     (args.nativeBuildInputs or []) ++ [
       perl qmake
-    ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ] ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
       pkgsHostTarget.qt5.qtbase.dev
     ];
   propagatedBuildInputs =
     (lib.warnIf (args ? qtInputs) "qt5.qtModule's qtInputs argument is deprecated" args.qtInputs or []) ++
     (args.propagatedBuildInputs or []);
-} // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+} // lib.optionalAttrs (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) {
   depsBuildBuild = [ buildPackages.stdenv.cc ] ++ (args.depsBuildBuild or []);
 } // {
 

--- a/pkgs/development/libraries/quictls/default.nix
+++ b/pkgs/development/libraries/quictls/default.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
       then "./Configure linux-mips64"
       else throw "unsupported ABI for ${stdenv.hostPlatform.system}";
   }.${stdenv.hostPlatform.system} or (
-    if stdenv.hostPlatform == stdenv.buildPlatform
+    if (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
     then "./config"
     else if stdenv.hostPlatform.isBSD && stdenv.hostPlatform.isx86_64
     then "./Configure BSD-x86_64"

--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -206,15 +206,15 @@ stdenv.mkDerivation rec {
     INTERFACE64 = blas64;
     NO_STATIC = !enableStatic;
     NO_SHARED = !enableShared;
-    CROSS = stdenv.hostPlatform != stdenv.buildPlatform;
+    CROSS = (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
     HOSTCC = "cc";
     # Makefile.system only checks defined status
     # This seems to be a bug in the openblas Makefile:
     # on x86_64 it expects NO_BINARY_MODE=
     # but on aarch64 it expects NO_BINARY_MODE=0
     NO_BINARY_MODE = if stdenv.isx86_64
-        then toString (stdenv.hostPlatform != stdenv.buildPlatform)
-        else stdenv.hostPlatform != stdenv.buildPlatform;
+        then toString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
+        else (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
     # This disables automatic build job count detection (which honours neither enableParallelBuilding nor NIX_BUILD_CORES)
     # and uses the main make invocation's job count, falling back to 1 if no parallelism is used.
     # https://github.com/OpenMathLib/OpenBLAS/blob/v0.3.20/getarch.c#L1781-L1792

--- a/pkgs/development/libraries/science/math/p4est-sc/default.nix
+++ b/pkgs/development/libraries/science/math/p4est-sc/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation {
 
   # disallow Darwin checks due to prototype incompatibility of qsort_r
   # to be fixed in a future version of the source code
-  doCheck = !stdenv.isDarwin && stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = !stdenv.isDarwin && (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 
   meta = {
     branch = "prev3-develop";

--- a/pkgs/development/libraries/science/math/petsc/default.nix
+++ b/pkgs/development/libraries/science/math/petsc/default.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
   configureScript = "python ./configure";
 
   enableParallelBuilding = true;
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 
   meta = with lib; {
     description = "Portable Extensible Toolkit for Scientific computation";

--- a/pkgs/development/libraries/spice-gtk/default.nix
+++ b/pkgs/development/libraries/spice-gtk/default.nix
@@ -90,7 +90,7 @@ stdenv.mkDerivation rec {
     python3.pkgs.six
     vala
     wrapGAppsHook3
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     mesonEmulatorHook
   ] ++ lib.optionals stdenv.isLinux [
     wayland-scanner

--- a/pkgs/development/libraries/startup-notification/default.nix
+++ b/pkgs/development/libraries/startup-notification/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "3c391f7e930c583095045cd2d10eb73a64f085c7fde9d260f2652c7cb3cfbe4a";
   };
 
-  configureFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  configureFlags = lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "lf_cv_sane_realloc=yes"
   ];
 

--- a/pkgs/development/libraries/talloc/default.nix
+++ b/pkgs/development/libraries/talloc/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     "--enable-talloc-compat1"
     "--bundled-libraries=NONE"
     "--builtin-libraries=replace"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "--cross-compile"
     "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
   ];

--- a/pkgs/development/libraries/tbb/2020_3.nix
+++ b/pkgs/development/libraries/tbb/2020_3.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = lib.optionals stdenv.cc.isClang [
     "compiler=clang"
-  ] ++ (lib.optional (stdenv.buildPlatform != stdenv.hostPlatform)
+  ] ++ (lib.optional (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
     (if stdenv.hostPlatform.isAarch64 then "arch=arm64"
     else if stdenv.hostPlatform.isx86_64 then "arch=intel64"
     else if stdenv.hostPlatform.isi686 then "arch=ia32"

--- a/pkgs/development/libraries/tdb/default.nix
+++ b/pkgs/development/libraries/tdb/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
   wafConfigureFlags = [
     "--bundled-libraries=NONE"
     "--builtin-libraries=replace"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "--cross-compile"
     "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
   ];

--- a/pkgs/development/libraries/tevent/default.nix
+++ b/pkgs/development/libraries/tevent/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
   wafConfigureFlags = [
     "--bundled-libraries=NONE"
     "--builtin-libraries=replace"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "--cross-compile"
     "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
   ];

--- a/pkgs/development/libraries/tinycdb/default.nix
+++ b/pkgs/development/libraries/tinycdb/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl }:
 let
-  isCross = stdenv.buildPlatform != stdenv.hostPlatform;
+  isCross = (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
   cross = "${stdenv.hostPlatform.config}";
   static = stdenv.hostPlatform.isStatic;
 

--- a/pkgs/development/libraries/totem-pl-parser/default.nix
+++ b/pkgs/development/libraries/totem-pl-parser/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ meson ninja pkg-config gettext glib gobject-introspection ];
   buildInputs = [ libxml2 glib ];
 
-  mesonFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  mesonFlags = lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "-Dintrospection=false"
   ];
 

--- a/pkgs/development/libraries/tpm2-tss/default.nix
+++ b/pkgs/development/libraries/tpm2-tss/default.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
   '';
 
   doCheck = false;
-  doInstallCheck = stdenv.buildPlatform == stdenv.hostPlatform;
+  doInstallCheck = (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
   # Since we rewrote the load path in the dynamic loader for the TCTI
   # The various tcti implementation should be placed in their target directory
   # before we could run tests, so we make turn checkPhase into installCheckPhase

--- a/pkgs/development/libraries/uriparser/default.nix
+++ b/pkgs/development/libraries/uriparser/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional (!doCheck) "-DURIPARSER_BUILD_TESTS=OFF";
 
   nativeCheckInputs = [ gtest ];
-  doCheck = stdenv.buildPlatform == stdenv.hostPlatform;
+  doCheck = (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
 
   meta = with lib; {
     changelog = "https://github.com/uriparser/uriparser/blob/uriparser-${version}/ChangeLog";

--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [ "-DCMAKE_INSTALL_INCLUDEDIR=${vulkan-headers}/include" ]
     ++ lib.optional stdenv.isDarwin "-DSYSCONFDIR=${moltenvk}/share"
     ++ lib.optional stdenv.isLinux "-DSYSCONFDIR=${addOpenGLRunpath.driverLink}/share"
-    ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "-DUSE_GAS=OFF";
+    ++ lib.optional (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) "-DUSE_GAS=OFF";
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -11,7 +11,7 @@
 , withTests ? stdenv.isLinux
 , libffi
 , epoll-shim
-, withDocumentation ? withLibraries && stdenv.hostPlatform == stdenv.buildPlatform
+, withDocumentation ? withLibraries && (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
 , graphviz-nox
 , doxygen
 , libxslt
@@ -30,7 +30,7 @@ assert withDocumentation -> withLibraries;
 assert withTests -> withLibraries;
 
 let
-  isCross = stdenv.buildPlatform != stdenv.hostPlatform;
+  isCross = (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "wayland";

--- a/pkgs/development/libraries/wayland/protocols.nix
+++ b/pkgs/development/libraries/wayland/protocols.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   version = "1.35";
 
   # https://gitlab.freedesktop.org/wayland/wayland-protocols/-/issues/48
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform && stdenv.hostPlatform.linker == "bfd" && wayland.withLibraries;
+  doCheck = (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) && stdenv.hostPlatform.linker == "bfd" && wayland.withLibraries;
 
   src = fetchurl {
     url = "https://gitlab.freedesktop.org/wayland/${pname}/-/releases/${version}/downloads/${pname}-${version}.tar.xz";

--- a/pkgs/development/libraries/waylandpp/default.nix
+++ b/pkgs/development/libraries/waylandpp/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DCMAKE_INSTALL_DATADIR=${placeholder "dev"}"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "-DWAYLAND_SCANNERPP=${buildPackages.waylandpp}/bin/wayland-scanner++"
   ];
 

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -94,7 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  preConfigure = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     # Ignore gettext in cmake_prefix_path so that find_program doesn't
     # pick up the wrong gettext. TODO: Find a better solution for
     # this, maybe make cmake not look up executables in

--- a/pkgs/development/libraries/webp-pixbuf-loader/default.nix
+++ b/pkgs/development/libraries/webp-pixbuf-loader/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
 
     # gdk-pixbuf disables the thumbnailer in cross-builds (https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/commit/fc37708313a5fc52083cf10c9326f3509d67701f)
     # and therefore makeWrapper will fail because 'gdk-pixbuf-thumbnailer' the executable does not exist.
-  '' + lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  '' + lib.optionalString (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     # It assumes gdk-pixbuf-thumbnailer can find the webp loader in the loaders.cache referenced by environment variable, breaking containment.
     # So we replace it with a wrapped executable.
     mkdir -p "$out/bin"

--- a/pkgs/development/libraries/x264/default.nix
+++ b/pkgs/development/libraries/x264/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = lib.optional enableShared "--enable-shared"
     ++ lib.optional (!stdenv.isi686) "--enable-pic"
-    ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "--cross-prefix=${stdenv.cc.targetPrefix}";
+    ++ lib.optional (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) "--cross-prefix=${stdenv.cc.targetPrefix}";
 
   makeFlags = [
     "BASHCOMPLETIONSDIR=$(out)/share/bash-completion/completions"

--- a/pkgs/development/libraries/x265/default.nix
+++ b/pkgs/development/libraries/x265/default.nix
@@ -25,7 +25,7 @@
 let
   mkFlag = optSet: flag: if optSet then "-D${flag}=ON" else "-D${flag}=OFF";
 
-  isCross = stdenv.buildPlatform != stdenv.hostPlatform;
+  isCross = (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontConfigure = stdenv.hostPlatform.isMinGW;
 
-  preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  preConfigure = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     export CHOST=${stdenv.hostPlatform.config}
   '';
 
@@ -114,7 +114,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # We don't strip on static cross-compilation because of reports that native
   # stripping corrupted the target library; see commit 12e960f5 for the report.
-  dontStrip = stdenv.hostPlatform != stdenv.buildPlatform && static;
+  dontStrip = (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) && static;
   configurePlatforms = [];
 
   installFlags = lib.optionals stdenv.hostPlatform.isMinGW [

--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -43,7 +43,7 @@ lib.throwIf (attrs ? name) "buildPerlPackage: `name` (\"${attrs.name}\") is depr
     builder = ./builder.sh;
 
     buildInputs = buildInputs ++ [ perl ];
-    nativeBuildInputs = nativeBuildInputs ++ (if stdenv.buildPlatform != stdenv.hostPlatform then [ perl.mini ] else [ perl ]);
+    nativeBuildInputs = nativeBuildInputs ++ (if (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) then [ perl.mini ] else [ perl ]);
 
     inherit outputs src doCheck checkTarget enableParallelBuilding;
     env = {

--- a/pkgs/development/python-modules/m2crypto/default.nix
+++ b/pkgs/development/python-modules/m2crypto/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
         "-Wno-error=incompatible-pointer-types"
       ]);
     }
-    // lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) {
+    // lib.optionalAttrs (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) {
       CPP = "${stdenv.cc.targetPrefix}cpp";
     };
 

--- a/pkgs/development/python-modules/psycopg2/default.nix
+++ b/pkgs/development/python-modules/psycopg2/default.nix
@@ -61,7 +61,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "psycopg2" ];
 
-  disallowedReferences = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  disallowedReferences = lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     buildPackages.postgresql
   ];
 

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -120,7 +120,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs =
     [ pkg-config ]
-    ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ libsForQt5.qmake ]
+    ++ lib.optionals (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [ libsForQt5.qmake ]
     ++ [
       setuptools
       lndir
@@ -129,7 +129,7 @@ buildPythonPackage rec {
     ++ (
       with pkgsBuildTarget.targetPackages.libsForQt5;
       [ ]
-      ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ qmake ]
+      ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [ qmake ]
       ++ [
         qtbase
         qtsvg
@@ -148,7 +148,7 @@ buildPythonPackage rec {
   buildInputs =
     with libsForQt5;
     [ dbus ]
-    ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ qtbase ]
+    ++ lib.optionals (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [ qtbase ]
     ++ [
       qtsvg
       qtdeclarative

--- a/pkgs/development/python-modules/pyqtwebengine/default.nix
+++ b/pkgs/development/python-modules/pyqtwebengine/default.nix
@@ -55,8 +55,8 @@ buildPythonPackage (
         pkg-config
         qmake
       ]
-      ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ sip ]
-      ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+      ++ lib.optionals (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [ sip ]
+      ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
         python.pythonOnBuildForHost.pkgs.sip
       ]
       ++ [
@@ -66,7 +66,7 @@ buildPythonPackage (
         pyqt-builder
         pythonPackages.setuptools
       ]
-      ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ qtdeclarative ]
+      ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [ qtdeclarative ]
       ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [ autoSignDarwinBinariesHook ];
 
     buildInputs =
@@ -76,7 +76,7 @@ buildPythonPackage (
         qtsvg
         qtwebengine
       ]
-      ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+      ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
         qtwebchannel
         qtdeclarative
       ];
@@ -109,7 +109,7 @@ buildPythonPackage (
       hydraPlatforms = lib.lists.intersectLists qtwebengine.meta.platforms platforms.mesaPlatforms;
     };
   }
-  // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+  // lib.optionalAttrs (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) {
     # TODO: figure out why the env hooks aren't adding these inclusions automatically
     env.NIX_CFLAGS_COMPILE = lib.concatStringsSep " " [
       "-I${lib.getDev qtbase}/include/QtPrintSupport/"

--- a/pkgs/development/python-modules/sigrok/default.nix
+++ b/pkgs/development/python-modules/sigrok/default.nix
@@ -33,7 +33,7 @@ toPythonModule (
         swig
         numpy
       ]
-      ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [
+      ++ lib.optionals (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
         pythonImportsCheckHook
         pythonCatchConflictsHook
       ];

--- a/pkgs/development/python-modules/tpm2-pytss/default.nix
+++ b/pkgs/development/python-modules/tpm2-pytss/default.nix
@@ -22,7 +22,7 @@
 }:
 
 let
-  isCross = (stdenv.buildPlatform != stdenv.hostPlatform);
+  isCross = (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
 in
 buildPythonPackage rec {
   pname = "tpm2-pytss";

--- a/pkgs/development/skaware-packages/s6-linux-init/default.nix
+++ b/pkgs/development/skaware-packages/s6-linux-init/default.nix
@@ -33,7 +33,7 @@ skawarePackages.buildPackage {
   ];
 
   # See ../s6-rc/default.nix for an explanation
-  postConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) ''
+  postConfigure = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform) ''
     substituteInPlace src/init/s6-linux-init-maker.c \
         --replace-fail '<execline/config.h>' '"${targetPackages.execline.dev}/include/execline/config.h"' \
         --replace-fail '<s6/config.h>' '"${targetPackages.s6.dev}/include/s6/config.h"' \

--- a/pkgs/development/skaware-packages/s6-rc/default.nix
+++ b/pkgs/development/skaware-packages/s6-rc/default.nix
@@ -48,7 +48,7 @@ skawarePackages.buildPackage {
   # only time hostPlatform != targetPlatform.  When that happens we
   # modify s6-rc-compile to use the configuration headers for the
   # system we're cross-compiling for.
-  postConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) ''
+  postConfigure = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform) ''
     substituteInPlace src/s6-rc/s6-rc-compile.c \
         --replace-fail '<execline/config.h>' '"${targetPackages.execline.dev}/include/execline/config.h"' \
         --replace-fail '<s6/config.h>' '"${targetPackages.s6.dev}/include/s6/config.h"' \

--- a/pkgs/development/tools/bpf-linker/default.nix
+++ b/pkgs/development/tools/bpf-linker/default.nix
@@ -39,6 +39,6 @@ rustPlatform.buildRustPackage rec {
     maintainers = with maintainers; [ nickcao ];
     # llvm-sys crate locates llvm by calling llvm-config
     # which is not available when cross compiling
-    broken = stdenv.buildPlatform != stdenv.hostPlatform;
+    broken = (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
   };
 }

--- a/pkgs/development/tools/build-managers/jam/default.nix
+++ b/pkgs/development/tools/build-managers/jam/default.nix
@@ -20,7 +20,7 @@ let
     # host platform. This looks a little ridiculous because the vast majority of
     # build tools don't embed target-specific information into their binary, but
     # in this case we behave more like a compiler than a make(1)-alike.
-    postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) ''
+    postPatch = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform) ''
       cat >>jam.h <<EOF
       #undef OSMAJOR
       #undef OSMINOR

--- a/pkgs/development/tools/k6/default.nix
+++ b/pkgs/development/tools/k6/default.nix
@@ -22,7 +22,7 @@ buildGoModule rec {
     $out/bin/k6 version | grep ${version} > /dev/null
   '';
 
-  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     installShellCompletion --cmd k6 \
       --bash <($out/bin/k6 completion bash) \
       --fish <($out/bin/k6 completion fish) \

--- a/pkgs/development/tools/knightos/scas/default.nix
+++ b/pkgs/development/tools/knightos/scas/default.nix
@@ -1,7 +1,7 @@
 { fetchFromGitHub, lib, stdenv, cmake, buildPackages, asciidoc, libxslt }:
 
 let
-  isCrossCompiling = stdenv.hostPlatform != stdenv.buildPlatform;
+  isCrossCompiling = (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/tools/misc/autogen/default.nix
+++ b/pkgs/development/tools/misc/autogen/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     which pkg-config perl autoreconfHook/*patches applied*/
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     # autogen needs a build autogen when cross-compiling
     buildPackages.buildPackages.autogen buildPackages.texinfo
   ];
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
     # Debian: https://salsa.debian.org/debian/autogen/-/blob/master/debian/rules#L21
     "--enable-timeout=78"
     "CFLAGS=-D_FILE_OFFSET_BITS=64"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     # the configure check for regcomp wants to run a host program
     "libopts_cv_with_libregex=yes"
     #"MAKEINFO=${buildPackages.texinfo}/bin/makeinfo"

--- a/pkgs/development/tools/misc/babeltrace/default.nix
+++ b/pkgs/development/tools/misc/babeltrace/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   # --enable-debug-info (default) requires the configure script to run host
   # executables to determine the elfutils library version, which cannot be done
   # while cross compiling.
-  configureFlags = lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "--disable-debug-info";
+  configureFlags = lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) "--disable-debug-info";
 
   meta = with lib; {
     description = "Command-line tool and library to read and convert LTTng tracefiles";

--- a/pkgs/development/tools/misc/binutils/2.38/default.nix
+++ b/pkgs/development/tools/misc/binutils/2.38/default.nix
@@ -194,7 +194,7 @@ stdenv.mkDerivation {
   postFixup = "";
 
   # Break dependency on pkgsBuildBuild.gcc when building a cross-binutils
-  stripDebugList = if stdenv.hostPlatform != stdenv.targetPlatform then "bin lib ${stdenv.hostPlatform.config}" else null;
+  stripDebugList = if (!lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform) then "bin lib ${stdenv.hostPlatform.config}" else null;
 
   # INFO: Otherwise it fails with:
   # `./sanity.sh: line 36: $out/bin/size: not found`

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -236,7 +236,7 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = false;
 
   # Break dependency on pkgsBuildBuild.gcc when building a cross-binutils
-  stripDebugList = if stdenv.hostPlatform != stdenv.targetPlatform then "bin lib ${stdenv.hostPlatform.config}" else null;
+  stripDebugList = if (!lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform) then "bin lib ${stdenv.hostPlatform.config}" else null;
 
   # INFO: Otherwise it fails with:
   # `./sanity.sh: line 36: $out/bin/size: not found`

--- a/pkgs/development/tools/misc/elfutils/default.nix
+++ b/pkgs/development/tools/misc/elfutils/default.nix
@@ -85,9 +85,9 @@ stdenv.mkDerivation rec {
     !stdenv.hostPlatform.isMusl
     # Test suite tries using `uname` to determine whether certain tests
     # can be executed, so we need to match build and host platform exactly.
-    && (stdenv.hostPlatform == stdenv.buildPlatform);
+    && (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
   doInstallCheck = !stdenv.hostPlatform.isMusl
-    && (stdenv.hostPlatform == stdenv.buildPlatform);
+    && (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 
   passthru.updateScript = gitUpdater {
     url = "https://sourceware.org/git/elfutils.git";

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -6,7 +6,7 @@
 # Run time
 , ncurses, readline, gmp, mpfr, expat, libipt, zlib, zstd, xz, dejagnu, sourceHighlight, libiconv
 
-, pythonSupport ? stdenv.hostPlatform == stdenv.buildPlatform && !stdenv.hostPlatform.isCygwin, python3 ? null
+, pythonSupport ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) && !stdenv.hostPlatform.isCygwin, python3 ? null
 , enableDebuginfod ? lib.meta.availableOn stdenv.hostPlatform elfutils, elfutils
 , guile ? null
 , hostCpuOnly ? false
@@ -22,7 +22,7 @@
 
 let
   basename = "gdb";
-  targetPrefix = lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform)
+  targetPrefix = lib.optionalString (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform)
                  "${stdenv.targetPlatform.config}-";
 in
 

--- a/pkgs/development/tools/misc/intltool/default.nix
+++ b/pkgs/development/tools/misc/intltool/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = with perlPackages; [ perl XMLParser ];
   propagatedBuildInputs = [ gettext ] ++ (with perlPackages; [ perl XMLParser ]);
 
-  postInstall = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     for f in $out/bin/*; do
       substituteInPlace $f --replace "${buildPackages.perl}" "${perlPackages.perl}"
     done

--- a/pkgs/development/tools/misc/luarocks/default.nix
+++ b/pkgs/development/tools/misc/luarocks/default.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
     export LUA_PATH="src/?.lua;''${LUA_PATH:-}"
   '';
 
-  disallowedReferences = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  disallowedReferences = lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     lua.luaOnBuild
   ];
 

--- a/pkgs/development/tools/misc/pkg-config/default.nix
+++ b/pkgs/development/tools/misc/pkg-config/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--with-internal-glib" ]
     ++ lib.optionals (stdenv.isSunOS) [ "--with-libiconv=gnu" "--with-system-library-path" "--with-system-include-path" "CFLAGS=-DENABLE_NLS" ]
        # Can't run these tests while cross-compiling
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform)
+    ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
        [ "glib_cv_stack_grows=no"
          "glib_cv_uscore=no"
          "ac_cv_func_posix_getpwuid_r=yes"

--- a/pkgs/development/tools/misc/texi2html/default.nix
+++ b/pkgs/development/tools/misc/texi2html/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     patchShebangs separated_to_hash.pl
   '';
 
-  postInstall = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  postInstall = lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
     for f in $out/bin/*; do
       substituteInPlace $f --replace "${buildPackages.perl}" "${perl}"
     done

--- a/pkgs/development/tools/misc/texinfo/common.nix
+++ b/pkgs/development/tools/misc/texinfo/common.nix
@@ -14,7 +14,7 @@
 
 let
   inherit (lib) getDev getLib optional optionals optionalString;
-  crossBuildTools = stdenv.hostPlatform != stdenv.buildPlatform;
+  crossBuildTools = (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 in
 
 stdenv.mkDerivation {

--- a/pkgs/development/tools/misc/texlab/default.nix
+++ b/pkgs/development/tools/misc/texlab/default.nix
@@ -11,7 +11,7 @@
 }:
 
 let
-  isCross = stdenv.hostPlatform != stdenv.buildPlatform;
+  isCross = (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 in
 rustPlatform.buildRustPackage rec {
   pname = "texlab";

--- a/pkgs/development/tools/pandoc/default.nix
+++ b/pkgs/development/tools/pandoc/default.nix
@@ -30,7 +30,7 @@ in
       remove-references-to \
         -t ${haskellPackages.pandoc} \
         $out/bin/pandoc
-    '' + lib.optionalString (stdenv.buildPlatform == stdenv.hostPlatform) ''
+    '' + lib.optionalString (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
       mkdir -p $out/share/bash-completion/completions
       $out/bin/pandoc --bash-completion > $out/share/bash-completion/completions/pandoc
     '' + ''

--- a/pkgs/development/tools/parsing/bison/default.nix
+++ b/pkgs/development/tools/parsing/bison/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   # there's a /bin/sh shebang in bin/yacc which when no strictDeps is patched with the build stdenv shell
   # however when cross-compiling it would still be patched with the build stdenv shell which would be wrong
   # cannot add bash to buildInputs due to infinite recursion
-  strictDeps = stdenv.hostPlatform != stdenv.buildPlatform;
+  strictDeps = (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 
   nativeBuildInputs = [ m4 perl ] ++ lib.optional stdenv.isSunOS help2man;
   propagatedBuildInputs = [ m4 ];

--- a/pkgs/development/tools/parsing/flex/2.5.35.nix
+++ b/pkgs/development/tools/parsing/flex/2.5.35.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ m4 ];
 
-  preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  preConfigure = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     ac_cv_func_malloc_0_nonnull=yes
     ac_cv_func_realloc_0_nonnull=yes
   '';

--- a/pkgs/development/tools/parsing/flex/default.nix
+++ b/pkgs/development/tools/parsing/flex/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs tests
-  '' + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  '' + lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
     substituteInPlace Makefile.in --replace "tests" " "
 
     substituteInPlace doc/Makefile.am --replace 'flex.1: $(top_srcdir)/configure.ac' 'flex.1: '
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ bison ];
   propagatedBuildInputs = [ m4 ];
 
-  preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  preConfigure = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     export ac_cv_func_malloc_0_nonnull=yes
     export ac_cv_func_realloc_0_nonnull=yes
   '';
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     sed -i Makefile -e 's/-no-undefined//;'
   '';
 
-  dontDisableStatic = stdenv.buildPlatform != stdenv.hostPlatform;
+  dontDisableStatic = (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
 
   postInstall = ''
     ln -s $out/bin/flex $out/bin/lex

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -14,7 +14,7 @@
 let
   inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices;
 
-  isCross = stdenv.hostPlatform != stdenv.buildPlatform;
+  isCross = (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 
   majorVersion = lib.versions.major version;
   minorVersion = lib.versions.minor version;

--- a/pkgs/games/nethack/default.nix
+++ b/pkgs/games/nethack/default.nix
@@ -77,7 +77,7 @@ in stdenv.mkDerivation rec {
       -e 's,moc-qt4,moc,' \
       -i sys/unix/hints/linux-qt4
     ''}
-    ${lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform)
+    ${lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
     # If we're cross-compiling, replace the paths to the data generation tools
     # with the ones from the build platform's nethack package, since we can't
     # run the ones we've built here.

--- a/pkgs/os-specific/bsd/freebsd/pkgs/install.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/install.nix
@@ -36,7 +36,7 @@ mkDerivation {
     makeMinimal
     mandoc
     groff
-    (if stdenv.hostPlatform == stdenv.buildPlatform then boot-install else install)
+    (if (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) then boot-install else install)
   ];
   skipIncludesPhase = true;
   buildInputs = compatIfNeeded ++ [
@@ -49,7 +49,7 @@ mkDerivation {
       "MK_WERROR=no"
       "TESTSDIR=${builtins.placeholder "test"}"
     ]
-    ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [
+    ++ lib.optionals (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
       "BOOTSTRAPPING=1"
       "INSTALL=boot-install"
     ];

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libnetbsd/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libnetbsd/package.nix
@@ -19,10 +19,10 @@ mkDerivation {
     makeMinimal
     mandoc
     groff
-    (if stdenv.hostPlatform == stdenv.buildPlatform then boot-install else install)
+    (if (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) then boot-install else install)
   ];
   makeFlags = [
     "STRIP=-s" # flag to install, not command
     "MK_WERROR=no"
-  ] ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) "INSTALL=boot-install";
+  ] ++ lib.optional (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) "INSTALL=boot-install";
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/ICU/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/ICU/default.nix
@@ -13,7 +13,7 @@ in
 appleDerivation {
   nativeBuildInputs = [ python3 ];
 
-  depsBuildBuild = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [ buildPackages.stdenv.cc ];
+  depsBuildBuild = lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [ buildPackages.stdenv.cc ];
 
   postPatch = ''
     substituteInPlace makefile \
@@ -38,7 +38,7 @@ appleDerivation {
       --replace "&TestMailFilterCSS" "NULL"
 
     patchShebangs icuSources
-  '' + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  '' + lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
 
     # This looks like a bug in the makefile. It defines ENV_BUILDHOST to
     # propagate the correct value of CC, CXX, etc, but has the following double
@@ -64,7 +64,7 @@ appleDerivation {
     "MAC_OS_X_VERSION_MIN_REQUIRED=${formatVersionNumeric stdenv.hostPlatform.darwinMinVersion}"
     "ICU_TARGET_VERSION=-m${stdenv.hostPlatform.darwinPlatform}-version-min=${stdenv.hostPlatform.darwinMinVersion}"
   ]
-  ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "CROSS_BUILD=YES"
     "BUILD_TYPE="
     "RC_ARCHS=${stdenv.hostPlatform.darwinArch}"

--- a/pkgs/os-specific/darwin/cctools/llvm.nix
+++ b/pkgs/os-specific/darwin/cctools/llvm.nix
@@ -1,7 +1,7 @@
 # Create a cctools-compatible bintools that uses equivalent tools from LLVM in place of the ones
 # from cctools when possible.
 
-{ lib, stdenv, makeWrapper, cctools-port, llvmPackages, enableManpages ? stdenv.targetPlatform == stdenv.hostPlatform }:
+{ lib, stdenv, makeWrapper, cctools-port, llvmPackages, enableManpages ? (lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform) }:
 
 let
   inherit (stdenv) targetPlatform hostPlatform;

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -11,7 +11,7 @@ let
   # The targetPrefix prepended to binary names to allow multiple binuntils on the
   # PATH to both be usable.
   targetPrefix = lib.optionalString
-    (stdenv.targetPlatform != stdenv.hostPlatform)
+    (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform)
     "${stdenv.targetPlatform.config}-";
 in
 
@@ -66,7 +66,7 @@ stdenv.mkDerivation {
 
   # TODO(@Ericson2314): Always pass "--target" and always targetPrefix.
   configurePlatforms = [ "build" "host" ]
-    ++ lib.optional (stdenv.targetPlatform != stdenv.hostPlatform) "target";
+    ++ lib.optional (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform) "target";
   configureFlags = [ "--disable-clang-as" ]
     ++ lib.optionals enableTapiSupport [
       "--enable-tapi-support"

--- a/pkgs/os-specific/darwin/libtapi/default.nix
+++ b/pkgs/os-specific/darwin/libtapi/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Also means we don't have to manually fix the result with install_name_tool.
   patches = [
     ./disable-rpath.patch
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     # TODO: make unconditional and rebuild the world
     # TODO: send upstream
     ./native-clang-tblgen.patch
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [ ncurses ];
 
   cmakeFlags = [ "-DLLVM_INCLUDE_TESTS=OFF" ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
       "-DCMAKE_CROSSCOMPILING=True"
       # This package could probably have a llvm_6 llvm-tblgen and clang-tblgen
       # provided to reduce some building. This package seems intended to

--- a/pkgs/os-specific/linux/apparmor/default.nix
+++ b/pkgs/os-specific/linux/apparmor/default.nix
@@ -3,8 +3,8 @@
 , flex, bison
 , linuxHeaders ? stdenv.cc.libc.linuxHeaders
 , gawk
-, withPerl ? stdenv.hostPlatform == stdenv.buildPlatform && lib.meta.availableOn stdenv.hostPlatform perl, perl
-, withPython ? stdenv.hostPlatform == stdenv.buildPlatform && lib.meta.availableOn stdenv.hostPlatform python3, python3
+, withPerl ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) && lib.meta.availableOn stdenv.hostPlatform perl, perl
+, withPython ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) && lib.meta.availableOn stdenv.hostPlatform python3, python3
 , swig
 , ncurses
 , pam

--- a/pkgs/os-specific/linux/audit/default.nix
+++ b/pkgs/os-specific/linux/audit/default.nix
@@ -11,7 +11,7 @@
 # Enabling python support while cross compiling would be possible, but the
 # configure script tries executing python to gather info instead of relying on
 # python3-config exclusively
-, enablePython ? stdenv.hostPlatform == stdenv.buildPlatform,
+, enablePython ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform),
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
       url = "https://git.alpinelinux.org/aports/plain/main/busybox/0002-nslookup-sanitize-all-printed-strings-with-printable.patch?id=ed92963eb55bbc8d938097b9ccb3e221a94653f4";
       sha256 = "sha256-vl1wPbsHtXY9naajjnTicQ7Uj3N+EQ8pRNnrdsiow+w=";
     })
-  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) ./clang-cross.patch;
+  ] ++ lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ./clang-cross.patch;
 
   separateDebugInfo = true;
 

--- a/pkgs/os-specific/linux/cifs-utils/default.nix
+++ b/pkgs/os-specific/linux/cifs-utils/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libkrb5 keyutils pam talloc python3 ];
 
-  configureFlags = [ "ROOTSBINDIR=$(out)/sbin" ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  configureFlags = [ "ROOTSBINDIR=$(out)/sbin" ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     # AC_FUNC_MALLOC is broken on cross builds.
     "ac_cv_func_malloc_0_nonnull=yes"
     "ac_cv_func_realloc_0_nonnull=yes"

--- a/pkgs/os-specific/linux/criu/default.nix
+++ b/pkgs/os-specific/linux/criu/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
     "PREFIX=$(out)"
     "ASCIIDOC=${buildPackages.asciidoc}/bin/asciidoc"
     "XMLTO=${buildPackages.xmlto}/bin/xmlto"
-  ] ++ (lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  ] ++ (lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "ARCH=${linuxArchMapping."${stdenv.hostPlatform.linuxArch}"}"
     "CROSS_COMPILE=${stdenv.hostPlatform.config}-"
   ]);

--- a/pkgs/os-specific/linux/exfat/default.nix
+++ b/pkgs/os-specific/linux/exfat/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   makeFlags = [
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "ARCH=${stdenv.hostPlatform.linuxArch}"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ];
 

--- a/pkgs/os-specific/linux/iproute/default.nix
+++ b/pkgs/os-specific/linux/iproute/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     "SHARED_LIBS=n"
     # all build .so plugins:
     "TC_CONFIG_NO_XT=y"
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "HOSTCC=$(CC_FOR_BUILD)"
   ];
 

--- a/pkgs/os-specific/linux/iwd/default.nix
+++ b/pkgs/os-specific/linux/iwd/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   };
 
   outputs = [ "out" "man" "doc" ]
-    ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) "test";
+    ++ lib.optional (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) "test";
 
   nativeBuildInputs = [
     autoreconfHook
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
 
   # wrapPython wraps the scripts in $test. They pull in gobject-introspection,
   # which doesn't cross-compile.
-  pythonPath = lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [
+  pythonPath = lib.optionals (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     python3Packages.dbus-python
     python3Packages.pygobject3
   ];
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
     mkdir -p $doc/share/doc
     cp -a doc $doc/share/doc/iwd
     cp -a README AUTHORS TODO $doc/share/doc/iwd
-  '' + lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  '' + lib.optionalString (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     mkdir -p $test/bin
     cp -a test/* $test/bin/
   '';

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -423,7 +423,7 @@ stdenv.mkDerivation ((drvAttrs config stdenv.hostPlatform.linux-kernel kernelPat
     "HOSTCC=${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc"
     "HOSTLD=${buildPackages.stdenv.cc.bintools}/bin/${buildPackages.stdenv.cc.targetPrefix}ld"
     "ARCH=${stdenv.hostPlatform.linuxArch}"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ] ++ (stdenv.hostPlatform.linux-kernel.makeFlags or [])
     ++ extraMakeFlags;

--- a/pkgs/os-specific/linux/klibc/default.nix
+++ b/pkgs/os-specific/linux/klibc/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   ] # TODO(@Ericson2314): We now can get the ABI from
     # `stdenv.hostPlatform.parsed.abi`, is this still a good idea?
     ++ lib.optional (stdenv.hostPlatform.linuxArch == "arm") "CONFIG_AEABI=y"
-    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "CROSS_COMPILE=${stdenv.cc.targetPrefix}";
+    ++ lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) "CROSS_COMPILE=${stdenv.cc.targetPrefix}";
 
   # Install static binaries as well.
   postInstall = ''

--- a/pkgs/os-specific/linux/kmod/default.nix
+++ b/pkgs/os-specific/linux/kmod/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchzip, autoconf, automake, docbook_xml_dtd_42
 , docbook_xml_dtd_43, docbook_xsl, gtk-doc, libtool, pkg-config
 , libxslt, xz, zstd, elf-header
-, withDevdoc ? stdenv.hostPlatform == stdenv.buildPlatform
+, withDevdoc ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
 , withStatic ? stdenv.hostPlatform.isStatic
 , gitUpdater
 }:

--- a/pkgs/os-specific/linux/lvm2/common.nix
+++ b/pkgs/os-specific/linux/lvm2/common.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
     "--enable-dmeventd"
     "--with-dmeventd-pidfile=/run/dmeventd/pid"
     "--with-default-dm-run-dir=/run/dmeventd"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"
     "ac_cv_func_realloc_0_nonnull=yes"
   ] ++ lib.optionals udevSupport [

--- a/pkgs/os-specific/linux/mdadm/default.nix
+++ b/pkgs/os-specific/linux/mdadm/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     "SYSTEMD_DIR=$(out)/lib/systemd/system"
     "MANDIR=$(out)/share/man" "RUN_DIR=/dev/.mdadm"
     "STRIP="
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ];
 

--- a/pkgs/os-specific/linux/pam/default.nix
+++ b/pkgs/os-specific/linux/pam/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   ];
 
   # Case-insensitivity workaround for https://github.com/linux-pam/linux-pam/issues/569
-  postPatch = if stdenv.buildPlatform.isDarwin && stdenv.buildPlatform != stdenv.hostPlatform then ''
+  postPatch = if stdenv.buildPlatform.isDarwin && (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) then ''
     rm CHANGELOG
     touch ChangeLog
   '' else null;

--- a/pkgs/os-specific/linux/procps-ng/default.nix
+++ b/pkgs/os-specific/linux/procps-ng/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
   # Too red; 8bit support for fixing https://github.com/NixOS/nixpkgs/issues/275220
   configureFlags = [ "--disable-modern-top" "--enable-watch8bit" ]
     ++ lib.optional withSystemd "--with-systemd"
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"
     "ac_cv_func_realloc_0_nonnull=yes"
   ];

--- a/pkgs/os-specific/linux/psmisc/default.nix
+++ b/pkgs/os-specific/linux/psmisc/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoconf automake gettext ];
   buildInputs = [ ncurses ];
 
-  preConfigure = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  preConfigure = lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
     # Goes past the rpl_malloc linking failure
     export ac_cv_func_malloc_0_nonnull=yes
     export ac_cv_func_realloc_0_nonnull=yes

--- a/pkgs/os-specific/linux/rtl8723ds/default.nix
+++ b/pkgs/os-specific/linux/rtl8723ds/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
   makeFlags = [
     "ARCH=${stdenv.hostPlatform.linuxArch}"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ];
 

--- a/pkgs/os-specific/linux/rtl8812au/default.nix
+++ b/pkgs/os-specific/linux/rtl8812au/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
     "ARCH=${stdenv.hostPlatform.linuxArch}"
     ("CONFIG_PLATFORM_I386_PC=" + (if stdenv.hostPlatform.isx86 then "y" else "n"))
     ("CONFIG_PLATFORM_ARM_RPI=" + (if stdenv.hostPlatform.isAarch then "y" else "n"))
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ];
 

--- a/pkgs/os-specific/linux/rtl8821au/default.nix
+++ b/pkgs/os-specific/linux/rtl8821au/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
     "ARCH=${stdenv.hostPlatform.linuxArch}"
     ("CONFIG_PLATFORM_I386_PC=" + (if stdenv.hostPlatform.isx86 then "y" else "n"))
     ("CONFIG_PLATFORM_ARM_RPI=" + (if (stdenv.hostPlatform.isAarch32 || stdenv.hostPlatform.isAarch64) then "y" else "n"))
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ];
 

--- a/pkgs/os-specific/linux/rtl8852au/default.nix
+++ b/pkgs/os-specific/linux/rtl8852au/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
     "ARCH=${stdenv.hostPlatform.linuxArch}"
     ("CONFIG_PLATFORM_I386_PC=" + (if stdenv.hostPlatform.isx86 then "y" else "n"))
     ("CONFIG_PLATFORM_ARM_RPI=" + (if stdenv.hostPlatform.isAarch then "y" else "n"))
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ];
 

--- a/pkgs/os-specific/linux/rtl8852bu/default.nix
+++ b/pkgs/os-specific/linux/rtl8852bu/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
     "ARCH=${stdenv.hostPlatform.linuxArch}"
     ("CONFIG_PLATFORM_I386_PC=" + (if stdenv.hostPlatform.isx86 then "y" else "n"))
     ("CONFIG_PLATFORM_ARM_RPI=" + (if stdenv.hostPlatform.isAarch then "y" else "n"))
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ];
 

--- a/pkgs/os-specific/linux/shadow/default.nix
+++ b/pkgs/os-specific/linux/shadow/default.nix
@@ -10,7 +10,7 @@
 }:
 let
   glibc =
-    if stdenv.hostPlatform != stdenv.buildPlatform then glibcCross
+    if (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) then glibcCross
     else assert stdenv.hostPlatform.libc == "glibc"; stdenv.cc.libc;
 
 in
@@ -92,7 +92,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  disallowedReferences = lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) stdenv.shellPackage;
+  disallowedReferences = lib.optional (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) stdenv.shellPackage;
 
   meta = with lib; {
     homepage = "https://github.com/shadow-maint";

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -860,7 +860,7 @@ stdenv.mkDerivation (finalAttrs: {
     wrapProgram $out/bin/ukify --prefix PATH : ${lib.makeBinPath [ targetPackages.stdenv.cc.bintools ] }:${placeholder "out"}/lib/systemd
   '';
 
-  disallowedReferences = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform)
+  disallowedReferences = lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
     # 'or p' is for manually specified buildPackages as they dont have __spliced
     (builtins.map (p: p.__spliced.buildHost or p) finalAttrs.nativeBuildInputs);
 

--- a/pkgs/os-specific/linux/udisks/2-default.nix
+++ b/pkgs/os-specific/linux/udisks/2-default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-L8jr1+SJWsCizkPXC8VKDy2eVa7/FpqdB8SkBYq6vwc=";
   };
 
-  outputs = [ "out" "man" "dev" ] ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) "devdoc";
+  outputs = [ "out" "man" "dev" ] ++ lib.optional (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) "devdoc";
 
   patches = [
     (substituteAll {
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
   preConfigure = "NOCONFIGURE=1 ./autogen.sh";
 
   configureFlags = [
-    (lib.enableFeature (stdenv.buildPlatform == stdenv.hostPlatform) "gtk-doc")
+    (lib.enableFeature (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) "gtk-doc")
     "--sysconfdir=/etc"
     "--localstatedir=/var"
     "--with-systemdsystemunitdir=$(out)/etc/systemd/system"

--- a/pkgs/os-specific/linux/util-linux/default.nix
+++ b/pkgs/os-specific/linux/util-linux/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
        "systemdsystemunitdir" "${placeholder "bin"}/lib/systemd/system/")
     (lib.enableFeature translateManpages "poman")
     "SYSCONFSTATICDIR=${placeholder "lib"}/lib"
-  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
+  ] ++ lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
        "scanf_cv_type_modifier=ms"
   ;
 

--- a/pkgs/os-specific/linux/wireguard/default.nix
+++ b/pkgs/os-specific/linux/wireguard/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   buildFlags = [ "module" ];
   makeFlags = [
     "ARCH=${stdenv.hostPlatform.linuxArch}"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ];
 

--- a/pkgs/servers/clickhouse/default.nix
+++ b/pkgs/servers/clickhouse/default.nix
@@ -216,6 +216,6 @@ in mkDerivation rec {
 
     # not supposed to work on 32-bit https://github.com/ClickHouse/ClickHouse/pull/23959#issuecomment-835343685
     platforms = lib.filter (x: (lib.systems.elaborate x).is64bit) (platforms.linux ++ platforms.darwin);
-    broken = stdenv.buildPlatform != stdenv.hostPlatform;
+    broken = (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
   };
 }

--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     "--without-lmdb"
     "--with-libidn2"
   ] ++ lib.optional enableGSSAPI "--with-gssapi=${libkrb5.dev}/bin/krb5-config"
-  ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "BUILD_CC=$(CC_FOR_BUILD)";
+  ++ lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) "BUILD_CC=$(CC_FOR_BUILD)";
 
   postInstall = ''
     moveToOutput bin/bind9-config $dev

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -155,7 +155,7 @@ stdenv.mkDerivation {
       '';
     })
     ./nix-skip-check-logs-path.patch
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     (fetchpatch {
       url = "https://raw.githubusercontent.com/openwrt/packages/c057dfb09c7027287c7862afab965a4cd95293a3/net/nginx/patches/102-sizeof_test_fix.patch";
       sha256 = "0i2k30ac8d7inj9l6bl0684kjglam2f68z8lf3xggcc2i5wzhh8a";

--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
     "--with-ldap"
     "--with-lucene"
     "--with-icu"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "i_cv_epoll_works=${if stdenv.isLinux then "yes" else "no"}"
     "i_cv_posix_fallocate_works=${if stdenv.isDarwin then "no" else "yes"}"
     "i_cv_inotify_works=${if stdenv.isLinux then "yes" else "no"}"

--- a/pkgs/servers/mail/mlmmj/default.nix
+++ b/pkgs/servers/mail/mlmmj/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1sghqvwizvm1a9w56r34qy5njaq1c26bagj85r60h32gh3fx02bn";
   };
 
-  configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  configureFlags = lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     # AC_FUNC_MALLOC is broken on cross builds.
     "ac_cv_func_malloc_0_nonnull=yes"
     "ac_cv_func_realloc_0_nonnull=yes"

--- a/pkgs/servers/mail/postfix/default.nix
+++ b/pkgs/servers/mail/postfix/default.nix
@@ -55,7 +55,7 @@ in stdenv.mkDerivation rec {
     })
   ];
 
-  postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  postPatch = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     sed -e 's!bin/postconf!${buildPackages.postfix}/bin/postconf!' -i postfix-install
   '' + ''
     sed -e '/^PATH=/d' -i postfix-install

--- a/pkgs/servers/monitoring/zabbix/proxy.nix
+++ b/pkgs/servers/monitoring/zabbix/proxy.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, pkg-config, libevent, libiconv, openssl, pcre, zlib
 , odbcSupport ? true, unixODBC
-, snmpSupport ? stdenv.buildPlatform == stdenv.hostPlatform, net-snmp
+, snmpSupport ? (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform), net-snmp
 , sshSupport ? true, libssh2
 , sqliteSupport ? false, sqlite
 , mysqlSupport ? false, libmysqlclient

--- a/pkgs/servers/nosql/redis/default.nix
+++ b/pkgs/servers/nosql/redis/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # More cross-compiling fixes.
   makeFlags = [ "PREFIX=${placeholder "out"}" ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ "AR=${stdenv.cc.targetPrefix}ar" "RANLIB=${stdenv.cc.targetPrefix}ranlib" ]
+    ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [ "AR=${stdenv.cc.targetPrefix}ar" "RANLIB=${stdenv.cc.targetPrefix}ranlib" ]
     ++ lib.optionals withSystemd [ "USE_SYSTEMD=yes" ]
     ++ lib.optionals tlsSupport [ "BUILD_TLS=yes" ];
 

--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -103,7 +103,7 @@ stdenv.mkDerivation rec {
     (lib.mesonBool "doxygen" false)
     (lib.mesonEnable "elogind" false)
     # gsettings does not support cross-compilation
-    (lib.mesonEnable "gsettings" (stdenv.isLinux && (stdenv.buildPlatform == stdenv.hostPlatform)))
+    (lib.mesonEnable "gsettings" (stdenv.isLinux && (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)))
     (lib.mesonEnable "gstreamer" false)
     (lib.mesonEnable "gtk" false)
     (lib.mesonEnable "jack" (jackaudioSupport && !libOnly))
@@ -155,7 +155,7 @@ stdenv.mkDerivation rec {
     cp config.h $dev/include/pulse
   '';
 
-  preFixup = lib.optionalString (stdenv.isLinux  && (stdenv.hostPlatform == stdenv.buildPlatform)) ''
+  preFixup = lib.optionalString (stdenv.isLinux  && (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)) ''
     wrapProgram $out/libexec/pulse/gsettings-helper \
      --prefix XDG_DATA_DIRS : "$out/share/gsettings-schemas/${pname}-${version}" \
      --prefix GIO_EXTRA_MODULES : "${lib.getLib dconf}/lib/gio/modules"

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -102,7 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
     rpcsvc-proto
   ] ++ optionals stdenv.isLinux [
     buildPackages.stdenv.cc
-  ] ++ optional (stdenv.buildPlatform != stdenv.hostPlatform) samba # asn1_compile/compile_et
+  ] ++ optional (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) samba # asn1_compile/compile_et
     ++ optionals stdenv.isDarwin [
     fixDarwinDylibNames
   ];
@@ -171,7 +171,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ optional enableProfiling "--with-profiling-data"
     ++ optional (!enableAcl) "--without-acl-support"
     ++ optional (!enablePam) "--without-pam"
-    ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "--bundled-libraries=!asn1_compile,!compile_et"
     "--cross-compile"
     "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
@@ -199,7 +199,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Save asn1_compile and compile_et so they are available to run on the build
   # platform when cross-compiling
-  postInstall = optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = optionalString (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     mkdir -p "$dev/bin"
     cp bin/asn1_compile bin/compile_et "$dev/bin"
   '';

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -22,7 +22,7 @@ let
     }:
 
   let
-    isCross = stdenv.buildPlatform != stdenv.hostPlatform;
+    isCross = (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
 
     libExt = stdenv.hostPlatform.extensions.sharedLibrary;
 

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -266,7 +266,7 @@ let
       # resulting LLVM IR isn't platform-independent this doesn't give you much.
       # In fact, I tried to test the result in a VM-test, but as soon as JIT was used to optimize
       # a query, postgres would coredump with `Illegal instruction`.
-      broken = (jitSupport && stdenv.hostPlatform != stdenv.buildPlatform)
+      broken = (jitSupport && (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform))
         # Allmost all tests fail FATAL errors for v12 and v13
         || (jitSupport && stdenv.hostPlatform.isMusl && olderThan "14");
     };

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -14,7 +14,7 @@ let
   inherit (stdenv) isDarwin;
 
   malloc0ReturnsNullCrossFlag = lib.optional
-    (stdenv.hostPlatform != stdenv.buildPlatform)
+    (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
     "--enable-malloc0returnsnull";
 
   addMainProgram = pkg: { mainProgram ? pkg.pname }: pkg.overrideAttrs (attrs: {
@@ -241,7 +241,7 @@ self: super:
     buildInputs = attrs.buildInputs ++ [ libxcrypt ];
     configureFlags = attrs.configureFlags or [] ++ [
       "ac_cv_path_RAWCPP=${stdenv.cc.targetPrefix}cpp"
-    ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform)
+    ] ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
       # checking for /dev/urandom... configure: error: cannot check for file existence when cross compiling
       [ "ac_cv_file__dev_urandom=true" "ac_cv_file__dev_random=true" ];
     meta = attrs.meta // { mainProgram = "xdm"; };
@@ -323,7 +323,7 @@ self: super:
   libXi = super.libXi.overrideAttrs (attrs: {
     outputs = [ "out" "dev" "man" "doc" ];
     propagatedBuildInputs = attrs.propagatedBuildInputs or [] ++ [ xorg.libXfixes xorg.libXext ];
-    configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    configureFlags = lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
       "xorg_cv_malloc0_returns_null=no"
     ] ++ lib.optional stdenv.hostPlatform.isStatic "--disable-shared";
   });

--- a/pkgs/shells/bash/5.nix
+++ b/pkgs/shells/bash/5.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
     # do the same.
     "--without-bash-malloc"
     (if interactive then "--with-installed-readline" else "--disable-readline")
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "bash_cv_job_control_missing=nomissing"
     "bash_cv_sys_named_pipes=nomissing"
     "bash_cv_getcwd_malloc=yes"

--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -224,7 +224,7 @@ let
     # was clobbering the PATH. It probably needs to be fixed at a lower level.
     preConfigure = ''
       patchShebangs ./build_tools/git_version_gen.sh
-    '' + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    '' + lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
       export CMAKE_PREFIX_PATH=
     '';
 

--- a/pkgs/shells/oksh/default.nix
+++ b/pkgs/shells/oksh/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
-  postPatch = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  postPatch = lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
     substituteInPlace configure --replace "./conftest" "echo"
   '';
 

--- a/pkgs/shells/zsh/default.nix
+++ b/pkgs/shells/zsh/default.nix
@@ -109,7 +109,7 @@ else
   fi
 fi
 EOF
-    ${if stdenv.hostPlatform == stdenv.buildPlatform then ''
+    ${if (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) then ''
       $out/bin/zsh -c "zcompile $out/etc/zshenv"
     '' else ''
       ${lib.getBin buildPackages.zsh}/bin/zsh -c "zcompile $out/etc/zshenv"

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -202,7 +202,7 @@ let
 , doInstallCheck ? config.doCheckByDefault or false
 
 , # TODO(@Ericson2314): Make always true and remove / resolve #178468
-  strictDeps ? if config.strictDepsByDefault then true else stdenv.hostPlatform != stdenv.buildPlatform
+  strictDeps ? if config.strictDepsByDefault then true else (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
 
 , enableParallelBuilding ? config.enableParallelBuildingByDefault
 

--- a/pkgs/test/cc-wrapper/default.nix
+++ b/pkgs/test/cc-wrapper/default.nix
@@ -3,7 +3,7 @@
 let
   # Sanitizers are not supported on Darwin.
   # Sanitizer headers aren't available in older libc++ stdenvs due to a bug
-  sanitizersWorking = (stdenv.buildPlatform == stdenv.hostPlatform) && !stdenv.isDarwin && !stdenv.hostPlatform.isMusl && (
+  sanitizersWorking = (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) && !stdenv.isDarwin && !stdenv.hostPlatform.isMusl && (
     (stdenv.cc.isClang && lib.versionAtLeast (lib.getVersion stdenv.cc.name) "5.0.0")
     || (stdenv.cc.isGNU && stdenv.isLinux)
   );

--- a/pkgs/tools/admin/colmena/default.nix
+++ b/pkgs/tools/admin/colmena/default.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage rec {
 
   NIX_EVAL_JOBS = "${nix-eval-jobs}/bin/nix-eval-jobs";
 
-  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     installShellCompletion --cmd colmena \
       --bash <($out/bin/colmena gen-completions bash) \
       --zsh <($out/bin/colmena gen-completions zsh) \

--- a/pkgs/tools/archivers/cabextract/default.nix
+++ b/pkgs/tools/archivers/cabextract/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   # Let's assume that fnmatch works for cross-compilation, otherwise it gives an error:
   # undefined reference to `rpl_fnmatch'.
-  configureFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  configureFlags = lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "ac_cv_func_fnmatch_works=yes"
   ];
 

--- a/pkgs/tools/archivers/p7zip/default.nix
+++ b/pkgs/tools/archivers/p7zip/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # I think this is a typo and should be CXX? Either way let's kill it
     sed -i '/XX=\/usr/d' makefile.macosx_llvm_64bits
-  '' + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  '' + lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
     substituteInPlace makefile.machine \
       --replace 'CC=gcc'  'CC=${stdenv.cc.targetPrefix}gcc' \
       --replace 'CXX=g++' 'CXX=${stdenv.cc.targetPrefix}g++'

--- a/pkgs/tools/backup/bacula/default.nix
+++ b/pkgs/tools/backup/bacula/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     "--with-logdir=/var/log/bacula"
     "--with-working-dir=/var/lib/bacula"
     "--mandir=\${out}/share/man"
-  ] ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "ac_cv_func_setpgrp_void=yes";
+  ] ++ lib.optional (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) "ac_cv_func_setpgrp_void=yes";
 
   installFlags = [
     "logdir=\${out}/logdir"

--- a/pkgs/tools/backup/restic/default.nix
+++ b/pkgs/tools/backup/restic/default.nix
@@ -31,7 +31,7 @@ buildGoModule rec {
 
   postInstall = ''
     wrapProgram $out/bin/restic --prefix PATH : '${rclone}/bin'
-  '' + lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  '' + lib.optionalString (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     $out/bin/restic generate \
       --bash-completion restic.bash \
       --fish-completion restic.fish \

--- a/pkgs/tools/cd-dvd/cdrkit/default.nix
+++ b/pkgs/tools/cd-dvd/cdrkit/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
     ln -s $out/bin/wodim $out/bin/cdrecord
   '';
 
-  cmakeFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ "-DBITFIELDS_HTOL=0" ];
+  cmakeFlags = lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [ "-DBITFIELDS_HTOL=0" ];
 
   makeFlags = [ "PREFIX=\$(out)" ];
 

--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -5,8 +5,8 @@
 , static ? stdenv.hostPlatform.isStatic # generates static libraries *only*
 , enableStatic ? static
 # these need to be ran on the host, thus disable when cross-compiling
-, buildContrib ? stdenv.hostPlatform == stdenv.buildPlatform
-, doCheck ? stdenv.hostPlatform == stdenv.buildPlatform
+, buildContrib ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
+, doCheck ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
 , nix-update-script
 
 # for passthru.tests

--- a/pkgs/tools/filesystems/mtdutils/default.nix
+++ b/pkgs/tools/filesystems/mtdutils/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     "AR:=$(AR)"
   ];
 
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/tools/filesystems/squashfs/default.nix
+++ b/pkgs/tools/filesystems/squashfs/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   strictDeps = true;
   nativeBuildInputs = [ which ]
     # when cross-compiling help2man cannot run the cross-compiled binary
-    ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [ help2man ];
+    ++ lib.optionals (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [ help2man ];
   buildInputs = [ zlib xz zstd lz4 lzo ];
 
   preBuild = ''

--- a/pkgs/tools/graphics/argyllcms/default.nix
+++ b/pkgs/tools/graphics/argyllcms/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     }
   );
 
-  postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  postPatch = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     substituteInPlace Jambase \
       --replace "-m64" ""
   '';

--- a/pkgs/tools/graphics/optipng/default.nix
+++ b/pkgs/tools/graphics/optipng/default.nix
@@ -29,11 +29,11 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-system-zlib"
     "--with-system-libpng"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     #"-prefix=$out"
   ];
 
-  postInstall = if stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform.isWindows then ''
+  postInstall = if (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) && stdenv.hostPlatform.isWindows then ''
     mv "$out"/bin/optipng{,.exe}
   '' else null;
 

--- a/pkgs/tools/graphics/scanbd/default.nix
+++ b/pkgs/tools/graphics/scanbd/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     "--enable-udev"
     "--with-scanbdconfdir=/etc/scanbd"
     "--with-systemdsystemunitdir=$out/lib/systemd/system"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     # AC_FUNC_MALLOC is broken on cross builds.
     "ac_cv_func_malloc_0_nonnull=yes"
     "ac_cv_func_realloc_0_nonnull=yes"

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -28,7 +28,7 @@ assert selinuxSupport -> libselinux != null && libsepol != null;
 
 let
   inherit (lib) concatStringsSep isString optional optionals optionalString;
-  isCross = (stdenv.hostPlatform != stdenv.buildPlatform);
+  isCross = (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 in
 stdenv.mkDerivation rec {
   pname = "coreutils" + (optionalString (!minimal) "-full");

--- a/pkgs/tools/misc/file/default.nix
+++ b/pkgs/tools/misc/file/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
 
   nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ]
-    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) file;
+    ++ lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) file;
   buildInputs = [ zlib ]
     ++ lib.optional stdenv.hostPlatform.isWindows libgnurx;
 

--- a/pkgs/tools/misc/findutils/default.nix
+++ b/pkgs/tools/misc/findutils/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     && !stdenv.hostPlatform.isFreeBSD
     && !(stdenv.hostPlatform.libc == "glibc" && stdenv.hostPlatform.isi686)
     && (stdenv.hostPlatform.libc != "musl")
-    && stdenv.hostPlatform == stdenv.buildPlatform;
+    && (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
 
   outputs = [ "out" "info" "locate"];
 

--- a/pkgs/tools/misc/grub/default.nix
+++ b/pkgs/tools/misc/grub/default.nix
@@ -142,7 +142,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--enable-grub-mount" # dep of os-prober
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     # grub doesn't do cross-compilation as usual and tries to use unprefixed
     # tools to target the host. Provide toolchain information explicitly for
     # cross builds.

--- a/pkgs/tools/misc/man-db/default.nix
+++ b/pkgs/tools/misc/man-db/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  disallowedReferences = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  disallowedReferences = lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     buildPackages.groff
   ];
 

--- a/pkgs/tools/misc/toybox/default.nix
+++ b/pkgs/tools/misc/toybox/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-7izs2C5/czec0Dt3apL8s7luARAlw4PfUFy9Xsxb0zw=";
   };
 
-  depsBuildBuild = optionals (stdenv.hostPlatform != stdenv.buildPlatform) [ buildPackages.stdenv.cc ];
+  depsBuildBuild = optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [ buildPackages.stdenv.cc ];
   buildInputs = [
     libxcrypt
   ] ++ optionals stdenv.isDarwin [

--- a/pkgs/tools/networking/curl-impersonate/default.nix
+++ b/pkgs/tools/networking/curl-impersonate/default.nix
@@ -57,7 +57,7 @@ let
 
     strictDeps = true;
 
-    depsBuildBuild = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    depsBuildBuild = lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
       buildPackages.stdenv.cc
     ];
 

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -11,7 +11,7 @@
     # the "mig" tool does not configure its compiler correctly. This could be
     # fixed in mig, but losing gss support on cross compilation to darwin is
     # not worth the effort.
-    !(isDarwin && (stdenv.buildPlatform != stdenv.hostPlatform))
+    !(isDarwin && (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform))
   ), libkrb5
 , http2Support ? true, nghttp2
 , http3Support ? false, nghttp3, ngtcp2
@@ -143,7 +143,7 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optional gssSupport "--with-gssapi=${lib.getDev libkrb5}"
        # For the 'urandom', maybe it should be a cross-system option
-    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
+    ++ lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
        "--with-random=/dev/urandom"
     ++ lib.optionals stdenv.hostPlatform.isWindows [
       "--disable-shared"

--- a/pkgs/tools/networking/hping/default.nix
+++ b/pkgs/tools/networking/hping/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   '' + lib.optionalString stdenv.isLinux ''
     sed -i -e 's|#include <net/bpf.h>|#include <pcap/bpf.h>|' \
       libpcap_stuff.c script.c
-  '' + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  '' + lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
     substituteInPlace configure --replace 'BYTEORDER=`./byteorder -m`' BYTEORDER=${
       {
         littleEndian = "__LITTLE_ENDIAN_BITFIELD";

--- a/pkgs/tools/networking/inetutils/default.nix
+++ b/pkgs/tools/networking/inetutils/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   # https://lists.gnu.org/archive/html/bug-sed/2017-01/msg00001.html
   # https://git.congatec.com/yocto/meta-openembedded/blob/3402bfac6b595c622e4590a8ff5eaaa854e2a2a3/meta-networking/recipes-connectivity/inetutils/inetutils_1.9.1.bb#L44
   preConfigure = let
-    isCross = stdenv.hostPlatform != stdenv.buildPlatform;
+    isCross = (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
   in lib.optionalString isCross ''
     export HELP2MAN=true
   '';

--- a/pkgs/tools/networking/networkmanager/default.nix
+++ b/pkgs/tools/networking/networkmanager/default.nix
@@ -113,7 +113,7 @@ stdenv.mkDerivation rec {
     # Miscellaneous
     # almost cross-compiles, however fails with
     # ** (process:9234): WARNING **: Failed to load shared library '/nix/store/...-networkmanager-aarch64-unknown-linux-gnu-1.38.2/lib/libnm.so.0' referenced by the typelib: /nix/store/...-networkmanager-aarch64-unknown-linux-gnu-1.38.2/lib/libnm.so.0: cannot open shared object file: No such file or directory
-    "-Ddocs=${lib.boolToString (stdenv.buildPlatform == stdenv.hostPlatform)}"
+    "-Ddocs=${lib.boolToString (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)}"
     # We don't use firewalld in NixOS
     "-Dfirewalld_zone=false"
     "-Dtests=no"
@@ -200,7 +200,7 @@ stdenv.mkDerivation rec {
     ln -s $PWD/src/libnm-client-impl/libnm.so.0 ${placeholder "out"}/lib/libnm.so.0
   '';
 
-  postFixup = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  postFixup = lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
     cp -r ${buildPackages.networkmanager.devdoc} $devdoc
     cp -r ${buildPackages.networkmanager.man} $man
   '';

--- a/pkgs/tools/networking/openconnect/common.nix
+++ b/pkgs/tools/networking/openconnect/common.nix
@@ -15,7 +15,7 @@
 , zlib
 , vpnc-scripts
 , PCSC
-, useDefaultExternalBrowser ? stdenv.isLinux && stdenv.buildPlatform == stdenv.hostPlatform # xdg-utils doesn't cross-compile
+, useDefaultExternalBrowser ? stdenv.isLinux && (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) # xdg-utils doesn't cross-compile
 , xdg-utils
 , autoreconfHook
 }:

--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -114,7 +114,7 @@ stdenv.mkDerivation {
   doCheck = true;
   enableParallelChecking = false;
   nativeCheckInputs = [ openssl ] ++ lib.optional (!stdenv.isDarwin) hostname;
-  preCheck = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  preCheck = lib.optionalString (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     # construct a dummy HOME
     export HOME=$(realpath ../dummy-home)
     mkdir -p ~/.ssh

--- a/pkgs/tools/networking/rp-pppoe/default.nix
+++ b/pkgs/tools/networking/rp-pppoe/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     export PPPD=${ppp}/sbin/pppd
   '';
 
-  configureFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ "rpppoe_cv_pack_bitfields=rev" ];
+  configureFlags = lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [ "rpppoe_cv_pack_bitfields=rev" ];
 
   postConfigure = ''
     sed -i Makefile -e 's@DESTDIR)/etc/ppp@out)/etc/ppp@'

--- a/pkgs/tools/networking/tcpdump/default.nix
+++ b/pkgs/tools/networking/tcpdump/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libpcap ];
 
-  configureFlags = lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "ac_cv_linux_vers=2";
+  configureFlags = lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) "ac_cv_linux_vers=2";
 
   meta = with lib; {
     description = "Network sniffer";

--- a/pkgs/tools/networking/zerotierone/default.nix
+++ b/pkgs/tools/networking/zerotierone/default.nix
@@ -80,7 +80,7 @@ in stdenv.mkDerivation {
 
   buildFlags = [ "all" "selftest" ];
 
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
   checkPhase = ''
     runHook preCheck
     ./zerotier-selftest

--- a/pkgs/tools/package-management/apk-tools/default.nix
+++ b/pkgs/tools/package-management/apk-tools/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitLab, pkg-config, scdoc, openssl, zlib
-, luaSupport ? stdenv.hostPlatform == stdenv.buildPlatform, lua
+, luaSupport ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform), lua
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/tools/package-management/lix/common.nix
+++ b/pkgs/tools/package-management/lix/common.nix
@@ -66,7 +66,7 @@ assert (hash == null) -> (src != null);
   xz,
   nixosTests,
 
-  enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
+  enableDocumentation ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform),
   enableStatic ? stdenv.hostPlatform.isStatic,
   withAWS ? !enableStatic && (stdenv.isLinux || stdenv.isDarwin),
   aws-sdk-cpp,

--- a/pkgs/tools/package-management/nix/common.nix
+++ b/pkgs/tools/package-management/nix/common.nix
@@ -72,7 +72,7 @@ in
 , util-linuxMinimal
 , xz
 
-, enableDocumentation ? !atLeast24 || stdenv.hostPlatform == stdenv.buildPlatform
+, enableDocumentation ? !atLeast24 || (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
 , enableStatic ? stdenv.hostPlatform.isStatic
 , withAWS ? !enableStatic && (stdenv.isLinux || stdenv.isDarwin), aws-sdk-cpp
 , withLibseccomp ? lib.meta.availableOn stdenv.hostPlatform libseccomp, libseccomp
@@ -219,7 +219,7 @@ self = stdenv.mkDerivation {
     # old style or LTO builds will run their linking on only one thread, which takes forever.
     "--jobserver-style=pipe"
     "profiledir=$(out)/etc/profile.d"
-  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "PRECOMPILE_HEADERS=0"
+  ] ++ lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) "PRECOMPILE_HEADERS=0"
     ++ lib.optional (stdenv.hostPlatform.isDarwin) "PRECOMPILE_HEADERS=1";
 
   installFlags = [ "sysconfdir=$(out)/etc" ];

--- a/pkgs/tools/security/hashcat/default.nix
+++ b/pkgs/tools/security/hashcat/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     "VERSION_TAG=${version}"
     "USE_SYSTEM_OPENCL=1"
     "USE_SYSTEM_XXHASH=1"
-  ] ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform == stdenv.buildPlatform) [
+  ] ++ lib.optionals (stdenv.hostPlatform.isDarwin && (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)) [
     "IS_APPLE_SILICON='${if stdenv.hostPlatform.isAarch64 then "1" else "0"}'"
   ];
 

--- a/pkgs/tools/security/nmap/default.nix
+++ b/pkgs/tools/security/nmap/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     install -m 444 -D nselib/data/passwords.lst $out/share/wordlists/nmap.lst
   '';
 
-  makeFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  makeFlags = lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "AR=${stdenv.cc.bintools.targetPrefix}ar"
     "RANLIB=${stdenv.cc.bintools.targetPrefix}ranlib"
     "CC=${stdenv.cc.targetPrefix}gcc"

--- a/pkgs/tools/security/opensc/default.nix
+++ b/pkgs/tools/security/opensc/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
       else
         "${lib.getLib pcsclite}/lib/libpcsclite${stdenv.hostPlatform.extensions.sharedLibrary}"
       }"
-    (lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform)
+    (lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
       "XSLTPROC=${buildPackages.libxslt}/bin/xsltproc")
   ];
 

--- a/pkgs/tools/security/tor/default.nix
+++ b/pkgs/tools/security/tor/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     [ "--enable-gpl" ]
     ++
     # cross compiles correctly but needs the following
-    lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [ "--disable-tool-name-check" ]
+    lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [ "--disable-tool-name-check" ]
     ++
     # sandbox is broken on aarch64-linux https://gitlab.torproject.org/tpo/core/tor/-/issues/40599
     lib.optionals (stdenv.isLinux && stdenv.isAarch64) [ "--disable-seccomp" ]

--- a/pkgs/tools/system/collectd/default.nix
+++ b/pkgs/tools/system/collectd/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     "--localstatedir=/var"
     "--disable-werror"
   ] ++ plugins.configureFlags
-  ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ "--with-fp-layout=nothing" ];
+  ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [ "--with-fp-layout=nothing" ];
 
   # do not create directories in /var during installPhase
   postConfigure = ''

--- a/pkgs/tools/system/freeipmi/default.nix
+++ b/pkgs/tools/system/freeipmi/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libgcrypt readline libgpg-error ];
 
-  configureFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform)
+  configureFlags = lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
     [ "ac_cv_file__dev_urandom=true" "ac_cv_file__dev_random=true" ];
 
   doCheck = true;

--- a/pkgs/tools/system/monit/default.nix
+++ b/pkgs/tools/system/monit/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     "--with-ssl-lib-dir=${lib.getLib openssl}/lib"
   ] else [
     "--without-ssl"
-  ]) ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ]) ++ lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     # will need to check both these are true for musl
     "libmonit_cv_setjmp_available=yes"
     "libmonit_cv_vsnprintf_c99_conformant=yes"

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -143,7 +143,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    broken = stdenv.isDarwin || stdenv.buildPlatform != stdenv.hostPlatform;
+    broken = stdenv.isDarwin || (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
     description = "Real-time performance monitoring tool";
     homepage = "https://www.netdata.cloud/";
     changelog = "https://github.com/netdata/netdata/releases/tag/v${version}";

--- a/pkgs/tools/text/diffutils/default.nix
+++ b/pkgs/tools/text/diffutils/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     # "pr" need not be on the PATH as a run-time dep, so we need to tell
     # configure where it is. Covers the cross and native case alike.
     lib.optional (coreutils != null) "PR_PROGRAM=${coreutils}/bin/pr"
-    ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "gl_cv_func_getopt_gnu=yes";
+    ++ lib.optional (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) "gl_cv_func_getopt_gnu=yes";
 
   # Test failure on QEMU only (#300550)
   doCheck = !stdenv.buildPlatform.isRiscV64;

--- a/pkgs/tools/text/gnupatch/default.nix
+++ b/pkgs/tools/text/gnupatch/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  configureFlags = lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "ac_cv_func_strnlen_working=yes"
   ];
 

--- a/pkgs/tools/text/gnused/default.nix
+++ b/pkgs/tools/text/gnused/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   preConfigure = "patchShebangs ./build-aux/help2man";
 
   # Prevents attempts of running 'help2man' on cross-built binaries.
-  PERL = if stdenv.hostPlatform == stdenv.buildPlatform then null else "missing";
+  PERL = if (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) then null else "missing";
 
   meta = {
     homepage = "https://www.gnu.org/software/sed/";

--- a/pkgs/tools/text/groff/default.nix
+++ b/pkgs/tools/text/groff/default.nix
@@ -66,11 +66,11 @@ stdenv.mkDerivation rec {
     "--with-gs=${lib.getBin ghostscript}/bin/gs"
     "--with-awk=${lib.getBin gawk}/bin/gawk"
     "--with-appresdir=${placeholder "out"}/lib/X11/app-defaults"
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  ] ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "gl_cv_func_signbit=yes"
   ];
 
-  makeFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  makeFlags = lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     # Trick to get the build system find the proper 'native' groff
     # http://www.mail-archive.com/bug-groff@gnu.org/msg01335.html
     "GROFF_BIN_PATH=${buildPackages.groff}/bin"

--- a/pkgs/tools/text/html-tidy/default.nix
+++ b/pkgs/tools/text/html-tidy/default.nix
@@ -18,9 +18,9 @@ stdenv.mkDerivation rec {
   });
 
   nativeBuildInputs = [ cmake libxslt/*manpage*/ ]
-    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) html-tidy;
+    ++ lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) html-tidy;
 
-  cmakeFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  cmakeFlags = lib.optionals (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) [
     "-DHOST_TIDY=tidy"
   ];
 

--- a/pkgs/tools/text/source-highlight/default.nix
+++ b/pkgs/tools/text/source-highlight/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   # source-highlight uses it's own binary to generate documentation.
   # During cross-compilation, that binary was built for the target
   # platform architecture, so it can't run on the build host.
-  postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  postPatch = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
     substituteInPlace Makefile.in --replace "src doc tests" "src tests"
   '';
 

--- a/pkgs/tools/typesetting/asciidoc/default.nix
+++ b/pkgs/tools/typesetting/asciidoc/default.nix
@@ -244,7 +244,7 @@ in python3.pkgs.buildPythonApplication rec {
       substituteInPlace $f --replace "2002-11-25" "1980-01-02"
       substituteInPlace $f --replace "00:37:42" "00:00:00"
     done
-  '' + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  '' + lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
     # We want to use asciidoc from the build platform to build the documentation.
     substituteInPlace Makefile.in \
       --replace "python3 -m asciidoc.a2x" "${buildPackages.asciidoc}/bin/a2x"

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -81,7 +81,7 @@ let
       # see "from TL tree" vs. "Using installed"  in configure output
       "zziplib" "mpfr" "gmp"
       "pixman" "potrace" "gd" "freetype2" "libpng" "libpaper" "zlib"
-    ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
+    ] ++ lib.optional (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
       "BUILDCC=${buildPackages.stdenv.cc.targetPrefix}cc";
 
     # move binaries to corresponding split outputs, based on content of texlive.tlpdb

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34,7 +34,7 @@ with pkgs;
   stdenvNoCC = stdenv.override (
     { cc = null; hasCC = false; }
 
-    // lib.optionalAttrs (stdenv.hostPlatform.isDarwin && (stdenv.hostPlatform != stdenv.buildPlatform)) {
+    // lib.optionalAttrs (stdenv.hostPlatform.isDarwin && (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)) {
       # TODO: This is a hack to use stdenvNoCC to produce a CF when cross
       # compiling. It's not very sound. The cross stdenv has:
       #   extraBuildInputs = [ targetPackages.darwin.apple_sdks.frameworks.CoreFoundation ]
@@ -61,7 +61,7 @@ with pkgs;
   };
 
   stdenvNoLibs =
-    if stdenv.hostPlatform != stdenv.buildPlatform && (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.useLLVM or false)
+    if (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) && (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.useLLVM or false)
     then
       # We cannot touch binutils or cc themselves, because that will cause
       # infinite recursion. So instead, we just choose a libc based on the
@@ -964,7 +964,7 @@ with pkgs;
 
   fetchbzr = callPackage ../build-support/fetchbzr { };
 
-  fetchcvs = if stdenv.buildPlatform != stdenv.hostPlatform
+  fetchcvs = if (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
     # hack around splicing being crummy with things that (correctly) don't eval.
     then buildPackages.fetchcvs
     else callPackage ../build-support/fetchcvs { };
@@ -1104,7 +1104,7 @@ with pkgs;
 
   fetchtorrent = callPackage ../build-support/fetchtorrent { };
 
-  fetchsvn = if stdenv.buildPlatform != stdenv.hostPlatform
+  fetchsvn = if (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
     # hack around splicing being crummy with things that (correctly) don't eval.
     then buildPackages.fetchsvn
     else callPackage ../build-support/fetchsvn { };
@@ -1123,7 +1123,7 @@ with pkgs;
   fetchNextcloudApp = callPackage ../build-support/fetchnextcloudapp { };
 
   # `fetchurl' downloads a file from the network.
-  fetchurl = if stdenv.buildPlatform != stdenv.hostPlatform
+  fetchurl = if (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
     then buildPackages.fetchurl # No need to do special overrides twice,
     else makeOverridable (import ../build-support/fetchurl) {
       inherit lib stdenvNoCC buildPackages;
@@ -3381,7 +3381,7 @@ with pkgs;
     callPackage ../stdenv/darwin/make-bootstrap-tools.nix {
       localSystem = stdenv.buildPlatform;
       crossSystem =
-        if stdenv.buildPlatform == stdenv.hostPlatform then null else stdenv.hostPlatform;
+        if (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) then null else stdenv.hostPlatform;
     }
   else if stdenv.hostPlatform.isLinux then
     callPackage ../stdenv/linux/make-bootstrap-tools.nix {}
@@ -15507,7 +15507,7 @@ with pkgs;
 
   # The GCC used to build libc for the target platform. Normal gccs will be
   # built with, and use, that cross-compiled libc.
-  gccWithoutTargetLibc = assert stdenv.targetPlatform != stdenv.hostPlatform; let
+  gccWithoutTargetLibc = assert (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform); let
     libcCross1 = binutilsNoLibc.libc;
     in wrapCCWith {
       cc = gccFun {
@@ -15674,13 +15674,13 @@ with pkgs;
     # should be done with a (native) compiler of the same version.
     # If we are cross-compiling GNAT, we may as well do the same.
     gnat-bootstrap =
-      if stdenv.hostPlatform == stdenv.targetPlatform
-         && stdenv.buildPlatform == stdenv.hostPlatform
+      if (lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform)
+         && (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
       then buildPackages.gnat-bootstrap11
       else buildPackages.gnat11;
     stdenv =
-      if stdenv.hostPlatform == stdenv.targetPlatform
-         && stdenv.buildPlatform == stdenv.hostPlatform
+      if (lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform)
+         && (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
          && stdenv.buildPlatform.isDarwin
          && stdenv.buildPlatform.isx86_64
       then overrideCC stdenv gnat-bootstrap11
@@ -15697,13 +15697,13 @@ with pkgs;
     # should be done with a (native) compiler of the same version.
     # If we are cross-compiling GNAT, we may as well do the same.
     gnat-bootstrap =
-      if stdenv.hostPlatform == stdenv.targetPlatform
-         && stdenv.buildPlatform == stdenv.hostPlatform
+      if (lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform)
+         && (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
       then buildPackages.gnat-bootstrap12
       else buildPackages.gnat12;
     stdenv =
-      if stdenv.hostPlatform == stdenv.targetPlatform
-         && stdenv.buildPlatform == stdenv.hostPlatform
+      if (lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform)
+         && (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
          && stdenv.buildPlatform.isDarwin
          && stdenv.buildPlatform.isx86_64
       then overrideCC stdenv gnat-bootstrap12
@@ -15720,13 +15720,13 @@ with pkgs;
     # should be done with a (native) compiler of the same version.
     # If we are cross-compiling GNAT, we may as well do the same.
     gnat-bootstrap =
-      if stdenv.hostPlatform == stdenv.targetPlatform
-         && stdenv.buildPlatform == stdenv.hostPlatform
+      if (lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform)
+         && (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
       then buildPackages.gnat-bootstrap12
       else buildPackages.gnat13;
     stdenv =
-      if stdenv.hostPlatform == stdenv.targetPlatform
-         && stdenv.buildPlatform == stdenv.hostPlatform
+      if (lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform)
+         && (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
          && stdenv.buildPlatform.isDarwin
          && stdenv.buildPlatform.isx86_64
       then overrideCC stdenv gnat-bootstrap12
@@ -15743,13 +15743,13 @@ with pkgs;
     # should be done with a (native) compiler of the same version.
     # If we are cross-compiling GNAT, we may as well do the same.
     gnat-bootstrap =
-      if stdenv.hostPlatform == stdenv.targetPlatform
-         && stdenv.buildPlatform == stdenv.hostPlatform
+      if (lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform)
+         && (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
       then buildPackages.gnat-bootstrap12
       else buildPackages.gnat13;
     stdenv =
-      if stdenv.hostPlatform == stdenv.targetPlatform
-         && stdenv.buildPlatform == stdenv.hostPlatform
+      if (lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform)
+         && (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)
          && stdenv.buildPlatform.isDarwin
          && stdenv.buildPlatform.isx86_64
       then overrideCC stdenv gnat-bootstrap12
@@ -16969,8 +16969,8 @@ with pkgs;
     , ...
     } @ extraArgs:
       callPackage ../build-support/cc-wrapper (let self = {
-    nativeTools = stdenv.targetPlatform == stdenv.hostPlatform && stdenv.cc.nativeTools or false;
-    nativeLibc = stdenv.targetPlatform == stdenv.hostPlatform && stdenv.cc.nativeLibc or false;
+    nativeTools = (lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform) && stdenv.cc.nativeTools or false;
+    nativeLibc = (lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform) && stdenv.cc.nativeLibc or false;
     nativePrefix = stdenv.cc.nativePrefix or "";
     noLibc = !self.nativeLibc && (self.libc == null);
 
@@ -16986,12 +16986,12 @@ with pkgs;
 
   wrapBintoolsWith =
     { bintools
-    , libc ? if stdenv.targetPlatform != stdenv.hostPlatform then libcCross else stdenv.cc.libc
+    , libc ? if (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform) then libcCross else stdenv.cc.libc
     , ...
     } @ extraArgs:
       callPackage ../build-support/bintools-wrapper (let self = {
-    nativeTools = stdenv.targetPlatform == stdenv.hostPlatform && stdenv.cc.nativeTools or false;
-    nativeLibc = stdenv.targetPlatform == stdenv.hostPlatform && stdenv.cc.nativeLibc or false;
+    nativeTools = (lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform) && stdenv.cc.nativeTools or false;
+    nativeLibc = (lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform) && stdenv.cc.nativeLibc or false;
     nativePrefix = stdenv.cc.nativePrefix or "";
 
     noLibc = (self.libc == null);
@@ -18107,12 +18107,12 @@ with pkgs;
   binutils-unwrapped = callPackage ../development/tools/misc/binutils {
     autoreconfHook = autoreconfHook269;
     # FHS sys dirs presumably only have stuff for the build platform
-    noSysDirs = (stdenv.targetPlatform != stdenv.hostPlatform) || noSysDirs;
+    noSysDirs = (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform) || noSysDirs;
   };
   binutils-unwrapped-all-targets = callPackage ../development/tools/misc/binutils {
     autoreconfHook = if targetPlatform.isiOS then autoreconfHook269 else autoreconfHook;
     # FHS sys dirs presumably only have stuff for the build platform
-    noSysDirs = (stdenv.targetPlatform != stdenv.hostPlatform) || noSysDirs;
+    noSysDirs = (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform) || noSysDirs;
     withAllTargets = true;
   };
   binutils = wrapBintoolsWith {
@@ -18136,7 +18136,7 @@ with pkgs;
   binutils-unwrapped_2_38 = callPackage ../development/tools/misc/binutils/2.38 {
     autoreconfHook = autoreconfHook269;
     # FHS sys dirs presumably only have stuff for the build platform
-    noSysDirs = (stdenv.targetPlatform != stdenv.hostPlatform) || noSysDirs;
+    noSysDirs = (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform) || noSysDirs;
   };
 
   libbfd_2_38 = callPackage ../development/tools/misc/binutils/2.38/libbfd.nix {
@@ -18461,7 +18461,7 @@ with pkgs;
 
   # This is for e.g. LLVM libraries on linux.
   gccForLibs =
-    if stdenv.targetPlatform == stdenv.hostPlatform && targetPackages.stdenv.cc.isGNU
+    if (lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform) && targetPackages.stdenv.cc.isGNU
     # Can only do this is in the native case, otherwise we might get infinite
     # recursion if `targetPackages.stdenv.cc.cc` itself uses `gccForLibs`.
       then targetPackages.stdenv.cc.cc
@@ -21015,7 +21015,7 @@ with pkgs;
     else if name == "relibc" then targetPackages.relibc or relibc
     else throw "Unknown libc ${name}";
 
-  libcCross = assert stdenv.targetPlatform != stdenv.buildPlatform; libcCrossChooser stdenv.targetPlatform.libc;
+  libcCross = assert (!lib.systems.equals stdenv.targetPlatform stdenv.buildPlatform); libcCrossChooser stdenv.targetPlatform.libc;
 
   threadsCross =
     lib.optionalAttrs (stdenv.targetPlatform.isMinGW && !(stdenv.targetPlatform.useLLVM or false)) {
@@ -22463,7 +22463,7 @@ with pkgs;
   # just in case you want it regardless of platform.
   libiconv =
     if lib.elem stdenv.hostPlatform.libc [ "glibc" "musl" "nblibc" "wasilibc" "fblibc" ]
-      then libcIconv (if stdenv.hostPlatform != stdenv.buildPlatform
+      then libcIconv (if (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
         then libcCross
         else stdenv.cc.libc)
     else if stdenv.hostPlatform.isDarwin
@@ -25279,7 +25279,7 @@ with pkgs;
 
   ### DEVELOPMENT / PERL MODULES
 
-  perlInterpreters = import ../development/interpreters/perl { inherit callPackage; };
+  perlInterpreters = import ../development/interpreters/perl { inherit callPackage lib; };
   inherit (perlInterpreters) perl536 perl538;
 
   perl536Packages = recurseIntoAttrs perl536.pkgs;

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -11,7 +11,7 @@ let
   #
   # TODO(@Ericson2314) Make unconditional, or optional but always true by
   # default.
-  targetPrefix = lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform)
+  targetPrefix = lib.optionalString (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform)
                                         (stdenv.targetPlatform.config + "-");
 
   # Bootstrap `fetchurl` needed to build SDK packages without causing an infinite recursion.
@@ -89,7 +89,7 @@ impure-cmds // appleSourcePackages // chooseLibs // {
 
   binutils = pkgs.wrapBintoolsWith {
     libc =
-      if stdenv.targetPlatform != stdenv.hostPlatform
+      if (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform)
       then pkgs.libcCross
       else pkgs.stdenv.cc.libc;
     bintools = self.binutils-unwrapped;
@@ -103,7 +103,7 @@ impure-cmds // appleSourcePackages // chooseLibs // {
 
   binutilsDualAs = pkgs.wrapBintoolsWith {
     libc =
-      if stdenv.targetPlatform != stdenv.hostPlatform
+      if (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform)
       then pkgs.libcCross
       else pkgs.stdenv.cc.libc;
     bintools = self.binutilsDualAs-unwrapped;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9395,7 +9395,7 @@ with self; {
       hash = "sha256-TH1g4m2iwH8Fik40UCHpJQUnOzPJVCIVl34IRhHwns8=";
     };
     buildInputs = [ FCGIClient ];
-    postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    postPatch = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
       sed -i '/use IO::File/d' Makefile.PL
     '';
     meta = {
@@ -13360,7 +13360,7 @@ with self; {
       hash = "sha256-34tRQ9mn3pnEe1XxoXC9H2n3EZNcGGptwKtW3QV1jjU=";
     };
     # Do not abort cross-compilation on failure to load native JSON module into host perl
-    preConfigure = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    preConfigure = lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
       substituteInPlace Makefile.PL --replace "exit 0;" ""
     '';
     buildInputs = [ TestPod ];
@@ -14690,7 +14690,7 @@ with self; {
       export NO_NETWORK_TESTING=1
     '';
     # support cross-compilation by avoiding using `has_module` which does not work in miniperl (it requires B native module)
-    postPatch = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    postPatch = lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
       substituteInPlace Makefile.PL --replace 'if has_module' 'if 0; #'
     '';
     doCheck = !stdenv.isDarwin;
@@ -16035,11 +16035,11 @@ with self; {
       url = "mirror://cpan/authors/id/L/LE/LEONT/Module-Build-0.4234.tar.gz";
       hash = "sha256-Zq6sYSdBi+XkcerTdEZIx2a9AUgoJcW2ZlJnXyvIao8=";
     };
-    postConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    postConfigure = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
       # for unknown reason, the first run of Build fails
       ./Build || true
     '';
-    postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    postPatch = lib.optionalString (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) ''
       # remove version check since miniperl uses a stub of File::Temp, which do not provide a version:
       # https://github.com/arsv/perl-cross/blob/master/cnf/stub/File/Temp.pm
       sed -i '/File::Temp/d' \
@@ -24274,7 +24274,7 @@ with self; {
   };
 
   TermReadKey = let
-    cross = stdenv.hostPlatform != stdenv.buildPlatform;
+    cross = (!lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform);
   in buildPerlPackage {
     pname = "TermReadKey";
     version = "2.38";
@@ -28660,7 +28660,7 @@ with self; {
       hash = "sha256-0zEzJJHFHMz7TLlP/ET5zXM3jmGEmNSjffngQ2YcUV0=";
     };
     patches = [ ../development/perl-modules/xml-parser-0001-HACK-Assumes-Expat-paths-are-good.patch ];
-    postPatch = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    postPatch = lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
       substituteInPlace Expat/Makefile.PL --replace 'use English;' '#'
     '' + lib.optionalString stdenv.isCygwin ''
       sed -i"" -e "s@my \$compiler = File::Spec->catfile(\$path, \$cc\[0\]) \. \$Config{_exe};@my \$compiler = File::Spec->catfile(\$path, \$cc\[0\]) \. (\$^O eq 'cygwin' ? \"\" : \$Config{_exe});@" inc/Devel/CheckLib.pm

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -210,7 +210,7 @@ let
       overlays = [ (self': super': {
         pkgsMusl = super';
       })] ++ overlays;
-      ${if stdenv.hostPlatform == stdenv.buildPlatform
+      ${if (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
         then "localSystem" else "crossSystem"} = {
         parsed = makeMuslParsedPlatform stdenv.hostPlatform.parsed;
       };
@@ -222,7 +222,7 @@ let
       overlays = [ (self': super': {
         pkgsi686Linux = super';
       })] ++ overlays;
-      ${if stdenv.hostPlatform == stdenv.buildPlatform
+      ${if (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform)
         then "localSystem" else "crossSystem"} = {
         parsed = stdenv.hostPlatform.parsed // {
           cpu = lib.systems.parse.cpuTypes.i686;


### PR DESCRIPTION
## Description of changes

https://github.com/NixOS/nixpkgs/blob/3f84a279f1a6290ce154c5531378acc827836fbb/lib/systems/default.nix#L30-L46

```
nix-repl> (lib.systems.elaborate { system = "x86_64-linux"; }) ==  (lib.systems.elaborate { config = "x86_64-unknown-linux-gnu"; })
false

nix-repl> lib.systems.equals (lib.systems.elaborate { system = "x86_64-linux"; }) (lib.systems.elaborate { config = "x86_64-unknown-linux-gnu"; })
true

nix-repl> lib.systems.equals (lib.systems.elaborate { system = "x86_64-linux"; }) stdenv.buildPlatform
true

nix-repl> (lib.systems.elaborate { system = "x86_64-linux"; }) == stdenv.buildPlatform
false

nix-repl> lib.systems.equals (lib.systems.elaborate { system = "x86_64-linux"; }) stdenv.buildPlatform
true
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
