### PR TITLE
nixos/amdgpu: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -207,6 +207,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - [xdg-terminal-exec](https://github.com/Vladimir-csp/xdg-terminal-exec), the proposed Default Terminal Execution Specification.
 
+- Convenience options for `amdgpu`, open source driver for Radeon cards, is now available under `hardware.amdgpu`.
+
 - [ydotool](https://github.com/ReimuNotMoe/ydotool), a generic command-line automation tool now has a module. Available as [programs.ydotool](#opt-programs.ydotool.enable).
 
 - [your_spotify](https://github.com/Yooooomi/your_spotify), a self hosted Spotify tracking dashboard. Available as [services.your_spotify](#opt-services.your_spotify.enable)

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -4,6 +4,8 @@
 
 ## Highlights {#sec-release-24.11-highlights}
 
+- Convenience options for `amdgpu`, open source driver for Radeon cards, is now available under `hardware.amdgpu`.
+
 - [AMDVLK](https://github.com/GPUOpen-Drivers/AMDVLK), AMD's open source Vulkan driver, is now available to be configured as `hardware.amdgpu.amdvlk` option.
   This also allows configuring runtime settings of AMDVLK and enabling experimental features.
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -549,6 +549,7 @@
   ./services/games/xonotic.nix
   ./services/hardware/acpid.nix
   ./services/hardware/actkbd.nix
+  ./services/hardware/amdgpu.nix
   ./services/hardware/amdvlk.nix
   ./services/hardware/argonone.nix
   ./services/hardware/asusd.nix

--- a/nixos/modules/services/hardware/amdgpu.nix
+++ b/nixos/modules/services/hardware/amdgpu.nix
@@ -1,0 +1,43 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.hardware.amdgpu;
+in {
+  options.hardware.amdgpu = {
+    legacySupport.enable = lib.mkEnableOption ''
+      using `amdgpu` kernel driver instead of `radeon` for Southern Islands
+      (Radeon HD 7000) series and Sea Islands (Radeon HD 8000)
+      series cards. Note: this removes support for analog video outputs,
+      which is only available in the `radeon` driver
+    '';
+    initrd.enable = lib.mkEnableOption ''
+      loading `amdgpu` kernelModule in stage 1.
+      Can fix lower resolution in boot screen during initramfs phase
+    '';
+    opencl.enable = lib.mkEnableOption ''OpenCL support using ROCM runtime library'';
+    # cfg.amdvlk option is defined in ./amdvlk.nix module
+  };
+
+  config = {
+    boot.kernelParams = lib.optionals cfg.legacySupport.enable [
+      "amdgpu.si_support=1"
+      "amdgpu.cik_support=1"
+      "radeon.si_support=0"
+      "radeon.cik_support=0"
+    ];
+
+    boot.initrd.kernelModules = lib.optionals cfg.initrd.enable [ "amdgpu" ];
+
+    hardware.opengl = lib.mkIf cfg.opencl.enable {
+      enable = lib.mkDefault true;
+      extraPackages = [
+        pkgs.rocmPackages.clr
+        pkgs.rocmPackages.clr.icd
+      ];
+    };
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ johnrtitor ];
+  };
+}


### PR DESCRIPTION
## Description of changes

As a follow up to #318175, add `hardware.amdgpu.*` options.

This PR adds:

1. `hardware.amdgpu.legacySupport.enable` option, which enables amdgpu driver for SI and CIK cards
2. `hardware.amdgpu.initrd.enable` option, which loads `amdgpu` kernel module in initrd stage 1
3. `hardware.amdgpu.rocm.enable` option, to enable rocm runtime driver support

## Things done

- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

CC: @pbsds @Mic92 @SuperSandro2000 @K900

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
