### PR TITLE
spacedrive: 0.2.14 -> 0.3.1

### DIFF
--- a/pkgs/by-name/sp/spacedrive/package.nix
+++ b/pkgs/by-name/sp/spacedrive/package.nix
@@ -1,73 +1,136 @@
-{ lib
-, pkgs
-, stdenv
-, fetchurl
-, appimageTools
-, undmg
-, nix-update-script
+{
+  lib,
+  stdenv,
+  fetchurl,
+  undmg,
+  nix-update-script,
+  #linux required
+  autoPatchelfHook,
+  dpkg,
+  gdk-pixbuf,
+  glib,
+  gst_all_1,
+  libsoup,
+  webkitgtk_4_1,
+  xdotool,
 }:
 
 let
   pname = "spacedrive";
-  version = "0.2.14";
+  version = "0.3.1";
 
-  src = fetchurl {
-    aarch64-darwin = {
-      url = "https://github.com/spacedriveapp/spacedrive/releases/download/${version}/Spacedrive-darwin-aarch64.dmg";
-      hash = "sha256-G0Ey7ewZeXegiqkAXFmS0MdaYllTphp7Buqs5/4/mWY=";
-    };
-    x86_64-darwin = {
-      url = "https://github.com/spacedriveapp/spacedrive/releases/download/${version}/Spacedrive-darwin-x86_64.dmg";
-      hash = "sha256-ypUDb94RlGqJfkf4htWKZ0UrGZ0SyCZrrAqtMuxDzDI=";
-    };
-    x86_64-linux = {
-      url = "https://github.com/spacedriveapp/spacedrive/releases/download/${version}/Spacedrive-linux-x86_64.AppImage";
-      hash = "sha256-DFJ1/uJW0BwEtJZxGpnvGC7U8YmsJTUbcuWEOAP2Bno=";
-    };
-  }.${stdenv.system} or (throw "${pname}-${version}: ${stdenv.system} is unsupported.");
+  src =
+    fetchurl
+      {
+        aarch64-darwin = {
+          url = "https://github.com/spacedriveapp/spacedrive/releases/download/${version}/Spacedrive-darwin-aarch64.dmg";
+          hash = "sha256-9E7h03zJtH8b6khDcbBsB46iVWwl48s+GJuBMOmEre4=";
+        };
+        x86_64-darwin = {
+          url = "https://github.com/spacedriveapp/spacedrive/releases/download/${version}/Spacedrive-darwin-x86_64.dmg";
+          hash = "sha256-h+B7tc6jXJUFNEMhG6ZNch+grtgUeAzfa37BDoZ6M8Q=";
+        };
+        x86_64-linux = {
+          url = "https://github.com/spacedriveapp/spacedrive/releases/download/${version}/Spacedrive-linux-x86_64.deb";
+          hash = "sha256-E1mOODG4YzBc0TPZJmKgrt/c5hp5LwzLaYPl+J5dnkg=";
+        };
+      }
+      .${stdenv.system} or (throw "${pname}-${version}: ${stdenv.system} is unsupported.");
 
   meta = {
     description = "Open source file manager, powered by a virtual distributed filesystem";
     homepage = "https://www.spacedrive.com";
     changelog = "https://github.com/spacedriveapp/spacedrive/releases/tag/${version}";
-    platforms = [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" ];
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
     license = lib.licenses.agpl3Plus;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    maintainers = with lib.maintainers; [ DataHearth heisfer mikaelfangel stepbrobd ];
+    maintainers = with lib.maintainers; [
+      DataHearth
+      heisfer
+      mikaelfangel
+      stepbrobd
+    ];
     mainProgram = "spacedrive";
   };
 
   passthru.updateScript = nix-update-script { };
 in
-if stdenv.isDarwin then stdenv.mkDerivation
-{
-  inherit pname version src meta passthru;
+if stdenv.isDarwin then
+  stdenv.mkDerivation {
+    inherit
+      pname
+      version
+      src
+      meta
+      passthru
+      ;
 
-  sourceRoot = "Spacedrive.app";
+    sourceRoot = "Spacedrive.app";
 
-  nativeBuildInputs = [ undmg ];
+    nativeBuildInputs = [ undmg ];
 
-  installPhase = ''
-    mkdir -p "$out/Applications/Spacedrive.app"
-    cp -r . "$out/Applications/Spacedrive.app"
-    mkdir -p "$out/bin"
-    ln -s "$out/Applications/Spacedrive.app/Contents/MacOS/Spacedrive" "$out/bin/spacedrive"
-  '';
-}
-else appimageTools.wrapType2 {
-  inherit pname version src meta passthru;
+    installPhase = ''
+      runHook preInstall
 
-  extraPkgs = pkgs: [ pkgs.libthai ];
+      mkdir -p "$out/Applications/Spacedrive.app"
+      cp -r . "$out/Applications/Spacedrive.app"
+      mkdir -p "$out/bin"
+      ln -s "$out/Applications/Spacedrive.app/Contents/MacOS/Spacedrive" "$out/bin/spacedrive"
 
-  extraInstallCommands =
-    let
-      appimageContents = appimageTools.extractType2 { inherit pname version src; };
-    in
-    ''
-      # Install .desktop files
-      install -Dm444 ${appimageContents}/com.spacedrive.desktop -t $out/share/applications
-      install -Dm444 ${appimageContents}/spacedrive.png -t $out/share/pixmaps
-      substituteInPlace $out/share/applications/com.spacedrive.desktop \
-        --replace 'Exec=usr/bin/spacedrive' 'Exec=spacedrive'
+      runHook postInstall
     '';
-}
+  }
+
+else
+  stdenv.mkDerivation {
+    inherit
+      pname
+      version
+      src
+      meta
+      passthru
+      ;
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+      dpkg
+    ];
+
+    # Depends: libc6, libxdo3, libwebkit2gtk-4.1-0, libgtk-3-0
+    # Recommends: gstreamer1.0-plugins-ugly
+    # Suggests: gstreamer1.0-plugins-bad
+    buildInputs = [
+      xdotool
+      glib
+      libsoup
+      webkitgtk_4_1
+      gdk-pixbuf
+      gst_all_1.gst-plugins-ugly
+      gst_all_1.gst-plugins-bad
+      gst_all_1.gst-plugins-base
+      gst_all_1.gstreamer
+    ];
+
+    unpackPhase = ''
+      runHook preUnpack
+
+      dpkg-deb -x $src .
+
+      runHook postUnpack
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin
+      cp -r usr/share $out/
+      cp -r usr/lib $out/
+      cp -r usr/bin $out/
+
+      runHook postInstall
+    '';
+  }


### PR DESCRIPTION
## Description of changes
resolves #320338 

release log: https://github.com/spacedriveapp/spacedrive/releases/tag/0.3.1
changelog: https://github.com/spacedriveapp/spacedrive/compare/0.2.14...0.3.1

Linux Note: Switched AppImage to deb.
Formatter: nixfmt-rfc-style

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
