### PR TITLE
prefetch-npm-deps: refactor lockfile fixup

### DIFF
--- a/pkgs/build-support/node/fetch-npm-deps/src/lockfile.rs
+++ b/pkgs/build-support/node/fetch-npm-deps/src/lockfile.rs
@@ -1,0 +1,150 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, PartialEq)]
+pub enum NpmLockfile {
+    V1(NpmLockfileV1),
+    V2(NpmLockfileV2),
+    V3(NpmLockfileV3),
+}
+
+impl<'de> Deserialize<'de> for NpmLockfile {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        let value = Value::deserialize(deserializer)?;
+        let lockfile_version_field = value
+            .get("lockfileVersion")
+            .ok_or_else(|| Error::missing_field("lockfileVersion"))?;
+        let lockfile = match lockfile_version_field
+            .as_i64()
+            .ok_or_else(|| Error::custom("lockfileVersion is a not valid integer"))?
+        {
+            1 => NpmLockfile::V1(NpmLockfileV1::deserialize(value).map_err(|e| {
+                Error::custom(format!("Couldn't deserialize lockfile version 1: {e}"))
+            })?),
+            2 => NpmLockfile::V2(NpmLockfileV2::deserialize(value).map_err(|e| {
+                Error::custom(format!("Couldn't deserialize lockfile version 2: {e}"))
+            })?),
+            3 => NpmLockfile::V3(NpmLockfileV3::deserialize(value).map_err(|e| {
+                Error::custom(format!("Couldn't deserialize lockfile version 3: {e}"))
+            })?),
+            _ => {
+                return Err(Error::custom(
+                    "Unsupported lockfile version. Please open an issue!",
+                ))
+            }
+        };
+        Ok(lockfile)
+    }
+}
+
+impl Serialize for NpmLockfile {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // only used for serialization, we cannot use NpmLockfile here because of recursion
+        #[derive(Serialize)]
+        #[serde(untagged)]
+        enum SerializedNpmLockfile<'a> {
+            V1(&'a NpmLockfileV1),
+            V2(&'a NpmLockfileV2),
+            V3(&'a NpmLockfileV3),
+        }
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct VersionedLockfile<'a> {
+            lockfile_version: i64,
+            #[serde(flatten)]
+            lockfile: SerializedNpmLockfile<'a>,
+        }
+
+        let lockfile_version = self.lockfile_version().into();
+        let versioned_lockfile = VersionedLockfile {
+            lockfile_version,
+            lockfile: match self {
+                NpmLockfile::V1(lock) => SerializedNpmLockfile::V1(lock),
+                NpmLockfile::V2(lock) => SerializedNpmLockfile::V2(lock),
+                NpmLockfile::V3(lock) => SerializedNpmLockfile::V3(lock),
+            },
+        };
+        versioned_lockfile.serialize(serializer)
+    }
+}
+
+impl NpmLockfile {
+    pub fn lockfile_version(&self) -> i32 {
+        match self {
+            NpmLockfile::V1(_) => 1,
+            NpmLockfile::V2(_) => 2,
+            NpmLockfile::V3(_) => 3,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct NpmLockfileV1 {
+    #[serde(default)]
+    pub dependencies: HashMap<String, NpmDependency>,
+    #[serde(flatten)]
+    pub untyped: HashMap<String, Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Default)]
+pub struct NpmDependency {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub integrity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub dependencies: HashMap<String, NpmDependency>,
+    #[serde(default)]
+    pub bundled: bool,
+    #[serde(flatten)]
+    pub untyped: HashMap<String, Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct NpmLockfileV2 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub dependencies: HashMap<String, NpmDependency>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub packages: HashMap<String, NpmPackage>,
+    #[serde(flatten)]
+    pub untyped: HashMap<String, Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Default)]
+pub struct NpmPackage {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub integrity: Option<String>,
+    #[serde(flatten)]
+    pub untyped: HashMap<String, Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct NpmLockfileV3 {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub packages: HashMap<String, NpmPackage>,
+    #[serde(flatten)]
+    pub untyped: HashMap<String, Value>,
+}


### PR DESCRIPTION
## Description of changes

Refactor the lockfile fixup to utilize serde based structs for deserializing the lockfile.
In the future this would also enable re-serializing the lockfile to do overrides.

This needs a check to make sure this does not break any existing FODs, i don't think it would, but better be sure.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
