### PR TITLE
river: 0.3.2 -> 0.3.3

### DIFF
--- a/pkgs/by-name/ri/river/build.zig.zon.nix
+++ b/pkgs/by-name/ri/river/build.zig.zon.nix
@@ -4,31 +4,31 @@
 
 linkFarm "zig-packages" [
   {
-    name = "122014eeb4600a059bdcfe1c864862f17e6d5e4237e3bb7d6818f2a5583f6f4eb843";
+    name = "1220687c8c47a48ba285d26a05600f8700d37fc637e223ced3aa8324f3650bf52242";
     path = fetchzip {
-      url = "https://codeberg.org/ifreund/zig-pixman/archive/v0.1.0.tar.gz";
-      hash = "sha256-Atfkiyt9v+GWry3xA2Y0Iv6AvwbZ+EHfHLmX0AUEz6Y=";
+      url = "https://codeberg.org/ifreund/zig-wayland/archive/v0.2.0.tar.gz";
+      hash = "sha256-dvit+yvc0MnipqWjxJdfIsA6fJaJZOaIpx4w4woCxbE=";
     };
   }
   {
-    name = "1220714d1cc39c3abb1d9c22a0b838d847ead099cb7d9931821490483f30c022e827";
+    name = "12209db20ce873af176138b76632931def33a10539387cba745db72933c43d274d56";
     path = fetchzip {
-      url = "https://codeberg.org/ifreund/zig-wlroots/archive/v0.17.0.tar.gz";
-      hash = "sha256-C1D2dBn65Z9PmDacpeYbdX574fcOyYi/BJVDUMibkPA=";
+      url = "https://codeberg.org/ifreund/zig-pixman/archive/v0.2.0.tar.gz";
+      hash = "sha256-zcfZEMnipWDPuptl9UN0PoaJDjy2EHc7Wwi4GQq3hkY=";
     };
   }
   {
-    name = "1220840390382c88caf9b0887f6cebbba3a7d05960b8b2ee6d80567b2950b71e5017";
+    name = "1220c65ab884c236cc950b564c70f6cd04046d86485ee76e0cde886cef7438021b4f";
     path = fetchzip {
-      url = "https://codeberg.org/ifreund/zig-xkbcommon/archive/v0.1.0.tar.gz";
-      hash = "sha256-xilmsDGWlkfpTiGff+/nb76jx87ANdr4zqYy6rKOBMg=";
+      url = "https://codeberg.org/ifreund/zig-wlroots/archive/v0.17.1.tar.gz";
+      hash = "sha256-rVI/tJD3cx8b+nGTG5u08/RYoI179oDY7AY0riTntA0=";
     };
   }
   {
-    name = "1220b0f8f822c1625af7aae4cb3ab2c4ec1a4c0e99ef32867b2a8d88bb070b3e7f6d";
+    name = "1220c90b2228d65fd8427a837d31b0add83e9fade1dcfa539bb56fd06f1f8461605f";
     path = fetchzip {
-      url = "https://codeberg.org/ifreund/zig-wayland/archive/v0.1.0.tar.gz";
-      hash = "sha256-VLEx8nRgmJZWgLNBRqrR7bZEkW0m5HTRv984HKwoIfA=";
+      url = "https://codeberg.org/ifreund/zig-xkbcommon/archive/v0.2.0.tar.gz";
+      hash = "sha256-T+EZiStBfmxFUjaX05WhYkFJ8tRok/UQtpc9QY9NxZk=";
     };
   }
 ]

--- a/pkgs/by-name/ri/river/package.nix
+++ b/pkgs/by-name/ri/river/package.nix
@@ -15,14 +15,14 @@
 , wayland-protocols
 , wlroots_0_17
 , xwayland
-, zig_0_12
+, zig_0_13
 , withManpages ? true
 , xwaylandSupport ? true
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "river";
-  version = "0.3.2";
+  version = "0.3.3";
 
   outputs = [ "out" ] ++ lib.optionals withManpages [ "man" ];
 
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "river";
     rev = "refs/tags/v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-I09cR5aN7qXOzV9HDXaL4TjoeJcVa0Ch00zxOJokdDE=";
+    hash = "sha256-DYaxtYJLZQqE2SyPfWec/zXsZKRnxK2QNgOkM7GJkLI=";
   };
 
   deps = callPackage ./build.zig.zon.nix { };
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     wayland
     xwayland
-    zig_0_12.hook
+    zig_0_13.hook
   ]
   ++ lib.optional withManpages scdoc;
 


### PR DESCRIPTION
## Description of changes

- Closes #318743
- Changelog: https://github.com/riverwm/river/compare/v0.3.2...v0.3.3
- Only a zig 0.13 compatibility release

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
