### PR TITLE
pgcli: 4.0.1 -> 4.1.0

### DIFF
--- a/pkgs/development/python-modules/pgcli/default.nix
+++ b/pkgs/development/python-modules/pgcli/default.nix
@@ -15,6 +15,7 @@
   keyring,
   pendulum,
   pytestCheckHook,
+  setuptools,
   sshtunnel,
   mock,
 }:
@@ -23,12 +24,12 @@
 # integrating with ipython-sql
 buildPythonPackage rec {
   pname = "pgcli";
-  version = "4.0.1";
-  format = "setuptools";
+  version = "4.1.0";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-8v7qIJnOGtXoqdXZOw7a9g3GHpeyG3XpHZcjk5zlO9I=";
+    hash = "sha256-P9Fsi1G9AUX/YYwscyZLzYVLqGaqIG1PB2hR9kG5shU=";
   };
 
   propagatedBuildInputs = [
@@ -46,12 +47,16 @@ buildPythonPackage rec {
     sshtunnel
   ];
 
+  nativeBuildInputs = [ setuptools ];
   nativeCheckInputs = [
     pytestCheckHook
     mock
   ];
 
-  disabledTests = lib.optionals stdenv.isDarwin [ "test_application_name_db_uri" ];
+  disabledTests = [
+    # requires running postgres
+    "test_application_name_in_env"
+  ] ++ lib.optionals stdenv.isDarwin [ "test_application_name_db_uri" ];
 
   meta = with lib; {
     description = "Command-line interface for PostgreSQL";


### PR DESCRIPTION


## Description of changes
- Migrate to `pyproject` to build the python package.
- Bump the version to 4.1.0 [changelog](https://github.com/dbcli/pgcli/blob/main/changelog.rst#410-2024-03-09). 
- Disables a broken test checking a feature to pass application name via cli and environment variables, but the feature works as intended (see details)

<details>

```
$ PGAPPNAME=app_name_env ./result/bin/pgcli -h 127.0.0.1 -U postgres  
Server: PostgreSQL 16.3 (Debian 16.3-1.pgdg120+1)
Version: 4.1.0
Home: http://pgcli.com
postgres@127.0.0.1:postgres> select current_setting('application_name');
+-----------------+
| current_setting |
|-----------------|
| app_name_env    |
+-----------------+
SELECT 1
Time: 0.007s
postgres@127.0.0.1:postgres>                                                                                                   
Goodbye!
$ ./result/bin/pgcli --application-name app_name_cli -h 127.0.0.1 -U postgres 
Server: PostgreSQL 16.3 (Debian 16.3-1.pgdg120+1)
Version: 4.1.0
Home: http://pgcli.com
postgres@127.0.0.1:postgres> select current_setting('application_name');
+-----------------+
| current_setting |
|-----------------|
| app_name_cli    |
+-----------------+
SELECT 1
Time: 0.010s
postgres@127.0.0.1:postgres>
```
</details>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
