### PR TITLE
btrfs-assistant: fix package

### DIFF
--- a/pkgs/by-name/bt/btrfs-assistant/package.nix
+++ b/pkgs/by-name/bt/btrfs-assistant/package.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     git
     pkg-config
+    qt6.wrapQtAppsHook
   ];
 
   buildInputs = [
@@ -39,7 +40,6 @@ stdenv.mkDerivation (finalAttrs: {
     qt6.qtwayland
   ];
 
-  propagatedBuildInputs = [ qt6.wrapQtAppsHook ];
 
   prePatch = ''
     substituteInPlace src/util/System.cpp \

--- a/pkgs/by-name/bt/btrfs-assistant/package.nix
+++ b/pkgs/by-name/bt/btrfs-assistant/package.nix
@@ -34,16 +34,21 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     btrfs-progs
+    coreutils
     qt6.qtbase
     qt6.qtsvg
     qt6.qttools
     qt6.qtwayland
-  ];
+    util-linux
+  ] ++ lib.optionals enableSnapper [ snapper ];
 
 
   prePatch = ''
     substituteInPlace src/util/System.cpp \
       --replace '/bin/bash' "${lib.getExe bash}"
+
+    substituteInPlace src/main.cpp \
+      --replace-fail 'if (!qEnvironmentVariableIsEmpty("DISPLAY"))' ' if(!qEnvironmentVariableIsEmpty("DISPLAY") || !qEnvironmentVariableIsEmpty("WAYLAND_DISPLAY"))'
   ''
   + lib.optionalString enableSnapper ''
     substituteInPlace src/main.cpp \

--- a/pkgs/by-name/bt/btrfs-assistant/package.nix
+++ b/pkgs/by-name/bt/btrfs-assistant/package.nix
@@ -1,17 +1,18 @@
-{ lib
-, stdenv
-, fetchFromGitLab
-, bash
-, btrfs-progs
-, cmake
-, coreutils
-, git
-, pkg-config
-, qt6
-, snapper
-, util-linux
-, enableSnapper ? true
-, nix-update-script
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  bash,
+  btrfs-progs,
+  cmake,
+  coreutils,
+  git,
+  pkg-config,
+  qt6,
+  snapper,
+  util-linux,
+  enableSnapper ? true,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -42,45 +43,34 @@ stdenv.mkDerivation (finalAttrs: {
     util-linux
   ] ++ lib.optionals enableSnapper [ snapper ];
 
+  prePatch =
+    ''
+      substituteInPlace src/util/System.cpp \
+        --replace-fail '/bin/bash' "${lib.getExe bash}"
 
-  prePatch = ''
-    substituteInPlace src/util/System.cpp \
-      --replace '/bin/bash' "${lib.getExe bash}"
+      substituteInPlace src/main.cpp \
+        --replace-fail 'if (!qEnvironmentVariableIsEmpty("DISPLAY"))' ' if(!qEnvironmentVariableIsEmpty("DISPLAY") || !qEnvironmentVariableIsEmpty("WAYLAND_DISPLAY"))'
+    ''
+    + lib.optionalString enableSnapper ''
+      substituteInPlace src/main.cpp \
+        --replace-fail '/usr/bin/snapper' "${lib.getExe snapper}"
+    '';
 
-    substituteInPlace src/main.cpp \
-      --replace-fail 'if (!qEnvironmentVariableIsEmpty("DISPLAY"))' ' if(!qEnvironmentVariableIsEmpty("DISPLAY") || !qEnvironmentVariableIsEmpty("WAYLAND_DISPLAY"))'
-  ''
-  + lib.optionalString enableSnapper ''
-    substituteInPlace src/main.cpp \
-      --replace '/usr/bin/snapper' "${lib.getExe snapper}"
-  '';
+  postPatch =
+    ''
+      substituteInPlace src/org.btrfs-assistant.pkexec.policy \
+        --replace-fail '/usr/bin' "$out/bin"
 
-  postPatch = ''
-    substituteInPlace src/org.btrfs-assistant.pkexec.policy \
-      --replace '/usr/bin' "$out/bin"
+      substituteInPlace src/btrfs-assistant \
+        --replace-fail 'btrfs-assistant-bin' "$out/bin/btrfs-assistant-bin"
 
-    substituteInPlace src/btrfs-assistant \
-      --replace 'btrfs-assistant-bin' "$out/bin/btrfs-assistant-bin"
-
-    substituteInPlace src/btrfs-assistant-launcher \
-      --replace 'btrfs-assistant' "$out/bin/btrfs-assistant"
-  ''
-  + lib.optionalString enableSnapper ''
-    substituteInPlace src/btrfs-assistant.conf \
-      --replace '/usr/bin/snapper' "${lib.getExe snapper}"
-  '';
-
-  qtWrapperArgs =
-    let
-      runtimeDeps = lib.makeBinPath ([
-        coreutils
-        util-linux
-      ]
-      ++ lib.optionals enableSnapper [ snapper ]);
-    in
-    [
-      "--prefix PATH : ${runtimeDeps}"
-    ];
+      substituteInPlace src/btrfs-assistant-launcher \
+        --replace-fail 'btrfs-assistant' "$out/bin/btrfs-assistant"
+    ''
+    + lib.optionalString enableSnapper ''
+      substituteInPlace src/btrfs-assistant.conf \
+        --replace-fail '/usr/bin/snapper' "${lib.getExe snapper}"
+    '';
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
## Description of changes
Resolves https://github.com/NixOS/nixpkgs/issues/319577

- Fixes nix-shell -p invoke 
- Fixes calling the launcher on wayland being treated as CLI error due to WAYLAND_DISPLAY not being checked in the program at runtime. 

Will just need to remove the substitutions after https://gitlab.com/btrfs-assistant/btrfs-assistant/-/merge_requests/81 is upstreamed and in next release.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
