### PR TITLE
haskellPackages.set-extra: unmark broken

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -5340,7 +5340,6 @@ broken-packages:
   - sessions # failure in job https://hydra.nixos.org/build/233214614 at 2023-09-02
   - sessiontypes # failure in job https://hydra.nixos.org/build/233224975 at 2023-09-02
   - setdown # failure in job https://hydra.nixos.org/build/241521053 at 2023-12-03
-  - set-extra # failure in job https://hydra.nixos.org/build/252738545 at 2024-03-16
   - setgame # failure in job https://hydra.nixos.org/build/233218664 at 2023-09-02
   - set-of # failure in job https://hydra.nixos.org/build/233202960 at 2023-09-02
   - setoid # failure in job https://hydra.nixos.org/build/233213744 at 2023-09-02


### PR DESCRIPTION
## Description of changes
1.4.2 [fixed](https://github.com/ddssff/set-extra/commit/f41b2a5e80238bf181375c0cbbed61a89ad48970) the [previous build failure](https://hydra.nixos.org/build/252738545/nixlog/2)

This should also fix pakcs as a consequence (ping @t4ccer)

## Things done
- [x] Built `haskellPackages.set-extra` on x86_64-linux

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
