### PR TITLE
cargo,clippy,rustc,rustfmt: 1.78.0 -> 1.79.0

### DIFF
--- a/pkgs/development/compilers/rust/1_79.nix
+++ b/pkgs/development/compilers/rust/1_79.nix
@@ -19,8 +19,8 @@
 } @ args:
 
 import ./default.nix {
-  rustcVersion = "1.78.0";
-  rustcSha256 = "/1RII6XLJ/JzgShXfx5+AO6PTIPyo0h4GuT8NV6R1ak=";
+  rustcVersion = "1.79.0";
+  rustcSha256 = "sha256-Fy7PPH0fnZ+xbNKmKIaXgmcEFt7QEp5SSoZ1H5YUSMA=";
 
   llvmSharedForBuild = pkgsBuildBuild.llvmPackages_18.libllvm.override { enableSharedLibraries = true; };
   llvmSharedForHost = pkgsBuildHost.llvmPackages_18.libllvm.override { enableSharedLibraries = true; };
@@ -34,25 +34,25 @@ import ./default.nix {
 
   # Note: the version MUST be one version prior to the version we're
   # building
-  bootstrapVersion = "1.77.2";
+  bootstrapVersion = "1.78.0";
 
   # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
   bootstrapHashes = {
-    i686-unknown-linux-gnu = "168e653fbc30b3a80801bc7735a79ff644651618434234959925f669bf77d1a2";
-    x86_64-unknown-linux-gnu = "b7d12b1b162c36c1fd5234b4b16856aa7eafca91d17c49787f6487cb26f4062d";
-    x86_64-unknown-linux-musl = "2e08fe23c4837a780a40ebfac601760cd6297581d21eae2f88cb59060243a375";
-    arm-unknown-linux-gnueabihf = "9f14a31dbef0153c0a7463a79cf8f9e8295b355354de41aa054953027beb70d7";
-    armv7-unknown-linux-gnueabihf = "b37649399081228244b3ff3acc6047f6c138e602c721cd500efe43715d043c5e";
-    aarch64-unknown-linux-gnu = "297c6201edd42e580f242fcd75b521b0392f6f3be02cf03ca76690fece4a74da";
-    aarch64-unknown-linux-musl = "fdd9c485f93c73a085c113b4f0fbad0989f79153079d394ec4bbac2b3804f71b";
-    x86_64-apple-darwin = "16bbbfcf0c982b35271d8904977d80fda1bb7caa7f898abceed3569a867d9cea";
-    aarch64-apple-darwin = "415bb2bc198feb0f2d8329e33c57d0890bbd57977d1ae48b17f6c7e1f632eaa7";
-    powerpc64le-unknown-linux-gnu = "79582acb339bd2d79fef095b977049049ffa04616011f1af1793fb8e98194b19";
-    riscv64gc-unknown-linux-gnu = "300fe4861e2d1f6e4c4f5e36ae7997beca8a979343a7f661237ab78a37a54648";
-    x86_64-unknown-freebsd = "72f49040fc2ed4492cddfaef3b4a9cb28d008f9f5ce5cac50802a5fca910f58c";
+    i686-unknown-linux-gnu = "8f3f5d2ab7b609ab30d584cfb5cecc3d8b16d2620fffb7643383c8a0a3881e21";
+    x86_64-unknown-linux-gnu = "1307747915e8bd925f4d5396ab2ae3d8d9c7fad564afbc358c081683d0f22e87";
+    x86_64-unknown-linux-musl = "c11ab908cbffbe98097d99ed62f5db00aa98496520b1e09583a151d36df7fca4";
+    arm-unknown-linux-gnueabihf = "2a2b1cf93b31e429624380e5b0d2bcce327274f8593b63657b863e38831f6421";
+    armv7-unknown-linux-gnueabihf = "fcce5ddb4f55bbdc9a1359a4cb6e65f2ff790d59ad228102cd472112ea65d3fe";
+    aarch64-unknown-linux-gnu = "131eda738cd977fff2c912e5838e8e9b9c260ecddc1247c0fe5473bf09c594af";
+    aarch64-unknown-linux-musl = "f328bcf109bf3eae01559b53939a9afbdb70ef30429f95109f7ea21030d60dfa";
+    x86_64-apple-darwin = "6c91ed3bd90253961fcb4a2991b8b22e042e2aaa9aba9f389f1e17008171d898";
+    aarch64-apple-darwin = "3be74c31ee8dc4f1d49e2f2888228de374138eaeca1876d0c1b1a61df6023b3b";
+    powerpc64le-unknown-linux-gnu = "c5aedb12c552daa18072e386697205fb7b91cef1e8791fe6fb74834723851388";
+    riscv64gc-unknown-linux-gnu = "847a925ace172d4c0a8d3da8d755b8678071ef73e659886128a3103bb896dcd9";
+    x86_64-unknown-freebsd = "b9cc84c60deb8da08a6c876426f8721758f4c7e7c553b4554385752ad37c63df";
   };
 
-  selectRustPackage = pkgs: pkgs.rust_1_78;
+  selectRustPackage = pkgs: pkgs.rust_1_79;
 
   rustcPatches = [ ];
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16397,11 +16397,11 @@ with pkgs;
   wrapRustcWith = { rustc-unwrapped, ... } @ args: callPackage ../build-support/rust/rustc-wrapper args;
   wrapRustc = rustc-unwrapped: wrapRustcWith { inherit rustc-unwrapped; };
 
-  rust_1_78 = callPackage ../development/compilers/rust/1_78.nix {
+  rust_1_79 = callPackage ../development/compilers/rust/1_79.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
     llvm_18 = llvmPackages_18.libllvm;
   };
-  rust = rust_1_78;
+  rust = rust_1_79;
 
   mrustc = callPackage ../development/compilers/mrustc { };
   mrustc-minicargo = callPackage ../development/compilers/mrustc/minicargo.nix { };
@@ -16409,8 +16409,8 @@ with pkgs;
     openssl = openssl_1_1;
   };
 
-  rustPackages_1_78 = rust_1_78.packages.stable;
-  rustPackages = rustPackages_1_78;
+  rustPackages_1_79 = rust_1_79.packages.stable;
+  rustPackages = rustPackages_1_79;
 
   inherit (rustPackages) cargo cargo-auditable cargo-auditable-cargo-wrapper clippy rustc rustPlatform;
 


### PR DESCRIPTION
## Description of changes

For the first time, it seems that no new kernel patch is required!

Built:
- [x] firefox on aarch64-linux
- [x] firefox on x86_64-linux
- [x] thunderbird on aarch64-linux
- [x] thunderbird on x86_64-linux
- [x] watchman on aarch64-linux
- [x] watchman on x86_64-linux
- [x] fd on aarch64-darwin
- [x] fd on aarch64-linux
- [x] fd on x86_64-darwin
- [x] fd on x86_64-linux

**Help needed testing fd on Darwin!**

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
