### PR TITLE
mss: init at 9.1.0

### DIFF
--- a/pkgs/by-name/ms/mss/fix-git-repo-error.patch
+++ b/pkgs/by-name/ms/mss/fix-git-repo-error.patch
@@ -1,0 +1,27 @@
+diff --git a/tests/constants.py b/tests/constants.py
+index be503bf8..bc6d2a48 100644
+--- a/tests/constants.py
++++ b/tests/constants.py
+@@ -29,17 +29,13 @@ import os
+ import fs
+ from fs.tempfs import TempFS
+ 
++import git
+ try:
+-    import git
+-except ImportError:
+-    SHA = ""
+-else:
+     repo = git.Repo(os.path.dirname(os.path.realpath(__file__)), search_parent_directories=True)
+-    try:
+-        SHA = repo.head.object.hexsha[0:10]
+-    except ValueError:
+-        # mounted dir in docker container and owner is not root
+-        SHA = ""
++    SHA = repo.head.object.hexsha[0:10]
++except (ValueError, git.InvalidGitRepositoryError):
++    # source under test is not a git repository
++    SHA = ""
+ 
+ CACHED_CONFIG_FILE = None
+ SERVER_CONFIG_FILE = "mswms_settings.py"

--- a/pkgs/by-name/ms/mss/package.nix
+++ b/pkgs/by-name/ms/mss/package.nix
@@ -1,0 +1,133 @@
+{ lib
+, fetchFromGitHub
+, hdf4
+, libtiff
+, python3
+, qt5
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "MSS";
+  version = "9.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Open-MSS";
+    repo = "MSS";
+    rev = version;
+    hash = "sha256-3TMnEvjxv5B0/1LYsLe/QcEtJSGeOeHMxRnGLz/QKY0=";
+  };
+
+  patches = [
+    ./fix-git-repo-error.patch
+  ];
+
+  nativeBuildInputs = with python3.pkgs; [
+    future
+    qt5.wrapQtAppsHook
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    basemap
+    cftime
+    chameleon
+    dbus-python
+    defusedxml
+    email-validator
+    execnet
+    fastkml
+    flask
+    flask-cors
+    flask-httpauth
+    flask-login
+    flask-mail
+    flask-migrate
+    flask-socketio
+    flask-sqlalchemy
+    flask-wtf
+    fs
+    fs_filepicker
+    gitpython
+    gpxpy
+    hdf4
+    isodate
+    itsdangerous
+    keyring
+    libtiff
+    lxml
+    markdown
+    matplotlib
+    metpy
+    multidict
+    netcdf4
+    owslib
+    passlib
+    pillow
+    pint
+    psycopg2
+    pycountry
+    pyjwt
+    pymysql
+    pyqt5
+    pysaml2
+    python-engineio
+    python-slugify
+    python-socketio
+    requests
+    scipy
+    shapely
+    skyfield
+    skyfield-data
+    sqlalchemy
+    tkinter
+    unicodecsv
+    validate-email
+    websocket-client
+    werkzeug
+    xmlsec
+    xstatic
+    xstatic-bootstrap
+    xstatic-jquery
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    eventlet
+    mock
+    pynco
+    pytest-qt
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+    export QT_PLUGIN_PATH="${qt5.qtbase.bin}/${qt5.qtbase.qtPluginPrefix}"
+    export QT_QPA_PLATFORM_PLUGIN_PATH="${qt5.qtbase.bin}/lib/qt-${qt5.qtbase.version}/plugins";
+    export QT_QPA_PLATFORM=offscreen
+  '';
+
+  # Both test_milestone_url and test_download_progress require network access
+  disabledTests = [
+    "test_download_progress"
+    "test_milestone_url"
+  ];
+
+  # The tests in these files are flaky (they also make problems upstream)
+  disabledTestFiles = [
+    "tests/_test_msui/test_sideview.py"
+    "tests/_test_msui/test_topview.py"
+    "tests/_test_msui/test_wms_control.py"
+  ];
+
+  # Properly wrap the pyqt application
+  dontWrapQtApps = true;
+  preFixup = ''
+    wrapQtApp "$out/bin/msui"
+  '';
+
+  meta = with lib; {
+    description = "QT application, OGC web map server, collaboration server to plan atmospheric research flights";
+    homepage = "https://github.com/Open-MSS/MSS";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ matrss ];
+  };
+}

--- a/pkgs/development/python-modules/fastkml/default.nix
+++ b/pkgs/development/python-modules/fastkml/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchPypi, pytestCheckHook, setuptools, python-dateutil, pygeoif_0_7 }:
+
+buildPythonPackage rec {
+  pname = "fastkml";
+  version = "0.12";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-NNjrL3e1VAAnQ7uL5WePidjs6lpk3tFIACj0NAXYtjg=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  propagatedBuildInputs = [ python-dateutil pygeoif_0_7 ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    homepage = "https://github.com/cleder/fastkml";
+    description = "Fast KML processing for python";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ matrss ];
+  };
+}

--- a/pkgs/development/python-modules/fs_filepicker/default.nix
+++ b/pkgs/development/python-modules/fs_filepicker/default.nix
@@ -1,0 +1,72 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fs
+, future
+, humanfriendly
+, mock
+, pyqt5
+, pytestCheckHook
+, pythonRelaxDepsHook
+, qt5
+}:
+
+buildPythonPackage rec {
+  pname = "fs_filepicker";
+  version = "0.3.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Open-MSS";
+    repo = pname;
+    rev = version;
+    hash = "sha256-p4Uxl+kVSNUBlfclceArfLTsJxyxHTze1FhzH2CKXvI=";
+  };
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+    qt5.wrapQtAppsHook
+  ];
+
+  propagatedBuildInputs = [
+    fs
+    future
+    humanfriendly
+    pyqt5
+  ];
+
+  nativeCheckInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  pythonRelaxDeps = [
+    "future"
+  ];
+
+  prePatch = ''
+    # Necessary to avoid a segmentation fault in the test suite
+    substituteInPlace tests/test_fs_filepicker.py \
+      --replace 'self.application = QtWidgets.QApplication([])' 'self.application = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])'
+  '';
+
+  # Properly wrap the pyqt application
+  dontWrapQtApps = true;
+  preFixup = ''
+    wrapQtApp "$out/bin/fs_filepicker"
+  '';
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+    export QT_PLUGIN_PATH="${qt5.qtbase.bin}/${qt5.qtbase.qtPluginPrefix}"
+    export QT_QPA_PLATFORM_PLUGIN_PATH="${qt5.qtbase.bin}/lib/qt-${qt5.qtbase.version}/plugins";
+    export QT_QPA_PLATFORM=offscreen
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/Open-MSS/fs_filepicker";
+    description = "QT file picker (Open|Save|GetDirectory) for accessing a pyfilesystem2";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ matrss ];
+  };
+}

--- a/pkgs/development/python-modules/metpy/default.nix
+++ b/pkgs/development/python-modules/metpy/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, matplotlib
+, pint
+, pooch
+, pyproj
+, pytest-mpl
+, pytestCheckHook
+, scipy
+, setuptools
+, setuptools-scm
+, traitlets
+, xarray
+}:
+
+buildPythonPackage rec {
+  pname = "metpy";
+  version = "1.6.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "MetPy";
+    inherit version;
+    hash = "sha256-6wZbrA14GFh/o4+myW3+cg2dFbWa9OSGZUGJTiZ0drs=";
+  };
+
+  nativeBuildInputs = [ setuptools setuptools-scm ];
+
+  propagatedBuildInputs = [
+    matplotlib
+    pint
+    pooch
+    pyproj
+    scipy
+    traitlets
+    xarray
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  checkInputs = [ pytest-mpl ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  # Many tests require fetching data from GitHub
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/Unidata/MetPy";
+    description = "Tools for reading, visualizing and performing calculations with weather data";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ matrss ];
+  };
+}

--- a/pkgs/development/python-modules/pygeoif/0.7.nix
+++ b/pkgs/development/python-modules/pygeoif/0.7.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, pytestCheckHook, setuptools }:
+
+buildPythonPackage rec {
+  pname = "pygeoif";
+  version = "0.7";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-EaoMBx04vvpK870SPvqDSr4II6hz83RPCgcKRAJa/gQ=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    homepage = "https://github.com/cleder/pygeoif";
+    description = "Basic implementation of the __geo_interface__";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ matrss ];
+  };
+}

--- a/pkgs/development/python-modules/pynco/default.nix
+++ b/pkgs/development/python-modules/pynco/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, nco
+, netcdf4
+, numpy
+, pytestCheckHook
+, python-dateutil
+, scipy
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "pynco";
+  version = "1.1.2";
+  pyproject = true;
+
+  # The source tarball on PyPI does not contain at least tests/conftest.py, so is not testable.
+  # Fetching from GitHub gives the full source code.
+  src = fetchFromGitHub {
+    owner = "nco";
+    repo = pname;
+    rev = version;
+    hash = "sha256-zU0Y11zYQPQ4poyvbSxeOP7NVfEVd6zxDpgtYp4hLKA=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  propagatedBuildInputs = [
+    netcdf4
+    numpy
+    scipy
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook nco ];
+
+  checkInputs = [ python-dateutil ];
+
+  meta = with lib; {
+    homepage = "https://github.com/nco/pynco";
+    description = "Python bindings for NCO";
+    license = licenses.mit;
+    maintainers = with maintainers; [ matrss ];
+  };
+}

--- a/pkgs/development/python-modules/skyfield-data/default.nix
+++ b/pkgs/development/python-modules/skyfield-data/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, mock
+, pytestCheckHook
+, setuptools
+, skyfield
+}:
+
+buildPythonPackage rec {
+  pname = "skyfield-data";
+  version = "6.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "brunobord";
+    repo = pname;
+    rev = version;
+    hash = "sha256-3DyPBgiyMOqoKM7pViHrRLkL52P9XwqYvGZ5Rr0LFeI=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  checkInputs = [ mock skyfield ];
+
+  meta = with lib; {
+    homepage = "https://github.com/brunobord/skyfield-data";
+    description = "Minimal data files to work with python-skyfield";
+    license = licenses.mit;
+    maintainers = with maintainers; [ matrss ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11205,6 +11205,8 @@ self: super: with self; {
 
   pygdbmi = callPackage ../development/python-modules/pygdbmi { };
 
+  pygeoif_0_7 = callPackage ../development/python-modules/pygeoif/0.7.nix { };
+
   pygeoip = callPackage ../development/python-modules/pygeoip { };
 
   pygetwindow = callPackage ../development/python-modules/pygetwindow { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14168,6 +14168,8 @@ self: super: with self; {
 
   skyfield = callPackage ../development/python-modules/skyfield { };
 
+  skyfield-data = callPackage ../development/python-modules/skyfield-data { };
+
   skytemple-dtef = callPackage ../development/python-modules/skytemple-dtef { };
 
   skytemple-eventserver = callPackage ../development/python-modules/skytemple-eventserver { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8808,6 +8808,8 @@ self: super: with self; {
 
   nclib = callPackage ../development/python-modules/nclib { };
 
+  pynco = callPackage ../development/python-modules/pynco { };
+
   ndeflib = callPackage ../development/python-modules/ndeflib { };
 
   ndg-httpsclient = callPackage ../development/python-modules/ndg-httpsclient { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4614,6 +4614,8 @@ self: super: with self; {
 
   fs = callPackage ../development/python-modules/fs { };
 
+  fs_filepicker = callPackage ../development/python-modules/fs_filepicker { };
+
   fs-s3fs = callPackage ../development/python-modules/fs-s3fs { };
 
   fschat = callPackage ../development/python-modules/fschat { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4195,6 +4195,8 @@ self: super: with self; {
     inherit (self) python;
   });
 
+  fastkml = callPackage ../development/python-modules/fastkml { };
+
   fastnumbers = callPackage ../development/python-modules/fastnumbers { };
 
   fastparquet = callPackage ../development/python-modules/fastparquet { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7513,6 +7513,8 @@ self: super: with self; {
 
   meteofrance-api = callPackage ../development/python-modules/meteofrance-api { };
 
+  metpy = callPackage ../development/python-modules/metpy { };
+
   mezzanine = callPackage ../development/python-modules/mezzanine { };
 
   mf2py = callPackage ../development/python-modules/mf2py { };


### PR DESCRIPTION
## Description of changes

https://github.com/Open-MSS/MSS is "A QT application, a OGC web map server, a collaboration server to plan atmospheric research flights.".

This PR adds a derivation for MSS and all of its dependencies that aren't available yet in nixpkgs. Except for metpy (too many network accesses) all run the upstream-provided test suite. The `fastkml` package has a dependency on `pygeoif<1`, so I've packaged `pygeoif=0.7` instead of the latest version to satisfy that constraint.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - NOTE: MSS provides a bunch of different entrypoints, because it is one package containing server and client code. The primary ones are `msui`, `mscolab`, and `mswms`, which I have tested. The `mssautoplot` entrypoint seems to be broken, not just here but also upstream.
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
