### PR TITLE
quickwit: enable UI

### DIFF
--- a/nixos/tests/quickwit.nix
+++ b/nixos/tests/quickwit.nix
@@ -24,6 +24,9 @@ import ./make-test-python.nix ({ lib, pkgs, ... }:
       "journalctl -o cat -u quickwit.service | grep 'transitioned to ready state'"
     )
 
+    with subtest("verify UI installed"):
+      machine.succeed("curl -sSf http://127.0.0.1:7280/ui/")
+
     quickwit.log(quickwit.succeed(
       "systemd-analyze security quickwit.service | grep -v '✓'"
     ))

--- a/nixos/tests/quickwit.nix
+++ b/nixos/tests/quickwit.nix
@@ -1,5 +1,54 @@
 import ./make-test-python.nix ({ lib, pkgs, ... }:
 
+let
+  # Define an example Quickwit index schema,
+  # and some `exampleDocs` below, to test if ingesting
+  # and querying works as expected.
+  index_yaml = ''
+    version: 0.7
+    index_id: example_server_logs
+    doc_mapping:
+      mode: dynamic
+      field_mappings:
+        - name: datetime
+          type: datetime
+          fast: true
+          input_formats:
+            - iso8601
+          output_format: iso8601
+          fast_precision: seconds
+          fast: true
+        - name: git
+          type: text
+          tokenizer: raw
+        - name: hostname
+          type: text
+          tokenizer: raw
+        - name: level
+          type: text
+          tokenizer: raw
+        - name: message
+          type: text
+        - name: location
+          type: text
+        - name: source
+          type: text
+      timestamp_field: datetime
+
+    search_settings:
+      default_search_fields: [message]
+
+    indexing_settings:
+      commit_timeout_secs: 10
+  '';
+
+  exampleDocs = ''
+    {"datetime":"2024-05-03T02:36:41.017674444Z","git":"e6e1f087ce12065e44ed3b87b50784e6f9bcc2f9","hostname":"machine-1","level":"Info","message":"Processing request done","location":"path/to/server.c:6442:32","source":""}
+    {"datetime":"2024-05-04T02:36:41.017674444Z","git":"e6e1f087ce12065e44ed3b87b50784e6f9bcc2f9","hostname":"machine-1","level":"Info","message":"Got exception processing request: HTTP 404","location":"path/to/server.c:6444:32","source":""}
+    {"datetime":"2024-05-05T02:36:41.017674444Z","git":"e6e1f087ce12065e44ed3b87b50784e6f9bcc2f9","hostname":"machine-1","level":"Info","message":"Got exception processing request: HTTP 404","location":"path/to/server.c:6444:32","source":""}
+    {"datetime":"2024-05-06T02:36:41.017674444Z","git":"e6e1f087ce12065e44ed3b87b50784e6f9bcc2f9","hostname":"machine-2","level":"Info","message":"Got exception processing request: HTTP 404","location":"path/to/server.c:6444:32","source":""}
+  '';
+in
 {
   name = "quickwit";
   meta.maintainers = [ pkgs.lib.maintainers.happysalada ];
@@ -26,6 +75,26 @@ import ./make-test-python.nix ({ lib, pkgs, ... }:
 
     with subtest("verify UI installed"):
       machine.succeed("curl -sSf http://127.0.0.1:7280/ui/")
+
+    with subtest("injest and query data"):
+      import json
+
+      # Test CLI ingestion
+      print(machine.succeed('${pkgs.quickwit}/bin/quickwit index create --index-config ${pkgs.writeText "index.yaml" index_yaml}'))
+      # Important to use `--wait`, otherwise the queries below race with index processing.
+      print(machine.succeed('${pkgs.quickwit}/bin/quickwit index ingest --index example_server_logs --input-path ${pkgs.writeText "exampleDocs.json" exampleDocs} --wait'))
+
+      # Test CLI query
+      cli_query_output = machine.succeed('${pkgs.quickwit}/bin/quickwit index search --index example_server_logs --query "exception"')
+      print(cli_query_output)
+
+      # Assert query result is as expected.
+      num_hits = len(json.loads(cli_query_output)["hits"])
+      assert num_hits == 3, f"cli_query_output contains unexpected number of results: {num_hits}"
+
+      # Test API query
+      api_query_output = machine.succeed('curl --fail http://127.0.0.1:7280/api/v1/example_server_logs/search?query=exception')
+      print(api_query_output)
 
     quickwit.log(quickwit.succeed(
       "systemd-analyze security quickwit.service | grep -v '✓'"

--- a/pkgs/servers/search/quickwit/default.nix
+++ b/pkgs/servers/search/quickwit/default.nix
@@ -7,14 +7,20 @@
 , protobuf
 , rust-jemalloc-sys
 , Security
+, nodejs
+, yarn
+, fetchYarnDeps
+, fixup-yarn-lock
 }:
 
 let
   pname = "quickwit";
   version = "0.8.1";
-in
-rustPlatform.buildRustPackage rec {
-  inherit pname version;
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = "${src}/quickwit/quickwit-ui/yarn.lock";
+    hash = "sha256-HppK9ycUxCOIagvzCmE+VfcmfMQfPIC8WeWM6WbA6fQ=";
+  };
 
   src = fetchFromGitHub {
     owner = "quickwit-oss";
@@ -22,6 +28,41 @@ rustPlatform.buildRustPackage rec {
     rev = "v${version}";
     hash = "sha256-B5U9nzXh6kj3/UnQzM3//h4hn9ippWHbeDMcMTP9XfM=";
   };
+
+  quickwit-ui = stdenv.mkDerivation {
+    name = "quickwit-ui";
+    src = "${src}/quickwit/quickwit-ui";
+
+    nativeBuildInputs = [
+      nodejs
+      yarn
+      fixup-yarn-lock
+    ];
+
+    configurePhase = ''
+      export HOME=$(mktemp -d)
+    '';
+
+    buildPhase = ''
+      yarn config --offline set yarn-offline-mirror ${yarnOfflineCache}
+      fixup-yarn-lock yarn.lock
+
+      yarn install --offline \
+        --frozen-lockfile --no-progress \
+        --ignore-engines --ignore-scripts
+      patchShebangs .
+
+      yarn build
+    '';
+
+    installPhase = ''
+      mkdir $out
+      mv build/* $out
+    '';
+  };
+in
+rustPlatform.buildRustPackage rec {
+  inherit pname version src;
 
   postPatch = ''
     substituteInPlace ./quickwit-ingest/build.rs \
@@ -33,6 +74,11 @@ rustPlatform.buildRustPackage rec {
   '';
 
   sourceRoot = "${src.name}/quickwit";
+
+  preBuild = ''
+    mkdir -p quickwit-ui/build
+    cp -r ${quickwit-ui}/* quickwit-ui/build
+  '';
 
   buildInputs = [
     rust-jemalloc-sys

--- a/pkgs/servers/search/quickwit/default.nix
+++ b/pkgs/servers/search/quickwit/default.nix
@@ -96,6 +96,9 @@ rustPlatform.buildRustPackage rec {
     };
   };
 
+  CARGO_PROFILE_RELEASE_LTO = "fat";
+  CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "1";
+
   # needed for internal protobuf c wrapper library
   PROTOC = "${protobuf}/bin/protoc";
   PROTOC_INCLUDE = "${protobuf}/include";


### PR DESCRIPTION
## Description of changes

Enables the UI shipped by Quickwit, initial derivation thanks to @tcheronneau.

Also enables full LTO build to bring down the binary size:

```
.r-xr-xr-x 120M root  1 Jan  1970 /nix/store/8zi54bviwnppqd30z5r9vhm3w4xdaq03-quickwit-0.8.1/bin/quickwit # non-LTO
.r-xr-xr-x  93M root  1 Jan  1970 /nix/store/rnm1p9nc89pkpg5x4w2vqi3xmv4b42gl-quickwit-0.8.0/bin/quickwit # 24.05
.r-xr-xr-x  94M root  1 Jan  1970 /nix/store/zrm2lhg8y0jlva1pymfvskn6nyhzhfwy-quickwit-0.8.1/bin/quickwit # LTO
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
