### PR TITLE
python311Packages.pint: fix pint-convert executable

### DIFF
--- a/pkgs/development/python-modules/flexcache/default.nix
+++ b/pkgs/development/python-modules/flexcache/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools-scm,
+  typing-extensions,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "flexcache";
+  version = "0.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "hgrecco";
+    repo = "flexcache";
+    rev = "refs/tags/${version}";
+    hash = "sha256-MAbTe7NxzfRPzo/Wnb5SnPJvJWf6zVeYsaw/g9OJYSE=";
+  };
+
+  build-system = [ setuptools-scm ];
+
+  dependencies = [ typing-extensions ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "flexcache" ];
+
+  meta = {
+    description = "An robust and extensible package to cache on disk the result of expensive calculations";
+    homepage = "https://github.com/hgrecco/flexcache";
+    changelog = "https://github.com/hgrecco/flexcache/blob/${src.rev}/CHANGES";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/development/python-modules/flexparser/default.nix
+++ b/pkgs/development/python-modules/flexparser/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools-scm,
+  typing-extensions,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "flexparser";
+  version = "0.3.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "hgrecco";
+    repo = "flexparser";
+    rev = "refs/tags/${version}";
+    hash = "sha256-9ImG8uh1SZ+pAbqzWBkTVn+3EBAGzzdP8vqqP59IgIw=";
+  };
+
+  build-system = [ setuptools-scm ];
+
+  dependencies = [ typing-extensions ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "flexparser" ];
+
+  meta = {
+    description = "Parsing made fun ... using typing";
+    homepage = "https://github.com/hgrecco/flexparser";
+    changelog = "https://github.com/hgrecco/flexparser/blob/${src.rev}/CHANGES";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/development/python-modules/pint/default.nix
+++ b/pkgs/development/python-modules/pint/default.nix
@@ -47,15 +47,18 @@ buildPythonPackage rec {
     flexcache
     flexparser
     typing-extensions
+    # Both uncertainties and numpy are not necessarily needed for every
+    # function of pint, but needed for the pint-convert executable which we
+    # necessarily distribute with this package as it is.
+    uncertainties
+    numpy
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
     pytest-subtests
     pytest-benchmark
-    numpy
     matplotlib
-    uncertainties
   ];
 
   pytestFlagsArray = [ "--benchmark-disable" ];

--- a/pkgs/development/python-modules/pint/default.nix
+++ b/pkgs/development/python-modules/pint/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   pythonOlder,
 
   # build-system
@@ -10,6 +10,9 @@
 
   # propagates
   typing-extensions,
+  appdirs,
+  flexcache,
+  flexparser,
 
   # tests
   pytestCheckHook,
@@ -22,15 +25,16 @@
 
 buildPythonPackage rec {
   pname = "pint";
-  version = "0.23";
+  version = "0.24";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
 
-  src = fetchPypi {
-    inherit version;
-    pname = "Pint";
-    hash = "sha256-4VCbkWBtvFJSfGAKTvdP+sEv/3Boiv8g6QckCTRuybQ=";
+  src = fetchFromGitHub {
+    owner = "hgrecco";
+    repo = "pint";
+    rev = "refs/tags/${version}";
+    hash = "sha256-zMcLC3SSl/W7+xX4ah3ZV7fN/LIGJzatqH4MNK8/fec=";
   };
 
   nativeBuildInputs = [
@@ -38,7 +42,12 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
-  propagatedBuildInputs = [ typing-extensions ];
+  propagatedBuildInputs = [
+    appdirs
+    flexcache
+    flexparser
+    typing-extensions
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook
@@ -54,13 +63,6 @@ buildPythonPackage rec {
   preCheck = ''
     export HOME=$(mktemp -d)
   '';
-
-  disabledTests = [
-    # https://github.com/hgrecco/pint/issues/1898
-    "test_load_definitions_stage_2"
-    # pytest8 deprecation
-    "test_nonnumeric_magnitudes"
-  ];
 
   meta = with lib; {
     changelog = "https://github.com/hgrecco/pint/blob/${version}/CHANGES";

--- a/pkgs/development/python-modules/uncertainties/default.nix
+++ b/pkgs/development/python-modules/uncertainties/default.nix
@@ -1,31 +1,32 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  future,
+  setuptools-scm,
+  fetchFromGitHub,
+  pytestCheckHook,
   numpy,
-  pynose,
 }:
 
 buildPythonPackage rec {
   pname = "uncertainties";
-  version = "3.1.7";
-  format = "setuptools";
+  version = "3.2.1";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-gBEeCDnyOcWyM8tHcgF7SDoLehVzpYG5Krd0ajXm+qs=";
+  src = fetchFromGitHub {
+    owner = "lmfit";
+    repo = "uncertainties";
+    rev = "refs/tags/${version}";
+    hash = "sha256-AaFazHeq7t4DnG2s9GvmAJ3ni62PWHR//mNPL+WyGSI=";
   };
 
-  propagatedBuildInputs = [ future ];
-  nativeCheckInputs = [
-    pynose
-    numpy
+  nativeBuildInputs = [
+    setuptools-scm
   ];
 
-  checkPhase = ''
-    nosetests -sve test_1to2
-  '';
+  nativeCheckInputs = [
+    pytestCheckHook
+    numpy
+  ];
 
   meta = with lib; {
     homepage = "https://pythonhosted.org/uncertainties/";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4432,6 +4432,8 @@ self: super: with self; {
 
   flet-runtime = callPackage ../development/python-modules/flet-runtime { };
 
+  flexcache = callPackage ../development/python-modules/flexcache { };
+
   flexmock = callPackage ../development/python-modules/flexmock { };
 
   flickrapi = callPackage ../development/python-modules/flickrapi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4434,6 +4434,8 @@ self: super: with self; {
 
   flexcache = callPackage ../development/python-modules/flexcache { };
 
+  flexparser = callPackage ../development/python-modules/flexparser { };
+
   flexmock = callPackage ../development/python-modules/flexmock { };
 
   flickrapi = callPackage ../development/python-modules/flickrapi { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
