### PR TITLE
treewide: remove myself from packages I don’t use

### DIFF
--- a/pkgs/applications/networking/instant-messengers/gomuks/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gomuks/default.nix
@@ -53,6 +53,6 @@ buildGoModule rec {
     description = "A terminal based Matrix client written in Go";
     mainProgram = "gomuks";
     license = licenses.agpl3Plus;
-    maintainers = with maintainers; [ chvp emily ];
+    maintainers = with maintainers; [ chvp ];
   };
 }

--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-autosort/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-autosort/default.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     description = "Autosort is a weechat script to automatically or manually keep your buffers sorted";
     homepage = "https://github.com/de-vri-es/weechat-autosort";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ emily flokli ];
+    maintainers = with maintainers; [ flokli ];
   };
 }

--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-matrix/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-matrix/default.nix
@@ -99,6 +99,6 @@ in buildPythonPackage {
     homepage = "https://github.com/poljar/weechat-matrix";
     license = licenses.isc;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ tilpner emily ];
+    maintainers = with maintainers; [ tilpner ];
   };
 }

--- a/pkgs/applications/science/logic/symbiyosys/default.nix
+++ b/pkgs/applications/science/logic/symbiyosys/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation {
     description = "Tooling for Yosys-based verification flows";
     homepage    = "https://symbiyosys.readthedocs.io/";
     license     = lib.licenses.isc;
-    maintainers = with lib.maintainers; [ thoughtpolice emily ];
+    maintainers = with lib.maintainers; [ thoughtpolice ];
     mainProgram = "sby";
     platforms   = lib.platforms.all;
   };

--- a/pkgs/by-name/ne/nextpnr/package.nix
+++ b/pkgs/by-name/ne/nextpnr/package.nix
@@ -89,6 +89,6 @@ stdenv.mkDerivation rec {
     homepage    = "https://github.com/yosyshq/nextpnr";
     license     = licenses.isc;
     platforms   = platforms.all;
-    maintainers = with maintainers; [ thoughtpolice emily ];
+    maintainers = with maintainers; [ thoughtpolice ];
   };
 }

--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -171,6 +171,6 @@ in stdenv.mkDerivation (finalAttrs: {
     homepage    = "https://yosyshq.net/yosys/";
     license     = licenses.isc;
     platforms   = platforms.all;
-    maintainers = with maintainers; [ shell thoughtpolice emily Luflosi ];
+    maintainers = with maintainers; [ shell thoughtpolice Luflosi ];
   };
 })

--- a/pkgs/development/embedded/blackmagic/default.nix
+++ b/pkgs/development/embedded/blackmagic/default.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/blacksphere/blackmagic";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ pjones emily sorki ];
+    maintainers = with maintainers; [ pjones sorki ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/embedded/fpga/icestorm/default.nix
+++ b/pkgs/development/embedded/fpga/icestorm/default.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
     '';
     homepage    = "https://github.com/YosysHQ/icestorm/";
     license     = lib.licenses.isc;
-    maintainers = with lib.maintainers; [ shell thoughtpolice emily ];
+    maintainers = with lib.maintainers; [ shell thoughtpolice ];
     platforms   = lib.platforms.all;
   };
 }

--- a/pkgs/development/embedded/fpga/tinyprog/default.nix
+++ b/pkgs/development/embedded/fpga/tinyprog/default.nix
@@ -34,7 +34,7 @@ with python3Packages; buildPythonApplication rec {
     homepage = "https://github.com/tinyfpga/TinyFPGA-Bootloader/tree/master/programmer";
     description = "Programmer for FPGA boards using the TinyFPGA USB Bootloader";
     mainProgram = "tinyprog";
-    maintainers = with maintainers; [ emily ];
+    maintainers = with maintainers; [ ];
     license = licenses.asl20;
   };
 }

--- a/pkgs/development/embedded/fpga/trellis/default.nix
+++ b/pkgs/development/embedded/fpga/trellis/default.nix
@@ -64,7 +64,7 @@ in stdenv.mkDerivation rec {
     '';
     homepage    = "https://github.com/YosysHQ/prjtrellis";
     license     = licenses.isc;
-    maintainers = with maintainers; [ q3k thoughtpolice emily rowanG077 ];
+    maintainers = with maintainers; [ q3k thoughtpolice rowanG077 ];
     platforms   = platforms.all;
   };
 }

--- a/pkgs/development/python-modules/amaranth-boards/default.nix
+++ b/pkgs/development/python-modules/amaranth-boards/default.nix
@@ -45,7 +45,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/amaranth-lang/amaranth-boards";
     license = licenses.bsd2;
     maintainers = with maintainers; [
-      emily
       thoughtpolice
       pbsds
     ];

--- a/pkgs/development/python-modules/amaranth-soc/default.nix
+++ b/pkgs/development/python-modules/amaranth-soc/default.nix
@@ -38,7 +38,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/amaranth-lang/amaranth-soc";
     license = licenses.bsd2;
     maintainers = with maintainers; [
-      emily
       thoughtpolice
       pbsds
     ];

--- a/pkgs/development/python-modules/amaranth/default.nix
+++ b/pkgs/development/python-modules/amaranth/default.nix
@@ -58,7 +58,6 @@ buildPythonPackage rec {
     homepage = "https://amaranth-lang.org/docs/amaranth";
     license = licenses.bsd2;
     maintainers = with maintainers; [
-      emily
       thoughtpolice
       pbsds
     ];

--- a/pkgs/development/python-modules/fx2/default.nix
+++ b/pkgs/development/python-modules/fx2/default.nix
@@ -46,6 +46,6 @@ buildPythonPackage rec {
     mainProgram = "fx2tool";
     homepage = "https://github.com/whitequark/libfx2";
     license = licenses.bsd0;
-    maintainers = with maintainers; [ emily ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/jsonmerge/default.nix
+++ b/pkgs/development/python-modules/jsonmerge/default.nix
@@ -26,6 +26,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/avian2/jsonmerge";
     changelog = "https://github.com/avian2/jsonmerge/blob/jsonmerge-${version}/ChangeLog";
     license = licenses.mit;
-    maintainers = with maintainers; [ emily ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/matrix-nio/default.nix
+++ b/pkgs/development/python-modules/matrix-nio/default.nix
@@ -112,7 +112,6 @@ buildPythonPackage rec {
     license = licenses.isc;
     maintainers = with maintainers; [
       tilpner
-      emily
       symphorien
     ];
   };

--- a/pkgs/development/python-modules/pyvcd/default.nix
+++ b/pkgs/development/python-modules/pyvcd/default.nix
@@ -32,7 +32,6 @@ buildPythonPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [
       sb0
-      emily
     ];
   };
 }

--- a/pkgs/development/python-modules/stm32loader/default.nix
+++ b/pkgs/development/python-modules/stm32loader/default.nix
@@ -50,6 +50,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/florisla/stm32loader";
     changelog = "https://github.com/florisla/stm32loader/blob/v${version}/CHANGELOG.md";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ emily ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/servers/http/openresty/default.nix
+++ b/pkgs/servers/http/openresty/default.nix
@@ -55,6 +55,6 @@ callPackage ../nginx/generic.nix args rec {
     homepage = "https://openresty.org";
     license = lib.licenses.bsd2;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ thoughtpolice lblasc emily ];
+    maintainers = with lib.maintainers; [ thoughtpolice lblasc ];
   };
 }

--- a/pkgs/tools/misc/glasgow/default.nix
+++ b/pkgs/tools/misc/glasgow/default.nix
@@ -76,7 +76,7 @@ python3.pkgs.buildPythonApplication rec {
     description = "Software for Glasgow, a digital interface multitool";
     homepage = "https://github.com/GlasgowEmbedded/Glasgow";
     license = licenses.bsd0;
-    maintainers = with maintainers; [ emily thoughtpolice ];
+    maintainers = with maintainers; [ thoughtpolice ];
     mainProgram = "glasgow";
   };
 }


### PR DESCRIPTION
## Description of changes

I’ve had an extended absence from Nix work and no longer actively use a bunch of packages I used to maintain, so remove myself as a maintainer from things I can’t usefully review/test changes for as I ease back into things. This does unfortunately leave a few packages orphaned (`stm32loader`, `tinyprog`, `python3Packages.fx2`, and `python3Packages.jsonmerge`).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
