### PR TITLE
iniparser: 4.2.3 -> 4.2.4

### DIFF
--- a/pkgs/development/libraries/iniparser/default.nix
+++ b/pkgs/development/libraries/iniparser/default.nix
@@ -1,14 +1,15 @@
-{ lib
-, stdenv
-, fetchFromGitLab
-, fetchFromGitHub
-, substituteAll
-, symlinkJoin
-, cmake
-, doxygen
-, ruby
-, validatePkgConfig
-, testers
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  fetchFromGitHub,
+  substituteAll,
+  symlinkJoin,
+  cmake,
+  doxygen,
+  ruby,
+  validatePkgConfig,
+  testers,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -43,11 +44,13 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  nativeBuildInputs = [ cmake doxygen validatePkgConfig ] ++ lib.optionals finalAttrs.doCheck [ ruby ];
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    validatePkgConfig
+  ] ++ lib.optionals finalAttrs.doCheck [ ruby ];
 
-  cmakeFlags = [
-    "-DBUILD_TESTING=${if finalAttrs.doCheck then "ON" else "OFF"}"
-  ];
+  cmakeFlags = [ "-DBUILD_TESTING=${if finalAttrs.doCheck then "ON" else "OFF"}" ];
 
   doCheck = false;
 
@@ -57,7 +60,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.tests = {
     pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    iniparser-with-tests = finalAttrs.overrideAttrs (_: { doCheck = true; });
+    iniparser-with-tests = finalAttrs.overrideAttrs (_: {
+      doCheck = true;
+    });
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/iniparser/default.nix
+++ b/pkgs/development/libraries/iniparser/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitLab
-, fetchpatch
 , fetchFromGitHub
 , substituteAll
 , symlinkJoin
@@ -14,22 +13,16 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "iniparser";
-  version = "4.2.3";
+  version = "4.2.4";
 
   src = fetchFromGitLab {
     owner = "iniparser";
     repo = "iniparser";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-rCp9whYPYmVd7saVFILmpdn041u6fYGqe1/Oqc7RaeA=";
+    hash = "sha256-R069LuOmjCFj7dHXiMjuK7WUupk5+dVd8IDKY/wBn2o=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "fix-paths-pkgconfig-file.patch";
-      url = "https://gitlab.com/iniparser/iniparser/-/commit/6a76cd5e97b32014b22d87039bf6f4ee425c79a2.patch";
-      hash = "sha256-KlTxeOzwBZiLNmuwbbem5c/xspxsflyYfeUaQnGyarI=";
-    })
-  ] ++ lib.optionals finalAttrs.doCheck [
+  patches = lib.optionals finalAttrs.doCheck [
     (substituteAll {
       # Do not let cmake's fetchContent download unity
       src = ./remove-fetchcontent-usage.patch;


### PR DESCRIPTION
## Description of changes

Changes:
https://gitlab.com/iniparser/iniparser/-/releases/v4.2.4
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>13 packages built:</summary>
  <ul>
    <li>apacheHttpdPackages.mod_tile</li>
    <li>cava</li>
    <li>cavalier</li>
    <li>deepin.dde-control-center</li>
    <li>deepin.dde-control-center.dev</li>
    <li>deepin.dde-gsettings-schemas</li>
    <li>deepin.dde-network-core</li>
    <li>deepin.dde-session-shell</li>
    <li>deepin.dde-session-shell.dev</li>
    <li>deepin.deepin-pw-check</li>
    <li>iniparser</li>
    <li>mpd-notification</li>
    <li>waybar</li>
  </ul>
</details>
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
