### PR TITLE
adgap: init at unstable-2024-06-01

### DIFF
--- a/pkgs/by-name/ad/adgap/package.nix
+++ b/pkgs/by-name/ad/adgap/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication {
+  pname = "adgap";
+  version = "0-unstable-2024-06-01";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "AlexandreDecan";
+    repo = "gap";
+    rev = "ae33cfd82779e06327e8178edf4946c8ec2ab92c";
+    hash = "sha256-Tcc22ohYFaZlhUpeKZxVz6s/LvDVNUI5Iz5ufIHJCco=";
+  };
+
+  build-system = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+  ];
+
+  dependencies = with python3.pkgs; [
+    dateutil
+    gitpython
+    python-dateutil
+    scipy
+    pandas
+    plotnine
+  ];
+
+  postInstall = ''
+    mv $out/bin/gap $out/bin/adgap
+  '';
+
+  pythonImportsCheck = [ "gap" ];
+
+  meta = {
+    description = "GAP: Forecasting Commit Activity in git Projects";
+    homepage = "https://github.com/AlexandreDecan/gap";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "adgap";
+    maintainers = with lib.maintainers; [ drupol ];
+  };
+}


### PR DESCRIPTION
This PR:

- [x] Introduce [`gap`](https://github.com/AlexandreDecan/gap) by @AlexandreDecan 

Todo:

- [ ] `gap` was already taken in `nixpkgs`, I renamed it to `adgap`, hope it's OK for you Alex? Feel free to suggest anything better, I'm very bad at naming things.
- [ ] I had to use a commit revision since no recent tag is available. It would be nice to create a tag so I can use it.
- [ ] When running it against `nixpkgs`, I get:

```
  ❯ ./result/bin/adgap --limit 30
Traceback (most recent call last):
  File "/nix/store/gzy0z06llvh3rmc6ifwq370gd5nmk64s-adgap-0-unstable-2024-06-01/bin/.adgap-wrapped", line 9, in <module>
    sys.exit(cli())
             ^^^^^
  File "/nix/store/gzy0z06llvh3rmc6ifwq370gd5nmk64s-adgap-0-unstable-2024-06-01/lib/python3.11/site-packages/gap.py", line 111, in cli
    df = pandas.DataFrame(
         ^^^^^^^^^^^^^^^^^
  File "/nix/store/a4rihhw5j33rswdlhl9fll9jx5gk8bgi-python3.11-pandas-2.2.1/lib/python3.11/site-packages/pandas/core/frame.py", line 731, in __init__
    raise ValueError("index cannot be a set")
ValueError: index cannot be a set
~
```
  I guess this issue comes from a too recent version of `pandas`.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
