### PR TITLE
Remove myself from some packages I no longer actively use

### DIFF
--- a/pkgs/applications/accessibility/wvkbd/default.nix
+++ b/pkgs/applications/accessibility/wvkbd/default.nix
@@ -44,7 +44,6 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/jjsullivan5196/wvkbd";
     description = "On-screen keyboard for wlroots";
-    maintainers = [ maintainers.elohmeier ];
     platforms = platforms.linux;
     license = licenses.gpl3Plus;
     mainProgram = "wvkbd-mobintl";

--- a/pkgs/applications/misc/gpu-burn/default.nix
+++ b/pkgs/applications/misc/gpu-burn/default.nix
@@ -39,7 +39,6 @@ stdenv.mkDerivation {
     homepage = "http://wili.cc/blog/gpu-burn.html";
     description = "Multi-GPU CUDA stress test";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ elohmeier ];
     license = licenses.bsd2;
     mainProgram = "gpu_burn";
   };

--- a/pkgs/applications/office/portfolio/default.nix
+++ b/pkgs/applications/office/portfolio/default.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.portfolio-performance.info/";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.epl10;
-    maintainers = with maintainers; [ elohmeier kilianar oyren shawn8901 ];
+    maintainers = with maintainers; [ kilianar oyren shawn8901 ];
     mainProgram = "portfolio";
     platforms = [ "x86_64-linux" ];
   };

--- a/pkgs/by-name/ba/baresip/package.nix
+++ b/pkgs/by-name/ba/baresip/package.nix
@@ -126,7 +126,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Modular SIP User-Agent with audio and video support";
     homepage = "https://github.com/baresip/baresip";
-    maintainers = with lib.maintainers; [ elohmeier raskin ehmry ];
+    maintainers = with lib.maintainers; [ raskin ehmry ];
     mainProgram = "baresip";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/sq/sqlite-vss/package.nix
+++ b/pkgs/by-name/sq/sqlite-vss/package.nix
@@ -47,7 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/asg017/sqlite-vss";
     changelog = "https://github.com/asg017/sqlite-vss/releases/tag/v${finalAttrs.version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ elohmeier ];
     platforms = platforms.unix;
   };
 })

--- a/pkgs/development/libraries/libre/default.nix
+++ b/pkgs/development/libraries/libre/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Library for real-time communications with async IO support and a complete SIP stack";
     homepage = "https://github.com/baresip/re";
-    maintainers = with lib.maintainers; [ elohmeier raskin ];
+    maintainers = with lib.maintainers; [ raskin ];
     license = lib.licenses.bsd3;
   };
 }

--- a/pkgs/development/libraries/librem/default.nix
+++ b/pkgs/development/libraries/librem/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Library for real-time audio and video processing";
     homepage = "https://github.com/baresip/rem";
-    maintainers = with lib.maintainers; [ elohmeier raskin ];
+    maintainers = with lib.maintainers; [ raskin ];
     license = lib.licenses.bsd3;
   };
 }

--- a/pkgs/development/python-modules/aiohttp-swagger/default.nix
+++ b/pkgs/development/python-modules/aiohttp-swagger/default.nix
@@ -54,6 +54,5 @@ buildPythonPackage rec {
     description = "Swagger API Documentation builder for aiohttp";
     homepage = "https://github.com/cr0hn/aiohttp-swagger";
     license = licenses.mit;
-    maintainers = with maintainers; [ elohmeier ];
   };
 }

--- a/pkgs/development/python-modules/clickclick/default.nix
+++ b/pkgs/development/python-modules/clickclick/default.nix
@@ -40,6 +40,5 @@ buildPythonPackage rec {
     description = "Click command line utilities";
     homepage = "https://github.com/hjacobs/python-clickclick/";
     license = licenses.asl20;
-    maintainers = with maintainers; [ elohmeier ];
   };
 }

--- a/pkgs/development/python-modules/connexion/default.nix
+++ b/pkgs/development/python-modules/connexion/default.nix
@@ -95,6 +95,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/spec-first/connexion";
     changelog = "https://github.com/spec-first/connexion/releases/tag/${version}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ elohmeier ];
   };
 }

--- a/pkgs/development/python-modules/django-sesame/default.nix
+++ b/pkgs/development/python-modules/django-sesame/default.nix
@@ -45,6 +45,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/aaugustin/django-sesame";
     changelog = "https://github.com/aaugustin/django-sesame/blob/${version}/docs/changelog.rst";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ elohmeier ];
   };
 }

--- a/pkgs/development/python-modules/dwdwfsapi/default.nix
+++ b/pkgs/development/python-modules/dwdwfsapi/default.nix
@@ -37,6 +37,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/stephan192/dwdwfsapi";
     changelog = "https://github.com/stephan192/dwdwfsapi/blob/v${version}/CHANGELOG.md";
     license = with licenses; [ mit ];
-    maintainers = with maintainers; [ elohmeier ];
   };
 }

--- a/pkgs/development/python-modules/favicon/default.nix
+++ b/pkgs/development/python-modules/favicon/default.nix
@@ -42,6 +42,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/scottwernervt/favicon";
     changelog = "https://github.com/scottwernervt/favicon/blob/${version}/CHANGELOG.rst";
     license = licenses.mit;
-    maintainers = with maintainers; [ elohmeier ];
   };
 }

--- a/pkgs/development/python-modules/fints/default.nix
+++ b/pkgs/development/python-modules/fints/default.nix
@@ -42,7 +42,6 @@ buildPythonPackage rec {
     description = "Pure-python FinTS (formerly known as HBCI) implementation";
     license = licenses.lgpl3Only;
     maintainers = with maintainers; [
-      elohmeier
       dotlambda
     ];
   };

--- a/pkgs/development/python-modules/jupyter-packaging/default.nix
+++ b/pkgs/development/python-modules/jupyter-packaging/default.nix
@@ -68,6 +68,5 @@ buildPythonPackage rec {
     description = "Jupyter Packaging Utilities";
     homepage = "https://github.com/jupyter/jupyter-packaging";
     license = licenses.bsd3;
-    maintainers = [ maintainers.elohmeier ];
   };
 }

--- a/pkgs/development/python-modules/nbclassic/default.nix
+++ b/pkgs/development/python-modules/nbclassic/default.nix
@@ -54,6 +54,5 @@ buildPythonPackage rec {
     description = "Jupyter lab environment notebook server extension";
     homepage = "https://github.com/jupyter/nbclassic";
     license = with licenses; [ bsd3 ];
-    maintainers = with maintainers; [ elohmeier ];
   };
 }

--- a/pkgs/development/python-modules/python-ethtool/default.nix
+++ b/pkgs/development/python-modules/python-ethtool/default.nix
@@ -31,6 +31,5 @@ buildPythonPackage rec {
     description = "Python bindings for the ethtool kernel interface";
     homepage = "https://github.com/fedora-python/python-ethtool";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ elohmeier ];
   };
 }

--- a/pkgs/development/python-modules/python-linux-procfs/default.nix
+++ b/pkgs/development/python-modules/python-linux-procfs/default.nix
@@ -26,6 +26,5 @@ buildPythonPackage rec {
     mainProgram = "pflags";
     homepage = "https://git.kernel.org/pub/scm/libs/python/python-linux-procfs/python-linux-procfs.git/";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ elohmeier ];
   };
 }

--- a/pkgs/development/python-modules/pyxlsb/default.nix
+++ b/pkgs/development/python-modules/pyxlsb/default.nix
@@ -22,6 +22,5 @@ buildPythonPackage rec {
     description = "Excel 2007-2010 Binary Workbook (xlsb) parser";
     homepage = "https://github.com/willtrnr/pyxlsb";
     license = licenses.lgpl3Plus;
-    maintainers = with maintainers; [ elohmeier ];
   };
 }

--- a/pkgs/development/python-modules/sepaxml/default.nix
+++ b/pkgs/development/python-modules/sepaxml/default.nix
@@ -39,6 +39,5 @@ buildPythonPackage rec {
     description = "SEPA Direct Debit XML generation in python";
     homepage = "https://github.com/raphaelm/python-sepaxml/";
     license = licenses.mit;
-    maintainers = with maintainers; [ elohmeier ];
   };
 }

--- a/pkgs/development/python-modules/swagger-ui-bundle/default.nix
+++ b/pkgs/development/python-modules/swagger-ui-bundle/default.nix
@@ -35,6 +35,5 @@ buildPythonPackage rec {
     description = "bundled swagger-ui pip package";
     homepage = "https://github.com/dtkav/swagger_ui_bundle";
     license = licenses.asl20;
-    maintainers = with maintainers; [ elohmeier ];
   };
 }

--- a/pkgs/development/python-modules/weasyprint/default.nix
+++ b/pkgs/development/python-modules/weasyprint/default.nix
@@ -98,6 +98,5 @@ buildPythonPackage rec {
     mainProgram = "weasyprint";
     homepage = "https://weasyprint.org/";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ elohmeier ];
   };
 }

--- a/pkgs/development/tools/continuous-integration/drone/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone/default.nix
@@ -25,7 +25,7 @@ buildGoModule rec {
     description = "Continuous Integration platform built on container technology";
     mainProgram = "drone-server";
     homepage = "https://github.com/harness/drone";
-    maintainers = with maintainers; [ elohmeier vdemeester techknowlogick ];
+    maintainers = with maintainers; [ vdemeester techknowlogick ];
     license = with licenses; if enableUnfree then unfreeRedistributable else asl20;
   };
 }

--- a/pkgs/os-specific/linux/ksmbd-tools/default.nix
+++ b/pkgs/os-specific/linux/ksmbd-tools/default.nix
@@ -37,6 +37,5 @@ stdenv.mkDerivation rec {
     homepage = "https://www.kernel.org/doc/html/latest/filesystems/cifs/ksmbd.html";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ elohmeier ];
   };
 }

--- a/pkgs/os-specific/linux/tuna/default.nix
+++ b/pkgs/os-specific/linux/tuna/default.nix
@@ -57,6 +57,5 @@ buildPythonApplication rec {
     homepage = "https://git.kernel.org/pub/scm/utils/tuna/tuna.git";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ elohmeier ];
   };
 }

--- a/pkgs/tools/networking/ligolo-ng/default.nix
+++ b/pkgs/tools/networking/ligolo-ng/default.nix
@@ -34,6 +34,5 @@ buildGoModule rec {
     homepage = "https://github.com/tnpitsecurity/ligolo-ng";
     changelog = "https://github.com/nicocha30/ligolo-ng/releases/tag/v${version}";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ elohmeier ];
   };
 }

--- a/pkgs/tools/networking/snmpcheck/default.nix
+++ b/pkgs/tools/networking/snmpcheck/default.nix
@@ -25,7 +25,6 @@ stdenv.mkDerivation rec {
     description = "SNMP enumerator";
     homepage = "http://www.nothink.org/codes/snmpcheck/";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ elohmeier ];
     mainProgram = "snmp-check";
   };
 }

--- a/pkgs/tools/security/cewl/default.nix
+++ b/pkgs/tools/security/cewl/default.nix
@@ -29,6 +29,5 @@ stdenv.mkDerivation rec {
     mainProgram = "cewl";
     homepage = "https://digi.ninja/projects/cewl.php/";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ elohmeier ];
   };
 }

--- a/pkgs/tools/security/evil-winrm/default.nix
+++ b/pkgs/tools/security/evil-winrm/default.nix
@@ -42,6 +42,5 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/Hackplayers/evil-winrm";
     changelog = "https://github.com/Hackplayers/evil-winrm/blob/v${version}/CHANGELOG.md";
     license = licenses.lgpl3Plus;
-    maintainers = with maintainers; [ elohmeier ];
   };
 }


### PR DESCRIPTION
I don't happen to use these programs frequently enough to provide useful maintenance.

- **wvkbd: remove elohmeier as maintainer**
- **gpu-burn: remove elohmeier as maintainer**
- **portfolio: remove elohmeier as maintainer**
- **baresip: remove elohmeier as maintainer**
- **sqlite-vss: remove elohmeier as maintainer**
- **libre: remove elohmeier as maintainer**
- **librem: remove elohmeier as maintainer**
- **python3Packages.aiohttp-swagger: remove elohmeier as maintainer**
- **python3Packages.clickclick: remove elohmeier as maintainer**
- **python3Packages.connexion: remove elohmeier as maintainer**
- **python3Packages.django-sesame: remove elohmeier as maintainer**
- **python3Packages.dwdwfsapi: remove elohmeier as maintainer**
- **python3Packages.favicon: remove elohmeier as maintainer**
- **python3Packages.fints: remove elohmeier as maintainer**
- **python3Packages.jupyter-packaging: remove elohmeier as maintainer**
- **python3Packages.nbclassic: remove elohmeier as maintainer**
- **python3Packages.python-ethtool: remove elohmeier as maintainer**
- **python3Packages.python-linux-procfs: remove elohmeier as maintainer**
- **python3Packages.pyxlsb: remove elohmeier as maintainer**
- **python3Packages.sepaxml: remove elohmeier as maintainer**
- **python3Packages.swagger-ui-bundle: remove elohmeier as maintainer**
- **python3Packages.weasyprint: remove elohmeier as maintainer**
- **drone: remove elohmeier as maintainer**
- **ksmbd-tools: remove elohmeier as maintainer**
- **tuna: remove elohmeier as maintainer**
- **ligolo-ng: remove elohmeier as maintainer**
- **snpmcheck: remove elohmeier as maintainer**
- **cewl: remove elohmeier as maintainer**
- **evil-winrm: remove elohmeier as maintainer**
