### PR TITLE
config.rust: update references from rustc

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -254,7 +254,7 @@ By default, it takes the `stdenv.hostPlatform.config` and replaces components
 where they are known to differ. But there are ways to customize the argument:
 
  - To choose a different target by name, define
-   `stdenv.hostPlatform.rustc.config` as that name (a string), and that
+   `stdenv.hostPlatform.rust.rustcTarget` as that name (a string), and that
    name will be used instead.
 
    For example:
@@ -262,7 +262,7 @@ where they are known to differ. But there are ways to customize the argument:
    ```nix
    import <nixpkgs> {
      crossSystem = (import <nixpkgs/lib>).systems.examples.armhf-embedded // {
-       rustc.config = "thumbv7em-none-eabi";
+       rust.rustcTarget = "thumbv7em-none-eabi";
      };
    }
    ```
@@ -274,10 +274,10 @@ where they are known to differ. But there are ways to customize the argument:
    ```
 
  - To pass a completely custom target, define
-   `stdenv.hostPlatform.rustc.config` with its name, and
-   `stdenv.hostPlatform.rustc.platform` with the value.  The value will be
+   `stdenv.hostPlatform.rust.rustcTarget` with its name, and
+   `stdenv.hostPlatform.rust.platform` with the value.  The value will be
    serialized to JSON in a file called
-   `${stdenv.hostPlatform.rustc.config}.json`, and the path of that file
+   `${stdenv.hostPlatform.rust.rustcTarget}.json`, and the path of that file
    will be used instead.
 
    For example:
@@ -285,8 +285,8 @@ where they are known to differ. But there are ways to customize the argument:
    ```nix
    import <nixpkgs> {
      crossSystem = (import <nixpkgs/lib>).systems.examples.armhf-embedded // {
-       rustc.config = "thumb-crazy";
-       rustc.platform = { foo = ""; bar = ""; };
+       rust.rustcTarget = "thumb-crazy";
+       rust.platform = { foo = ""; bar = ""; };
      };
    }
    ```

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -59,7 +59,7 @@ rec {
 
   armv7a-android-prebuilt = {
     config = "armv7a-unknown-linux-androideabi";
-    rustc.config = "armv7-linux-androideabi";
+    rust.rustcTarget = "armv7-linux-androideabi";
     sdkVer = "28";
     ndkVer = "24";
     useAndroidPrebuilt = true;
@@ -67,7 +67,7 @@ rec {
 
   aarch64-android-prebuilt = {
     config = "aarch64-unknown-linux-android";
-    rustc.config = "aarch64-linux-android";
+    rust.rustcTarget = "aarch64-linux-android";
     sdkVer = "28";
     ndkVer = "24";
     useAndroidPrebuilt = true;
@@ -207,7 +207,7 @@ rec {
   aarch64-embedded = {
     config = "aarch64-none-elf";
     libc = "newlib";
-    rustc.config = "aarch64-unknown-none";
+    rust.rustcTarget = "aarch64-unknown-none";
   };
 
   aarch64be-embedded = {

--- a/pkgs/applications/virtualization/rust-hypervisor-firmware/default.nix
+++ b/pkgs/applications/virtualization/rust-hypervisor-firmware/default.nix
@@ -17,8 +17,8 @@ let
   cross = import ../../../.. {
     system = hostPlatform.system;
     crossSystem = lib.systems.examples."${arch}-embedded" // {
-      rustc.config = "${arch}-unknown-none";
-      rustc.platform = lib.importJSON target;
+      rust.rustcTarget = "${arch}-unknown-none";
+      rust.platform = lib.importJSON target;
     };
   };
 


### PR DESCRIPTION
`rustc.config` is called `rust.rustcTarget` now, and `{rustc -> rust}.platform`.

This is the new way (tm), and is preferred since
https://github.com/NixOS/nixpkgs/pull/271707 -
though the documentation still is outdated, and some expressions in nixpkgs were using the old interface.

This updates both.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (`rust-hypervisor-firmware`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
