### PR TITLE
makeBinaryWrapper: build static wrappers on static platforms

### DIFF
--- a/pkgs/build-support/setup-hooks/make-binary-wrapper/default.nix
+++ b/pkgs/build-support/setup-hooks/make-binary-wrapper/default.nix
@@ -1,4 +1,5 @@
-{ targetPackages
+{ stdenv
+, targetPackages
 , lib
 , makeSetupHook
 , dieHook
@@ -14,6 +15,7 @@ makeSetupHook {
 
   substitutions = {
     cc = "${cc}/bin/${cc.targetPrefix}cc ${lib.escapeShellArgs (map (s: "-fsanitize=${s}") sanitizers)}";
+    maybeStaticFlag = lib.optionalString stdenv.hostPlatform.isStatic "-static";
   };
 
   passthru = {

--- a/pkgs/build-support/setup-hooks/make-binary-wrapper/make-binary-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-binary-wrapper/make-binary-wrapper.sh
@@ -48,6 +48,7 @@ makeBinaryWrapper() {
 
     makeDocumentedCWrapper "$original" "$@" | \
       @cc@ \
+        @maybeStaticFlag@ \
         -Wall -Werror -Wpedantic \
         -Wno-overlength-strings \
         -Os \

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -164,8 +164,11 @@ with pkgs;
   makeBinaryWrapper = callPackage ./make-binary-wrapper {
     makeBinaryWrapper = pkgs.makeBinaryWrapper.override {
       # Enable sanitizers in the tests only, to avoid the performance cost in regular usage.
-      # The sanitizers cause errors on aarch64-darwin, see https://github.com/NixOS/nixpkgs/pull/150079#issuecomment-994132734
-      sanitizers = pkgs.lib.optionals (! (pkgs.stdenv.isDarwin && pkgs.stdenv.isAarch64))
+      sanitizers = pkgs.lib.optionals (!(
+        pkgs.stdenv.hostPlatform.isStatic
+        # The sanitizers cause errors on aarch64-darwin, see https://github.com/NixOS/nixpkgs/pull/150079#issuecomment-994132734
+        || (pkgs.stdenv.isDarwin && pkgs.stdenv.isAarch64)
+      ))
         [ "undefined" "address" ];
     };
   };

--- a/pkgs/test/make-binary-wrapper/default.nix
+++ b/pkgs/test/make-binary-wrapper/default.nix
@@ -9,8 +9,9 @@
 
 let
   env = { nativeBuildInputs = [ makeBinaryWrapper ]; };
+  maybeStaticFlag = lib.optionalString stdenv.hostPlatform.isStatic "-static";
   envCheck = runCommandCC "envcheck" env ''
-    cc -Wall -Werror -Wpedantic -o $out ${./envcheck.c}
+    $CC ${maybeStaticFlag} -Wall -Werror -Wpedantic -o $out ${./envcheck.c}
   '';
   makeGoldenTest = testname: runCommand "make-binary-wrapper-test-${testname}" env ''
     mkdir -p tmp/foo # for the chdir test


### PR DESCRIPTION
## Description of changes

I'm not very big on static stdenv's so this may be naive, but it feels like we should be building static binary wrappers on static platforms.

Also fixed `tests.makeBinaryWrapper` to work on static platforms (though with sanitizers disabled)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
