### PR TITLE
reason.tests.hello: Prevent unnecessary rebuilds

### DIFF
--- a/pkgs/development/compilers/reason/tests/hello/default.nix
+++ b/pkgs/development/compilers/reason/tests/hello/default.nix
@@ -1,10 +1,18 @@
-{ buildDunePackage, ppxlib, reason }:
+{ lib, buildDunePackage, ppxlib, reason }:
 
 buildDunePackage rec {
   pname = "helloreason";
   version = "0.0.1";
 
-  src = ./.;
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.unions [
+      ./helloreason.opam
+      ./helloreason.re
+      ./dune-project
+      ./dune
+    ];
+  };
 
   nativeBuildInputs = [
     reason


### PR DESCRIPTION
## Description of changes

E.g. from Nix file changes, see https://github.com/NixOS/nixpkgs/issues/301014

## Things done
- [x] Built `nix-build -A reason.tests.hello` on x86_64-linux

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
