### PR TITLE
nwipe: 0.34 -> 0.37; move to by-name

### DIFF
--- a/pkgs/by-name/nw/nwipe/package.nix
+++ b/pkgs/by-name/nw/nwipe/package.nix
@@ -1,43 +1,53 @@
 { lib
 , stdenv
 , autoreconfHook
+, makeWrapper
 , fetchFromGitHub
 , ncurses
 , parted
 , pkg-config
+, libconfig
+, hdparm
+, smartmontools
+, dmidecode
 }:
 
 stdenv.mkDerivation rec {
   pname = "nwipe";
-  version = "0.34";
+  version = "0.37";
 
   src = fetchFromGitHub {
     owner = "martijnvanbrummelen";
     repo = "nwipe";
     rev = "v${version}";
-    sha256 = "sha256-7WI8AwWkg9rOjAbOyDgCVOpeMxvJ5Bd1yvzfSv6TPLs=";
+    sha256 = "sha256-0mBiWKkMV8i9n158k843caulF90k43ctpMvKhc4HZxY";
   };
 
   nativeBuildInputs = [
     autoreconfHook
+    makeWrapper
     pkg-config
   ];
 
   buildInputs = [
     ncurses
     parted
+    libconfig
   ];
 
-  preConfigure = ''
-    sh init.sh || :
+  postInstall = ''
+    wrapProgram $out/bin/nwipe \
+      --prefix PATH : ${lib.makeBinPath [ hdparm smartmontools dmidecode ]}
   '';
+
+  enableParallelBuilding = true;
 
   meta = with lib; {
     description = "Securely erase disks";
     mainProgram = "nwipe";
     homepage = "https://github.com/martijnvanbrummelen/nwipe";
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ woffs ];
+    maintainers = with maintainers; [ vifino woffs ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5937,8 +5937,6 @@ with pkgs;
 
   nsz = with python3.pkgs; toPythonApplication nsz;
 
-  nwipe = callPackage ../tools/security/nwipe { };
-
   nx2elf = callPackage ../tools/compression/nx2elf { };
 
   nx-libs = callPackage ../tools/X11/nx-libs { };


### PR DESCRIPTION
## Description of changes

https://github.com/martijnvanbrummelen/nwipe/releases/tag/v0.35
https://github.com/martijnvanbrummelen/nwipe/releases/tag/v0.36
https://github.com/martijnvanbrummelen/nwipe/releases/tag/v0.37

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
