### PR TITLE
bpftune: 0-unstable-2024-05-17 -> 0-unstable-2024-06-07

### DIFF
--- a/pkgs/os-specific/linux/bpftune/default.nix
+++ b/pkgs/os-specific/linux/bpftune/default.nix
@@ -12,31 +12,28 @@
 
 stdenv.mkDerivation rec {
   pname = "bpftune";
-  version = "0-unstable-2024-05-17";
+  version = "0-unstable-2024-06-07";
 
   src = fetchFromGitHub {
     owner = "oracle";
     repo = "bpftune";
-    rev = "83115c56cf9620fe5669f4a3be67ab779d8f4536";
-    hash = "sha256-er2i7CEUXF3BpWTG//s8C0xfIk5gSVOHB8nE1r7PX78=";
+    rev = "04bab5dd306b55b3e4e13e261af2480b7ccff9fc";
+    hash = "sha256-kVjvupZ6HxJocwXWOrxUNqEGl0welJRlZwvOmMKqeBA=";
   };
 
   postPatch = ''
     # otherwise shrink rpath would drop $out/lib from rpath
     substituteInPlace src/Makefile \
-      --replace /lib64   /lib \
-      --replace /sbin    /bin \
-      --replace ldconfig true
+      --replace-fail /lib64   /lib \
+      --replace-fail /sbin    /bin \
+      --replace-fail ldconfig true
     substituteInPlace src/bpftune.service \
-      --replace /usr/sbin/bpftune "$out/bin/bpftune"
+      --replace-fail /usr/sbin/bpftune "$out/bin/bpftune"
     substituteInPlace include/bpftune/libbpftune.h \
-      --replace /usr/lib64/bpftune/       "$out/lib/bpftune/" \
-      --replace /usr/local/lib64/bpftune/ "$out/lib/bpftune/"
+      --replace-fail /usr/lib64/bpftune/       "$out/lib/bpftune/" \
+      --replace-fail /usr/local/lib64/bpftune/ "$out/lib/bpftune/"
     substituteInPlace src/libbpftune.c \
-      --replace /lib/modules /run/booted-system/kernel-modules/lib/modules
-
-    substituteInPlace src/Makefile sample_tuner/Makefile \
-      --replace 'BPF_INCLUDE := /usr/include' 'BPF_INCLUDE := ${lib.getDev libbpf}/include' \
+      --replace-fail /lib/modules /run/booted-system/kernel-modules/lib/modules
   '';
 
   nativeBuildInputs = [
@@ -56,6 +53,7 @@ stdenv.mkDerivation rec {
     "confprefix=${placeholder "out"}/etc"
     "BPFTUNE_VERSION=${version}"
     "NL_INCLUDE=${lib.getDev libnl}/include/libnl3"
+    "BPF_INCLUDE=${lib.getDev libbpf}/include"
   ];
 
   hardeningDisable = [


### PR DESCRIPTION
Diff: https://github.com/oracle/bpftune/compare/83115c56cf9620fe5669f4a3be67ab779d8f4536...04bab5dd306b55b3e4e13e261af2480b7ccff9fc

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
