### PR TITLE
start-stop-daemon: init at 1.22.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18996,6 +18996,12 @@
     githubId = 2666479;
     name = "Y Nguyen";
   };
+  supercoolspy = {
+    email = "nix@cosmics.dev";
+    github = "supercoolspy";
+    githubId = 66487448;
+    name = "Spy";
+  };
   superherointj = {
     email = "sergiomarcelo@yandex.com";
     github = "superherointj";

--- a/pkgs/by-name/st/start-stop-daemon/package.nix
+++ b/pkgs/by-name/st/start-stop-daemon/package.nix
@@ -1,0 +1,31 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, gnumake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "start-stop-daemon";
+  version = "1.22.1";
+
+  src = fetchFromGitHub {
+    owner = "zeppe-lin";
+    repo = "start-stop-daemon";
+    rev = "v${version}";
+    hash = "sha256-zeem291FACUxX5eodwXi/Z3xG0NHQDNWCIKiD25NfKc=";
+  };
+
+  preConfigure = ''
+    substituteInPlace config.mk \
+      --replace "/usr/local" "$out"
+  '';
+
+  meta = with lib; {
+    description = "Start and stop daemon programs";
+    homepage = "https://github.com/zeppe-lin/start-stop-daemon";
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ supercoolspy ];
+    mainProgram = "start-stop-daemon";
+  };
+}


### PR DESCRIPTION
## Description of changes
Adds [start-stop-daemon](https://github.com/zeppe-lin/start-stop-daemon) package which helps run processes in the background easily

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
