### PR TITLE
pcsx2: darwin support, add maintainer

### DIFF
--- a/pkgs/by-name/pc/pcsx2/darwin.nix
+++ b/pkgs/by-name/pc/pcsx2/darwin.nix
@@ -1,0 +1,32 @@
+{
+  stdenvNoCC,
+  fetchurl,
+  pname,
+  version,
+  meta,
+  makeWrapper
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  inherit pname version meta;
+
+  src = fetchurl {
+    url = "https://github.com/PCSX2/pcsx2/releases/download/v${version}/pcsx2-v${version}-macos-Qt.tar.xz";
+    hash = "sha256-QdYV63lrAwYSDhUOy4nB8qL5LfZkrg/EYHtY2smtZuk=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,Applications}
+    cp -r "PCSX2-v${finalAttrs.version}.app" $out/Applications/PCSX2.app
+    makeWrapper $out/Applications/PCSX2.app/Contents/MacOS/PCSX2 $out/bin/pcsx2-qt
+    runHook postInstall
+  '';
+})

--- a/pkgs/by-name/pc/pcsx2/linux.nix
+++ b/pkgs/by-name/pc/pcsx2/linux.nix
@@ -1,0 +1,136 @@
+{
+  cmake,
+  fetchFromGitHub,
+  lib,
+  llvmPackages_17,
+  callPackage,
+  cubeb,
+  curl,
+  extra-cmake-modules,
+  fetchpatch,
+  ffmpeg,
+  libaio,
+  libbacktrace,
+  libpcap,
+  libwebp,
+  libXrandr,
+  lz4,
+  makeWrapper,
+  pkg-config,
+  qt6,
+  SDL2,
+  soundtouch,
+  strip-nondeterminism,
+  vulkan-headers,
+  vulkan-loader,
+  wayland,
+  zip,
+  zstd,
+
+  pname,
+  version,
+  meta,
+}:
+
+let
+  shaderc-patched = callPackage ./shaderc-patched.nix { };
+  # The pre-zipped files in releases don't have a versioned link, we need to zip them ourselves
+  pcsx2_patches = fetchFromGitHub {
+    owner = "PCSX2";
+    repo = "pcsx2_patches";
+    rev = "b3a788e16ea12efac006cbbe1ece45b6b9b34326";
+    sha256 = "sha256-Uvpz2Gpj533Sr6wLruubZxssoXefQDey8GHIDKWhW3s=";
+  };
+  inherit (qt6)
+    qtbase
+    qtsvg
+    qttools
+    qtwayland
+    wrapQtAppsHook
+    ;
+in
+llvmPackages_17.stdenv.mkDerivation (finalAttrs: {
+  inherit pname version meta;
+
+  src = fetchFromGitHub {
+    owner = "PCSX2";
+    repo = "pcsx2";
+    fetchSubmodules = true;
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-WiwnP5yoBy8bRLUPuCZ7z4nhIzrY8P29KS5ZjErM/A4=";
+  };
+
+  patches = [
+    ./define-rev.patch
+    # Backport patches to fix random crashes on startup
+    (fetchpatch {
+      url = "https://github.com/PCSX2/pcsx2/commit/e47bcf8d80df9a93201eefbaf169ec1a0673a833.patch";
+      sha256 = "sha256-7CL1Kpu+/JgtKIenn9rQKAs3A+oJ40W5XHlqSg77Q7Y=";
+    })
+    (fetchpatch {
+      url = "https://github.com/PCSX2/pcsx2/commit/92b707db994f821bccc35d6eef67727ea3ab496b.patch";
+      sha256 = "sha256-HWJ8KZAY/qBBotAJerZg6zi5QUHuTD51zKH1rAtZ3tc=";
+    })
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "DISABLE_ADVANCE_SIMD" true)
+    (lib.cmakeBool "USE_LINKED_FFMPEG" true)
+    (lib.cmakeFeature "PCSX2_GIT_REV" finalAttrs.src.rev)
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    pkg-config
+    strip-nondeterminism
+    wrapQtAppsHook
+    zip
+  ];
+
+  buildInputs = [
+    curl
+    ffmpeg
+    libaio
+    libbacktrace
+    libpcap
+    libwebp
+    libXrandr
+    lz4
+    qtbase
+    qtsvg
+    qttools
+    qtwayland
+    SDL2
+    shaderc-patched
+    soundtouch
+    vulkan-headers
+    wayland
+    zstd
+  ] ++ cubeb.passthru.backendLibs;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -a bin/pcsx2-qt bin/resources $out/bin/
+
+    install -Dm644 $src/pcsx2-qt/resources/icons/AppIcon64.png $out/share/pixmaps/PCSX2.png
+    install -Dm644 $src/.github/workflows/scripts/linux/pcsx2-qt.desktop $out/share/applications/PCSX2.desktop
+
+    zip -jq $out/bin/resources/patches.zip ${pcsx2_patches}/patches/*
+    strip-nondeterminism $out/bin/resources/patches.zip
+  '';
+
+  qtWrapperArgs =
+    let
+      libs = lib.makeLibraryPath ([ vulkan-loader ] ++ cubeb.passthru.backendLibs);
+    in
+    [ "--prefix LD_LIBRARY_PATH : ${libs}" ];
+
+  # https://github.com/PCSX2/pcsx2/pull/10200
+  # Can't avoid the double wrapping, the binary wrapper from qtWrapperArgs doesn't support --run
+  postFixup = ''
+    source "${makeWrapper}/nix-support/setup-hook"
+    wrapProgram $out/bin/pcsx2-qt \
+      --run 'if [[ -z $I_WANT_A_BROKEN_WAYLAND_UI ]]; then export QT_QPA_PLATFORM=xcb; fi'
+  '';
+})

--- a/pkgs/by-name/pc/pcsx2/package.nix
+++ b/pkgs/by-name/pc/pcsx2/package.nix
@@ -1,139 +1,11 @@
-{ cmake
-, fetchFromGitHub
-, lib
-, llvmPackages_17
-, callPackage
-, cubeb
-, curl
-, extra-cmake-modules
-, fetchpatch
-, ffmpeg
-, libaio
-, libbacktrace
-, libpcap
-, libwebp
-, libXrandr
-, lz4
-, makeWrapper
-, pkg-config
-, qt6
-, SDL2
-, soundtouch
-, strip-nondeterminism
-, vulkan-headers
-, vulkan-loader
-, wayland
-, zip
-, zstd
+{
+  stdenv,
+  lib,
+  callPackage,
 }:
-
 let
-  shaderc-patched = callPackage ./shaderc-patched.nix { };
-  # The pre-zipped files in releases don't have a versioned link, we need to zip them ourselves
-  pcsx2_patches = fetchFromGitHub {
-    owner = "PCSX2";
-    repo = "pcsx2_patches";
-    rev = "b3a788e16ea12efac006cbbe1ece45b6b9b34326";
-    sha256 = "sha256-Uvpz2Gpj533Sr6wLruubZxssoXefQDey8GHIDKWhW3s=";
-  };
-  inherit (qt6)
-    qtbase
-    qtsvg
-    qttools
-    qtwayland
-    wrapQtAppsHook
-  ;
-in
-llvmPackages_17.stdenv.mkDerivation (finalAttrs: {
   pname = "pcsx2";
   version = "1.7.5779";
-
-  src = fetchFromGitHub {
-    owner = "PCSX2";
-    repo = "pcsx2";
-    fetchSubmodules = true;
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-WiwnP5yoBy8bRLUPuCZ7z4nhIzrY8P29KS5ZjErM/A4=";
-  };
-
-  patches = [
-    ./define-rev.patch
-    # Backport patches to fix random crashes on startup
-    (fetchpatch {
-      url = "https://github.com/PCSX2/pcsx2/commit/e47bcf8d80df9a93201eefbaf169ec1a0673a833.patch";
-      sha256 = "sha256-7CL1Kpu+/JgtKIenn9rQKAs3A+oJ40W5XHlqSg77Q7Y=";
-    })
-    (fetchpatch {
-      url = "https://github.com/PCSX2/pcsx2/commit/92b707db994f821bccc35d6eef67727ea3ab496b.patch";
-      sha256 = "sha256-HWJ8KZAY/qBBotAJerZg6zi5QUHuTD51zKH1rAtZ3tc=";
-    })
-  ];
-
-  cmakeFlags = [
-    (lib.cmakeBool "DISABLE_ADVANCE_SIMD" true)
-    (lib.cmakeBool "USE_LINKED_FFMPEG" true)
-    (lib.cmakeFeature "PCSX2_GIT_REV" finalAttrs.src.rev)
-  ];
-
-  nativeBuildInputs = [
-    cmake
-    extra-cmake-modules
-    pkg-config
-    strip-nondeterminism
-    wrapQtAppsHook
-    zip
-  ];
-
-  buildInputs = [
-    curl
-    ffmpeg
-    libaio
-    libbacktrace
-    libpcap
-    libwebp
-    libXrandr
-    lz4
-    qtbase
-    qtsvg
-    qttools
-    qtwayland
-    SDL2
-    shaderc-patched
-    soundtouch
-    vulkan-headers
-    wayland
-    zstd
-  ]
-  ++ cubeb.passthru.backendLibs;
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp -a bin/pcsx2-qt bin/resources $out/bin/
-
-    install -Dm644 $src/pcsx2-qt/resources/icons/AppIcon64.png $out/share/pixmaps/PCSX2.png
-    install -Dm644 $src/.github/workflows/scripts/linux/pcsx2-qt.desktop $out/share/applications/PCSX2.desktop
-
-    zip -jq $out/bin/resources/patches.zip ${pcsx2_patches}/patches/*
-    strip-nondeterminism $out/bin/resources/patches.zip
-  '';
-
-  qtWrapperArgs =
-    let
-      libs = lib.makeLibraryPath ([
-        vulkan-loader
-      ] ++ cubeb.passthru.backendLibs);
-    in [
-      "--prefix LD_LIBRARY_PATH : ${libs}"
-    ];
-
-  # https://github.com/PCSX2/pcsx2/pull/10200
-  # Can't avoid the double wrapping, the binary wrapper from qtWrapperArgs doesn't support --run
-  postFixup = ''
-    source "${makeWrapper}/nix-support/setup-hook"
-    wrapProgram $out/bin/pcsx2-qt \
-      --run 'if [[ -z $I_WANT_A_BROKEN_WAYLAND_UI ]]; then export QT_QPA_PLATFORM=xcb; fi'
-  '';
-
   meta = with lib; {
     description = "Playstation 2 emulator";
     longDescription = ''
@@ -143,10 +15,25 @@ llvmPackages_17.stdenv.mkDerivation (finalAttrs: {
       states and PS2 system memory. This allows you to play PS2 games on your
       PC, with many additional features and benefits.
     '';
+    hydraPlatforms = platforms.linux;
     homepage = "https://pcsx2.net";
-    license = with licenses; [ gpl3Plus lgpl3Plus ];
-    maintainers = with maintainers; [ hrdinka govanify ];
+    license = with licenses; [
+      gpl3Plus
+      lgpl3Plus
+    ];
+    maintainers = with maintainers; [
+      hrdinka
+      govanify
+      matteopacini
+    ];
     mainProgram = "pcsx2-qt";
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    sourceProvenance =
+      lib.optional stdenv.isDarwin sourceTypes.binaryNativeCode
+      ++ lib.optional stdenv.isLinux sourceTypes.fromSource;
   };
-})
+in
+if stdenv.isDarwin then
+  callPackage ./darwin.nix { inherit pname version meta; }
+else
+  callPackage ./linux.nix { inherit pname version meta; }


### PR DESCRIPTION
## Description of changes

- Split the package in `linux.nix` and `darwin.nix`
- `darwin.nix` fetches the pre-compiled binaries from GitHub
    - Tried to compile this but fails on `aarch64-darwin`, requires a `x86_64-darwin` machine
    -  Cannot be compiled also as Xcode is needed to build Metal shaders
    - The pre-compiled app runs fine under Rosetta, the version is in sync with the Linux one
- The three files have been formatted with `nixfmt-rfc-style`.
- Added myself as maintainer for Darwin

![Screenshot 2024-06-15 at 20 09 40](https://github.com/NixOS/nixpkgs/assets/3139724/82f32eb8-c116-4cdd-9e85-312c345c9946)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
