### PR TITLE
python3Packages.pyinstaller: init at 6.8.0, with dependencies

### DIFF
--- a/pkgs/development/python-modules/altgraph/default.nix
+++ b/pkgs/development/python-modules/altgraph/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools
 }:
 
 buildPythonPackage rec {
@@ -14,6 +15,12 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "sha256-G1r7uY9sTcrbLirmq5+plLu4wddfT6ltNA+UN65FRAY=";
   };
+
+  dependencies = [
+    # setuptools in dependencies is intentional
+    # https://github.com/ronaldoussoren/altgraph/issues/21
+    setuptools
+  ];
 
   pythonImportsCheck = [ "altgraph" ];
 

--- a/pkgs/development/python-modules/pyinstaller-hooks-contrib/default.nix
+++ b/pkgs/development/python-modules/pyinstaller-hooks-contrib/default.nix
@@ -1,0 +1,45 @@
+{
+  lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "pyinstaller-hooks-contrib";
+  version = "2024.7";
+
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "pyinstaller_hooks_contrib";
+    inherit version;
+    hash = "sha256-/V833Pmb7OGE5AZCr4i+Fqm4lhPsuViovRE2Y0/J+sU=";
+  };
+
+  build-system = [ setuptools ];
+
+  # There are tests for every hook, which means that
+  # new updates are going to require changes to test inputs
+  # and building tests creates a very big closure.
+  doCheck = false;
+
+  meta = {
+    description = "Community maintained hooks for PyInstaller";
+    longDescription = ''
+      A "hook" file extends PyInstaller to adapt it to the special needs and methods used by a Python package.
+      The word "hook" is used for two kinds of files. A runtime hook helps the bootloader to launch an app,
+      setting up the environment. A package hook (there are several types of those) tells PyInstaller
+      what to include in the final app - such as the data files and (hidden) imports mentioned above.
+      This repository is a collection of hooks for many packages, and allows PyInstaller to work with these packages seamlessly.
+    '';
+    homepage = "https://github.com/pyinstaller/pyinstaller-hooks-contrib";
+    # See https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/761
+    changelog = "https://github.com/pyinstaller/pyinstaller-hooks-contrib/blob/master/CHANGELOG.rst";
+    license = with lib.licenses; [
+      gpl2Plus
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ h7x4 ];
+  };
+}

--- a/pkgs/development/python-modules/pyinstaller/default.nix
+++ b/pkgs/development/python-modules/pyinstaller/default.nix
@@ -1,0 +1,67 @@
+{
+  lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, zlib
+, altgraph
+, packaging
+, pyinstaller-hooks-contrib
+, testers
+, pyinstaller
+, glibc
+, binutils
+, installShellFiles
+}:
+
+buildPythonPackage rec {
+  pname = "pyinstaller";
+  version = "6.8.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-P0tlIPRCP+GbzC/WOrcjiFGuK9y8mPJbxdL5fMYgEuk=";
+  };
+
+
+  build-system = [ setuptools ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  buildInputs = [ zlib.dev ];
+
+  dependencies = [
+    altgraph
+    packaging
+    pyinstaller-hooks-contrib
+  ];
+
+  makeWrapperArgs = [
+    "--prefix" "PATH" ":"  (lib.makeBinPath [ glibc binutils ])
+  ];
+
+  postInstall = ''
+    installManPage doc/pyinstaller.1 doc/pyi-makespec.1
+  '';
+
+  pythonImportsCheck = [ "PyInstaller" ];
+
+  passthru.tests.version = testers.testVersion {
+    package = pyinstaller;
+  };
+
+  meta = {
+    description = "A tool to bundle a python application with dependencies into a single package";
+    homepage = "https://pyinstaller.org/";
+    changelog = "https://pyinstaller.org/en/v${version}/CHANGES.html";
+    downloadPage = "https://pypi.org/project/pyinstaller/";
+    license = with lib.licenses; [
+      mit
+      asl20
+      gpl2Plus
+    ];
+    maintainers = with lib.maintainers; [ h7x4 ];
+    mainProgram = "pyinstaller";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10031,6 +10031,8 @@ self: super: with self; {
 
   pyindego = callPackage ../development/python-modules/pyindego { };
 
+  pyinstaller-hooks-contrib = callPackage ../development/python-modules/pyinstaller-hooks-contrib { };
+
   pyinstaller-versionfile = callPackage ../development/python-modules/pyinstaller-versionfile { };
 
   pyisemail = callPackage ../development/python-modules/pyisemail { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10031,6 +10031,8 @@ self: super: with self; {
 
   pyindego = callPackage ../development/python-modules/pyindego { };
 
+  pyinstaller = callPackage ../development/python-modules/pyinstaller { };
+
   pyinstaller-hooks-contrib = callPackage ../development/python-modules/pyinstaller-hooks-contrib { };
 
   pyinstaller-versionfile = callPackage ../development/python-modules/pyinstaller-versionfile { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes #249327

I have tested pyinstaller on a small project, verifying that the basic functionality of the main executable works, but not much more.

@septem9er: I have taken you out of the maintainer list for `python3Packages.pyinstaller-hooks-contrib` for now. Considering you closed #224865, I am guessing you do not want to maintain it. Ping me or open a PR if this is not the case

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
