### PR TITLE
nixos/alsa: rename `sound.*` to `hardware.alsa.*`; explicitly conflict with PW

### DIFF
--- a/nixos/doc/manual/configuration/profiles/headless.section.md
+++ b/nixos/doc/manual/configuration/profiles/headless.section.md
@@ -2,7 +2,7 @@
 
 Common configuration for headless machines (e.g., Amazon EC2 instances).
 
-Disables [sound](#opt-sound.enable),
+Disables [ALSA](#opt-hardware.alsa.enable),
 [vesa](#opt-boot.vesa), serial consoles,
 [emergency mode](#opt-systemd.enableEmergencyMode),
 [grub splash images](#opt-boot.loader.grub.splashImage)

--- a/nixos/doc/manual/configuration/profiles/minimal.section.md
+++ b/nixos/doc/manual/configuration/profiles/minimal.section.md
@@ -6,4 +6,4 @@ graphical stuff. It's a very short file that enables
 [](#opt-i18n.supportedLocales) to
 only support the user-selected locale,
 [disables packages' documentation](#opt-documentation.enable),
-and [disables sound](#opt-sound.enable).
+and [disables ALSA](#opt-hardware.alsa.enable).

--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -221,7 +221,7 @@ in {
 
       environment.systemPackages = [ overriddenPackage ];
 
-      sound.enable = true;
+      hardware.alsa.enable = true;
 
       environment.etc = {
         "asound.conf".source = alsaConf;

--- a/nixos/modules/services/audio/alsa.nix
+++ b/nixos/modules/services/audio/alsa.nix
@@ -1,8 +1,6 @@
 # ALSA sound support.
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
   inherit (pkgs) alsa-utils;
 
@@ -14,12 +12,12 @@ in
 
 {
   imports = [
-    (mkRenamedOptionModule [ "sound" "enable" ] [ "hardware" "alsa" "enable" ])
-    (mkRenamedOptionModule [ "sound" "enableOSSEmulation" ] [ "hardware" "alsa" "enableOSSEmulation" ])
-    (mkRenamedOptionModule [ "sound" "extraConfig" ] [ "hardware" "alsa" "extraConfig" ])
-    (mkRenamedOptionModule [ "sound" "enableMediaKeys" ] [ "hardware" "alsa" "mediaKeys" "enable" ])
-    (mkRenamedOptionModule [ "sound" "mediaKeys" "enable" ] [ "hardware" "alsa" "mediaKeys" "enable" ])
-    (mkRenamedOptionModule [ "sound" "mediaKeys" "volumeStep" ] [ "hardware" "alsa" "mediaKeys" "volumeStep" ])
+    (lib.mkRenamedOptionModule [ "sound" "enable" ] [ "hardware" "alsa" "enable" ])
+    (lib.mkRenamedOptionModule [ "sound" "enableOSSEmulation" ] [ "hardware" "alsa" "enableOSSEmulation" ])
+    (lib.mkRenamedOptionModule [ "sound" "extraConfig" ] [ "hardware" "alsa" "extraConfig" ])
+    (lib.mkRenamedOptionModule [ "sound" "enableMediaKeys" ] [ "hardware" "alsa" "mediaKeys" "enable" ])
+    (lib.mkRenamedOptionModule [ "sound" "mediaKeys" "enable" ] [ "hardware" "alsa" "mediaKeys" "enable" ])
+    (lib.mkRenamedOptionModule [ "sound" "mediaKeys" "volumeStep" ] [ "hardware" "alsa" "mediaKeys" "volumeStep" ])
   ];
 
   ###### interface
@@ -28,24 +26,12 @@ in
 
     hardware.alsa = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable ALSA sound.
-        '';
-      };
+      enable = lib.mkEnableOption "ALSA sound";
 
-      enableOSSEmulation = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable ALSA OSS emulation (with certain cards sound mixing may not work!).
-        '';
-      };
+      enableOSSEmulation = lib.mkEnableOption "ALSA OSS emulation (with certain cards sound mixing may not work!)";
 
-      extraConfig = mkOption {
-        type = types.lines;
+      extraConfig = lib.mkOption {
+        type = lib.types.lines;
         default = "";
         example = ''
           defaults.pcm.!card 3
@@ -57,8 +43,8 @@ in
 
       mediaKeys = {
 
-        enable = mkOption {
-          type = types.bool;
+        enable = lib.mkOption {
+          type = lib.types.bool;
           default = false;
           description = ''
             Whether to enable volume and capture control with keyboard media keys.
@@ -72,8 +58,8 @@ in
           '';
         };
 
-        volumeStep = mkOption {
-          type = types.str;
+        volumeStep = lib.mkOption {
+          type = lib.types.str;
           default = "1";
           example = "1%";
           description = ''
@@ -92,17 +78,17 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     environment.systemPackages = [ alsa-utils ];
 
-    environment.etc = mkIf (!pulseaudioEnabled && cfg.extraConfig != "")
+    environment.etc = lib.mkIf (!pulseaudioEnabled && cfg.extraConfig != "")
       { "asound.conf".text = cfg.extraConfig; };
 
     # ALSA provides a udev rule for restoring volume settings.
     services.udev.packages = [ alsa-utils ];
 
-    boot.kernelModules = optional cfg.enableOSSEmulation "snd_pcm_oss";
+    boot.kernelModules = lib.optional cfg.enableOSSEmulation "snd_pcm_oss";
 
     systemd.services.alsa-store =
       { description = "Store Sound Card State";
@@ -118,7 +104,7 @@ in
         };
       };
 
-    services.actkbd = mkIf cfg.mediaKeys.enable {
+    services.actkbd = lib.mkIf cfg.mediaKeys.enable {
       enable = true;
       bindings = [
         # "Mute" media key

--- a/nixos/modules/services/audio/jack.nix
+++ b/nixos/modules/services/audio/jack.nix
@@ -122,7 +122,7 @@ in {
   config = mkMerge [
 
     (mkIf pcmPlugin {
-      sound.extraConfig = ''
+      hardware.alsa.extraConfig = ''
         pcm_type.jack {
           libs.native = ${pkgs.alsa-plugins}/lib/alsa-lib/libasound_module_pcm_jack.so ;
           ${lib.optionalString enable32BitAlsaPlugins
@@ -139,7 +139,7 @@ in {
     (mkIf loopback {
       boot.kernelModules = [ "snd-aloop" ];
       boot.kernelParams = [ "snd-aloop.index=${toString cfg.loopback.index}" ];
-      sound.extraConfig = cfg.loopback.config;
+      hardware.alsa.extraConfig = cfg.loopback.config;
     })
 
     (mkIf cfg.jackd.enable {

--- a/nixos/modules/services/desktops/pipewire/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire/pipewire.nix
@@ -322,6 +322,10 @@ in {
   config = mkIf cfg.enable {
     assertions = [
       {
+        assertion = cfg.audio.enable -> !config.hardware.alsa.enable;
+        message = "PipeWire-based ALSA emulation doesn't use the standalone ALSA service. Set `hardware.alsa.enable` to false";
+      }
+      {
         assertion = cfg.audio.enable -> !config.hardware.pulseaudio.enable;
         message = "Using PipeWire as the sound server conflicts with PulseAudio. This option requires `hardware.pulseaudio.enable` to be set to false";
       }

--- a/nixos/modules/services/hardware/actkbd.nix
+++ b/nixos/modules/services/hardware/actkbd.nix
@@ -83,7 +83,7 @@ in
 
           See {command}`actkbd` {file}`README` for documentation.
 
-          The example shows a piece of what {option}`sound.mediaKeys.enable` does when enabled.
+          The example shows a piece of what {option}`hardware.alsa.mediaKeys.enable` does when enabled.
         '';
       };
 

--- a/nixos/modules/virtualisation/vagrant-virtualbox-image.nix
+++ b/nixos/modules/virtualisation/vagrant-virtualbox-image.nix
@@ -15,7 +15,7 @@
     usb = "off";
     usbehci = "off";
   };
-  sound.enable = false;
+  hardware.alsa.enable = false;
   documentation.man.enable = false;
   documentation.nixos.enable = false;
 

--- a/nixos/tests/domination.nix
+++ b/nixos/tests/domination.nix
@@ -10,7 +10,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     ];
 
     services.xserver.enable = true;
-    sound.enable = true;
+    hardware.alsa.enable = true;
     environment.systemPackages = [ pkgs.domination ];
   };
 

--- a/nixos/tests/firefox.nix
+++ b/nixos/tests/firefox.nix
@@ -21,8 +21,8 @@ import ./make-test-python.nix ({ lib, pkgs, firefoxPackage, ... }:
       # Create a virtual sound device, with mixing
       # and all, for recording audio.
       boot.kernelModules = [ "snd-aloop" ];
-      sound.enable = true;
-      sound.extraConfig = ''
+      hardware.alsa.enable = true;
+      hardware.alsa.extraConfig = ''
         pcm.!default {
           type plug
           slave.pcm pcm.dmixer

--- a/nixos/tests/ft2-clone.nix
+++ b/nixos/tests/ft2-clone.nix
@@ -9,7 +9,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
       ./common/x11.nix
     ];
 
-    sound.enable = true;
+    hardware.alsa.enable = true;
     environment.systemPackages = [ pkgs.ft2-clone ];
   };
 

--- a/nixos/tests/login.nix
+++ b/nixos/tests/login.nix
@@ -9,7 +9,7 @@ import ./make-test-python.nix ({ pkgs, latestKernel ? false, ... }:
   nodes.machine =
     { pkgs, lib, ... }:
     { boot.kernelPackages = lib.mkIf latestKernel pkgs.linuxPackages_latest;
-      sound.enable = true; # needed for the factl test, /dev/snd/* exists without them but udev doesn't care then
+      hardware.alsa.enable = true; # needed for the factl test, /dev/snd/* exists without them but udev doesn't care then
     };
 
   testScript = ''

--- a/nixos/tests/mpd.nix
+++ b/nixos/tests/mpd.nix
@@ -37,7 +37,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
 
     mkServer = { mpd, musicService, }:
       { boot.kernelModules = [ "snd-dummy" ];
-        sound.enable = true;
+        hardware.alsa.enable = true;
         services.mpd = mpd;
         systemd.services.musicService = musicService;
       };

--- a/nixos/tests/pt2-clone.nix
+++ b/nixos/tests/pt2-clone.nix
@@ -10,7 +10,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     ];
 
     services.xserver.enable = true;
-    sound.enable = true;
+    hardware.alsa.enable = true;
     environment.systemPackages = [ pkgs.pt2-clone ];
   };
 

--- a/nixos/tests/sfxr-qt.nix
+++ b/nixos/tests/sfxr-qt.nix
@@ -10,7 +10,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     ];
 
     services.xserver.enable = true;
-    sound.enable = true;
+    hardware.alsa.enable = true;
     environment.systemPackages = [ pkgs.sfxr-qt ];
   };
 

--- a/nixos/tests/shattered-pixel-dungeon.nix
+++ b/nixos/tests/shattered-pixel-dungeon.nix
@@ -10,7 +10,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     ];
 
     services.xserver.enable = true;
-    sound.enable = true;
+    hardware.alsa.enable = true;
     environment.systemPackages = [ pkgs.shattered-pixel-dungeon ];
   };
 

--- a/nixos/tests/slimserver.nix
+++ b/nixos/tests/slimserver.nix
@@ -8,7 +8,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
       enable = true;
       extraArguments = "-s 127.0.0.1 -d slimproto=info";
     };
-    sound.enable = true;
+    hardware.alsa.enable = true;
     boot.initrd.kernelModules = ["snd-dummy"];
   };
 

--- a/nixos/tests/systemd-analyze.nix
+++ b/nixos/tests/systemd-analyze.nix
@@ -9,7 +9,7 @@ import ./make-test-python.nix ({ pkgs, latestKernel ? false, ... }:
   nodes.machine =
     { pkgs, lib, ... }:
     { boot.kernelPackages = lib.mkIf latestKernel pkgs.linuxPackages_latest;
-      sound.enable = true; # needed for the factl test, /dev/snd/* exists without them but udev doesn't care then
+      hardware.alsa.enable = true; # needed for the factl test, /dev/snd/* exists without them but udev doesn't care then
     };
 
   testScript = ''


### PR DESCRIPTION
## Description of changes

The naming of `sound.enable` has been a source of confusion for years.
Hence we should name the options more consistently, and highlight that it is not useful in PW configurations.

- **nixos/alsa:**
  - **rename `sound.*` options to `hardware.alsa.*`**
  - remove top-level `with lib;`
  - use `mkEnableOption`
  - add package option
- **nixos/pipewire: enforce disabling ALSA when using PW**

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
