### PR TITLE
tests.haskell: prevent unnecessary rebuilds

### DIFF
--- a/pkgs/test/haskell/cabalSdist/local/generated.nix
+++ b/pkgs/test/haskell/cabalSdist/local/generated.nix
@@ -3,7 +3,14 @@
 mkDerivation {
   pname = "local";
   version = "0.1.0.0";
-  src = ./.;
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.unions [
+      ./app
+      ./CHANGELOG.md
+      ./local.cabal
+    ];
+  };
   isLibrary = false;
   isExecutable = true;
   executableHaskellDepends = [ base ];

--- a/pkgs/test/haskell/setBuildTarget/default.nix
+++ b/pkgs/test/haskell/setBuildTarget/default.nix
@@ -7,7 +7,15 @@ let
       mkDerivation {
         pname = "haskell-setBuildTarget";
         version = "0.1.0.0";
-        src = ./.;
+        src = lib.fileset.toSource {
+          root = ./.;
+          fileset = lib.fileset.unions [
+            ./haskell-setBuildTarget.cabal
+            ./Bar.hs
+            ./Foo.hs
+            ./Setup.hs
+          ];
+        };
         isLibrary = false;
         isExecutable = true;
         executableHaskellDepends = [ base ];


### PR DESCRIPTION
## Description of changes

Prevent unnecessary rebuilds when Nix code is reformatted.

- #301014 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [x] `nix-build -A tests.haskell.setBuildTarget`
  - [x] `nix-build -A tests.haskell.cabalSdist.localFromCabalSdist`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).