### PR TITLE
flutter.engine: improvements

### DIFF
--- a/pkgs/development/compilers/flutter/default.nix
+++ b/pkgs/development/compilers/flutter/default.nix
@@ -8,6 +8,8 @@ let
   mkFlutter =
     { version
     , engineVersion
+    , engineSwiftShaderHash
+    , engineSwiftShaderRev
     , engineHashes
     , enginePatches
     , dartVersion
@@ -20,7 +22,7 @@ let
     }@fargs:
     let
       args = {
-        inherit version engineVersion engineHashes enginePatches patches pubspecLock artifactHashes useNixpkgsEngine channel;
+        inherit version engineVersion engineSwiftShaderRev engineSwiftShaderHash engineHashes enginePatches patches pubspecLock artifactHashes useNixpkgsEngine channel;
 
         dart = dart.override {
           version = dartVersion;

--- a/pkgs/development/compilers/flutter/engine/dart.nix
+++ b/pkgs/development/compilers/flutter/engine/dart.nix
@@ -1,0 +1,13 @@
+{ engine, runCommand }:
+runCommand "flutter-engine-${engine.version}-dart" {
+  version = engine.dartSdkVersion;
+
+  inherit engine;
+  inherit (engine) outName;
+
+  meta = engine.meta // {
+    description = "Dart SDK compiled from the Flutter Engine";
+  };
+} ''
+  ln -s ${engine}/out/$outName/dart-sdk $out
+''

--- a/pkgs/development/compilers/flutter/engine/default.nix
+++ b/pkgs/development/compilers/flutter/engine/default.nix
@@ -53,11 +53,6 @@ stdenv.mkDerivation (
     installPhase =
       ''
         mkdir -p $out/out
-
-        for dir in $(find $src/src -mindepth 1 -maxdepth 1); do
-          ln -sf $dir $out/$(basename $dir)
-        done
-
       ''
       + lib.concatMapStrings (
         runtimeMode:

--- a/pkgs/development/compilers/flutter/engine/default.nix
+++ b/pkgs/development/compilers/flutter/engine/default.nix
@@ -44,7 +44,9 @@ stdenv.mkDerivation (
       dartSdkVersion
       isOptimized
       runtimeMode
-      outName;
+      outName
+      dart
+      ;
     inherit altRuntimeMode;
 
     dontUnpack = true;

--- a/pkgs/development/compilers/flutter/engine/default.nix
+++ b/pkgs/development/compilers/flutter/engine/default.nix
@@ -2,6 +2,8 @@
   callPackage,
   dartSdkVersion,
   flutterVersion,
+  swiftshaderHash,
+  swiftshaderRev,
   version,
   hashes,
   url,
@@ -10,6 +12,7 @@
   isOptimized ? true,
   lib,
   stdenv,
+  dart,
   mainRuntimeMode ? null,
   altRuntimeMode ? null,
 }@args:
@@ -23,6 +26,8 @@ let
       inherit
         dartSdkVersion
         flutterVersion
+        swiftshaderHash
+        swiftshaderRev
         version
         hashes
         url

--- a/pkgs/development/compilers/flutter/engine/default.nix
+++ b/pkgs/development/compilers/flutter/engine/default.nix
@@ -10,10 +10,12 @@
   isOptimized ? true,
   lib,
   stdenv,
-}:
+  mainRuntimeMode ? null,
+  altRuntimeMode ? null,
+}@args:
 let
-  mainRuntimeMode = builtins.elemAt runtimeModes 0;
-  altRuntimeMode = builtins.elemAt runtimeModes 1;
+  mainRuntimeMode = args.mainRuntimeMode or builtins.elemAt runtimeModes 0;
+  altRuntimeMode = args.altRuntimeMode or builtins.elemAt runtimeModes 1;
 
   runtimeModesBuilds = lib.genAttrs runtimeModes (
     runtimeMode:
@@ -42,7 +44,7 @@ stdenv.mkDerivation (
       dartSdkVersion
       isOptimized
       runtimeMode
-      ;
+      outName;
     inherit altRuntimeMode;
 
     dontUnpack = true;
@@ -61,9 +63,7 @@ stdenv.mkDerivation (
         runtimeMode:
         let
           runtimeModeBuild = runtimeModesBuilds.${runtimeMode};
-          runtimeModeOut = "host_${runtimeMode}${
-            lib.optionalString (!runtimeModeBuild.isOptimized) "_unopt"
-          }";
+          runtimeModeOut = runtimeModeBuild.outName;
         in
         ''
           ln -sf ${runtimeModeBuild}/out/${runtimeModeOut} $out/out/${runtimeModeOut}

--- a/pkgs/development/compilers/flutter/engine/package.nix
+++ b/pkgs/development/compilers/flutter/engine/package.nix
@@ -209,7 +209,7 @@ stdenv.mkDerivation {
       git add .
       git config user.name "nobody"
       git config user.email "nobody@local.host"
-      git commit -a -m "$rev"
+      git commit -a -m "$rev" --quiet
       popd
     done
 
@@ -256,8 +256,7 @@ stdenv.mkDerivation {
         --runtime-mode $runtimeMode \
         --out-dir $out \
         --target-sysroot $toolchain \
-        --target-dir $outName \
-        --verbose
+        --target-dir $outName
 
       runHook postConfigure
     '';

--- a/pkgs/development/compilers/flutter/engine/package.nix
+++ b/pkgs/development/compilers/flutter/engine/package.nix
@@ -57,7 +57,7 @@ let
       ;
   };
 
-  outName = "host_$runtimeMode${lib.optionalString (!isOptimized) "_unopt --unoptimized"}";
+  outName = "host_${runtimeMode}${lib.optionalString (!isOptimized) "_unopt --unoptimized"}";
 in
 stdenv.mkDerivation {
   pname = "flutter-engine-${runtimeMode}${lib.optionalString (!isOptimized) "-unopt"}";
@@ -283,13 +283,13 @@ stdenv.mkDerivation {
     runHook postBuild
   '';
 
-  # Link sources so we can set $FLUTTER_ENGINE to this derivation
   installPhase = ''
     runHook preInstall
 
-    for dir in $(find $src/src -mindepth 1 -maxdepth 1); do
-      ln -sf $dir $out/$(basename $dir)
-    done
+    rm -rf $out/out/$outName/{obj,gen,exe.unstripped,lib.unstripped,zip_archives}
+    rm $out/out/$outName/{args.gn,build.ninja,build.ninja.d,compile_commands.json,display_list_rendertests,flutter_tester,toolchain.ninja}
+    find $out/out/$outName -name '*_unittests' -delete
+    find $out/out/$outName -name '*_benchmarks' -delete
 
     runHook postInstall
   '';

--- a/pkgs/development/compilers/flutter/engine/package.nix
+++ b/pkgs/development/compilers/flutter/engine/package.nix
@@ -60,7 +60,7 @@ let
 
   outName = "host_${runtimeMode}${lib.optionalString (!isOptimized) "_unopt --unoptimized"}";
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "flutter-engine-${runtimeMode}${lib.optionalString (!isOptimized) "-unopt"}";
   inherit
     version
@@ -307,6 +307,10 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
+  passthru = {
+    dart = callPackage ./dart.nix { engine = finalAttrs.finalPackage; };
+  };
+
   meta = {
     # Very broken on Darwin
     broken = stdenv.isDarwin;
@@ -321,4 +325,4 @@ stdenv.mkDerivation {
       "aarch64-darwin"
     ];
   };
-}
+})

--- a/pkgs/development/compilers/flutter/engine/source.nix
+++ b/pkgs/development/compilers/flutter/engine/source.nix
@@ -66,13 +66,13 @@ runCommand "flutter-engine-source-${version}-${targetPlatform.system}"
     cd $out
 
     export PATH=$PATH:$depot_tools
-    python3 $depot_tools/gclient.py sync --no-history --shallow --nohooks >/dev/null
+    python3 $depot_tools/gclient.py sync --no-history --shallow --nohooks 2>&1 >/dev/null
     find $out -name '.git' -exec dirname {} \; | xargs bash -c 'make_deterministic_repo $@' _
     find $out -path '*/.git/*' ! -name 'HEAD' -prune -exec rm -rf {} \;
     find $out -name '.git' -exec mkdir {}/logs \;
     find $out -name '.git' -exec cp {}/HEAD {}/logs/HEAD \;
 
-    python3 src/build/linux/sysroot_scripts/install-sysroot.py --arch=${constants.arch} >/dev/null
+    python3 src/build/linux/sysroot_scripts/install-sysroot.py --arch=${constants.arch} 2>&1 >/dev/null
 
     rm -rf $out/.cipd $out/.gclient $out/.gclient_entries $out/.gclient_previous_custom_vars $out/.gclient_previous_sync_commits
   ''

--- a/pkgs/development/compilers/flutter/engine/source.nix
+++ b/pkgs/development/compilers/flutter/engine/source.nix
@@ -2,6 +2,7 @@
   callPackage,
   hostPlatform,
   targetPlatform,
+  fetchgit,
   tools ? callPackage ./tools.nix { inherit hostPlatform; },
   curl,
   pkg-config,
@@ -16,6 +17,7 @@
 }:
 let
   constants = callPackage ./constants.nix { inherit targetPlatform; };
+  boolOption = value: if value then "True" else "False";
 in
 runCommand "flutter-engine-source-${version}-${targetPlatform.system}"
   {
@@ -42,6 +44,14 @@ runCommand "flutter-engine-source-${version}-${targetPlatform.system}"
         "managed": False,
         "name": "src/flutter",
         "url": "${url}",
+        "custom_vars": {
+          "download_fuchsia_deps": False,
+          "download_android_deps": False,
+          "download_linux_deps": ${boolOption targetPlatform.isLinux},
+          "setup_githooks": False,
+          "download_esbuild": False,
+          "download_dart_sdk": False,
+        },
       }]
     '';
 
@@ -72,7 +82,7 @@ runCommand "flutter-engine-source-${version}-${targetPlatform.system}"
     find $out -name '.git' -exec mkdir {}/logs \;
     find $out -name '.git' -exec cp {}/HEAD {}/logs/HEAD \;
 
-    python3 src/build/linux/sysroot_scripts/install-sysroot.py --arch=${constants.arch} 2>&1 >/dev/null
+    rm -rf $out/src/flutter/{buildtools,prebuilts,third_party/swiftshader}
 
     rm -rf $out/.cipd $out/.gclient $out/.gclient_entries $out/.gclient_previous_custom_vars $out/.gclient_previous_sync_commits
   ''

--- a/pkgs/development/compilers/flutter/flutter.nix
+++ b/pkgs/development/compilers/flutter/flutter.nix
@@ -5,6 +5,8 @@
 , engineUrl ? "https://github.com/flutter/engine.git@${engineVersion}"
 , enginePatches ? []
 , engineRuntimeModes ? [ "release" "debug" ]
+, engineSwiftShaderHash
+, engineSwiftShaderRev
 , patches
 , channel
 , dart
@@ -25,8 +27,11 @@
 let
   engine = if args.useNixpkgsEngine or false then
     callPackage ./engine/default.nix {
+      inherit (args) dart;
       dartSdkVersion = args.dart.version;
       flutterVersion = version;
+      swiftshaderRev = engineSwiftShaderRev;
+      swiftshaderHash = engineSwiftShaderHash;
       version = engineVersion;
       hashes = engineHashes;
       url = engineUrl;

--- a/pkgs/development/compilers/flutter/flutter.nix
+++ b/pkgs/development/compilers/flutter/flutter.nix
@@ -19,19 +19,13 @@
 , git
 , which
 , jq
-, flutterTools ? callPackage ./flutter-tools.nix {
-    inherit dart version;
-    flutterSrc = src;
-    inherit patches;
-    inherit pubspecLock;
-    systemPlatform = stdenv.hostPlatform.system;
-  }
+, flutterTools ? null
 }@args:
 
 let
   engine = if args.useNixpkgsEngine or false then
     callPackage ./engine/default.nix {
-      dartSdkVersion = dart.version;
+      dartSdkVersion = args.dart.version;
       flutterVersion = version;
       version = engineVersion;
       hashes = engineHashes;
@@ -39,6 +33,17 @@ let
       patches = enginePatches;
       runtimeModes = engineRuntimeModes;
     } else null;
+
+  dart = if args.useNixpkgsEngine or false then
+    engine.dart else args.dart;
+
+  flutterTools = args.flutterTools or (callPackage ./flutter-tools.nix {
+    inherit dart version;
+    flutterSrc = src;
+    inherit patches;
+    inherit pubspecLock;
+    systemPlatform = stdenv.hostPlatform.system;
+  });
 
   unwrapped =
     stdenv.mkDerivation {

--- a/pkgs/development/compilers/flutter/update/get-engine-swiftshader.nix.in
+++ b/pkgs/development/compilers/flutter/update/get-engine-swiftshader.nix.in
@@ -1,0 +1,5 @@
+{ fetchgit }:
+fetchgit {
+  url = "https://swiftshader.googlesource.com/SwiftShader.git";
+  rev = "@engine_swiftshader_rev@";
+}

--- a/pkgs/development/compilers/flutter/update/update.py
+++ b/pkgs/development/compilers/flutter/update/update.py
@@ -14,6 +14,7 @@ import argparse
 import yaml
 import json
 
+FAKE_HASH = 'sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
 
 NIXPKGS_ROOT = subprocess.Popen(['git',
                                  'rev-parse',
@@ -200,6 +201,22 @@ def get_pubspec_lock(flutter_compact_version, flutter_src):
 
     return yaml.safe_load(pubspec_lock_yaml)
 
+def get_engine_swiftshader_rev(engine_version):
+    with urllib.request.urlopen(f"https://github.com/flutter/engine/raw/{engine_version}/DEPS") as f:
+        deps = f.read().decode('utf-8')
+        pattern = re.compile(r"Var\('swiftshader_git'\) \+ '\/SwiftShader\.git' \+ '@' \+ \'([0-9a-fA-F]{40})\'\,")
+        rev = pattern.findall(deps)[0]
+        return rev
+
+def get_engine_swiftshader_hash(engine_swiftshader_rev):
+    code = load_code(
+        "get-engine-swiftshader.nix",
+        engine_swiftshader_rev=engine_swiftshader_rev,
+        hash="")
+
+    stderr = nix_build_to_fail(code)
+    pattern = re.compile(r"got:\s+(.+?)\n")
+    return pattern.findall(stderr)[0]
 
 def write_data(
         nixpkgs_flutter_version_directory,
@@ -207,6 +224,8 @@ def write_data(
         channel,
         engine_hash,
         engine_hashes,
+        engine_swiftshader_hash,
+        engine_swiftshader_rev,
         dart_version,
         dart_hash,
         flutter_hash,
@@ -216,6 +235,8 @@ def write_data(
         f.write(json.dumps({
             "version": flutter_version,
             "engineVersion": engine_hash,
+            "engineSwiftShaderHash": engine_swiftshader_hash,
+            "engineSwiftShaderRev": engine_swiftshader_rev,
             "channel": channel,
             "engineHashes": engine_hashes,
             "dartVersion": dart_version,
@@ -360,6 +381,8 @@ def main():
         pubspec_lock={},
         artifact_hashes={},
         engine_hashes={},
+        engine_swiftshader_hash=FAKE_HASH,
+        engine_swiftshader_rev='0',
         **common_data_args)
 
     pubspec_lock = get_pubspec_lock(flutter_compact_version, flutter_src)
@@ -368,6 +391,8 @@ def main():
         pubspec_lock=pubspec_lock,
         artifact_hashes={},
         engine_hashes={},
+        engine_swiftshader_hash=FAKE_HASH,
+        engine_swiftshader_rev='0',
         **common_data_args)
 
     artifact_hashes = get_artifact_hashes(flutter_compact_version)
@@ -376,6 +401,8 @@ def main():
         pubspec_lock=pubspec_lock,
         artifact_hashes=artifact_hashes,
         engine_hashes={},
+        engine_swiftshader_hash=FAKE_HASH,
+        engine_swiftshader_rev='0',
         **common_data_args)
 
     engine_hashes = get_engine_hashes(engine_hash)
@@ -384,6 +411,19 @@ def main():
         pubspec_lock=pubspec_lock,
         artifact_hashes=artifact_hashes,
         engine_hashes=engine_hashes,
+        engine_swiftshader_hash=FAKE_HASH,
+        engine_swiftshader_rev='0',
+        **common_data_args)
+
+    engine_swiftshader_rev = get_engine_swiftshader_rev(engine_hash)
+    engine_swiftshader_hash = get_engine_swiftshader_hash(engine_swiftshader_rev)
+
+    write_data(
+        pubspec_lock=pubspec_lock,
+        artifact_hashes=artifact_hashes,
+        engine_hashes=engine_hashes,
+        engine_swiftshader_hash=engine_swiftshader_hash,
+        engine_swiftshader_rev=engine_swiftshader_rev,
         **common_data_args)
 
 

--- a/pkgs/development/compilers/flutter/versions/3_13/data.json
+++ b/pkgs/development/compilers/flutter/versions/3_13/data.json
@@ -1,9 +1,12 @@
 {
   "version": "3.13.8",
   "engineVersion": "767d8c75e898091b925519803830fc2721658d07",
+  "engineSwiftShaderHash": "sha256-N6f5aeDroqEwZlUBZi7nhDW8leE/7DqmOtRYOY4wzf4=",
+  "engineSwiftShaderRev": "5f9ed9b16931c7155171d31f75004f73f0a3abc8",
   "channel": "stable",
   "engineHashes": {
-    "aarch64-linux": "sha256-1s7I+AWb2kNDzJ5k2XYm7rSK8yj1wqTjPUuS0f85Jig="
+    "aarch64-linux": "sha256-+MIGPmKHkcn3TlFYu6jXv8KBRqdECgtGSqAKQE33iAM=",
+    "x86_64-linux": "sha256-+MIGPmKHkcn3TlFYu6jXv8KBRqdECgtGSqAKQE33iAM="
   },
   "dartVersion": "3.1.4",
   "dartHash": {
@@ -15,52 +18,52 @@
   "flutterHash": "sha256-00G030FvZZTsdf9ruFs9jdIHcC5h+xpp4NlmL64qVZA=",
   "artifactHashes": {
     "android": {
-      "x86_64-linux": "sha256-Uc36aBq8wQo2aEvjAPOoixZElWOE/GNRm2GUfhbwT3Y=",
+      "aarch64-darwin": "sha256-v/6/GTj7732fEOIgSaoM00yaw2qNwOMuvbuoCvii7vQ=",
       "aarch64-linux": "sha256-Uc36aBq8wQo2aEvjAPOoixZElWOE/GNRm2GUfhbwT3Y=",
       "x86_64-darwin": "sha256-v/6/GTj7732fEOIgSaoM00yaw2qNwOMuvbuoCvii7vQ=",
-      "aarch64-darwin": "sha256-v/6/GTj7732fEOIgSaoM00yaw2qNwOMuvbuoCvii7vQ="
+      "x86_64-linux": "sha256-Uc36aBq8wQo2aEvjAPOoixZElWOE/GNRm2GUfhbwT3Y="
     },
     "fuchsia": {
-      "x86_64-linux": "sha256-eu0BERdz53CkSexbpu3KA7O6Q4g0s9SGD3t1Snsk3Fk=",
+      "aarch64-darwin": "sha256-eu0BERdz53CkSexbpu3KA7O6Q4g0s9SGD3t1Snsk3Fk=",
       "aarch64-linux": "sha256-eu0BERdz53CkSexbpu3KA7O6Q4g0s9SGD3t1Snsk3Fk=",
       "x86_64-darwin": "sha256-eu0BERdz53CkSexbpu3KA7O6Q4g0s9SGD3t1Snsk3Fk=",
-      "aarch64-darwin": "sha256-eu0BERdz53CkSexbpu3KA7O6Q4g0s9SGD3t1Snsk3Fk="
+      "x86_64-linux": "sha256-eu0BERdz53CkSexbpu3KA7O6Q4g0s9SGD3t1Snsk3Fk="
     },
     "ios": {
-      "x86_64-linux": "sha256-QwkeGnutTVsm682CqxRtEd9rKUvN7zlAJcqkvAQYwao=",
+      "aarch64-darwin": "sha256-QwkeGnutTVsm682CqxRtEd9rKUvN7zlAJcqkvAQYwao=",
       "aarch64-linux": "sha256-QwkeGnutTVsm682CqxRtEd9rKUvN7zlAJcqkvAQYwao=",
       "x86_64-darwin": "sha256-QwkeGnutTVsm682CqxRtEd9rKUvN7zlAJcqkvAQYwao=",
-      "aarch64-darwin": "sha256-QwkeGnutTVsm682CqxRtEd9rKUvN7zlAJcqkvAQYwao="
+      "x86_64-linux": "sha256-QwkeGnutTVsm682CqxRtEd9rKUvN7zlAJcqkvAQYwao="
     },
     "linux": {
-      "x86_64-linux": "sha256-0gIOwux3YBdmcXgwICr8dpftj1CauaBUX8Rt5GG0WSs=",
+      "aarch64-darwin": "sha256-drGHsuJoOCLqrhVrXczqJRCOtpeWVlqdWW0OSMS/l5M=",
       "aarch64-linux": "sha256-drGHsuJoOCLqrhVrXczqJRCOtpeWVlqdWW0OSMS/l5M=",
       "x86_64-darwin": "sha256-0gIOwux3YBdmcXgwICr8dpftj1CauaBUX8Rt5GG0WSs=",
-      "aarch64-darwin": "sha256-drGHsuJoOCLqrhVrXczqJRCOtpeWVlqdWW0OSMS/l5M="
+      "x86_64-linux": "sha256-0gIOwux3YBdmcXgwICr8dpftj1CauaBUX8Rt5GG0WSs="
     },
     "macos": {
-      "x86_64-linux": "sha256-9WqCJQ37mcGc5tzfqQoY5CqHWHGTizjXf9p73bdnNWc=",
+      "aarch64-darwin": "sha256-9WqCJQ37mcGc5tzfqQoY5CqHWHGTizjXf9p73bdnNWc=",
       "aarch64-linux": "sha256-9WqCJQ37mcGc5tzfqQoY5CqHWHGTizjXf9p73bdnNWc=",
       "x86_64-darwin": "sha256-9WqCJQ37mcGc5tzfqQoY5CqHWHGTizjXf9p73bdnNWc=",
-      "aarch64-darwin": "sha256-9WqCJQ37mcGc5tzfqQoY5CqHWHGTizjXf9p73bdnNWc="
+      "x86_64-linux": "sha256-9WqCJQ37mcGc5tzfqQoY5CqHWHGTizjXf9p73bdnNWc="
     },
     "universal": {
-      "x86_64-linux": "sha256-wATt1UPjo/fh7RFO1vvcUAdo0dMAaaOUIuzYodsM0v0=",
+      "aarch64-darwin": "sha256-mSpAPKyP9v0dbkXqYkzGOnD5OEjRZigiRElXXcHZ5TE=",
       "aarch64-linux": "sha256-Z9bszNaIpCccG7OfvE5WFsw36dITiyCQAZ6p29+Yq68=",
       "x86_64-darwin": "sha256-qN5bAXRfQ78TWF3FLBIxWzUB5y5OrZVQTEilY5J/+2k=",
-      "aarch64-darwin": "sha256-mSpAPKyP9v0dbkXqYkzGOnD5OEjRZigiRElXXcHZ5TE="
+      "x86_64-linux": "sha256-wATt1UPjo/fh7RFO1vvcUAdo0dMAaaOUIuzYodsM0v0="
     },
     "web": {
-      "x86_64-linux": "sha256-DVXJOOFxv7tKt3d0NaYMexkphEcr7+gDFV67I6iAYa0=",
+      "aarch64-darwin": "sha256-DVXJOOFxv7tKt3d0NaYMexkphEcr7+gDFV67I6iAYa0=",
       "aarch64-linux": "sha256-DVXJOOFxv7tKt3d0NaYMexkphEcr7+gDFV67I6iAYa0=",
       "x86_64-darwin": "sha256-DVXJOOFxv7tKt3d0NaYMexkphEcr7+gDFV67I6iAYa0=",
-      "aarch64-darwin": "sha256-DVXJOOFxv7tKt3d0NaYMexkphEcr7+gDFV67I6iAYa0="
+      "x86_64-linux": "sha256-DVXJOOFxv7tKt3d0NaYMexkphEcr7+gDFV67I6iAYa0="
     },
     "windows": {
-      "x86_64-linux": "sha256-s8fJtwQkuZaGXr6vrPiKfpwP/NfewbETwyp9ERGqHYI=",
+      "aarch64-darwin": "sha256-s8fJtwQkuZaGXr6vrPiKfpwP/NfewbETwyp9ERGqHYI=",
       "aarch64-linux": "sha256-s8fJtwQkuZaGXr6vrPiKfpwP/NfewbETwyp9ERGqHYI=",
       "x86_64-darwin": "sha256-s8fJtwQkuZaGXr6vrPiKfpwP/NfewbETwyp9ERGqHYI=",
-      "aarch64-darwin": "sha256-s8fJtwQkuZaGXr6vrPiKfpwP/NfewbETwyp9ERGqHYI="
+      "x86_64-linux": "sha256-s8fJtwQkuZaGXr6vrPiKfpwP/NfewbETwyp9ERGqHYI="
     }
   },
   "pubspecLock": {

--- a/pkgs/development/compilers/flutter/versions/3_16/data.json
+++ b/pkgs/development/compilers/flutter/versions/3_16/data.json
@@ -1,9 +1,12 @@
 {
   "version": "3.16.7",
   "engineVersion": "4a585b79294e830fa89c24924d58a27cc8fbf406",
+  "engineSwiftShaderHash": "sha256-N6f5aeDroqEwZlUBZi7nhDW8leE/7DqmOtRYOY4wzf4=",
+  "engineSwiftShaderRev": "5f9ed9b16931c7155171d31f75004f73f0a3abc8",
   "channel": "stable",
   "engineHashes": {
-    "aarch64-linux": "sha256-xqniT1rYrzCuq6542KfqWRigYtLnmaT0z5Es/59iFMw="
+    "aarch64-linux": "sha256-irrfyKvTHqaBgcKg3jJzEDs1B4Q91u/e6Ui01MDI+oU=",
+    "x86_64-linux": "sha256-irrfyKvTHqaBgcKg3jJzEDs1B4Q91u/e6Ui01MDI+oU="
   },
   "dartVersion": "3.2.4",
   "dartHash": {
@@ -15,51 +18,51 @@
   "flutterHash": "sha256-j+tc8hMgZMBhju89n4e9tKRrq+CFBGOyeE0y+Z4FtHE=",
   "artifactHashes": {
     "android": {
+      "aarch64-darwin": "sha256-0FBI0CGMcxyttkzrdyjJlkGAjFd/yMuAQS3pDrNXZZw=",
       "aarch64-linux": "sha256-j8jstEE1RsTVHJbq6f6We0An+CyJz9JH/YClyNA4mwg=",
       "x86_64-darwin": "sha256-0FBI0CGMcxyttkzrdyjJlkGAjFd/yMuAQS3pDrNXZZw=",
-      "aarch64-darwin": "sha256-0FBI0CGMcxyttkzrdyjJlkGAjFd/yMuAQS3pDrNXZZw=",
       "x86_64-linux": "sha256-j8jstEE1RsTVHJbq6f6We0An+CyJz9JH/YClyNA4mwg="
     },
     "fuchsia": {
+      "aarch64-darwin": "sha256-eu0BERdz53CkSexbpu3KA7O6Q4g0s9SGD3t1Snsk3Fk=",
       "aarch64-linux": "sha256-eu0BERdz53CkSexbpu3KA7O6Q4g0s9SGD3t1Snsk3Fk=",
       "x86_64-darwin": "sha256-eu0BERdz53CkSexbpu3KA7O6Q4g0s9SGD3t1Snsk3Fk=",
-      "aarch64-darwin": "sha256-eu0BERdz53CkSexbpu3KA7O6Q4g0s9SGD3t1Snsk3Fk=",
       "x86_64-linux": "sha256-eu0BERdz53CkSexbpu3KA7O6Q4g0s9SGD3t1Snsk3Fk="
     },
     "ios": {
+      "aarch64-darwin": "sha256-V3VXRX8hn45J+NhzKli+NAc3TGiSoeVQRlJte8DDbZw=",
       "aarch64-linux": "sha256-V3VXRX8hn45J+NhzKli+NAc3TGiSoeVQRlJte8DDbZw=",
       "x86_64-darwin": "sha256-V3VXRX8hn45J+NhzKli+NAc3TGiSoeVQRlJte8DDbZw=",
-      "aarch64-darwin": "sha256-V3VXRX8hn45J+NhzKli+NAc3TGiSoeVQRlJte8DDbZw=",
       "x86_64-linux": "sha256-V3VXRX8hn45J+NhzKli+NAc3TGiSoeVQRlJte8DDbZw="
     },
     "linux": {
+      "aarch64-darwin": "sha256-LWpou3L7bAWGn8i4nDT/BZez2Uhf/LbqC2C4Z98hCHQ=",
       "aarch64-linux": "sha256-LWpou3L7bAWGn8i4nDT/BZez2Uhf/LbqC2C4Z98hCHQ=",
       "x86_64-darwin": "sha256-BzjmO4F8B9GagYPbdvoT55r+YgZcP4BUaKgJPGZDXOU=",
-      "aarch64-darwin": "sha256-LWpou3L7bAWGn8i4nDT/BZez2Uhf/LbqC2C4Z98hCHQ=",
       "x86_64-linux": "sha256-BzjmO4F8B9GagYPbdvoT55r+YgZcP4BUaKgJPGZDXOU="
     },
     "macos": {
+      "aarch64-darwin": "sha256-BMFqhhy1O1hK33Pj2cxnCAzK9wwHkwT4gNbJ1GaLrnk=",
       "aarch64-linux": "sha256-BMFqhhy1O1hK33Pj2cxnCAzK9wwHkwT4gNbJ1GaLrnk=",
       "x86_64-darwin": "sha256-BMFqhhy1O1hK33Pj2cxnCAzK9wwHkwT4gNbJ1GaLrnk=",
-      "aarch64-darwin": "sha256-BMFqhhy1O1hK33Pj2cxnCAzK9wwHkwT4gNbJ1GaLrnk=",
       "x86_64-linux": "sha256-BMFqhhy1O1hK33Pj2cxnCAzK9wwHkwT4gNbJ1GaLrnk="
     },
     "universal": {
+      "aarch64-darwin": "sha256-Emus5J3mqPv47PD6xqNUD1KpXhVkX4JpURWuYG6KC14=",
       "aarch64-linux": "sha256-uB2YZRjioP/koMbPvaBHsezjPO0w5a+BpxZaDuiINIY=",
       "x86_64-darwin": "sha256-Qwf12gMqrW5nDC9Is08oxWTbKMptRQRAIb58JETq3xA=",
-      "aarch64-darwin": "sha256-Emus5J3mqPv47PD6xqNUD1KpXhVkX4JpURWuYG6KC14=",
       "x86_64-linux": "sha256-quSFKx7TZRJpK+4YDt5f9jwr7rZsSsaXMxhJ8vIcczQ="
     },
     "web": {
+      "aarch64-darwin": "sha256-rQphVm+T4k5B4OYYw0sJwYBOsNvUOC9fu8IuvXN7hVw=",
       "aarch64-linux": "sha256-rQphVm+T4k5B4OYYw0sJwYBOsNvUOC9fu8IuvXN7hVw=",
       "x86_64-darwin": "sha256-rQphVm+T4k5B4OYYw0sJwYBOsNvUOC9fu8IuvXN7hVw=",
-      "aarch64-darwin": "sha256-rQphVm+T4k5B4OYYw0sJwYBOsNvUOC9fu8IuvXN7hVw=",
       "x86_64-linux": "sha256-rQphVm+T4k5B4OYYw0sJwYBOsNvUOC9fu8IuvXN7hVw="
     },
     "windows": {
+      "aarch64-darwin": "sha256-HL3QLwzze9aO+T/2/xbHqhKV1/ba++MuRnk206hfJdU=",
       "aarch64-linux": "sha256-HL3QLwzze9aO+T/2/xbHqhKV1/ba++MuRnk206hfJdU=",
       "x86_64-darwin": "sha256-HL3QLwzze9aO+T/2/xbHqhKV1/ba++MuRnk206hfJdU=",
-      "aarch64-darwin": "sha256-HL3QLwzze9aO+T/2/xbHqhKV1/ba++MuRnk206hfJdU=",
       "x86_64-linux": "sha256-HL3QLwzze9aO+T/2/xbHqhKV1/ba++MuRnk206hfJdU="
     }
   },

--- a/pkgs/development/compilers/flutter/versions/3_19/data.json
+++ b/pkgs/development/compilers/flutter/versions/3_19/data.json
@@ -1,11 +1,12 @@
 {
   "version": "3.19.4",
   "engineVersion": "a5c24f538d05aaf66f7972fb23959d8cafb9f95a",
+  "engineSwiftShaderHash": "sha256-J8TKwbIQ7hdWCGIu1T//MJlRzT7OTVL0MG/dmMyutPQ=",
+  "engineSwiftShaderRev": "2fa7e9b99ae4e70ea5ae2cc9c8d3afb43391384f",
   "channel": "stable",
   "engineHashes": {
-    "x86_64-linux": "sha256-xhihh4v9bh2ZxAewKEdhpXerLDoXFm8YO72+tGRnkCw=",
-    "aarch64-linux": "sha256-mUimQRg0UqvTueuDWO8Isy0FKOxJLvVZrehv4SMj0XY=",
-    "aarch64-darwin": "sha256-5DcD7ebrANznB++QOQOoynr1aOgJqTF8QfSihQnghoY="
+    "aarch64-linux": "sha256-YTG46ZYCOu0OJGIILV6NGvIEhQU0yHNFSMR38Xvqa9E=",
+    "x86_64-linux": "sha256-YTG46ZYCOu0OJGIILV6NGvIEhQU0yHNFSMR38Xvqa9E="
   },
   "dartVersion": "3.3.2",
   "dartHash": {

--- a/pkgs/development/compilers/flutter/versions/3_22/data.json
+++ b/pkgs/development/compilers/flutter/versions/3_22/data.json
@@ -1,10 +1,12 @@
 {
   "version": "3.22.2",
   "engineVersion": "edd8546116457bdf1c5bdfb13ecb9463d2bb5ed4",
+  "engineSwiftShaderHash": "sha256-J8TKwbIQ7hdWCGIu1T//MJlRzT7OTVL0MG/dmMyutPQ=",
+  "engineSwiftShaderRev": "2fa7e9b99ae4e70ea5ae2cc9c8d3afb43391384f",
   "channel": "stable",
   "engineHashes": {
-    "aarch64-linux": "sha256-xPVhLxO9AgXC2+Hwm1lWRfNZhLwZHdKW92WXgv3ImZk=",
-    "x86_64-linux": "sha256-klODJpmlWynYx+MqqGGeTzzPtmQTEUV47hnzjIVDCK8="
+    "aarch64-linux": "sha256-OPgevqdMwKhXml+PS5Z1DW0wg843NVN57CiLbXve8kE=",
+    "x86_64-linux": "sha256-OPgevqdMwKhXml+PS5Z1DW0wg843NVN57CiLbXve8kE="
   },
   "dartVersion": "3.4.3",
   "dartHash": {

--- a/pkgs/development/compilers/flutter/versions/3_23/data.json
+++ b/pkgs/development/compilers/flutter/versions/3_23/data.json
@@ -1,9 +1,12 @@
 {
   "version": "3.23.0-0.1.pre",
   "engineVersion": "bb10c5466638e963479ba5e64e601e42d1a43447",
+  "engineSwiftShaderHash": "sha256-J8TKwbIQ7hdWCGIu1T//MJlRzT7OTVL0MG/dmMyutPQ=",
+  "engineSwiftShaderRev": "2fa7e9b99ae4e70ea5ae2cc9c8d3afb43391384f",
   "channel": "beta",
   "engineHashes": {
-    "aarch64-linux": "sha256-WHWxYOHd3jxE5CQNt0+9qxlsCLK5y9iJsVERtJ4Ylbk="
+    "aarch64-linux": "sha256-g169BDV6NtiyriMSgK3GOwhkVi9X23SqB9HOxxtGPK4=",
+    "x86_64-linux": "sha256-g169BDV6NtiyriMSgK3GOwhkVi9X23SqB9HOxxtGPK4="
   },
   "dartVersion": "3.5.0-180.3.beta",
   "dartHash": {

--- a/pkgs/development/compilers/flutter/wrapper.nix
+++ b/pkgs/development/compilers/flutter/wrapper.nix
@@ -147,7 +147,7 @@ in
       --set-default ANDROID_EMULATOR_USE_SYSTEM_LIBS 1 \
       '' + lib.optionalString (flutter ? engine && flutter.engine.meta.available) ''
         --set-default FLUTTER_ENGINE "${flutter.engine}" \
-        --add-flags "--local-engine-host host_${flutter.engine.runtimeMode}${lib.optionalString (!flutter.engine.isOptimized) "_unopt"}" \
+        --add-flags "--local-engine-host ${flutter.engine.outName}" \
       '' + '' --suffix PATH : '${lib.makeBinPath (tools ++ buildTools)}' \
       --suffix PKG_CONFIG_PATH : "$FLUTTER_PKG_CONFIG_PATH" \
       --suffix LIBRARY_PATH : '${lib.makeLibraryPath appStaticBuildDeps}' \

--- a/pkgs/development/compilers/flutter/wrapper.nix
+++ b/pkgs/development/compilers/flutter/wrapper.nix
@@ -7,7 +7,7 @@
     "universal"
     "web"
   ]
-  ++ lib.optional stdenv.hostPlatform.isLinux "linux"
+  ++ lib.optional (stdenv.hostPlatform.isLinux && !(flutter ? engine)) "linux"
   ++ lib.optional (stdenv.hostPlatform.isx86_64 || stdenv.hostPlatform.isDarwin) "android"
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ "macos" "ios" ]
 , artifactHashes ? flutter.artifactHashes


### PR DESCRIPTION
## Description of changes

As suggested by @tomberek in #212328, let's use the `builtins.storePath` for the toolchain. Also incorporates another change, adds an `outName` attribute to the engine to easily know where in `$out/out/` the engine is at instead of duplicating the logic. Other changes will be added as well, such as:

- [x] Optimize space used in `$out` of engine builds (takes ~30GB currently, goal is 10GB)
- [x] All binaries should have no missing solibs
- [x] Unit test execution
- [x] Disable artifact fetching for engine enabled Flutter
- [x] Use Engine's Dart & wrap it to be compatible with Nixpkg's

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
