### PR TITLE
nvidia-container-toolkit: only mount existing paths in the host

### DIFF
--- a/nixos/modules/services/hardware/nvidia-container-toolkit/cdi-generate.nix
+++ b/nixos/modules/services/hardware/nvidia-container-toolkit/cdi-generate.nix
@@ -13,11 +13,14 @@
     inherit hostPath containerPath;
     options = mountOptions;
   };
-  jqAddMountExpression = ".containerEdits.mounts[.containerEdits.mounts | length] |= . +";
-  allJqMounts = lib.concatMap
-    (mount:
-      ["${lib.getExe jq} '${jqAddMountExpression} ${builtins.toJSON (mkMount mount)}'"])
-    mounts;
+  mountToCommand = mount:
+    "additionalMount \"${mount.hostPath}\" \"${mount.containerPath}\" '${builtins.toJSON mount.mountOptions}'";
+  mountsToCommands = mounts:
+    if (builtins.length mounts) == 0 then
+      "cat"
+    else
+      (lib.strings.concatMapStringsSep " | \\\n"
+        mountToCommand mounts);
 in
 writeScriptBin "nvidia-cdi-generator"
 ''
@@ -32,6 +35,18 @@ function cdiGenerate {
     --nvidia-ctk-path ${lib.getExe' nvidia-container-toolkit "nvidia-ctk"}
 }
 
-cdiGenerate | \
-  ${lib.concatStringsSep " | " allJqMounts} > $RUNTIME_DIRECTORY/nvidia-container-toolkit.json
+function additionalMount {
+  local hostPath="$1"
+  local containerPath="$2"
+  local mountOptions="$3"
+  if [ -e "$hostPath" ]; then
+    ${lib.getExe jq} ".containerEdits.mounts[.containerEdits.mounts | length] = { \"hostPath\": \"$hostPath\", \"containerPath\": \"$containerPath\", \"options\": $mountOptions }"
+  else
+    echo "Mount $hostPath ignored: could not find path in the host machine" >&2
+    cat
+  fi
+}
+
+cdiGenerate |
+  ${mountsToCommands mounts} > $RUNTIME_DIRECTORY/nvidia-container-toolkit.json
 ''

--- a/nixos/modules/services/hardware/nvidia-container-toolkit/default.nix
+++ b/nixos/modules/services/hardware/nvidia-container-toolkit/default.nix
@@ -71,6 +71,8 @@
           /usr/local/nvidia/lib64.
         '';
       };
+
+      package = lib.mkPackageOption pkgs "nvidia-container-toolkit" { };
     };
 
   };
@@ -129,6 +131,7 @@
           let
             script = pkgs.callPackage ./cdi-generate.nix {
               inherit (config.hardware.nvidia-container-toolkit) mounts;
+              nvidia-container-toolkit = config.hardware.nvidia-container-toolkit.package;
               nvidia-driver = config.hardware.nvidia.package;
               deviceNameStrategy = config.hardware.nvidia-container-toolkit.device-name-strategy;
             };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -699,6 +699,7 @@ in {
   ntfy-sh = handleTest ./ntfy-sh.nix {};
   ntfy-sh-migration = handleTest ./ntfy-sh-migration.nix {};
   ntpd-rs = handleTest ./ntpd-rs.nix {};
+  nvidia-container-toolkit = handleTest ./nvidia-container-toolkit.nix {};
   nvmetcfg = handleTest ./nvmetcfg.nix {};
   nzbget = handleTest ./nzbget.nix {};
   nzbhydra2 = handleTest ./nzbhydra2.nix {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -699,7 +699,7 @@ in {
   ntfy-sh = handleTest ./ntfy-sh.nix {};
   ntfy-sh-migration = handleTest ./ntfy-sh-migration.nix {};
   ntpd-rs = handleTest ./ntpd-rs.nix {};
-  nvidia-container-toolkit = handleTest ./nvidia-container-toolkit.nix {};
+  nvidia-container-toolkit = runTest ./nvidia-container-toolkit.nix;
   nvmetcfg = handleTest ./nvmetcfg.nix {};
   nzbget = handleTest ./nzbget.nix {};
   nzbhydra2 = handleTest ./nzbhydra2.nix {};

--- a/nixos/tests/nvidia-container-toolkit.nix
+++ b/nixos/tests/nvidia-container-toolkit.nix
@@ -39,7 +39,7 @@ import ./make-test-python.nix (
         name = "cdi-test";
         tag = "latest";
         config = {
-          Cmd = [ "${testCDIScript}/bin/test-cdi" ];
+          Cmd = [ (lib.getExe testCDIScript) ];
         };
         copyToRoot = (
           with pkgs.dockerTools;

--- a/nixos/tests/nvidia-container-toolkit.nix
+++ b/nixos/tests/nvidia-container-toolkit.nix
@@ -1,0 +1,177 @@
+import ./make-test-python.nix (
+  {
+    pkgs,
+    lib,
+    system,
+    ...
+  }:
+  let
+    testContainerImage =
+      let
+        testCDIScript = pkgs.writeShellScriptBin "test-cdi" ''
+          die() {
+            echo "$1"
+            exit 1
+          }
+
+          check_file_referential_integrity() {
+            echo "checking $1 referential integrity"
+            ( ${pkgs.glibc.bin}/bin/ldd "$1" | ${lib.getExe pkgs.gnugrep} "not found" &> /dev/null ) && return 1
+            return 0
+          }
+
+          check_directory_referential_integrity() {
+            ${lib.getExe pkgs.findutils} "$1" -type f -print0 | while read -d $'\0' file; do
+              if [[ $(${lib.getExe pkgs.file} "$file" | ${lib.getExe pkgs.gnugrep} ELF) ]]; then
+                check_file_referential_integrity "$file" || exit 1
+              else
+                echo "skipping $file: not an ELF file"
+              fi
+            done
+          }
+
+          check_directory_referential_integrity "/usr/bin" || exit 1
+          check_directory_referential_integrity "${pkgs.addDriverRunpath.driverLink}" || exit 1
+          check_directory_referential_integrity "/usr/local/nvidia" || exit 1
+        '';
+      in
+      pkgs.dockerTools.buildImage {
+        name = "cdi-test";
+        tag = "latest";
+        config = {
+          Cmd = [ "${testCDIScript}/bin/test-cdi" ];
+        };
+        copyToRoot = (
+          with pkgs.dockerTools;
+          [
+            usrBinEnv
+            binSh
+          ]
+        );
+      };
+    emptyCDISpec = ''
+      #! ${pkgs.runtimeShell}
+      cat <<CDI_DOCUMENT
+        {
+          "cdiVersion": "0.5.0",
+          "kind": "nvidia.com/gpu",
+          "devices": [
+            {
+              "name": "all",
+              "containerEdits": {
+                "deviceNodes": [
+                  {
+                    "path": "/dev/urandom"
+                  }
+                ],
+                "hooks": [],
+                "mounts": []
+              }
+            }
+          ],
+          "containerEdits": {
+            "deviceNodes": [],
+            "hooks": [],
+            "mounts": []
+          }
+        }
+      CDI_DOCUMENT
+    '';
+    nvidia-container-toolkit = {
+      enable = true;
+      package = pkgs.stdenv.mkDerivation {
+        name = "nvidia-ctk-dummy";
+        version = "1.0.0";
+        dontUnpack = true;
+        dontBuild = true;
+        installPhase = ''
+          mkdir -p $out/bin
+          cat <<EOF > $out/bin/nvidia-ctk
+            ${emptyCDISpec}
+          EOF
+          chmod +x $out/bin/nvidia-ctk
+        '';
+      };
+    };
+  in
+  {
+    name = "nvidia-container-toolkit";
+    meta = with lib.maintainers; {
+      maintainers = [ ereslibre ];
+    };
+    nodes = {
+      no-nvidia-gpus =
+        { config, ... }:
+        {
+          environment.systemPackages = with pkgs; [ jq ];
+          hardware = {
+            inherit nvidia-container-toolkit;
+            nvidia = {
+              open = true;
+              package = config.boot.kernelPackages.nvidiaPackages.stable.open;
+            };
+          };
+        };
+
+      nvidia-one-gpu =
+        { config, pkgs, ... }:
+        {
+          virtualisation.diskSize = 10240;
+          environment.systemPackages = with pkgs; [
+            jq
+            podman
+          ];
+          hardware = {
+            inherit nvidia-container-toolkit;
+            nvidia = {
+              open = true;
+              package = config.boot.kernelPackages.nvidiaPackages.stable.open;
+            };
+            opengl.enable = true;
+          };
+          virtualisation.containers.enable = true;
+        };
+
+      nvidia-one-gpu-invalid-host-paths =
+        { config, pkgs, ... }:
+        {
+          virtualisation.diskSize = 10240;
+          environment.systemPackages = with pkgs; [ jq ];
+          hardware = {
+            nvidia-container-toolkit = nvidia-container-toolkit // {
+              mounts = [
+                {
+                  hostPath = "/non-existant-path";
+                  containerPath = "/some/path";
+                }
+              ];
+            };
+            nvidia = {
+              open = true;
+              package = config.boot.kernelPackages.nvidiaPackages.stable.open;
+            };
+            opengl.enable = true;
+          };
+          virtualisation.containers.enable = true;
+        };
+    };
+    testScript = ''
+      start_all()
+
+      with subtest("Generate an empty CDI spec for a machine with no Nvidia GPUs"):
+        no_nvidia_gpus.wait_for_unit("nvidia-container-toolkit-cdi-generator.service")
+        no_nvidia_gpus.succeed("cat /var/run/cdi/nvidia-container-toolkit.json | jq")
+
+      with subtest("Podman loads the generated CDI spec for a machine with an Nvidia GPU"):
+        nvidia_one_gpu.wait_for_unit("nvidia-container-toolkit-cdi-generator.service")
+        nvidia_one_gpu.succeed("cat /var/run/cdi/nvidia-container-toolkit.json | jq")
+        nvidia_one_gpu.succeed("podman load < ${testContainerImage}")
+        print(nvidia_one_gpu.succeed("podman run --pull=never --device=nvidia.com/gpu=all -v /run/opengl-driver:/run/opengl-driver:ro cdi-test:latest"))
+
+      # Issue: https://github.com/NixOS/nixpkgs/issues/319201
+      with subtest("The generated CDI spec skips specified non-existant paths in the host"):
+        nvidia_one_gpu_invalid_host_paths.wait_for_unit("nvidia-container-toolkit-cdi-generator.service")
+        nvidia_one_gpu_invalid_host_paths.fail("grep 'non-existant-path' /var/run/cdi/nvidia-container-toolkit.json")
+    '';
+  }
+)

--- a/nixos/tests/nvidia-container-toolkit.nix
+++ b/nixos/tests/nvidia-container-toolkit.nix
@@ -1,176 +1,149 @@
-import ./make-test-python.nix (
-  {
-    pkgs,
-    lib,
-    system,
-    ...
-  }:
-  let
-    testCDIScript = pkgs.writeShellScriptBin "test-cdi" ''
-      die() {
-        echo "$1"
-        exit 1
-      }
+{ pkgs, lib, ... }:
+let
+  testCDIScript = pkgs.writeShellScriptBin "test-cdi" ''
+    die() {
+      echo "$1"
+      exit 1
+    }
 
-      check_file_referential_integrity() {
-        echo "checking $1 referential integrity"
-        ( ${pkgs.glibc.bin}/bin/ldd "$1" | ${lib.getExe pkgs.gnugrep} "not found" &> /dev/null ) && return 1
-        return 0
-      }
+    check_file_referential_integrity() {
+      echo "checking $1 referential integrity"
+      ( ${pkgs.glibc.bin}/bin/ldd "$1" | ${lib.getExe pkgs.gnugrep} "not found" &> /dev/null ) && return 1
+      return 0
+    }
 
-      check_directory_referential_integrity() {
-        ${lib.getExe pkgs.findutils} "$1" -type f -print0 | while read -d $'\0' file; do
-          if [[ $(${lib.getExe pkgs.file} "$file" | ${lib.getExe pkgs.gnugrep} ELF) ]]; then
-            check_file_referential_integrity "$file" || exit 1
-          else
-            echo "skipping $file: not an ELF file"
-          fi
-        done
-      }
+    check_directory_referential_integrity() {
+      ${lib.getExe pkgs.findutils} "$1" -type f -print0 | while read -d $'\0' file; do
+        if [[ $(${lib.getExe pkgs.file} "$file" | ${lib.getExe pkgs.gnugrep} ELF) ]]; then
+          check_file_referential_integrity "$file" || exit 1
+        else
+          echo "skipping $file: not an ELF file"
+        fi
+      done
+    }
 
-      check_directory_referential_integrity "/usr/bin" || exit 1
-      check_directory_referential_integrity "${pkgs.addDriverRunpath.driverLink}" || exit 1
-      check_directory_referential_integrity "/usr/local/nvidia" || exit 1
-    '';
-    testContainerImage = pkgs.dockerTools.buildImage {
-      name = "cdi-test";
-      tag = "latest";
-      config = {
-        Cmd = [ (lib.getExe testCDIScript) ];
+    check_directory_referential_integrity "/usr/bin" || exit 1
+    check_directory_referential_integrity "${pkgs.addDriverRunpath.driverLink}" || exit 1
+    check_directory_referential_integrity "/usr/local/nvidia" || exit 1
+  '';
+  testContainerImage = pkgs.dockerTools.buildImage {
+    name = "cdi-test";
+    tag = "latest";
+    config = {
+      Cmd = [ (lib.getExe testCDIScript) ];
+    };
+    copyToRoot = with pkgs.dockerTools; [
+      usrBinEnv
+      binSh
+    ];
+  };
+  emptyCDISpec = ''
+    {
+      "cdiVersion": "0.5.0",
+      "kind": "nvidia.com/gpu",
+      "devices": [
+        {
+          "name": "all",
+          "containerEdits": {
+            "deviceNodes": [
+              {
+                "path": "/dev/urandom"
+              }
+            ],
+            "hooks": [],
+            "mounts": []
+          }
+        }
+      ],
+      "containerEdits": {
+        "deviceNodes": [],
+        "hooks": [],
+        "mounts": []
+      }
+    }
+  '';
+  nvidia-container-toolkit = {
+    enable = true;
+    package = pkgs.stdenv.mkDerivation {
+      pname = "nvidia-ctk-dummy";
+      version = "1.0.0";
+      dontUnpack = true;
+      dontBuild = true;
+
+      inherit emptyCDISpec;
+      passAsFile = [ "emptyCDISpec" ];
+
+      installPhase = ''
+        mkdir -p $out/bin $out/share/nvidia-container-toolkit
+        cp "$emptyCDISpecPath" "$out/share/nvidia-container-toolkit/spec.json"
+        echo -n "$emptyCDISpec" > "$out/bin/nvidia-ctk";
+        cat << EOF > "$out/bin/nvidia-ctk"
+        #!${pkgs.runtimeShell}
+        cat "$out/share/nvidia-container-toolkit/spec.json"
+        EOF
+        chmod +x $out/bin/nvidia-ctk
+      '';
+      meta.mainProgram = "nvidia-ctk";
+    };
+  };
+in
+{
+  name = "nvidia-container-toolkit";
+  meta = with lib.maintainers; {
+    maintainers = [ ereslibre ];
+  };
+  defaults =
+    { config, ... }:
+    {
+      environment.systemPackages = with pkgs; [ jq ];
+      virtualisation.diskSize = lib.mkDefault 10240;
+      virtualisation.containers.enable = lib.mkDefault true;
+      hardware = {
+        inherit nvidia-container-toolkit;
+        nvidia = {
+          open = true;
+          package = config.boot.kernelPackages.nvidiaPackages.stable.open;
+        };
+        graphics.enable = lib.mkDefault true;
       };
-      copyToRoot = with pkgs.dockerTools; [
-        usrBinEnv
-        binSh
+    };
+  nodes = {
+    no-gpus = {
+      virtualisation.containers.enable = false;
+      hardware.graphics.enable = false;
+    };
+    one-gpu =
+      { pkgs, ... }:
+      {
+        environment.systemPackages = with pkgs; [ podman ];
+        hardware.graphics.enable = true;
+      };
+
+    one-gpu-invalid-host-paths = {
+      hardware.nvidia-container-toolkit.mounts = [
+        {
+          hostPath = "/non-existant-path";
+          containerPath = "/some/path";
+        }
       ];
     };
-    emptyCDISpec = ''
-      {
-        "cdiVersion": "0.5.0",
-        "kind": "nvidia.com/gpu",
-        "devices": [
-          {
-            "name": "all",
-            "containerEdits": {
-              "deviceNodes": [
-                {
-                  "path": "/dev/urandom"
-                }
-              ],
-              "hooks": [],
-              "mounts": []
-            }
-          }
-        ],
-        "containerEdits": {
-          "deviceNodes": [],
-          "hooks": [],
-          "mounts": []
-        }
-      }
-    '';
-    nvidia-container-toolkit = {
-      enable = true;
-      package = pkgs.stdenv.mkDerivation {
-        pname = "nvidia-ctk-dummy";
-        version = "1.0.0";
-        dontUnpack = true;
-        dontBuild = true;
+  };
+  testScript = ''
+    start_all()
 
-        inherit emptyCDISpec;
-        passAsFile = [ "emptyCDISpec" ];
+    with subtest("Generate an empty CDI spec for a machine with no Nvidia GPUs"):
+      no_gpus.wait_for_unit("nvidia-container-toolkit-cdi-generator.service")
+      no_gpus.succeed("cat /var/run/cdi/nvidia-container-toolkit.json | jq")
 
-        installPhase = ''
-          mkdir -p $out/bin $out/share/nvidia-container-toolkit
-          cp "$emptyCDISpecPath" "$out/share/nvidia-container-toolkit/spec.json"
-          echo -n "$emptyCDISpec" > "$out/bin/nvidia-ctk";
-          cat << EOF > "$out/bin/nvidia-ctk"
-          #!${pkgs.runtimeShell}
-          cat "$out/share/nvidia-container-toolkit/spec.json"
-          EOF
-          chmod +x $out/bin/nvidia-ctk
-        '';
-        meta.mainProgram = "nvidia-ctk";
-      };
-    };
-  in
-  {
-    name = "nvidia-container-toolkit";
-    meta = with lib.maintainers; {
-      maintainers = [ ereslibre ];
-    };
-    nodes = {
-      no-gpus =
-        { config, ... }:
-        {
-          environment.systemPackages = with pkgs; [ jq ];
-          hardware = {
-            inherit nvidia-container-toolkit;
-            nvidia = {
-              open = true;
-              package = config.boot.kernelPackages.nvidiaPackages.stable.open;
-            };
-          };
-        };
+    with subtest("Podman loads the generated CDI spec for a machine with an Nvidia GPU"):
+      one_gpu.wait_for_unit("nvidia-container-toolkit-cdi-generator.service")
+      one_gpu.succeed("cat /var/run/cdi/nvidia-container-toolkit.json | jq")
+      one_gpu.succeed("podman load < ${testContainerImage}")
+      print(one_gpu.succeed("podman run --pull=never --device=nvidia.com/gpu=all -v /run/opengl-driver:/run/opengl-driver:ro cdi-test:latest"))
 
-      one-gpu =
-        { config, pkgs, ... }:
-        {
-          virtualisation.diskSize = 10240;
-          environment.systemPackages = with pkgs; [
-            jq
-            podman
-          ];
-          hardware = {
-            inherit nvidia-container-toolkit;
-            nvidia = {
-              open = true;
-              package = config.boot.kernelPackages.nvidiaPackages.stable.open;
-            };
-            graphics.enable = true;
-          };
-          virtualisation.containers.enable = true;
-        };
-
-      one-gpu-invalid-host-paths =
-        { config, pkgs, ... }:
-        {
-          virtualisation.diskSize = 10240;
-          environment.systemPackages = with pkgs; [ jq ];
-          hardware = {
-            nvidia-container-toolkit = nvidia-container-toolkit // {
-              mounts = [
-                {
-                  hostPath = "/non-existant-path";
-                  containerPath = "/some/path";
-                }
-              ];
-            };
-            nvidia = {
-              open = true;
-              package = config.boot.kernelPackages.nvidiaPackages.stable.open;
-            };
-            graphics.enable = true;
-          };
-          virtualisation.containers.enable = true;
-        };
-    };
-    testScript = ''
-      start_all()
-
-      with subtest("Generate an empty CDI spec for a machine with no Nvidia GPUs"):
-        no_gpus.wait_for_unit("nvidia-container-toolkit-cdi-generator.service")
-        no_gpus.succeed("cat /var/run/cdi/nvidia-container-toolkit.json | jq")
-
-      with subtest("Podman loads the generated CDI spec for a machine with an Nvidia GPU"):
-        one_gpu.wait_for_unit("nvidia-container-toolkit-cdi-generator.service")
-        one_gpu.succeed("cat /var/run/cdi/nvidia-container-toolkit.json | jq")
-        one_gpu.succeed("podman load < ${testContainerImage}")
-        print(one_gpu.succeed("podman run --pull=never --device=nvidia.com/gpu=all -v /run/opengl-driver:/run/opengl-driver:ro cdi-test:latest"))
-
-      # Issue: https://github.com/NixOS/nixpkgs/issues/319201
-      with subtest("The generated CDI spec skips specified non-existant paths in the host"):
-        one_gpu_invalid_host_paths.wait_for_unit("nvidia-container-toolkit-cdi-generator.service")
-        one_gpu_invalid_host_paths.fail("grep 'non-existant-path' /var/run/cdi/nvidia-container-toolkit.json")
-    '';
-  }
-)
+    # Issue: https://github.com/NixOS/nixpkgs/issues/319201
+    with subtest("The generated CDI spec skips specified non-existant paths in the host"):
+      one_gpu_invalid_host_paths.wait_for_unit("nvidia-container-toolkit-cdi-generator.service")
+      one_gpu_invalid_host_paths.fail("grep 'non-existant-path' /var/run/cdi/nvidia-container-toolkit.json")
+  '';
+}

--- a/nixos/tests/nvidia-container-toolkit.nix
+++ b/nixos/tests/nvidia-container-toolkit.nix
@@ -99,7 +99,7 @@ import ./make-test-python.nix (
       maintainers = [ ereslibre ];
     };
     nodes = {
-      no-nvidia-gpus =
+      no-gpus =
         { config, ... }:
         {
           environment.systemPackages = with pkgs; [ jq ];
@@ -112,7 +112,7 @@ import ./make-test-python.nix (
           };
         };
 
-      nvidia-one-gpu =
+      one-gpu =
         { config, pkgs, ... }:
         {
           virtualisation.diskSize = 10240;
@@ -131,7 +131,7 @@ import ./make-test-python.nix (
           virtualisation.containers.enable = true;
         };
 
-      nvidia-one-gpu-invalid-host-paths =
+      one-gpu-invalid-host-paths =
         { config, pkgs, ... }:
         {
           virtualisation.diskSize = 10240;
@@ -158,19 +158,19 @@ import ./make-test-python.nix (
       start_all()
 
       with subtest("Generate an empty CDI spec for a machine with no Nvidia GPUs"):
-        no_nvidia_gpus.wait_for_unit("nvidia-container-toolkit-cdi-generator.service")
-        no_nvidia_gpus.succeed("cat /var/run/cdi/nvidia-container-toolkit.json | jq")
+        no_gpus.wait_for_unit("nvidia-container-toolkit-cdi-generator.service")
+        no_gpus.succeed("cat /var/run/cdi/nvidia-container-toolkit.json | jq")
 
       with subtest("Podman loads the generated CDI spec for a machine with an Nvidia GPU"):
-        nvidia_one_gpu.wait_for_unit("nvidia-container-toolkit-cdi-generator.service")
-        nvidia_one_gpu.succeed("cat /var/run/cdi/nvidia-container-toolkit.json | jq")
-        nvidia_one_gpu.succeed("podman load < ${testContainerImage}")
-        print(nvidia_one_gpu.succeed("podman run --pull=never --device=nvidia.com/gpu=all -v /run/opengl-driver:/run/opengl-driver:ro cdi-test:latest"))
+        one_gpu.wait_for_unit("nvidia-container-toolkit-cdi-generator.service")
+        one_gpu.succeed("cat /var/run/cdi/nvidia-container-toolkit.json | jq")
+        one_gpu.succeed("podman load < ${testContainerImage}")
+        print(one_gpu.succeed("podman run --pull=never --device=nvidia.com/gpu=all -v /run/opengl-driver:/run/opengl-driver:ro cdi-test:latest"))
 
       # Issue: https://github.com/NixOS/nixpkgs/issues/319201
       with subtest("The generated CDI spec skips specified non-existant paths in the host"):
-        nvidia_one_gpu_invalid_host_paths.wait_for_unit("nvidia-container-toolkit-cdi-generator.service")
-        nvidia_one_gpu_invalid_host_paths.fail("grep 'non-existant-path' /var/run/cdi/nvidia-container-toolkit.json")
+        one_gpu_invalid_host_paths.wait_for_unit("nvidia-container-toolkit-cdi-generator.service")
+        one_gpu_invalid_host_paths.fail("grep 'non-existant-path' /var/run/cdi/nvidia-container-toolkit.json")
     '';
   }
 )

--- a/nixos/tests/nvidia-container-toolkit.nix
+++ b/nixos/tests/nvidia-container-toolkit.nix
@@ -126,7 +126,7 @@ import ./make-test-python.nix (
               open = true;
               package = config.boot.kernelPackages.nvidiaPackages.stable.open;
             };
-            opengl.enable = true;
+            graphics.enable = true;
           };
           virtualisation.containers.enable = true;
         };
@@ -149,7 +149,7 @@ import ./make-test-python.nix (
               open = true;
               package = config.boot.kernelPackages.nvidiaPackages.stable.open;
             };
-            opengl.enable = true;
+            graphics.enable = true;
           };
           virtualisation.containers.enable = true;
         };


### PR DESCRIPTION
## Description of changes

Although the final fix for this kind of issues is https://github.com/NixOS/nixpkgs/issues/290609 (`unbreak: we're currently mounting incomplete closures; need to use exportReferencesGraph.`), this adds yet another fix for a symptom.

Fixes: https://github.com/NixOS/nixpkgs/issues/319201

I will address the `exportReferencesGraph` soon that I expect will fix all these problems once and for all, but fix this problem in the meantime.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
