### PR TITLE
Minor Nixpkgs doc improvements

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -2,6 +2,7 @@
 let
   inherit (pkgs) lib;
   inherit (lib) hasPrefix removePrefix;
+  fs = lib.fileset;
 
   common = import ./common.nix;
 
@@ -99,7 +100,19 @@ in pkgs.stdenv.mkDerivation {
     nixos-render-docs
   ];
 
-  src = ./.;
+  src = fs.toSource {
+    root = ./.;
+    fileset = fs.unions [
+      (fs.fileFilter (file:
+        file.hasExt "md"
+        || file.hasExt "md.in"
+      ) ./.)
+      ./style.css
+      ./anchor-use.js
+      ./anchor.min.js
+      ./manpage-urls.json
+    ];
+  };
 
   postPatch = ''
     ln -s ${optionsDoc.optionsJSON}/share/doc/nixos/options.json ./config-options.json

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -105,14 +105,12 @@ in pkgs.stdenv.mkDerivation {
     ln -s ${optionsDoc.optionsJSON}/share/doc/nixos/options.json ./config-options.json
   '';
 
-  buildPhase = let
-    pythonInterpreterTable = pkgs.callPackage ./doc-support/python-interpreter-table.nix {};
-    pythonSection = with lib.strings; replaceStrings
-      [ "@python-interpreter-table@" ]
-      [ pythonInterpreterTable ]
-      (readFile ./languages-frameworks/python.section.md);
-  in ''
-    cp ${builtins.toFile "python.section.md" pythonSection} ./languages-frameworks/python.section.md
+  pythonInterpreterTable = pkgs.callPackage ./doc-support/python-interpreter-table.nix {};
+
+  passAsFile = [ "pythonInterpreterTable" ];
+
+  buildPhase = ''
+    substituteInPlace ./languages-frameworks/python.section.md --subst-var-by python-interpreter-table "$(<"$pythonInterpreterTablePath")"
 
     cat \
       ./functions/library.md.in \


### PR DESCRIPTION
## Description of changes
- Insert the python interpreter table at build-time instead of eval-time (originally from https://github.com/NixOS/nixpkgs/pull/313408)
- Remove an unnecessary dir that doesn't have any files in it anymore for years
- Prevent unnecessary rebuilds (e.g. when only Nix files change), see https://github.com/NixOS/nixpkgs/issues/301014

## Things done
- [x] Built the manual successfully using `nix-build doc`
- [x] Checked that changing the Nix files doesn't cause a rebuild

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
