### PR TITLE
python311Packages.fastembed: 0.2.7 -> 0.3.0

### DIFF
--- a/pkgs/development/python-modules/fastembed/default.nix
+++ b/pkgs/development/python-modules/fastembed/default.nix
@@ -1,23 +1,31 @@
 {
   lib,
   buildPythonPackage,
+  pythonOlder,
   fetchFromGitHub,
+  pythonRelaxDepsHook,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
   huggingface-hub,
   loguru,
-  pythonOlder,
-  pythonRelaxDepsHook,
-  poetry-core,
+  mmh3,
+  numpy,
   onnx,
   onnxruntime,
+  pillow,
+  pystemmer,
   requests,
+  snowballstemmer,
   tokenizers,
   tqdm,
-  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "fastembed";
-  version = "0.2.7";
+  version = "0.3.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -26,7 +34,7 @@ buildPythonPackage rec {
     owner = "qdrant";
     repo = "fastembed";
     rev = "refs/tags/v${version}";
-    hash = "sha256-ArLilvixzpHIGGAom4smX0jZ6lJSZe6tSGreeD+Pzmk=";
+    hash = "sha256-Tfj0YdUW/Nnvn4+RoOWj9l0gDkWbpVgiADA09ht4xxM=";
   };
 
   build-system = [ poetry-core ];
@@ -36,30 +44,32 @@ buildPythonPackage rec {
   dependencies = [
     huggingface-hub
     loguru
+    mmh3
+    numpy
     onnx
     onnxruntime
+    pillow
+    pystemmer
     requests
+    snowballstemmer
     tokenizers
     tqdm
   ];
 
   pythonImportsCheck = [ "fastembed" ];
 
-  pythonRelaxDeps = [
-    "huggingface-hub"
-    "onnxruntime"
-    "tokenizers"
-  ];
-
-  nativeCheckInputs = [ pytestCheckHook ];
+  pythonRelaxDeps = [ "onnxruntime" ];
 
   # there is one test and it requires network
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Fast, Accurate, Lightweight Python library to make State of the Art Embedding";
     homepage = "https://github.com/qdrant/fastembed";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ happysalada ];
+    changelog = "https://github.com/qdrant/fastembed/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ happysalada ];
+    # terminate called after throwing an instance of 'onnxruntime::OnnxRuntimeException'
+    badPlatforms = [ "aarch64-linux" ];
   };
 }


### PR DESCRIPTION
## Description of changes

I also disabled aarch64-linux support as the package is currently broken on this platform (OnnxRuntime issue).

Changelog: https://github.com/qdrant/fastembed/releases/tag/v0.3.0

cc @happysalada 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
