### PR TITLE
Mobroute, Mobsql, Transito: init at 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21229,6 +21229,13 @@
     github = "Trundle";
     githubId = 332418;
   };
+  trungtruong1 = {
+    name = "Truong Huy Trung";
+    email = "truonghuytrung2001@gmail.com";
+    matrix = "@trungtruong1:mtrx.nz";
+    github = "trungtruong1";
+    githubId = 108263341;
+  };
   tsandrini = {
     email = "tomas.sandrini@seznam.cz";
     name = "Tomáš Sandrini";

--- a/pkgs/by-name/mo/mobroute/package.nix
+++ b/pkgs/by-name/mo/mobroute/package.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildGoModule
+, fetchFromSourcehut
+}:
+
+buildGoModule rec {
+  pname = "mobroute";
+  version = "0.5.0";
+
+  src = fetchFromSourcehut {
+    owner = "~mil";
+    repo = "mobroute";
+    rev = "v${version}";
+    hash = "sha256-2NDZbv3jDM9INl/ZteSL6ege1vRhaeO5LYGBEMuSrmg=";
+  };
+
+  proxyVendor = true;
+
+  vendorHash = "sha256-meOYwLTkBAq7G0r9H5GtaT78Ztlxgo3Sfis/qwdC2dQ=";
+
+  buildPhase = ''
+    runHook preBuild
+    go build -o $GOPATH/bin/${pname} -tags=sqlite_math_functions -buildvcs=false cli/mobroutecli.go
+    runHook postBuild
+  '';
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    go test -failfast -p 1 -v -tags=sqlite_math_functions -buildvcs=false ./...
+  '';
+
+  meta = with lib; {
+    description = "General purpose public transportation router";
+    homepage = "https://git.sr.ht/~mil/mobroute";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.trungtruong1 ];
+    mainProgram = "mobroute";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/by-name/mo/mobsql/package.nix
+++ b/pkgs/by-name/mo/mobsql/package.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildGoModule
+, fetchFromSourcehut
+}:
+
+buildGoModule rec {
+  pname = "mobsql";
+  version = "0.5.0";
+
+  src = fetchFromSourcehut {
+    owner = "~mil";
+    repo = "mobsql";
+    rev = "v${version}";
+    hash = "sha256-OKwl9SudYUGAjR8l3y7BCSmCIuDo7IKosh02TedLvnQ=";
+  };
+
+  proxyVendor = true;
+
+  vendorHash = "sha256-4Ajo9+MOHh8sew0380kEl4i29UaF7bMm83WomcExH80=";
+
+  buildPhase = ''
+    runHook preBuild
+    go build -o $GOPATH/bin/${pname} -tags=sqlite_math_functions cli/mobsqlcli.go
+    runHook postBuild
+  '';
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    go test -v ./...
+  '';
+
+  meta = with lib; {
+    description = "Load Mobility Databases source GTFS feed archives into a SQLite database";
+    homepage = "https://git.sr.ht/~mil/mobsql";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.trungtruong1 ];
+    mainProgram = "mobsql";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/by-name/tr/transito/package.nix
+++ b/pkgs/by-name/tr/transito/package.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildGoModule
+, fetchFromSourcehut
+, pkg-config
+, vulkan-headers
+, libxkbcommon
+, wayland
+, xorg
+, libGL
+}:
+
+buildGoModule rec {
+  pname = "transito";
+  version = "0.5.0";
+
+  src = fetchFromSourcehut {
+    owner = "~mil";
+    repo = "transito";
+    rev = "v${version}";
+    hash = "sha256-EM7hnHZjchpRzjl+iCBeLqLcyZhIS2Tl9opDx/w7Dcw=";
+  };
+
+  proxyVendor = true;
+
+  vendorHash = "sha256-8GLtZxn8q0VAmgs8fwqLNriKiRr2VjgvfFx9QdR4x5I=";
+
+  doCheck = true;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    vulkan-headers
+    libxkbcommon
+    wayland
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXfixes
+    libGL
+  ];
+
+  ldflags = [
+    "-X git.sr.ht/~mil/transito/uipages/pageconfig.Commit=${version}"
+  ];
+
+  tags = [
+    "sqlite_math_functions"
+  ];
+
+  meta = with lib; {
+    description = "Data-provider-agnostic public transportation app";
+    homepage = "https://git.sr.ht/~mil/transito";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.trungtruong1 ];
+    mainProgram = "transito";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds 3 packages: Mobroute, Mobsql, and Transito. 

[Mobroute](https://git.sr.ht/~mil/mobroute) is a general purpose FOSS public transportation router (e.g. trip planner) Go library and CLI that works by directly ingesting timetable (GTFS) data from transit agencies themselves (sourced from the [Mobility Database](https://database.mobilitydata.org/))

[Mobsql](https://git.sr.ht/~mil/mobsql): is a GTFS-to-SQL ETL tool which pulls GTFS sources from the MobilityDB into a SQLite database. It exposes both a CLI & a Go library (consumed by Mobroute).

[Transito](https://git.sr.ht/~mil/transito): is a simple Android & Linux GUI app to use Mobroute. It allows querying from/to via Nominatim and performing routing calculations on-the-go via Mobroute's underlying routing mechanism (implicitly integrates Mobsql as well).

This is my first contribution so please let me know if any changes or improvements are needed!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
