### PR TITLE
maintainers: rename nu-nu-ko to fsnkty

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7154,6 +7154,13 @@
     githubId = 77672306;
     name = "Florian Agbuya";
   };
+  fsnkty = {
+    name = "fsnkty";
+    github = "fsnkty";
+    githubId = 153512689;
+    email = "fsnkty@shimeji.cafe";
+    matrix = "@nuko:shimeji.cafe";
+  };
   fstamour = {
     email = "fr.st-amour@gmail.com";
     github = "fstamour";
@@ -15238,13 +15245,6 @@
     matrix = "@numkem:matrix.org";
     github = "numkem";
     githubId = 332423;
-  };
-  nu-nu-ko = {
-    email = "nuko@shimeji.cafe";
-    matrix = "@nuko:shimeji.cafe";
-    github = "nu-nu-ko";
-    githubId = 153512689;
-    name = "nuko";
   };
   nviets = {
     email = "nathan.g.viets@gmail.com";

--- a/nixos/modules/services/audio/navidrome.nix
+++ b/nixos/modules/services/audio/navidrome.nix
@@ -157,5 +157,5 @@ in
 
       networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.settings.Port ];
     };
-  meta.maintainers = with maintainers; [ nu-nu-ko ];
+  meta.maintainers = with maintainers; [ fsnkty ];
 }

--- a/nixos/modules/services/misc/jellyfin.nix
+++ b/nixos/modules/services/misc/jellyfin.nix
@@ -160,5 +160,5 @@ in
 
   };
 
-  meta.maintainers = with maintainers; [ minijackson nu-nu-ko ];
+  meta.maintainers = with maintainers; [ minijackson fsnkty ];
 }

--- a/pkgs/by-name/rw/rwpspread/package.nix
+++ b/pkgs/by-name/rw/rwpspread/package.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
     description = "Multi-Monitor Wallpaper Utility";
     homepage = "https://github.com/0xk1f0/rwpspread";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ nu-nu-ko ];
+    maintainers = with lib.maintainers; [ fsnkty ];
     platforms = lib.platforms.linux;
     mainProgram = "rwpspread";
   };

--- a/pkgs/by-name/wp/wpaperd/package.nix
+++ b/pkgs/by-name/wp/wpaperd/package.nix
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/danyspin97/wpaperd";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ DPDmancul nu-nu-ko ];
+    maintainers = with maintainers; [ DPDmancul fsnkty ];
     mainProgram = "wpaperd";
   };
 }


### PR DESCRIPTION
## Description of changes
my github profile has been renamed from `nu-nu-ko` to `fsnkty`, just looking to update it here now

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).