### PR TITLE
lisp-modules: Add coalton

### DIFF
--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -913,6 +913,33 @@ let
     };
   });
 
+  coalton = build-asdf-system {
+    pname = "coalton";
+    version = "trunk";
+    src = pkgs.fetchFromGitHub {
+      owner = "coalton-lang";
+      repo = "coalton";
+      rev = "05111b8a59e3f7346b175ce1ec621bff588e1e1f";
+      hash = "sha256-L9o7Y3zDx9qLXGe/70c1LWEKUWsSRgBQru66mIuaCFw=";
+    };
+    lispLibs = with super; [
+      alexandria
+      eclector-concrete-syntax-tree
+      fiasco
+      float-features
+      self.fset
+      named-readtables
+      trivial-garbage
+    ];
+    nativeLibs = [ pkgs.mpfr ];
+    systems = [ "coalton" "coalton/tests" ];
+    meta = {
+      description = "statically typed functional programming language that supercharges Common Lisp";
+      homepage = "https://coalton-lang.github.io";
+      license = pkgs.lib.licenses.mit;
+    };
+  };
+
   });
 
 in packages

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -419,8 +419,8 @@ let
         src = pkgs.fetchFromGitHub {
           owner = "andy128k";
           repo = "cl-gobject-introspection";
-          rev = "83beec4492948b52aae4d4152200de5d5c7ac3e9";
-          sha256 = "sha256-g/FwWE+Rzmzm5Y+irvd1AJodbp6kPHJIFOFDPhaRlXc=";
+          rev = "4908a84c16349929b309c50409815ff81fb9b3c4";
+          sha256 = "sha256-krVU5TQsVAbglxXMq29WJriWBIgQDLy1iCvB5iNziEc=";
         };}))
       (cl-webkit2.overrideAttrs (final: prev: {
         src = pkgs.fetchFromGitHub {

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -882,6 +882,17 @@ let
     meta.mainProgram = "qlot";
   };
 
+  misc-extensions = super.misc-extensions.overrideLispAttrs (old: rec {
+    version = "4.0.3";
+    src = pkgs.fetchFromGitLab {
+      domain = "gitlab.common-lisp.net";
+      owner = "misc-extensions";
+      repo = "misc-extensions";
+      rev = "v${version}";
+      hash = "sha256-bDNI4mIaNw/rf7ZwvwolKo6+mUUxsgubGUd/988sHAo=";
+    };
+  });
+
   });
 
 in packages

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -893,6 +893,26 @@ let
     };
   });
 
+  fset = super.fset.overrideLispAttrs (old: rec {
+    version = "1.4.0";
+    src = pkgs.fetchFromGitHub {
+      owner = "slburson";
+      repo = "fset";
+      rev = "v${version}";
+      hash = "sha256-alO8Ek5Xpyl5N99/LgyIZ50aoRbY7bKh3XBntFV6Q5k=";
+    };
+    lispLibs = with super; [
+      self.misc-extensions
+      mt19937
+      named-readtables
+    ];
+    meta = {
+      description = "functional collections library";
+      homepage = "https://gitlab.common-lisp.net/fset/fset/-/wikis/home";
+      license = pkgs.lib.licenses.llgpl21;
+    };
+  });
+
   });
 
 in packages


### PR DESCRIPTION
## Description of changes

Add the coalton functional typesystem library for Common Lisp.

Happens to also need fset, so #318943 gets solved I think?
And fset needed a newer misc-extensions, since the one from QuickLisp didn't provide the constant symbol in GMap which fset uses.

FSet is probably a big breaking update: https://github.com/slburson/fset/releases/tag/v1.4.0
With misc-extensions I'm not sure, they don't seem to have a comprehensive list anywhere, but it doesn't look like there's anything being taken out.

Sorry for the ping, I didn't realize nyxt references self and so would be affected by the fset update.
I moved the rev in cl-gobject-introspection to the commit that explicitly fixed the change in SBCL, this should've probably been another pull request, but I wanted to make sure none of these changes broke nyxt in the end, so it now compiles and runs.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - I ran it and about 11 packages failed, all of which were already failing so I guess that's fine, the rest build.
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
