### PR TITLE
versionCheckHook: init

### DIFF
--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -120,9 +120,10 @@ It has two modes:
 
 Checks that the output from running a command contains the specified version string in it as a whole word.
 
-Although simplistic, this test assures that the main program can run.
-While there's no substitute for a real test case, it does catch dynamic linking errors and such.
-It also provides some protection against accidentally building the wrong version, for example when using an "old" hash in a fixed-output derivation.
+NOTE: In most cases, [`versionCheckHook`](#versioncheckhook) should be preferred, but this function is provided and documented here anyway. The motivation for adding either tests would be:
+
+- Catch dynamic linking errors and such and missing environment variables that should be added by wrapping.
+- Probable protection against accidentally building the wrong version, for example when using an "old" hash in a fixed-output derivation.
 
 By default, the command to be run will be inferred from the given `package` attribute:
 it will check `meta.mainProgram` first, and fall back to `pname` or `name`.

--- a/doc/hooks/index.md
+++ b/doc/hooks/index.md
@@ -29,6 +29,7 @@ scons.section.md
 tetex-tex-live.section.md
 unzip.section.md
 validatePkgConfig.section.md
+versionCheckHook.section.md
 waf.section.md
 zig.section.md
 xcbuild.section.md

--- a/doc/hooks/versionCheckHook.section.md
+++ b/doc/hooks/versionCheckHook.section.md
@@ -1,0 +1,35 @@
+# versionCheckHook {#versioncheckhook}
+
+This hook adds a `versionCheckPhase` to the [`preInstallCheckHooks`](#ssec-installCheck-phase) that runs the main program of the derivation with a `--help` or `--version` argument, and checks that the `${version}` string is found in that output. You use it like this:
+
+```nix
+{
+  lib,
+  stdenv,
+  versionCheckHook,
+  # ...
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  # ...
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  # ...
+})
+```
+
+Note that for [`buildPythonPackage`](#buildpythonpackage-function) and [`buildPythonApplication`](#buildpythonapplication-function), `doInstallCheck` is enabled by default.
+
+It does so in a clean environment (using `env --ignore-environment`), and it checks for the `${version}` string in both the `stdout` and the `stderr` of the command. It will report to you in the build log the output it received and it will fail the build if it failed to find `${version}`.
+
+The variables that this phase control are:
+
+- `dontVersionCheck`: Disable adding this hook to the [`preDistPhases`](#var-stdenv-preDist). Useful if you do want to load the bash functions of the hook, but run them differently.
+- `versionCheckProgram`: The full path to the program that should print the `${version}` string. Defaults roughly to `${placeholder "out"}/bin/${pname}`. Using `$out` in the value of this variable won't work, as environment variables from this variable are not expanded by the hook. Hence using `placeholder` is unavoidable.
+- `versionCheckProgramArg`: The argument that needs to be passed to `versionCheckProgram`. If undefined the hook tries first `--help` and then `--version`. Examples: `version`, `-V`, `-v`.
+- `preVersionCheck`: A hook to run before the check is done.
+- `postVersionCheck`: A hook to run after the check is done.

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -762,6 +762,8 @@ Before and after running `make`, the hooks `preBuild` and `postBuild` are called
 
 The check phase checks whether the package was built correctly by running its test suite. The default `checkPhase` calls `make $checkTarget`, but only if the [`doCheck` variable](#var-stdenv-doCheck) is enabled.
 
+It is highly recommended, for packages' sources that are not distributed with any tests, to at least use [`versionCheckHook`](#versioncheckhook) to test that the resulting executable is basically functional.
+
 #### Variables controlling the check phase {#variables-controlling-the-check-phase}
 
 ##### `doCheck` {#var-stdenv-doCheck}

--- a/pkgs/applications/misc/syncthingtray/default.nix
+++ b/pkgs/applications/misc/syncthingtray/default.nix
@@ -31,6 +31,7 @@ during runtime. Alternatively, one can edit the desktop file themselves after
 it is generated See:
 https://github.com/NixOS/nixpkgs/issues/199596#issuecomment-1310136382 */
 , autostartExecPath ? "syncthingtray"
+, versionCheckHook
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -85,9 +86,10 @@ stdenv.mkDerivation (finalAttrs: {
     # Make binary available in PATH like on other platforms
     ln -s $out/Applications/syncthingtray.app/Contents/MacOS/syncthingtray $out/bin/syncthingtray
   '';
-  installCheckPhase = ''
-    $out/bin/syncthingtray --help | grep ${finalAttrs.version}
-  '';
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
 
   cmakeFlags = [
     "-DQT_PACKAGE_PREFIX=Qt${lib.versions.major qtbase.version}"

--- a/pkgs/by-name/he/hello/package.nix
+++ b/pkgs/by-name/he/hello/package.nix
@@ -4,6 +4,7 @@
 , fetchurl
 , nixos
 , testers
+, versionCheckHook
 , hello
 }:
 
@@ -19,6 +20,9 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
 
   # Give hello some install checks for testing purpose.
   postInstallCheck = ''

--- a/pkgs/by-name/ve/versionCheckHook/hook.sh
+++ b/pkgs/by-name/ve/versionCheckHook/hook.sh
@@ -1,0 +1,60 @@
+_handleCmdOutput(){
+    local versionOutput
+    versionOutput="$(env --chdir=/ --argv0="$(basename "$1")" --ignore-environment "$@" 2>&1 || true)"
+    if [[ "$versionOutput" =~ "$version" ]]; then
+        echoPrefix="Successfully managed to"
+    else
+        echoPrefix="Did not"
+    fi
+    # The return value of this function is this variable:
+    echo "$echoPrefix"
+    # And in anycase we want these to be printed in the build log, useful for
+    # debugging, so we print these to stderr.
+    echo "$echoPrefix" find version "$version" in the output of the command \
+        "$@" >&2
+    echo "$versionOutput" >&2
+}
+versionCheckHook(){
+    runHook preVersionCheck
+    echo Executing versionCheckPhase
+
+    local cmdProgram cmdArg echoPrefix
+    if [[ -z "${versionCheckProgram-}" ]]; then
+        if [[ -z "${pname-}" ]]; then
+            echo "both \$pname and \$versionCheckProgram are empty, so" \
+                "we don't know which program to run the versionCheckPhase" \
+                "upon" >&2
+            exit 2
+        else
+            cmdProgram="${!outputBin}/bin/$pname"
+        fi
+    else
+        cmdProgram="$versionCheckProgram"
+    fi
+    if [[ ! -x "$cmdProgram" ]]; then
+        echo "versionCheckHook: $cmdProgram was not found, or is not an executable" >&2
+        exit 2
+    fi
+    if [[ -z "${versionCheckProgramArg}" ]]; then
+        for cmdArg in "--help" "--version"; do
+            echoPrefix="$(_handleCmdOutput "$cmdProgram" "$cmdArg")"
+            if [[ "$echoPrefix" == "Successfully managed to" ]]; then
+                break
+            fi
+        done
+    else
+        cmdArg="$versionCheckProgramArg"
+        echoPrefix="$(_handleCmdOutput "$cmdProgram" "$cmdArg")"
+    fi
+    if [[ "$echoPrefix" == "Did not" ]]; then
+        exit 2
+    fi
+
+    runHook postVersionCheck
+    echo Finished versionCheckPhase
+}
+
+if [[ -z "${dontVersionCheck-}" ]]; then
+    echo "Using versionCheckHook"
+    preInstallCheckHooks+=(versionCheckHook)
+fi

--- a/pkgs/by-name/ve/versionCheckHook/package.nix
+++ b/pkgs/by-name/ve/versionCheckHook/package.nix
@@ -1,0 +1,12 @@
+{
+  lib,
+  makeSetupHook,
+}:
+
+makeSetupHook {
+  name = "version-check-hook";
+  meta = {
+    description = "Lookup for $version in the output of --help and --version";
+    maintainers = with lib.maintainers; [ doronbehar ];
+  };
+} ./hook.sh

--- a/pkgs/development/python-modules/ftfy/default.nix
+++ b/pkgs/development/python-modules/ftfy/default.nix
@@ -12,6 +12,7 @@
 
   # tests
   pytestCheckHook,
+  versionCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -30,7 +31,10 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ wcwidth ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    versionCheckHook
+    pytestCheckHook
+  ];
 
   preCheck = ''
     export PATH=$out/bin:$PATH


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
