### PR TITLE
python312Packages.pylibjpeg-openjpeg: init at 2.3.0

### DIFF
--- a/pkgs/development/python-modules/highdicom/default.nix
+++ b/pkgs/development/python-modules/highdicom/default.nix
@@ -10,6 +10,7 @@
   pydicom,
   pylibjpeg,
   pylibjpeg-libjpeg,
+  pylibjpeg-openjpeg,
 }:
 
 let
@@ -45,7 +46,7 @@ buildPythonPackage rec {
     libjpeg = [
       pylibjpeg
       pylibjpeg-libjpeg
-      #pylibjpeg-openjpeg  # not in nixpkgs yet
+      #pylibjpeg-openjpeg  # broken on aarch64-linux
     ];
   };
 

--- a/pkgs/development/python-modules/pylibjpeg-data/default.nix
+++ b/pkgs/development/python-modules/pylibjpeg-data/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  flit-core,
+}:
+
+buildPythonPackage rec {
+  pname = "pylibjpeg-data";
+  version = "unstable-2024-03-28";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "pydicom";
+    repo = "pylibjpeg-data";
+    rev = "8253566715800a7fc3d4d949abab102c8172bca0";
+    hash = "sha256-TzhiZ4LCFZX75h3YRrEFO5kRVc5VwTOJd+1VFW3LsaQ=";
+  };
+
+  build-system = [ flit-core ];
+
+  doCheck = false; # no tests
+
+  pythonImportsCheck = [
+    "ljdata"
+    "ljdata.ds"
+    "ljdata.jpg"
+  ];
+
+  meta = {
+    description = "JPEG and DICOM data used for testing pylibjpeg";
+    homepage = "https://github.com/pydicom/pylibjpeg-data";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/pylibjpeg-openjpeg/default.nix
+++ b/pkgs/development/python-modules/pylibjpeg-openjpeg/default.nix
@@ -1,0 +1,76 @@
+{
+  stdenv,
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  cmake,
+  cython,
+  poetry-core,
+  setuptools,
+  numpy,
+  openjpeg,
+  pytestCheckHook,
+  pydicom,
+  pylibjpeg,
+  pylibjpeg-data,
+}:
+
+buildPythonPackage rec {
+  pname = "pylibjpeg-openjpeg";
+  version = "2.3.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "pydicom";
+    repo = "pylibjpeg-openjpeg";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-cCDnARElNn+uY+HQ39OnGJRz2vTz0I8s0Oe+qGvqM1o=";
+  };
+
+  # don't use vendored openjpeg submodule:
+  # (note build writes into openjpeg source dir, so we have to make it writable)
+  postPatch = ''
+    rmdir lib/openjpeg
+    cp -r ${openjpeg.src} lib/openjpeg
+    chmod +rwX -R lib/openjpeg
+  '';
+
+  dontUseCmakeConfigure = true;
+
+  build-system = [
+    cmake
+    cython
+    poetry-core
+    setuptools
+  ];
+
+  dependencies = [ numpy ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pydicom
+    pylibjpeg-data
+    pylibjpeg
+  ];
+  disabledTestPaths = [
+    # ignore a few Python test files (e.g. performance tests) in openjpeg itself:
+    "lib/openjpeg"
+  ];
+
+  pytestFlagsArray = [ "openjpeg/tests" ];
+
+  pythonImportsCheck = [ "openjpeg" ];
+
+  meta = {
+    description = "A J2K and JP2 plugin for pylibjpeg";
+    homepage = "https://github.com/pydicom/pylibjpeg-openjpeg";
+    license = [ lib.licenses.mit ];
+    maintainers = with lib.maintainers; [ bcdarwin ];
+    # x86-linux: test_encode.py::TestEncodeBuffer failures
+    # darwin: numerous test failures, seemingly due to issues setting up test data
+    broken = (stdenv.isAarch64 && stdenv.isLinux) || stdenv.isDarwin;
+  };
+}

--- a/pkgs/development/python-modules/pylibjpeg/default.nix
+++ b/pkgs/development/python-modules/pylibjpeg/default.nix
@@ -8,27 +8,9 @@
   setuptools,
   numpy,
   pydicom,
+  pylibjpeg-data,
   pylibjpeg-libjpeg,
 }:
-
-let
-  pylibjpeg-data = buildPythonPackage {
-    pname = "pylibjpeg-data";
-    version = "1.0.0dev0";
-    pyproject = true;
-
-    nativeBuildInputs = [ setuptools ];
-
-    src = fetchFromGitHub {
-      owner = "pydicom";
-      repo = "pylibjpeg-data";
-      rev = "2ab4b8a65b070656eca2582bd23197a3d01cdccd";
-      hash = "sha256-cFE1XjrqyGqwHCYGRucXK+q4k7ftUIbYwBw4WwIFtEc=";
-    };
-
-    doCheck = false;
-  };
-in
 
 buildPythonPackage rec {
   pname = "pylibjpeg";
@@ -44,9 +26,9 @@ buildPythonPackage rec {
     hash = "sha256-qGtrphsBBVieGS/8rdymbsjLMU/QEd7zFNAANN8bD+k=";
   };
 
-  nativeBuildInputs = [ flit-core ];
+  build-system = [ flit-core ];
 
-  propagatedBuildInputs = [ numpy ];
+  dependencies = [ numpy ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11389,6 +11389,8 @@ self: super: with self; {
 
   pylibjpeg = callPackage ../development/python-modules/pylibjpeg { };
 
+  pylibjpeg-data = callPackage ../development/python-modules/pylibjpeg-data { };
+
   pylibjpeg-libjpeg = callPackage ../development/python-modules/pylibjpeg-libjpeg { };
 
   pyliblo = callPackage ../development/python-modules/pyliblo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11393,6 +11393,8 @@ self: super: with self; {
 
   pylibjpeg-libjpeg = callPackage ../development/python-modules/pylibjpeg-libjpeg { };
 
+  pylibjpeg-openjpeg = callPackage ../development/python-modules/pylibjpeg-openjpeg { };
+
   pyliblo = callPackage ../development/python-modules/pyliblo { };
 
   pylibmc = callPackage ../development/python-modules/pylibmc { };


### PR DESCRIPTION
python311Packages.pylibjpeg-data: init at unstable-2024-03-24

## Description of changes

Add `pylibjpeg-openjpeg`, a J2K and JP2 plugin for pylibjpeg.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
