### PR TITLE
andromeda-gtk-theme: 0-unstable-2024-03-04 -> 0-unstable-2024-06-08

### DIFF
--- a/pkgs/data/themes/andromeda-gtk-theme/default.nix
+++ b/pkgs/data/themes/andromeda-gtk-theme/default.nix
@@ -2,22 +2,22 @@
 
 stdenvNoCC.mkDerivation {
   pname = "andromeda-gtk-theme";
-  version = "0-unstable-2024-03-04";
+  version = "0-unstable-2024-06-08";
 
   srcs = [
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = "Andromeda-gtk";
-      rev = "250751a546dd0fa2e67eef86d957fbf993b61dfe";
-      hash = "sha256-exr9j/jW2P9cBhKUPQy3AtK5Vgav5vOyWInXUyVhBk0=";
+      rev = "8efb8ffef7118adf7a22d34a287594499d62b9b8";
+      hash = "sha256-AlPSD6tPNYY8iqPFS5IVOO5Zd3UqR3uS5h4l48UZ+dw=";
       name = "Andromeda";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = "Andromeda-gtk";
-      rev = "11a6194d19cb846447db048455a5e782ec830ae1";
-      hash = "sha256-Yy3mih0nyA+ahLqj2D99EKqtmWYJRsvQMkmlLfUPcqQ=";
+      rev = "b8c1a8bd0ba8d3e35dcd43f3fc3c177844b02c9c";
+      hash = "sha256-51IWJtbAHA8jNbrGbudiwqQ9SC4dpj9CTHqovNWOtc8=";
       name = "Andromeda-standard-buttons";
     })
   ];


### PR DESCRIPTION
## Description of changes

Update to version [0-unstable-2024-06-08](https://github.com/EliverLara/Andromeda-gtk/commits/main)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
