### PR TITLE
kodi-skyvideoitalia: init at 1.0.4

### DIFF
--- a/pkgs/applications/video/kodi/addons/skyvideoitalia/default.nix
+++ b/pkgs/applications/video/kodi/addons/skyvideoitalia/default.nix
@@ -1,0 +1,31 @@
+{ lib, rel, buildKodiAddon, fetchzip, addonUpdateScript, requests, inputstreamhelper, simplecache }:
+
+buildKodiAddon rec {
+  pname = "skyvideoitalia";
+  namespace = "plugin.video.skyvideoitalia";
+  version = "1.0.4";
+
+  src = fetchzip {
+    url = "https://mirrors.kodi.tv/addons/${lib.toLower rel}/${namespace}/${namespace}-${version}.zip";
+    sha256 = "sha256-ciLtqT++6bn7la4xRVvlRwzbbUUUPN5WU35rJpR4l+w=";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    inputstreamhelper
+    simplecache
+  ];
+
+  passthru = {
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.skyvideoitalia";
+    };
+  };
+
+  meta = with lib; {
+    homepage = "https://www.github.com/nixxo/plugin.video.skyvideoitalia";
+    description = "Show video content from the website of Sky Italia (video.sky.it). News, sport, entertainment and much more";
+    license = licenses.gpl3Plus;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -101,6 +101,8 @@ let
 
     raiplay = callPackage ../applications/video/kodi/addons/raiplay { };
 
+    skyvideoitalia = callPackage ../applications/video/kodi/addons/skyvideoitalia { };
+
     svtplay = callPackage ../applications/video/kodi/addons/svtplay { };
 
     steam-controller = callPackage ../applications/video/kodi/addons/steam-controller { };


### PR DESCRIPTION
## Description of changes

Adds the Kodi Addon Sky Video Italia, to access the contents from the website

pinging @aanderse (last time for this weekend ;) )

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tested on my HTPC

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
