### PR TITLE
spicedb: Set version flag

### DIFF
--- a/pkgs/servers/spicedb/default.nix
+++ b/pkgs/servers/spicedb/default.nix
@@ -17,6 +17,10 @@ buildGoModule rec {
 
   vendorHash = "sha256-pqHDSQQMvfas9yeyhs5cWokBPISQygz2aHf6W5Zc+co=";
 
+  ldflags = [
+    "-X 'github.com/jzelinskie/cobrautil/v2.Version=${src.rev}'"
+  ];
+
   subPackages = [ "cmd/spicedb" ];
 
   meta = with lib; {

--- a/pkgs/servers/spicedb/zed.nix
+++ b/pkgs/servers/spicedb/zed.nix
@@ -16,6 +16,10 @@ buildGoModule rec {
 
   vendorHash = "sha256-Z6j4w4/anfK0ln2MvgnwZFoe8BA5jVHG3g9m2TynmmE=";
 
+  ldflags = [
+    "-X 'github.com/jzelinskie/cobrautil/v2.Version=${src.rev}'"
+  ];
+
   meta = with lib; {
     description = "Command line for managing SpiceDB";
     mainProgram = "zed";


### PR DESCRIPTION
## Description of changes

Set version flag according to [spicedb goreleaser](https://github.com/authzed/spicedb/blob/main/.goreleaser.yml)
Before:
```
$ spicedb version
spicedb (devel)

$ zed version
zed (devel)
```

After:
```
$ spicedb version
spicedb v1.33.0

$ zed version
zed v0.18.1
```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
