### PR TITLE
python311Packages.rioxarray: disable failing tests on aarch64-linux

### DIFF
--- a/pkgs/development/python-modules/rioxarray/default.nix
+++ b/pkgs/development/python-modules/rioxarray/default.nix
@@ -1,18 +1,21 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
-  pytestCheckHook,
   pythonOlder,
-
-  dask,
-  netcdf4,
+  fetchFromGitHub,
+  # build-system
+  setuptools,
+  # dependencies
   numpy,
   packaging,
   pyproj,
   rasterio,
-  setuptools,
   xarray,
+  # tests
+  dask,
+  netcdf4,
+  pytestCheckHook,
+  stdenv,
 }:
 
 buildPythonPackage rec {
@@ -24,13 +27,13 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "corteva";
     repo = "rioxarray";
-    rev = version;
+    rev = "refs/tags/${version}";
     hash = "sha256-bumFZQktgUqo2lyoLtDXkh6Vv5oS/wobqYpvNYy7La0=";
   };
 
   build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     numpy
     packaging
     pyproj
@@ -44,13 +47,20 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  disabledTests = [ "test_clip_geojson__no_drop" ];
+  disabledTests =
+    [ "test_clip_geojson__no_drop" ]
+    ++ lib.optionals (stdenv.hostPlatform.system == "aarch64-linux") [
+      # numerical errors
+      "test_clip_geojson"
+      "test_open_rasterio_mask_chunk_clip"
+    ];
 
   pythonImportsCheck = [ "rioxarray" ];
 
   meta = {
     description = "geospatial xarray extension powered by rasterio";
     homepage = "https://corteva.github.io/rioxarray/";
+    changelog = "https://github.com/corteva/rioxarray/releases/tag/${version}";
     license = lib.licenses.asl20;
     maintainers = lib.teams.geospatial.members;
   };


### PR DESCRIPTION
## Description of changes

All failing with `AssertionError`s:
```
>           return func(*args, **kwds)
E           AssertionError: 
E           Arrays are not almost equal to 7 decimals
E           
E           Mismatched elements: 375 / 441 (85%)
E           Max absolute difference: 7
E           Max relative difference: 0.00022836
E            x: array([[[30692, 30696, 30699, 30702, 30704, 30705, 30705, 30704, 30703],
E                   [30690, 30694, 30697, 30700, 30703, 30705, 30704, 30704, 30703],
E                   [30687, 30692, 30695, 30699, 30703, 30704, 30703, 30702, 30701],...
E            y: array([[[30696, 30699, 30702, 30704, 30705, 30705, 30704, 30703, 30701],
E                   [30694, 30697, 30700, 30703, 30705, 30704, 30704, 30703, 30700],
E                   [30692, 30695, 30699, 30703, 30704, 30703, 30702, 30701, 30698],...
```

cc @NixOS/geospatial 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
