### PR TITLE
nixos/akkoma: Make imports explicit

### DIFF
--- a/nixos/modules/services/web-apps/akkoma.nix
+++ b/nixos/modules/services/web-apps/akkoma.nix
@@ -1,11 +1,56 @@
 { config, lib, pkgs, ... }:
 
-with lib;
 let
+  inherit (lib)
+    any
+    attrsets
+    attrByPath
+    catAttrs
+    collect
+    concatMapStrings
+    concatStringsSep
+    escape
+    escapeShellArg
+    escapeShellArgs
+    hasInfix
+    isAttrs
+    isList
+    isStorePath
+    isString
+    mapAttrs
+    mapAttrsToList
+    optionalString
+    optionals
+    replaceStrings
+    splitString
+    substring
+    versionOlder
+
+    fileContents
+    readFile
+
+    literalExpression
+    literalMD
+    mkBefore
+    mkEnableOption
+    mkIf
+    mkMerge
+    mkOption
+    mkOptionType
+    mkPackageOption
+    types;
+
   cfg = config.services.akkoma;
   ex = cfg.config;
   db = ex.":pleroma"."Pleroma.Repo";
   web = ex.":pleroma"."Pleroma.Web.Endpoint";
+
+  format = pkgs.formats.elixirConf { elixir = cfg.package.elixirPackage; };
+  inherit (format.lib)
+    mkAtom
+    mkMap
+    mkRaw
+    mkTuple;
 
   isConfined = config.systemd.services.akkoma.confinement.enable;
   hasSmtp = (attrByPath [ ":pleroma" "Pleroma.Emails.Mailer" "adapter" "value" ] null ex) == "Swoosh.Adapters.SMTP";
@@ -96,16 +141,15 @@ let
       passAsFile = [ "code" ];
     } ''elixir "$codePath" >"$out"'');
 
-  format = pkgs.formats.elixirConf { elixir = cfg.package.elixirPackage; };
   configFile = format.generate "config.exs"
     (replaceSec
       (attrsets.updateManyAttrsByPath [{
         path = [ ":pleroma" "Pleroma.Web.Endpoint" "http" "ip" ];
         update = addr:
           if isAbsolutePath addr
-            then format.lib.mkTuple
-              [ (format.lib.mkAtom ":local") addr ]
-            else format.lib.mkRaw (erlAddr addr);
+            then mkTuple
+              [ (mkAtom ":local") addr ]
+            else mkRaw (erlAddr addr);
       }] cfg.config));
 
   writeShell = { name, text, runtimeInputs ? [ ] }:
@@ -282,7 +326,7 @@ let
         AKKOMA_CONFIG_PATH="''${RUNTIME_DIRECTORY%%:*}/config.exs" \
         ERL_EPMD_ADDRESS="${cfg.dist.address}" \
         ERL_EPMD_PORT="${toString cfg.dist.epmdPort}" \
-        ERL_FLAGS=${lib.escapeShellArg (lib.escapeShellArgs ([
+        ERL_FLAGS=${escapeShellArg (escapeShellArgs ([
           "-kernel" "inet_dist_use_interface" (erlAddr cfg.dist.address)
           "-kernel" "inet_dist_listen_min" (toString cfg.dist.portMin)
           "-kernel" "inet_dist_listen_max" (toString cfg.dist.portMax)
@@ -639,7 +683,7 @@ in {
               "Pleroma.Repo" = mkOption {
                 type = elixirValue;
                 default = {
-                  adapter = format.lib.mkRaw "Ecto.Adapters.Postgres";
+                  adapter = mkRaw "Ecto.Adapters.Postgres";
                   socket_dir = "/run/postgresql";
                   username = cfg.user;
                   database = "akkoma";
@@ -769,7 +813,7 @@ in {
               in {
                 base_url = mkOption {
                     type = types.nonEmptyStr;
-                    default = if lib.versionOlder config.system.stateVersion "24.05"
+                    default = if versionOlder config.system.stateVersion "24.05"
                               then "${httpConf.scheme}://${httpConf.host}:${builtins.toString httpConf.port}/media/"
                               else null;
                     defaultText = literalExpression ''
@@ -787,7 +831,7 @@ in {
               ":frontends" = mkOption {
                 type = elixirValue;
                 default = mapAttrs
-                  (key: val: format.lib.mkMap { name = val.name; ref = val.ref; })
+                  (key: val: mkMap { name = val.name; ref = val.ref; })
                   cfg.frontends;
                 defaultText = literalExpression ''
                   lib.mapAttrs (key: val:
@@ -816,7 +860,7 @@ in {
                 };
                 base_url = mkOption {
                     type = types.nullOr types.nonEmptyStr;
-                    default = if lib.versionOlder config.system.stateVersion "24.05"
+                    default = if versionOlder config.system.stateVersion "24.05"
                               then "${httpConf.scheme}://${httpConf.host}:${builtins.toString httpConf.port}"
                               else null;
                     defaultText = literalExpression ''
@@ -899,7 +943,7 @@ in {
               ":backends" = mkOption {
                 type = types.listOf elixirValue;
                 visible = false;
-                default = with format.lib; [
+                default = [
                   (mkTuple [ (mkRaw "ExSyslogger") (mkAtom ":ex_syslogger") ])
                 ];
               };
@@ -913,7 +957,7 @@ in {
 
                 level = mkOption {
                   type = types.nonEmptyStr;
-                  apply = format.lib.mkAtom;
+                  apply = mkAtom;
                   default = ":info";
                   example = ":warning";
                   description = ''
@@ -931,7 +975,7 @@ in {
               ":data_dir" = mkOption {
                 type = elixirValue;
                 internal = true;
-                default = format.lib.mkRaw ''
+                default = mkRaw ''
                   Path.join(System.fetch_env!("CACHE_DIRECTORY"), "tzdata")
                 '';
               };
@@ -1136,6 +1180,6 @@ in {
     };
   };
 
-  meta.maintainers = with maintainers; [ mvs ];
+  meta.maintainers = with lib.maintainers; [ mvs ];
   meta.doc = ./akkoma.md;
 }


### PR DESCRIPTION
## Description of changes

This is a non‐functional change to replace `with lib;` with explict `let inherit (lib) … in`.

In addition, a few functions from `pkgs.formats.elixirConf { … }.lib` are brought in the right scope to improve readability.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Successfully ran the module tests locally on Linux x86-64.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
