### PR TITLE
nixos/doc: add documentation for `formats.hocon` and `formats.libconfig`

### DIFF
--- a/nixos/doc/manual/development/settings-options.section.md
+++ b/nixos/doc/manual/development/settings-options.section.md
@@ -207,6 +207,68 @@ have a predefined type and string generator already declared under
       you will want to either use an alternative validator
       or set `doCheck = false` in the format options.
 
+`pkgs.formats.libconfig` { *`generator`* ? `<derivation>`, *`validator`* ? `<derivation>` }
+
+:  A function taking an attribute set with values
+
+    `generator`
+
+    :   A derivation used for converting the JSON output
+        from the nix settings into libconfig. This might be
+        useful if your libconfig variant is slightly different
+        from the original one, or for testing purposes.
+
+    `validator`
+
+    :   A derivation used for verifying that the libconfig
+        output is correct and parsable. This might be
+        useful if your libconfig variant is slightly different
+        from the original one, or for testing purposes.
+
+    It returns an attrset with a `type`, `generate` function,
+    and a `lib` attset, as specified [below](#pkgs-formats-result).
+    Some of the lib functions will be best understood if you have
+    read the reference specification. You can find this
+    specification here:
+
+    <https://hyperrealm.github.io/libconfig/libconfig_manual.html#Configuration-Files>
+
+    Inside of `lib`, you will find these functions
+
+    `mkHex`, `mkOctal`, `mkFloat`
+
+    :   Use these to specify numbers in other formats.
+
+        `Example usage:`
+
+        ```nix
+          let
+            format = pkgs.formats.libconfig { };
+          in {
+            myHexValue = format.lib.mkHex "0x1FC3";
+            myOctalValue = format.lib.mkOctal "0027";
+            myFloatValue = format.lib.mkFloat "1.2E-3";
+          }
+        ```
+
+    `mkArray`, `mkList`
+
+    :   Use these to differentiate between whether
+        a nix list should be considered as a libconfig
+        array or a libconfig list. See the upstream
+        documentation for the semantics behind these types.
+
+        `Example usage:`
+
+        ```nix
+          let
+            format = pkgs.formats.libconfig { };
+          in {
+            myList = format.lib.mkList [ "foo" 1 true ];
+            myArray = format.lib.mkArray [ 1 2 3 ];
+          }
+        ```
+
 `pkgs.formats.json` { }
 
 :   A function taking an empty attribute set (for future extensibility)

--- a/nixos/doc/manual/development/settings-options.section.md
+++ b/nixos/doc/manual/development/settings-options.section.md
@@ -46,6 +46,159 @@ have a predefined type and string generator already declared under
     `generate` to build a Java `.properties` file, taking
     care of the correct escaping, etc.
 
+`pkgs.formats.hocon` { *`generator`* ? `<derivation>`, *`validator`* ? `<derivation>`, *`doCheck`* ? true }
+
+:  A function taking an attribute set with values
+
+    `generator`
+
+    :   A derivation used for converting the JSON output
+        from the nix settings into HOCON. This might be
+        useful if your HOCON variant is slightly different
+        from the java-based one, or for testing purposes.
+
+    `validator`
+
+    :   A derivation used for verifying that the HOCON
+        output is correct and parsable. This might be
+        useful if your HOCON variant is slightly different
+        from the java-based one, or for testing purposes.
+
+    `doCheck`
+
+    :   Whether to enable/disable the validator check.
+
+    It returns an attrset with a `type`, `generate` function,
+    and a `lib` attset, as specified [below](#pkgs-formats-result).
+    Some of the lib functions will be best understood if you have
+    read the reference specification. You can find this
+    specification here:
+
+    <https://github.com/lightbend/config/blob/main/HOCON.md>
+
+    Inside of `lib`, you will find these functions
+
+    `mkInclude`
+
+    :   This is used together with a specially named
+        attribute `includes`, to include other HOCON
+        sources into the document.
+
+        The function has a shorthand variant where it
+        is up to the HOCON parser to figure out what type
+        of include is being used. The include will default
+        to being non-required. If you want to be more
+        explicit about the details of the include, you can
+        provide an attrset with following arguments
+
+        `required`
+
+        :   Whether the parser should fail upon failure
+            to include the document
+
+        `type`
+
+        :   Type of the source of the included document.
+            Valid values are `file`, `url` and `classpath`.
+            See upstream documentation for the semantics
+            behind each value
+
+        `value`
+
+        :   The URI/path/classpath pointing to the source of
+            the document to be included.
+
+        `Example usage:`
+
+        ```nix
+          let
+            format = pkgs.formats.hocon { };
+            hocon_file = pkgs.writeText "to_include.hocon" ''
+              a = 1;
+            '';
+          in {
+            some.nested.hocon.attrset = {
+              _includes = [
+                (format.lib.mkInclude hocon_file)
+                (format.lib.mkInclude "https://example.com/to_include.hocon")
+                (format.lib.mkInclude {
+                  required = true;
+                  type = "file";
+                  value = include_file;
+                })
+              ];
+              ...
+            };
+          }
+        ```
+
+    `mkAppend`
+
+    :   This is used to invoke the `+=` operator.
+        This can be useful if you need to add something
+        to a list that is included from outside of nix.
+        See upstream documentation for the semantics
+        behind the `+=` operation.
+
+        `Example usage:`
+
+        ```nix
+          let
+            format = pkgs.formats.hocon { };
+            hocon_file = pkgs.writeText "to_include.hocon" ''
+              a = [ 1 ];
+              b = [ 2 ];
+            '';
+          in {
+            _includes = [
+              (format.lib.mkInclude hocon_file)
+            ];
+
+            c = 3;
+            a = format.lib.mkAppend 3;
+            b = format.lib.mkAppend (format.lib.mkSubstitution "c");
+          }
+        ```
+
+    `mkSubstitution`
+
+    :   This is used to make HOCON substitutions.
+        Similarly to `mkInclude`, this function has
+        a shorthand variant where you just give it
+        the string with the substitution value.
+        The substitution is not optional by default.
+        Alternatively, you can provide an attrset
+        with more options
+
+        `optional`
+
+        :   Whether the parser should fail upon
+            failure to fetch the substitution value.
+
+        `value`
+
+        :   The name of the variable to use for
+            substitution.
+
+        See upstream documentation for semantics
+        behind the substitution functionality.
+
+        `Example usage:`
+
+        ```nix
+          let
+            format = pkgs.formats.hocon { };
+          in {
+            a = 1;
+            b = format.lib.mkSubstitution "a";
+            c = format.lib.mkSubstition "SOME_ENVVAR";
+            d = format.lib.mkSubstition {
+              value = "SOME_OPTIONAL_ENVVAR";
+              optional = true;
+            };
+          }
+        ```
+
 `pkgs.formats.json` { }
 
 :   A function taking an empty attribute set (for future extensibility)

--- a/nixos/doc/manual/development/settings-options.section.md
+++ b/nixos/doc/manual/development/settings-options.section.md
@@ -269,6 +269,14 @@ have a predefined type and string generator already declared under
           }
         ```
 
+    `Implementation notes:`
+
+    - Since libconfig does not allow setting names to start with an underscore,
+      this is used as a prefix for both special types and include directives.
+
+    - The difference between 32bit and 64bit values became optional in libconfig
+      1.5, so we assume 64bit values for all numbers.
+
 `pkgs.formats.json` { }
 
 :   A function taking an empty attribute set (for future extensibility)

--- a/nixos/doc/manual/development/settings-options.section.md
+++ b/nixos/doc/manual/development/settings-options.section.md
@@ -199,6 +199,14 @@ have a predefined type and string generator already declared under
           }
         ```
 
+    `Implementation notes:`
+
+    - classpath includes are not implemented in pyhocon,
+      which is used for validating the HOCON output. This
+      means that if you are using classpath includes,
+      you will want to either use an alternative validator
+      or set `doCheck = false` in the format options.
+
 `pkgs.formats.json` { }
 
 :   A function taking an empty attribute set (for future extensibility)

--- a/pkgs/pkgs-lib/formats/hocon/default.nix
+++ b/pkgs/pkgs-lib/formats/hocon/default.nix
@@ -27,13 +27,9 @@ let
   '';
 in
 {
-  # https://github.com/lightbend/config/blob/main/HOCON.md
   format = {
     generator ? hocon-generator
     , validator ? hocon-validator
-    # `include classpath("")` is not implemented in pyhocon.
-    # In the case that you need this functionality,
-    # you will have to disable pyhocon validation.
     , doCheck ? true
   }: let
     hoconLib = {

--- a/pkgs/pkgs-lib/formats/libconfig/default.nix
+++ b/pkgs/pkgs-lib/formats/libconfig/default.nix
@@ -3,14 +3,6 @@
 }:
 let
   inherit (pkgs) buildPackages callPackage;
-  # Implementation notes:
-  #   Libconfig spec: https://hyperrealm.github.io/libconfig/libconfig_manual.html
-  #
-  #   Since libconfig does not allow setting names to start with an underscore,
-  #   this is used as a prefix for both special types and include directives.
-  #
-  #   The difference between 32bit and 64bit values became optional in libconfig
-  #   1.5, so we assume 64bit values for all numbers.
 
   libconfig-generator = buildPackages.rustPlatform.buildRustPackage {
     name = "libconfig-generator";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added docs for HOCON and libconfig. Fixes #288163

I have built `.#htmlDocs.nixosManual.x86_64-linux` and verified that everything looks okay

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
