### PR TITLE
nixos/snapper: Don't create broken snapper-boot.service

### DIFF
--- a/nixos/modules/services/misc/snapper.nix
+++ b/nixos/modules/services/misc/snapper.nix
@@ -235,7 +235,7 @@ in
       timerConfig.OnUnitActiveSec = cfg.cleanupInterval;
     };
 
-    systemd.services.snapper-boot = lib.optionalAttrs cfg.snapshotRootOnBoot {
+    systemd.services.snapper-boot = lib.mkIf cfg.snapshotRootOnBoot {
       description = "Take snapper snapshot of root on boot";
       inherit documentation;
       serviceConfig.ExecStart = "${pkgs.snapper}/bin/snapper --config root create --cleanup-algorithm number --description boot";


### PR DESCRIPTION
## Description of changes

If `services.snapper.snapshotRootOnBoot` is disabled (the default), the NixOS snapper module still creates an empty and invalid systemd service for snapper-boot. This PR fixes it.

cc: @markuskowa @Artturin

## Things done

- [x] Added a check in the snapper nixos test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
