### PR TITLE
exhibit: init at 1.2.0; enable f3d and vtk external rendering, add f3d python module

### DIFF
--- a/pkgs/applications/graphics/f3d/default.nix
+++ b/pkgs/applications/graphics/f3d/default.nix
@@ -54,6 +54,7 @@ stdenv.mkDerivation rec {
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
     "-DCMAKE_INSTALL_BINDIR=bin"
+    "-DF3D_MODULE_EXTERNAL_RENDERING=ON"
   ] ++ lib.optionals withManual [
     "-DF3D_LINUX_GENERATE_MAN=ON"
   ] ++ lib.optionals withPythonBinding [

--- a/pkgs/applications/graphics/f3d/default.nix
+++ b/pkgs/applications/graphics/f3d/default.nix
@@ -6,11 +6,11 @@
 , gzip
 , vtk_9
 , autoPatchelfHook
-, libX11
-, libGL
 , Cocoa
 , OpenGL
+, python3Packages
 , withManual ? !stdenv.isDarwin
+, withPythonBinding ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -37,7 +37,16 @@ stdenv.mkDerivation rec {
     autoPatchelfHook
   ];
 
-  buildInputs = [ vtk_9 ] ++ lib.optionals stdenv.isDarwin [ Cocoa OpenGL ];
+  buildInputs = [
+    vtk_9
+  ] ++ lib.optionals stdenv.isDarwin [
+    Cocoa
+    OpenGL
+  ] ++ lib.optionals withPythonBinding [
+    python3Packages.python
+    # Using C++ header files, not Python import
+    python3Packages.pybind11
+  ];
 
   cmakeFlags = [
     # conflict between VTK and Nixpkgs;
@@ -47,6 +56,8 @@ stdenv.mkDerivation rec {
     "-DCMAKE_INSTALL_BINDIR=bin"
   ] ++ lib.optionals withManual [
     "-DF3D_LINUX_GENERATE_MAN=ON"
+  ] ++ lib.optionals withPythonBinding [
+    "-DF3D_BINDINGS_PYTHON=ON"
   ];
 
   meta = with lib; {

--- a/pkgs/by-name/ex/exhibit/package.nix
+++ b/pkgs/by-name/ex/exhibit/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  gobject-introspection,
+  wrapGAppsHook4,
+  desktop-file-utils,
+  libadwaita,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "exhibit";
+  version = "1.2.0";
+  pyproject = false; # Built with meson
+
+  src = fetchFromGitHub {
+    owner = "Nokse22";
+    repo = "Exhibit";
+    rev = "v${version}";
+    hash = "sha256-yNS6q7XbWda2+so9QRS/c4uYaVPo7b4JCite5nzc3Eo=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gobject-introspection
+    wrapGAppsHook4
+    desktop-file-utils
+  ];
+
+  buildInputs = [ libadwaita ];
+
+  dependencies = with python3Packages; [
+    pygobject3
+    f3d
+  ];
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  meta = {
+    description = "3D model viewer for the GNOME desktop powered by f3d";
+    homepage = "https://github.com/Nokse22/Exhibit";
+    license = with lib.licenses; [
+      gpl3Plus
+      cc0
+    ];
+    mainProgram = "exhibit";
+    maintainers = with lib.maintainers; [ aleksana ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -79,8 +79,10 @@ in stdenv.mkDerivation {
     "-DCMAKE_CXX_FLAGS=-fPIC"
     "-DVTK_MODULE_USE_EXTERNAL_vtkpng=ON"
     "-DVTK_MODULE_USE_EXTERNAL_vtktiff=1"
+    "-DVTK_MODULE_ENABLE_VTK_RenderingExternal=YES"
   ] ++ lib.optionals (!stdenv.isDarwin) [
     "-DOPENGL_INCLUDE_DIR=${libGL}/include"
+    "-DVTK_OPENGL_HAS_EGL=ON"
   ] ++ [
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DCMAKE_INSTALL_INCLUDEDIR=include"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4052,6 +4052,11 @@ self: super: with self; {
 
   ezyrb = callPackage ../development/python-modules/ezyrb { };
 
+  f3d = toPythonModule (pkgs.f3d.override {
+    withPythonBinding = true;
+    python3Packages = self;
+  });
+
   f5-icontrol-rest = callPackage ../development/python-modules/f5-icontrol-rest { };
 
   f5-sdk = callPackage ../development/python-modules/f5-sdk { };


### PR DESCRIPTION
## Description of changes

![image](https://github.com/NixOS/nixpkgs/assets/42209822/5556ac3c-c6d3-4b5b-93db-02562c48cf63)

See https://github.com/Nokse22/Exhibit?tab=readme-ov-file#screenshots-credits for some testing models.

I'm not sure if the changes to vtk are justified, but it built successfully and only increased the closure size by 0.5M. EGL support is necessary to run this application under wayland.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
