### PR TITLE
mk-python-derivation: add pythonRelaxDepsHook

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -1315,9 +1315,6 @@ we can do:
 
 ```nix
 {
-  nativeBuildInputs = [
-    pythonRelaxDepsHook
-  ];
   pythonRelaxDeps = [
     "pkg1"
     "pkg3"
@@ -1340,7 +1337,6 @@ example:
 
 ```nix
 {
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
   pythonRelaxDeps = true;
 }
 ```
@@ -1362,8 +1358,11 @@ instead of a dev dependency).
 Keep in mind that while the examples above are done with `requirements.txt`,
 `pythonRelaxDepsHook` works by modifying the resulting wheel file, so it should
 work with any of the [existing hooks](#setup-hooks).
-It indicates that `pythonRelaxDepsHook` has no effect on build time dependencies, such as in `build-system`.
-If a package requires incompatible build time dependencies, they should be removed in `postPatch` with `substituteInPlace` or something similar.
+
+The `pythonRelaxDepsHook` has no effect on build time dependencies, such as
+those specified in `build-system`. If a package requires incompatible build
+time dependencies, they should be removed in `postPatch` through
+`substituteInPlace` or similar.
 
 #### Using unittestCheckHook {#using-unittestcheckhook}
 

--- a/pkgs/applications/audio/ledfx/default.nix
+++ b/pkgs/applications/audio/ledfx/default.nix
@@ -26,7 +26,6 @@ python3.pkgs.buildPythonPackage rec {
     poetry-core
   ];
 
-  nativeBuildInputs = with python3.pkgs; [ pythonRelaxDepsHook ];
 
   dependencies = with python3.pkgs; [
     aiohttp

--- a/pkgs/applications/audio/puddletag/default.nix
+++ b/pkgs/applications/audio/puddletag/default.nix
@@ -45,7 +45,6 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   nativeBuildInputs = [
-    python3.pkgs.pythonRelaxDepsHook
     wrapQtAppsHook
   ];
 

--- a/pkgs/applications/backup/unifi-protect-backup/default.nix
+++ b/pkgs/applications/backup/unifi-protect-backup/default.nix
@@ -40,7 +40,6 @@ python.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python.pkgs; [

--- a/pkgs/applications/file-managers/browsr/default.nix
+++ b/pkgs/applications/file-managers/browsr/default.nix
@@ -18,7 +18,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     hatchling
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/applications/misc/archivy/default.nix
+++ b/pkgs/applications/misc/archivy/default.nix
@@ -32,7 +32,6 @@ buildPythonApplication rec {
     hash = "sha256-ns1Y0DqqnTAQMEt+oBJ/P2gqKqPsX9P3/Z4561qzuns";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRelaxDeps = true;
 

--- a/pkgs/applications/misc/dbx/default.nix
+++ b/pkgs/applications/misc/dbx/default.nix
@@ -30,7 +30,6 @@ python.pkgs.buildPythonApplication rec {
 
   build-system = with python.pkgs; [ setuptools ];
 
-  nativeBuildInputs = with python.pkgs; [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs =
     with python.pkgs;

--- a/pkgs/applications/misc/pysentation/default.nix
+++ b/pkgs/applications/misc/pysentation/default.nix
@@ -17,7 +17,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     setuptools
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/applications/misc/shell-genie/default.nix
+++ b/pkgs/applications/misc/shell-genie/default.nix
@@ -25,10 +25,6 @@ buildPythonPackage rec {
     poetry-core
   ];
 
-  nativeBuildInputs = [
-    pythonRelaxDepsHook
-  ];
-
   dependencies = [
     colorama
     openai

--- a/pkgs/applications/misc/snagboot/default.nix
+++ b/pkgs/applications/misc/snagboot/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, pythonRelaxDepsHook
 , python3
 , snagboot
 , testers
@@ -21,7 +20,6 @@ python3.pkgs.buildPythonApplication rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
   ];
 
   pythonRemoveDeps = [

--- a/pkgs/applications/misc/yubioath-flutter/helper.nix
+++ b/pkgs/applications/misc/yubioath-flutter/helper.nix
@@ -4,7 +4,6 @@
 , zxing-cpp
 , pillow
 , poetry-core
-, pythonRelaxDepsHook
 
 , src
 , version
@@ -21,7 +20,6 @@ buildPythonApplication {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = true;

--- a/pkgs/applications/networking/cluster/tftui/default.nix
+++ b/pkgs/applications/networking/cluster/tftui/default.nix
@@ -24,7 +24,6 @@ python3.pkgs.buildPythonApplication rec {
   nativeBuildInputs = with python3.pkgs; [
     makeWrapper
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/applications/networking/dyndns/dyndnsc/default.nix
+++ b/pkgs/applications/networking/dyndns/dyndnsc/default.nix
@@ -24,7 +24,6 @@ python3Packages.buildPythonApplication rec {
 
   build-system = with python3Packages; [ setuptools ];
 
-  nativeBuildInputs = with python3Packages; [ pythonRelaxDepsHook ];
 
   dependencies = with python3Packages; [
     daemonocle

--- a/pkgs/applications/networking/errbot/default.nix
+++ b/pkgs/applications/networking/errbot/default.nix
@@ -16,10 +16,6 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-BmHChLWWnrtg0p4WH8bANwpo+p4RTwjYbXfyPnz6mp8=";
   };
 
-  nativeBuildInputs = with python3.pkgs; [
-    pythonRelaxDepsHook
-  ];
-
   pythonRelaxDeps = true;
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/applications/networking/instant-messengers/pantalaimon/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pantalaimon/default.nix
@@ -24,7 +24,6 @@ python3Packages.buildPythonApplication rec {
     installShellFiles
   ] ++ (with python3Packages; [
     setuptools
-    pythonRelaxDepsHook
   ]);
 
   pythonRelaxDeps = [

--- a/pkgs/applications/networking/p2p/pyrosimple/default.nix
+++ b/pkgs/applications/networking/p2p/pyrosimple/default.nix
@@ -27,7 +27,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/applications/science/math/sage/sagelib.nix
+++ b/pkgs/applications/science/math/sage/sagelib.nix
@@ -6,7 +6,6 @@
 , perl
 , pkg-config
 , sage-setup
-, pythonRelaxDepsHook
 , gd
 , iml
 , libpng
@@ -103,7 +102,6 @@ buildPythonPackage rec {
     pip # needed to query installed packages
     pkg-config
     sage-setup
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/applications/version-management/commitizen/default.nix
+++ b/pkgs/applications/version-management/commitizen/default.nix
@@ -29,7 +29,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
     installShellFiles
   ];
 

--- a/pkgs/applications/version-management/gitless/default.nix
+++ b/pkgs/applications/version-management/gitless/default.nix
@@ -15,7 +15,6 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-XDB1i2b1reMCM6i1uK3IzTnsoLXO7jldYtNlYUo1AoQ=";
   };
 
-  nativeBuildInputs = [ python3.pkgs.pythonRelaxDepsHook ];
 
   propagatedBuildInputs = with python3.pkgs; [
     pygit2

--- a/pkgs/applications/video/animdl/default.nix
+++ b/pkgs/applications/video/animdl/default.nix
@@ -2,7 +2,6 @@
   buildPythonApplication,
   fetchFromGitHub,
   poetry-core,
-  pythonRelaxDepsHook,
   anchor-kr,
   anitopy,
   click,
@@ -47,7 +46,6 @@ buildPythonApplication {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
   propagatedBuildInputs = [
     anchor-kr

--- a/pkgs/by-name/ad/ad-miner/package.nix
+++ b/pkgs/by-name/ad/ad-miner/package.nix
@@ -22,10 +22,6 @@ python3.pkgs.buildPythonApplication rec {
     poetry-core
   ];
 
-  nativeBuildInputs = with python3.pkgs; [
-    pythonRelaxDepsHook
-  ];
-
   dependencies = with python3.pkgs; [
     neo4j
     numpy

--- a/pkgs/by-name/ai/airlift/package.nix
+++ b/pkgs/by-name/ai/airlift/package.nix
@@ -27,7 +27,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = [
     python3.pkgs.poetry-core
-    python3.pkgs.pythonRelaxDepsHook
   ];
 
   buildInputs = [

--- a/pkgs/by-name/au/audible-cli/package.nix
+++ b/pkgs/by-name/au/audible-cli/package.nix
@@ -13,7 +13,6 @@ python3Packages.buildPythonApplication rec {
   };
 
   nativeBuildInputs = with python3Packages; [
-    pythonRelaxDepsHook
     setuptools
   ] ++ [
     installShellFiles

--- a/pkgs/by-name/au/audiness/package.nix
+++ b/pkgs/by-name/au/audiness/package.nix
@@ -23,7 +23,6 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = with python3.pkgs; [ poetry-core ];
 
-  nativeBuildInputs = with python3.pkgs; [ pythonRelaxDepsHook ];
 
   dependencies =
     with python3.pkgs;

--- a/pkgs/by-name/aw/aws-gate/package.nix
+++ b/pkgs/by-name/aw/aws-gate/package.nix
@@ -27,7 +27,6 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = [
     installShellFiles
-    python3Packages.pythonRelaxDepsHook
     python3Packages.setuptools
     python3Packages.wheel
   ];

--- a/pkgs/by-name/ba/backgroundremover/package.nix
+++ b/pkgs/by-name/ba/backgroundremover/package.nix
@@ -32,7 +32,7 @@ let
         --replace 'os.path.expanduser(os.path.join("~", ".u2net", model_name + ".pth"))' "os.path.join(\"$models\", model_name + \".pth\")"
     '';
 
-    nativeBuildInputs = [ p.setuptools p.wheel p.pythonRelaxDepsHook ];
+    nativeBuildInputs = [ p.setuptools p.wheel ];
 
     pythonRelaxDeps = [ "pillow" "torchvision" ];
 

--- a/pkgs/by-name/ch/charmcraft/package.nix
+++ b/pkgs/by-name/ch/charmcraft/package.nix
@@ -45,7 +45,6 @@ python3Packages.buildPythonApplication rec {
   ];
 
   nativeBuildInputs = with python3Packages; [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/by-name/co/corrscope/package.nix
+++ b/pkgs/by-name/co/corrscope/package.nix
@@ -26,7 +26,6 @@ python3Packages.buildPythonApplication rec {
     wrapQtAppsHook
   ]) ++ (with python3Packages; [
     poetry-core
-    pythonRelaxDepsHook
   ]);
 
   buildInputs = [

--- a/pkgs/by-name/cu/cups-printers/package.nix
+++ b/pkgs/by-name/cu/cups-printers/package.nix
@@ -23,7 +23,6 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = with python3.pkgs; [ poetry-core ];
 
-  nativeBuildInputs = with python3.pkgs; [ pythonRelaxDepsHook ];
 
   dependencies =
     with python3.pkgs;

--- a/pkgs/by-name/do/donpapi/package.nix
+++ b/pkgs/by-name/do/donpapi/package.nix
@@ -23,7 +23,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/by-name/do/dooit/package.nix
+++ b/pkgs/by-name/do/dooit/package.nix
@@ -20,7 +20,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/by-name/gc/gcp-scanner/package.nix
+++ b/pkgs/by-name/gc/gcp-scanner/package.nix
@@ -20,7 +20,6 @@ python3.pkgs.buildPythonApplication rec {
   nativeBuildInputs = with python3.pkgs; [
     setuptools
     setuptools-git-versioning
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/by-name/gh/ghunt/package.nix
+++ b/pkgs/by-name/gh/ghunt/package.nix
@@ -18,7 +18,6 @@ python3.pkgs.buildPythonApplication rec {
   pythonRelaxDeps = true;
 
   nativeBuildInputs = with python3.pkgs; [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/by-name/ha/ha-mqtt-discoverable-cli/package.nix
+++ b/pkgs/by-name/ha/ha-mqtt-discoverable-cli/package.nix
@@ -20,7 +20,6 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = with python3.pkgs; [ poetry-core ];
 
-  nativeBuildInputs = with python3.pkgs; [ pythonRelaxDepsHook ];
 
   dependencies = with python3.pkgs; [ ha-mqtt-discoverable ];
 

--- a/pkgs/by-name/he/hekatomb/package.nix
+++ b/pkgs/by-name/he/hekatomb/package.nix
@@ -21,7 +21,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/by-name/ho/homeassistant-satellite/package.nix
+++ b/pkgs/by-name/ho/homeassistant-satellite/package.nix
@@ -16,7 +16,6 @@ python3.pkgs.buildPythonApplication rec {
   };
 
   nativeBuildInputs = with python3.pkgs; [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/by-name/ic/icloudpd/package.nix
+++ b/pkgs/by-name/ic/icloudpd/package.nix
@@ -20,10 +20,6 @@ python3Packages.buildPythonApplication rec {
 
   pythonRelaxDeps = true;
 
-  nativeBuildInputs = with python3Packages; [
-    pythonRelaxDepsHook
-  ];
-
   propagatedBuildInputs = with python3Packages; [
     wheel
     setuptools

--- a/pkgs/by-name/ir/irrd/package.nix
+++ b/pkgs/by-name/ir/irrd/package.nix
@@ -76,7 +76,6 @@ py.pkgs.buildPythonPackage rec {
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   nativeCheckInputs = [

--- a/pkgs/by-name/ki/kikit/solidpython/default.nix
+++ b/pkgs/by-name/ki/kikit/solidpython/default.nix
@@ -2,7 +2,6 @@
 { buildPythonPackage
 , fetchFromGitHub
 , lib
-, pythonRelaxDepsHook
 
 , poetry-core
 , prettytable
@@ -24,7 +23,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/ko/koodousfinder/package.nix
+++ b/pkgs/by-name/ko/koodousfinder/package.nix
@@ -22,7 +22,6 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = with python3.pkgs; [ poetry-core ];
 
-  nativeBuildInputs = with python3.pkgs; [ pythonRelaxDepsHook ];
 
   dependencies = with python3.pkgs; [
     keyring

--- a/pkgs/by-name/kr/krbjack/package.nix
+++ b/pkgs/by-name/kr/krbjack/package.nix
@@ -23,7 +23,6 @@ python3.pkgs.buildPythonApplication rec {
     poetry-core
   ];
 
-  nativeBuildInputs = with python3.pkgs; [ pythonRelaxDepsHook ];
 
   dependencies = with python3.pkgs; [
     colorama

--- a/pkgs/by-name/ma/malwoverview/package.nix
+++ b/pkgs/by-name/ma/malwoverview/package.nix
@@ -19,10 +19,6 @@ python3.pkgs.buildPythonApplication rec {
     "pathlib"
   ];
 
-  nativeBuildInputs = with python3.pkgs; [
-    pythonRelaxDepsHook
-  ];
-
   build-system  = with python3.pkgs; [
     setuptools
   ];

--- a/pkgs/by-name/me/mealie/package.nix
+++ b/pkgs/by-name/me/mealie/package.nix
@@ -39,7 +39,6 @@ in pythonpkgs.buildPythonPackage rec {
 
   nativeBuildInputs = [
     pythonpkgs.poetry-core
-    pythonpkgs.pythonRelaxDepsHook
     makeWrapper
   ];
 

--- a/pkgs/by-name/mo/mokuro/package.nix
+++ b/pkgs/by-name/mo/mokuro/package.nix
@@ -22,7 +22,6 @@ python3Packages.buildPythonApplication rec {
         --replace-fail 'opencv-python' 'opencv'
   '';
 
-  nativeBuildInputs = with python3Packages; [ pythonRelaxDepsHook ];
 
   pythonRelaxDeps = [ "torchvision" ];
 

--- a/pkgs/by-name/mo/mov-cli/package.nix
+++ b/pkgs/by-name/mo/mov-cli/package.nix
@@ -35,10 +35,6 @@ python3.pkgs.buildPythonPackage {
     tldextract
   ];
 
-  nativeBuildInputs = [
-    python3.pkgs.pythonRelaxDepsHook
-  ];
-
   pythonRelaxDeps = [
     "httpx"
     "tldextract"

--- a/pkgs/by-name/ng/nginx-language-server/package.nix
+++ b/pkgs/by-name/ng/nginx-language-server/package.nix
@@ -17,7 +17,6 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/by-name/no/normcap/package.nix
+++ b/pkgs/by-name/no/normcap/package.nix
@@ -52,7 +52,6 @@ ps.buildPythonApplication rec {
   ];
 
   nativeBuildInputs = [
-    ps.pythonRelaxDepsHook
     ps.hatchling
     ps.babel
   ];

--- a/pkgs/by-name/on/onthespot/package.nix
+++ b/pkgs/by-name/on/onthespot/package.nix
@@ -20,7 +20,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     copyDesktopItems
-    pythonRelaxDepsHook
     libsForQt5.wrapQtAppsHook
   ];
 

--- a/pkgs/by-name/op/open-webui/package.nix
+++ b/pkgs/by-name/op/open-webui/package.nix
@@ -117,7 +117,6 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = with python3.pkgs; [ hatchling ];
 
-  nativeBuildInputs = [ python3.pkgs.pythonRelaxDepsHook ];
 
   pythonImportsCheck = [ "open_webui" ];
 

--- a/pkgs/by-name/ot/oterm/package.nix
+++ b/pkgs/by-name/ot/oterm/package.nix
@@ -27,7 +27,6 @@ python3Packages.buildPythonApplication rec {
 
   build-system = with python3Packages; [ poetry-core ];
 
-  nativeBuildInputs = with python3Packages; [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = with python3Packages; [
     aiohttp

--- a/pkgs/by-name/pa/pacu/package.nix
+++ b/pkgs/by-name/pa/pacu/package.nix
@@ -32,7 +32,6 @@ python.pkgs.buildPythonApplication rec {
 
   build-system = with python.pkgs; [ poetry-core ];
 
-  nativeBuildInputs = with python.pkgs; [ pythonRelaxDepsHook ];
 
   dependencies =
     [ awscli ]

--- a/pkgs/by-name/pr/pre2k/package.nix
+++ b/pkgs/by-name/pr/pre2k/package.nix
@@ -24,7 +24,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/by-name/pr/pretalx/package.nix
+++ b/pkgs/by-name/pr/pretalx/package.nix
@@ -91,7 +91,6 @@ python.pkgs.buildPythonApplication rec {
   nativeBuildInputs = [
     gettext
   ] ++ (with python.pkgs; [
-    pythonRelaxDepsHook
     setuptools
   ]);
 

--- a/pkgs/by-name/pr/prowler/package.nix
+++ b/pkgs/by-name/pr/prowler/package.nix
@@ -33,10 +33,6 @@ python3.pkgs.buildPythonApplication rec {
     "slack-sdk"
   ];
 
-  nativeBuildInputs = with python3.pkgs; [
-    pythonRelaxDepsHook
-  ];
-
   build-system = with python3.pkgs; [
     poetry-core
   ];

--- a/pkgs/by-name/py/pysqlrecon/package.nix
+++ b/pkgs/by-name/py/pysqlrecon/package.nix
@@ -22,7 +22,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/by-name/ra/rabbit/package.nix
+++ b/pkgs/by-name/ra/rabbit/package.nix
@@ -20,7 +20,6 @@ python3.pkgs.buildPythonApplication rec {
   build-system = [
     python3.pkgs.setuptools
     python3.pkgs.wheel
-    python3.pkgs.pythonRelaxDepsHook
   ];
 
   dependencies = with python3.pkgs; [

--- a/pkgs/by-name/rc/rclip/package.nix
+++ b/pkgs/by-name/rc/rclip/package.nix
@@ -27,7 +27,7 @@ python3Packages.buildPythonApplication rec {
     tqdm
   ];
 
-  nativeCheckInputs = with python3Packages; [ pytestCheckHook pythonRelaxDepsHook ];
+  nativeCheckInputs = with python3Packages; [ pytestCheckHook ];
 
   pythonRelaxDeps = [ "torch" "torchvision" ];
 

--- a/pkgs/by-name/rd/rdwatool/package.nix
+++ b/pkgs/by-name/rd/rdwatool/package.nix
@@ -24,7 +24,6 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   nativeBuildInputs = with python3.pkgs; [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/by-name/re/retool/package.nix
+++ b/pkgs/by-name/re/retool/package.nix
@@ -21,7 +21,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     hatchling
-    pythonRelaxDepsHook
     qt6.wrapQtAppsHook
   ];
 

--- a/pkgs/by-name/ro/route-graph/package.nix
+++ b/pkgs/by-name/ro/route-graph/package.nix
@@ -25,10 +25,6 @@ python3.pkgs.buildPythonApplication rec {
     poetry-core
   ];
 
-  nativeBuildInputs = with python3.pkgs; [
-    pythonRelaxDepsHook
-  ];
-
   propagatedBuildInputs = [
     graphviz
   ] ++ (with python3.pkgs; [

--- a/pkgs/by-name/sh/shell-gpt/package.nix
+++ b/pkgs/by-name/sh/shell-gpt/package.nix
@@ -26,7 +26,6 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = with python3.pkgs; [ hatchling ];
 
-  nativeBuildInputs = with python3.pkgs; [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = with python3.pkgs; [
     click

--- a/pkgs/by-name/sm/smassh/package.nix
+++ b/pkgs/by-name/sm/smassh/package.nix
@@ -19,7 +19,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/by-name/sn/snapcraft/package.nix
+++ b/pkgs/by-name/sn/snapcraft/package.nix
@@ -105,7 +105,6 @@ python3Packages.buildPythonApplication rec {
   ];
 
   nativeBuildInputs = with python3Packages; [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/by-name/st/streamdeck-ui/package.nix
+++ b/pkgs/by-name/st/streamdeck-ui/package.nix
@@ -40,7 +40,6 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = [
     python3Packages.poetry-core
-    python3Packages.pythonRelaxDepsHook
     copyDesktopItems
     qt6.wrapQtAppsHook
     wrapGAppsHook3

--- a/pkgs/by-name/st/strictdoc/package.nix
+++ b/pkgs/by-name/st/strictdoc/package.nix
@@ -17,7 +17,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = [
     python3.pkgs.hatchling
-    python3.pkgs.pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/by-name/tb/tbump/package.nix
+++ b/pkgs/by-name/tb/tbump/package.nix
@@ -18,7 +18,6 @@ python3Packages.buildPythonApplication rec {
 
   pythonRelaxDeps = [ "tomlkit" ];
 
-  nativeBuildInputs = with python3Packages; [ pythonRelaxDepsHook ];
 
   build-system = with python3Packages; [ poetry-core ];
 

--- a/pkgs/by-name/tr/troubadix/package.nix
+++ b/pkgs/by-name/tr/troubadix/package.nix
@@ -21,7 +21,6 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = with python3.pkgs; [ poetry-core ];
 
-  nativeBuildInputs = with python3.pkgs; [ pythonRelaxDepsHook ];
 
   dependencies = with python3.pkgs; [
     chardet

--- a/pkgs/by-name/tu/tunnelgraf/package.nix
+++ b/pkgs/by-name/tu/tunnelgraf/package.nix
@@ -22,7 +22,6 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = with python3.pkgs; [
     hatchling
-    pythonRelaxDepsHook
   ];
 
   dependencies = with python3.pkgs; [

--- a/pkgs/by-name/tw/twitch-dl/package.nix
+++ b/pkgs/by-name/tw/twitch-dl/package.nix
@@ -24,7 +24,6 @@ python3Packages.buildPythonApplication rec {
   nativeBuildInputs = [
     python3Packages.setuptools
     python3Packages.setuptools-scm
-    python3Packages.pythonRelaxDepsHook
     installShellFiles
     scdoc
   ];

--- a/pkgs/by-name/un/unsilence/package.nix
+++ b/pkgs/by-name/un/unsilence/package.nix
@@ -17,7 +17,6 @@ python3Packages.buildPythonPackage rec {
 
   nativeBuildInputs = with python3Packages; [
     rich
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/up/upiano/package.nix
+++ b/pkgs/by-name/up/upiano/package.nix
@@ -23,7 +23,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/by-name/uw/uwhoisd/package.nix
+++ b/pkgs/by-name/uw/uwhoisd/package.nix
@@ -22,7 +22,6 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/by-name/vu/vunnel/package.nix
+++ b/pkgs/by-name/vu/vunnel/package.nix
@@ -22,7 +22,6 @@ python3.pkgs.buildPythonApplication rec {
     "sqlalchemy"
   ];
 
-  nativeBuildInputs = with python3.pkgs; [ pythonRelaxDepsHook ];
 
   build-system = with python3.pkgs; [
     poetry-core

--- a/pkgs/by-name/wi/witnessme/package.nix
+++ b/pkgs/by-name/wi/witnessme/package.nix
@@ -28,10 +28,6 @@ python3.pkgs.buildPythonApplication rec {
 
   pythonRelaxDeps = true;
 
-  nativeBuildInputs = with python3.pkgs; [
-    pythonRelaxDepsHook
-  ];
-
   build-system = with python3.pkgs; [
     poetry-core
   ];

--- a/pkgs/by-name/ws/wsrepl/package.nix
+++ b/pkgs/by-name/ws/wsrepl/package.nix
@@ -19,10 +19,6 @@ python3.pkgs.buildPythonApplication rec {
     "textual"
   ];
 
-  nativeBuildInputs = with python3.pkgs; [
-    pythonRelaxDepsHook
-  ];
-
   build-system = with python3.pkgs; [
     poetry-core
   ];

--- a/pkgs/by-name/wt/wtfis/package.nix
+++ b/pkgs/by-name/wt/wtfis/package.nix
@@ -17,10 +17,6 @@ in python3.pkgs.buildPythonApplication {
 
   format = "pyproject";
 
-  nativeBuildInputs = [
-    python3.pkgs.pythonRelaxDepsHook
-  ];
-
   propagatedBuildInputs = [
     python3.pkgs.hatchling
     python3.pkgs.pydantic

--- a/pkgs/by-name/wy/wyoming-satellite/package.nix
+++ b/pkgs/by-name/wy/wyoming-satellite/package.nix
@@ -17,7 +17,6 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = with python3Packages; [
     setuptools
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/desktops/gnome/misc/gnome-extensions-cli/default.nix
+++ b/pkgs/desktops/gnome/misc/gnome-extensions-cli/default.nix
@@ -1,7 +1,6 @@
 { lib
 , fetchPypi
 , buildPythonApplication
-, pythonRelaxDepsHook
 , poetry-core
 , colorama
 , packaging
@@ -28,7 +27,6 @@ buildPythonApplication rec {
     gobject-introspection
     poetry-core
     wrapGAppsNoGuiHook
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/compilers/vyper/default.nix
+++ b/pkgs/development/compilers/vyper/default.nix
@@ -9,7 +9,6 @@
 , pycryptodome
 , pytest-runner
 , pythonOlder
-, pythonRelaxDepsHook
 , recommonmark
 , setuptools-scm
 , sphinx
@@ -50,7 +49,6 @@ buildPythonPackage rec {
     # ever since https://github.com/vyperlang/vyper/pull/2816
     git
 
-    pythonRelaxDepsHook
     pytest-runner
     setuptools-scm
   ];

--- a/pkgs/development/embedded/platformio/core.nix
+++ b/pkgs/development/embedded/platformio/core.nix
@@ -50,7 +50,6 @@ with python3Packages; buildPythonApplication rec {
 
   nativeBuildInputs = [
     installShellFiles
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -17,6 +17,7 @@
 , pythonImportsCheckHook
 , pythonNamespacesHook
 , pythonOutputDistHook
+, pythonRelaxDepsHook
 , pythonRemoveBinBytecodeHook
 , pythonRemoveTestsDirHook
 , pythonRuntimeDepsCheckHook
@@ -252,6 +253,8 @@ let
       #    because the hook that checks for conflicts uses setuptools.
       #
       pythonCatchConflictsHook
+    ] ++ optionals (attrs ? pythonRelaxDeps || attrs ? pythonRemoveDeps) [
+      pythonRelaxDepsHook
     ] ++ optionals removeBinBytecode [
       pythonRemoveBinBytecodeHook
     ] ++ optionals (hasSuffix "zip" (attrs.src.name or "")) [

--- a/pkgs/development/python-modules/aio-geojson-generic-client/default.nix
+++ b/pkgs/development/python-modules/aio-geojson-generic-client/default.nix
@@ -9,7 +9,6 @@
   pytest-asyncio,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   pytz,
   setuptools,
 }:
@@ -31,7 +30,6 @@ buildPythonPackage rec {
   __darwinAllowLocalNetworking = true;
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/aiobiketrax/default.nix
+++ b/pkgs/development/python-modules/aiobiketrax/default.nix
@@ -10,7 +10,6 @@
   pytestCheckHook,
   python-dateutil,
   pythonOlder,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -37,7 +36,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     aiohttp

--- a/pkgs/development/python-modules/aioboto3/default.nix
+++ b/pkgs/development/python-modules/aioboto3/default.nix
@@ -13,7 +13,6 @@
   pytest-asyncio,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
 }:
 
@@ -34,7 +33,6 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     poetry-core
     poetry-dynamic-versioning
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "aiobotocore" ];

--- a/pkgs/development/python-modules/aiogram/default.nix
+++ b/pkgs/development/python-modules/aiogram/default.nix
@@ -20,7 +20,6 @@
   pytest-lazy-fixture,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   pytz,
   redis,
 }:
@@ -41,7 +40,6 @@ buildPythonPackage rec {
 
   build-system = [ hatchling ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRelaxDeps = [ "pydantic" ];
 

--- a/pkgs/development/python-modules/aiomisc-pytest/default.nix
+++ b/pkgs/development/python-modules/aiomisc-pytest/default.nix
@@ -6,7 +6,6 @@
   poetry-core,
   pytest,
   pythonOlder,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -24,7 +23,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRelaxDeps = [ "pytest" ];
 

--- a/pkgs/development/python-modules/aioopenexchangerates/default.nix
+++ b/pkgs/development/python-modules/aioopenexchangerates/default.nix
@@ -9,7 +9,6 @@
   pytest-aiohttp,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -35,7 +34,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     aiohttp

--- a/pkgs/development/python-modules/aiooss2/default.nix
+++ b/pkgs/development/python-modules/aiooss2/default.nix
@@ -8,7 +8,6 @@
   pytest-mock,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   setuptools,
   setuptools-scm,
@@ -38,7 +37,6 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     aiohttp

--- a/pkgs/development/python-modules/aiormq/default.nix
+++ b/pkgs/development/python-modules/aiormq/default.nix
@@ -4,7 +4,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
-  pythonRelaxDepsHook,
   pytestCheckHook,
   pamqp,
   yarl,
@@ -27,7 +26,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "pamqp" ];

--- a/pkgs/development/python-modules/aioxmpp/default.nix
+++ b/pkgs/development/python-modules/aioxmpp/default.nix
@@ -14,7 +14,6 @@
   pytestCheckHook,
   pythonAtLeast,
   pythonOlder,
-  pythonRelaxDepsHook,
   pytz,
   setuptools,
   sortedcollections,
@@ -41,7 +40,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     aiosasl

--- a/pkgs/development/python-modules/airtouch5py/default.nix
+++ b/pkgs/development/python-modules/airtouch5py/default.nix
@@ -6,7 +6,6 @@
 
   # build-system
   poetry-core,
-  pythonRelaxDepsHook,
 
   # dependencies
   bitarray,
@@ -31,7 +30,6 @@ buildPythonPackage rec {
   };
 
   build-system = [ poetry-core ];
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
   pythonRelaxDeps = [ "crc" ];
 
   dependencies = [

--- a/pkgs/development/python-modules/albumentations/default.nix
+++ b/pkgs/development/python-modules/albumentations/default.nix
@@ -13,7 +13,6 @@
   pydantic,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   torch,
   torchvision,
   typing-extensions,
@@ -33,7 +32,6 @@ buildPythonPackage rec {
     hash = "sha256-7t1+22zzFtkZaAyOo6xjk+MXT9N44PmQ/NRRfvLeRVk=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRemoveDeps = [
     "opencv-python"

--- a/pkgs/development/python-modules/alexapy/default.nix
+++ b/pkgs/development/python-modules/alexapy/default.nix
@@ -12,7 +12,6 @@
   poetry-core,
   pyotp,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   simplejson,
   yarl,
@@ -36,7 +35,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/aliyun-python-sdk-core/default.nix
+++ b/pkgs/development/python-modules/aliyun-python-sdk-core/default.nix
@@ -5,7 +5,6 @@
   fetchPypi,
   jmespath,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
 }:
 
@@ -25,7 +24,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     cryptography

--- a/pkgs/development/python-modules/angr/default.nix
+++ b/pkgs/development/python-modules/angr/default.nix
@@ -23,7 +23,6 @@
   pycparser,
   pyformlang,
   pythonOlder,
-  pythonRelaxDepsHook,
   pyvex,
   rich,
   rpyc,
@@ -52,7 +51,6 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "capstone" ];
 
   build-system = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/ansible/core.nix
+++ b/pkgs/development/python-modules/ansible/core.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchPypi,
   pythonOlder,
-  pythonRelaxDepsHook,
   installShellFiles,
   docutils,
   ansible,
@@ -51,7 +50,7 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     installShellFiles
     docutils
-  ] ++ lib.optionals (pythonOlder "3.10") [ pythonRelaxDepsHook ];
+  ];
 
   propagatedBuildInputs =
     [

--- a/pkgs/development/python-modules/apache-beam/default.nix
+++ b/pkgs/development/python-modules/apache-beam/default.nix
@@ -33,7 +33,6 @@
   pytestCheckHook,
   python,
   python-dateutil,
-  pythonRelaxDepsHook,
   pytz,
   pyyaml,
   regex,
@@ -96,7 +95,6 @@ buildPythonPackage rec {
     cython
     grpcio-tools
     mypy-protobuf
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/appthreat-vulnerability-db/default.nix
+++ b/pkgs/development/python-modules/appthreat-vulnerability-db/default.nix
@@ -10,7 +10,6 @@
   packageurl-python,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   semver,
   setuptools,
   tabulate,
@@ -42,7 +41,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     appdirs

--- a/pkgs/development/python-modules/argilla/default.nix
+++ b/pkgs/development/python-modules/argilla/default.nix
@@ -41,7 +41,6 @@
   python-jose,
   python-multipart,
   pythonOlder,
-  pythonRelaxDepsHook,
   pyyaml,
   rich,
   schedule,
@@ -90,7 +89,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     httpx

--- a/pkgs/development/python-modules/arsenic/default.nix
+++ b/pkgs/development/python-modules/arsenic/default.nix
@@ -7,7 +7,6 @@
   fetchpatch,
   packaging,
   poetry-core,
-  pythonRelaxDepsHook,
   pythonOlder,
   structlog,
 }:
@@ -43,7 +42,6 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = [ "structlog" ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   build-system = [ poetry-core ];
 

--- a/pkgs/development/python-modules/asf-search/default.nix
+++ b/pkgs/development/python-modules/asf-search/default.nix
@@ -9,7 +9,6 @@
   pytestCheckHook,
   python-dateutil,
   pythonOlder,
-  pythonRelaxDepsHook,
   pytz,
   remotezip,
   requests-mock,
@@ -37,7 +36,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools-scm ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     dateparser

--- a/pkgs/development/python-modules/async-tkinter-loop/default.nix
+++ b/pkgs/development/python-modules/async-tkinter-loop/default.nix
@@ -6,7 +6,6 @@
   poetry-core,
   tkinter,
   typing-extensions,
-  pythonRelaxDepsHook,
   pytestCheckHook,
 }:
 
@@ -22,7 +21,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     poetry-core
   ];
 

--- a/pkgs/development/python-modules/atomman/default.nix
+++ b/pkgs/development/python-modules/atomman/default.nix
@@ -20,7 +20,6 @@
   toolz,
   wheel,
   xmltodict,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage {
@@ -37,7 +36,6 @@ buildPythonPackage {
     hash = "sha256-WfB+OY61IPprT6OCVHl8VA60p7lLVkRGuyYX+nm7bbA=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   build-system = [
     setuptools

--- a/pkgs/development/python-modules/audio-metadata/default.nix
+++ b/pkgs/development/python-modules/audio-metadata/default.nix
@@ -10,7 +10,6 @@
   poetry-core,
   pprintpp,
   pythonOlder,
-  pythonRelaxDepsHook,
   tbm-utils,
 }:
 
@@ -44,7 +43,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     attrs

--- a/pkgs/development/python-modules/autarco/default.nix
+++ b/pkgs/development/python-modules/autarco/default.nix
@@ -10,7 +10,6 @@
   pytest-asyncio,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   syrupy,
   yarl,
 }:
@@ -40,7 +39,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/auth0-python/default.nix
+++ b/pkgs/development/python-modules/auth0-python/default.nix
@@ -13,7 +13,6 @@
   pyopenssl,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   urllib3,
 }:
@@ -35,7 +34,6 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     poetry-core
     poetry-dynamic-versioning
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/autofaiss/default.nix
+++ b/pkgs/development/python-modules/autofaiss/default.nix
@@ -9,7 +9,6 @@
   numpy,
   pyarrow,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   pythonOlder,
 }:
 
@@ -27,7 +26,6 @@ buildPythonPackage rec {
     hash = "sha256-pey3wrW7CDLMiPPKnmYrcSJqGuy6ecA2SE9m3Jtt6DU=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRemoveDeps = [
     # The `dataclasses` packages is a python2-only backport, unnecessary in

--- a/pkgs/development/python-modules/aw-core/default.nix
+++ b/pkgs/development/python-modules/aw-core/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
-  pythonRelaxDepsHook,
   poetry-core,
   jsonschema,
   peewee,
@@ -36,7 +35,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/aws-adfs/default.nix
+++ b/pkgs/development/python-modules/aws-adfs/default.nix
@@ -12,7 +12,6 @@
   pyopenssl,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   requests-kerberos,
   toml,
@@ -34,7 +33,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "configparser" ];

--- a/pkgs/development/python-modules/awswrangler/default.nix
+++ b/pkgs/development/python-modules/awswrangler/default.nix
@@ -20,7 +20,6 @@
   pyparsing,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   redshift-connector,
   requests-aws4auth,
 }:
@@ -43,7 +42,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     boto3

--- a/pkgs/development/python-modules/axisregistry/default.nix
+++ b/pkgs/development/python-modules/axisregistry/default.nix
@@ -4,7 +4,6 @@
   fetchPypi,
   fonttools,
   protobuf,
-  pythonRelaxDepsHook,
   pytestCheckHook,
   setuptools-scm,
 }:
@@ -24,7 +23,6 @@ buildPythonPackage rec {
     protobuf
   ];
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools-scm
   ];
 

--- a/pkgs/development/python-modules/b2sdk/default.nix
+++ b/pkgs/development/python-modules/b2sdk/default.nix
@@ -13,7 +13,6 @@
   pytest-mock,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   tqdm,
   typing-extensions,
@@ -35,7 +34,6 @@ buildPythonPackage rec {
 
   build-system = [ pdm-backend ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRemoveDeps = [ "setuptools" ];
 

--- a/pkgs/development/python-modules/barectf/default.nix
+++ b/pkgs/development/python-modules/barectf/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   poetry-core,
   pytest7CheckHook,
-  pythonRelaxDepsHook,
   setuptools,
   jsonschema,
   pyyaml,
@@ -26,7 +25,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/basemap/default.nix
+++ b/pkgs/development/python-modules/basemap/default.nix
@@ -12,7 +12,6 @@
   pyproj,
   pyshp,
   python,
-  pythonRelaxDepsHook,
   setuptools,
 }:
 
@@ -33,7 +32,6 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     cython
     geos
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/biopandas/default.nix
+++ b/pkgs/development/python-modules/biopandas/default.nix
@@ -9,7 +9,6 @@
   pandas,
   pynose,
   pytestCheckHook,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -24,7 +23,6 @@ buildPythonPackage rec {
     hash = "sha256-1c78baBBsDyvAWrNx5mZI/Q75wyXv0DAwAdWm3EwX/I=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRelaxDeps = [ "looseversion" ];
 

--- a/pkgs/development/python-modules/boiboite-opener-framework/default.nix
+++ b/pkgs/development/python-modules/boiboite-opener-framework/default.nix
@@ -5,7 +5,6 @@
   packaging,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   scapy,
   setuptools,
 }:

--- a/pkgs/development/python-modules/bork/default.nix
+++ b/pkgs/development/python-modules/bork/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
   build,
   coloredlogs,
@@ -29,7 +28,6 @@ buildPythonPackage rec {
   };
 
   build-system = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/boto3/default.nix
+++ b/pkgs/development/python-modules/boto3/default.nix
@@ -7,7 +7,6 @@
   pytest-xdist,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   s3transfer,
   setuptools,
 }:
@@ -27,7 +26,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -8,7 +8,6 @@
   pytestCheckHook,
   python-dateutil,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
   urllib3,
 }:
@@ -28,7 +27,6 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "urllib3" ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/botorch/default.nix
+++ b/pkgs/development/python-modules/botorch/default.nix
@@ -12,7 +12,6 @@
   torch,
   scipy,
   pytestCheckHook,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -28,7 +27,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
     setuptools-scm
     wheel

--- a/pkgs/development/python-modules/cachier/default.nix
+++ b/pkgs/development/python-modules/cachier/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   pythonOlder,
   fetchFromGitHub,
-  pythonRelaxDepsHook,
   setuptools,
   watchdog,
   portalocker,
@@ -32,7 +31,6 @@ buildPythonPackage rec {
   pythonRemoveDeps = [ "setuptools" ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/case/default.nix
+++ b/pkgs/development/python-modules/case/default.nix
@@ -4,7 +4,6 @@
   fetchPypi,
   pynose,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
   six,
 }:
@@ -23,7 +22,6 @@ buildPythonPackage rec {
 
   build-system = [
     setuptools
-    pythonRelaxDepsHook
   ];
 
   pythonRemoveDeps = [

--- a/pkgs/development/python-modules/censys/default.nix
+++ b/pkgs/development/python-modules/censys/default.nix
@@ -10,7 +10,6 @@
   pytest-mock,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   requests-mock,
   responses,
@@ -38,7 +37,6 @@ buildPythonPackage rec {
 
   build-system = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/chromadb/default.nix
+++ b/pkgs/development/python-modules/chromadb/default.nix
@@ -32,7 +32,6 @@
   pytest-asyncio,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   pyyaml,
   requests,
   rustc,
@@ -74,7 +73,6 @@ buildPythonPackage rec {
     cargo
     pkg-config
     protobuf
-    pythonRelaxDepsHook
     rustc
     rustPlatform.cargoSetupHook
     setuptools

--- a/pkgs/development/python-modules/cirq-google/default.nix
+++ b/pkgs/development/python-modules/cirq-google/default.nix
@@ -5,7 +5,6 @@
   google-api-core,
   protobuf,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   setuptools,
 }:
 
@@ -17,7 +16,6 @@ buildPythonPackage rec {
   sourceRoot = "${src.name}/${pname}";
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/ciscoconfparse/default.nix
+++ b/pkgs/development/python-modules/ciscoconfparse/default.nix
@@ -9,7 +9,6 @@
   poetry-core,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   toml,
 }:
 
@@ -43,7 +42,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/clarifai/default.nix
+++ b/pkgs/development/python-modules/clarifai/default.nix
@@ -13,7 +13,6 @@
   pypdf,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   pyyaml,
   rich,
   schema,
@@ -43,7 +42,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     clarifai-grpc

--- a/pkgs/development/python-modules/claripy/default.nix
+++ b/pkgs/development/python-modules/claripy/default.nix
@@ -7,7 +7,6 @@
   pysmt,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
   z3-solver,
 }:
@@ -30,7 +29,6 @@ buildPythonPackage rec {
   pythonRemoveDeps = [ "z3-solver" ];
 
   build-system = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/cleo/default.nix
+++ b/pkgs/development/python-modules/cleo/default.nix
@@ -6,7 +6,6 @@
   poetry-core,
   pytest-mock,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   rapidfuzz,
 }:
 
@@ -24,7 +23,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "rapidfuzz" ];

--- a/pkgs/development/python-modules/cli-ui/default.nix
+++ b/pkgs/development/python-modules/cli-ui/default.nix
@@ -3,7 +3,6 @@
   python3Packages,
   fetchPypi,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   pythonOlder,
   poetry-core,
   colorama,
@@ -24,7 +23,6 @@ python3Packages.buildPythonPackage rec {
 
   pythonRelaxDeps = [ "tabulate" ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   build-system = [ poetry-core ];
 

--- a/pkgs/development/python-modules/clickhouse-cli/default.nix
+++ b/pkgs/development/python-modules/clickhouse-cli/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonRelaxDepsHook,
   setuptools,
   click,
   prompt-toolkit,
@@ -22,7 +21,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/cmdstanpy/default.nix
+++ b/pkgs/development/python-modules/cmdstanpy/default.nix
@@ -5,7 +5,6 @@
   fetchpatch,
   substituteAll,
   cmdstan,
-  pythonRelaxDepsHook,
   setuptools,
   pandas,
   numpy,
@@ -47,7 +46,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/coinmetrics-api-client/default.nix
+++ b/pkgs/development/python-modules/coinmetrics-api-client/default.nix
@@ -9,7 +9,6 @@
   pytestCheckHook,
   python-dateutil,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   tqdm,
   typer,
@@ -35,7 +34,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/comicon/default.nix
+++ b/pkgs/development/python-modules/comicon/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   poetry-core,
-  pythonRelaxDepsHook,
   pythonOlder,
   ebooklib,
   lxml,
@@ -27,7 +26,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "pypdf" ];

--- a/pkgs/development/python-modules/conda-libmamba-solver/default.nix
+++ b/pkgs/development/python-modules/conda-libmamba-solver/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  pythonRelaxDepsHook,
   fetchFromGitHub,
   libmambapy,
   hatchling,
@@ -21,7 +20,6 @@ buildPythonPackage rec {
     hash = "sha256-vsUYrDVNMKHd3mlaAFYCP4uPQ9HxeKsose5O8InaMcE=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   build-system = [
     hatchling

--- a/pkgs/development/python-modules/conda/default.nix
+++ b/pkgs/development/python-modules/conda/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  pythonRelaxDepsHook,
   hostPlatform,
   fetchFromGitHub,
   # build dependencies
@@ -38,7 +37,6 @@ buildPythonPackage rec {
     hash = "sha256-LdoBlR5EFYd2mQIjOgp1MH3w6osfRfurPq+N5Y1iaFw=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   build-system = [
     hatchling

--- a/pkgs/development/python-modules/ctap-keyring-device/default.nix
+++ b/pkgs/development/python-modules/ctap-keyring-device/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonRelaxDepsHook,
   setuptools-scm,
   # install requirements
   fido2,
@@ -40,7 +39,6 @@ buildPythonPackage rec {
   '';
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools-scm
   ];
 

--- a/pkgs/development/python-modules/cyclonedx-python-lib/default.nix
+++ b/pkgs/development/python-modules/cyclonedx-python-lib/default.nix
@@ -9,7 +9,6 @@
   lxml,
   packageurl-python,
   py-serializable,
-  pythonRelaxDepsHook,
   poetry-core,
   pytestCheckHook,
   pythonOlder,
@@ -38,7 +37,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     importlib-metadata

--- a/pkgs/development/python-modules/cypherpunkpay/default.nix
+++ b/pkgs/development/python-modules/cypherpunkpay/default.nix
@@ -16,7 +16,6 @@
   pysocks,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   tzlocal,
   waitress,
@@ -50,7 +49,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/dask-awkward/default.nix
+++ b/pkgs/development/python-modules/dask-awkward/default.nix
@@ -14,7 +14,6 @@
   pyarrow,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   typing-extensions,
   uproot,
 }:
@@ -38,7 +37,6 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     hatch-vcs
     hatchling
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/databricks-sql-connector/default.nix
+++ b/pkgs/development/python-modules/databricks-sql-connector/default.nix
@@ -12,7 +12,6 @@
   pyarrow,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   sqlalchemy,
   thrift,
 }:
@@ -38,7 +37,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/dataprep-ml/default.nix
+++ b/pkgs/development/python-modules/dataprep-ml/default.nix
@@ -12,7 +12,6 @@
   pydateinfer,
   python-dateutil,
   pythonOlder,
-  pythonRelaxDepsHook,
   scipy,
   symlinkJoin,
   type-infer,
@@ -44,7 +43,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/dbt-bigquery/default.nix
+++ b/pkgs/development/python-modules/dbt-bigquery/default.nix
@@ -9,7 +9,6 @@
   google-cloud-storage,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
   urllib3,
 }:
@@ -31,7 +30,6 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "agate" ];
 
   build-system = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/dbt-core/default.nix
+++ b/pkgs/development/python-modules/dbt-core/default.nix
@@ -21,7 +21,6 @@
   protobuf,
   python3,
   pythonOlder,
-  pythonRelaxDepsHook,
   pytz,
   pyyaml,
   requests,
@@ -59,7 +58,6 @@ buildPythonPackage rec {
   ];
 
   build-system = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/dbt-redshift/default.nix
+++ b/pkgs/development/python-modules/dbt-redshift/default.nix
@@ -8,7 +8,6 @@
   fetchFromGitHub,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   redshift-connector,
   setuptools,
 }:
@@ -32,7 +31,6 @@ buildPythonPackage rec {
     "redshift-connector"
   ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/dbt-semantic-interfaces/default.nix
+++ b/pkgs/development/python-modules/dbt-semantic-interfaces/default.nix
@@ -6,7 +6,6 @@
   dbt-postgres,
   fetchFromGitHub,
   hatchling,
-  pythonRelaxDepsHook,
   hypothesis,
   importlib-metadata,
   jinja2,
@@ -37,7 +36,6 @@ buildPythonPackage rec {
 
   build-system = [
     hatchling
-    pythonRelaxDepsHook
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/deal-solver/default.nix
+++ b/pkgs/development/python-modules/deal-solver/default.nix
@@ -8,7 +8,6 @@
   astroid,
   pytestCheckHook,
   hypothesis,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -27,7 +26,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     flit-core
-    pythonRelaxDepsHook
   ];
 
   # z3 does not provide a dist-info, so python-runtime-deps-check will fail

--- a/pkgs/development/python-modules/demetriek/default.nix
+++ b/pkgs/development/python-modules/demetriek/default.nix
@@ -12,7 +12,6 @@
   pytest-asyncio,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   yarl,
 }:
 
@@ -54,7 +53,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/detectron2/default.nix
+++ b/pkgs/development/python-modules/detectron2/default.nix
@@ -3,7 +3,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonRelaxDepsHook,
   ninja,
   which,
   # build inputs
@@ -72,7 +71,6 @@ buildPythonPackage {
   '';
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     ninja
     which
   ];

--- a/pkgs/development/python-modules/devito/default.nix
+++ b/pkgs/development/python-modules/devito/default.nix
@@ -19,7 +19,6 @@
   pytest-xdist,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   scipy,
   sympy,
 }:
@@ -47,7 +46,6 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = true;
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     anytree

--- a/pkgs/development/python-modules/diffsync/default.nix
+++ b/pkgs/development/python-modules/diffsync/default.nix
@@ -6,7 +6,6 @@
   packaging,
   poetry-core,
   pydantic,
-  pythonRelaxDepsHook,
   redis,
   structlog,
 }:
@@ -25,7 +24,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/dissect/default.nix
+++ b/pkgs/development/python-modules/dissect/default.nix
@@ -30,7 +30,6 @@
   dissect-xfs,
   fetchFromGitHub,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
   setuptools-scm,
 }:
@@ -56,7 +55,6 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     dissect-archive

--- a/pkgs/development/python-modules/distributed/default.nix
+++ b/pkgs/development/python-modules/distributed/default.nix
@@ -11,7 +11,6 @@
   packaging,
   psutil,
   pythonOlder,
-  pythonRelaxDepsHook,
   pyyaml,
   setuptools,
   setuptools-scm,
@@ -45,7 +44,6 @@ buildPythonPackage rec {
   '';
 
   build-system = [
-    pythonRelaxDepsHook
     setuptools
     setuptools-scm
     versioneer

--- a/pkgs/development/python-modules/django-cacheops/default.nix
+++ b/pkgs/development/python-modules/django-cacheops/default.nix
@@ -3,7 +3,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonRelaxDepsHook,
   django,
   funcy,
   redis,
@@ -31,7 +30,6 @@ buildPythonPackage rec {
     hash = "sha256-d6N8c9f6z8cpk2XtZqEr56SH3XRd2GwdM8ouv9OzKHg=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
   pythonRelaxDeps = [ "funcy" ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/django-compressor/default.nix
+++ b/pkgs/development/python-modules/django-compressor/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonRelaxDepsHook,
 
   # build-system
   setuptools,
@@ -37,7 +36,6 @@ buildPythonPackage rec {
 
   build-system = [
     setuptools
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/django-import-export/default.nix
+++ b/pkgs/development/python-modules/django-import-export/default.nix
@@ -8,7 +8,6 @@
   psycopg2,
   python,
   pythonOlder,
-  pythonRelaxDepsHook,
   pytz,
   setuptools-scm,
   tablib,
@@ -32,7 +31,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools-scm ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     diff-match-patch

--- a/pkgs/development/python-modules/django-oauth-toolkit/default.nix
+++ b/pkgs/development/python-modules/django-oauth-toolkit/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonRelaxDepsHook,
 
   # propagates
   django,
@@ -41,7 +40,6 @@ buildPythonPackage rec {
     requests
   ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
   pythonRelaxDeps = [ "django" ];
 
   DJANGO_SETTINGS_MODULE = "tests.settings";

--- a/pkgs/development/python-modules/django-two-factor-auth/default.nix
+++ b/pkgs/development/python-modules/django-two-factor-auth/default.nix
@@ -9,7 +9,6 @@
   phonenumbers,
   pydantic,
   pythonOlder,
-  pythonRelaxDepsHook,
   qrcode,
   setuptools-scm,
   twilio,
@@ -31,7 +30,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools-scm
   ];
 

--- a/pkgs/development/python-modules/django-webpush/default.nix
+++ b/pkgs/development/python-modules/django-webpush/default.nix
@@ -4,7 +4,6 @@
   django,
   fetchFromGitHub,
   pythonOlder,
-  pythonRelaxDepsHook,
   pywebpush,
   setuptools-scm,
 }:
@@ -26,7 +25,6 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "pywebpush" ];
 
   build-system = [
-    pythonRelaxDepsHook
     setuptools-scm
   ];
 

--- a/pkgs/development/python-modules/dm-control/default.nix
+++ b/pkgs/development/python-modules/dm-control/default.nix
@@ -6,7 +6,6 @@
   absl-py,
   mujoco,
   pyparsing,
-  pythonRelaxDepsHook,
   setuptools,
   wheel,
   dm-env,
@@ -46,7 +45,6 @@ buildPythonPackage rec {
     absl-py
     mujoco
     pyparsing
-    pythonRelaxDepsHook
     setuptools
     wheel
   ];

--- a/pkgs/development/python-modules/dploot/default.nix
+++ b/pkgs/development/python-modules/dploot/default.nix
@@ -8,7 +8,6 @@
   poetry-core,
   pyasn1,
   pythonOlder,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -29,7 +28,6 @@ buildPythonPackage rec {
     "pyasn1"
   ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   build-system = [ poetry-core ];
 

--- a/pkgs/development/python-modules/dropbox/default.nix
+++ b/pkgs/development/python-modules/dropbox/default.nix
@@ -12,7 +12,6 @@
   pytestCheckHook,
   sphinxHook,
   sphinx-rtd-theme,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -60,7 +59,6 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     sphinxHook
     sphinx-rtd-theme
-    pythonRelaxDepsHook
   ];
 
   # Version 12.0.0 re-introduced Python 2 support and set some very restrictive version bounds

--- a/pkgs/development/python-modules/dvc-azure/default.nix
+++ b/pkgs/development/python-modules/dvc-azure/default.nix
@@ -6,7 +6,6 @@
   dvc-objects,
   fetchPypi,
   knack,
-  pythonRelaxDepsHook,
   setuptools-scm,
 }:
 
@@ -25,7 +24,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools-scm
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/dvc-gs/default.nix
+++ b/pkgs/development/python-modules/dvc-gs/default.nix
@@ -4,7 +4,6 @@
   dvc-objects,
   fetchPypi,
   gcsfs,
-  pythonRelaxDepsHook,
   setuptools-scm,
 }:
 
@@ -23,7 +22,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools-scm
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/dvc-http/default.nix
+++ b/pkgs/development/python-modules/dvc-http/default.nix
@@ -7,7 +7,6 @@
   fsspec,
   funcy,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools-scm,
 }:
 

--- a/pkgs/development/python-modules/dvc-s3/default.nix
+++ b/pkgs/development/python-modules/dvc-s3/default.nix
@@ -6,7 +6,6 @@
   dvc-objects,
   fetchPypi,
   flatten-dict,
-  pythonRelaxDepsHook,
   s3fs,
   setuptools-scm,
 }:
@@ -31,7 +30,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools-scm
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/dvc-ssh/default.nix
+++ b/pkgs/development/python-modules/dvc-ssh/default.nix
@@ -4,7 +4,6 @@
   buildPythonPackage,
   dvc-objects,
   fetchPypi,
-  pythonRelaxDepsHook,
   setuptools-scm,
   sshfs,
 }:
@@ -26,7 +25,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools-scm
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/dvc/default.nix
+++ b/pkgs/development/python-modules/dvc/default.nix
@@ -36,7 +36,6 @@
   pygtrie,
   pyparsing,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   rich,
   ruamel-yaml,
@@ -84,7 +83,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools-scm ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies =
     [

--- a/pkgs/development/python-modules/elastic-apm/default.nix
+++ b/pkgs/development/python-modules/elastic-apm/default.nix
@@ -19,7 +19,6 @@
   pytest-random-order,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   sanic,
   sanic-testing,
   setuptools,
@@ -49,7 +48,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     aiohttp

--- a/pkgs/development/python-modules/embedding-reader/default.nix
+++ b/pkgs/development/python-modules/embedding-reader/default.nix
@@ -7,7 +7,6 @@
   pandas,
   pyarrow,
   pytestCheckHook,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -22,7 +21,6 @@ buildPythonPackage rec {
     hash = "sha256-paN6rAyH3L7qCfWPr5kXo9Xl57gRMhdcDnoyLJ7II2w=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRelaxDeps = [ "pyarrow" ];
 

--- a/pkgs/development/python-modules/es-client/default.nix
+++ b/pkgs/development/python-modules/es-client/default.nix
@@ -12,7 +12,6 @@
   pytest-asyncio,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   pyyaml,
   requests,
   six,
@@ -37,7 +36,6 @@ buildPythonPackage rec {
 
   build-system = [ hatchling ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     certifi

--- a/pkgs/development/python-modules/explorerscript/default.nix
+++ b/pkgs/development/python-modules/explorerscript/default.nix
@@ -7,7 +7,6 @@
   igraph,
   pygments,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   setuptools,
 }:
 
@@ -25,7 +24,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     antlr4
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/extract-msg/default.nix
+++ b/pkgs/development/python-modules/extract-msg/default.nix
@@ -8,7 +8,6 @@
   olefile,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   red-black-tree-mod,
   rtfde,
   setuptools,
@@ -35,7 +34,6 @@ buildPythonPackage rec {
   ];
 
   build-system = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/extruct/default.nix
+++ b/pkgs/development/python-modules/extruct/default.nix
@@ -10,7 +10,6 @@
   pyrdfa3,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   rdflib,
   setuptools,
   six,

--- a/pkgs/development/python-modules/fairseq/default.nix
+++ b/pkgs/development/python-modules/fairseq/default.nix
@@ -7,7 +7,6 @@
 
   # Native build inputs
   cython,
-  pythonRelaxDepsHook,
   which,
 
   # Propagated build inputs
@@ -53,7 +52,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     cython
-    pythonRelaxDepsHook
     which
   ];
 

--- a/pkgs/development/python-modules/farm-haystack/default.nix
+++ b/pkgs/development/python-modules/farm-haystack/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonRelaxDepsHook,
   hatchling,
   boilerpy3,
   events,
@@ -104,7 +103,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     hatchling
-    pythonRelaxDepsHook
   ];
 
   pythonRemoveDeps = [

--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
-  pythonRelaxDepsHook,
 
   # build-system
   hatchling,
@@ -53,7 +52,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     hatchling
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/fastembed/default.nix
+++ b/pkgs/development/python-modules/fastembed/default.nix
@@ -5,7 +5,6 @@
   huggingface-hub,
   loguru,
   pythonOlder,
-  pythonRelaxDepsHook,
   poetry-core,
   onnx,
   onnxruntime,
@@ -31,7 +30,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     huggingface-hub

--- a/pkgs/development/python-modules/faster-whisper/default.nix
+++ b/pkgs/development/python-modules/faster-whisper/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonRelaxDepsHook,
 
   # build-system
   setuptools,
@@ -32,7 +31,6 @@ buildPythonPackage rec {
 
   build-system = [
     setuptools
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "tokenizers" ];

--- a/pkgs/development/python-modules/flax/default.nix
+++ b/pkgs/development/python-modules/flax/default.nix
@@ -15,7 +15,6 @@
   pytest-xdist,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   pyyaml,
   rich,
   setuptools-scm,
@@ -40,7 +39,6 @@ buildPythonPackage rec {
 
   build-system = [
     jaxlib
-    pythonRelaxDepsHook
     setuptools-scm
   ];
 

--- a/pkgs/development/python-modules/flet-runtime/default.nix
+++ b/pkgs/development/python-modules/flet-runtime/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   flet-client-flutter,
   poetry-core,
-  pythonRelaxDepsHook,
   flet-core,
   httpx,
   oauthlib,
@@ -26,7 +25,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "httpx" ];

--- a/pkgs/development/python-modules/flet/default.nix
+++ b/pkgs/development/python-modules/flet/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   flet-client-flutter,
-  pythonRelaxDepsHook,
 
   # build-system
   poetry-core,
@@ -33,7 +32,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/fontbakery/default.nix
+++ b/pkgs/development/python-modules/fontbakery/default.nix
@@ -29,7 +29,6 @@
   protobuf,
   pytestCheckHook,
   pytest-xdist,
-  pythonRelaxDepsHook,
   pyyaml,
   requests,
   requests-mock,
@@ -96,7 +95,6 @@ buildPythonPackage rec {
   ];
   nativeBuildInputs = [
     installShellFiles
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/freebox-api/default.nix
+++ b/pkgs/development/python-modules/freebox-api/default.nix
@@ -6,7 +6,6 @@
   poetry-core,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   urllib3,
 }:
 
@@ -26,7 +25,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "urllib3" ];

--- a/pkgs/development/python-modules/furo/default.nix
+++ b/pkgs/development/python-modules/furo/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   pythonOlder,
   fetchPypi,
-  pythonRelaxDepsHook,
   sphinx,
   beautifulsoup4,
   sphinx-basic-ng,
@@ -23,7 +22,6 @@ buildPythonPackage rec {
     hash = "sha256-NUi+LO9Foy+M3AJy1BX8s+X6ag603f4h3z7PH+RaE88=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRelaxDeps = [ "sphinx" ];
 

--- a/pkgs/development/python-modules/galois/default.nix
+++ b/pkgs/development/python-modules/galois/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   setuptools-scm,
   pythonOlder,
-  pythonRelaxDepsHook,
   fetchFromGitHub,
   pytestCheckHook,
   pytest-xdist,
@@ -28,7 +27,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools-scm
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/gcs-oauth2-boto-plugin/default.nix
+++ b/pkgs/development/python-modules/gcs-oauth2-boto-plugin/default.nix
@@ -11,7 +11,6 @@
   pyopenssl,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   retry-decorator,
   rsa,
   six,

--- a/pkgs/development/python-modules/gflanguages/default.nix
+++ b/pkgs/development/python-modules/gflanguages/default.nix
@@ -5,7 +5,6 @@
   protobuf,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
   setuptools-scm,
   uharfbuzz,
@@ -39,7 +38,6 @@ buildPythonPackage rec {
   dependencies = [ protobuf ];
 
   nativeCheckInputs = [
-    pythonRelaxDepsHook
     pytestCheckHook
     uharfbuzz
     youseedee

--- a/pkgs/development/python-modules/gitdb/default.nix
+++ b/pkgs/development/python-modules/gitdb/default.nix
@@ -4,7 +4,6 @@
   fetchPypi,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
   smmap,
 }:
@@ -23,7 +22,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "smmap" ];

--- a/pkgs/development/python-modules/githubkit/default.nix
+++ b/pkgs/development/python-modules/githubkit/default.nix
@@ -11,7 +11,6 @@
   pytest-xdist,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   typing-extensions,
 }:
 
@@ -38,7 +37,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     hishel

--- a/pkgs/development/python-modules/google-cloud-storage/default.nix
+++ b/pkgs/development/python-modules/google-cloud-storage/default.nix
@@ -12,7 +12,6 @@
   protobuf,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   setuptools,
 }:
@@ -30,7 +29,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/google-generativeai/default.nix
+++ b/pkgs/development/python-modules/google-generativeai/default.nix
@@ -9,7 +9,6 @@
   protobuf,
   pydantic,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
   tqdm,
   typing-extensions,
@@ -33,7 +32,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     google-ai-generativelanguage

--- a/pkgs/development/python-modules/gophish/default.nix
+++ b/pkgs/development/python-modules/gophish/default.nix
@@ -10,7 +10,6 @@
   pyparsing,
   python-dateutil,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   setuptools,
   six,
@@ -35,7 +34,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     appdirs

--- a/pkgs/development/python-modules/gpsoauth/default.nix
+++ b/pkgs/development/python-modules/gpsoauth/default.nix
@@ -5,7 +5,6 @@
   poetry-core,
   pycryptodomex,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
 }:
 
@@ -22,7 +21,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     poetry-core
   ];
 

--- a/pkgs/development/python-modules/gpustat/default.nix
+++ b/pkgs/development/python-modules/gpustat/default.nix
@@ -8,7 +8,6 @@
   psutil,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools-scm,
 }:
 
@@ -27,7 +26,6 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "nvidia-ml-py" ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools-scm
   ];
 

--- a/pkgs/development/python-modules/grad-cam/default.nix
+++ b/pkgs/development/python-modules/grad-cam/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   pythonOlder,
   fetchPypi,
-  pythonRelaxDepsHook,
   setuptools,
   matplotlib,
   numpy,
@@ -34,7 +33,6 @@ buildPythonPackage rec {
   '';
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/gradio/client.nix
+++ b/pkgs/development/python-modules/gradio/client.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   nix-update-script,
   pythonOlder,
-  pythonRelaxDepsHook,
   # pyproject
   hatchling,
   hatch-requirements-txt,
@@ -58,7 +57,6 @@ buildPythonPackage rec {
     hatchling
     hatch-requirements-txt
     hatch-fancy-pypi-readme
-    pythonRelaxDepsHook
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -4,7 +4,6 @@
   buildPythonPackage,
   fetchPypi,
   pythonOlder,
-  pythonRelaxDepsHook,
   writeShellScriptBin,
   gradio,
 
@@ -91,7 +90,6 @@ buildPythonPackage rec {
   ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     hatchling
     hatch-requirements-txt
     hatch-fancy-pypi-readme

--- a/pkgs/development/python-modules/grpcio-channelz/default.nix
+++ b/pkgs/development/python-modules/grpcio-channelz/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  pythonRelaxDepsHook,
   fetchPypi,
   grpcio,
   protobuf,
@@ -17,7 +16,6 @@ buildPythonPackage rec {
     hash = "sha256-bkrCxD12skXF9m2Y9SPbCHhrGGEoplXubyCjCn5o5Pk=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
   pythonRelaxDeps = [ "grpcio" ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/grpcio-health-checking/default.nix
+++ b/pkgs/development/python-modules/grpcio-health-checking/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  pythonRelaxDepsHook,
   fetchPypi,
   grpcio,
   protobuf,
@@ -22,7 +21,6 @@ buildPythonPackage rec {
     protobuf
   ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
   pythonRelaxDeps = [ "grpcio" ];
 
   pythonImportsCheck = [ "grpc_health" ];

--- a/pkgs/development/python-modules/grpcio-reflection/default.nix
+++ b/pkgs/development/python-modules/grpcio-reflection/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonRelaxDepsHook,
   grpcio,
   protobuf,
 }:
@@ -17,7 +16,6 @@ buildPythonPackage rec {
     hash = "sha256-LdRIBtaNAAZjZSm9pXMBKxmkIoFHjC0FHNquu5HiUWw=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
   pythonRelaxDeps = [ "grpcio" ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/grpcio-testing/default.nix
+++ b/pkgs/development/python-modules/grpcio-testing/default.nix
@@ -5,7 +5,6 @@
   grpcio,
   protobuf,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
 }:
 

--- a/pkgs/development/python-modules/ha-mqtt-discoverable/default.nix
+++ b/pkgs/development/python-modules/ha-mqtt-discoverable/default.nix
@@ -8,7 +8,6 @@
   pyaml,
   pydantic,
   pythonOlder,
-  pythonRelaxDepsHook,
   thelogrus,
 }:
 
@@ -30,7 +29,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     gitlike-commands

--- a/pkgs/development/python-modules/hass-nabucasa/default.nix
+++ b/pkgs/development/python-modules/hass-nabucasa/default.nix
@@ -14,7 +14,6 @@
   pytest-timeout,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
   snitun,
   syrupy,
@@ -37,7 +36,6 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = [ "acme" ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/hdate/default.nix
+++ b/pkgs/development/python-modules/hdate/default.nix
@@ -4,7 +4,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   poetry-core,
-  pythonRelaxDepsHook,
   pytestCheckHook,
   pythonOlder,
   pytz,
@@ -26,7 +25,6 @@ buildPythonPackage rec {
 
   build-system = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/hdbscan/default.nix
+++ b/pkgs/development/python-modules/hdbscan/default.nix
@@ -9,7 +9,6 @@
   fetchPypi,
   joblib,
   six,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -24,7 +23,6 @@ buildPythonPackage rec {
 
   pythonRemoveDeps = [ "cython" ];
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     cython
   ];
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/hikari/default.nix
+++ b/pkgs/development/python-modules/hikari/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   pytest-runner,
   aiohttp,
   attrs,
@@ -37,7 +36,6 @@ buildPythonPackage rec {
     '';
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = [
     aiohttp

--- a/pkgs/development/python-modules/hologram/default.nix
+++ b/pkgs/development/python-modules/hologram/default.nix
@@ -6,7 +6,6 @@
   jsonschema,
   pytestCheckHook,
   python-dateutil,
-  pythonRelaxDepsHook,
   setuptools,
   wheel,
 }:
@@ -33,7 +32,6 @@ buildPythonPackage rec {
   ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
     wheel
   ];

--- a/pkgs/development/python-modules/httpbin/default.nix
+++ b/pkgs/development/python-modules/httpbin/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonRelaxDepsHook,
 
   # build-system
   setuptools,
@@ -36,7 +35,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "greenlet" ];

--- a/pkgs/development/python-modules/icalevents/default.nix
+++ b/pkgs/development/python-modules/icalevents/default.nix
@@ -5,7 +5,6 @@
   pythonOlder,
   pytestCheckHook,
   poetry-core,
-  pythonRelaxDepsHook,
   datetime,
   httplib2,
   icalendar,
@@ -29,7 +28,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/instructor/default.nix
+++ b/pkgs/development/python-modules/instructor/default.nix
@@ -15,7 +15,6 @@
   diskcache,
   redis,
   pythonOlder,
-  pythonRelaxDepsHook,
   rich,
   tenacity,
   typer,
@@ -42,7 +41,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     aiohttp

--- a/pkgs/development/python-modules/intensity-normalization/default.nix
+++ b/pkgs/development/python-modules/intensity-normalization/default.nix
@@ -4,7 +4,6 @@
   fetchPypi,
   pythonOlder,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   matplotlib,
   nibabel,
   numpy,
@@ -36,7 +35,6 @@ buildPythonPackage rec {
     substituteInPlace setup.cfg --replace "pytest-runner" ""
   '';
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
   pythonRelaxDeps = [ "nibabel" ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/ipwhois/default.nix
+++ b/pkgs/development/python-modules/ipwhois/default.nix
@@ -9,7 +9,6 @@
   libredirect,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
 }:
 
@@ -41,7 +40,6 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "dnspython" ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/jaxtyping/default.nix
+++ b/pkgs/development/python-modules/jaxtyping/default.nix
@@ -4,7 +4,6 @@
   pythonOlder,
   fetchFromGitHub,
   hatchling,
-  pythonRelaxDepsHook,
   numpy,
   typeguard,
   typing-extensions,
@@ -35,7 +34,6 @@ let
 
     nativeBuildInputs = [
       hatchling
-      pythonRelaxDepsHook
     ];
 
     propagatedBuildInputs = [

--- a/pkgs/development/python-modules/jiwer/default.nix
+++ b/pkgs/development/python-modules/jiwer/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   poetry-core,
-  pythonRelaxDepsHook,
   rapidfuzz,
   click,
   pythonOlder,
@@ -25,7 +24,6 @@ buildPythonPackage rec {
 
   build-system = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/json-schema-for-humans/default.nix
+++ b/pkgs/development/python-modules/json-schema-for-humans/default.nix
@@ -12,7 +12,6 @@
   pygments,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   pytz,
   pyyaml,
   requests,
@@ -36,7 +35,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     click

--- a/pkgs/development/python-modules/jsonconversion/default.nix
+++ b/pkgs/development/python-modules/jsonconversion/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonRelaxDepsHook,
   pytestCheckHook,
   pdm-backend,
   numpy,
@@ -23,7 +22,6 @@ buildPythonPackage rec {
 
   build-system = [
     pdm-backend
-    pythonRelaxDepsHook
   ];
 
   pythonRemoveDeps = [

--- a/pkgs/development/python-modules/jsonschema-path/default.nix
+++ b/pkgs/development/python-modules/jsonschema-path/default.nix
@@ -4,7 +4,6 @@
   pythonOlder,
   fetchFromGitHub,
   poetry-core,
-  pythonRelaxDepsHook,
   pathable,
   pyyaml,
   referencing,
@@ -33,7 +32,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "referencing" ];

--- a/pkgs/development/python-modules/jsonschema-spec/default.nix
+++ b/pkgs/development/python-modules/jsonschema-spec/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
-  pythonRelaxDepsHook,
 
   # build
   poetry-core,
@@ -42,7 +41,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "referencing" ];

--- a/pkgs/development/python-modules/karton-dashboard/default.nix
+++ b/pkgs/development/python-modules/karton-dashboard/default.nix
@@ -8,7 +8,6 @@
   networkx,
   prometheus-client,
   pythonOlder,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -32,7 +31,6 @@ buildPythonPackage rec {
     "prometheus-client"
   ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = [
     flask

--- a/pkgs/development/python-modules/kserve/default.nix
+++ b/pkgs/development/python-modules/kserve/default.nix
@@ -5,7 +5,6 @@
   fetchFromGitHub,
   deprecation,
   poetry-core,
-  pythonRelaxDepsHook,
   async-timeout,
   cloudevents,
   fastapi,
@@ -56,7 +55,6 @@ buildPythonPackage rec {
     poetry-core
   ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     async-timeout

--- a/pkgs/development/python-modules/kubernetes/default.nix
+++ b/pkgs/development/python-modules/kubernetes/default.nix
@@ -10,7 +10,6 @@
   pytestCheckHook,
   python-dateutil,
   pythonOlder,
-  pythonRelaxDepsHook,
   pyyaml,
   requests,
   requests-oauthlib,
@@ -42,7 +41,6 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "urllib3" ];
 
   build-system = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/labelbox/default.nix
+++ b/pkgs/development/python-modules/labelbox/default.nix
@@ -16,7 +16,6 @@
   pytestCheckHook,
   python-dateutil,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   setuptools,
   shapely,
@@ -49,7 +48,6 @@ buildPythonPackage rec {
       --replace-fail "pytest_plugins" "_pytest_plugins"
   '';
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRelaxDeps = [ "python-dateutil" ];
 

--- a/pkgs/development/python-modules/labgrid/default.nix
+++ b/pkgs/development/python-modules/labgrid/default.nix
@@ -15,7 +15,6 @@
   pytestCheckHook,
   pytest-dependency,
   pytest-mock,
-  pythonRelaxDepsHook,
   pyudev,
   pyusb,
   pyyaml,
@@ -38,7 +37,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
     setuptools-scm
     wheel

--- a/pkgs/development/python-modules/lacuscore/default.nix
+++ b/pkgs/development/python-modules/lacuscore/default.nix
@@ -10,7 +10,6 @@
   pythonOlder,
   redis,
   requests,
-  pythonRelaxDepsHook,
   sphinx,
   ua-parser,
 }:
@@ -36,7 +35,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     async-timeout

--- a/pkgs/development/python-modules/langchain-core/default.nix
+++ b/pkgs/development/python-modules/langchain-core/default.nix
@@ -15,7 +15,6 @@
   pytest-xdist,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   pyyaml,
   syrupy,
   tenacity,
@@ -45,7 +44,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     jsonpatch

--- a/pkgs/development/python-modules/langfuse/default.nix
+++ b/pkgs/development/python-modules/langfuse/default.nix
@@ -11,7 +11,6 @@
   packaging,
   poetry-core,
   pydantic,
-  pythonRelaxDepsHook,
   wrapt,
 }:
 
@@ -29,7 +28,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRelaxDeps = [ "packaging" ];
 

--- a/pkgs/development/python-modules/langsmith/default.nix
+++ b/pkgs/development/python-modules/langsmith/default.nix
@@ -15,7 +15,6 @@
   pytest-asyncio,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   uvicorn,
 }:
@@ -40,7 +39,6 @@ buildPythonPackage rec {
 
   build-system = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/ledgerblue/default.nix
+++ b/pkgs/development/python-modules/ledgerblue/default.nix
@@ -16,7 +16,6 @@
   python-gnupg,
   python-u2flib-host,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
   setuptools-scm,
   websocket-client,
@@ -37,7 +36,6 @@ buildPythonPackage rec {
   build-system = [
     setuptools
     setuptools-scm
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "protobuf" ];

--- a/pkgs/development/python-modules/librespot/default.nix
+++ b/pkgs/development/python-modules/librespot/default.nix
@@ -7,7 +7,6 @@
   pycryptodomex,
   pyogg,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   requests,
   websocket-client,
   zeroconf,
@@ -27,7 +26,6 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = true;
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = [
     defusedxml

--- a/pkgs/development/python-modules/libretranslate/default.nix
+++ b/pkgs/development/python-modules/libretranslate/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonRelaxDepsHook,
   pytestCheckHook,
   hatchling,
   argostranslate,
@@ -43,7 +42,6 @@ buildPythonPackage rec {
 
   build-system = [
     hatchling
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = true;

--- a/pkgs/development/python-modules/linear-operator/default.nix
+++ b/pkgs/development/python-modules/linear-operator/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   jaxtyping,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   scipy,
   setuptools,
   setuptools-scm,
@@ -26,7 +25,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
     setuptools-scm
     wheel

--- a/pkgs/development/python-modules/llama-index-agent-openai/default.nix
+++ b/pkgs/development/python-modules/llama-index-agent-openai/default.nix
@@ -6,7 +6,6 @@
   llama-index-llms-openai,
   poetry-core,
   pythonOlder,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -26,7 +25,6 @@ buildPythonPackage rec {
 
   build-system = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/llama-index-embeddings-gemini/default.nix
+++ b/pkgs/development/python-modules/llama-index-embeddings-gemini/default.nix
@@ -6,7 +6,6 @@
   llama-index-core,
   poetry-core,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   pythonOlder,
 }:
 
@@ -27,7 +26,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     google-generativeai

--- a/pkgs/development/python-modules/llama-index-embeddings-google/default.nix
+++ b/pkgs/development/python-modules/llama-index-embeddings-google/default.nix
@@ -6,7 +6,6 @@
   llama-index-core,
   poetry-core,
   pythonOlder,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -26,7 +25,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     google-generativeai

--- a/pkgs/development/python-modules/llama-index-program-openai/default.nix
+++ b/pkgs/development/python-modules/llama-index-program-openai/default.nix
@@ -7,7 +7,6 @@
   llama-index-llms-openai,
   poetry-core,
   pythonOlder,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -27,7 +26,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     llama-index-agent-openai

--- a/pkgs/development/python-modules/llama-index-readers-file/default.nix
+++ b/pkgs/development/python-modules/llama-index-readers-file/default.nix
@@ -8,7 +8,6 @@
   pymupdf,
   pypdf,
   pythonOlder,
-  pythonRelaxDepsHook,
   striprtf,
 }:
 
@@ -32,7 +31,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     beautifulsoup4

--- a/pkgs/development/python-modules/llama-index-readers-llama-parse/default.nix
+++ b/pkgs/development/python-modules/llama-index-readers-llama-parse/default.nix
@@ -6,7 +6,6 @@
   llama-parse,
   poetry-core,
   pythonOlder,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -26,7 +25,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/llama-index-vector-stores-google/default.nix
+++ b/pkgs/development/python-modules/llama-index-vector-stores-google/default.nix
@@ -6,7 +6,6 @@
   llama-index-core,
   poetry-core,
   pythonOlder,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -26,7 +25,6 @@ buildPythonPackage rec {
 
   build-system = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/llama-index-vector-stores-postgres/default.nix
+++ b/pkgs/development/python-modules/llama-index-vector-stores-postgres/default.nix
@@ -7,7 +7,6 @@
   pgvector,
   poetry-core,
   psycopg2,
-  pythonRelaxDepsHook,
   pythonOlder,
 }:
 
@@ -28,7 +27,6 @@ buildPythonPackage rec {
 
   build-system = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/lsassy/default.nix
+++ b/pkgs/development/python-modules/lsassy/default.nix
@@ -7,7 +7,6 @@
   poetry-core,
   pypykatz,
   pythonOlder,
-  pythonRelaxDepsHook,
   rich,
 }:
 
@@ -31,7 +30,6 @@ buildPythonPackage rec {
     "rich"
   ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   build-system = [ poetry-core ];
 

--- a/pkgs/development/python-modules/maison/default.nix
+++ b/pkgs/development/python-modules/maison/default.nix
@@ -7,7 +7,6 @@
   pydantic,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   toml,
 }:
 
@@ -29,7 +28,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/mandown/default.nix
+++ b/pkgs/development/python-modules/mandown/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   poetry-core,
-  pythonRelaxDepsHook,
   beautifulsoup4,
   comicon,
   feedparser,
@@ -32,7 +31,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/manifest-ml/default.nix
+++ b/pkgs/development/python-modules/manifest-ml/default.nix
@@ -12,7 +12,6 @@
   pydantic,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   redis,
   requests,
   sentence-transformers,
@@ -46,7 +45,6 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "pydantic" ];
 
   build-system = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/manim-slides/default.nix
+++ b/pkgs/development/python-modules/manim-slides/default.nix
@@ -5,7 +5,6 @@
   pythonOlder,
 
   hatchling,
-  pythonRelaxDepsHook,
   manim,
   ffmpeg,
 
@@ -49,7 +48,6 @@ buildPythonPackage rec {
 
   build-system = [
     hatchling
-    pythonRelaxDepsHook
   ];
 
   pythonRemoveDeps = [ "opencv-python" ];

--- a/pkgs/development/python-modules/manim/default.nix
+++ b/pkgs/development/python-modules/manim/default.nix
@@ -6,7 +6,6 @@
   pytest-xdist,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
 
   cairo,
   ffmpeg,
@@ -191,7 +190,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/markdown-it-py/default.nix
+++ b/pkgs/development/python-modules/markdown-it-py/default.nix
@@ -21,7 +21,6 @@
   stdenv,
   pytest-regressions,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   pythonOlder,
 }:
 
@@ -43,7 +42,6 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "linkify-it-py" ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     flit-core
   ];
 

--- a/pkgs/development/python-modules/material-color-utilities/default.nix
+++ b/pkgs/development/python-modules/material-color-utilities/default.nix
@@ -3,7 +3,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonRelaxDepsHook,
   pillow,
   regex,
 }:
@@ -17,7 +16,6 @@ buildPythonPackage rec {
     sha256 = "sha256-PG8C585wWViFRHve83z3b9NijHyV+iGY2BdMJpyVH64=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
   pythonRelaxDeps = [ "Pillow" ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/meteofrance-api/default.nix
+++ b/pkgs/development/python-modules/meteofrance-api/default.nix
@@ -5,7 +5,6 @@
   poetry-core,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   pytz,
   requests,
   requests-mock,
@@ -29,7 +28,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "urllib3" ];

--- a/pkgs/development/python-modules/miauth/default.nix
+++ b/pkgs/development/python-modules/miauth/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchPypi,
   pythonOlder,
-  pythonRelaxDepsHook,
 
   # build-system
   setuptools,
@@ -30,7 +29,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "cryptography" ];

--- a/pkgs/development/python-modules/mido/default.nix
+++ b/pkgs/development/python-modules/mido/default.nix
@@ -8,7 +8,6 @@
   # build-system
   setuptools,
   setuptools-scm,
-  pythonRelaxDepsHook,
 
   # dependencies
   packaging,
@@ -49,7 +48,6 @@ buildPythonPackage rec {
   build-system = [
     setuptools
     setuptools-scm
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "packaging" ];

--- a/pkgs/development/python-modules/minichain/default.nix
+++ b/pkgs/development/python-modules/minichain/default.nix
@@ -9,7 +9,6 @@
   openai,
   pytestCheckHook,
   pythonAtLeast,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -32,7 +31,6 @@ buildPythonPackage rec {
     substituteInPlace ./minichain/__init__.py --replace "from .gradio import GradioConf, show" ""
   '';
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRemoveDeps = [
     # Only used in the examples:

--- a/pkgs/development/python-modules/mitmproxy/default.nix
+++ b/pkgs/development/python-modules/mitmproxy/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   buildPythonPackage,
   pythonOlder,
-  pythonRelaxDepsHook,
   # Mitmproxy requirements
   aioquic,
   asgiref,
@@ -58,7 +57,6 @@ buildPythonPackage rec {
     hash = "sha256-rIyRY1FolbdoaI4OgFG7D2/mot8NiRHalgittPzledw=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRelaxDeps = [
     "aioquic"

--- a/pkgs/development/python-modules/mkdocs-jupyter/default.nix
+++ b/pkgs/development/python-modules/mkdocs-jupyter/default.nix
@@ -11,7 +11,6 @@
   pygments,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -37,7 +36,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     hatchling
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/mlflow/default.nix
+++ b/pkgs/development/python-modules/mlflow/default.nix
@@ -23,7 +23,6 @@
   protobuf,
   python-dateutil,
   pythonOlder,
-  pythonRelaxDepsHook,
   pyarrow,
   pytz,
   pyyaml,
@@ -53,7 +52,6 @@ buildPythonPackage rec {
   # This seems quite unprincipled especially with tests not being enabled,
   # but not mlflow has a 'skinny' install option which does not require `shap`.
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
   pythonRemoveDeps = [ "shap" ];

--- a/pkgs/development/python-modules/mobi/default.nix
+++ b/pkgs/development/python-modules/mobi/default.nix
@@ -5,7 +5,6 @@
   loguru,
   poetry-core,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
 }:
 
@@ -27,7 +26,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/moddb/default.nix
+++ b/pkgs/development/python-modules/moddb/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonRelaxDepsHook,
   beautifulsoup4,
   pyrate-limiter,
   requests,
@@ -21,7 +20,6 @@ buildPythonPackage rec {
     hash = "sha256-2t5QQAmSLOrdNCl0XdsFPdP2UF10/qq69DovqeQ1Vt8=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = [
     beautifulsoup4

--- a/pkgs/development/python-modules/model-checker/default.nix
+++ b/pkgs/development/python-modules/model-checker/default.nix
@@ -5,7 +5,6 @@
   setuptools,
   pythonOlder,
   z3-solver,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -26,7 +25,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [ z3-solver ];
 

--- a/pkgs/development/python-modules/moderngl-window/default.nix
+++ b/pkgs/development/python-modules/moderngl-window/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonRelaxDepsHook,
   setuptools,
   glfw,
   moderngl,
@@ -37,7 +36,6 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "pillow" ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/molbar/default.nix
+++ b/pkgs/development/python-modules/molbar/default.nix
@@ -1,6 +1,5 @@
 { buildPythonPackage
 , python
-, pythonRelaxDepsHook
 , lib
 , gfortran
 , fetchgit
@@ -34,7 +33,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     gfortran
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "networkx" ];

--- a/pkgs/development/python-modules/molecule/plugins.nix
+++ b/pkgs/development/python-modules/molecule/plugins.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonRelaxDepsHook,
   setuptools-scm,
   python-vagrant,
   docker,
@@ -22,7 +21,6 @@ buildPythonPackage rec {
   pythonRemoveDeps = [ "molecule" ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools-scm
   ];
 

--- a/pkgs/development/python-modules/mpris-server/default.nix
+++ b/pkgs/development/python-modules/mpris-server/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  pythonRelaxDepsHook,
   fetchPypi,
   emoji,
   pydbus,
@@ -21,7 +20,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/mwcli/default.nix
+++ b/pkgs/development/python-modules/mwcli/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonRelaxDepsHook,
   docopt,
   para,
 }:
@@ -20,7 +19,6 @@ buildPythonPackage rec {
   # Prevent circular dependency
   pythonRemoveDeps = [ "mwxml" ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = [
     docopt

--- a/pkgs/development/python-modules/myjwt/default.nix
+++ b/pkgs/development/python-modules/myjwt/default.nix
@@ -13,7 +13,6 @@
   pytest-mock,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   questionary,
   requests,
   requests-mock,
@@ -46,7 +45,6 @@ buildPythonPackage rec {
 
   build-system = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/mypy-protobuf/default.nix
+++ b/pkgs/development/python-modules/mypy-protobuf/default.nix
@@ -7,7 +7,6 @@
   protobuf,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
   testers,
   types-protobuf,
@@ -25,7 +24,6 @@ buildPythonPackage rec {
     hash = "sha256-AvJC6zQJ9miJ8rGjqlg1bsTZCc3Q+TEVYi6ecDZuyjw=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRelaxDeps = [ "protobuf" ];
 

--- a/pkgs/development/python-modules/myst-parser/default.nix
+++ b/pkgs/development/python-modules/myst-parser/default.nix
@@ -18,7 +18,6 @@
   pytest-regressions,
   sphinx-pytest,
   pytestCheckHook,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -45,7 +44,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     flit-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/nbdev/default.nix
+++ b/pkgs/development/python-modules/nbdev/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonRelaxDepsHook,
   setuptools,
   ipywidgets,
   fastcore,
@@ -26,7 +25,6 @@ buildPythonPackage rec {
     hash = "sha256-MntVdZ6LazdFCm+h5FaTxvzEwCtoJjrW/EJPTt2fdnU=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRelaxDeps = [ "ipywidgets" ];
 

--- a/pkgs/development/python-modules/nbmake/default.nix
+++ b/pkgs/development/python-modules/nbmake/default.nix
@@ -4,7 +4,6 @@
   pythonOlder,
   fetchFromGitHub,
   poetry-core,
-  pythonRelaxDepsHook,
   setuptools,
   wheel,
   ipykernel,
@@ -34,7 +33,6 @@ buildPythonPackage rec {
 
   build-system = [
     poetry-core
-    pythonRelaxDepsHook
     setuptools
     wheel
   ];

--- a/pkgs/development/python-modules/nethsm/default.nix
+++ b/pkgs/development/python-modules/nethsm/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonRelaxDepsHook,
   flit-core,
   certifi,
   cryptography,
@@ -35,7 +34,6 @@ buildPythonPackage {
 
   nativeBuildInputs = [
     flit-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = true;

--- a/pkgs/development/python-modules/netio/default.nix
+++ b/pkgs/development/python-modules/netio/default.nix
@@ -5,7 +5,6 @@
   poetry-core,
   pyopenssl,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
 }:
 
@@ -25,7 +24,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "pyopenssl" ];

--- a/pkgs/development/python-modules/niaaml/default.nix
+++ b/pkgs/development/python-modules/niaaml/default.nix
@@ -8,7 +8,6 @@
   poetry-core,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   scikit-learn,
   toml-adapt,
 }:
@@ -31,7 +30,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
     toml-adapt
   ];
 

--- a/pkgs/development/python-modules/niaclass/default.nix
+++ b/pkgs/development/python-modules/niaclass/default.nix
@@ -8,7 +8,6 @@
   poetry-core,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   scikit-learn,
   toml-adapt,
 }:
@@ -31,7 +30,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
     toml-adapt
   ];
 

--- a/pkgs/development/python-modules/nipype/default.nix
+++ b/pkgs/development/python-modules/nipype/default.nix
@@ -4,7 +4,6 @@
   buildPythonPackage,
   fetchPypi,
   pythonOlder,
-  pythonRelaxDepsHook,
   # python dependencies
   click,
   python-dateutil,
@@ -58,7 +57,6 @@ buildPythonPackage rec {
       --replace "/usr/bin/env bash" "${bash}/bin/bash"
   '';
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRelaxDeps = [ "traits" ];
 

--- a/pkgs/development/python-modules/nitransforms/default.nix
+++ b/pkgs/development/python-modules/nitransforms/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchPypi,
   pythonOlder,
-  pythonRelaxDepsHook,
   h5py,
   nibabel,
   numpy,
@@ -23,7 +22,6 @@ buildPythonPackage rec {
     hash = "sha256-Lty4aPzSlwRJSqCXeIVICF+gudYqto1OS4cVZyrB2nY=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
   buildInputs = [
     setuptools-scm
     toml

--- a/pkgs/development/python-modules/norfair/default.nix
+++ b/pkgs/development/python-modules/norfair/default.nix
@@ -11,7 +11,6 @@
   motmetrics,
   opencv4,
   pytestCheckHook,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -28,7 +27,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "rich" ];

--- a/pkgs/development/python-modules/notify-py/default.nix
+++ b/pkgs/development/python-modules/notify-py/default.nix
@@ -9,7 +9,6 @@
   libnotify,
   which,
   poetry-core,
-  pythonRelaxDepsHook,
   jeepney,
   loguru,
   pytest,
@@ -50,7 +49,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "loguru" ];

--- a/pkgs/development/python-modules/notus-scanner/default.nix
+++ b/pkgs/development/python-modules/notus-scanner/default.nix
@@ -8,7 +8,6 @@
   pytestCheckHook,
   python-gnupg,
   pythonOlder,
-  pythonRelaxDepsHook,
   sentry-sdk,
   tomli,
 }:
@@ -34,7 +33,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = [
     paho-mqtt

--- a/pkgs/development/python-modules/numba-scipy/default.nix
+++ b/pkgs/development/python-modules/numba-scipy/default.nix
@@ -7,7 +7,6 @@
   numba,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -29,7 +28,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    pythonRelaxDepsHook
   ];
   pythonRelaxDeps = [
     "scipy"

--- a/pkgs/development/python-modules/oci/default.nix
+++ b/pkgs/development/python-modules/oci/default.nix
@@ -8,7 +8,6 @@
   pyopenssl,
   python-dateutil,
   pythonOlder,
-  pythonRelaxDepsHook,
   pytz,
   setuptools,
 }:
@@ -33,7 +32,6 @@ buildPythonPackage rec {
   ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/odp-amsterdam/default.nix
+++ b/pkgs/development/python-modules/odp-amsterdam/default.nix
@@ -5,7 +5,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   poetry-core,
-  pythonRelaxDepsHook,
   pythonOlder,
   pytest-asyncio,
   pytestCheckHook,
@@ -34,7 +33,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "pytz" ];

--- a/pkgs/development/python-modules/ollama/default.nix
+++ b/pkgs/development/python-modules/ollama/default.nix
@@ -9,7 +9,6 @@
   pytest-httpserver,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -35,7 +34,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [ httpx ];
 

--- a/pkgs/development/python-modules/onnxruntime/default.nix
+++ b/pkgs/development/python-modules/onnxruntime/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildPythonPackage,
   autoPatchelfHook,
-  pythonRelaxDepsHook,
   onnxruntime,
   coloredlogs,
   numpy,
@@ -36,7 +35,7 @@ buildPythonPackage {
     chmod +w dist
   '';
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ] ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
 
   # This project requires fairly large dependencies such as sympy which we really don't always need.
   pythonRemoveDeps = [

--- a/pkgs/development/python-modules/open-interpreter/default.nix
+++ b/pkgs/development/python-modules/open-interpreter/default.nix
@@ -3,7 +3,6 @@
   fetchFromGitHub,
   buildPythonPackage,
   pythonOlder,
-  pythonRelaxDepsHook,
   poetry-core,
 
   appdirs,
@@ -50,7 +49,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/openai-triton/bin.nix
+++ b/pkgs/development/python-modules/openai-triton/bin.nix
@@ -13,7 +13,6 @@
   autoPatchelfHook,
   filelock,
   lit,
-  pythonRelaxDepsHook,
   zlib,
 }:
 
@@ -34,13 +33,13 @@ buildPythonPackage rec {
 
   pythonRemoveDeps = [
     "cmake"
+    # torch and triton refer to each other so this hook is included to mitigate that.
     "torch"
   ];
 
   buildInputs = [ zlib ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook # torch and triton refer to each other so this hook is included to mitigate that.
     autoPatchelfHook
   ];
 

--- a/pkgs/development/python-modules/openai-triton/default.nix
+++ b/pkgs/development/python-modules/openai-triton/default.nix
@@ -7,7 +7,6 @@
   addOpenGLRunpath,
   setuptools,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   cmake,
   ninja,
   pybind11,
@@ -59,7 +58,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools
-    pythonRelaxDepsHook
     # pytestCheckHook # Requires torch (circular dependency) and probably needs GPUs:
     cmake
     ninja

--- a/pkgs/development/python-modules/openllm-core/default.nix
+++ b/pkgs/development/python-modules/openllm-core/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
-  pythonRelaxDepsHook,
   accelerate,
   attrs,
   bitsandbytes,
@@ -39,7 +38,6 @@ buildPythonPackage rec {
 
   sourceRoot = "${src.name}/openllm-core";
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \

--- a/pkgs/development/python-modules/openllm/default.nix
+++ b/pkgs/development/python-modules/openllm/default.nix
@@ -6,7 +6,6 @@
   hatchling,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   accelerate,
   bentoml,
   bitsandbytes,
@@ -54,7 +53,6 @@ buildPythonPackage rec {
 
   sourceRoot = "${src.name}/openllm-python";
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRemoveDeps = [
     # remove cuda-python as it has an unfree license

--- a/pkgs/development/python-modules/opentelemetry-api/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-api/default.nix
@@ -9,7 +9,6 @@
   opentelemetry-test-utils,
   setuptools,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   writeScript,
 }:
 
@@ -31,7 +30,6 @@ let
 
     sourceRoot = "${src.name}/opentelemetry-api";
 
-    nativeBuildInputs = [ pythonRelaxDepsHook ];
 
     build-system = [ hatchling ];
 

--- a/pkgs/development/python-modules/orange3/default.nix
+++ b/pkgs/development/python-modules/orange3/default.nix
@@ -6,7 +6,6 @@
   buildPythonPackage,
   chardet,
   copyDesktopItems,
-  pythonRelaxDepsHook,
   cython,
   catboost,
   xgboost,
@@ -74,7 +73,6 @@ let
 
     nativeBuildInputs = [
       copyDesktopItems
-      pythonRelaxDepsHook
       oldest-supported-numpy
       cython
       qt5.wrapQtAppsHook

--- a/pkgs/development/python-modules/ormar/default.nix
+++ b/pkgs/development/python-modules/ormar/default.nix
@@ -21,7 +21,6 @@
   pytest-asyncio,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   sqlalchemy,
   typing-extensions,
 }:
@@ -48,7 +47,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs =

--- a/pkgs/development/python-modules/osqp/default.nix
+++ b/pkgs/development/python-modules/osqp/default.nix
@@ -9,7 +9,6 @@
   oldest-supported-numpy,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   qdldl,
   scipy,
   setuptools-scm,
@@ -33,7 +32,6 @@ buildPythonPackage rec {
     cmake
     oldest-supported-numpy
     setuptools-scm
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "scipy" ];

--- a/pkgs/development/python-modules/oss2/default.nix
+++ b/pkgs/development/python-modules/oss2/default.nix
@@ -10,7 +10,6 @@
   pycryptodome,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   six,
 }:
@@ -29,7 +28,6 @@ buildPythonPackage rec {
     hash = "sha256-jDSXPVyy8XvPgsGZXsdfavFPptq28pCwr9C63OZvNrY=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = [
     requests

--- a/pkgs/development/python-modules/ossfs/default.nix
+++ b/pkgs/development/python-modules/ossfs/default.nix
@@ -6,7 +6,6 @@
   fsspec,
   oss2,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools-scm,
 }:
 
@@ -31,7 +30,6 @@ buildPythonPackage rec {
   ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools-scm
   ];
 

--- a/pkgs/development/python-modules/paddleocr/default.nix
+++ b/pkgs/development/python-modules/paddleocr/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  pythonRelaxDepsHook,
   fetchFromGitHub,
   attrdict,
   beautifulsoup4,
@@ -55,7 +54,6 @@ buildPythonPackage {
     ./remove-import-imaug.patch
   ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
   # trying to relax only pymupdf makes the whole build fail
   pythonRelaxDeps = true;
   pythonRemoveDeps = [

--- a/pkgs/development/python-modules/panel/default.nix
+++ b/pkgs/development/python-modules/panel/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonRelaxDepsHook,
   bleach,
   bokeh,
   param,
@@ -31,7 +30,6 @@ buildPythonPackage rec {
     python = "py3";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRelaxDeps = [ "bokeh" ];
 

--- a/pkgs/development/python-modules/parsedmarc/default.nix
+++ b/pkgs/development/python-modules/parsedmarc/default.nix
@@ -28,7 +28,6 @@
   opensearch-py,
   publicsuffixlist,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   tqdm,
   xmltodict,
@@ -54,7 +53,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     hatchling
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/pathy/default.nix
+++ b/pkgs/development/python-modules/pathy/default.nix
@@ -6,7 +6,6 @@
   pathlib-abc,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
   smart-open,
   typer,
@@ -24,7 +23,6 @@ buildPythonPackage rec {
     hash = "sha256-uz0OawuL92709jxxkeluCvLtZcj9tfoXSI+ch55jcG0=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRelaxDeps = [ "smart-open" ];
 

--- a/pkgs/development/python-modules/pdb2pqr/default.nix
+++ b/pkgs/development/python-modules/pdb2pqr/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchPypi,
   pythonOlder,
-  pythonRelaxDepsHook,
   mmcif-pdbx,
   numpy,
   propka,
@@ -26,7 +25,6 @@ buildPythonPackage rec {
     hash = "sha256-He301TJ1bzWub0DZ6Ro/Xc+JMtJBbyygVpWjPY6RMbA=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRelaxDeps = [ "docutils" ];
 

--- a/pkgs/development/python-modules/pdf2docx/default.nix
+++ b/pkgs/development/python-modules/pdf2docx/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   python,
   buildPythonPackage,
-  pythonRelaxDepsHook,
   imagemagick,
   pip,
   pytestCheckHook,
@@ -33,7 +32,6 @@ buildPythonPackage {
 
   nativeBuildInputs = [
     pip
-    pythonRelaxDepsHook
     imagemagick
   ];
 

--- a/pkgs/development/python-modules/pelican/default.nix
+++ b/pkgs/development/python-modules/pelican/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
-  pythonRelaxDepsHook,
 
   # build-system
   pdm-backend,
@@ -61,7 +60,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     pdm-backend
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "unidecode" ];

--- a/pkgs/development/python-modules/pinecone-client/default.nix
+++ b/pkgs/development/python-modules/pinecone-client/default.nix
@@ -8,7 +8,6 @@
   poetry-core,
   python-dateutil,
   pythonOlder,
-  pythonRelaxDepsHook,
   pyyaml,
   requests,
   setuptools,
@@ -32,7 +31,6 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = [ "urllib3" ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   build-system = [
     setuptools

--- a/pkgs/development/python-modules/pixel-font-builder/default.nix
+++ b/pkgs/development/python-modules/pixel-font-builder/default.nix
@@ -12,7 +12,6 @@
   fonttools,
   pypng,
   pcffont,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -30,7 +29,6 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = [ "fonttools" ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   build-system = [
     hatch-vcs

--- a/pkgs/development/python-modules/pkutils/default.nix
+++ b/pkgs/development/python-modules/pkutils/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   nose3,
   pythonOlder,
-  pythonRelaxDepsHook,
   semver,
 }:
 
@@ -24,7 +23,6 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = [ "semver" ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = [ semver ];
 

--- a/pkgs/development/python-modules/playwright/default.nix
+++ b/pkgs/development/python-modules/playwright/default.nix
@@ -12,7 +12,6 @@
   setuptools,
   setuptools-scm,
   playwright-driver,
-  pythonRelaxDepsHook,
 }:
 
 let
@@ -72,7 +71,6 @@ buildPythonPackage rec {
     git
     setuptools-scm
     setuptools
-    pythonRelaxDepsHook
   ] ++ lib.optionals stdenv.isLinux [ auditwheel ];
 
   pythonRelaxDeps = [ "pyee" ];

--- a/pkgs/development/python-modules/playwrightcapture/default.nix
+++ b/pkgs/development/python-modules/playwrightcapture/default.nix
@@ -12,7 +12,6 @@
   puremagic,
   pydub,
   pythonOlder,
-  pythonRelaxDepsHook,
   pytz,
   requests,
   setuptools,
@@ -44,7 +43,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     aiohttp

--- a/pkgs/development/python-modules/polyswarm-api/default.nix
+++ b/pkgs/development/python-modules/polyswarm-api/default.nix
@@ -7,7 +7,6 @@
   pytestCheckHook,
   python-dateutil,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   responses,
   setuptools,
@@ -30,7 +29,6 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = [ "future" ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/ppscore/default.nix
+++ b/pkgs/development/python-modules/ppscore/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonRelaxDepsHook,
   setuptools,
   pandas,
   pytestCheckHook,
@@ -25,7 +24,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/prometrix/default.nix
+++ b/pkgs/development/python-modules/prometrix/default.nix
@@ -11,7 +11,6 @@
   poetry-core,
   prometheus-api-client,
   pydantic,
-  pythonRelaxDepsHook,
   requests,
 }:
 
@@ -35,7 +34,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     boto3

--- a/pkgs/development/python-modules/pwndbg/default.nix
+++ b/pkgs/development/python-modules/pwndbg/default.nix
@@ -19,7 +19,6 @@
   unicorn,
   gdb-pt-dump,
   poetry-core,
-  pythonRelaxDepsHook,
 }:
 let
   # The newest gdb-pt-dump is incompatible with pwndbg 2024.02.14.
@@ -52,7 +51,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
   pythonRelaxDeps = true;
 

--- a/pkgs/development/python-modules/py-pdf-parser/default.nix
+++ b/pkgs/development/python-modules/py-pdf-parser/default.nix
@@ -5,7 +5,6 @@
   fetchPypi,
   pdfminer-six,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
   wand,
 }:
@@ -24,7 +23,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyatv/default.nix
+++ b/pkgs/development/python-modules/pyatv/default.nix
@@ -18,7 +18,6 @@
   pytest-httpserver,
   pytest-timeout,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   pythonAtLeast,
   pythonOlder,
   requests,
@@ -64,7 +63,6 @@ buildPythonPackage rec {
   ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/pybids/default.nix
+++ b/pkgs/development/python-modules/pybids/default.nix
@@ -14,7 +14,6 @@
   sqlalchemy,
   pytestCheckHook,
   versioneer,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -33,7 +32,6 @@ buildPythonPackage rec {
   ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
     versioneer
   ] ++ versioneer.optional-dependencies.toml;

--- a/pkgs/development/python-modules/pycardano/default.nix
+++ b/pkgs/development/python-modules/pycardano/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonRelaxDepsHook,
   # Python deps
   blockfrost-python,
   cachetools,
@@ -45,7 +44,6 @@ buildPythonPackage rec {
     hash = "sha256-LP/W8IC2del476fGFq10VMWwMrbAoCCcZOngA8unBM0=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = [
     blockfrost-python

--- a/pkgs/development/python-modules/pycfmodel/default.nix
+++ b/pkgs/development/python-modules/pycfmodel/default.nix
@@ -6,7 +6,6 @@
   pydantic,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
 }:
 
@@ -28,7 +27,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [ pydantic ];
 

--- a/pkgs/development/python-modules/pycookiecheat/default.nix
+++ b/pkgs/development/python-modules/pycookiecheat/default.nix
@@ -7,7 +7,6 @@
   keyring,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   playwright,
   setuptools,
   setuptools-scm,
@@ -37,7 +36,6 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     cryptography

--- a/pkgs/development/python-modules/pydicom-seg/default.nix
+++ b/pkgs/development/python-modules/pydicom-seg/default.nix
@@ -5,7 +5,6 @@
   fetchpatch,
   pythonOlder,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   poetry-core,
   jsonschema,
   numpy,
@@ -41,7 +40,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pydiscovergy/default.nix
+++ b/pkgs/development/python-modules/pydiscovergy/default.nix
@@ -11,7 +11,6 @@
   poetry-core,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   pytz,
   respx,
 }:
@@ -36,7 +35,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     authlib

--- a/pkgs/development/python-modules/pyefergy/default.nix
+++ b/pkgs/development/python-modules/pyefergy/default.nix
@@ -5,7 +5,6 @@
   fetchFromGitHub,
   poetry-core,
   poetry-dynamic-versioning,
-  pythonRelaxDepsHook,
   iso4217,
   pythonOlder,
   pytz,
@@ -28,7 +27,6 @@ buildPythonPackage rec {
   build-system = [
     poetry-core
     poetry-dynamic-versioning
-    pythonRelaxDepsHook
   ];
 
   pythonRemoveDeps = [

--- a/pkgs/development/python-modules/pygitguardian/default.nix
+++ b/pkgs/development/python-modules/pygitguardian/default.nix
@@ -6,7 +6,6 @@
   marshmallow-dataclass,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   responses,
   setuptools,
@@ -31,7 +30,6 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "marshmallow-dataclass" ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/pygls/default.nix
+++ b/pkgs/development/python-modules/pygls/default.nix
@@ -8,7 +8,6 @@
   pytest-asyncio,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   typeguard,
   websockets,
 }:
@@ -34,7 +33,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pykoplenti/default.nix
+++ b/pkgs/development/python-modules/pykoplenti/default.nix
@@ -8,7 +8,6 @@
   pycryptodome,
   pydantic,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
 }:
 
@@ -29,7 +28,6 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "pydantic" ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/pylxd/default.nix
+++ b/pkgs/development/python-modules/pylxd/default.nix
@@ -10,7 +10,6 @@
   pythonOlder,
   requests,
   urllib3,
-  pythonRelaxDepsHook,
   requests-toolbelt,
   requests-unixsocket,
   setuptools,
@@ -34,7 +33,6 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "urllib3" ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/pymilvus/default.nix
+++ b/pkgs/development/python-modules/pymilvus/default.nix
@@ -12,7 +12,6 @@
   pyarrow,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   scikit-learn,
   setuptools-scm,
@@ -41,7 +40,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     gitpython
-    pythonRelaxDepsHook
     setuptools-scm
     wheel
   ];

--- a/pkgs/development/python-modules/pyngo/default.nix
+++ b/pkgs/development/python-modules/pyngo/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
-  pythonRelaxDepsHook,
 
   # build-system
   hatchling,
@@ -35,7 +34,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     hatchling
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/pynitrokey/default.nix
+++ b/pkgs/development/python-modules/pynitrokey/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonRelaxDepsHook,
   installShellFiles,
   libnitrokey,
   flit-core,
@@ -71,7 +70,6 @@ buildPythonPackage {
   nativeBuildInputs = [
     flit-core
     installShellFiles
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = true;

--- a/pkgs/development/python-modules/pyorthanc/default.nix
+++ b/pkgs/development/python-modules/pyorthanc/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
-  pythonRelaxDepsHook,
   poetry-core,
   httpx,
   pydicom,
@@ -24,7 +23,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     poetry-core
   ];
 

--- a/pkgs/development/python-modules/pyowm/default.nix
+++ b/pkgs/development/python-modules/pyowm/default.nix
@@ -8,7 +8,6 @@
   requests,
   setuptools,
   pytestCheckHook,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -29,7 +28,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     geojson

--- a/pkgs/development/python-modules/pyquil/default.nix
+++ b/pkgs/development/python-modules/pyquil/default.nix
@@ -15,7 +15,6 @@
   pytest-mock,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   qcs-sdk-python,
   respx,
   rpcq,
@@ -51,7 +50,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     deprecated

--- a/pkgs/development/python-modules/pysaml2/default.nix
+++ b/pkgs/development/python-modules/pysaml2/default.nix
@@ -12,7 +12,6 @@
   pytestCheckHook,
   python-dateutil,
   pythonOlder,
-  pythonRelaxDepsHook,
   pytz,
   repoze-who,
   requests,
@@ -54,7 +53,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pysigma-backend-insightidr/default.nix
+++ b/pkgs/development/python-modules/pysigma-backend-insightidr/default.nix
@@ -6,7 +6,6 @@
   pysigma,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -25,7 +24,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [ pysigma ];

--- a/pkgs/development/python-modules/pysigma-backend-opensearch/default.nix
+++ b/pkgs/development/python-modules/pysigma-backend-opensearch/default.nix
@@ -7,7 +7,6 @@
   pysigma-backend-elasticsearch,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
 }:
 
@@ -34,7 +33,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     pysigma

--- a/pkgs/development/python-modules/pysigma-backend-qradar/default.nix
+++ b/pkgs/development/python-modules/pysigma-backend-qradar/default.nix
@@ -7,7 +7,6 @@
   pysigma-pipeline-sysmon,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
 }:
 
@@ -29,7 +28,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [ pysigma ];

--- a/pkgs/development/python-modules/pysigma/default.nix
+++ b/pkgs/development/python-modules/pysigma/default.nix
@@ -8,7 +8,6 @@
   pyparsing,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   pyyaml,
   requests,
 }:
@@ -34,7 +33,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     jinja2

--- a/pkgs/development/python-modules/pysilero-vad/default.nix
+++ b/pkgs/development/python-modules/pysilero-vad/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   stdenv,
-  pythonRelaxDepsHook,
 
   # build-system
   setuptools,
@@ -30,7 +29,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "numpy" ];

--- a/pkgs/development/python-modules/pysolcast/default.nix
+++ b/pkgs/development/python-modules/pysolcast/default.nix
@@ -10,7 +10,6 @@
   requests,
   responses,
   poetry-core,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -31,7 +30,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     anyconfig

--- a/pkgs/development/python-modules/pytest-examples/default.nix
+++ b/pkgs/development/python-modules/pytest-examples/default.nix
@@ -8,7 +8,6 @@
   pytest,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   ruff,
 }:
 
@@ -47,7 +46,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     hatchling
-    pythonRelaxDepsHook
   ];
 
   buildInputs = [ pytest ];

--- a/pkgs/development/python-modules/pytest-golden/default.nix
+++ b/pkgs/development/python-modules/pytest-golden/default.nix
@@ -10,7 +10,6 @@
   pytest-asyncio,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   testfixtures,
 }:
 
@@ -39,7 +38,6 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     # hatchling used for > 0.2.2
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   buildInputs = [ pytest ];

--- a/pkgs/development/python-modules/pytest-httpx/default.nix
+++ b/pkgs/development/python-modules/pytest-httpx/default.nix
@@ -7,7 +7,6 @@
   pytest-asyncio,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
   setuptools-scm,
 }:
@@ -27,7 +26,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
     setuptools-scm
   ];

--- a/pkgs/development/python-modules/pytest-notebook/default.nix
+++ b/pkgs/development/python-modules/pytest-notebook/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   flit-core,
-  pythonRelaxDepsHook,
   attrs,
   jsonschema,
   nbclient,
@@ -32,7 +31,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     flit-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/python-benedict/default.nix
+++ b/pkgs/development/python-modules/python-benedict/default.nix
@@ -15,7 +15,6 @@
   python-fsutil,
   python-slugify,
   pythonOlder,
-  pythonRelaxDepsHook,
   pyyaml,
   requests,
   setuptools,
@@ -41,7 +40,6 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "boto3" ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/python-fx/default.nix
+++ b/pkgs/development/python-modules/python-fx/default.nix
@@ -19,7 +19,6 @@
   pytestCheckHook,
   pythonOlder,
   antlr4,
-  pythonRelaxDepsHook,
   pyyaml,
   setuptools,
   six,
@@ -52,7 +51,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     antlr4
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/python-jenkins/default.nix
+++ b/pkgs/development/python-modules/python-jenkins/default.nix
@@ -14,7 +14,6 @@
   requests-mock,
   stestr,
   multiprocess,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -34,7 +33,6 @@ buildPythonPackage rec {
       --replace test_jenkins_open_no_timeout dont_test_jenkins_open_no_timeout
   '';
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
   pythonRelaxDeps = [ "setuptools" ];
 
   buildInputs = [ mock ];

--- a/pkgs/development/python-modules/python-lsp-server/default.nix
+++ b/pkgs/development/python-modules/python-lsp-server/default.nix
@@ -22,7 +22,6 @@
   pytestCheckHook,
   python-lsp-jsonrpc,
   pythonOlder,
-  pythonRelaxDepsHook,
   rope,
   setuptools,
   setuptools-scm,

--- a/pkgs/development/python-modules/python-matter-server/default.nix
+++ b/pkgs/development/python-modules/python-matter-server/default.nix
@@ -8,7 +8,6 @@
 
   # build
   setuptools,
-  pythonRelaxDepsHook,
 
   # propagates
   aiohttp,
@@ -83,7 +82,6 @@ buildPythonPackage rec {
 
   build-system = [
     setuptools
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "home-assistant-chip-clusters" ];

--- a/pkgs/development/python-modules/python-ndn/default.nix
+++ b/pkgs/development/python-modules/python-ndn/default.nix
@@ -10,7 +10,6 @@
   pycryptodomex,
   pygtrie,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   pythonOlder,
   setuptools,
 }:
@@ -33,7 +32,6 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     setuptools
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/python-roborock/default.nix
+++ b/pkgs/development/python-modules/python-roborock/default.nix
@@ -15,7 +15,6 @@
   pytest-asyncio,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -41,7 +40,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = [
     aiohttp

--- a/pkgs/development/python-modules/qcs-api-client/default.nix
+++ b/pkgs/development/python-modules/qcs-api-client/default.nix
@@ -15,7 +15,6 @@
   python-dateutil,
   pythonAtLeast,
   pythonOlder,
-  pythonRelaxDepsHook,
   respx,
   retrying,
   rfc3339,
@@ -54,7 +53,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     attrs

--- a/pkgs/development/python-modules/qudida/default.nix
+++ b/pkgs/development/python-modules/qudida/default.nix
@@ -5,7 +5,6 @@
   numpy,
   opencv4,
   pythonOlder,
-  pythonRelaxDepsHook,
   scikit-learn,
   typing-extensions,
 }:
@@ -22,7 +21,6 @@ buildPythonPackage rec {
     hash = "sha256-2xmOKIerDJqgAj5WWvv/Qd+3azYfhf1eE/eA11uhjMg=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRemoveDeps = [ "opencv-python" ];
 

--- a/pkgs/development/python-modules/questionary/default.nix
+++ b/pkgs/development/python-modules/questionary/default.nix
@@ -7,7 +7,6 @@
   prompt-toolkit,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -26,7 +25,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "prompt_toolkit" ];

--- a/pkgs/development/python-modules/radios/default.nix
+++ b/pkgs/development/python-modules/radios/default.nix
@@ -4,7 +4,6 @@
   pythonOlder,
   fetchFromGitHub,
   poetry-core,
-  pythonRelaxDepsHook,
   aiodns,
   aiohttp,
   awesomeversion,
@@ -41,7 +40,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "pycountry" ];

--- a/pkgs/development/python-modules/ray/default.nix
+++ b/pkgs/development/python-modules/ray/default.nix
@@ -37,7 +37,6 @@
   python,
   pythonAtLeast,
   pythonOlder,
-  pythonRelaxDepsHook,
   pyyaml,
   requests,
   scikit-image,
@@ -112,7 +111,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     autoPatchelfHook
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/redis-om/default.nix
+++ b/pkgs/development/python-modules/redis-om/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
-  pythonRelaxDepsHook,
   unasync,
   poetry-core,
   python,
@@ -35,7 +34,6 @@ buildPythonPackage rec {
   };
 
   build-system = [
-    pythonRelaxDepsHook
     unasync
     poetry-core
   ];

--- a/pkgs/development/python-modules/remarshal/default.nix
+++ b/pkgs/development/python-modules/remarshal/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonRelaxDepsHook,
 
   # build deps
   poetry-core,
@@ -32,7 +31,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "pytest" ];

--- a/pkgs/development/python-modules/reptor/default.nix
+++ b/pkgs/development/python-modules/reptor/default.nix
@@ -16,7 +16,6 @@
   pytest,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   pyyaml,
   reptor,
   requests,
@@ -49,7 +48,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     asgiref

--- a/pkgs/development/python-modules/reqif/default.nix
+++ b/pkgs/development/python-modules/reqif/default.nix
@@ -9,7 +9,6 @@
   pytestCheckHook,
   python,
   pythonOlder,
-  pythonRelaxDepsHook,
   xmlschema,
 }:
 
@@ -35,7 +34,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     hatchling
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/rich-pixels/default.nix
+++ b/pkgs/development/python-modules/rich-pixels/default.nix
@@ -8,7 +8,6 @@
   syrupy,
   pillow,
   rich,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -33,7 +32,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/riscv-config/default.nix
+++ b/pkgs/development/python-modules/riscv-config/default.nix
@@ -7,7 +7,6 @@
   pyyaml,
   ruamel-yaml,
   setuptools,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -28,7 +27,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     cerberus

--- a/pkgs/development/python-modules/rising/default.nix
+++ b/pkgs/development/python-modules/rising/default.nix
@@ -5,7 +5,6 @@
   pythonOlder,
   fetchFromGitHub,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   dill,
   lightning-utilities,
   numpy,
@@ -27,7 +26,6 @@ buildPythonPackage rec {
     hash = "sha256-sBzVTst5Tp2oZZ+Xsg3M7uAMbucL6idlpYwHvib3EaY=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRelaxDeps = [ "lightning-utilities" ];
 

--- a/pkgs/development/python-modules/rmrl/default.nix
+++ b/pkgs/development/python-modules/rmrl/default.nix
@@ -4,7 +4,6 @@
   pythonOlder,
   fetchFromGitHub,
   poetry-core,
-  pythonRelaxDepsHook,
   pdfrw,
   reportlab,
   rmscene,
@@ -30,7 +29,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/rmscene/default.nix
+++ b/pkgs/development/python-modules/rmscene/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   pythonOlder,
-  pythonRelaxDepsHook,
   fetchFromGitHub,
   poetry-core,
   packaging,
@@ -26,7 +25,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "packaging" ];

--- a/pkgs/development/python-modules/rnginline/default.nix
+++ b/pkgs/development/python-modules/rnginline/default.nix
@@ -3,7 +3,6 @@
   fetchPypi,
   buildPythonPackage,
   poetry-core,
-  pythonRelaxDepsHook,
   lxml,
   docopt-ng,
   typing-extensions,
@@ -31,7 +30,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     docopt-ng

--- a/pkgs/development/python-modules/roadrecon/default.nix
+++ b/pkgs/development/python-modules/roadrecon/default.nix
@@ -11,7 +11,6 @@
   marshmallow-sqlalchemy,
   openpyxl,
   pythonOlder,
-  pythonRelaxDepsHook,
   roadlib,
   setuptools,
   sqlalchemy,
@@ -32,7 +31,6 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "flask" ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/robomachine/default.nix
+++ b/pkgs/development/python-modules/robomachine/default.nix
@@ -5,7 +5,6 @@
   buildPythonPackage,
   fetchPypi,
   pyparsing,
-  pythonRelaxDepsHook,
   robotframework,
   setuptools,
 }:
@@ -22,7 +21,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/roombapy/default.nix
+++ b/pkgs/development/python-modules/roombapy/default.nix
@@ -11,7 +11,6 @@
   pytest-asyncio,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   tabulate,
 }:
 
@@ -31,7 +30,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "orjson" ];

--- a/pkgs/development/python-modules/safety-schemas/default.nix
+++ b/pkgs/development/python-modules/safety-schemas/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchPypi,
   hatchling,
-  pythonRelaxDepsHook,
   dparse,
   packaging,
   pydantic,
@@ -24,7 +23,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     hatchling
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "dparse" ];

--- a/pkgs/development/python-modules/safety/default.nix
+++ b/pkgs/development/python-modules/safety/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   pythonOlder,
   fetchPypi,
-  pythonRelaxDepsHook,
   setuptools,
   click,
   urllib3,
@@ -49,7 +48,6 @@ buildPythonPackage rec {
   '';
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/sagemaker/default.nix
+++ b/pkgs/development/python-modules/sagemaker/default.nix
@@ -4,7 +4,6 @@
   pythonOlder,
   fetchFromGitHub,
   fetchpatch,
-  pythonRelaxDepsHook,
   setuptools,
   attrs,
   boto3,
@@ -60,7 +59,6 @@ buildPythonPackage rec {
 
   build-system = [
     setuptools
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/sarif-tools/default.nix
+++ b/pkgs/development/python-modules/sarif-tools/default.nix
@@ -11,7 +11,6 @@
   pyyaml,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -30,7 +29,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/schema-salad/default.nix
+++ b/pkgs/development/python-modules/schema-salad/default.nix
@@ -9,7 +9,6 @@
   mypy,
   mypy-extensions,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   pythonOlder,
   rdflib,
   requests,

--- a/pkgs/development/python-modules/schema/default.nix
+++ b/pkgs/development/python-modules/schema/default.nix
@@ -5,7 +5,6 @@
   mock,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -20,7 +19,6 @@ buildPythonPackage rec {
     hash = "sha256-8GcXESxhiVyrxHB3UriHFuhCCogZ1xQEUB4RT5EEMZc=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRemoveDeps = [ "contextlib2" ];
 

--- a/pkgs/development/python-modules/scikit-learn/default.nix
+++ b/pkgs/development/python-modules/scikit-learn/default.nix
@@ -16,7 +16,6 @@
   glibcLocales,
   llvmPackages,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   pytest-xdist,
   pillow,
   joblib,
@@ -50,7 +49,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     gfortran
-    pythonRelaxDepsHook
   ];
 
   build-system = [

--- a/pkgs/development/python-modules/sev-snp-measure/default.nix
+++ b/pkgs/development/python-modules/sev-snp-measure/default.nix
@@ -3,7 +3,6 @@
   cryptography,
   fetchFromGitHub,
   lib,
-  pythonRelaxDepsHook,
   setuptools,
 }:
 
@@ -22,7 +21,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "cryptography" ];

--- a/pkgs/development/python-modules/signalslot/default.nix
+++ b/pkgs/development/python-modules/signalslot/default.nix
@@ -3,7 +3,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonRelaxDepsHook,
   contexter,
   eventlet,
   mock,
@@ -28,7 +27,6 @@ buildPythonPackage rec {
       --replace "--cov-report html" ""
   '';
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = [
     contexter

--- a/pkgs/development/python-modules/sisyphus-control/default.nix
+++ b/pkgs/development/python-modules/sisyphus-control/default.nix
@@ -7,7 +7,6 @@
   python-engineio,
   python-socketio,
   pythonOlder,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -29,7 +28,6 @@ buildPythonPackage rec {
     "python-socketio"
   ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = [
     aiohttp

--- a/pkgs/development/python-modules/skl2onnx/default.nix
+++ b/pkgs/development/python-modules/skl2onnx/default.nix
@@ -11,7 +11,6 @@
   onnxruntime,
   pandas,
   unittestCheckHook,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -33,7 +32,6 @@ buildPythonPackage rec {
     onnxconverter-common
   ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRelaxDeps = [ "scikit-learn" ];
 

--- a/pkgs/development/python-modules/snowflake-connector-python/default.nix
+++ b/pkgs/development/python-modules/snowflake-connector-python/default.nix
@@ -19,7 +19,6 @@
   pyjwt,
   pyopenssl,
   pythonOlder,
-  pythonRelaxDepsHook,
   pytz,
   requests,
   setuptools,
@@ -47,7 +46,6 @@ buildPythonPackage rec {
     wheel
   ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     asn1crypto

--- a/pkgs/development/python-modules/spacy-transformers/default.nix
+++ b/pkgs/development/python-modules/spacy-transformers/default.nix
@@ -6,7 +6,6 @@
   fetchFromGitHub,
   setuptools,
   cython,
-  pythonRelaxDepsHook,
   spacy,
   numpy,
   transformers,
@@ -35,7 +34,6 @@ buildPythonPackage rec {
     cython
   ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     spacy

--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -22,7 +22,6 @@
   pytestCheckHook,
   python,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   setuptools,
   spacy-legacy,
@@ -58,7 +57,6 @@ buildPythonPackage rec {
   ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     cython_0
   ];
 

--- a/pkgs/development/python-modules/sphinx-prompt/default.nix
+++ b/pkgs/development/python-modules/sphinx-prompt/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonRelaxDepsHook,
 
   # build-system
   poetry-core,
@@ -37,7 +36,6 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     poetry-core
     poetry-dynamic-versioning
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/sphinx-rtd-theme/default.nix
+++ b/pkgs/development/python-modules/sphinx-rtd-theme/default.nix
@@ -7,7 +7,6 @@
   readthedocs-sphinx-ext,
   sphinxcontrib-jquery,
   pytestCheckHook,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -32,7 +31,6 @@ buildPythonPackage rec {
     sphinxcontrib-jquery
   ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/sphinxawesome-theme/default.nix
+++ b/pkgs/development/python-modules/sphinxawesome-theme/default.nix
@@ -5,7 +5,6 @@
   poetry-core,
   sphinx,
   beautifulsoup4,
-  pythonRelaxDepsHook
 }:
 
 buildPythonPackage rec {
@@ -19,7 +18,7 @@ buildPythonPackage rec {
     hash = "sha256-wk8eXAueR1OA0W/F8fO/2ElVgX2gkF2V9+IICdfNPF0=";
   };
 
-  build-system = [ poetry-core pythonRelaxDepsHook ];
+  build-system = [ poetry-core ];
   dependencies = [
     sphinx
     beautifulsoup4

--- a/pkgs/development/python-modules/spsdk/default.nix
+++ b/pkgs/development/python-modules/spsdk/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonRelaxDepsHook,
   asn1crypto,
   astunparse,
   bincopy,
@@ -51,7 +50,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/steamship/default.nix
+++ b/pkgs/development/python-modules/steamship/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchPypi,
   setuptools-scm,
-  pythonRelaxDepsHook,
   requests,
   pydantic,
   aiohttp,
@@ -29,7 +28,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools-scm
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/streamlit/default.nix
+++ b/pkgs/development/python-modules/streamlit/default.nix
@@ -19,7 +19,6 @@
   pympler,
   python-dateutil,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
   requests,
   rich,
@@ -46,7 +45,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "packaging" ];

--- a/pkgs/development/python-modules/succulent/default.nix
+++ b/pkgs/development/python-modules/succulent/default.nix
@@ -8,7 +8,6 @@
   pyyaml,
   poetry-core,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   pythonOlder,
   toml-adapt,
   xmltodict,
@@ -32,7 +31,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/svg2tikz/default.nix
+++ b/pkgs/development/python-modules/svg2tikz/default.nix
@@ -7,7 +7,6 @@
   inkex,
   lxml,
   pytestCheckHook,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -38,7 +37,6 @@ buildPythonPackage rec {
     "lxml"
   ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/syncedlyrics/default.nix
+++ b/pkgs/development/python-modules/syncedlyrics/default.nix
@@ -5,7 +5,6 @@
   fetchFromGitHub,
   poetry-core,
   pythonOlder,
-  pythonRelaxDepsHook,
   rapidfuzz,
   requests,
 }:
@@ -26,7 +25,6 @@ buildPythonPackage rec {
 
   build-system = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "rapidfuzz" ];

--- a/pkgs/development/python-modules/synologydsm-api/default.nix
+++ b/pkgs/development/python-modules/synologydsm-api/default.nix
@@ -5,7 +5,6 @@
   fetchFromGitHub,
   fetchpatch,
   poetry-core,
-  pythonRelaxDepsHook,
   requests,
   urllib3,
   pytestCheckHook,
@@ -37,7 +36,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "urllib3" ];

--- a/pkgs/development/python-modules/tabcmd/default.nix
+++ b/pkgs/development/python-modules/tabcmd/default.nix
@@ -12,7 +12,6 @@
   pytestCheckHook,
   python3,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   setuptools,
   setuptools-scm,
@@ -47,7 +46,6 @@ buildPythonPackage rec {
     "urllib3"
   ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/tableauserverclient/default.nix
+++ b/pkgs/development/python-modules/tableauserverclient/default.nix
@@ -6,7 +6,6 @@
   packaging,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   requests-mock,
   setuptools,
@@ -34,7 +33,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools
-    pythonRelaxDepsHook
     versioneer
   ];
 

--- a/pkgs/development/python-modules/tago/default.nix
+++ b/pkgs/development/python-modules/tago/default.nix
@@ -6,7 +6,6 @@
   promise,
   python-socketio,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   websockets,
 }:
@@ -27,7 +26,6 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = true;
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = [
     aiohttp

--- a/pkgs/development/python-modules/tagoio-sdk/default.nix
+++ b/pkgs/development/python-modules/tagoio-sdk/default.nix
@@ -8,7 +8,6 @@
   python-dateutil,
   python-socketio,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   requests-mock,
 }:
@@ -31,7 +30,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/taskw-ng/default.nix
+++ b/pkgs/development/python-modules/taskw-ng/default.nix
@@ -8,7 +8,6 @@
   poetry-dynamic-versioning,
   python-dateutil,
   pythonOlder,
-  pythonRelaxDepsHook,
   pytz,
   taskwarrior,
 }:
@@ -37,7 +36,6 @@ buildPythonPackage rec {
     poetry-dynamic-versioning
   ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = [
     kitchen

--- a/pkgs/development/python-modules/tbm-utils/default.nix
+++ b/pkgs/development/python-modules/tbm-utils/default.nix
@@ -10,7 +10,6 @@
   pprintpp,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   wrapt,
 }:
 
@@ -52,7 +51,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = [
     attrs

--- a/pkgs/development/python-modules/tensorboard/default.nix
+++ b/pkgs/development/python-modules/tensorboard/default.nix
@@ -3,7 +3,6 @@
   fetchPypi,
   buildPythonPackage,
   pythonOlder,
-  pythonRelaxDepsHook,
   numpy,
   wheel,
   werkzeug,
@@ -35,7 +34,6 @@ buildPythonPackage rec {
     hash = "sha256-nytOfa2GZnYVwOXNBy8eqEA/wDKimfAHLW90hVd1zEU=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRelaxDeps = [
     "google-auth-oauthlib"

--- a/pkgs/development/python-modules/testtools/default.nix
+++ b/pkgs/development/python-modules/testtools/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchPypi,
   pythonAtLeast,
-  pythonRelaxDepsHook,
 
   # build-system
   hatchling,
@@ -26,7 +25,6 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     hatchling
     hatch-vcs
-    pythonRelaxDepsHook
   ];
 
   pythonRemoveDeps = [ "fixtures" ];

--- a/pkgs/development/python-modules/textnets/default.nix
+++ b/pkgs/development/python-modules/textnets/default.nix
@@ -10,7 +10,6 @@
   poetry-core,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   scipy,
   setuptools,
   spacy,
@@ -34,7 +33,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     cython
     poetry-core
     setuptools

--- a/pkgs/development/python-modules/tf-keras/default.nix
+++ b/pkgs/development/python-modules/tf-keras/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   pythonOlder,
   fetchPypi,
-  pythonRelaxDepsHook,
   setuptools,
   wheel,
   numpy,
@@ -25,7 +24,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/tf2onnx/default.nix
+++ b/pkgs/development/python-modules/tf2onnx/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonRelaxDepsHook,
   pytest-runner,
   # runtime dependencies
   numpy,
@@ -36,7 +35,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     pytest-runner
   ];
 

--- a/pkgs/development/python-modules/thelogrus/default.nix
+++ b/pkgs/development/python-modules/thelogrus/default.nix
@@ -6,7 +6,6 @@
   poetry-core,
   pyaml,
   pythonOlder,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -25,7 +24,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "pyaml" ];

--- a/pkgs/development/python-modules/tilequant/default.nix
+++ b/pkgs/development/python-modules/tilequant/default.nix
@@ -6,7 +6,6 @@
   ordered-set,
   pillow,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
   setuptools-dso,
   sortedcollections,
@@ -27,7 +26,6 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "pillow" ];
 
   build-system = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/torch/default.nix
+++ b/pkgs/development/python-modules/torch/default.nix
@@ -30,7 +30,6 @@
   which,
   pybind11,
   removeReferencesTo,
-  pythonRelaxDepsHook,
 
   # Build inputs
   numactl,
@@ -429,7 +428,6 @@ buildPythonPackage rec {
       which
       ninja
       pybind11
-      pythonRelaxDepsHook
       removeReferencesTo
     ]
     ++ lib.optionals cudaSupport (

--- a/pkgs/development/python-modules/treex/default.nix
+++ b/pkgs/development/python-modules/treex/default.nix
@@ -16,7 +16,6 @@
   tensorflow,
   treeo,
   torchmetrics,
-  pythonRelaxDepsHook,
   torch,
 }:
 
@@ -44,7 +43,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   buildInputs = [ jaxlib ];

--- a/pkgs/development/python-modules/tubeup/default.nix
+++ b/pkgs/development/python-modules/tubeup/default.nix
@@ -6,7 +6,6 @@
   yt-dlp,
   docopt,
   pythonOlder,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -21,7 +20,6 @@ buildPythonPackage rec {
     sha256 = "sha256-Pp4h0MBoYhczmxPq21cLiYpLUeFP+2JoACcFpBl3b0E=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = [
     internetarchive

--- a/pkgs/development/python-modules/twill/default.nix
+++ b/pkgs/development/python-modules/twill/default.nix
@@ -7,7 +7,6 @@
   pyparsing,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   quixote,
   setuptools,
 }:
@@ -28,7 +27,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     httpx

--- a/pkgs/development/python-modules/txtai/default.nix
+++ b/pkgs/development/python-modules/txtai/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   pythonOlder,
   fetchFromGitHub,
-  pythonRelaxDepsHook,
   # propagated build input
   faiss,
   torch,
@@ -157,7 +156,6 @@ buildPythonPackage {
     hash = "sha256-2d31wzUz0/FcrejDIog2EI4BXgjd7XXpN4tRXpLk5DI=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRemoveDeps = [
     # We call it faiss, not faiss-cpu.

--- a/pkgs/development/python-modules/typer-shell/default.nix
+++ b/pkgs/development/python-modules/typer-shell/default.nix
@@ -6,7 +6,6 @@
   fetchFromGitHub,
   iterfzf,
   poetry-core,
-  pythonRelaxDepsHook,
   pythonOlder,
   pyyaml,
   rich,
@@ -34,7 +33,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     click

--- a/pkgs/development/python-modules/typical/default.nix
+++ b/pkgs/development/python-modules/typical/default.nix
@@ -12,7 +12,6 @@
   pydantic,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   sqlalchemy,
   ujson,
 }:
@@ -35,7 +34,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     fastjsonschema

--- a/pkgs/development/python-modules/ufo2ft/default.nix
+++ b/pkgs/development/python-modules/ufo2ft/default.nix
@@ -11,7 +11,6 @@
   fonttools,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools-scm,
   skia-pathops,
   ufolib2,
@@ -31,7 +30,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools-scm
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "cffsubr" ];

--- a/pkgs/development/python-modules/universal-silabs-flasher/default.nix
+++ b/pkgs/development/python-modules/universal-silabs-flasher/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonRelaxDepsHook,
 
   # build-system
   setuptools,
@@ -43,7 +42,6 @@ buildPythonPackage rec {
       --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
   '';
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/uplc/default.nix
+++ b/pkgs/development/python-modules/uplc/default.nix
@@ -2,7 +2,6 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
-  pythonRelaxDepsHook,
   # Python deps
   frozenlist2,
   python-secp256k1-cardano,
@@ -27,7 +26,6 @@ buildPythonPackage rec {
     hash = "sha256-djJMNXijMVzMVzw8NZSe3YFRGyAPqdvr0P374Za5XkU=";
   };
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = [
     setuptools

--- a/pkgs/development/python-modules/vallox-websocket-api/default.nix
+++ b/pkgs/development/python-modules/vallox-websocket-api/default.nix
@@ -3,7 +3,6 @@
   aiohttp,
   buildPythonPackage,
   pythonOlder,
-  pythonRelaxDepsHook,
   fetchFromGitHub,
   setuptools,
   construct,
@@ -28,7 +27,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "websockets" ];

--- a/pkgs/development/python-modules/vdirsyncer/default.nix
+++ b/pkgs/development/python-modules/vdirsyncer/default.nix
@@ -23,7 +23,6 @@
   aioresponses,
   vdirsyncer,
   testers,
-  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
@@ -46,7 +45,6 @@ buildPythonPackage rec {
     setuptools
     setuptools-scm
     wheel
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "aiostream" ];

--- a/pkgs/development/python-modules/vega/default.nix
+++ b/pkgs/development/python-modules/vega/default.nix
@@ -4,7 +4,6 @@
   fetchpatch,
   fetchPypi,
   pythonOlder,
-  pythonRelaxDepsHook,
   altair,
   ipytablewidgets,
   ipywidgets,
@@ -39,7 +38,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "pandas" ];

--- a/pkgs/development/python-modules/vivisect/default.nix
+++ b/pkgs/development/python-modules/vivisect/default.nix
@@ -8,7 +8,6 @@
   pyasn1-modules,
   pycparser,
   pyqt5,
-  pythonRelaxDepsHook,
   pyqtwebengine,
   pythonOlder,
   withGui ? false,
@@ -34,7 +33,6 @@ buildPythonPackage rec {
   ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     wrapQtAppsHook
   ];
 

--- a/pkgs/development/python-modules/vt-py/default.nix
+++ b/pkgs/development/python-modules/vt-py/default.nix
@@ -6,7 +6,6 @@
   pytest-asyncio,
   pytest-httpserver,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   pythonOlder,
   setuptools,
 }:
@@ -34,7 +33,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [ aiohttp ];
 

--- a/pkgs/development/python-modules/vulcan-api/default.nix
+++ b/pkgs/development/python-modules/vulcan-api/default.nix
@@ -8,7 +8,6 @@
   fetchFromGitHub,
   pyopenssl,
   pythonOlder,
-  pythonRelaxDepsHook,
   pytz,
   related,
   requests,
@@ -32,7 +31,6 @@ buildPythonPackage rec {
 
   pythonRemoveDeps = [ "faust-cchardet" ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = [
     aenum

--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -40,7 +40,6 @@
   pytest-xdist,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   pyyaml,
   requests,
   responses,
@@ -77,7 +76,6 @@ buildPythonPackage rec {
   ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/weasel/default.nix
+++ b/pkgs/development/python-modules/weasel/default.nix
@@ -8,7 +8,6 @@
   pydantic,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   setuptools,
   smart-open,
@@ -38,7 +37,6 @@ buildPythonPackage rec {
   ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/weaviate-client/default.nix
+++ b/pkgs/development/python-modules/weaviate-client/default.nix
@@ -9,7 +9,6 @@
   httpx,
   pydantic,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools-scm,
   tqdm,
   validators,
@@ -36,7 +35,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools-scm ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     authlib

--- a/pkgs/development/python-modules/weconnect-mqtt/default.nix
+++ b/pkgs/development/python-modules/weconnect-mqtt/default.nix
@@ -6,7 +6,6 @@
   pytestCheckHook,
   python-dateutil,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
   weconnect,
 }:
@@ -39,7 +38,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   dependencies = [
     paho-mqtt

--- a/pkgs/development/python-modules/wheel-inspect/default.nix
+++ b/pkgs/development/python-modules/wheel-inspect/default.nix
@@ -7,7 +7,6 @@
   hatchling,
   headerparser,
   jsonschema,
-  pythonRelaxDepsHook,
   packaging,
   pytestCheckHook,
   pythonOlder,
@@ -42,7 +41,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     hatchling
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/woob/default.nix
+++ b/pkgs/development/python-modules/woob/default.nix
@@ -4,7 +4,6 @@
   buildPythonPackage,
   fetchFromGitLab,
   fetchpatch,
-  pythonRelaxDepsHook,
   html2text,
   lxml,
   packaging,
@@ -48,7 +47,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "packaging" ];

--- a/pkgs/development/python-modules/xarray-dataclasses/default.nix
+++ b/pkgs/development/python-modules/xarray-dataclasses/default.nix
@@ -5,7 +5,6 @@
   pythonOlder,
   poetry-core,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   numpy,
   typing-extensions,
   xarray,
@@ -27,7 +26,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [ "xarray" ];

--- a/pkgs/development/python-modules/xhtml2pdf/default.nix
+++ b/pkgs/development/python-modules/xhtml2pdf/default.nix
@@ -12,7 +12,6 @@
   pytestCheckHook,
   python-bidi,
   pythonOlder,
-  pythonRelaxDepsHook,
   reportlab,
   setuptools,
   svglib,
@@ -42,7 +41,6 @@ buildPythonPackage rec {
   ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/python-modules/xiaomi-ble/default.nix
+++ b/pkgs/development/python-modules/xiaomi-ble/default.nix
@@ -12,7 +12,6 @@
   pycryptodomex,
   pytestCheckHook,
   pythonOlder,
-  pythonRelaxDepsHook,
   sensor-state-data,
 }:
 
@@ -37,7 +36,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   pythonRelaxDeps = [ "pycryptodomex" ];
 

--- a/pkgs/development/python-modules/yark/default.nix
+++ b/pkgs/development/python-modules/yark/default.nix
@@ -8,7 +8,6 @@
   poetry-core,
   progress,
   pythonOlder,
-  pythonRelaxDepsHook,
   requests,
   yt-dlp,
 }:
@@ -33,7 +32,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/ypy-websocket/default.nix
+++ b/pkgs/development/python-modules/ypy-websocket/default.nix
@@ -9,7 +9,6 @@
   y-py,
   pytest-asyncio,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   uvicorn,
   websockets,
 }:
@@ -32,7 +31,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     hatchling
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/zha/default.nix
+++ b/pkgs/development/python-modules/zha/default.nix
@@ -13,7 +13,6 @@
   pytestCheckHook,
   python-slugify,
   pythonOlder,
-  pythonRelaxDepsHook,
   setuptools,
   universal-silabs-flasher,
   wheel,
@@ -51,7 +50,6 @@ buildPythonPackage rec {
     "zha-quirks"
   ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   build-system = [
     setuptools

--- a/pkgs/development/tools/analysis/checkov/default.nix
+++ b/pkgs/development/tools/analysis/checkov/default.nix
@@ -47,7 +47,6 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   nativeBuildInputs = with python3.pkgs; [
-    pythonRelaxDepsHook
   ];
 
   dependencies = with python3.pkgs; [

--- a/pkgs/development/tools/aws-sam-cli/default.nix
+++ b/pkgs/development/tools/aws-sam-cli/default.nix
@@ -23,7 +23,6 @@ python3.pkgs.buildPythonApplication rec {
   };
 
   build-system = with python3.pkgs; [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/development/tools/build-managers/conan/default.nix
+++ b/pkgs/development/tools/build-managers/conan/default.nix
@@ -21,7 +21,6 @@ python3.pkgs.buildPythonApplication rec {
   };
 
   nativeBuildInputs = with python3.pkgs; [
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/development/tools/circup/default.nix
+++ b/pkgs/development/tools/circup/default.nix
@@ -21,7 +21,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     setuptools-scm
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/development/tools/continuous-integration/buildbot/master.nix
+++ b/pkgs/development/tools/continuous-integration/buildbot/master.nix
@@ -9,7 +9,6 @@
 , buildbot
 , pythonOlder
 , python
-, pythonRelaxDepsHook
 , twisted
 , jinja2
 , msgpack
@@ -86,7 +85,6 @@ buildPythonApplication rec {
   };
 
   build-system = [
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/tools/djlint/default.nix
+++ b/pkgs/development/tools/djlint/default.nix
@@ -17,7 +17,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/tools/enochecker-test/default.nix
+++ b/pkgs/development/tools/enochecker-test/default.nix
@@ -2,7 +2,6 @@
 , buildPythonApplication
 , fetchPypi
 , pythonOlder
-, pythonRelaxDepsHook
 
 , certifi
 , charset-normalizer
@@ -34,7 +33,6 @@ buildPythonApplication rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = true;

--- a/pkgs/development/tools/fdroidserver/default.nix
+++ b/pkgs/development/tools/fdroidserver/default.nix
@@ -4,7 +4,6 @@
 , apksigner
 , buildPythonApplication
 , python3
-, pythonRelaxDepsHook
 , installShellFiles
 , androguard
 , babel
@@ -59,7 +58,6 @@ buildPythonApplication rec {
   '';
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     installShellFiles
   ];
 

--- a/pkgs/development/tools/prospector/default.nix
+++ b/pkgs/development/tools/prospector/default.nix
@@ -27,7 +27,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/development/tools/skjold/default.nix
+++ b/pkgs/development/tools/skjold/default.nix
@@ -20,7 +20,6 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = with python3.pkgs; [ poetry-core ];
 
-  nativeBuildInputs = with python3.pkgs; [ pythonRelaxDepsHook ];
 
   dependencies = with python3.pkgs; [
     click

--- a/pkgs/misc/flashfocus/default.nix
+++ b/pkgs/misc/flashfocus/default.nix
@@ -17,7 +17,6 @@ python3Packages.buildPythonApplication rec {
   '';
 
   nativeBuildInputs = with python3Packages; [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/misc/rich-cli/default.nix
+++ b/pkgs/misc/rich-cli/default.nix
@@ -39,7 +39,6 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   nativeBuildInputs = with python3.pkgs; [
-    pythonRelaxDepsHook
   ];
 
   dependencies = with python3.pkgs; [

--- a/pkgs/servers/apache-airflow/default.nix
+++ b/pkgs/servers/apache-airflow/default.nix
@@ -17,7 +17,6 @@ let
         };
         nativeBuildInputs = with pySelf; [
           setuptools
-          pythonRelaxDepsHook
         ];
         pythonRelaxDeps = [
           "werkzeug"

--- a/pkgs/servers/apache-airflow/python-package.nix
+++ b/pkgs/servers/apache-airflow/python-package.nix
@@ -61,7 +61,6 @@
 , python-slugify
 , python3-openid
 , pythonOlder
-, pythonRelaxDepsHook
 , pyyaml
 , rich
 , rich-argparse
@@ -227,7 +226,6 @@ buildPythonPackage rec {
 
   buildInputs = [
     airflow-frontend
-    pythonRelaxDepsHook
   ];
 
   nativeCheckInputs = [

--- a/pkgs/servers/home-assistant/appdaemon.nix
+++ b/pkgs/servers/home-assistant/appdaemon.nix
@@ -18,7 +18,6 @@ python3.pkgs.buildPythonApplication rec {
   pythonRelaxDeps = true;
 
   nativeBuildInputs = with python3.pkgs; [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -434,7 +434,6 @@ let
         };
         nativeBuildInputs = with self; [
           flit-core
-          pythonRelaxDepsHook
         ];
         pythonRelaxDeps = [
           "betterproto"
@@ -561,7 +560,6 @@ in python.pkgs.buildPythonApplication rec {
   };
 
   build-system = with python.pkgs; [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/servers/monitoring/prometheus/dmarc-metrics-exporter/default.nix
+++ b/pkgs/servers/monitoring/prometheus/dmarc-metrics-exporter/default.nix
@@ -22,7 +22,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/servers/pinnwand/default.nix
+++ b/pkgs/servers/pinnwand/default.nix
@@ -27,7 +27,6 @@ with python3.pkgs; buildPythonApplication rec {
 
   nativeBuildInputs = [
     pdm-pep517
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/tools/admin/ansible/doctor.nix
+++ b/pkgs/tools/admin/ansible/doctor.nix
@@ -30,7 +30,6 @@ python3.pkgs.buildPythonApplication rec {
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
     poetry-dynamic-versioning
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/tools/admin/ansible/later.nix
+++ b/pkgs/tools/admin/ansible/later.nix
@@ -45,7 +45,6 @@ python3.pkgs.buildPythonApplication rec {
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
     poetry-dynamic-versioning
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/tools/admin/ansible/lint.nix
+++ b/pkgs/tools/admin/ansible/lint.nix
@@ -23,7 +23,6 @@ python3.pkgs.buildPythonApplication rec {
   nativeBuildInputs = with python3.pkgs; [
     setuptools
     setuptools-scm
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -23,10 +23,6 @@ let
       hash = "sha256-96hFvXs3Fcvad+PBEpS9RFMJkcD1qHqfQ+8gtVfEbnc=";
     };
 
-    nativeBuildInputs = [
-      python3.pkgs.pythonRelaxDepsHook
-    ];
-
     pythonRelaxDeps = [
       # botocore must not be relaxed
       "colorama"

--- a/pkgs/tools/admin/gimme-aws-creds/default.nix
+++ b/pkgs/tools/admin/gimme-aws-creds/default.nix
@@ -37,7 +37,6 @@ python.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python.pkgs; [
     installShellFiles
-    pythonRelaxDepsHook
   ];
 
   pythonRemoveDeps = [

--- a/pkgs/tools/audio/spotdl/default.nix
+++ b/pkgs/tools/audio/spotdl/default.nix
@@ -20,7 +20,6 @@ in python.pkgs.buildPythonApplication rec {
 
   build-system = with python.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = true;

--- a/pkgs/tools/audio/wyoming/faster-whisper.nix
+++ b/pkgs/tools/audio/wyoming/faster-whisper.nix
@@ -17,7 +17,6 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = with python3Packages; [
     setuptools
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/tools/audio/wyoming/openwakeword.nix
+++ b/pkgs/tools/audio/wyoming/openwakeword.nix
@@ -17,7 +17,6 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = with python3Packages; [
     setuptools
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/tools/audio/wyoming/piper.nix
+++ b/pkgs/tools/audio/wyoming/piper.nix
@@ -17,7 +17,6 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = with python3Packages; [
     setuptools
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/tools/backup/tarsnapper/default.nix
+++ b/pkgs/tools/backup/tarsnapper/default.nix
@@ -26,7 +26,6 @@ python3Packages.buildPythonApplication rec {
   ];
 
   nativeBuildInputs = with python3Packages; [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/tools/backup/zfs-autobackup/default.nix
+++ b/pkgs/tools/backup/zfs-autobackup/default.nix
@@ -10,7 +10,6 @@ python3Packages.buildPythonApplication rec {
     sha256 = "sha256-rvtY7fsn2K2hueAsQkaPXcwxUAgE8j+GsQFF3eJKG2o=";
   };
 
-  nativeBuildInputs = with python3Packages; [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = with python3Packages; [ colorama ];
 

--- a/pkgs/tools/filesystems/rmfuse/default.nix
+++ b/pkgs/tools/filesystems/rmfuse/default.nix
@@ -18,7 +18,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/tools/games/steamback/default.nix
+++ b/pkgs/tools/games/steamback/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonApplication
 , fetchPypi
-, pythonRelaxDepsHook
 , setuptools
 , setuptools-scm
 , wheel
@@ -24,7 +23,6 @@ buildPythonApplication rec {
   };
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
     setuptools-scm
     wheel
   ];

--- a/pkgs/tools/misc/csvs-to-sqlite/default.nix
+++ b/pkgs/tools/misc/csvs-to-sqlite/default.nix
@@ -27,7 +27,6 @@ with python3.pkgs; buildPythonApplication rec {
   ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/tools/misc/cyclonedx-python/default.nix
+++ b/pkgs/tools/misc/cyclonedx-python/default.nix
@@ -36,7 +36,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with py.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with py.pkgs; [

--- a/pkgs/tools/misc/esphome/default.nix
+++ b/pkgs/tools/misc/esphome/default.nix
@@ -33,7 +33,6 @@ python.pkgs.buildPythonApplication rec {
     setuptools
     argcomplete
     installShellFiles
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = true;

--- a/pkgs/tools/misc/nanoemoji/default.nix
+++ b/pkgs/tools/misc/nanoemoji/default.nix
@@ -23,7 +23,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     setuptools-scm
-    pythonRelaxDepsHook
 
     pngquant
     resvg

--- a/pkgs/tools/misc/parquet-tools/default.nix
+++ b/pkgs/tools/misc/parquet-tools/default.nix
@@ -39,7 +39,6 @@ buildPythonApplication rec {
 
   nativeBuildInputs = [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/tools/misc/piston-cli/default.nix
+++ b/pkgs/tools/misc/piston-cli/default.nix
@@ -18,7 +18,6 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = with python3Packages; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/tools/misc/pricehist/default.nix
+++ b/pkgs/tools/misc/pricehist/default.nix
@@ -9,7 +9,6 @@
 , pytest-mock
 , responses
 , pytestCheckHook
-, pythonRelaxDepsHook
 }:
 
 buildPythonApplication rec {
@@ -33,7 +32,6 @@ buildPythonApplication rec {
   ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
   ];
 
   nativeCheckInputs = [

--- a/pkgs/tools/misc/sqlite3-to-mysql/default.nix
+++ b/pkgs/tools/misc/sqlite3-to-mysql/default.nix
@@ -23,7 +23,6 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = with python3Packages; [
     hatchling
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3Packages; [

--- a/pkgs/tools/misc/yubikey-manager/default.nix
+++ b/pkgs/tools/misc/yubikey-manager/default.nix
@@ -25,7 +25,6 @@ python3Packages.buildPythonPackage rec {
 
   nativeBuildInputs = with python3Packages; [
     poetry-core
-    pythonRelaxDepsHook
     installShellFiles
   ];
 

--- a/pkgs/tools/networking/cloud-custodian/default.nix
+++ b/pkgs/tools/networking/cloud-custodian/default.nix
@@ -25,7 +25,6 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = with python3.pkgs; [ poetry-core ];
 
-  nativeBuildInputs = with python3.pkgs; [ pythonRelaxDepsHook ];
 
   dependencies = with python3.pkgs; [
     argcomplete

--- a/pkgs/tools/security/amoco/default.nix
+++ b/pkgs/tools/security/amoco/default.nix
@@ -16,7 +16,6 @@ python3.pkgs.buildPythonApplication rec {
   };
 
   nativeBuildInputs = with python3.pkgs; [
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/tools/security/cfripper/default.nix
+++ b/pkgs/tools/security/cfripper/default.nix
@@ -25,7 +25,6 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   nativeBuildInputs = with python3.pkgs; [
-    pythonRelaxDepsHook
   ];
 
   dependencies = with python3.pkgs; [

--- a/pkgs/tools/security/coercer/default.nix
+++ b/pkgs/tools/security/coercer/default.nix
@@ -17,7 +17,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/tools/security/crackmapexec/default.nix
+++ b/pkgs/tools/security/crackmapexec/default.nix
@@ -17,7 +17,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/tools/security/crackql/default.nix
+++ b/pkgs/tools/security/crackql/default.nix
@@ -23,7 +23,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/tools/security/expliot/default.nix
+++ b/pkgs/tools/security/expliot/default.nix
@@ -40,7 +40,6 @@ buildPythonApplication rec {
   ];
 
   nativeBuildInputs = [
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/tools/security/faraday-agent-dispatcher/default.nix
+++ b/pkgs/tools/security/faraday-agent-dispatcher/default.nix
@@ -29,7 +29,6 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   nativeBuildInputs = with python3.pkgs; [
-    pythonRelaxDepsHook
   ];
 
   dependencies = with python3.pkgs; [

--- a/pkgs/tools/security/gallia/default.nix
+++ b/pkgs/tools/security/gallia/default.nix
@@ -21,7 +21,6 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = with python3.pkgs; [ poetry-core ];
 
-  nativeBuildInputs = with python3.pkgs; [ pythonRelaxDepsHook ];
 
   dependencies = with python3.pkgs; [
     aiofiles

--- a/pkgs/tools/security/ggshield/default.nix
+++ b/pkgs/tools/security/ggshield/default.nix
@@ -21,7 +21,6 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = with python3.pkgs; [ setuptools ];
 
-  nativeBuildInputs = with python3.pkgs; [ pythonRelaxDepsHook ];
 
   dependencies = with python3.pkgs; [
     appdirs

--- a/pkgs/tools/security/ioccheck/default.nix
+++ b/pkgs/tools/security/ioccheck/default.nix
@@ -46,7 +46,6 @@ in py.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with py.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/tools/security/knockpy/default.nix
+++ b/pkgs/tools/security/knockpy/default.nix
@@ -23,7 +23,6 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   build-system = with python3.pkgs; [
-    pythonRelaxDepsHook
     setuptools
   ];
 

--- a/pkgs/tools/security/knowsmore/default.nix
+++ b/pkgs/tools/security/knowsmore/default.nix
@@ -25,7 +25,6 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = with python3.pkgs; [ setuptools ];
 
-  nativeBuildInputs = with python3.pkgs; [ pythonRelaxDepsHook ];
 
   dependencies = with python3.pkgs; [
     aioconsole

--- a/pkgs/tools/security/ldeep/default.nix
+++ b/pkgs/tools/security/ldeep/default.nix
@@ -25,7 +25,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     cython
-    pythonRelaxDepsHook
   ];
 
   dependencies = with python3.pkgs; [

--- a/pkgs/tools/security/maigret/default.nix
+++ b/pkgs/tools/security/maigret/default.nix
@@ -26,7 +26,6 @@ python3.pkgs.buildPythonApplication rec {
     })
   ];
 
-  nativeBuildInputs = [ python3.pkgs.pythonRelaxDepsHook ];
 
   propagatedBuildInputs = with python3.pkgs; [
     aiodns

--- a/pkgs/tools/security/mitmproxy2swagger/default.nix
+++ b/pkgs/tools/security/mitmproxy2swagger/default.nix
@@ -17,7 +17,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/tools/security/netexec/default.nix
+++ b/pkgs/tools/security/netexec/default.nix
@@ -48,7 +48,6 @@ python.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python.pkgs; [

--- a/pkgs/tools/security/ospd-openvas/default.nix
+++ b/pkgs/tools/security/ospd-openvas/default.nix
@@ -23,7 +23,6 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = with python3.pkgs; [ poetry-core ];
 
-  nativeBuildInputs = with python3.pkgs; [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = with python3.pkgs; [
     defusedxml

--- a/pkgs/tools/security/quark-engine/default.nix
+++ b/pkgs/tools/security/quark-engine/default.nix
@@ -19,7 +19,6 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = with python3.pkgs; [ setuptools ];
 
-  nativeBuildInputs = with python3.pkgs; [ pythonRelaxDepsHook ];
 
   dependencies = with python3.pkgs; [
     androguard

--- a/pkgs/tools/security/semgrep/default.nix
+++ b/pkgs/tools/security/semgrep/default.nix
@@ -3,7 +3,6 @@
 , semgrep-core
 , buildPythonApplication
 , pythonPackages
-, pythonRelaxDepsHook
 
 , pytestCheckHook
 , git
@@ -42,7 +41,6 @@ buildPythonApplication rec {
     cd cli
   '';
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
   # tell cli/setup.py to not copy semgrep-core into the result
   # this means we can share a copy of semgrep-core and avoid an issue where it
   # copies the binary but doesn't retain the executable bit

--- a/pkgs/tools/security/tell-me-your-secrets/default.nix
+++ b/pkgs/tools/security/tell-me-your-secrets/default.nix
@@ -22,7 +22,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/tools/security/trueseeing/default.nix
+++ b/pkgs/tools/security/trueseeing/default.nix
@@ -17,7 +17,6 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = with python3.pkgs; [
     flit-core
-    pythonRelaxDepsHook
   ];
 
   pythonRelaxDeps = true;

--- a/pkgs/tools/security/wapiti/default.nix
+++ b/pkgs/tools/security/wapiti/default.nix
@@ -26,7 +26,6 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = with python3.pkgs; [ setuptools ];
 
-  nativeBuildInputs = with python3.pkgs; [ pythonRelaxDepsHook ];
 
   dependencies =
     with python3.pkgs;

--- a/pkgs/tools/security/yaralyzer/default.nix
+++ b/pkgs/tools/security/yaralyzer/default.nix
@@ -22,7 +22,6 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = with python3.pkgs; [
     poetry-core
-    pythonRelaxDepsHook
   ];
 
   dependencies = with python3.pkgs; [

--- a/pkgs/tools/system/nvitop/default.nix
+++ b/pkgs/tools/system/nvitop/default.nix
@@ -16,7 +16,6 @@ python3Packages.buildPythonApplication rec {
 
   pythonRelaxDeps = [ "nvidia-ml-py" ];
 
-  nativeBuildInputs = with python3Packages; [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = with python3Packages; [
     cachetools

--- a/pkgs/tools/text/frogmouth/default.nix
+++ b/pkgs/tools/text/frogmouth/default.nix
@@ -17,7 +17,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = [
     python3.pkgs.poetry-core
-    python3.pkgs.pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/tools/virtualization/awsebcli/default.nix
+++ b/pkgs/tools/virtualization/awsebcli/default.nix
@@ -35,7 +35,6 @@ localPython.pkgs.buildPythonApplication rec {
   '';
 
   nativeBuildInputs = with localPython.pkgs; [
-    pythonRelaxDepsHook
   ];
 
   buildInputs = [


### PR DESCRIPTION
Configuring `pythonRelaxDeps` or `pythonRemoveDeps` does not require
adding `pythonRelaxDepsHook` into `nativeBuildInputs` anymore.

Simple alternative to #319432

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc