### PR TITLE
dnsmap: init at 0.36-unstable-2024-08-20

### DIFF
--- a/pkgs/by-name/dn/dnsmap/package.nix
+++ b/pkgs/by-name/dn/dnsmap/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoconf,
+  automake,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dnsmap";
+  tag = "0.36";
+  version = "${finalAttrs.tag}-unstable-2024-08-20";
+
+  src = fetchFromGitHub {
+    owner = "resurrecting-open-source-projects";
+    repo = "dnsmap";
+    rev = "b5b4b1a7764e141f2551584d9fad3a973951eafe";
+    hash = "sha256-RTZe0kb/Fq9kIdnHQO//OP+Uop2Z5r22Z7+rQdCFsl4=";
+  };
+
+  strictDeps = true;
+
+  preConfigure = ''
+    autoreconf -i
+  '';
+
+  configureFlags = [ "--prefix=$(out)" ];
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+  ];
+
+  meta = {
+    description = "Scan for subdomains using brute-force techniques";
+    homepage = "https://github.com/resurrecting-open-source-projects/dnsmap";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ heywoodlh ];
+    changelog = "https://github.com/resurrecting-open-source-projects/dnsmap/releases/tag/${finalAttrs.tag}";
+    mainProgram = "dnsmap";
+  };
+})


### PR DESCRIPTION
## Description of changes

Added dnsmap

Related: https://github.com/NixOS/nixpkgs/issues/81418

(I didn't add myself as a maintainer because of [all the other open commits I have in a pending state](https://github.com/NixOS/nixpkgs/pulls?q=author%3Aheywoodlh) -- please let me know if I should add the maintainer commit to this PR as well)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
