### PR TITLE
onnxruntime: 1.16.3 -> 1.18.1

### DIFF
--- a/pkgs/development/libraries/onnxruntime/0001-eigen-allow-dependency-injection.patch
+++ b/pkgs/development/libraries/onnxruntime/0001-eigen-allow-dependency-injection.patch
@@ -1,45 +1,20 @@
-From a29cffa646356228d6ec7bd7ce21fe3ab90fdd19 Mon Sep 17 00:00:00 2001
-From: Someone Serge <sergei.kozlukov@aalto.fi>
-Date: Wed, 7 Feb 2024 16:59:09 +0000
-Subject: [PATCH] eigen: allow dependency injection
-
----
- cmake/external/eigen.cmake | 12 +++++++++---
- 1 file changed, 9 insertions(+), 3 deletions(-)
-
 diff --git a/cmake/external/eigen.cmake b/cmake/external/eigen.cmake
-index c0f7ddc50e..996b83d18a 100644
+index b123adb..aab2483 100644
 --- a/cmake/external/eigen.cmake
 +++ b/cmake/external/eigen.cmake
-@@ -1,4 +1,3 @@
--
- if (onnxruntime_USE_PREINSTALLED_EIGEN)
-     add_library(eigen INTERFACE)
-     file(TO_CMAKE_PATH ${eigen_SOURCE_PATH} eigen_INCLUDE_DIRS)
-@@ -10,14 +9,21 @@ else ()
-             URL ${DEP_URL_eigen}
-             URL_HASH SHA1=${DEP_SHA1_eigen}
-             PATCH_COMMAND ${Patch_EXECUTABLE} --ignore-space-change --ignore-whitespace < ${PROJECT_SOURCE_DIR}/patches/eigen/Fix_Eigen_Build_Break.patch
-+            FIND_PACKAGE_ARGS NAMES Eigen3
-         )
-     else()
-         FetchContent_Declare(
-             eigen
-             URL ${DEP_URL_eigen}
-             URL_HASH SHA1=${DEP_SHA1_eigen}
-+            FIND_PACKAGE_ARGS NAMES Eigen3
-         )
-     endif()
+@@ -7,8 +7,13 @@ else ()
+         eigen
+         URL ${DEP_URL_eigen}
+         URL_HASH SHA1=${DEP_SHA1_eigen}
++	FIND_PACKAGE_ARGS NAMES Eigen3
+     )
+ 
 -    FetchContent_Populate(eigen)
 -    set(eigen_INCLUDE_DIRS  "${eigen_SOURCE_DIR}")
 +    FetchContent_MakeAvailable(eigen)
 +    add_library(eigen ALIAS Eigen3::Eigen)
-+
 +    # Onnxruntime doesn't always use `eigen` as a target in
 +    # `target_link_libraries`, sometimes it just uses
 +    # `target_include_directories`:
 +    get_target_property(eigen_INCLUDE_DIRS Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES)
  endif()
--- 
-2.42.0
-

--- a/pkgs/development/libraries/onnxruntime/default.nix
+++ b/pkgs/development/libraries/onnxruntime/default.nix
@@ -2,10 +2,15 @@
 , stdenv
 , lib
 , fetchFromGitHub
+, fetchpatch
 , Foundation
 , abseil-cpp
 , cmake
+, cpuinfo
 , eigen
+, flatbuffers
+, gbenchmark
+, glibcLocales
 , gtest
 , libpng
 , nlohmann_json
@@ -24,7 +29,7 @@
 
 
 let
-  version = "1.16.3";
+  version = "1.18.1";
 
   stdenv = throw "Use effectiveStdenv instead";
   effectiveStdenv = if cudaSupport then cudaPackages.backendStdenv else inputs.stdenv;
@@ -34,15 +39,15 @@ let
   howard-hinnant-date = fetchFromGitHub {
     owner = "HowardHinnant";
     repo = "date";
-    rev = "v2.4.1";
-    sha256 = "sha256-BYL7wxsYRI45l8C3VwxYIIocn5TzJnBtU0UZ9pHwwZw=";
+    rev = "v3.0.1";
+    sha256 = "sha256-ZSjeJKAcT7mPym/4ViDvIR9nFMQEBCSUtPEuMO27Z+I=";
   };
 
   mp11 = fetchFromGitHub {
     owner = "boostorg";
     repo = "mp11";
-    rev = "boost-1.79.0";
-    hash = "sha256-ZxgPDLvpISrjpEHKpLGBowRKGfSwTf6TBfJD18yw+LM=";
+    rev = "boost-1.82.0";
+    hash = "sha256-cLPvjkf2Au+B19PJNrUkTW/VPxybi1MpPxnIl4oo4/o=";
   };
 
   safeint = fetchFromGitHub {
@@ -52,34 +57,34 @@ let
     hash = "sha256-PK1ce4C0uCR4TzLFg+elZdSk5DdPCRhhwT3LvEwWnPU=";
   };
 
-  pytorch_cpuinfo = fetchFromGitHub {
-    owner = "pytorch";
-    repo = "cpuinfo";
-    # There are no tags in the repository
-    rev = "5916273f79a21551890fd3d56fc5375a78d1598d";
-    hash = "sha256-nXBnloVTuB+AVX59VDU/Wc+Dsx94o92YQuHp3jowx2A=";
-  };
+  pytorch_clog = effectiveStdenv.mkDerivation {
+    pname = "clog";
+    version = "3c8b153";
+    src = "${cpuinfo.src}/deps/clog";
 
-  flatbuffers = fetchFromGitHub {
-    owner = "google";
-    repo = "flatbuffers";
-    rev = "v1.12.0";
-    hash = "sha256-L1B5Y/c897Jg9fGwT2J3+vaXsZ+lfXnskp8Gto1p/Tg=";
+    nativeBuildInputs = [ cmake gbenchmark gtest ];
+    cmakeFlags = [
+      "-DUSE_SYSTEM_GOOGLEBENCHMARK=ON"
+      "-DUSE_SYSTEM_GOOGLETEST=ON"
+      "-DUSE_SYSTEM_LIBS=ON"
+      # 'clog' tests set 'CXX_STANDARD 11'; this conflicts with our 'gtest'.
+      "-DCLOG_BUILD_TESTS=OFF"
+    ];
   };
 
   onnx = fetchFromGitHub {
     owner = "onnx";
     repo = "onnx";
-    rev = "refs/tags/v1.14.1";
-    hash = "sha256-ZVSdk6LeAiZpQrrzLxphMbc1b3rNUMpcxcXPP8s/5tE=";
+    rev = "refs/tags/v1.16.1";
+    hash = "sha256-I1wwfn91hdH3jORIKny0Xc73qW2P04MjkVCgcaNnQUE=";
   };
 
    cutlass = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "cutlass";
-    rev = "v3.0.0";
-    sha256 = "sha256-YPD5Sy6SvByjIcGtgeGH80TEKg2BtqJWSg46RvnJChY=";
-   };
+    rev = "v3.1.0";
+    hash = "sha256-mpaiCxiYR1WaSSkcEPTzvcREenJWklD+HRdTT5/pD54=";
+ };
 in
 effectiveStdenv.mkDerivation rec {
   pname = "onnxruntime";
@@ -89,7 +94,7 @@ effectiveStdenv.mkDerivation rec {
     owner = "microsoft";
     repo = "onnxruntime";
     rev = "refs/tags/v${version}";
-    hash = "sha256-bTW9Pc3rvH+c8VIlDDEtAXyA3sajVyY5Aqr6+SxaMF4=";
+    hash = "sha256-+zWtbLKekGhwdBU3bm1u2F7rYejQ62epE+HcHj05/8A=";
     fetchSubmodules = true;
   };
 
@@ -102,6 +107,13 @@ effectiveStdenv.mkDerivation rec {
     # - use MakeAvailable instead of the low-level Populate,
     # - use Eigen3::Eigen as the target name (as declared by libeigen/eigen).
     ./0001-eigen-allow-dependency-injection.patch
+    # Incorporate a patch that has landed upstream which exposes new
+    # 'abseil-cpp' libraries & modifies the 're2' CMakeLists to fix a
+    # configuration error that around missing 'gmock' exports.
+    #
+    # TODO: Check if it can be dropped after 1.19.0
+    # https://github.com/microsoft/onnxruntime/commit/b522df0ae477e59f60acbe6c92c8a64eda96cace
+    ./update-re2.patch
   ] ++ lib.optionals cudaSupport [
     # We apply the referenced 1064.patch ourselves to our nix dependency.
     #  FIND_PACKAGE_ARGS for CUDA was added in https://github.com/microsoft/onnxruntime/commit/87744e5 so it might be possible to delete this patch after upgrading to 1.17.0
@@ -124,11 +136,14 @@ effectiveStdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    cpuinfo
     eigen
+    glibcLocales
     libpng
-    zlib
     nlohmann_json
     microsoft-gsl
+    pytorch_clog
+    zlib
   ] ++ lib.optionals pythonSupport (with python3Packages; [
     numpy
     pybind11
@@ -168,11 +183,11 @@ effectiveStdenv.mkDerivation rec {
     "-DFETCHCONTENT_QUIET=OFF"
     "-DFETCHCONTENT_SOURCE_DIR_ABSEIL_CPP=${abseil-cpp.src}"
     "-DFETCHCONTENT_SOURCE_DIR_DATE=${howard-hinnant-date}"
-    "-DFETCHCONTENT_SOURCE_DIR_FLATBUFFERS=${flatbuffers}"
+    "-DFETCHCONTENT_SOURCE_DIR_FLATBUFFERS=${flatbuffers.src}"
+    "-DFETCHCONTENT_SOURCE_DIR_GOOGLETEST=${gtest.src}"
     "-DFETCHCONTENT_SOURCE_DIR_GOOGLE_NSYNC=${nsync.src}"
     "-DFETCHCONTENT_SOURCE_DIR_MP11=${mp11}"
     "-DFETCHCONTENT_SOURCE_DIR_ONNX=${onnx}"
-    "-DFETCHCONTENT_SOURCE_DIR_PYTORCH_CPUINFO=${pytorch_cpuinfo}"
     "-DFETCHCONTENT_SOURCE_DIR_RE2=${re2.src}"
     "-DFETCHCONTENT_SOURCE_DIR_SAFEINT=${safeint}"
     "-DFETCHCONTENT_TRY_FIND_PACKAGE_MODE=ALWAYS"
@@ -194,11 +209,13 @@ effectiveStdenv.mkDerivation rec {
   env = lib.optionalAttrs effectiveStdenv.cc.isClang {
     NIX_CFLAGS_COMPILE = toString [
       "-Wno-error=deprecated-declarations"
+      "-Wno-error=deprecated-pragma"
       "-Wno-error=unused-but-set-variable"
     ];
   };
 
-  doCheck = !cudaSupport;
+  # aarch64-linux fails cpuinfo test, because /sys/devices/system/cpu/ does not exist in the sandbox
+  doCheck = !(cudaSupport || effectiveStdenv.buildPlatform.system == "aarch64-linux");
 
   requiredSystemFeatures = lib.optionals cudaSupport [ "big-parallel" ];
 

--- a/pkgs/development/libraries/onnxruntime/nvcc-gsl.patch
+++ b/pkgs/development/libraries/onnxruntime/nvcc-gsl.patch
@@ -1,8 +1,8 @@
 diff --git a/cmake/external/onnxruntime_external_deps.cmake b/cmake/external/onnxruntime_external_deps.cmake
-index 9effd1a2db..faff5e8de7 100644
+index 775576a..ccea13c 100644
 --- a/cmake/external/onnxruntime_external_deps.cmake
 +++ b/cmake/external/onnxruntime_external_deps.cmake
-@@ -280,21 +280,12 @@ if (NOT WIN32)
+@@ -367,22 +367,12 @@ if (NOT WIN32)
    endif()
  endif()
  
@@ -12,6 +12,7 @@ index 9effd1a2db..faff5e8de7 100644
 -    URL ${DEP_URL_microsoft_gsl}
 -    URL_HASH SHA1=${DEP_SHA1_microsoft_gsl}
 -    PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/gsl/1064.patch
+-    FIND_PACKAGE_ARGS 4.0 NAMES Microsoft.GSL
 -  )
 -else()
 -  FetchContent_Declare(

--- a/pkgs/development/libraries/onnxruntime/update-re2.patch
+++ b/pkgs/development/libraries/onnxruntime/update-re2.patch
@@ -1,0 +1,132 @@
+From 0d1e631c365944d54e87bdce39beb13b225ba8f8 Mon Sep 17 00:00:00 2001
+From: Changming Sun <chasun@microsoft.com>
+Date: Thu, 23 May 2024 14:30:15 -0700
+Subject: [PATCH] Update RE2 to the latest (#20775)
+
+Update RE2 to the latest.
+
+To keep the components up to date.
+
+(cherry picked from commit b522df0ae477e59f60acbe6c92c8a64eda96cace)
+---
+ cgmanifests/generated/cgmanifest.json |  2 +-
+ cmake/deps.txt                        |  4 +--
+ cmake/external/abseil-cpp.cmake       | 35 ++++++++++++++++++++++-----
+ cmake/external/helper_functions.cmake |  6 +++++
+ 4 files changed, 38 insertions(+), 9 deletions(-)
+
+diff --git a/cgmanifests/generated/cgmanifest.json b/cgmanifests/generated/cgmanifest.json
+index eb74178b3e..e3e9be67ae 100644
+--- a/cgmanifests/generated/cgmanifest.json
++++ b/cgmanifests/generated/cgmanifest.json
+@@ -276,7 +276,7 @@
+       "component": {
+         "type": "git",
+         "git": {
+-          "commitHash": "5723bb8950318135ed9cf4fc76bed988a087f536",
++          "commitHash": "2b354c6ad0d0479dcff68dab23fb0d1143a482c2",
+           "repositoryUrl": "https://github.com/google/re2.git"
+         },
+         "comments": "re2"
+diff --git a/cmake/deps.txt b/cmake/deps.txt
+index d213b09034..d4d19dea08 100644
+--- a/cmake/deps.txt
++++ b/cmake/deps.txt
+@@ -50,11 +50,11 @@ psimd;https://github.com/Maratyszcza/psimd/archive/072586a71b55b7f8c584153d223e9
+ pthreadpool;https://github.com/Maratyszcza/pthreadpool/archive/4fe0e1e183925bf8cfa6aae24237e724a96479b8.zip;07a0aa91dd9bf86f31b95497e00f31d8a261a4bd
+ pybind11;https://github.com/pybind/pybind11/archive/refs/tags/v2.10.1.zip;769b6aa67a77f17a770960f604b727645b6f6a13
+ pytorch_cpuinfo;https://github.com/pytorch/cpuinfo/archive/959002f82d7962a473d8bf301845f2af720e0aa4.zip;85da3caa60eb2b148613b443fbc2bfdc30689965
+-re2;https://github.com/google/re2/archive/refs/tags/2022-06-01.zip;aa77313b76e91b531ee7f3e45f004c6a502a5374
++re2;https://github.com/google/re2/archive/refs/tags/2024-05-01.tar.gz;206cfee5ee0b4c6844680ba66275e9e8faa77405
+ safeint;https://github.com/dcleblanc/SafeInt/archive/refs/tags/3.0.28.zip;23f252040ff6cb9f1fd18575b32fa8fb5928daac
+ tensorboard;https://github.com/tensorflow/tensorboard/archive/373eb09e4c5d2b3cc2493f0949dc4be6b6a45e81.zip;67b833913605a4f3f499894ab11528a702c2b381
+ cutlass;https://github.com/NVIDIA/cutlass/archive/refs/tags/v3.1.0.zip;757f90a795034a89d4f48a79d1f009f7a04c8dee
+ utf8_range;https://github.com/protocolbuffers/utf8_range/archive/72c943dea2b9240cd09efde15191e144bc7c7d38.zip;9925739c9debc0efa2adcb194d371a35b6a03156
+ extensions;https://github.com/microsoft/onnxruntime-extensions/archive/94142d8391c9791ec71c38336436319a2d4ac7a0.zip;4365ac5140338b4cb75a39944a4be276e3829b3c
+ composable_kernel;https://github.com/ROCmSoftwarePlatform/composable_kernel/archive/5356c4a943a35e74d7cdc69486afcb8703b9a59a.zip;522382c2af437e09124287e5879ab64af5b2e299
+-directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v1.613.1.zip;47653509a3371eabb156360f42faf582f314bf2e
+\ No newline at end of file
++directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v1.613.1.zip;47653509a3371eabb156360f42faf582f314bf2e
+diff --git a/cmake/external/abseil-cpp.cmake b/cmake/external/abseil-cpp.cmake
+index 57cfbee464..c01195c99e 100644
+--- a/cmake/external/abseil-cpp.cmake
++++ b/cmake/external/abseil-cpp.cmake
+@@ -45,10 +45,8 @@ endif()
+ 
+ # TODO: since multiple ORT's dependencies depend on Abseil, the list below would vary from version to version.
+ # We'd better to not manually manage the list.
+-set(ABSEIL_LIBS absl::base
++set(ABSEIL_LIBS
+ absl::city
+-absl::core_headers
+-absl::fixed_array
+ absl::flags
+ absl::flat_hash_map
+ absl::flat_hash_set
+@@ -60,9 +58,34 @@ absl::node_hash_set
+ absl::optional
+ absl::raw_hash_set
+ absl::raw_logging_internal
+-absl::span
+ absl::str_format
+-absl::strings
++absl::str_format_internal
++absl::bits
++absl::fixed_array
++absl::numeric_representation
++absl::utility
++absl::type_traits
++absl::string_view
++absl::core_headers
++absl::nullability
++absl::span
++absl::config
+ absl::synchronization
++absl::base
++absl::civil_time
++absl::debugging_internal
++absl::demangle_internal
++absl::graphcycles_internal
++absl::int128
++absl::kernel_timeout_internal
++absl::log_severity
++absl::malloc_internal
++absl::spinlock_wait
++absl::stacktrace
++absl::string_view
++absl::strings
++absl::strings_internal
++absl::symbolize
+ absl::throw_delegate
+-absl::time)
++absl::time
++absl::time_zone)
+\ No newline at end of file
+diff --git a/cmake/external/helper_functions.cmake b/cmake/external/helper_functions.cmake
+index 768e807b40..eefb3ba2e8 100644
+--- a/cmake/external/helper_functions.cmake
++++ b/cmake/external/helper_functions.cmake
+@@ -159,7 +159,12 @@ macro(onnxruntime_fetchcontent_makeavailable)
+       endif()
+ 
+       if(EXISTS ${__cmake_srcdir}/CMakeLists.txt)
++        set(CMAKE_SKIP_INSTALL_RULES TRUE)
++        if (__cmake_arg_SYSTEM)
++          add_subdirectory(${__cmake_srcdir} ${${__cmake_contentNameLower}_BINARY_DIR} SYSTEM)
++        else()
+           add_subdirectory(${__cmake_srcdir} ${${__cmake_contentNameLower}_BINARY_DIR} EXCLUDE_FROM_ALL)
++        endif()
+           get_property(subdir_import_targets DIRECTORY "${__cmake_srcdir}" PROPERTY BUILDSYSTEM_TARGETS)
+           foreach(subdir_target ${subdir_import_targets})
+             if(TARGET ${subdir_target})
+@@ -176,6 +181,7 @@ macro(onnxruntime_fetchcontent_makeavailable)
+               set_target_properties(${subdir_target} PROPERTIES COMPILE_WARNING_AS_ERROR OFF)
+             endif()
+           endforeach()
++          set(CMAKE_SKIP_INSTALL_RULES FALSE)
+       endif()
+ 
+       unset(__cmake_srcdir)
+-- 
+2.45.2
+


### PR DESCRIPTION
Release notes:
- https://github.com/microsoft/onnxruntime/releases/tag/v1.17.0
- https://github.com/microsoft/onnxruntime/releases/tag/v1.17.1
- https://github.com/microsoft/onnxruntime/releases/tag/v1.17.3
- https://github.com/microsoft/onnxruntime/releases/tag/v1.18.0
- https://github.com/microsoft/onnxruntime/releases/tag/v1.18.1

continuation of my last PR, which i somehow messed up so bad that GitHub automatically pinged everyone for some reason i cannot even remotely discern...?

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
