### PR TITLE
CHOWTapeModel,Chow{Centaur,Phaser,Kick}: rename to chow-{tape-model,centaur,phaser,kick}

### DIFF
--- a/pkgs/by-name/ch/chow-centaur/package.nix
+++ b/pkgs/by-name/ch/chow-centaur/package.nix
@@ -2,14 +2,14 @@
 , xcbutilcursor, xcbutilkeysyms, xcbutil, libXrandr, libXinerama, libXcursor
 , alsa-lib, libjack2, lv2, gcc-unwrapped }:
 
-stdenv.mkDerivation rec {
-  pname = "ChowCentaur";
+stdenv.mkDerivation (finalAttrs: {
+  pname = "chow-centaur";
   version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "jatinchowdhury18";
     repo = "KlonCentaur";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "0mrzlf4a6f25xd7z9xanpyq7ybb4al01dzpjsgi0jkmlmadyhc4h";
     fetchSubmodules = true;
   };
@@ -50,4 +50,4 @@ stdenv.mkDerivation rec {
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ magnetophon ];
   };
-}
+})

--- a/pkgs/by-name/ch/chow-kick/package.nix
+++ b/pkgs/by-name/ch/chow-kick/package.nix
@@ -35,14 +35,14 @@
 , webkitgtk
 }:
 
-stdenv.mkDerivation rec {
-  pname = "ChowKick";
+stdenv.mkDerivation (finalAttrs: {
+  pname = "chow-kick";
   version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "Chowdhury-DSP";
-    repo = pname;
-    rev = "v${version}";
+    repo = "ChowKick";
+    rev = "v${finalAttrs.version}";
     sha256 = "0amnp0p7ckbbr9dcbdnld1ryv46kvza2dj8m6hzmi7c1s4df8x5q";
     fetchSubmodules = true;
   };
@@ -91,9 +91,9 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/lib/lv2 $out/lib/vst3 $out/bin
-    cp -r ChowKick_artefacts/Release/LV2//${pname}.lv2 $out/lib/lv2
-    cp -r ChowKick_artefacts/Release/VST3/${pname}.vst3 $out/lib/vst3
-    cp ChowKick_artefacts/Release/Standalone/${pname}  $out/bin
+    cp -r ChowKick_artefacts/Release/LV2/ChowKick.lv2 $out/lib/lv2
+    cp -r ChowKick_artefacts/Release/VST3/ChowKick.vst3 $out/lib/vst3
+    cp ChowKick_artefacts/Release/Standalone/ChowKick  $out/bin
   '';
 
   meta = with lib; {
@@ -104,4 +104,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     mainProgram = "ChowKick";
   };
-}
+})

--- a/pkgs/by-name/ch/chow-phaser/package.nix
+++ b/pkgs/by-name/ch/chow-phaser/package.nix
@@ -4,14 +4,14 @@
 , libsepol, libsysprof-capture, libthai, libxkbcommon, pcre, pkg-config
 , python3, sqlite, stdenv }:
 
-stdenv.mkDerivation rec {
-  pname = "ChowPhaser";
+stdenv.mkDerivation (finalAttrs: {
+  pname = "chow-phaser";
   version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "jatinchowdhury18";
     repo = "ChowPhaser";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
     sha256 = "sha256-9wo7ZFMruG3QNvlpILSvrFh/Sx6J1qnlWc8+aQyS4tQ=";
   };
@@ -70,7 +70,8 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/jatinchowdhury18/ChowPhaser";
     description = "Phaser effect based loosely on the Schulte Compact Phasing 'A'";
     license = with licenses; [ bsd3 ];
+    mainProgram = "ChowPhaserStereo";
     maintainers = with maintainers; [ magnetophon ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/ch/chow-tape-model/package.nix
+++ b/pkgs/by-name/ch/chow-tape-model/package.nix
@@ -39,14 +39,14 @@ let
   # See here: https://forum.juce.com/t/build-fails-on-fedora-wrong-c-version/50902/2
   stdenv = gcc11Stdenv;
 in
-stdenv.mkDerivation rec {
-  pname = "CHOWTapeModel";
+stdenv.mkDerivation (finalAttrs: {
+  pname = "chow-tape-model";
   version = "2.11.4";
 
   src = fetchFromGitHub {
     owner = "jatinchowdhury18";
     repo = "AnalogTapeModel";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-WriHi68Y6hAsrwE+74JtVlAKUR9lfTczj6UK9h2FOGM=";
     fetchSubmodules = true;
   };
@@ -99,7 +99,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/lib/lv2 $out/lib/vst3 $out/lib/clap $out/bin $out/share/doc/CHOWTapeModel/
-    cd CHOWTapeModel_artefacts/${cmakeBuildType}
+    cd CHOWTapeModel_artefacts/${finalAttrs.cmakeBuildType}
     cp -r LV2/CHOWTapeModel.lv2 $out/lib/lv2
     cp -r VST3/CHOWTapeModel.vst3 $out/lib/vst3
     cp -r CLAP/CHOWTapeModel.clap $out/lib/clap
@@ -129,4 +129,4 @@ stdenv.mkDerivation rec {
     broken = stdenv.isAarch64; # since 2021-12-27 on hydra (update to 2.10): https://hydra.nixos.org/build/162558991
     mainProgram = "CHOWTapeModel";
   };
-}
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -178,6 +178,7 @@ mapAliases ({
   chocolateDoom = chocolate-doom; # Added 2023-05-01
   ChowCentaur = chow-centaur; # Added 2024-06-12
   ChowPhaser = chow-phaser; # Added 2024-06-12
+  ChowKick = chow-kick; # Added 2024-06-12
   CHOWTapeModel = chow-tape-model; # Added 2024-06-12
   chrome-gnome-shell = gnome-browser-connector; # Added 2022-07-27
   chromiumBeta = throw "'chromiumBeta' has been removed due to the lack of maintenance in nixpkgs. Consider using 'chromium' instead."; # Added 2023-10-18

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -176,6 +176,7 @@ mapAliases ({
   chia-plotter = throw "chia-plotter has been removed. see https://github.com/NixOS/nixpkgs/pull/270254"; # Added 2023-11-30
   chkservice = throw "chkservice has been removed from nixpkgs, as it has been deleted upstream"; # Added 2024-01-08
   chocolateDoom = chocolate-doom; # Added 2023-05-01
+  ChowCentaur = chow-centaur; # Added 2024-06-12
   CHOWTapeModel = chow-tape-model; # Added 2024-06-12
   chrome-gnome-shell = gnome-browser-connector; # Added 2022-07-27
   chromiumBeta = throw "'chromiumBeta' has been removed due to the lack of maintenance in nixpkgs. Consider using 'chromium' instead."; # Added 2023-10-18

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -177,6 +177,7 @@ mapAliases ({
   chkservice = throw "chkservice has been removed from nixpkgs, as it has been deleted upstream"; # Added 2024-01-08
   chocolateDoom = chocolate-doom; # Added 2023-05-01
   ChowCentaur = chow-centaur; # Added 2024-06-12
+  ChowPhaser = chow-phaser; # Added 2024-06-12
   CHOWTapeModel = chow-tape-model; # Added 2024-06-12
   chrome-gnome-shell = gnome-browser-connector; # Added 2022-07-27
   chromiumBeta = throw "'chromiumBeta' has been removed due to the lack of maintenance in nixpkgs. Consider using 'chromium' instead."; # Added 2023-10-18

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -176,6 +176,7 @@ mapAliases ({
   chia-plotter = throw "chia-plotter has been removed. see https://github.com/NixOS/nixpkgs/pull/270254"; # Added 2023-11-30
   chkservice = throw "chkservice has been removed from nixpkgs, as it has been deleted upstream"; # Added 2024-01-08
   chocolateDoom = chocolate-doom; # Added 2023-05-01
+  CHOWTapeModel = chow-tape-model; # Added 2024-06-12
   chrome-gnome-shell = gnome-browser-connector; # Added 2022-07-27
   chromiumBeta = throw "'chromiumBeta' has been removed due to the lack of maintenance in nixpkgs. Consider using 'chromium' instead."; # Added 2023-10-18
   chromiumDev = throw "'chromiumDev' has been removed due to the lack of maintenance in nixpkgs. Consider using 'chromium' instead."; # Added 2023-10-18

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29975,8 +29975,6 @@ with pkgs;
 
   ChowKick  = callPackage ../applications/audio/ChowKick { };
 
-  ChowPhaser  = callPackage ../applications/audio/ChowPhaser { };
-
   chromium = callPackage ../applications/networking/browsers/chromium (config.chromium or {});
 
   chuck = callPackage ../applications/audio/chuck {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29979,8 +29979,6 @@ with pkgs;
 
   ChowPhaser  = callPackage ../applications/audio/ChowPhaser { };
 
-  CHOWTapeModel = callPackage ../applications/audio/CHOWTapeModel { };
-
   chromium = callPackage ../applications/networking/browsers/chromium (config.chromium or {});
 
   chuck = callPackage ../applications/audio/chuck {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29973,8 +29973,6 @@ with pkgs;
 
   cgif = callPackage ../tools/graphics/cgif { };
 
-  ChowKick  = callPackage ../applications/audio/ChowKick { };
-
   chromium = callPackage ../applications/networking/browsers/chromium (config.chromium or {});
 
   chuck = callPackage ../applications/audio/chuck {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29973,8 +29973,6 @@ with pkgs;
 
   cgif = callPackage ../tools/graphics/cgif { };
 
-  ChowCentaur  = callPackage ../applications/audio/ChowCentaur { };
-
   ChowKick  = callPackage ../applications/audio/ChowKick { };
 
   ChowPhaser  = callPackage ../applications/audio/ChowPhaser { };


### PR DESCRIPTION
## Description of changes

renamed to fit package naming conventions
split of https://github.com/NixOS/nixpkgs/pull/319219

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
