### PR TITLE
libhwy: 1.0.7 -> 1.3.0, gcc15: backport aarch64 ICE on vreg split

### DIFF
--- a/pkgs/by-name/li/libhwy/package.nix
+++ b/pkgs/by-name/li/libhwy/package.nix
@@ -10,26 +10,30 @@
 
 stdenv.mkDerivation rec {
   pname = "libhwy";
-  version = "1.0.7";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "highway";
     rev = version;
-    hash = "sha256-Z+mAR9nSAbCskUvo6oK79Yd85bu0HtI2aR5THS1EozM=";
+    hash = "sha256-8QOk96Y3GIIvBUGIDikMgTylx8y5aCyr68/TP5w5ha4=";
   };
 
-  patches =
-    lib.optional stdenv.hostPlatform.isRiscV
-      # Adds CMake option HWY_CMAKE_RVV
-      # https://github.com/google/highway/pull/1743
-      (
-        fetchpatch {
-          name = "libhwy-add-rvv-optout.patch";
-          url = "https://github.com/google/highway/commit/5d58d233fbcec0c6a39df8186a877329147324b3.patch";
-          hash = "sha256-ileSNYddOt1F5rooRB0fXT20WkVlnG+gP5w7qJdBuww=";
-        }
-      );
+  patches = [
+    # Apply upstream workaround for gcc-15 bug:
+    #   https://github.com/google/highway/issues/2813
+    #   https://github.com/google/highway/pull/2824
+    (fetchpatch {
+      name = "gcc-15-clone-hack-prerequisite.patch";
+      url = "https://github.com/google/highway/commit/3b680cde3a556bead9cc23c8f595d07a44d5a0d5.patch";
+      hash = "sha256-8xBPuhsifalhzKgeEOQq6yZw2NWas+SFQrNIaMicRnY=";
+    })
+    (fetchpatch {
+      name = "gcc-15-clone-hack.patch";
+      url = "https://github.com/google/highway/commit/5af21b8a9078330a3d7456d855e69245bb87bc7a.patch";
+      hash = "sha256-hC/oEdxHsdZKlLFIw929ZHjffPURGzk9jiKz6iGSLkY=";
+    })
+  ];
 
   hardeningDisable = lib.optionals stdenv.hostPlatform.isAarch64 [
     # aarch64-specific code gets:

--- a/pkgs/development/compilers/gcc/patches/15/aarch64-sve-rtx.patch
+++ b/pkgs/development/compilers/gcc/patches/15/aarch64-sve-rtx.patch
@@ -1,0 +1,87 @@
+Without the change `libhwy-1.3.0` ICEs when built for aarch64-linux as:
+https://github.com/NixOS/nixpkgs/pull/320616#issuecomment-3764400891
+
+Upstream report: http://gcc.gnu.org/PR120718
+Upstream fix: https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=d755aa03db0ad5b71ee7f39b09c92870789f2f00
+Fetched as:
+$ curl -L 'https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff_plain;h=d755aa03db0ad5b71ee7f39b09c92870789f2f00' > aarch64-sve-rtx.patch
+
+From: Richard Sandiford <richard.sandiford@arm.com>
+Date: Thu, 14 Aug 2025 16:56:50 +0000 (+0100)
+Subject: Remove MODE_COMPOSITE_P test from simplify_gen_subreg [PR120718]
+X-Git-Url: https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff_plain;h=d755aa03db0ad5b71ee7f39b09c92870789f2f00
+
+Remove MODE_COMPOSITE_P test from simplify_gen_subreg [PR120718]
+
+simplify_gen_subreg rejected subregs of literal constants if
+MODE_COMPOSITE_P.  This was added by the fix for PR96648 in
+g:c0f772894b6b3cd8ed5c5dd09d0c7917f51cf70f.  Jakub said:
+
+  As for the simplify_gen_subreg change, I think it would be desirable
+  to just avoid creating SUBREGs of constants on all targets and for all
+  constants, if simplify_immed_subreg simplified, fine, otherwise punt,
+  but as we are late in GCC11 development, the patch instead guards this
+  behavior on MODE_COMPOSITE_P (outermode) - i.e. only conversions to
+  powerpc{,64,64le} double double long double - and only for the cases where
+  simplify_immed_subreg was called.
+
+I'm not sure about relaxing the codes further, since subregs might
+be wanted for CONST, SYMBOL_REF and LABEL_REF.  But removing the
+MODE_COMPOSITE_P is needed to fix PR120718, where we get an ICE
+from generating a subreg of a V2SI const_vector.
+
+Unlike the trunk version, this backport does not remove the
+VOIDmode test; see PR121501.
+
+gcc/
+	PR rtl-optimization/120718
+	* simplify-rtx.cc (simplify_context::simplify_gen_subreg):
+	Remove MODE_COMPOSITE_P condition.
+
+gcc/testsuite/
+	PR rtl-optimization/120718
+	* gcc.target/aarch64/sve/acle/general/pr120718.c: New test.
+---
+
+diff --git a/gcc/simplify-rtx.cc b/gcc/simplify-rtx.cc
+index 88d31a71c05a..8d4cbf1371a3 100644
+--- a/gcc/simplify-rtx.cc
++++ b/gcc/simplify-rtx.cc
+@@ -8317,14 +8317,11 @@ simplify_context::simplify_gen_subreg (machine_mode outermode, rtx op,
+ 
+   if (GET_CODE (op) == SUBREG
+       || GET_CODE (op) == CONCAT
+-      || GET_MODE (op) == VOIDmode)
+-    return NULL_RTX;
+-
+-  if (MODE_COMPOSITE_P (outermode)
+-      && (CONST_SCALAR_INT_P (op)
+-	  || CONST_DOUBLE_AS_FLOAT_P (op)
+-	  || CONST_FIXED_P (op)
+-	  || GET_CODE (op) == CONST_VECTOR))
++      || GET_MODE (op) == VOIDmode
++      || CONST_SCALAR_INT_P (op)
++      || CONST_DOUBLE_AS_FLOAT_P (op)
++      || CONST_FIXED_P (op)
++      || GET_CODE (op) == CONST_VECTOR)
+     return NULL_RTX;
+ 
+   if (validate_subreg (outermode, innermode, op, byte))
+diff --git a/gcc/testsuite/gcc.target/aarch64/sve/acle/general/pr120718.c b/gcc/testsuite/gcc.target/aarch64/sve/acle/general/pr120718.c
+new file mode 100644
+index 000000000000..9ca0938e36bf
+--- /dev/null
++++ b/gcc/testsuite/gcc.target/aarch64/sve/acle/general/pr120718.c
+@@ -0,0 +1,12 @@
++/* { dg-options "-O2" } */
++
++#include <arm_sve.h>
++typedef int __attribute__((vector_size(8))) v2si;
++typedef struct { int x; int y; } A;
++void bar(A a);
++void foo()
++{
++    A a;
++    *(v2si *)&a = (v2si){0, (int)svcntd_pat(SV_ALL)};
++    bar(a);
++}

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -100,6 +100,9 @@ optionals noSysDirs (
 # c++tools: Don't check --enable-default-pie.
 # --enable-default-pie breaks bootstrap gcc otherwise, because libiberty.a is not found
 ++ optional (is14 || is15) ./c++tools-dont-check-enable-default-pie.patch
+# http://gcc.gnu.org/PR120718 backport (will be inclkuded in 15.3.0) to
+# fix `highway-1.3.0` ICE on aarch64-linux.
+++ optional is15 ./15/aarch64-sve-rtx.patch
 
 ## 2. Patches relevant on specific platforms ####################################
 


### PR DESCRIPTION
Changes:
- https://github.com/google/highway/releases/tag/1.1.0
- https://github.com/google/highway/releases/tag/1.2.0
- https://github.com/google/highway/releases/tag/1.3.0

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
