### PR TITLE
python3.tests.nix-pythonprefix-mypy: Avoid unnecessary rebuilds

### DIFF
--- a/pkgs/development/interpreters/python/tests/test_nix_pythonprefix/typeddep/default.nix
+++ b/pkgs/development/interpreters/python/tests/test_nix_pythonprefix/typeddep/default.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, pythonOlder }:
+{ lib, buildPythonPackage, pythonOlder }:
 
 
 buildPythonPackage {
@@ -6,7 +6,13 @@ buildPythonPackage {
   pname = "typeddep";
   version = "1.3.3.7";
 
-  src = ./.;
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.unions [
+      ./setup.py
+      ./typeddep
+    ];
+  };
 
   disabled = pythonOlder "3.7";
 


### PR DESCRIPTION
## Description of changes

E.g. when the Nix is changed, see https://github.com/NixOS/nixpkgs/issues/301014

## Things done
- [x] Built `python3.tests.nix-pythonprefix-mypy` on x86_64-linux

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
