### PR TITLE
pest-ide-tools: remove openssl dependency & MIT license

### DIFF
--- a/pkgs/development/tools/misc/pest-ide-tools/default.nix
+++ b/pkgs/development/tools/misc/pest-ide-tools/default.nix
@@ -3,8 +3,6 @@
 , fetchFromGitHub
 , rustPlatform
 , nix-update-script
-, pkg-config
-, openssl
 , darwin
 }:
 
@@ -19,10 +17,7 @@ rustPlatform.buildRustPackage rec {
     rev = "v${version}";
     sha256 = "sha256-12/FndzUbUlgcYcwMT1OfamSKgy2q+CvtGyx5YY4IFQ=";
   };
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [
-    openssl
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     darwin.apple_sdk.frameworks.Security
   ];
 

--- a/pkgs/development/tools/misc/pest-ide-tools/default.nix
+++ b/pkgs/development/tools/misc/pest-ide-tools/default.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "IDE support for Pest, via the LSP";
     homepage = "https://pest.rs";
-    license = with licenses; [ mit asl20 ];
+    license = with licenses; [ asl20 ];
     maintainers = with maintainers; [ nickhu ];
     mainProgram = "pest-language-server";
   };


### PR DESCRIPTION
openssl was dropped in favor of rustls in 0.3.9[^openssl]

[^openssl]: https://github.com/pest-parser/pest-ide-tools/commit/7d6d1ef59a386e30d5e7bb7ced4d7bd1c75101b7

Despite the common practise among rustaceans to use a dual Apache-2.0/MIT license, `pest-ide-tools` has only ever been licensed under Apache-2.0[^mit]

[^mit]: https://github.com/pest-parser/pest-ide-tools/commits/v0.3.11/LICENSE

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable[^tests]:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`[^RAM]. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^tests]: This package has 0 tests, so I have technically run all the tests for it.
[^RAM]: Wow, this was consuming like 9.5 gigs of RAM & 100% CPU (1 core out of 12) for solid 10 minutes. What an experience.