### PR TITLE
build-support/ocaml: deprecate minimumOCamlVersion

### DIFF
--- a/doc/languages-frameworks/ocaml.section.md
+++ b/doc/languages-frameworks/ocaml.section.md
@@ -120,14 +120,6 @@ buildDunePackage rec {
 }
 ```
 
-Note about `minimalOCamlVersion`.  A deprecated version of this argument was
-spelled `minimumOCamlVersion`; setting the old attribute wrongly modifies the
-derivation hash and is therefore inappropriate. As a technical dept, currently
-packaged libraries may still use the old spelling: maintainers are invited to
-fix this when updating packages. Massive renaming is strongly discouraged as it
-would be challenging to review, difficult to test, and will cause unnecessary
-rebuild.
-
 The build will automatically fail if two distinct versions of the same library
 are added to `buildInputs` (which usually happens transitively because of
 `propagatedBuildInputs`). Set `dontDetectOcamlConflicts` to true to disable this

--- a/pkgs/build-support/ocaml/dune.nix
+++ b/pkgs/build-support/ocaml/dune.nix
@@ -7,8 +7,7 @@ let Dune =
   { "1" = dune_1; "2" = dune_2; "3" = dune_3; }."${dune-version}"
 ; in
 
-if (args ? minimumOCamlVersion && lib.versionOlder ocaml.version args.minimumOCamlVersion) ||
-   (args ? minimalOCamlVersion && lib.versionOlder ocaml.version args.minimalOCamlVersion)
+if args ? minimalOCamlVersion && lib.versionOlder ocaml.version args.minimalOCamlVersion
 then throw "${pname}-${version} is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/cpuid/default.nix
+++ b/pkgs/development/ocaml-modules/cpuid/default.nix
@@ -6,7 +6,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  minimumOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.03";
 
   src = fetchurl {
     url = "https://github.com/pqwy/cpuid/releases/download/v${version}/cpuid-v${version}.tbz";

--- a/pkgs/development/ocaml-modules/directories/default.nix
+++ b/pkgs/development/ocaml-modules/directories/default.nix
@@ -5,7 +5,7 @@ buildDunePackage rec {
   version = "0.5";
   useDune2 = true;
 
-  minimumOCamlVersion = "4.07";
+  minimalOCamlVersion = "4.07";
 
   src = fetchFromGitHub {
     owner = "ocamlpro";

--- a/pkgs/development/ocaml-modules/earley/default.nix
+++ b/pkgs/development/ocaml-modules/earley/default.nix
@@ -12,7 +12,7 @@ buildDunePackage rec {
     sha256 = "1vi58zdxchpw6ai0bz9h2ggcmg8kv57yk6qbx82lh47s5wb3mz5y";
   };
 
-  minimumOCamlVersion = "4.07";
+  minimalOCamlVersion = "4.07";
   useDune2 = true;
 
   buildInputs = [ stdlib-shims ];

--- a/pkgs/development/ocaml-modules/eigen/default.nix
+++ b/pkgs/development/ocaml-modules/eigen/default.nix
@@ -13,7 +13,7 @@ buildDunePackage rec {
     sha256 = "1zaw03as14hyvfpyj6bjrfbcxp2ljdbqcqqgm53kms244mig425f";
   };
 
-  minimumOCamlVersion = "4.02";
+  minimalOCamlVersion = "4.02";
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-I${lib.getDev libcxx}/include/c++/v1";
 

--- a/pkgs/development/ocaml-modules/fix/default.nix
+++ b/pkgs/development/ocaml-modules/fix/default.nix
@@ -12,7 +12,7 @@ buildDunePackage rec {
     sha256 = "sha256-Xuw4pEPqAbQjSHrpMCNE7Th0mpbNMSxdEdwvH4hu2SM=";
   };
 
-  minimumOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.03";
   useDune2 = true;
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/gnuplot/default.nix
+++ b/pkgs/development/ocaml-modules/gnuplot/default.nix
@@ -6,7 +6,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  minimumOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.03";
 
   src = fetchFromGitHub {
     owner  = "c-cube";

--- a/pkgs/development/ocaml-modules/lacaml/default.nix
+++ b/pkgs/development/ocaml-modules/lacaml/default.nix
@@ -10,7 +10,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/mmottl/lacaml/releases/download/${version}/lacaml-${version}.tbz";

--- a/pkgs/development/ocaml-modules/lwt-dllist/default.nix
+++ b/pkgs/development/ocaml-modules/lwt-dllist/default.nix
@@ -6,7 +6,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  minimumOCamlVersion = "4.02";
+  minimalOCamlVersion = "4.02";
 
   src = fetchurl {
     url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-v${version}.tbz";

--- a/pkgs/development/ocaml-modules/opam-format/default.nix
+++ b/pkgs/development/ocaml-modules/opam-format/default.nix
@@ -7,7 +7,7 @@ buildDunePackage rec {
 
   inherit (opam-core) src version;
 
-  minimumOCamlVersion = "4.02.3";
+  minimalOCamlVersion = "4.02.3";
 
   # get rid of check for curl at configure time
   # opam-format does not call curl at run time

--- a/pkgs/development/ocaml-modules/opam-repository/default.nix
+++ b/pkgs/development/ocaml-modules/opam-repository/default.nix
@@ -3,7 +3,7 @@
 buildDunePackage rec {
   pname = "opam-repository";
 
-  minimumOCamlVersion = "4.02";
+  minimalOCamlVersion = "4.02";
 
   useDune2 = true;
 

--- a/pkgs/development/ocaml-modules/opti/default.nix
+++ b/pkgs/development/ocaml-modules/opti/default.nix
@@ -6,7 +6,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  minimumOCamlVersion = "4.02";
+  minimalOCamlVersion = "4.02";
 
   src = fetchurl {
     url = "https://github.com/magnusjonsson/opti/releases/download/${version}/opti-${version}.tbz";

--- a/pkgs/development/ocaml-modules/postgresql/default.nix
+++ b/pkgs/development/ocaml-modules/postgresql/default.nix
@@ -6,7 +6,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.08";
 
   src = fetchFromGitHub {
     owner = "mmottl";

--- a/pkgs/development/ocaml-modules/ppx_yojson_conv/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_yojson_conv/default.nix
@@ -10,7 +10,7 @@ buildDunePackage rec {
   pname = "ppx_yojson_conv";
   version = "0.15.1";
   duneVersion = "3";
-  minimumOCamlVersion = "4.08.0";
+  minimalOCamlVersion = "4.08.0";
 
   src = fetchFromGitHub {
     owner = "janestreet";

--- a/pkgs/development/ocaml-modules/wtf8/default.nix
+++ b/pkgs/development/ocaml-modules/wtf8/default.nix
@@ -6,7 +6,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  minimumOCamlVersion = "4.02";
+  minimalOCamlVersion = "4.02";
 
   src = fetchurl {
     url = "https://github.com/flowtype/ocaml-${pname}/releases/download/v${version}/${pname}-v${version}.tbz";


### PR DESCRIPTION
build-support/ocaml: deprecate minimumOCamlVersion

It's been a long time since `minimumOCamlVersion` is deprecated.
I think, it is time to end it's existence.

Only 17 packages using it. And commits can be squashed if necessary.

CC @vbgl @ulrikstrid @alizter @sternenseemann 