### PR TITLE
[staging-next-24.11] python312Packages.pydantic-core: fix build

### DIFF
--- a/pkgs/development/python-modules/pydantic-core/default.nix
+++ b/pkgs/development/python-modules/pydantic-core/default.nix
@@ -28,7 +28,13 @@ let
       hash = "sha256-RXytujvx/23Z24TWpvnHdjJ4/dXqjs5uiavUmukaD9A=";
     };
 
-    patches = [ ./01-remove-benchmark-flags.patch ];
+    patches = [
+      ./01-remove-benchmark-flags.patch
+
+      # Fix missing recursive_guard paramter value on 3.12.4 and newer, based on
+      # https://github.com/pydantic/pydantic-core/commit/d7946da7455fc269f69d6ae01abe2ba61266a0f2
+      ./python3.12.4-compat.patch
+    ];
 
     cargoDeps = rustPlatform.fetchCargoTarball {
       inherit src;

--- a/pkgs/development/python-modules/pydantic-core/python3.12.4-compat.patch
+++ b/pkgs/development/python-modules/pydantic-core/python3.12.4-compat.patch
@@ -1,0 +1,30 @@
+diff --git a/generate_self_schema.py b/generate_self_schema.py
+index 8d27247..814c88e 100644
+--- a/generate_self_schema.py
++++ b/generate_self_schema.py
+@@ -9,6 +9,7 @@ from __future__ import annotations as _annotations
+ import decimal
+ import importlib.util
+ import re
++import sys
+ from collections.abc import Callable
+ from datetime import date, datetime, time, timedelta
+ from pathlib import Path
+@@ -188,12 +189,12 @@ def all_literal_values(type_: type[core_schema.Literal]) -> list[any]:
+ 
+ 
+ def eval_forward_ref(type_: Any) -> Any:
+-    try:
+-        return type_._evaluate(core_schema.__dict__, None, set())
+-    except TypeError:
+-        # for Python 3.8
++    if sys.version_info < (3, 9):
+         return type_._evaluate(core_schema.__dict__, None)
+-
++    elif sys.version_info < (3, 12, 4):
++        return type_._evaluate(core_schema.__dict__, None, recursive_guard=set())
++    else:
++        return type_._evaluate(core_schema.__dict__, None, type_params=set(), recursive_guard=set())
+ 
+ def main() -> None:
+     schema_union = core_schema.CoreSchema


### PR DESCRIPTION
Due a missing default value to the recursive_guard attribute we've seen this package fail to build from Python 3.12.4.

https://hydra.nixos.org/build/263292352

The fix for unstable would be to bump to pydantic-core 2.19.0.

cc #317935

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
