### PR TITLE
ustreamer: add janus-gateway webrtc support

### DIFF
--- a/pkgs/applications/video/ustreamer/default.nix
+++ b/pkgs/applications/video/ustreamer/default.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
       screencast hardware data with the highest resolution and FPS possible.
     '';
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ tfc ];
+    maintainers = with maintainers; [ tfc matthewcroughan ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/video/ustreamer/default.nix
+++ b/pkgs/applications/video/ustreamer/default.nix
@@ -1,5 +1,19 @@
-{ lib, stdenv, fetchFromGitHub, libbsd, libevent, libjpeg, libdrm, pkg-config }:
-
+{ lib
+, stdenv
+, fetchFromGitHub
+, libbsd
+, libevent
+, libjpeg
+, libdrm
+, pkg-config
+, janus-gateway
+, glib
+, alsa-lib
+, speex
+, jansson
+, libopus
+, withJanus ? true
+}:
 stdenv.mkDerivation rec {
   pname = "ustreamer";
   version = "6.12";
@@ -11,13 +25,30 @@ stdenv.mkDerivation rec {
     hash = "sha256-iaCgPHgklk7tbhJhQmyjKggb1bMWBD+Zurgfk9sCQ3E=";
   };
 
-  buildInputs = [ libbsd libevent libjpeg libdrm ];
+  buildInputs = [
+    libbsd
+    libevent
+    libjpeg
+    libdrm
+  ] ++ lib.optionals withJanus [
+    janus-gateway
+    glib
+    alsa-lib
+    jansson
+    speex
+    libopus
+  ];
 
   nativeBuildInputs = [ pkg-config ];
 
   makeFlags = [
     "PREFIX=${placeholder "out"}"
     "WITH_V4P=1"
+  ] ++ lib.optionals withJanus [
+    "WITH_JANUS=1"
+    # Workaround issues with Janus C Headers
+    # https://github.com/pikvm/ustreamer/blob/793f24c4/docs/h264.md#fixing-janus-c-headers
+    "CFLAGS=-I${lib.getDev janus-gateway}/include/janus"
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
## Description of changes

Adds webrtc support to ustreamer to be used with janus-gateway. This was achieved by following the documentation at https://github.com/pikvm/ustreamer/blob/793f24c48ea780fb0846b3db26ecc04603d95439/docs/h264.md#fixing-janus-c-headers

I'm also interested in being a maintainer of this package so added a commit for that.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
