### PR TITLE
qdrant-web-ui: init at 0.1.28

### DIFF
--- a/nixos/modules/services/search/qdrant.nix
+++ b/nixos/modules/services/search/qdrant.nix
@@ -60,6 +60,7 @@ in {
 
   config = mkIf cfg.enable {
     services.qdrant.settings = {
+      service.static_content_dir = mkDefault pkgs.qdrant-web-ui;
       storage.storage_path = mkDefault "/var/lib/qdrant/storage";
       storage.snapshots_path = mkDefault "/var/lib/qdrant/snapshots";
       # The following default values are the same as in the default config,

--- a/pkgs/by-name/qd/qdrant-web-ui/package.nix
+++ b/pkgs/by-name/qd/qdrant-web-ui/package.nix
@@ -1,0 +1,35 @@
+{
+  buildNpmPackage,
+  fetchFromGitHub,
+  lib,
+}:
+buildNpmPackage rec {
+  pname = "qdrant-web-ui";
+  version = "0.1.28";
+
+  src = fetchFromGitHub {
+    owner = "qdrant";
+    repo = "qdrant-web-ui";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-jbr1PdoYcBxT7EOksLOPYNGz+GG5HVG406S+GRyWeiE=";
+  };
+
+  npmDepsHash = "sha256-8sk2QyunSrKE5/kjSoo0whdVbY9IXCF+n7ZIjP4Mgq8=";
+
+  npmBuildScript = "build-qdrant";
+
+  installPhase = ''
+    runHook preInstall
+    cp -r dist $out
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Self-hosted web UI for Qdrant";
+    homepage = "https://github.com/qdrant/qdrant-web-ui";
+    changelog = "https://github.com/qdrant/qdrant-web-ui/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ xzfc ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add [qdrant-web-ui](https://github.com/qdrant/qdrant-web-ui), and wire it into the default module configuration.

To test, add `services.qdrant.enable = true;` to NixOS config and go to http://localhost:6333/dashboard.

cc maintainers/recent contributors: @dit7ya @happysalada @risicle

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
