### PR TITLE
discord-gamesdk: set autoPatchelfHook for linux targets only

### DIFF
--- a/pkgs/by-name/di/discord-gamesdk/package.nix
+++ b/pkgs/by-name/di/discord-gamesdk/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ (stdenv.cc.cc.libgcc or null) ];
 
-  nativeBuildInputs = [ autoPatchelfHook ];
+  nativeBuildInputs = lib.optional stdenv.isLinux autoPatchelfHook;
 
   installPhase =
     let


### PR DESCRIPTION
## Description of changes

`discord-gamesdk` fails to realise on `aarch64-darwin` (and on Intel cpus too, most likely) because the `autoPatchelfHook` being triggered on all platforms.

```
Traceback (most recent call last):
  File "/nix/store/sqiijbqkk8ka809y7gdfy60q0fyd5c3k-auto-patchelf.py", line 371, in <module>
    with open_elf(interpreter_path) as interpreter:
  File "/nix/store/327bf08j5b7l9cnzink3g4vp32y5352j-python3-3.11.9/lib/python3.11/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/nix/store/sqiijbqkk8ka809y7gdfy60q0fyd5c3k-auto-patchelf.py", line 25, in open_elf
    yield ELFFile(stream)
          ^^^^^^^^^^^^^^^
  File "/nix/store/apak42f7am62lypcwz3gfl04yrv509r8-python3-3.11.9-env/lib/python3.11/site-packages/elftools/elf/elffile.py", line 84, in __init__
    self._identify_file()
  File "/nix/store/apak42f7am62lypcwz3gfl04yrv509r8-python3-3.11.9-env/lib/python3.11/site-packages/elftools/elf/elffile.py", line 570, in _identify_file
    elf_assert(magic == b'\x7fELF', 'Magic number does not match')
  File "/nix/store/apak42f7am62lypcwz3gfl04yrv509r8-python3-3.11.9-env/lib/python3.11/site-packages/elftools/common/utils.py", line 80, in elf_assert
    _assert_with_exception(cond, msg, ELFError)
  File "/nix/store/apak42f7am62lypcwz3gfl04yrv509r8-python3-3.11.9-env/lib/python3.11/site-packages/elftools/common/utils.py", line 143, in _assert_with_exception
    raise exception_type(msg)
elftools.common.exceptions.ELFError: Magic number does not match
error: builder for '/nix/store/znljxn8fb8nrxyaiqvcba5l96mf0gf7h-discord-gamesdk-3.2.1.drv' failed with exit code 1;
       last 10 log lines:
       >           ^^^^^^^^^^^^^^^
       >   File "/nix/store/apak42f7am62lypcwz3gfl04yrv509r8-python3-3.11.9-env/lib/python3.11/site-packages/elftools/elf/elffile.py", line 84, in __init__
       >     self._identify_file()
       >   File "/nix/store/apak42f7am62lypcwz3gfl04yrv509r8-python3-3.11.9-env/lib/python3.11/site-packages/elftools/elf/elffile.py", line 570, in _identify_file
       >     elf_assert(magic == b'\x7fELF', 'Magic number does not match')
       >   File "/nix/store/apak42f7am62lypcwz3gfl04yrv509r8-python3-3.11.9-env/lib/python3.11/site-packages/elftools/common/utils.py", line 80, in elf_assert
       >     _assert_with_exception(cond, msg, ELFError)
       >   File "/nix/store/apak42f7am62lypcwz3gfl04yrv509r8-python3-3.11.9-env/lib/python3.11/site-packages/elftools/common/utils.py", line 143, in _assert_with_exception
       >     raise exception_type(msg)
       > elftools.common.exceptions.ELFError: Magic number does not match
```

The hook is now activated for Linux targets only.

Result of `nixpkgs-review` run on aarch64-darwin [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>discord-gamesdk</li>
    <li>discord-gamesdk.dev</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
