### PR TITLE
homebox: init at 0.13.0; nixos/homebox: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -49,6 +49,8 @@
 
 - [Immersed VR](https://immersed.com/), a closed-source coworking platform. Available as [programs.immersed-vr](#opt-programs.immersed-vr.enable).
 
+- [HomeBox](https://github.com/hay-kot/homebox/): the inventory and organization system built for the Home User. Available as [services.homebox](#opt-services.homebox.enable).
+
 - [Renovate](https://github.com/renovatebot/renovate), a dependency updating tool for various git forges and language ecosystems. Available as [services.renovate](#opt-services.renovate.enable).
 
 - [Music Assistant](https://music-assistant.io/), a music library manager for your offline and online music sources which can easily stream your favourite music to a wide range of supported players. Available as [services.music-assistant](#opt-services.music-assistant.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1414,6 +1414,7 @@
   ./services/web-apps/healthchecks.nix
   ./services/web-apps/hedgedoc.nix
   ./services/web-apps/hledger-web.nix
+  ./services/web-apps/homebox.nix
   ./services/web-apps/honk.nix
   ./services/web-apps/icingaweb2/icingaweb2.nix
   ./services/web-apps/icingaweb2/module-monitoring.nix

--- a/nixos/modules/services/web-apps/homebox.nix
+++ b/nixos/modules/services/web-apps/homebox.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.homebox;
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkDefault
+    types
+    mkIf
+    ;
+in
+{
+  options.services.homebox = {
+    enable = mkEnableOption "homebox";
+    package = mkPackageOption pkgs "homebox" { };
+    settings = lib.mkOption {
+      type = types.attrsOf types.str;
+      defaultText = ''
+        HBOX_STORAGE_DATA = "/var/lib/homebox/data";
+        HBOX_STORAGE_SQLITE_URL = "/var/lib/homebox/data/homebox.db?_pragma=busy_timeout=999&_pragma=journal_mode=WAL&_fk=1";
+        HBOX_OPTIONS_ALLOW_REGISTRATION = "false";
+        HBOX_MODE = "production";
+      '';
+      description = ''
+        The homebox configuration as Environment variables. For definitions and available options see the upstream
+        [documentation](https://hay-kot.github.io/homebox/quick-start/#env-variables-configuration).
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users.homebox = {
+      isSystemUser = true;
+      group = "homebox";
+    };
+    users.groups.homebox = { };
+    services.homebox.settings = {
+      HBOX_STORAGE_DATA = mkDefault "/var/lib/homebox/data";
+      HBOX_STORAGE_SQLITE_URL = mkDefault "/var/lib/homebox/data/homebox.db?_pragma=busy_timeout=999&_pragma=journal_mode=WAL&_fk=1";
+      HBOX_OPTIONS_ALLOW_REGISTRATION = mkDefault "false";
+      HBOX_MODE = mkDefault "production";
+    };
+    systemd.services.homebox = {
+      after = [ "network.target" ];
+      environment = cfg.settings;
+      serviceConfig = {
+        User = "homebox";
+        Group = "homebox";
+        ExecStart = lib.getExe cfg.package;
+        StateDirectory = "homebox";
+        WorkingDirectory = "/var/lib/homebox";
+        LimitNOFILE = "1048576";
+        PrivateTmp = true;
+        PrivateDevices = true;
+        StateDirectoryMode = "0700";
+        Restart = "always";
+
+        # Hardening
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_NETLINK"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "@pkey"
+        ];
+        RestrictSUIDSGID = true;
+        PrivateMounts = true;
+        UMask = "0077";
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
+  meta.maintainers = with lib.maintainers; [ patrickdag ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -420,6 +420,7 @@ in {
   hddfancontrol = handleTest ./hddfancontrol.nix {};
   hedgedoc = handleTest ./hedgedoc.nix {};
   herbstluftwm = handleTest ./herbstluftwm.nix {};
+  homebox = handleTest ./homebox.nix {};
   homepage-dashboard = handleTest ./homepage-dashboard.nix {};
   honk = runTest ./honk.nix;
   installed-tests = pkgs.recurseIntoAttrs (handleTest ./installed-tests {});

--- a/nixos/tests/homebox.nix
+++ b/nixos/tests/homebox.nix
@@ -1,0 +1,26 @@
+import ./make-test-python.nix (
+  { pkgs, ... }:
+  let
+    port = "7745";
+  in
+  {
+    name = "homebox";
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [ patrickdag ];
+    };
+    nodes.machine = {
+      services.homebox = {
+        enable = true;
+        settings.HBOX_WEB_PORT = port;
+      };
+    };
+    testScript = ''
+      machine.wait_for_unit("homebox.service")
+      machine.wait_for_open_port(${port})
+
+      machine.succeed("curl --fail -X GET 'http://localhost:${port}/'")
+      out = machine.succeed("curl --fail 'http://localhost:${port}/api/v1/status'")
+      assert '"health":true' in out
+    '';
+  }
+)

--- a/pkgs/by-name/ho/homebox/package.nix
+++ b/pkgs/by-name/ho/homebox/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  pnpm,
+  nodejs,
+  go,
+  git,
+  cacert,
+}:
+let
+  pname = "homebox";
+  version = "0.13.0";
+  src = fetchFromGitHub {
+    owner = "sysadminsmedia";
+    repo = "homebox";
+    rev = "v${version}";
+    hash = "sha256-mhb4q0ja94TjvOzl28WVb3uzkR9MKlqifFJgUo6hfrA=";
+  };
+in
+buildGoModule {
+  inherit pname version src;
+
+  vendorHash = "sha256-QRmP6ichKjwDWEx13sEs1oetc4nojGyJnKafAATTNTA=";
+  modRoot = "backend";
+  # the goModules derivation inherits our buildInputs and buildPhases
+  # Since we do pnpm thing in those it fails if we don't explicitely remove them
+  overrideModAttrs = _: {
+    nativeBuildInputs = [
+      go
+      git
+      cacert
+    ];
+    preBuild = "";
+  };
+
+  pnpmDeps = pnpm.fetchDeps {
+    inherit pname version;
+    src = "${src}/frontend";
+    hash = "sha256-MdTZJ/Ichpwc54r7jZjiFD12YOdRzHSuzRZ/PnDk2mY=";
+  };
+  pnpmRoot = "../frontend";
+
+  env.NUXT_TELEMETRY_DISABLED = 1;
+
+  preBuild = ''
+    pushd ../frontend
+
+    pnpm build
+
+    popd
+
+    mkdir -p ./app/api/static/public
+    cp -r ../frontend/.output/public/* ./app/api/static/public
+  '';
+
+  nativeBuildInputs = [
+    pnpm
+    pnpm.configHook
+    nodejs
+  ];
+
+  CGO_ENABLED = 0;
+  GOOS = "linux";
+  doCheck = false;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-extldflags=-static"
+    "-X main.version=${version}"
+    "-X main.commit=${version}"
+  ];
+
+  meta = {
+    mainProgram = "api";
+    homepage = "https://hay-kot.github.io/homebox/";
+    description = "Inventory and organization system built for the Home User";
+    maintainers = with lib.maintainers; [ patrickdag ];
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Added a new module for homebox.
This closes #309299 and would replace #273639 as that seems abandoned.

The project itself was archived a few days ago, but since it is currently still working perfectly fine I would not see this as blocking. I will keep looking if any promising forks turn up and might switch to that or if the project actually dies I will try to keep it working as long as I can, removing it if it turns out to be broken for good.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
