### PR TITLE
fira-sans: 4.202 -> 4.301; fira-mono: 4.202 -> 3.2; fira: use version from fira-mono and update home page

### DIFF
--- a/pkgs/by-name/fi/fira-mono/package.nix
+++ b/pkgs/by-name/fi/fira-mono/package.nix
@@ -1,24 +1,27 @@
-{ lib, stdenvNoCC, fetchzip }:
+{ lib
+, stdenvNoCC
+, fetchzip
+}:
 
 stdenvNoCC.mkDerivation rec {
   pname = "fira-mono";
-  version = "4.202";
+  version = "3.2";
 
   src = fetchzip {
-    url = "https://github.com/mozilla/Fira/archive/${version}.zip";
-    hash = "sha256-HLReqgL0PXF5vOpwLN0GiRwnzkjGkEVEyOEV2Z4R0oQ=";
+    url = "https://bboxtype.com/downloads/Fira/Fira_Mono_${lib.replaceStrings ["."] ["_"] version}.zip";
+    hash = "sha256-Ukc+K2sdSz+vUQFD8mmwJHZQ3N68oM4fk6YzGLwzAfQ=";
   };
 
   installPhase = ''
     runHook preInstall
 
-    install -Dm644 otf/FiraMono*.otf -t $out/share/fonts/opentype
+    install -Dm644 Fonts/FiraMono_OTF*/*.otf -t $out/share/fonts/opentype
 
     runHook postInstall
   '';
 
   meta = with lib; {
-    homepage = "https://mozilla.github.io/Fira/";
+    homepage = "https://bboxtype.com/fira/";
     description = "Monospace font for Firefox OS";
     longDescription = ''
       Fira Mono is a monospace font designed by Erik Spiekermann,

--- a/pkgs/by-name/fi/fira-sans/package.nix
+++ b/pkgs/by-name/fi/fira-sans/package.nix
@@ -1,22 +1,28 @@
 { lib
 , stdenvNoCC
-, fira-mono
+, fetchzip
 }:
 
-stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation rec {
   pname = "fira-sans";
-  inherit (fira-mono) version src;
+  version = "4.301";
+
+  src = fetchzip {
+    url = "https://bboxtype.com/downloads/Fira/Download_Folder_FiraSans_${lib.replaceStrings ["."] [""] version}.zip";
+    hash = "sha256-WBt3oqPK7ACqMhilYkyFx9Ek2ugwdCDFZN+8HLRnGRs";
+    stripRoot = false;
+  };
 
   installPhase = ''
     runHook preInstall
 
-    install --mode=-x -Dt $out/share/fonts/opentype otf/FiraSans*.otf
+    install --mode=-x -Dt $out/share/fonts/opentype Download_Folder_FiraSans*/Fonts/Fira_Sans_OTF*/*/*/*.otf
 
     runHook postInstall
   '';
 
   meta = with lib; {
-    homepage = "https://mozilla.github.io/Fira/";
+    homepage = "https://bboxtype.com/fira/";
     description = "Sans-serif font for Firefox OS";
     longDescription = ''
       Fira Sans is a sans-serif font designed by Erik Spiekermann,

--- a/pkgs/by-name/fi/fira/package.nix
+++ b/pkgs/by-name/fi/fira/package.nix
@@ -6,7 +6,7 @@
 
 symlinkJoin rec {
   pname = "fira";
-  inherit (fira-mono) version;
+  inherit (fira-sans) version;
   name = "${pname}-${version}";
 
   paths = [
@@ -16,7 +16,7 @@ symlinkJoin rec {
 
   meta = {
     description = "Fira font family including Fira Sans and Fira Mono";
-    homepage = "https://mozilla.github.io/Fira/";
+    homepage = "https://bboxtype.com/fira/";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;
   };


### PR DESCRIPTION
## Description of changes

- The sources at the mozilla github repository are not up to date, after Mozilla decided to not put effort into the project anymore.

- Update home page.

- Update to latest versions:
  - fira-sans: 4.202 -> 4.301
  - fira-mono: 4.202 -> 3.2
  - fira: use version from fira-mono and update home page

Closes https://github.com/NixOS/nixpkgs/issues/320308

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
