### PR TITLE
gnomeExtensions.open-bar: init at unstable-2024-06-17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8348,6 +8348,12 @@
       fingerprint = "4304 6B43 8D83 078E 3DF7  10D6 DEB0 E15C 6D2A 5A7C";
     }];
   };
+  heywoodlh = {
+    email = "nixpkgs@heywoodlh.io";
+    github = "heywoodlh";
+    githubId = 18178614;
+    name = "Spencer Heywood";
+  };
   hh = {
     email = "hh@m-labs.hk";
     github = "HarryMakes";

--- a/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
+++ b/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
@@ -8,6 +8,7 @@
   "gsconnect@andyholmes.github.io" = callPackage ./gsconnect { };
   "impatience@gfxmonk.net" = callPackage ./impatience { };
   "no-title-bar@jonaspoehler.de" = callPackage ./no-title-bar { };
+  "openbar@neuromorph" = callPackage ./openbar { };
   "pidgin@muffinmad" = callPackage ./pidgin-im-integration { };
   "pop-shell@system76.com" = callPackage ./pop-shell { };
   "sound-output-device-chooser@kgshank.net" = callPackage ./sound-output-device-chooser { };

--- a/pkgs/desktops/gnome/extensions/openbar/default.nix
+++ b/pkgs/desktops/gnome/extensions/openbar/default.nix
@@ -1,0 +1,33 @@
+{ fetchFromGitHub, lib, stdenv, unstableGitUpdater }:
+
+stdenv.mkDerivation rec {
+  pname = "openbar";
+  version = "unstable-2024-06-17";
+
+  src = fetchFromGitHub {
+    owner = "neuromorph";
+    repo = "openbar";
+    rev = "efb86d5734d1a86f40d4ca7a18f4c0313f8d5743";
+    hash = "sha256-q9RzzCtU5whY//Nq7d7iUNYaHaXJGhDgAA+glclOG2I=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/share/gnome-shell/extensions/openbar@neuromorph"
+    cp -a . "$out/share/gnome-shell/extensions/openbar@neuromorph"
+    runHook postInstall
+  '';
+
+  passthru = {
+    extensionUuid = "openbar@neuromorph";
+    extensionPortalSlug = "open-bar";
+    updateScript = unstableGitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "A GNOME Shell extension for customizing Gnome Top Bar / Top Panel, menus and more.";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ heywoodlh ];
+    homepage = "https://github.com/neuromorph/openbar";
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds openbar GNOME extension

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
