### PR TITLE
wiringpi: 2.61-1 -> 3.6

### DIFF
--- a/pkgs/os-specific/linux/wiringpi/default.nix
+++ b/pkgs/os-specific/linux/wiringpi/default.nix
@@ -7,14 +7,15 @@
 
 let
   version = "2.61-1";
-  mkSubProject = { subprj # The only mandatory argument
-  , buildInputs ? []
-  , src ? fetchFromGitHub {
+  srcAll = fetchFromGitHub {
     owner = "WiringPi";
     repo = "WiringPi";
     rev = version;
     sha256 = "sha256-VxAaPhaPXd9xYt663Ju6SLblqiSLizauhhuFqCqbO5M=";
-  }
+  };
+  mkSubProject = { subprj # The only mandatory argument
+  , buildInputs ? []
+  , src ? srcAll
   }: stdenv.mkDerivation (finalAttrs: {
     pname = "wiringpi-${subprj}";
     inherit version src;
@@ -33,6 +34,9 @@ let
     ];
   });
   passthru = {
+    # Helps nix-update and probably nixpkgs-update find the src of this package
+    # automatically.
+    src = srcAll;
     inherit mkSubProject;
     wiringPi = mkSubProject {
       subprj = "wiringPi";

--- a/pkgs/os-specific/linux/wiringpi/default.nix
+++ b/pkgs/os-specific/linux/wiringpi/default.nix
@@ -7,12 +7,12 @@
 }:
 
 let
-  version = "2.61-1";
+  version = "3.6";
   srcAll = fetchFromGitHub {
     owner = "WiringPi";
     repo = "WiringPi";
     rev = version;
-    sha256 = "sha256-VxAaPhaPXd9xYt663Ju6SLblqiSLizauhhuFqCqbO5M=";
+    sha256 = "sha256-Hw81Ua9LTb/9l3Js1rx8TfCOF59MrrvH6AGsAsG1SoE=";
   };
   mkSubProject =
     {

--- a/pkgs/os-specific/linux/wiringpi/default.nix
+++ b/pkgs/os-specific/linux/wiringpi/default.nix
@@ -1,8 +1,9 @@
-{ lib
-, stdenv
-, symlinkJoin
-, fetchFromGitHub
-, libxcrypt
+{
+  lib,
+  stdenv,
+  symlinkJoin,
+  fetchFromGitHub,
+  libxcrypt,
 }:
 
 let
@@ -13,26 +14,29 @@ let
     rev = version;
     sha256 = "sha256-VxAaPhaPXd9xYt663Ju6SLblqiSLizauhhuFqCqbO5M=";
   };
-  mkSubProject = { subprj # The only mandatory argument
-  , buildInputs ? []
-  , src ? srcAll
-  }: stdenv.mkDerivation (finalAttrs: {
-    pname = "wiringpi-${subprj}";
-    inherit version src;
-    sourceRoot = "${src.name}/${subprj}";
-    inherit buildInputs;
-    # Remove (meant for other OSs) lines from Makefiles
-    preInstall = ''
-      sed -i "/chown root/d" Makefile
-      sed -i "/chmod/d" Makefile
-    '';
-    makeFlags = [
-      "DESTDIR=${placeholder "out"}"
-      "PREFIX=/."
-      # On NixOS we don't need to run ldconfig during build:
-      "LDCONFIG=echo"
-    ];
-  });
+  mkSubProject =
+    {
+      subprj, # The only mandatory argument
+      buildInputs ? [ ],
+      src ? srcAll,
+    }:
+    stdenv.mkDerivation (finalAttrs: {
+      pname = "wiringpi-${subprj}";
+      inherit version src;
+      sourceRoot = "${src.name}/${subprj}";
+      inherit buildInputs;
+      # Remove (meant for other OSs) lines from Makefiles
+      preInstall = ''
+        sed -i "/chown root/d" Makefile
+        sed -i "/chmod/d" Makefile
+      '';
+      makeFlags = [
+        "DESTDIR=${placeholder "out"}"
+        "PREFIX=/."
+        # On NixOS we don't need to run ldconfig during build:
+        "LDCONFIG=echo"
+      ];
+    });
   passthru = {
     # Helps nix-update and probably nixpkgs-update find the src of this package
     # automatically.
@@ -40,15 +44,11 @@ let
     inherit mkSubProject;
     wiringPi = mkSubProject {
       subprj = "wiringPi";
-      buildInputs = [
-        libxcrypt
-      ];
+      buildInputs = [ libxcrypt ];
     };
     devLib = mkSubProject {
       subprj = "devLib";
-      buildInputs = [
-        passthru.wiringPi
-      ];
+      buildInputs = [ passthru.wiringPi ];
     };
     wiringPiD = mkSubProject {
       subprj = "wiringPiD";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
