### PR TITLE
jbang: make jbang able to see itself

### DIFF
--- a/pkgs/development/tools/jbang/default.nix
+++ b/pkgs/development/tools/jbang/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     cp -r . $out
     wrapProgram $out/bin/jbang \
       --set JAVA_HOME ${jdk} \
-      --set PATH ${lib.makeBinPath [ coreutils jdk curl ]}
+      --set PATH ${lib.makeBinPath [ (placeholder "out") coreutils jdk curl ]}
     runHook postInstall
   '';
 


### PR DESCRIPTION
I understand why it has been restricted to a limited PATH, but it seems
reasonable that jbang can execute itself. There are tools out there that
assume as much (e.g. the Jupyter kernel jbang-catalog).