### PR TITLE
python311Packages.insightface: mark as broken on aarch64-linux

### DIFF
--- a/pkgs/development/python-modules/insightface/default.nix
+++ b/pkgs/development/python-modules/insightface/default.nix
@@ -19,12 +19,13 @@
   tensorboard,
   testers,
   tqdm,
+  stdenv,
 }:
 
 buildPythonPackage rec {
   pname = "insightface";
   version = "0.7.3";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.8";
 
@@ -33,9 +34,9 @@ buildPythonPackage rec {
     hash = "sha256-8ZH3GWEuuzcBj0GTaBRQBUTND4bm/NZ2wCPzVMZo3fc=";
   };
 
-  nativeBuildInputs = [ cython ];
+  build-system = [ cython ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     easydict
     matplotlib
     mxnet
@@ -67,11 +68,13 @@ buildPythonPackage rec {
 
   doCheck = false; # Upstream has no tests
 
-  meta = with lib; {
+  meta = {
     description = "State-of-the-art 2D and 3D Face Analysis Project";
     mainProgram = "insightface-cli";
     homepage = "https://github.com/deepinsight/insightface";
-    license = licenses.mit;
-    maintainers = with maintainers; [ oddlama ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ oddlama ];
+    # terminate called after throwing an instance of 'onnxruntime::OnnxRuntimeException'
+    broken = stdenv.system == "aarch64-linux";
   };
 }


### PR DESCRIPTION
## Description of changes

Is failing on `aarch64-linux` with:
```
Executing pythonImportsCheckPhase
Check whether the following modules can be imported: insightface insightface.app insightface.data
Error in cpuinfo: failed to parse the list of possible processors in /sys/devices/system/cpu/possible
Error in cpuinfo: failed to parse the list of present processors in /sys/devices/system/cpu/present
Error in cpuinfo: failed to parse both lists of possible and present processors
terminate called after throwing an instance of 'onnxruntime::OnnxRuntimeException'
  what():  /build/source/include/onnxruntime/core/common/logging/logging.h:294 static const onnxruntime::logging::Logger& onnxruntime::logging::LoggingManager::DefaultLogger() Attempt to use DefaultLogger but none has been registered.

/nix/store/hvkmqyqzbl4nf8i74cnlpk1i67jbyskm-python-imports-check-hook.sh/nix-support/setup-hook: line 10:   407 Aborted                 (core dumped) /nix/store/q3x28mimkawkdjlvd78jxv3s0fk25vz8-python3-3.11.9/bin/python3.11 -c 'import os; import importlib; list(map(lambda mod: importlib.import_module(mod), os.environ["pythonImportsCheck"].split()))'
```

cc @oddlama 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
