### PR TITLE
gmic{,-qt}: 3.3.6 -> 3.4.0

### DIFF
--- a/pkgs/by-name/gm/gmic-qt/package.nix
+++ b/pkgs/by-name/gm/gmic-qt/package.nix
@@ -49,13 +49,13 @@ assert lib.assertMsg
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gmic-qt${lib.optionalString (variant != "standalone") "-${variant}"}";
-  version = "3.3.6";
+  version = "3.4.0";
 
   src = fetchFromGitHub {
     owner = "c-koi";
     repo = "gmic-qt";
     rev = "v.${finalAttrs.version}";
-    hash = "sha256-0MtQTc2nUF8N1IDIcRxGqfXKULl9ZjnqDt4q84jA5ow=";
+    hash = "sha256-IZMvvhWQwbnyxF3CkvEjySl3o3DB6UucpjqOFR9NjQ0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gm/gmic/package.nix
+++ b/pkgs/by-name/gm/gmic/package.nix
@@ -26,7 +26,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gmic";
-  version = "3.3.6";
+  version = "3.4.0";
 
   outputs = [ "out" "lib" "dev" "man" ];
 
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "GreycLab";
     repo = "gmic";
     rev = "v.${finalAttrs.version}";
-    hash = "sha256-gyQP+ulXLMVkNn1Bss7zlQINcTunwbP+MAsftADqtOk=";
+    hash = "sha256-uK/kgzlUvEAxRB8Wc3Inspv4/8vnjXrCilP1g/QMuCs=";
   };
 
   # TODO: build this from source
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   gmic_stdlib = fetchurl {
     name = "gmic_stdlib_community.h";
     url = "http://gmic.eu/gmic_stdlib_community${lib.replaceStrings ["."] [""] finalAttrs.version}.h";
-    hash = "sha256-mj6yOGc+CGY6oFDv9PJ7y9KABdn9DG32m2IVlLAhrsc=";
+    hash = "sha256-wq8yQ0pxEGH3sOmwmgQfRVluHAC4JBYgs2mto1PNLP4=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

https://github.com/GreycLab/gmic/compare/v.3.3.6...v.3.4.0
https://github.com/c-koi/gmic-qt/compare/v.3.3.6...v.3.4.0

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>10 packages built:</summary>
  <ul>
    <li>ansel</li>
    <li>darktable</li>
    <li>gimp-with-plugins</li>
    <li>gimpPlugins.gmic</li>
    <li>gmic</li>
    <li>gmic-qt</li>
    <li>gmic.dev</li>
    <li>gmic.lib</li>
    <li>gmic.man</li>
    <li>photoprism</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc