### PR TITLE
fsautocomplete: v0.73.1 -> v0.73.2

### DIFF
--- a/pkgs/development/tools/fsautocomplete/default.nix
+++ b/pkgs/development/tools/fsautocomplete/default.nix
@@ -2,13 +2,13 @@
 
 buildDotnetModule rec {
   pname = "fsautocomplete";
-  version = "0.73.1";
+  version = "0.73.2";
 
   src = fetchFromGitHub {
     owner = "fsharp";
     repo = "FsAutoComplete";
     rev = "v${version}";
-    hash = "sha256-esvnbmifLFwzNUHTTwl6yEYPwFgWgKfaZGMQDJ+puus=";
+    hash = "sha256-iiV/Tw3gOteARrOEbLjPA/jGawoxJVBZg6GvF9p9HHA=";
   };
 
   nugetDeps = ./deps.nix;

--- a/pkgs/development/tools/fsautocomplete/deps.nix
+++ b/pkgs/development/tools/fsautocomplete/deps.nix
@@ -45,7 +45,7 @@
   (fetchNuGet { pname = "ICSharpCode.Decompiler"; version = "7.2.1.6856"; sha256 = "19z68rgzl93lh1h8anbgzw119mhvcgr9nh5q2nxk6qihl2mx97ba"; })
   (fetchNuGet { pname = "Ionide.Analyzers"; version = "0.11.0"; sha256 = "1wsx7gbr4macmim5z1iz9clgq9xfmg423snb589bvaiyg5k6ha00"; })
   (fetchNuGet { pname = "Ionide.KeepAChangelog.Tasks"; version = "0.1.8"; sha256 = "066zla2rp1sal6by3h3sg6ibpkk52kbhn30bzk58l6ym7q1kqa6b"; })
-  (fetchNuGet { pname = "Ionide.LanguageServerProtocol"; version = "0.4.23"; sha256 = "0jfsan2d7aj68xksn1xrdiww1fdz34n7k91r5y4a77jx6h4ngbxq"; })
+  (fetchNuGet { pname = "Ionide.LanguageServerProtocol"; version = "0.6.0"; sha256 = "15wjmm91qdvhdpjjggqqsqgwlsi0wwsdzqarvdx9l1h2681hq9g0"; })
   (fetchNuGet { pname = "Ionide.ProjInfo"; version = "0.65.0"; sha256 = "0aka78yaj7h3apbr9ia7rdikr2hhyizl1xakks90h47nax00kscz"; })
   (fetchNuGet { pname = "Ionide.ProjInfo.FCS"; version = "0.65.0"; sha256 = "0kjrn6r6nwd5m5wlb8jpyzaicjcw64dg7w7vqndrwv7nw0wd4di0"; })
   (fetchNuGet { pname = "Ionide.ProjInfo.ProjectSystem"; version = "0.65.0"; sha256 = "15080y3f0zqvdzi6ks9v6jhih5xsrgi08ji5zym88qvmp81g1m8q"; })


### PR DESCRIPTION
## Description of changes


fsautocomplete: v0.73.1 -> v0.73.2 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
