### PR TITLE
nixos/scrutiny: use genJqSecretsReplacementSnippet

### DIFF
--- a/nixos/modules/services/monitoring/scrutiny.nix
+++ b/nixos/modules/services/monitoring/scrutiny.nix
@@ -1,10 +1,11 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, utils, ... }:
 let
   inherit (lib) maintainers;
   inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.options) literalExpression mkEnableOption mkOption mkPackageOption;
   inherit (lib.types) bool enum nullOr port str submodule;
+  inherit (utils) genJqSecretsReplacementSnippet;
 
   cfg = config.services.scrutiny;
   # Define the settings format used for this program
@@ -36,6 +37,11 @@ in
           Scrutiny settings to be rendered into the configuration file.
 
           See <https://github.com/AnalogJ/scrutiny/blob/master/example.scrutiny.yaml>.
+
+          Options containing secret data should be set to an attribute set
+          containing the attribute `_secret`. This attribute should be a string
+          or structured JSON with `quote = false;`, pointing to a file that
+          contains the value the option should be set to.
         '';
         default = { };
         type = submodule {
@@ -130,6 +136,11 @@ in
             Collector settings to be rendered into the collector configuration file.
 
             See <https://github.com/AnalogJ/scrutiny/blob/master/example.collector.yaml>.
+
+            Options containing secret data should be set to an attribute set
+            containing the attribute `_secret`. This attribute should be a string
+            or structured JSON with `quote = false;`, pointing to a file that
+            contains the value the option should be set to.
           '';
           default = { };
           type = submodule {
@@ -177,6 +188,9 @@ in
           SCRUTINY_WEB_DATABASE_LOCATION = "/var/lib/scrutiny/scrutiny.db";
           SCRUTINY_WEB_SRC_FRONTEND_PATH = "${cfg.package}/share/scrutiny";
         };
+        preStart = ''
+          ${genJqSecretsReplacementSnippet cfg.settings "/run/scrutiny/config.yaml"}
+        '';
         postStart = ''
           for i in $(seq 300); do
               if "${lib.getExe pkgs.curl}" --fail --silent --head "http://${cfg.settings.web.listen.host}:${toString cfg.settings.web.listen.port}" >/dev/null; then
@@ -191,8 +205,10 @@ in
         '';
         serviceConfig = {
           DynamicUser = true;
-          ExecStart = "${getExe cfg.package} start --config ${settingsFormat.generate "scrutiny.yaml" cfg.settings}";
+          ExecStart = "${getExe cfg.package} start --config /run/scrutiny/config.yaml";
           Restart = "always";
+          RuntimeDirectory = "scrutiny";
+          RuntimeDirectoryMode = "0700";
           StateDirectory = "scrutiny";
           StateDirectoryMode = "0750";
         };
@@ -216,9 +232,14 @@ in
             COLLECTOR_VERSION = "1";
             COLLECTOR_API_ENDPOINT = cfg.collector.settings.api.endpoint;
           };
+          preStart = ''
+            ${genJqSecretsReplacementSnippet cfg.collector.settings "/run/scrutiny-collector/config.yaml"}
+          '';
           serviceConfig = {
             Type = "oneshot";
-            ExecStart = "${getExe cfg.collector.package} run --config ${settingsFormat.generate "scrutiny-collector.yaml" cfg.collector.settings}";
+            ExecStart = "${getExe cfg.collector.package} run --config /run/scrutiny-collector/config.yaml";
+            RuntimeDirectory = "scrutiny-collector";
+            RuntimeDirectoryMode = "0700";
           };
           startAt = cfg.collector.schedule;
         };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1051,7 +1051,7 @@ in {
   scaphandre = handleTest ./scaphandre.nix {};
   schleuder = handleTest ./schleuder.nix {};
   scion-freestanding-deployment = handleTest ./scion/freestanding-deployment {};
-  scrutiny = handleTest ./scrutiny.nix {};
+  scrutiny = runTest ./scrutiny.nix;
   sddm = handleTest ./sddm.nix {};
   sdl3 = handleTest ./sdl3.nix { };
   seafile = handleTest ./seafile.nix {};

--- a/nixos/tests/scrutiny.nix
+++ b/nixos/tests/scrutiny.nix
@@ -1,100 +1,98 @@
-import ./make-test-python.nix (
-  { lib, ... }:
+{ lib, ... }:
 
-  {
-    name = "scrutiny";
-    meta.maintainers = with lib.maintainers; [ jnsgruk ];
+{
+  name = "scrutiny";
+  meta.maintainers = with lib.maintainers; [ jnsgruk ];
 
-    nodes = {
-      machine =
-        {
-          self,
-          pkgs,
-          lib,
-          ...
-        }:
-        {
-          services = {
-            scrutiny = {
-              enable = true;
-              settings = {
-                notify.urls = [
-                  {
-                    _secret = pkgs.writeText "notify-script" "script://${pkgs.writeShellScript "touch-test-file" ''
-                      echo "HelloWorld" > /run/scrutiny/hello
-                    ''}";
-                  }
-                ];
-              };
+  nodes = {
+    machine =
+      {
+        self,
+        pkgs,
+        lib,
+        ...
+      }:
+      {
+        services = {
+          scrutiny = {
+            enable = true;
+            settings = {
+              notify.urls = [
+                {
+                  _secret = pkgs.writeText "notify-script" "script://${pkgs.writeShellScript "touch-test-file" ''
+                    echo "HelloWorld" > /run/scrutiny/hello
+                  ''}";
+                }
+              ];
             };
-            scrutiny.collector.enable = true;
           };
-
-          environment.systemPackages =
-            let
-              seleniumScript =
-                pkgs.writers.writePython3Bin "selenium-script"
-                  {
-                    libraries = with pkgs.python3Packages; [ selenium ];
-                  }
-                  ''
-                    from selenium import webdriver
-                    from selenium.webdriver.common.by import By
-                    from selenium.webdriver.firefox.options import Options
-                    from selenium.webdriver.support.ui import WebDriverWait
-                    from selenium.webdriver.support import expected_conditions as EC
-
-                    options = Options()
-                    options.add_argument("--headless")
-                    service = webdriver.FirefoxService(executable_path="${lib.getExe pkgs.geckodriver}")  # noqa: E501
-
-                    driver = webdriver.Firefox(options=options, service=service)
-                    driver.implicitly_wait(10)
-                    driver.get("http://localhost:8080/web/dashboard")
-
-                    wait = WebDriverWait(driver, 10).until(
-                      EC.text_to_be_present_in_element(
-                        (By.TAG_NAME, "body"), "Drive health at a glance")
-                    )
-
-                    body_text = driver.find_element(By.TAG_NAME, "body").text
-                    assert "Temperature history for each device" in body_text
-
-                    driver.close()
-                  '';
-            in
-            with pkgs;
-            [
-              curl
-              firefox-unwrapped
-              geckodriver
-              seleniumScript
-            ];
+          scrutiny.collector.enable = true;
         };
-    };
-    # This is the test code that will check if our service is running correctly:
-    testScript = ''
-      start_all()
 
-      # Wait for Scrutiny to be available
-      machine.wait_for_unit("scrutiny")
-      machine.wait_for_open_port(8080)
+        environment.systemPackages =
+          let
+            seleniumScript =
+              pkgs.writers.writePython3Bin "selenium-script"
+                {
+                  libraries = with pkgs.python3Packages; [ selenium ];
+                }
+                ''
+                  from selenium import webdriver
+                  from selenium.webdriver.common.by import By
+                  from selenium.webdriver.firefox.options import Options
+                  from selenium.webdriver.support.ui import WebDriverWait
+                  from selenium.webdriver.support import expected_conditions as EC
 
-      # Ensure the API responds as we expect
-      output = machine.succeed("curl localhost:8080/api/health")
-      assert output == '{"success":true}'
+                  options = Options()
+                  options.add_argument("--headless")
+                  service = webdriver.FirefoxService(executable_path="${lib.getExe pkgs.geckodriver}")  # noqa: E501
 
-      # Start the collector service to send some metrics
-      collect = machine.succeed("systemctl start scrutiny-collector.service")
+                  driver = webdriver.Firefox(options=options, service=service)
+                  driver.implicitly_wait(10)
+                  driver.get("http://localhost:8080/web/dashboard")
 
-      # Ensure the application is actually rendered by the Javascript
-      machine.succeed("PYTHONUNBUFFERED=1 selenium-script")
+                  wait = WebDriverWait(driver, 10).until(
+                    EC.text_to_be_present_in_element(
+                      (By.TAG_NAME, "body"), "Drive health at a glance")
+                  )
 
-      # Test notification and genJqSecretsReplacementSnippet
-      machine.succeed("curl -X POST http://localhost:8080/api/health/notify")
-      machine.wait_for_file("/run/scrutiny/hello")
-      output = machine.succeed("cat /run/scrutiny/hello")
-      assert "HelloWorld" in output
-    '';
-  }
-)
+                  body_text = driver.find_element(By.TAG_NAME, "body").text
+                  assert "Temperature history for each device" in body_text
+
+                  driver.close()
+                '';
+          in
+          with pkgs;
+          [
+            curl
+            firefox-unwrapped
+            geckodriver
+            seleniumScript
+          ];
+      };
+  };
+  # This is the test code that will check if our service is running correctly:
+  testScript = ''
+    start_all()
+
+    # Wait for Scrutiny to be available
+    machine.wait_for_unit("scrutiny")
+    machine.wait_for_open_port(8080)
+
+    # Ensure the API responds as we expect
+    output = machine.succeed("curl localhost:8080/api/health")
+    assert output == '{"success":true}'
+
+    # Start the collector service to send some metrics
+    collect = machine.succeed("systemctl start scrutiny-collector.service")
+
+    # Ensure the application is actually rendered by the Javascript
+    machine.succeed("PYTHONUNBUFFERED=1 selenium-script")
+
+    # Test notification and genJqSecretsReplacementSnippet
+    machine.succeed("curl -X POST http://localhost:8080/api/health/notify")
+    machine.wait_for_file("/run/scrutiny/hello")
+    output = machine.succeed("cat /run/scrutiny/hello")
+    assert "HelloWorld" in output
+  '';
+}


### PR DESCRIPTION
## Description of changes

Use `genJqSecretsReplacementSnippet` to support adding secrets in config.

`scrutiny` has [several notifiction methods](https://github.com/AnalogJ/scrutiny/blob/5e6ab2290be335076ab4015b5d607a79a06c5be9/example.scrutiny.yaml#L68-L85) may need password to work

~~should merge after https://github.com/NixOS/nixpkgs/pull/319969 (Done)~~

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
