### PR TITLE
zig: fix build on Darwin with sandbox enabled

### DIFF
--- a/pkgs/development/compilers/zig/0.12/default.nix
+++ b/pkgs/development/compilers/zig/0.12/default.nix
@@ -38,6 +38,16 @@ stdenv.mkDerivation (finalAttrs: {
       llvm
     ]);
 
+  # On Darwin, Zig calls std.zig.system.darwin.macos.detect during the build,
+  # which parses /System/Library/CoreServices/SystemVersion.plist and
+  # /System/Library/CoreServices/.SystemVersionPlatform.plist to determine the
+  # OS version. This causes the build to fail during stage 3 with
+  # OSVersionDetectionFail when the sandbox is enabled.
+  __impureHostDeps = lib.optionals stdenv.isDarwin [
+    "/System/Library/CoreServices/.SystemVersionPlatform.plist"
+    "/System/Library/CoreServices/SystemVersion.plist"
+  ];
+
   outputs = [
     "out"
     "doc"

--- a/pkgs/development/compilers/zig/0.13/default.nix
+++ b/pkgs/development/compilers/zig/0.13/default.nix
@@ -38,6 +38,16 @@ stdenv.mkDerivation (finalAttrs: {
       llvm
     ]);
 
+  # On Darwin, Zig calls std.zig.system.darwin.macos.detect during the build,
+  # which parses /System/Library/CoreServices/SystemVersion.plist and
+  # /System/Library/CoreServices/.SystemVersionPlatform.plist to determine the
+  # OS version. This causes the build to fail during stage 3 with
+  # OSVersionDetectionFail when the sandbox is enabled.
+  __impureHostDeps = lib.optionals stdenv.isDarwin [
+    "/System/Library/CoreServices/.SystemVersionPlatform.plist"
+    "/System/Library/CoreServices/SystemVersion.plist"
+  ];
+
   outputs = [
     "out"
     "doc"

--- a/pkgs/development/compilers/zig/generic.nix
+++ b/pkgs/development/compilers/zig/generic.nix
@@ -36,6 +36,16 @@ stdenv.mkDerivation (finalAttrs: {
     llvm
   ]);
 
+  # On Darwin, Zig calls std.zig.system.darwin.macos.detect during the build,
+  # which parses /System/Library/CoreServices/SystemVersion.plist and
+  # /System/Library/CoreServices/.SystemVersionPlatform.plist to determine the
+  # OS version. This causes the build to fail during stage 3 with
+  # OSVersionDetectionFail when the sandbox is enabled.
+  __impureHostDeps = lib.optionals stdenv.isDarwin [
+    "/System/Library/CoreServices/.SystemVersionPlatform.plist"
+    "/System/Library/CoreServices/SystemVersion.plist"
+  ];
+
   env.ZIG_GLOBAL_CACHE_DIR = "$TMPDIR/zig-cache";
 
   # Zig's build looks at /usr/bin/env to find dynamic linking info. This doesn't


### PR DESCRIPTION
## Description of changes

During stage 3 of compilation, Zig calls `std.zig.system.darwin.macos.detect`, [which parses /System/Library/CoreServices/.SystemVersionPlatform.plist and /System/Library/CoreServices/SystemVersion.plist][1] to determine the OS version. These paths are inaccessible when the sandbox is enabled, [which causes the build to fail with `OSVersionDetectionFail`][2]. Fix the build with the relaxed sandbox option by adding these paths to `__impureHostDeps`.

[1]: https://github.com/ziglang/zig/blob/cd62005f19ff966d2c42de4daeb9a1e4b644bf76/lib/std/zig/system/darwin/macos.zig
[2]: https://github.com/NixOS/nixpkgs/issues/287861#issuecomment-2148703491

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
