### PR TITLE
nixos/lib/test-driver: Prevent unnecessary rebuilds

### DIFF
--- a/nixos/lib/test-driver/default.nix
+++ b/nixos/lib/test-driver/default.nix
@@ -13,11 +13,20 @@
 , extraPythonPackages ? (_ : [])
 , nixosTests
 }:
-
+let
+  fs = lib.fileset;
+in
 python3Packages.buildPythonApplication {
   pname = "nixos-test-driver";
   version = "1.1";
-  src = ./.;
+  src = fs.toSource {
+    root = ./.;
+    fileset = fs.unions [
+      ./pyproject.toml
+      ./test_driver
+      ./extract-docstrings.py
+    ];
+  };
   pyproject = true;
 
   propagatedBuildInputs = [


### PR DESCRIPTION
## Description of changes

E.g. when only Nix files change, see https://github.com/NixOS/nixpkgs/issues/301014

Ping @hertrste

## Things done

- [x] Successfully built `nix-build nixos/tests/simple.nix`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
