### PR TITLE
[23.11] vlc: 3.0.20 -> 3.0.21

### DIFF
--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -102,11 +102,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "${optionalString onlyLibVLC "lib"}vlc";
-  version = "3.0.20";
+  version = "3.0.21";
 
   src = fetchurl {
     url = "http://get.videolan.org/vlc/${finalAttrs.version}/vlc-${finalAttrs.version}.tar.xz";
-    hash = "sha256-rccoW00nIc3fQOtScMraKqoQozTLVG/VWgY1NEe6KbU=";
+    hash = "sha256-JNu+HX367qCZTV3vC73iABdzRxNtv+Vz9bakzuJa+7A=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

Manual backport of #319262.

Upstream changelog: https://code.videolan.org/videolan/vlc/-/blob/dd8bfdbabe8ae3974ca3864ad3125879f523e3a2/NEWS

Fixes https://www.videolan.org/security/sb-vlc3021.html (VideoLAN-SB-VLC-3021).
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review pr 320006` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package marked as broken and skipped:</summary>
  <ul>
    <li>obs-studio-plugins.obs-hyperion</li>
  </ul>
</details>
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>obs-studio-plugins.obs-ndi</li>
  </ul>
</details>
<details>
  <summary>66 packages built:</summary>
  <ul>
    <li>anilibria-winmaclinux</li>
    <li>arcanPackages.all-wrapped</li>
    <li>arcanPackages.arcan</li>
    <li>arcanPackages.arcan-wrapped</li>
    <li>arcanPackages.cat9-wrapped</li>
    <li>arcanPackages.durden-wrapped</li>
    <li>arcanPackages.pipeworld-wrapped</li>
    <li>arcanPackages.prio-wrapped</li>
    <li>arcanPackages.xarcan</li>
    <li>deepin.deepin-music</li>
    <li>deepin.deepin-voice-note</li>
    <li>eaglemode</li>
    <li>emulationstation</li>
    <li>kaffeine</li>
    <li>kphotoalbum</li>
    <li>libsForQt5.elisa</li>
    <li>libsForQt5.elisa.dev</li>
    <li>libsForQt5.phonon-backend-vlc</li>
    <li>libvlc</li>
    <li>megaglest</li>
    <li>minitube</li>
    <li>obs-studio</li>
    <li>obs-studio-plugins.advanced-scene-switcher</li>
    <li>obs-studio-plugins.droidcam-obs</li>
    <li>obs-studio-plugins.input-overlay</li>
    <li>obs-studio-plugins.looking-glass-obs</li>
    <li>obs-studio-plugins.obs-3d-effect</li>
    <li>obs-studio-plugins.obs-backgroundremoval</li>
    <li>obs-studio-plugins.obs-command-source</li>
    <li>obs-studio-plugins.obs-freeze-filter</li>
    <li>obs-studio-plugins.obs-gradient-source</li>
    <li>obs-studio-plugins.obs-gstreamer</li>
    <li>obs-studio-plugins.obs-livesplit-one</li>
    <li>obs-studio-plugins.obs-move-transition</li>
    <li>obs-studio-plugins.obs-multi-rtmp</li>
    <li>obs-studio-plugins.obs-mute-filter</li>
    <li>obs-studio-plugins.obs-nvfbc</li>
    <li>obs-studio-plugins.obs-pipewire-audio-capture</li>
    <li>obs-studio-plugins.obs-replay-source</li>
    <li>obs-studio-plugins.obs-rgb-levels-filter</li>
    <li>obs-studio-plugins.obs-scale-to-sound</li>
    <li>obs-studio-plugins.obs-shaderfilter</li>
    <li>obs-studio-plugins.obs-source-clone</li>
    <li>obs-studio-plugins.obs-source-record</li>
    <li>obs-studio-plugins.obs-source-switcher</li>
    <li>obs-studio-plugins.obs-teleport</li>
    <li>obs-studio-plugins.obs-text-pthread</li>
    <li>obs-studio-plugins.obs-transition-table</li>
    <li>obs-studio-plugins.obs-tuna</li>
    <li>obs-studio-plugins.obs-vaapi</li>
    <li>obs-studio-plugins.obs-vertical-canvas</li>
    <li>obs-studio-plugins.obs-vintage-filter</li>
    <li>obs-studio-plugins.obs-vkcapture</li>
    <li>obs-studio-plugins.obs-websocket</li>
    <li>obs-studio-plugins.waveform</li>
    <li>obs-studio-plugins.wlrobs</li>
    <li>pympress</li>
    <li>pympress.dist</li>
    <li>python310Packages.python-vlc</li>
    <li>python310Packages.python-vlc.dist</li>
    <li>python311Packages.python-vlc</li>
    <li>python311Packages.python-vlc.dist</li>
    <li>reaper</li>
    <li>strawberry</li>
    <li>vlc</li>
    <li>wtwitch</li>
  </ul>
</details>
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
