### PR TITLE
cc-wrapper: add support for `hardbackedgecfi` hardening flag on x86_64 & aarch64

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1677,6 +1677,10 @@ Adds the `-ftrivial-auto-var-init=pattern` compiler option. This causes "trivial
 
 Use of this flag is controversial as it can prevent tools that detect uninitialized variable use (such as valgrind) from operating correctly.
 
+#### `stackclashprotection` {#stackclashprotection}
+
+This flag adds the `-fstack-clash-protection` compiler option, which causes growth of a program's stack to access each successive page in order. This should force the guard page to be accessed and cause an attempt to "jump over" this guard page to crash.
+
 [^footnote-stdenv-ignored-build-platform]: The build platform is ignored because it is a mere implementation detail of the package satisfying the dependency: As a general programming principle, dependencies are always *specified* as interfaces, not concrete implementation.
 [^footnote-stdenv-native-dependencies-in-path]: Currently, this means for native builds all dependencies are put on the `PATH`. But in the future that may not be the case for sake of matching cross: the platforms would be assumed to be unique for native and cross builds alike, so only the `depsBuild*` and `nativeBuildInputs` would be added to the `PATH`.
 [^footnote-stdenv-propagated-dependencies]: Nix itself already takes a package’s transitive dependencies into account, but this propagation ensures nixpkgs-specific infrastructure like [setup hooks](#ssec-setup-hooks) also are run as if it were a propagated dependency.

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -62,6 +62,8 @@
 
 - The `zerocallusedregs` hardening flag is enabled by default on compilers that support it.
 
+- The `stackclashprotection` hardening flag has been added, though disabled by default.
+
 - `hareHook` has been added as the language framework for Hare. From now on, it,
   not the `hare` package, should be added to `nativeBuildInputs` when building
   Hare programs.

--- a/pkgs/applications/emulators/wine/base.nix
+++ b/pkgs/applications/emulators/wine/base.nix
@@ -176,7 +176,7 @@ lib.optionalAttrs (buildScript != null) { builder = buildScript; }
 
   # https://bugs.winehq.org/show_bug.cgi?id=43530
   # https://github.com/NixOS/nixpkgs/issues/31989
-  hardeningDisable = [ "bindnow" ]
+  hardeningDisable = [ "bindnow" "stackclashprotection" ]
     ++ lib.optional (stdenv.hostPlatform.isDarwin) "fortify"
     ++ lib.optional (supportFlags.mingwSupport) "format";
 

--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -32,7 +32,7 @@ if [[ -n "${hardeningEnableMap[fortify3]-}" ]]; then
 fi
 
 if (( "${NIX_DEBUG:-0}" >= 1 )); then
-  declare -a allHardeningFlags=(fortify fortify3 stackprotector pie pic strictoverflow format trivialautovarinit zerocallusedregs)
+  declare -a allHardeningFlags=(fortify fortify3 stackprotector stackclashprotection pie pic strictoverflow format trivialautovarinit zerocallusedregs)
   declare -A hardeningDisableMap=()
 
   # Determine which flags were effectively disabled so we can report below.
@@ -78,6 +78,10 @@ for flag in "${!hardeningEnableMap[@]}"; do
     stackprotector)
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling stackprotector >&2; fi
       hardeningCFlagsBefore+=('-fstack-protector-strong' '--param' 'ssp-buffer-size=4')
+      ;;
+    stackclashprotection)
+      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling stack-clash-protection >&2; fi
+      hardeningCFlagsBefore+=('-fstack-clash-protection')
       ;;
     pie)
       # NB: we do not use `+=` here, because PIE flags must occur before any PIC flags

--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -32,7 +32,7 @@ if [[ -n "${hardeningEnableMap[fortify3]-}" ]]; then
 fi
 
 if (( "${NIX_DEBUG:-0}" >= 1 )); then
-  declare -a allHardeningFlags=(fortify fortify3 stackprotector stackclashprotection pie pic strictoverflow format trivialautovarinit zerocallusedregs)
+  declare -a allHardeningFlags=(fortify fortify3 hardbackedgecfi stackprotector stackclashprotection pie pic strictoverflow format trivialautovarinit zerocallusedregs)
   declare -A hardeningDisableMap=()
 
   # Determine which flags were effectively disabled so we can report below.
@@ -74,6 +74,14 @@ for flag in "${!hardeningEnableMap[@]}"; do
           # Ignore unsupported.
           ;;
       esac
+      ;;
+    hardbackedgecfi)
+      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling hardbackedgecfi >&2; fi
+      if (( @isPacRetTarget@ )); then
+        hardeningCFlagsBefore+=('-mbranch-protection=pac-ret')
+      else
+        hardeningCFlagsBefore+=('-fcf-protection=return')
+      fi
       ;;
     stackprotector)
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling stackprotector >&2; fi

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -752,6 +752,7 @@ stdenvNoCC.mkDerivation {
     inherit libc_bin libc_dev libc_lib;
     inherit darwinPlatformForCC darwinMinVersion darwinMinVersionVariable;
     default_hardening_flags_str = builtins.toString defaultHardeningFlags;
+    isPacRetTarget = targetPlatform.isAarch64;
   };
 
   meta =

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -280,7 +280,7 @@ pipe ((callFile ./common/builder.nix {}) ({
 
   libc_dev = stdenv.cc.libc_dev;
 
-  hardeningDisable = [ "format" "pie" ]
+  hardeningDisable = [ "format" "pie" "stackclashprotection" ]
   ++ optionals (is11 && langAda) [ "fortify3" ];
 
   postPatch = optionalString atLeast7 ''
@@ -425,6 +425,9 @@ pipe ((callFile ./common/builder.nix {}) ({
     inherit langC langCC langObjC langObjCpp langAda langFortran langGo langD langJava version;
     isGNU = true;
     hardeningUnsupportedFlags = optional is48 "stackprotector"
+      ++ optional (
+        (targetPlatform.isAarch64 && !atLeast9) || !atLeast8
+      ) "stackclashprotection"
       ++ optional (!atLeast11) "zerocallusedregs"
       ++ optionals (!atLeast12) [ "fortify3" "trivialautovarinit" ]
       ++ optionals (langFortran) [ "fortify" "format" ];

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -430,6 +430,10 @@ pipe ((callFile ./common/builder.nix {}) ({
       ) "stackclashprotection"
       ++ optional (!atLeast11) "zerocallusedregs"
       ++ optionals (!atLeast12) [ "fortify3" "trivialautovarinit" ]
+      ++ optional (!(
+        (atLeast8 && targetPlatform.isLinux && targetPlatform.isx86_64)
+        || (atLeast9 && targetPlatform.isLinux && targetPlatform.isAarch64)
+      )) "hardbackedgecfi"
       ++ optionals (langFortran) [ "fortify" "format" ];
   };
 

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -137,6 +137,12 @@ let
       hardeningUnsupportedFlagsByTargetPlatform = targetPlatform:
         [ "fortify3" ]
         ++ lib.optional (
+          (targetPlatform.isx86_64 && (lib.versionOlder release_version "7"))
+          || (targetPlatform.isAarch64 && (lib.versionOlder release_version "8"))
+          || !targetPlatform.isLinux
+          || !(targetPlatform.isx86_64 || targetPlatform.isAarch64)
+        ) "hardbackedgecfi"
+        ++ lib.optional (
           (lib.versionOlder release_version "11")
           || (targetPlatform.isAarch64 && (lib.versionOlder release_version "18.1"))
           || (targetPlatform.isFreeBSD && (lib.versionOlder release_version "15"))

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -134,16 +134,26 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
-    } // (lib.optionalAttrs (lib.versionAtLeast release_version "15") {
-      hardeningUnsupportedFlags = [
-        "fortify3"
-      ];
       hardeningUnsupportedFlagsByTargetPlatform = targetPlatform:
-        lib.optional (!(targetPlatform.isx86_64 || targetPlatform.isAarch64)) "zerocallusedregs"
+        [ "fortify3" ]
+        ++ lib.optional (
+          (lib.versionOlder release_version "11")
+          || (targetPlatform.isAarch64 && (lib.versionOlder release_version "18.1"))
+          || (targetPlatform.isFreeBSD && (lib.versionOlder release_version "15"))
+          || !(targetPlatform.isLinux || targetPlatform.isFreeBSD)
+          || !(
+            targetPlatform.isx86
+            || targetPlatform.isPower64
+            || targetPlatform.isS390x
+            || targetPlatform.isAarch64
+          )
+        ) "stackclashprotection"
+        ++ lib.optional (
+          (lib.versionOlder release_version "15")
+          || !(targetPlatform.isx86_64 || targetPlatform.isAarch64)
+        ) "zerocallusedregs"
         ++ (finalAttrs.passthru.hardeningUnsupportedFlags or []);
-    }) // (lib.optionalAttrs (lib.versionOlder release_version "15") {
-      hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" ];
-    });
+    };
 
     meta = llvm_meta // {
       homepage = "https://clang.llvm.org/";

--- a/pkgs/development/libraries/glibc/2.39-revert-cet-default-disable.patch
+++ b/pkgs/development/libraries/glibc/2.39-revert-cet-default-disable.patch
@@ -1,0 +1,49 @@
+Revert 55d63e731253de82e96ed4ddca2e294076cd0bc5
+
+--- b/sysdeps/x86/cpu-features.c
++++ a/sysdeps/x86/cpu-features.c
+@@ -110,7 +110,7 @@
+   if (!CPU_FEATURES_CPU_P (cpu_features, RTM_ALWAYS_ABORT))
+     CPU_FEATURE_SET_ACTIVE (cpu_features, RTM);
+ 
++#if CET_ENABLED
+-#if CET_ENABLED && 0
+   CPU_FEATURE_SET_ACTIVE (cpu_features, IBT);
+   CPU_FEATURE_SET_ACTIVE (cpu_features, SHSTK);
+ #endif
+reverted:
+--- b/sysdeps/x86/cpu-tunables.c
++++ a/sysdeps/x86/cpu-tunables.c
+@@ -35,17 +35,6 @@
+       break;								\
+     }
+ 
+-#define CHECK_GLIBC_IFUNC_CPU_BOTH(f, cpu_features, name, len)		\
+-  _Static_assert (sizeof (#name) - 1 == len, #name " != " #len);	\
+-  if (tunable_str_comma_strcmp_cte (&f, #name))				\
+-    {									\
+-      if (f.disable)							\
+-	CPU_FEATURE_UNSET (cpu_features, name)				\
+-      else								\
+-	CPU_FEATURE_SET_ACTIVE (cpu_features, name)			\
+-      break;								\
+-    }
+-
+ /* Disable a preferred feature NAME.  We don't enable a preferred feature
+    which isn't available.  */
+ #define CHECK_GLIBC_IFUNC_PREFERRED_OFF(f, cpu_features, name, len)	\
+@@ -142,13 +131,11 @@
+ 	    }
+ 	  break;
+ 	case 5:
+-	  {
+-	    CHECK_GLIBC_IFUNC_CPU_BOTH (n, cpu_features, SHSTK, 5);
+-	  }
+ 	  if (n.disable)
+ 	    {
+ 	      CHECK_GLIBC_IFUNC_CPU_OFF (n, cpu_features, LZCNT, 5);
+ 	      CHECK_GLIBC_IFUNC_CPU_OFF (n, cpu_features, MOVBE, 5);
++	      CHECK_GLIBC_IFUNC_CPU_OFF (n, cpu_features, SHSTK, 5);
+ 	      CHECK_GLIBC_IFUNC_CPU_OFF (n, cpu_features, SSSE3, 5);
+ 	      CHECK_GLIBC_IFUNC_CPU_OFF (n, cpu_features, XSAVE, 5);
+ 	    }

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -114,7 +114,8 @@ stdenv.mkDerivation ({
       lib.optional (isAarch64 && isLinux) ./0001-aarch64-math-vector.h-add-NVCC-include-guard.patch
     )
     ++ lib.optional stdenv.hostPlatform.isMusl ./fix-rpc-types-musl-conflicts.patch
-    ++ lib.optional stdenv.buildPlatform.isDarwin ./darwin-cross-build.patch;
+    ++ lib.optional stdenv.buildPlatform.isDarwin ./darwin-cross-build.patch
+    ++ lib.optional (enableCET != false) ./2.39-revert-cet-default-disable.patch;
 
   postPatch =
     ''

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -2,7 +2,7 @@
 , withLinuxHeaders ? true
 , profilingLibraries ? false
 , withGd ? false
-, enableCET ? if stdenv.hostPlatform.isx86_64 then "permissive" else false
+, enableCET ? false
 , pkgsBuildBuild
 , libgcc
 }:

--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -29,7 +29,7 @@ in stdenv.mkDerivation {
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ windows.mingw_w64_headers ];
-  hardeningDisable = [ "stackprotector" "fortify" ];
+  hardeningDisable = [ "stackprotector" "stackclashprotection" "fortify" ];
 
   meta = {
     platforms = lib.platforms.windows;

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -329,6 +329,7 @@ in
                 isFromBootstrapFiles = true;
                 hardeningUnsupportedFlags = [
                   "fortify3"
+                  "hardbackedgecfi"
                   "stackclashprotection"
                   "zerocallusedregs"
                 ];

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -327,7 +327,11 @@ in
               '';
               passthru = {
                 isFromBootstrapFiles = true;
-                hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" ];
+                hardeningUnsupportedFlags = [
+                  "fortify3"
+                  "stackclashprotection"
+                  "zerocallusedregs"
+                ];
               };
             };
             clang-unwrapped = selfTools.libclang;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -119,6 +119,7 @@ let
     "pie"
     "relro"
     "stackprotector"
+    "stackclashprotection"
     "strictoverflow"
     "trivialautovarinit"
     "zerocallusedregs"

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -115,6 +115,7 @@ let
     "format"
     "fortify"
     "fortify3"
+    "hardbackedgecfi"
     "pic"
     "pie"
     "relro"

--- a/pkgs/stdenv/linux/bootstrap-tools/default.nix
+++ b/pkgs/stdenv/linux/bootstrap-tools/default.nix
@@ -15,5 +15,10 @@ derivation ({
   langC = true;
   langCC = true;
   isGNU = true;
-  hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" "trivialautovarinit" ];
+  hardeningUnsupportedFlags = [
+    "fortify3"
+    "stackclashprotection"
+    "trivialautovarinit"
+    "zerocallusedregs"
+  ];
 } // extraAttrs)

--- a/pkgs/stdenv/linux/bootstrap-tools/default.nix
+++ b/pkgs/stdenv/linux/bootstrap-tools/default.nix
@@ -17,6 +17,7 @@ derivation ({
   isGNU = true;
   hardeningUnsupportedFlags = [
     "fortify3"
+    "hardbackedgecfi"
     "stackclashprotection"
     "trivialautovarinit"
     "zerocallusedregs"

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -292,6 +292,7 @@ let
           pkgsExtraHardening = super';
           stdenv = super'.withDefaultHardeningFlags (
             super'.stdenv.cc.defaultHardeningFlags ++ [
+              "hardbackedgecfi"
               "stackclashprotection"
               "trivialautovarinit"
             ]

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -292,6 +292,7 @@ let
           pkgsExtraHardening = super';
           stdenv = super'.withDefaultHardeningFlags (
             super'.stdenv.cc.defaultHardeningFlags ++ [
+              "stackclashprotection"
               "trivialautovarinit"
             ]
           ) super'.stdenv;

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -297,6 +297,7 @@ let
               "trivialautovarinit"
             ]
           ) super'.stdenv;
+          glibc = super'.glibc.override { enableCET = if stdenv.hostPlatform.isx86_64 then "permissive" else false; };
         })
       ] ++ overlays;
     };


### PR DESCRIPTION
## Description of changes

(This sits on top of  #318256 ~(go review that!)~, because it takes advantage of a refactoring done there - the only "interesting" commit in this PR is the last one)

Some background: https://discourse.nixos.org/t/future-design-of-hardening-flags/38826

This experimentally implements the hardening flag `hardbackedgecfi` (**hard**ware-based **back**ward edge **C**ontrol **F**low **I**ntegrity) _in different ways_ on the x86_64 and aarch64 linux platforms. The flag is only enabled on the `pkgsExtraHardening` package set here.

Here's where I need some help - I don't have access to hardware that implements either of these features. So while I can do a large rebuild and ensure it doesn't break anything on older systems (for which the features are effectively a no-op), I'm unable to find out how many packages these flags break when the features are actually _active_.

On x86_64 this enables CET "shadow stack" features implemented in (a seemingly random selection of) new Intel processors and AMD Zen3+. It requires a 6.6+ kernel. Helpfully those VPS providers that _do_ have processors supporting this don't necessarily expose the feature to guests, so I'm probably appealing to people with bare metal here to be able to test this properly.

On aarch64 this uses "pac-ret" - pointer authentication of return addresses on the stack. This uses instructions added in ARM 8.3. Unfortunately most (all?) dev board SoCs don't implement anything further than 8.2, and the most widely used processor for cloud ARM instances, the Ampere Altra series, is also ARM 8.2. I do hear that the latest AWS Gravitons implement ARM 9.0, so that's a possibility (I have no personal AWS account though). So far I've managed to test packages (built on native ARM 8.2 hardware) on qemu's TCG aarch64 implementation - which luckily _does_ implement the pointer authentication instructions. Although it's obviously extremely slow and it took me a weekend to (re-)build a small selection of packages with good test suites on some fairly beefy x86_64 hardware. And there are some spurious test failures caused by running the tests on qemu in the first place which doesn't help..

What am I trying to discover? Whether there's significant overlap in the sets of packages broken by these two features. If there isn't, they probably shouldn't be covered by the same hardening flag and I should rethink this.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
