### PR TITLE
dbeaver-bin: add darwin support

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23018,6 +23018,15 @@
     githubId = 5253988;
     name = "yvt";
   };
+  yzx9 = {
+    email = "yuan.zx@outlook.com";
+    github = "yzx9";
+    githubId = 41458459;
+    name = "Zexin Yuan";
+    keys = [{
+      fingerprint = "FE16 B281 90EF 6C3F F661  6441 C2DD 1916 FE47 1BE2";
+    }];
+  };
   zachcoyle = {
     email = "zach.coyle@gmail.com";
     github = "zachcoyle";

--- a/pkgs/by-name/db/dbeaver-bin/package.nix
+++ b/pkgs/by-name/db/dbeaver-bin/package.nix
@@ -1,23 +1,27 @@
-{ lib
-, stdenvNoCC
-, fetchurl
-, makeWrapper
-, openjdk17
-, gnused
-, autoPatchelfHook
-, wrapGAppsHook3
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  undmg,
+  makeWrapper,
+  openjdk17,
+  gnused,
+  autoPatchelfHook,
+  wrapGAppsHook3,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "dbeaver-bin";
   version = "24.0.5";
 
-  nativeBuildInputs = [
-    makeWrapper
-    gnused
-    autoPatchelfHook
-    wrapGAppsHook3
-  ];
+  nativeBuildInputs =
+    [ makeWrapper ]
+    ++ lib.optionals (!stdenvNoCC.isDarwin) [
+      gnused
+      wrapGAppsHook3
+      autoPatchelfHook
+    ]
+    ++ lib.optionals stdenvNoCC.isDarwin [ undmg ];
 
   src =
     let
@@ -26,10 +30,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       suffix = selectSystem {
         x86_64-linux = "linux.gtk.x86_64-nojdk.tar.gz";
         aarch64-linux = "linux.gtk.aarch64-nojdk.tar.gz";
+        x86_64-darwin = "macos-x86_64.dmg";
+        aarch64-darwin = "macos-aarch64.dmg";
       };
       hash = selectSystem {
         x86_64-linux = "sha256-q6VIr55hXn47kZrE2i6McEOfp2FBOvwB0CcUnRHFMZs=";
         aarch64-linux = "sha256-Xn3X1C31UALBAsZIGyMWdp0HNhJEm5N+7Go7nMs8W64=";
+        x86_64-darwin = "sha256-XOQaMNQHOC4dVJXIUn4l4Oa7Gohbq+JMDFusIy/U+tc=";
+        aarch64-darwin = "sha256-554ea5p1MR4XIHtSeByd4S/Ke4cKRZbITTNRRDoRqPI=";
       };
     in
     fetchurl {
@@ -40,28 +48,44 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   dontConfigure = true;
   dontBuild = true;
 
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/opt/dbeaver $out/bin
-    cp -r * $out/opt/dbeaver
-    makeWrapper $out/opt/dbeaver/dbeaver $out/bin/dbeaver \
-      --prefix PATH : "${openjdk17}/bin" \
-      --set JAVA_HOME "${openjdk17.home}"
+  sourceRoot = lib.optional stdenvNoCC.isDarwin "dbeaver.app";
 
-    mkdir -p $out/share/icons/hicolor/256x256/apps
-    ln -s $out/opt/dbeaver/dbeaver.png $out/share/icons/hicolor/256x256/apps/dbeaver.png
+  installPhase =
+    if !stdenvNoCC.isDarwin then
+      ''
+        runHook preInstall
+        mkdir -p $out/opt/dbeaver $out/bin
+        cp -r * $out/opt/dbeaver
+        makeWrapper $out/opt/dbeaver/dbeaver $out/bin/dbeaver \
+          --prefix PATH : "${openjdk17}/bin" \
+          --set JAVA_HOME "${openjdk17.home}"
 
-    mkdir -p $out/share/applications
-    ln -s $out/opt/dbeaver/dbeaver-ce.desktop $out/share/applications/dbeaver.desktop
+        mkdir -p $out/share/icons/hicolor/256x256/apps
+        ln -s $out/opt/dbeaver/dbeaver.png $out/share/icons/hicolor/256x256/apps/dbeaver.png
 
-    substituteInPlace $out/opt/dbeaver/dbeaver-ce.desktop \
-      --replace-fail "/usr/share/dbeaver-ce/dbeaver.png" "dbeaver" \
-      --replace-fail "/usr/share/dbeaver-ce/dbeaver" "$out/bin/dbeaver"
+        mkdir -p $out/share/applications
+        ln -s $out/opt/dbeaver/dbeaver-ce.desktop $out/share/applications/dbeaver.desktop
 
-    sed -i '/^Path=/d' $out/share/applications/dbeaver.desktop
+        substituteInPlace $out/opt/dbeaver/dbeaver-ce.desktop \
+          --replace-fail "/usr/share/dbeaver-ce/dbeaver.png" "dbeaver" \
+          --replace-fail "/usr/share/dbeaver-ce/dbeaver" "$out/bin/dbeaver"
 
-    runHook postInstall
-  '';
+        sed -i '/^Path=/d' $out/share/applications/dbeaver.desktop
+
+        runHook postInstall
+      ''
+    else
+      ''
+        runHook preInstall
+
+        mkdir -p $out/{Applications/dbeaver.app,bin}
+        cp -R . $out/Applications/dbeaver.app
+        makeWrapper $out/{Applications/dbeaver.app/Contents/MacOS,bin}/dbeaver \
+          --prefix PATH : "${openjdk17}/bin" \
+          --set JAVA_HOME "${openjdk17.home}"
+
+        runHook postInstall
+      '';
 
   passthru.updateScript = ./update.sh;
 
@@ -76,8 +100,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     '';
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.asl20;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ gepbird mkg20001 ];
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [
+      gepbird
+      mkg20001
+      yzx9
+    ];
     mainProgram = "dbeaver";
   };
 })

--- a/pkgs/by-name/db/dbeaver-bin/update.sh
+++ b/pkgs/by-name/db/dbeaver-bin/update.sh
@@ -14,7 +14,9 @@ fi
 
 for i in \
     "x86_64-linux linux.gtk.x86_64-nojdk.tar.gz" \
-    "aarch64-linux linux.gtk.aarch64-nojdk.tar.gz"
+    "aarch64-linux linux.gtk.aarch64-nojdk.tar.gz" \
+    "x86_64-darwin macos-x86_64.dmg" \
+    "aarch64-darwin macos-aarch64.dmg"
 do
     set -- $i
     prefetch=$(nix-prefetch-url "https://github.com/dbeaver/dbeaver/releases/download/$latestVersion/dbeaver-ce-$latestVersion-$2")


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR restores support for DBeaver on Darwin (See #311888). I have tested it on aarch64, and the software successfully opens and connects to a MySQL server using the local driver.

I am new to contributing to nixpkgs, and this is my first PR. I hope I haven't caused any issues. If there are any mistakes, please let me know!


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
