### PR TITLE
oidc-agent: init at 5.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21972,6 +21972,13 @@
     github = "peterablehmann";
     githubId = 36541313;
   };
+  xinyangli = {
+    email = "lixinyang411@gmail.com";
+    matrix = "@me:xinyang.life";
+    github = "xinyangli";
+    githubId = 16359093;
+    name = "Xinyang Li";
+  };
   xiorcale = {
     email = "quentin.vaucher@pm.me";
     github = "xiorcale";

--- a/pkgs/by-name/oi/oidc-agent/package.nix
+++ b/pkgs/by-name/oi/oidc-agent/package.nix
@@ -1,0 +1,61 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, curl
+, webkitgtk
+, libmicrohttpd
+, libsecret
+, qrencode
+, libsodium
+, pkg-config
+, help2man
+, nix-update-script
+}:
+
+stdenv.mkDerivation rec {
+  pname = "oidc-agent";
+  version = "5.1.0";
+
+  src = fetchFromGitHub {
+    owner = "indigo-dc";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-cOK/rZ/jnyALLuhDM3+qvwwe4Fjkv8diQBkw7NfVo0c=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    help2man
+  ];
+
+  buildInputs = [
+    curl
+    webkitgtk
+    libmicrohttpd
+    libsecret
+    qrencode
+    libsodium
+  ];
+
+  enableParallelBuilding = true;
+
+  makeFlags = [ "PREFIX=$(out)" "BIN_PATH=$(out)" "LIB_PATH=$(out)/lib" ];
+
+  installTargets = [ "install_bin" "install_lib" "install_conf" ];
+
+  postFixup = ''
+    # Override with patched binary to be used by help2man
+    cp -r $out/bin/* bin
+    make install_man PREFIX=$out
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "Manage OpenID Connect tokens on the command line";
+    homepage = "https://github.com/indigo-dc/oidc-agent";
+    maintainers = with maintainers; [ xinyangli ];
+    license = licenses.mit;
+  };
+}
+


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`oidc-agent` is a set of tools to manage OpenID Connect tokens and make them easily usable from the command line.

This package is based on https://github.com/indigo-dc/oidc-agent/issues/574. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
