### PR TITLE
[Backport 24.05] freebsd: various improvements and new packages

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/patches/13.1/compat-install-dirs.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/13.1/compat-install-dirs.patch
@@ -2,12 +2,11 @@ diff --git a/tools/build/Makefile b/tools/build/Makefile
 index 948a5f9dfdb..592af84eeae 100644
 --- a/tools/build/Makefile
 +++ b/tools/build/Makefile
-@@ -327,15 +327,15 @@ host-symlinks:
+@@ -327,14 +327,14 @@ host-symlinks:
  # and cross-tools stages. We do this here using mkdir since mtree may not exist
  # yet (this happens if we are crossbuilding from Linux/Mac).
  INSTALLDIR_LIST= \
 -	bin \
--	lib/casper \
 -	lib/geom \
 -	usr/include/casper \
 -	usr/include/private/ucl \
@@ -16,7 +15,6 @@ index 948a5f9dfdb..592af84eeae 100644
 -	usr/libdata/pkgconfig \
 -	usr/libexec
 +	${BINDIR} \
-+	${LIBDIR}/casper \
 +	${LIBDIR}/geom \
 +	${INCLUDEDIR}/casper \
 +	${INCLUDEDIR}/private/ucl \

--- a/pkgs/os-specific/bsd/freebsd/patches/14.0/localedef.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/14.0/localedef.patch
@@ -1,0 +1,158 @@
+diff --git a/include/_ctype.h b/include/_ctype.h
+index 91e6b1d14f6b..a6896b598da3 100644
+--- a/include/_ctype.h
++++ b/include/_ctype.h
+@@ -44,7 +44,7 @@
+ #define	__CTYPE_H_
+ 
+ #include <sys/cdefs.h>
+-#include <sys/_types.h>
++#include <sys/types.h>
+ 
+ #define	_CTYPE_A	0x00000100L		/* Alpha */
+ #define	_CTYPE_C	0x00000200L		/* Control */
+diff --git a/lib/libc/locale/collate.h b/lib/libc/locale/collate.h
+index 2d3723b49f5b..6bbff732b9d7 100644
+--- a/lib/libc/locale/collate.h
++++ b/lib/libc/locale/collate.h
+@@ -36,6 +36,7 @@
+ #ifndef _COLLATE_H_
+ #define	_COLLATE_H_
+ 
++#include <stdint.h>
+ #include <sys/cdefs.h>
+ #include <sys/types.h>
+ #include <limits.h>
+diff --git a/usr.bin/localedef/charmap.c b/usr.bin/localedef/charmap.c
+index 44b7e3292eae..79c30b7cf372 100644
+--- a/usr.bin/localedef/charmap.c
++++ b/usr.bin/localedef/charmap.c
+@@ -31,6 +31,7 @@
+ /*
+  * CHARMAP file handling for localedef.
+  */
++#include <stdint.h>
+ #include <sys/cdefs.h>
+ #include <sys/types.h>
+ #include <sys/tree.h>
+diff --git a/usr.bin/localedef/collate.c b/usr.bin/localedef/collate.c
+index 2a080773a95e..3f0030c638f5 100644
+--- a/usr.bin/localedef/collate.c
++++ b/usr.bin/localedef/collate.c
+@@ -31,6 +31,7 @@
+ /*
+  * LC_COLLATE database generation routines for localedef.
+  */
++#include <stdint.h>
+ #include <sys/cdefs.h>
+ #include <sys/types.h>
+ #include <sys/tree.h>
+diff --git a/usr.bin/localedef/ctype.c b/usr.bin/localedef/ctype.c
+index ab7b76e57b2d..846c6d6480a8 100644
+--- a/usr.bin/localedef/ctype.c
++++ b/usr.bin/localedef/ctype.c
+@@ -32,6 +32,7 @@
+ /*
+  * LC_CTYPE database generation routines for localedef.
+  */
++#include <stdint.h>
+ #include <sys/cdefs.h>
+ #include <sys/tree.h>
+ 
+diff --git a/usr.bin/localedef/localedef.c b/usr.bin/localedef/localedef.c
+index 5ff146d6f655..ed69aa1f0c0e 100644
+--- a/usr.bin/localedef/localedef.c
++++ b/usr.bin/localedef/localedef.c
+@@ -32,7 +32,7 @@
+  * POSIX localedef.
+  */
+ #include <sys/cdefs.h>
+-#include <sys/endian.h>
++#include <endian.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ 
+diff --git a/usr.bin/localedef/messages.c b/usr.bin/localedef/messages.c
+index 6b8eb9d684dd..0155821d0e56 100644
+--- a/usr.bin/localedef/messages.c
++++ b/usr.bin/localedef/messages.c
+@@ -31,6 +31,7 @@
+ /*
+  * LC_MESSAGES database generation routines for localedef.
+  */
++#include <stdint.h>
+ #include <sys/cdefs.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+diff --git a/usr.bin/localedef/monetary.c b/usr.bin/localedef/monetary.c
+index 7a77ac7e256c..7636c4deca1f 100644
+--- a/usr.bin/localedef/monetary.c
++++ b/usr.bin/localedef/monetary.c
+@@ -31,6 +31,7 @@
+ /*
+  * LC_MONETARY database generation routines for localedef.
+  */
++#include <stdint.h>
+ #include <sys/cdefs.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+diff --git a/usr.bin/localedef/numeric.c b/usr.bin/localedef/numeric.c
+index 5533b7c10e1a..9c47494f815c 100644
+--- a/usr.bin/localedef/numeric.c
++++ b/usr.bin/localedef/numeric.c
+@@ -31,6 +31,7 @@
+ /*
+  * LC_NUMERIC database generation routines for localedef.
+  */
++#include <stdint.h>
+ #include <sys/cdefs.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+diff --git a/usr.bin/localedef/parser.y b/usr.bin/localedef/parser.y
+index 23b3b54f8a6e..e01330f0152d 100644
+--- a/usr.bin/localedef/parser.y
++++ b/usr.bin/localedef/parser.y
+@@ -33,6 +33,7 @@
+  * POSIX localedef grammar.
+  */
+ 
++#include <stdint.h>
+ #include <wchar.h>
+ #include <stdio.h>
+ #include <limits.h>
+diff --git a/usr.bin/localedef/scanner.c b/usr.bin/localedef/scanner.c
+index c6d45a993f28..b17670ef4b4a 100644
+--- a/usr.bin/localedef/scanner.c
++++ b/usr.bin/localedef/scanner.c
+@@ -32,6 +32,7 @@
+  * This file contains the "scanner", which tokenizes the input files
+  * for localedef for processing by the higher level grammar processor.
+  */
++#include <stdint.h>
+ #include <sys/cdefs.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+diff --git a/usr.bin/localedef/time.c b/usr.bin/localedef/time.c
+index 7a56e244c921..0e409a742d0a 100644
+--- a/usr.bin/localedef/time.c
++++ b/usr.bin/localedef/time.c
+@@ -31,6 +31,7 @@
+ /*
+  * LC_TIME database generation routines for localedef.
+  */
++#include <stdint.h>
+ #include <sys/cdefs.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+diff --git a/usr.bin/localedef/wide.c b/usr.bin/localedef/wide.c
+index 062e120e6912..a199cddb198d 100644
+--- a/usr.bin/localedef/wide.c
++++ b/usr.bin/localedef/wide.c
+@@ -34,6 +34,7 @@
+  * to the wide character forms used internally by libc.  Unfortunately,
+  * this approach means that we need a method for each and every encoding.
+  */
++#include <stdint.h>
+ #include <sys/cdefs.h>
+ #include <ctype.h>
+ #include <stdlib.h>

--- a/pkgs/os-specific/bsd/freebsd/patches/14.0/tinfo-host-cc.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/14.0/tinfo-host-cc.patch
@@ -1,0 +1,15 @@
+--- a/lib/ncurses/tinfo/Makefile	2023-12-26 23:02:07.827892619 -0800
++++ b/lib/ncurses/tinfo/Makefile	2023-12-26 23:01:24.175546100 -0800
+@@ -282,10 +282,10 @@
+ build-tools: make_hash make_keys
+ 
+ make_keys: make_keys.c names.c ncurses_def.h ${HEADERS} ${BUILD_TOOLS_META}
+-	${CC:N${CCACHE_BIN}} -o $@ ${CFLAGS} ${NCURSES_DIR}/ncurses/tinfo/make_keys.c
++	${CC_HOST:N${CCACHE_BIN}} -o $@ ${CFLAGS} ${NCURSES_DIR}/ncurses/tinfo/make_keys.c
+ 
+ make_hash: make_hash.c hashsize.h ncurses_def.h ${HEADERS} ${BUILD_TOOLS_META}
+-	${CC:N${CCACHE_BIN}} -o $@ ${CFLAGS} -DMAIN_PROGRAM \
++	${CC_HOST:N${CCACHE_BIN}} -o $@ ${CFLAGS} -DMAIN_PROGRAM \
+ 		${NCURSES_DIR}/ncurses/tinfo/make_hash.c
+ .endif
+ .if ${MK_DIRDEPS_BUILD} == "yes" && ${MACHINE} != "host"

--- a/pkgs/os-specific/bsd/freebsd/pkgs/bin.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/bin.nix
@@ -1,0 +1,92 @@
+{
+  mkDerivation,
+  pkgsBuildBuild,
+  libjail,
+  libmd,
+  libnetbsd,
+  libcapsicum,
+  libcasper,
+  libelf,
+  libxo,
+  libncurses-tinfo,
+  libedit,
+  lib,
+  stdenv,
+  bsdSetupHook,
+  freebsdSetupHook,
+  makeMinimal,
+  install,
+  tsort,
+  lorder,
+  mandoc,
+  groff,
+  byacc,
+  gencat,
+}:
+mkDerivation {
+  pname = "bins";
+  path = "bin";
+  extraPaths = [
+    "sys/conf"
+    "sys/sys/param.h"
+    "contrib/sendmail"
+    "contrib/tcsh"
+    "usr.bin/printf"
+    "lib/libsm"
+  ];
+  buildInputs = [
+    libjail
+    libmd
+    libnetbsd
+    libcapsicum
+    libcasper
+    libelf
+    libxo
+    libncurses-tinfo
+    libedit
+  ];
+  nativeBuildInputs = [
+    bsdSetupHook
+    freebsdSetupHook
+    makeMinimal
+    install
+    tsort
+    lorder
+    mandoc
+    groff
+
+    byacc
+    gencat
+  ];
+
+  MK_TESTS = "no";
+
+  postPatch = ''
+    sed -E -i -e '/#define\tBSD.*/d' $BSDSRCDIR/sys/sys/param.h
+    sed -E -i -e '/^SYMLINKS.*/d' $BSDSRCDIR/bin/*/Makefile
+    sed -E -i -e 's/mktemp -t ka/mktemp -t kaXXXXXX/' $BSDSRCDIR/bin/sh/mkbuiltins $BSDSRCDIR/bin/sh/mktokens
+  '';
+
+  preBuild = ''
+    export NIX_CFLAGS_COMPILE="-I$BSDSRCDIR/sys $NIX_CFLAGS_COMPILE"
+
+    make -C $BSDSRCDIR/lib/libsm $makeFlags
+
+    make -C $BSDSRCDIR/bin/sh $makeFlags "CC=${pkgsBuildBuild.stdenv.cc}/bin/cc" CFLAGS="-D__unused= -D__printf0like\(a,b\)= -D__dead2=" ${
+      lib.optionalString (!stdenv.buildPlatform.isFreeBSD) "MK_PIE=no "
+    }mkbuiltins mksyntax mktokens mknodes
+    make -C $BSDSRCDIR/bin/csh $makeFlags "CC=${pkgsBuildBuild.stdenv.cc}/bin/cc" CFLAGS="-D__unused= -D__printf0like\(a,b\)= -D__dead2= -I$BSDSRCDIR/contrib/tcsh -I." ${
+      lib.optionalString (!stdenv.buildPlatform.isFreeBSD) "MK_PIE=no "
+    }gethost
+  '';
+
+  preInstall = ''
+    makeFlags="$makeFlags ROOTDIR=$out/root"
+  '';
+
+  outputs = [
+    "out"
+    "man"
+    "debug"
+  ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/boot-install.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/boot-install.nix
@@ -1,10 +1,23 @@
 { buildPackages, freebsd-lib }:
 
-# Wrap NetBSD's install
+# Wrap GNU coreutils' install
+# The -l flag causes a symlink instead of a copy to be installed, so
+# it is safe to discard during bootstrap since coreutils does not support it.
+
 buildPackages.writeShellScriptBin "boot-install" (
   freebsd-lib.install-wrapper
   + ''
+    fixed_args=()
+    while [[ ''${#args[0]} > 0 ]]; do
+      case "''${args[0]}" in
+        -l)
+          args=("''${args[@]:2}")
+          continue
+      esac
+      fixed_args+=("''${args[0]}")
+      args=("''${args[@]:1}")
+    done
 
-    ${buildPackages.netbsd.install}/bin/xinstall "''${args[@]}"
+    ${buildPackages.coreutils}/bin/install "''${fixed_args[@]}"
   ''
 )

--- a/pkgs/os-specific/bsd/freebsd/pkgs/cp.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/cp.nix
@@ -1,0 +1,10 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/cp";
+
+  extraPaths = [ "sys" ];
+
+  postPatch = ''
+    substituteInPlace $BSDSRCDIR/bin/cp/Makefile --replace 'tests' ""
+  '';
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/csu.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/csu.nix
@@ -12,7 +12,7 @@
 }:
 
 mkDerivation {
-  isStatic = true;
+  noLibc = true;
   path = "lib/csu";
   extraPaths = [
     "lib/Makefile.inc"

--- a/pkgs/os-specific/bsd/freebsd/pkgs/filterSource.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/filterSource.nix
@@ -18,6 +18,17 @@ let
     lib.concatMapStringsSep "\n" (path: "/${path}") sortedPaths
   );
 in
-runCommand "${pname}-filtered-src" { nativeBuildInputs = [ pkgsBuildBuild.rsync ]; } ''
-  rsync -a -r --files-from=${filterText} ${source}/ $out
-''
+runCommand "${pname}-filtered-src"
+  {
+    nativeBuildInputs = [
+      (pkgsBuildBuild.rsync.override {
+        enableZstd = false;
+        enableXXHash = false;
+        enableOpenSSL = false;
+        enableLZ4 = false;
+      })
+    ];
+  }
+  ''
+    rsync -a -r --files-from=${filterText} ${source}/ $out
+  ''

--- a/pkgs/os-specific/bsd/freebsd/pkgs/iconv.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/iconv.nix
@@ -1,0 +1,12 @@
+{
+  mkDerivation,
+  libcapsicum,
+  libcasper,
+}:
+mkDerivation {
+  path = "usr.bin/iconv";
+  buildInputs = [
+    libcapsicum
+    libcasper
+  ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/include/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/include/package.nix
@@ -7,7 +7,7 @@
 }:
 
 mkDerivation {
-  isStatic = true;
+  noLibc = true;
   path = "include";
 
   extraPaths = [

--- a/pkgs/os-specific/bsd/freebsd/pkgs/ldd.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/ldd.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  stdenv,
+  mkDerivation,
+  libelf,
+}:
+mkDerivation {
+  path = "usr.bin/ldd";
+  extraPaths = [
+    "libexec/rtld-elf"
+    "contrib/elftoolchain/libelf"
+  ];
+
+  buildInputs = [ libelf ];
+
+  env = {
+    NIX_CFLAGS_COMPILE = "-D_RTLD_PATH=${lib.getLib stdenv.cc.libc}/libexec/ld-elf.so.1";
+  };
+
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libc/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libc/package.nix
@@ -21,7 +21,7 @@
 }:
 
 mkDerivation {
-  isStatic = true;
+  noLibc = true;
   pname = "libc";
   path = "lib/libc";
   extraPaths =

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libcapsicum.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libcapsicum.nix
@@ -1,0 +1,1 @@
+{ mkDerivation }: mkDerivation { path = "lib/libcapsicum"; }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libcasper.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libcasper.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  stdenv,
+  mkDerivation,
+  libnv,
+}:
+mkDerivation {
+  path = "lib/libcasper/libcasper";
+  extraPaths = [
+    "lib/Makefile.inc"
+    "lib/libcasper"
+  ];
+  buildInputs = [ libnv ];
+
+  MK_TESTS = "no";
+
+  makeFlags = [
+    "STRIP=-s" # flag to install, not command
+    "CFLAGS=-DWITH_CASPER"
+  ] ++ lib.optional (!stdenv.hostPlatform.isFreeBSD) "MK_WERROR=no";
+
+  postInstall = ''
+    make -C $BSDSRCDIR/lib/libcasper/services $makeFlags CFLAGS="-DWITH_CASPER -I$out/include"
+    make -C $BSDSRCDIR/lib/libcasper/services $makeFlags install
+  '';
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libdl.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libdl.nix
@@ -1,0 +1,9 @@
+{ mkDerivation, ... }:
+mkDerivation {
+  path = "lib/libdl";
+  extraPaths = [
+    "lib/libc"
+    "libexec/rtld-elf"
+  ];
+  buildInputs = [ ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libedit.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libedit.nix
@@ -1,0 +1,7 @@
+{ mkDerivation, libncurses-tinfo }:
+mkDerivation {
+  path = "lib/libedit";
+  extraPaths = [ "contrib/libedit" ];
+  buildInputs = [ libncurses-tinfo ];
+  MK_TESTS = "no";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libelf.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libelf.nix
@@ -1,0 +1,29 @@
+{
+  mkDerivation,
+  lib,
+  bsdSetupHook,
+  freebsdSetupHook,
+  makeMinimal,
+  install,
+  m4,
+}:
+mkDerivation {
+  path = "lib/libelf";
+  extraPaths = [
+    "lib/libc"
+    "contrib/elftoolchain"
+    "sys/sys/elf32.h"
+    "sys/sys/elf64.h"
+    "sys/sys/elf_common.h"
+  ];
+  buildInputs = [ ];
+  nativeBuildInputs = [
+    bsdSetupHook
+    freebsdSetupHook
+    makeMinimal
+    install
+    m4
+  ];
+
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libjail.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libjail.nix
@@ -1,0 +1,5 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "lib/libjail";
+  MK_TESTS = "no";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libncurses-tinfo.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libncurses-tinfo.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, pkgsBuildBuild }:
+mkDerivation {
+  path = "lib/ncurses/tinfo";
+  extraPaths = [
+    "lib/ncurses"
+    "contrib/ncurses"
+    "lib/Makefile.inc"
+  ];
+  CC_HOST = "${pkgsBuildBuild.stdenv.cc}/bin/cc";
+  MK_TESTS = "no";
+  preBuild = ''
+    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -D_VA_LIST -D_VA_LIST_DECLARED -Dva_list=__builtin_va_list -D_SIZE_T -D_WCHAR_T"
+    make $makeFlags "CFLAGS=-D_VA_LIST -D_VA_LIST_DECLARED -Dva_list=__builtin_va_list -I$BSDSRCDIR/contrib/ncurses/ncurses -I$BSDSRCDIR/contrib/ncurses/include -I." ncurses_dll.h make_hash make_keys
+  '';
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libncurses.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libncurses.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  versionData,
+  mkDerivation,
+  libncurses-tinfo,
+  ...
+}:
+mkDerivation {
+  path = "lib/ncurses/ncurses";
+  extraPaths = [
+    "lib/ncurses"
+    "contrib/ncurses"
+    "lib/Makefile.inc"
+  ];
+  MK_TESTS = "no";
+  preBuild = lib.optionalString (versionData.major == 14) ''
+    make -C ../tinfo $makeFlags curses.h ncurses_dll.h ncurses_def.h
+  '';
+  buildInputs = lib.optionals (versionData.major == 14) [ libncurses-tinfo ];
+
+  # some packages depend on libncursesw.so.8
+  postInstall = ''
+    ln -s $out/lib/libncursesw.so.9 $out/lib/libncursesw.so.8
+  '';
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libxo.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libxo.nix
@@ -1,0 +1,6 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "lib/libxo";
+  extraPaths = [ "contrib/libxo" ];
+  MK_TESTS = "no";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/locale.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/locale.nix
@@ -1,0 +1,7 @@
+{ mkDerivation, libsbuf }:
+mkDerivation {
+  path = "usr.bin/locale";
+  buildInputs = [ libsbuf ];
+  extraPaths = [ "lib/libc/locale" ];
+  MK_TESTS = "no";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/localedef.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/localedef.nix
@@ -1,0 +1,39 @@
+{
+  mkDerivation,
+  lib,
+  stdenv,
+  compat,
+  bsdSetupHook,
+  byacc,
+  freebsdSetupHook,
+  makeMinimal,
+  install,
+}:
+mkDerivation (
+  {
+    path = "usr.bin/localedef";
+
+    extraPaths = [
+      "lib/libc/locale"
+      "lib/libc/stdtime"
+    ] ++ lib.optionals (!stdenv.hostPlatform.isFreeBSD) [ "." ];
+
+    nativeBuildInputs = [
+      bsdSetupHook
+      byacc
+      freebsdSetupHook
+      makeMinimal
+      install
+    ];
+
+    buildInputs = [ ];
+
+    preBuild = lib.optionalString (!stdenv.hostPlatform.isFreeBSD) ''
+      export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${compat}/include -D__unused= -D__pure= -Wno-strict-aliasing"
+      export NIX_LDFLAGS="$NIX_LDFLAGS -L${compat}/lib"
+    '';
+
+    MK_TESTS = "no";
+  }
+  // lib.optionalAttrs (!stdenv.hostPlatform.isFreeBSD) { BOOTSTRAPPING = 1; }
+)

--- a/pkgs/os-specific/bsd/freebsd/pkgs/locales.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/locales.nix
@@ -1,0 +1,51 @@
+{
+  mkDerivation,
+  lib,
+  symlinkJoin,
+  bsdSetupHook,
+  freebsdSetupHook,
+  makeMinimal,
+  install,
+  tsort,
+  lorder,
+  mandoc,
+  groff,
+  localedef,
+  allLocales ? true,
+  locales ? [ "en_US.UTF-8" ],
+}:
+let
+  build =
+    name: needsLocaledef:
+    mkDerivation {
+      path = "share/${name}";
+
+      extraPaths = lib.optional needsLocaledef "tools/tools/locale/etc/final-maps";
+      nativeBuildInputs = [
+        bsdSetupHook
+        freebsdSetupHook
+        makeMinimal
+        install
+        tsort
+        lorder
+        mandoc
+        groff
+      ] ++ lib.optional needsLocaledef localedef;
+    };
+  directories = {
+    colldef = true;
+    colldef_unicode = true;
+    ctypedef = true;
+    monetdef = false;
+    monetdef_unicode = false;
+    msgdef = false;
+    msgdef_unicode = false;
+    numericdef = false;
+    numericdef_unicode = false;
+    timedef = false;
+  };
+in
+symlinkJoin {
+  name = "freebsd-locales";
+  paths = lib.mapAttrsToList build directories;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
@@ -128,15 +128,17 @@ lib.makeOverridable (
           splitPatch =
             patchFile:
             let
+              allLines' = lib.strings.splitString "\n" (builtins.readFile patchFile);
+              allLines = builtins.filter (
+                line: !((lib.strings.hasPrefix "diff --git" line) || (lib.strings.hasPrefix "index " line))
+              ) allLines';
               foldFunc =
                 a: b:
-                if (lib.strings.hasPrefix "--- " b) then
+                if ((lib.strings.hasPrefix "--- " b) || (lib.strings.hasPrefix "diff --git " b)) then
                   (a ++ [ [ b ] ])
                 else
                   ((lib.lists.init a) ++ (lib.lists.singleton ((lib.lists.last a) ++ [ b ])));
-              partitionedPatches' = lib.lists.foldl foldFunc [ [ ] ] (
-                lib.strings.splitString "\n" (builtins.readFile patchFile)
-              );
+              partitionedPatches' = lib.lists.foldl foldFunc [ [ ] ] allLines;
               partitionedPatches =
                 if (builtins.length partitionedPatches' > 1) then
                   (lib.lists.drop 1 partitionedPatches')

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   stdenvNoCC,
+  stdenvNoLibs,
   versionData,
   writeText,
   patches,
@@ -21,7 +22,13 @@
 lib.makeOverridable (
   attrs:
   let
-    stdenv' = if attrs.noCC or false then stdenvNoCC else stdenv;
+    stdenv' =
+      if attrs.noCC or false then
+        stdenvNoCC
+      else if attrs.noLibc or false then
+        stdenvNoLibs
+      else
+        stdenv;
   in
   stdenv'.mkDerivation (
     rec {


### PR DESCRIPTION
## Description of changes

Backport of #315176. Backporting because want the keep the more nixpkgs architectural stuff in sync.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
