### PR TITLE
freebsd: various new packages to support a NixBSD system

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/lib/default.nix
+++ b/pkgs/os-specific/bsd/freebsd/lib/default.nix
@@ -1,4 +1,8 @@
-{ version }:
+{
+  version,
+  lib,
+  writeText,
+}:
 
 {
   inherit version;
@@ -15,4 +19,65 @@
     .${stdenv'.hostPlatform.parsed.cpu.name} or stdenv'.hostPlatform.parsed.cpu.name;
 
   install-wrapper = builtins.readFile ../../lib/install-wrapper.sh;
+
+  # this function takes a list of patches and a list of paths and returns a list of derivations,
+  # one per file that is patched, containing the actual patch contents. This allows us to have
+  # extract only the patches that are relevant for a given subset of the source tree.
+  # note: the "list of patches" input can be a directory containing patch files, a path or a list of valid inputs to this argument, recursively.
+  filterPatches =
+    patches: paths:
+    let
+      isDir =
+        file:
+        let
+          base = baseNameOf file;
+          type = (builtins.readDir (dirOf file)).${base} or null;
+        in
+        file == /. || type == "directory";
+      consolidatePatches =
+        patches:
+        if (lib.isDerivation patches) then
+          [ patches ]
+        else if (builtins.isPath patches) then
+          (if (isDir patches) then (lib.filesystem.listFilesRecursive patches) else [ patches ])
+        else if (builtins.isList patches) then
+          (lib.flatten (builtins.map consolidatePatches patches))
+        else
+          throw "Bad patches - must be path or derivation or list thereof";
+      consolidated = consolidatePatches patches;
+      splitPatch =
+        patchFile:
+        let
+          allLines' = lib.strings.splitString "\n" (builtins.readFile patchFile);
+          allLines = builtins.filter (
+            line: !((lib.strings.hasPrefix "diff --git" line) || (lib.strings.hasPrefix "index " line))
+          ) allLines';
+          foldFunc =
+            a: b:
+            if ((lib.strings.hasPrefix "--- " b) || (lib.strings.hasPrefix "diff --git " b)) then
+              (a ++ [ [ b ] ])
+            else
+              ((lib.lists.init a) ++ (lib.lists.singleton ((lib.lists.last a) ++ [ b ])));
+          partitionedPatches' = lib.lists.foldl foldFunc [ [ ] ] allLines;
+          partitionedPatches =
+            if (builtins.length partitionedPatches' > 1) then
+              (lib.lists.drop 1 partitionedPatches')
+            else
+              (throw "${patchFile} does not seem to be a unified patch (diff -u). this is required for FreeBSD.");
+          filterFunc =
+            patchLines:
+            let
+              prefixedPath = builtins.elemAt (builtins.split " |\t" (builtins.elemAt patchLines 1)) 2;
+              unfixedPath = lib.path.subpath.join (lib.lists.drop 1 (lib.path.subpath.components prefixedPath));
+            in
+            lib.lists.any (included: lib.path.hasPrefix (/. + ("/" + included)) (/. + ("/" + unfixedPath))) (
+              paths
+            );
+          filteredLines = builtins.filter filterFunc partitionedPatches;
+          derive = patchLines: writeText "freebsd-patch" (lib.concatLines patchLines);
+          derivedPatches = builtins.map derive filteredLines;
+        in
+        derivedPatches;
+    in
+    lib.lists.concatMap splitPatch consolidated;
 }

--- a/pkgs/os-specific/bsd/freebsd/package-set.nix
+++ b/pkgs/os-specific/bsd/freebsd/package-set.nix
@@ -7,6 +7,7 @@
   versionData,
   buildFreebsd,
   patchesRoot,
+  writeText,
 }:
 
 self:
@@ -39,6 +40,7 @@ lib.packagesFromDirectoryRecursive {
         ]
       )
     );
+    inherit lib writeText;
   };
 
   # The manual callPackages below should in principle be unnecessary, but are

--- a/pkgs/os-specific/bsd/freebsd/patches/14.0/libifconfig-no-internal.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/14.0/libifconfig-no-internal.patch
@@ -1,0 +1,36 @@
+diff --git a/lib/libifconfig/Makefile b/lib/libifconfig/Makefile
+index 6bdb202bec1d..ebc626901cfc 100644
+--- a/lib/libifconfig/Makefile
++++ b/lib/libifconfig/Makefile
+@@ -1,7 +1,6 @@
+ 
+ PACKAGE=	lib${LIB}
+ LIB=		ifconfig
+-INTERNALLIB=	true
+ 
+ LIBADD=		m
+ 
+@@ -36,8 +35,8 @@ SRCS+=	${GEN}
+ CLEANFILES+= ${GEN}
+ 
+ # If libifconfig become public uncomment those two lines
+-#INCSDIR=	${INCLUDEDIR}
+-#INCS=		libifconfig.h libifconfig_sfp.h libifconfig_sfp_tables.h
++INCSDIR=	${INCLUDEDIR}
++INCS=		libifconfig.h libifconfig_sfp.h libifconfig_sfp_tables.h
+ 
+ #MAN=		libifconfig.3
+ 
+diff --git a/lib/libifconfig/Symbol.map b/lib/libifconfig/Symbol.map
+index 2d80fb31652a..8b08947112e5 100644
+--- a/lib/libifconfig/Symbol.map
++++ b/lib/libifconfig/Symbol.map
+@@ -2,6 +2,8 @@ FBSD_1.6 {
+ 	ifconfig_bridge_get_bridge_status;
+ 	ifconfig_bridge_free_bridge_status;
+ 	ifconfig_carp_get_info;
++	ifconfig_carp_get_vhid;
++	ifconfig_carp_set_info;
+ 	ifconfig_close;
+ 	ifconfig_create_interface;
+ 	ifconfig_create_interface_vlan;

--- a/pkgs/os-specific/bsd/freebsd/patches/14.0/mount-use-path.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/14.0/mount-use-path.patch
@@ -1,0 +1,18 @@
+diff --git a/sbin/mount/mount.c b/sbin/mount/mount.c
+index 2fcc94e40818..7de6da1bb20e 100644
+--- a/sbin/mount/mount.c
++++ b/sbin/mount/mount.c
+@@ -155,12 +155,9 @@ exec_mountprog(const char *name, const char *execname, char *const argv[])
+ 		EXIT(1);
+ 	case 0:					/* Child. */
+ 		/* Go find an executable. */
+-		execvP(execname, _PATH_SYSPATH, argv);
++		execvp(execname, argv);
+ 		if (errno == ENOENT) {
+ 			xo_warn("exec %s not found", execname);
+-			if (execname[0] != '/') {
+-				xo_warnx("in path: %s", _PATH_SYSPATH);
+-			}
+ 		}
+ 		EXIT(1);
+ 	default:				/* Parent. */

--- a/pkgs/os-specific/bsd/freebsd/patches/14.0/rc-user.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/14.0/rc-user.patch
@@ -1,0 +1,17 @@
+diff --git a/libexec/rc/rc b/libexec/rc/rc
+index 0ea61a4b2c0a..d9bfb228224c 100644
+--- a/libexec/rc/rc
++++ b/libexec/rc/rc
+@@ -87,6 +87,12 @@ if ! [ -e ${firstboot_sentinel} ]; then
+ 	skip_firstboot="-s firstboot"
+ fi
+ 
++if [ -z "$USER_LOGIN" ]; then
++        skip="$skip -s user"
++else
++        skip="$skip -k user"
++fi
++
+ # Do a first pass to get everything up to $early_late_divider so that
+ # we can do a second pass that includes $local_startup directories
+ #

--- a/pkgs/os-specific/bsd/freebsd/pkgs/bintrans.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/bintrans.nix
@@ -1,0 +1,5 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "usr.bin/bintrans";
+  MK_TESTS = "no";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/bsdlabel.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/bsdlabel.nix
@@ -1,0 +1,6 @@
+{ mkDerivation, libgeom }:
+mkDerivation {
+  path = "sbin/bsdlabel";
+  extraPaths = [ "sys/geom" ];
+  buildInputs = [ libgeom ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/cap_mkdb.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/cap_mkdb.nix
@@ -1,0 +1,6 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "usr.bin/cap_mkdb";
+
+  MK_TESTS = "no";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/daemon.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/daemon.nix
@@ -1,0 +1,5 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "usr.sbin/daemon";
+  MK_TESTS = "no";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/devfs.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/devfs.nix
@@ -1,0 +1,10 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "sbin/devfs";
+
+  # These config files are mostly examples and not super useful
+  # in nixbsd
+  postPatch = ''
+    sed -i 's/^CONFS=.*$//' $BSDSRCDIR/sbin/devfs/Makefile
+  '';
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/dmesg.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/dmesg.nix
@@ -1,0 +1,6 @@
+{ mkDerivation, lib }:
+mkDerivation {
+  path = "sbin/dmesg";
+
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod-firmware.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod-firmware.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  mkDerivation,
+  fetchFromGitHub,
+  buildFreebsd,
+  sys,
+  withAmd ? true,
+  withIntel ? true,
+}:
+mkDerivation rec {
+  pname =
+    "drm-kmod-firmware" + lib.optionalString withAmd "-amd" + lib.optionalString withIntel "-intel";
+
+  version = "20230625_8";
+
+  src = fetchFromGitHub {
+    owner = "freebsd";
+    repo = "drm-kmod-firmware";
+    rev = version;
+    hash = "sha256-Ly9B0zf+YODel/X1sZYVVUVWh38faNLhkcXcjEnQwII=";
+  };
+
+  extraNativeBuildInputs = [ buildFreebsd.xargs-j ];
+
+  hardeningDisable = [
+    "pic" # generates relocations the linker can't handle
+    "stackprotector" # generates stack protection for the function generating the stack canary
+  ];
+
+  # hardeningDisable = stackprotector doesn't seem to be enough, put it in cflags too
+  NIX_CFLAGS_COMPILE = "-fno-stack-protector";
+
+  KMODS =
+    lib.optional withIntel "i915kmsfw"
+    ++ lib.optionals withAmd [
+      "amdgpukmsfw"
+      "radeonkmsfw"
+    ];
+
+  env = sys.passthru.env;
+  SYSDIR = "${sys.src}/sys";
+
+  KMODDIR = "${builtins.placeholder "out"}/kernel";
+
+  meta = with lib; {
+    description = "GPU firmware for FreeBSD drm-kmod";
+    platforms = lib.platforms.freebsd;
+    license =
+      lib.optional withAmd licenses.unfreeRedistributableFirmware
+      # Intel license prohibits modification. this will wrap firmware files in an ELF
+      ++ lib.optional withIntel licenses.unfree;
+    sourceProvenance = [ sourceTypes.binaryFirmware ];
+  };
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod-firmware.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod-firmware.nix
@@ -42,13 +42,13 @@ mkDerivation rec {
 
   KMODDIR = "${builtins.placeholder "out"}/kernel";
 
-  meta = with lib; {
+  meta = {
     description = "GPU firmware for FreeBSD drm-kmod";
     platforms = lib.platforms.freebsd;
     license =
-      lib.optional withAmd licenses.unfreeRedistributableFirmware
+      lib.optional withAmd lib.licenses.unfreeRedistributableFirmware
       # Intel license prohibits modification. this will wrap firmware files in an ELF
-      ++ lib.optional withIntel licenses.unfree;
-    sourceProvenance = [ sourceTypes.binaryFirmware ];
+      ++ lib.optional withIntel lib.licenses.unfree;
+    sourceProvenance = [ lib.sourceTypes.binaryFirmware ];
   };
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  mkDerivation,
+  fetchFromGitHub,
+  xargs-j,
+  versionData,
+  sys,
+}:
+let
+  # Based off ports tree versions
+  reldate = lib.toIntBase10 versionData.reldate;
+  branch =
+    if reldate >= 1500008 then
+      "6.1-lts"
+    else if reldate >= 1400097 then
+      "5.15-lts"
+    else if reldate >= 1302000 then
+      "5.10-lts"
+    else
+      throw "drm-kmod not supported on FreeBSD version ${reldate}";
+
+  fetchOptions = (lib.importJSON ./versions.json).${branch};
+in
+mkDerivation {
+  pname = "drm-kmod";
+  version = branch;
+
+  src = fetchFromGitHub fetchOptions;
+
+  extraNativeBuildInputs = [ xargs-j ];
+
+  hardeningDisable = [
+    "pic" # generates relocations the linker can't handle
+    "stackprotector" # generates stack protection for the function generating the stack canary
+  ];
+
+  # hardeningDisable = stackprotector doesn't seem to be enough, put it in cflags too
+  NIX_CFLAGS_COMPILE = "-fno-stack-protector";
+
+  env = sys.passthru.env;
+  SYSDIR = "${sys.src}/sys";
+
+  KMODDIR = "${builtins.placeholder "out"}/kernel";
+
+  meta = with lib; {
+    description = "Linux drm driver, ported to FreeBSD";
+    platforms = lib.platforms.freebsd;
+    license = with licenses; [
+      bsd2
+      gpl2Only
+    ];
+  };
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/package.nix
@@ -42,10 +42,10 @@ mkDerivation {
 
   KMODDIR = "${builtins.placeholder "out"}/kernel";
 
-  meta = with lib; {
+  meta = {
     description = "Linux drm driver, ported to FreeBSD";
     platforms = lib.platforms.freebsd;
-    license = with licenses; [
+    license = with lib.licenses; [
       bsd2
       gpl2Only
     ];

--- a/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/update.py
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/update.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python -p python3 nix-prefetch-github git
+
+import subprocess
+import json
+import os.path
+
+BRANCHES = ["5.10-lts", "5.15-lts", "6.1-lts"]
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+versions = dict()
+
+for branch in BRANCHES:
+    text = subprocess.check_output(
+        ["nix-prefetch-github", "freebsd", "drm-kmod", "--rev", branch, "--json"]
+    ).decode("utf-8")
+    versions[branch] = json.loads(text)
+
+with open(os.path.join(BASE_DIR, "versions.json"), "w") as out:
+    json.dump(versions, out, sort_keys=True, indent=2)
+    out.write("\n")

--- a/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/versions.json
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/versions.json
@@ -1,0 +1,20 @@
+{
+  "5.10-lts": {
+    "hash": "sha256-6v8FhaEch9fJfo0/1UXeo0bcZh5n4Y2TyAsyHmCBJgw=",
+    "owner": "freebsd",
+    "repo": "drm-kmod",
+    "rev": "e7950546196d44af502dd6abf162d1453f6f0dd0"
+  },
+  "5.15-lts": {
+    "hash": "sha256-i768QfnYo2hqxnoCEnfYqOurDSRwkAsC4qsP7TUalxc=",
+    "owner": "freebsd",
+    "repo": "drm-kmod",
+    "rev": "d7dc64fb8e63208afaca01e6d48284aa2305df35"
+  },
+  "6.1-lts": {
+    "hash": "sha256-+CsqQ0beJgoO3SSWzwLcAO8JP15oaDW9HR+bxwPaan4=",
+    "owner": "freebsd",
+    "repo": "drm-kmod",
+    "rev": "f2d6d4b58446fa45de575bae76d6435439b3ca8b"
+  }
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/fdisk.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/fdisk.nix
@@ -1,0 +1,6 @@
+{ mkDerivation, libgeom }:
+mkDerivation {
+  path = "sbin/fdisk";
+
+  buildInputs = [ libgeom ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/fsck.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/fsck.nix
@@ -1,0 +1,5 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "sbin/fsck";
+  extraPaths = [ "sbin/mount" ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/geom.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/geom.nix
@@ -1,0 +1,44 @@
+{
+  mkDerivation,
+  libgeom,
+  libufs,
+  openssl,
+}:
+let
+  libs = mkDerivation {
+    name = "geom-class-libs";
+    path = "lib/geom";
+    extraPaths = [
+      "lib/Makefile.inc"
+      "sbin/geom"
+      "sys/geom"
+
+      # geli isn't okay with just libcrypt, it wants files in here
+      "sys/crypto/sha2"
+      "sys/opencrypto"
+    ];
+
+    # libgeom needs sbuf and bsdxml but linker doesn't know that
+    buildInputs = [
+      libgeom
+      libufs
+      openssl
+    ];
+
+    # tools want geom headers but don't seem to declare it
+    preBuild = ''
+      export NIX_CFLAGS_COMPILE="-I$BSDSRCDIR/sys $NIX_CFLAGS_COMPILE";
+    '';
+  };
+in
+mkDerivation {
+  path = "sbin/geom";
+  extraPaths = [
+    "lib/Makefile.inc"
+    "lib/geom"
+  ];
+
+  GEOM_CLASS_DIR = "${libs}/lib";
+
+  buildInputs = [ libgeom ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/getent.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/getent.nix
@@ -1,0 +1,1 @@
+{ mkDerivation }: mkDerivation { path = "usr.bin/getent"; }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/getty.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/getty.nix
@@ -1,0 +1,21 @@
+{
+  mkDerivation,
+  login,
+  wrappedLogin ? null,
+}:
+mkDerivation {
+  path = "libexec/getty";
+
+  postPatch = ''
+    sed -E -i -e "s|/usr/bin/login|${
+      if (wrappedLogin != null) then wrappedLogin else "${login}/bin/login"
+    }|g" $BSDSRCDIR/libexec/getty/*.h
+  '';
+
+  MK_TESTS = "no";
+
+  postInstall = ''
+    mkdir -p $out/etc
+    cp $BSDSRCDIR/libexec/getty/gettytab $out/etc/gettytab
+  '';
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/id.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/id.nix
@@ -1,0 +1,1 @@
+{ mkDerivation }: mkDerivation { path = "usr.bin/id"; }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/ifconfig.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/ifconfig.nix
@@ -1,0 +1,24 @@
+{
+  mkDerivation,
+  compatIfNeeded,
+  libifconfig,
+  lib80211,
+  libjail,
+  libnv,
+}:
+mkDerivation {
+  path = "sbin/ifconfig";
+
+  buildInputs = compatIfNeeded ++ [
+    libifconfig
+    lib80211
+    libjail
+    libnv
+  ];
+
+  # ifconfig believes libifconfig is internal and thus PIE.
+  # We build libifconfig as an external library
+  MK_PIE = "no";
+
+  MK_TESTS = "no";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/init.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/init.nix
@@ -1,0 +1,7 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "sbin/init";
+  extraPaths = [ "sbin/mount" ];
+  NO_FSCHG = "yes";
+  MK_TESTS = "no";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/kldconfig.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/kldconfig.nix
@@ -1,0 +1,6 @@
+{ mkDerivation, lib }:
+mkDerivation {
+  path = "sbin/kldconfig";
+
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/kldload.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/kldload.nix
@@ -1,0 +1,6 @@
+{ mkDerivation, lib }:
+mkDerivation {
+  path = "sbin/kldload";
+
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/kldstat.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/kldstat.nix
@@ -1,0 +1,6 @@
+{ mkDerivation, lib }:
+mkDerivation {
+  path = "sbin/kldstat";
+
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/kldunload.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/kldunload.nix
@@ -1,0 +1,6 @@
+{ mkDerivation, lib }:
+mkDerivation {
+  path = "sbin/kldunload";
+
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/lib80211.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/lib80211.nix
@@ -1,0 +1,13 @@
+{
+  mkDerivation,
+  libsbuf,
+  libbsdxml,
+}:
+mkDerivation {
+  path = "lib/lib80211";
+  buildInputs = [
+    libsbuf
+    libbsdxml
+  ];
+  clangFixup = true;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libbsdxml.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libbsdxml.nix
@@ -1,0 +1,6 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "lib/libexpat";
+  extraPaths = [ "contrib/expat" ];
+  buildInputs = [ ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libbsm.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libbsm.nix
@@ -1,0 +1,7 @@
+{ mkDerivation, libpam }:
+mkDerivation {
+  path = "lib/libbsm";
+  extraPaths = [ "contrib/openbsm" ];
+  buildInputs = [ libpam ];
+  MK_TESTS = "no";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libgeom.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libgeom.nix
@@ -1,0 +1,17 @@
+{
+  mkDerivation,
+  libbsdxml,
+  libsbuf,
+}:
+mkDerivation {
+  path = "lib/libgeom";
+  buildInputs = [
+    libbsdxml
+    libsbuf
+  ];
+
+  makeFlags = [
+    "SHLIB_MAJOR=1"
+    "STRIP=-s"
+  ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libifconfig.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libifconfig.nix
@@ -1,0 +1,9 @@
+{ mkDerivation, buildPackages }:
+mkDerivation {
+  path = "lib/libifconfig";
+  extraPaths = [
+    "tools/lua"
+    "lib/libc/Versions.def"
+  ];
+  LUA = "${buildPackages.lua}/bin/lua";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libipsec.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libipsec.nix
@@ -1,0 +1,9 @@
+{ mkDerivation, buildPackages }:
+mkDerivation {
+  path = "lib/libipsec";
+
+  extraNativeBuildInputs = [
+    buildPackages.byacc
+    buildPackages.flex
+  ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libkiconv.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libkiconv.nix
@@ -1,0 +1,5 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "lib/libkiconv";
+  extraPaths = [ "sys" ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libpam.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libpam.nix
@@ -1,0 +1,44 @@
+{
+  mkDerivation,
+  openssl,
+  libradius,
+}:
+mkDerivation {
+  path = "lib/libpam/libpam";
+  extraPaths = [
+    "lib/libpam"
+    "contrib/openpam"
+    "lib/Makefile.inc"
+    "contrib/pam_modules"
+    "crypto/openssh"
+  ];
+  buildInputs = [
+    libradius
+    openssl
+  ];
+
+  MK_NIS = "no"; # TODO
+
+  # TODO
+  postPatch = ''
+    sed -E -i -e /pam_tacplus/d $BSDSRCDIR/lib/libpam/modules/modules.inc
+    sed -E -i -e /pam_krb5/d $BSDSRCDIR/lib/libpam/modules/modules.inc
+    sed -E -i -e /pam_ksu/d $BSDSRCDIR/lib/libpam/modules/modules.inc
+    sed -E -i -e /pam_ssh/d $BSDSRCDIR/lib/libpam/modules/modules.inc
+  '';
+
+  preBuild = ''
+    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I$BSDSRCDIR/lib/libpam/libpam -DOPENPAM_MODULES_DIRECTORY=\"$out/lib\""
+  '';
+
+  MK_TESTS = "no";
+
+  postInstall = ''
+    make $makeFlags installconfig
+
+    export NIX_LDFLAGS="$NIX_LDFLAGS -L$out/lib"
+    make -C $BSDSRCDIR/lib/libpam/modules $makeFlags
+    make -C $BSDSRCDIR/lib/libpam/modules $makeFlags install
+    make -C $BSDSRCDIR/lib/libpam/modules $makeFlags installconfig
+  '';
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libradius.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libradius.nix
@@ -1,0 +1,14 @@
+{
+  mkDerivation,
+  openssl,
+  libmd,
+}:
+mkDerivation {
+  path = "lib/libradius";
+  buildInputs = [
+    libmd
+    openssl
+  ];
+
+  MK_TESTS = "no";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libsysdecode.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libsysdecode.nix
@@ -1,0 +1,14 @@
+{ mkDerivation, stdenv }:
+mkDerivation {
+  path = "lib/libsysdecode";
+  extraPaths = [
+    "sys"
+    "libexec/rtld-elf"
+  ];
+
+  preBuild = ''
+    sed -E -i -e "s|..INCLUDEDIR.|${stdenv.cc.libc}/include|g" $BSDSRCDIR/lib/libsysdecode/Makefile
+  '';
+
+  MK_TESTS = "no";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libufs.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libufs.nix
@@ -1,0 +1,8 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "lib/libufs";
+  extraPaths = [
+    "sys/libkern"
+    "sys/ufs"
+  ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libzfs.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libzfs.nix
@@ -1,0 +1,85 @@
+{
+  mkDerivation,
+  lib,
+  libbsdxml,
+  libgeom,
+  openssl,
+  zfs-data,
+  zlib,
+}:
+# When I told you this was libzfs, I lied.
+# This is actually all the openzfs libs.
+# We need to build a bunch of them before libzfs otherwise it complains
+# For the dependency tree see sys/contrib/openzfs/lib/Makefile.am
+# or cddl/lib/Makefile
+let
+  libs = [
+    # Not really "zfs" libraries, they're solaris compatiblity libraries
+    "libspl"
+    "libumem"
+
+    # Libraires with no dependencies here execpt libumem and libspl
+    "libavl"
+    "libicp"
+    "libnvpair"
+    "libtpool"
+
+    # Depend only on the previous ones
+    "libzutil"
+    "libzfs_core"
+    "libuutil"
+
+    # Final libraries
+    "libzpool"
+    "libzfs"
+  ];
+in
+mkDerivation {
+  path = "cddl/lib/libzfs";
+  extraPaths = [
+    "cddl/Makefile.inc"
+    "cddl/compat/opensolaris"
+    "cddl/lib"
+    "sys/contrib/openzfs"
+    "sys/modules/zfs"
+  ];
+
+  buildInputs = [
+    libbsdxml
+    libgeom
+    openssl
+    zlib
+  ];
+
+  postPatch = ''
+    # libnvpair uses `struct xdr_bytesrec`, which is never defined when this is set
+    # no idea how this works upstream
+    sed -i 's/-DHAVE_XDR_BYTESREC//' $BSDSRCDIR/cddl/lib/libnvpair/Makefile
+
+    # libzfs wants some files from compatibility.d, put them in the store
+    sed -i 's|/usr/share/zfs|${zfs-data}/share/zfs|' $BSDSRCDIR/cddl/lib/libzfs/Makefile
+  '';
+
+  # If we don't specify an object directory then
+  # make will try to put openzfs objects in nonexistant directories.
+  # This one seems to work
+  preBuild =
+    ''
+      export MAKEOBJDIRPREFIX=$BSDSRCDIR/obj
+    ''
+    + lib.flip lib.concatMapStrings libs (libname: ''
+      echo "building dependency ${libname}"
+      make -C $BSDSRCDIR/cddl/lib/${libname} $makeFlags
+      make -C $BSDSRCDIR/cddl/lib/${libname} $makeFlags install
+    '');
+
+  outputs = [
+    "out"
+    "debug"
+  ];
+
+  meta = with lib; {
+    platforms = platforms.freebsd;
+    license = with licenses; [ cddl ];
+  };
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libzfs.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libzfs.nix
@@ -78,8 +78,8 @@ mkDerivation {
     "debug"
   ];
 
-  meta = with lib; {
-    platforms = platforms.freebsd;
-    license = with licenses; [ cddl ];
+  meta = {
+    platforms = lib.platforms.freebsd;
+    license = with lib.licenses; [ cddl ];
   };
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/limits.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/limits.nix
@@ -1,0 +1,6 @@
+{ mkDerivation, libutil }:
+mkDerivation {
+  path = "usr.bin/limits";
+  buildInputs = [ libutil ];
+  MK_TESTS = "no";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/login.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/login.nix
@@ -1,0 +1,28 @@
+{
+  mkDerivation,
+  libutil,
+  libpam,
+  libbsm,
+  cap_mkdb,
+}:
+mkDerivation {
+  path = "usr.bin/login";
+  buildInputs = [
+    libutil
+    libpam
+    libbsm
+  ];
+  extraNativeBuildInputs = [ cap_mkdb ];
+
+  postPatch = ''
+    sed -E -i -e "s|..DESTDIR./etc|\''${CONFDIR}|g" $BSDSRCDIR/usr.bin/login/Makefile
+  '';
+
+  MK_TESTS = "no";
+  MK_SETUID_LOGIN = "no";
+
+  postInstall = ''
+    mkdir -p $out/etc
+    make $makeFlags installconfig
+  '';
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/makefs.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/makefs.nix
@@ -1,0 +1,24 @@
+{
+  mkDerivation,
+  libnetbsd,
+  compatIfNeeded,
+  libsbuf,
+}:
+mkDerivation {
+  path = "usr.sbin/makefs";
+  extraPaths = [
+    "stand/libsa"
+    "sys/cddl/boot"
+    "sys/ufs/ffs"
+    "sbin/newfs_msdos"
+    "contrib/mtree"
+    "contrib/mknod"
+    "sys/fs/cd9660"
+  ];
+  buildInputs = compatIfNeeded ++ [
+    libnetbsd
+    libsbuf
+  ];
+  MK_TESTS = "no";
+  MK_PIE = "no";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mdconfig.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mdconfig.nix
@@ -1,0 +1,7 @@
+{ mkDerivation, libgeom }:
+mkDerivation {
+  path = "sbin/mdconfig";
+  buildInputs = [ libgeom ];
+
+  MK_TESTS = "no";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkimg.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkimg.nix
@@ -1,0 +1,6 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "usr.bin/mkimg";
+  extraPaths = [ "sys/sys/disk" ];
+  MK_TESTS = "no";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mount.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mount.nix
@@ -1,0 +1,13 @@
+{
+  mkDerivation,
+  libutil,
+  libxo,
+  ...
+}:
+mkDerivation {
+  path = "sbin/mount";
+  buildInputs = [
+    libutil
+    libxo
+  ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mount_msdosfs.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mount_msdosfs.nix
@@ -1,0 +1,6 @@
+{ mkDerivation, libkiconv }:
+mkDerivation {
+  path = "sbin/mount_msdosfs";
+  extraPaths = [ "sbin/mount" ];
+  buildInputs = [ libkiconv ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/newfs.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/newfs.nix
@@ -1,0 +1,6 @@
+{ mkDerivation, libufs }:
+mkDerivation {
+  path = "sbin/newfs";
+  extraPaths = [ "sys/geom" ];
+  buildInputs = [ libufs ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/newfs_msdos.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/newfs_msdos.nix
@@ -1,0 +1,6 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "sbin/newfs_msdos";
+
+  MK_TESTS = "no";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/newsyslog.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/newsyslog.nix
@@ -1,0 +1,15 @@
+{
+  mkDerivation,
+  compatIfNeeded,
+  libsbuf,
+}:
+mkDerivation {
+  path = "usr.sbin/newsyslog";
+
+  buildInputs = compatIfNeeded ++ [ libsbuf ];
+
+  # The only subdir is newsyslog.conf.d, all config files we don't want
+  postPatch = ''
+    sed -E -i -e '/^SUBDIR/d' $BSDSRCDIR/usr.sbin/newsyslog/Makefile
+  '';
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/nscd.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/nscd.nix
@@ -1,0 +1,5 @@
+{ mkDerivation, libutil, ... }:
+mkDerivation {
+  path = "usr.sbin/nscd";
+  buildInputs = [ libutil ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/ping.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/ping.nix
@@ -1,0 +1,24 @@
+{
+  mkDerivation,
+  lib,
+  libcasper,
+  libcapsicum,
+  libipsec,
+}:
+mkDerivation {
+  path = "sbin/ping";
+  buildInputs = [
+    libcasper
+    libcapsicum
+    libipsec
+  ];
+
+  postPatch = ''
+    sed -i 's/4555/0555/' $BSDSRCDIR/sbin/ping/Makefile
+  '';
+
+  MK_TESTS = "no";
+  clangFixup = true;
+
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/protect.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/protect.nix
@@ -1,0 +1,1 @@
+{ mkDerivation }: mkDerivation { path = "usr.bin/protect"; }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/pwd_mkdb.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/pwd_mkdb.nix
@@ -1,0 +1,6 @@
+{ mkDerivation, ... }:
+mkDerivation {
+  path = "usr.sbin/pwd_mkdb";
+
+  extraPaths = [ "lib/libc/gen" ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/rc.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/rc.nix
@@ -1,0 +1,76 @@
+{
+  mkDerivation,
+  lib,
+  sysctl,
+  bash,
+  rcorder,
+  bin,
+  stat,
+  id,
+  protect,
+  mount,
+}:
+let
+  rcDepsPath = lib.makeBinPath [
+    sysctl
+    bin
+    bash
+    rcorder
+    stat
+    id
+    mount
+    protect
+  ];
+in
+mkDerivation {
+  path = "libexec/rc";
+  MK_TESTS = "no";
+
+  postPatch =
+    ''
+      substituteInPlace "$BSDSRCDIR/libexec/rc/rc.d/Makefile" "$BSDSRCDIR/libexec/rc/Makefile" --replace-fail /etc $out/etc
+      substituteInPlace "$BSDSRCDIR/libexec/rc/rc.d/Makefile" --replace-fail /var $out/var
+    ''
+    + (
+      let
+        bins = [
+          "/sbin/sysctl"
+          "/usr/bin/protect"
+          "/usr/bin/id"
+          "/bin/ps"
+          "/bin/cpuset"
+          "/usr/bin/stat"
+          "/bin/rm"
+          "/bin/chmod"
+          "/bin/cat"
+          "/bin/sync"
+          "/bin/sleep"
+          "/bin/date"
+        ];
+        scripts = [
+          "rc"
+          "rc.initdiskless"
+          "rc.shutdown"
+          "rc.subr"
+          "rc.suspend"
+          "rc.resume"
+        ];
+        scriptPaths = "$BSDSRCDIR/libexec/rc/{${lib.concatStringsSep "," scripts}}";
+      in
+      # set PATH correctly in scripts
+      ''
+        sed -E -i -e "s|PATH=.*|PATH=${rcDepsPath}|g" ${scriptPaths}
+      ''
+      # replace executable absolute filepaths with PATH lookups
+      + lib.concatMapStringsSep "\n" (fname: ''
+        sed -E -i -e "s|${fname}|${lib.last (lib.splitString "/" fname)}|g" \
+          ${scriptPaths}'') bins
+    );
+
+  skipIncludesPhase = true;
+
+  postInstall = ''
+    makeFlags="$(sed -E -e 's/CONFDIR=[^ ]*//g' <<<"$makeFlags")"
+    make $makeFlags installconfig
+  '';
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/rcorder.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/rcorder.nix
@@ -1,0 +1,1 @@
+{ mkDerivation }: mkDerivation { path = "sbin/rcorder"; }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/reboot.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/reboot.nix
@@ -1,0 +1,6 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "sbin/reboot";
+
+  MK_TESTS = "no";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/route.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/route.nix
@@ -1,0 +1,10 @@
+{
+  mkDerivation,
+  compatIfNeeded,
+  libjail,
+}:
+mkDerivation {
+  path = "sbin/route";
+  buildInputs = compatIfNeeded ++ [ libjail ];
+  MK_TESTS = "no";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/services_mkdb.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/services_mkdb.nix
@@ -1,0 +1,8 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "usr.sbin/services_mkdb";
+  postInstall = ''
+    mkdir -p $out/etc
+    cp $BSDSRCDIR/usr.sbin/services_mkdb/services $out/etc/services
+  '';
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/shutdown.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/shutdown.nix
@@ -1,0 +1,9 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "sbin/shutdown";
+
+  MK_TESTS = "no";
+  preBuild = ''
+    sed -i 's/4554/0554/' Makefile
+  '';
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/stand-efi.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/stand-efi.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  mkDerivation,
+  include,
+  buildPackages,
+  freebsd-lib,
+  vtfontcvt,
+}:
+let
+  hostArchBsd = freebsd-lib.mkBsdArch stdenv;
+in
+mkDerivation {
+  path = "stand/efi";
+  extraPaths = [
+    "contrib/bzip2"
+    "contrib/llvm-project/compiler-rt/lib/builtins"
+    "contrib/lua"
+    "contrib/pnglite"
+    "contrib/terminus"
+    "lib/libc"
+    "lib/liblua"
+    "libexec/flua"
+    "stand"
+    "sys"
+  ];
+  extraNativeBuildInputs = [ vtfontcvt ];
+
+  makeFlags = [
+    "STRIP=-s" # flag to install, not command
+    "MK_MAN=no"
+    "MK_TESTS=no"
+    "OBJCOPY=${lib.getBin buildPackages.binutils-unwrapped}/bin/${buildPackages.binutils-unwrapped.targetPrefix}objcopy"
+  ] ++ lib.optional (!stdenv.hostPlatform.isFreeBSD) "MK_WERROR=no";
+
+  hardeningDisable = [ "stackprotector" ];
+
+  # ???
+  preBuild = ''
+    NIX_CFLAGS_COMPILE+=" -I${include}/include -I$BSDSRCDIR/sys/sys -I$BSDSRCDIR/sys/${hostArchBsd}/include"
+    export NIX_CFLAGS_COMPILE
+
+    make -C $BSDSRCDIR/stand/libsa $makeFlags
+    make -C $BSDSRCDIR/stand/ficl $makeFlags
+    make -C $BSDSRCDIR/stand/liblua $makeFlags
+  '';
+
+  postPatch = ''
+    sed -E -i -e 's|/bin/pwd|${buildPackages.coreutils}/bin/pwd|' $BSDSRCDIR/stand/defs.mk
+    #sed -E -i -e 's|-e start|-Wl,-e,start|g' $BSDSRCDIR/stand/i386/Makefile.inc $BSDSRCDIR/stand/i386/*/Makefile
+  '';
+
+  postInstall = ''
+    mkdir -p $out/bin/lua
+    cp $BSDSRCDIR/stand/lua/*.lua $out/bin/lua
+    cp -r $BSDSRCDIR/stand/defaults $out/bin/defaults
+  '';
+
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/stat.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/stat.nix
@@ -19,4 +19,6 @@ mkDerivation {
     mandoc
     groff
   ];
+
+  MK_TESTS = "no";
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/swapon.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/swapon.nix
@@ -1,0 +1,1 @@
+{ mkDerivation }: mkDerivation { path = "sbin/swapon"; }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/sys/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/sys/package.nix
@@ -1,85 +1,137 @@
 {
-  stdenv,
+  lib,
   mkDerivation,
-  freebsd-lib,
+  stdenv,
   buildPackages,
+  freebsd-lib,
+  patches,
+  filterSource,
+  applyPatches,
+  baseConfig ? "GENERIC",
+  extraFlags ? { },
   bsdSetupHook,
+  mandoc,
+  groff,
+  gawk,
   freebsdSetupHook,
   makeMinimal,
   install,
-  mandoc,
-  groff,
   config,
   rpcgen,
   file2c,
-  gawk,
-  uudecode,
+  bintrans,
   xargs-j,
 }:
-
-mkDerivation (
-  let
-    cfg = "MINIMAL";
-  in
-  rec {
+let
+  hostArchBsd = freebsd-lib.mkBsdArch stdenv;
+  filteredSource = filterSource {
+    pname = "sys";
     path = "sys";
-
-    nativeBuildInputs = [
-      bsdSetupHook
-      freebsdSetupHook
-      makeMinimal
-      install
-      mandoc
-      groff
-
-      config
-      rpcgen
-      file2c
-      gawk
-      uudecode
-      xargs-j
+    extraPaths = [ "include" ];
+  };
+  patchedSource = applyPatches {
+    src = filteredSource;
+    patches = freebsd-lib.filterPatches patches [
+      "sys"
+      "include"
     ];
-
-    # --dynamic-linker /red/herring is used when building the kernel.
-    NIX_ENFORCE_PURITY = 0;
-
-    AWK = "${buildPackages.gawk}/bin/awk";
-
-    CWARNEXTRA = "-Wno-error=shift-negative-value -Wno-address-of-packed-member";
-
-    MK_CTF = "no";
-
-    KODIR = "${builtins.placeholder "out"}/kernel";
-    KMODDIR = "${builtins.placeholder "out"}/kernel";
-    DTBDIR = "${builtins.placeholder "out"}/dbt";
-
-    KERN_DEBUGDIR = "${builtins.placeholder "out"}/debug";
-    KERN_DEBUGDIR_KODIR = "${KERN_DEBUGDIR}/kernel";
-    KERN_DEBUGDIR_KMODDIR = "${KERN_DEBUGDIR}/kernel";
-
-    skipIncludesPhase = true;
-
-    configurePhase = ''
-      runHook preConfigure
-
-      for f in conf/kmod.mk contrib/dev/acpica/acpica_prep.sh; do
-        substituteInPlace "$f" --replace 'xargs -J' 'xargs-j '
+    postPatch = ''
+      for f in sys/conf/kmod.mk sys/contrib/dev/acpica/acpica_prep.sh; do
+        substituteInPlace "$f" --replace-warn 'xargs -J' 'xargs-j '
       done
 
-      for f in conf/*.mk; do
-        substituteInPlace "$f" --replace 'KERN_DEBUGDIR}''${' 'KERN_DEBUGDIR_'
+      for f in sys/conf/*.mk; do
+        substituteInPlace "$f" --replace-quiet 'KERN_DEBUGDIR}''${' 'KERN_DEBUGDIR_'
       done
 
-      cd ${freebsd-lib.mkBsdArch stdenv}/conf
-      sed -i ${cfg} \
+      sed -i sys/${hostArchBsd}/conf/${baseConfig} \
         -e 's/WITH_CTF=1/WITH_CTF=0/' \
         -e '/KDTRACE/d'
-      config ${cfg}
+    '';
+  };
 
-      runHook postConfigure
-    '';
-    preBuild = ''
-      cd ../compile/${cfg}
-    '';
-  }
-)
+  # Kernel modules need this for kern.opts.mk
+  env =
+    {
+      MK_CTF = "no";
+    }
+    // (lib.flip lib.mapAttrs' extraFlags (
+      name: value: {
+        name = "MK_${lib.toUpper name}";
+        value = if value then "yes" else "no";
+      }
+    ));
+in
+mkDerivation rec {
+  pname = "sys";
+
+  # Patch source outside of this derivation so out-of-tree modules can use it
+  src = patchedSource;
+  path = "sys";
+  autoPickPatches = false;
+
+  nativeBuildInputs = [
+    bsdSetupHook
+    mandoc
+    groff
+    gawk
+    freebsdSetupHook
+    makeMinimal
+    install
+    config
+    rpcgen
+    file2c
+    bintrans
+    xargs-j
+  ];
+
+  # --dynamic-linker /red/herring is used when building the kernel.
+  NIX_ENFORCE_PURITY = 0;
+
+  AWK = "${buildPackages.gawk}/bin/awk";
+
+  CWARNEXTRA = "-Wno-error=shift-negative-value -Wno-address-of-packed-member";
+
+  hardeningDisable = [
+    "pic" # generates relocations the linker can't handle
+    "stackprotector" # generates stack protection for the function generating the stack canary
+  ];
+
+  # hardeningDisable = stackprotector doesn't seem to be enough, put it in cflags too
+  NIX_CFLAGS_COMPILE = "-fno-stack-protector";
+
+  inherit env;
+  passthru.env = env;
+
+  KODIR = "${builtins.placeholder "out"}/kernel";
+  KMODDIR = "${builtins.placeholder "out"}/kernel";
+  DTBDIR = "${builtins.placeholder "out"}/dbt";
+
+  KERN_DEBUGDIR = "${builtins.placeholder "debug"}/lib/debug";
+  KERN_DEBUGDIR_KODIR = "${KERN_DEBUGDIR}/kernel";
+  KERN_DEBUGDIR_KMODDIR = "${KERN_DEBUGDIR}/kernel";
+
+  skipIncludesPhase = true;
+
+  configurePhase = ''
+    runHook preConfigure
+
+    cd ${hostArchBsd}/conf
+    config ${baseConfig}
+
+    runHook postConfigure
+  '';
+  preBuild = ''
+    cd ../compile/${baseConfig}
+  '';
+
+  outputs = [
+    "out"
+    "debug"
+  ];
+
+  meta = {
+    description = "FreeBSD kernel and modules";
+    platforms = lib.platforms.freebsd;
+  };
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/sysctl.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/sysctl.nix
@@ -1,0 +1,5 @@
+{ mkDerivation, ... }:
+mkDerivation {
+  path = "sbin/sysctl";
+  MK_TESTS = "no";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/syslogd.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/syslogd.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, lib }:
+mkDerivation {
+  path = "usr.sbin/syslogd";
+
+  extraPaths = [
+    "usr.bin/wall"
+    "sys/sys"
+  ];
+
+  # These want to install some config files which we don't want
+  MK_FTP = "no";
+  MK_LPR = "no";
+  MK_PPP = "no";
+
+  MK_TESTS = "no";
+
+  meta = with lib; {
+    description = "FreeBSD syslog daemon";
+    maintainers = with maintainers; [ artemist ];
+    platforms = platforms.freebsd;
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/syslogd.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/syslogd.nix
@@ -14,10 +14,10 @@ mkDerivation {
 
   MK_TESTS = "no";
 
-  meta = with lib; {
+  meta = {
     description = "FreeBSD syslog daemon";
-    maintainers = with maintainers; [ artemist ];
-    platforms = platforms.freebsd;
-    license = licenses.bsd2;
+    maintainers = with lib.maintainers; [ artemist ];
+    platforms = lib.platforms.freebsd;
+    license = lib.licenses.bsd2;
   };
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/top.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/top.nix
@@ -1,0 +1,17 @@
+{
+  mkDerivation,
+  libjail,
+  libncurses-tinfo,
+  libutil,
+  libsbuf,
+  ...
+}:
+mkDerivation {
+  path = "usr.bin/top";
+  buildInputs = [
+    libjail
+    libncurses-tinfo
+    libutil
+    libsbuf
+  ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/truss.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/truss.nix
@@ -1,0 +1,5 @@
+{ mkDerivation, libsysdecode }:
+mkDerivation {
+  path = "usr.bin/truss";
+  buildInputs = [ libsysdecode ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/vtfontcvt.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/vtfontcvt.nix
@@ -1,0 +1,5 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "usr.bin/vtfontcvt";
+  extraPaths = [ "sys/cddl/contrib/opensolaris/common/lz4" ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/zfs-data.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/zfs-data.nix
@@ -1,0 +1,9 @@
+{ mkDerivation, lib }:
+mkDerivation {
+  path = "cddl/share/zfs/compatibility.d";
+  extraPaths = [ "sys/contrib/openzfs/cmd/zpool/compatibility.d" ];
+
+  meta = with lib; {
+    license = licenses.cddl;
+  };
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/zfs.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/zfs.nix
@@ -1,0 +1,49 @@
+{
+  mkDerivation,
+  lib,
+  libgeom,
+  libjail,
+  libzfs,
+  openssl,
+  zfs-data,
+}:
+mkDerivation {
+  path = "cddl/sbin/zfs";
+  extraPaths = [
+    "cddl/compat/opensolaris"
+    "cddl/sbin/zpool"
+    "sys/contrib/openzfs"
+    "sys/modules/zfs"
+  ];
+
+  buildInputs = [
+    libgeom
+    libjail
+    libzfs
+    openssl
+  ];
+
+  postPatch = ''
+    sed -i 's|/usr/share/zfs|${zfs-data}/share/zfs|' $BSDSRCDIR/cddl/sbin/zpool/Makefile
+  '';
+
+  # I lied, this is both zpool and zfs
+  preBuild = ''
+    make -C $BSDSRCDIR/cddl/sbin/zpool $makeFlags
+    make -C $BSDSRCDIR/cddl/sbin/zpool $makeFlags install
+  '';
+
+  outputs = [
+    "out"
+    "man"
+    "debug"
+  ];
+
+  meta = with lib; {
+    platforms = platforms.freebsd;
+    license = with licenses; [
+      cddl
+      bsd2
+    ];
+  };
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/zfs.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/zfs.nix
@@ -39,9 +39,9 @@ mkDerivation {
     "debug"
   ];
 
-  meta = with lib; {
-    platforms = platforms.freebsd;
-    license = with licenses; [
+  meta = {
+    platforms = lib.platforms.freebsd;
+    license = with lib.licenses; [
       cddl
       bsd2
     ];


### PR DESCRIPTION
## Description of changes

61 of them,1 small package diff, 1 large package diff (sys), and 1 commit modifying lib and mkDerivation. This lets us boot NixBSD!

![nixbsd neofetch](https://github.com/NixOS/nixpkgs/assets/2498805/b00c7bf2-5177-400a-9e85-b28476d5d0c8)

There are a few TODOs left in the code but I think they're fine for followup PRs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd (cross from linux)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
