### PR TITLE
wiringpi: 2.61-1 -> 3.6

### DIFF
--- a/pkgs/os-specific/linux/wiringpi/default.nix
+++ b/pkgs/os-specific/linux/wiringpi/default.nix
@@ -6,32 +6,33 @@
 }:
 
 let
-  version = "2.61-1";
-  mkSubProject = { subprj # The only mandatory argument
-  , buildInputs ? []
-  , src ? fetchFromGitHub {
-    owner = "WiringPi";
-    repo = "WiringPi";
-    rev = version;
-    sha256 = "sha256-VxAaPhaPXd9xYt663Ju6SLblqiSLizauhhuFqCqbO5M=";
-  }
-  }: stdenv.mkDerivation (finalAttrs: {
-    pname = "wiringpi-${subprj}";
-    inherit version src;
-    sourceRoot = "${src.name}/${subprj}";
-    inherit buildInputs;
-    # Remove (meant for other OSs) lines from Makefiles
-    preInstall = ''
-      sed -i "/chown root/d" Makefile
-      sed -i "/chmod/d" Makefile
-    '';
-    makeFlags = [
-      "DESTDIR=${placeholder "out"}"
-      "PREFIX=/."
-      # On NixOS we don't need to run ldconfig during build:
-      "LDCONFIG=echo"
-    ];
-  });
+  version = "3.6";
+  mkSubProject =
+    { subprj # The only mandatory argument
+    , buildInputs ? [ ]
+    , src ? fetchFromGitHub {
+        owner = "WiringPi";
+        repo = "WiringPi";
+        rev = version;
+        sha256 = "sha256-Hw81Ua9LTb/9l3Js1rx8TfCOF59MrrvH6AGsAsG1SoE=";
+      }
+    }: stdenv.mkDerivation (finalAttrs: {
+      pname = "wiringpi-${subprj}";
+      inherit version src;
+      sourceRoot = "${src.name}/${subprj}";
+      inherit buildInputs;
+      # Remove (meant for other OSs) lines from Makefiles
+      preInstall = ''
+        sed -i "/chown root/d" Makefile
+        sed -i "/chmod/d" Makefile
+      '';
+      makeFlags = [
+        "DESTDIR=${placeholder "out"}"
+        "PREFIX=/."
+        # On NixOS we don't need to run ldconfig during build:
+        "LDCONFIG=echo"
+      ];
+    });
   passthru = {
     inherit mkSubProject;
     wiringPi = mkSubProject {


### PR DESCRIPTION
## Description of changes

wiringpi: 2.61-1 -> 3.6

Since `linuxKernel.kernels.linux_rpi4` upgrade to `6.1.63-stable_20231123`, `/proc/cpuinfo` remove "Hardware" line. Leading to wiringpi 2.61-1 failure, like https://github.com/WiringPi/WiringPi/issues/194 . Latest version solved this problem.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
