### PR TITLE
python3Packages.tree-sitter-grammars: init at 0.22.5

### DIFF
--- a/doc/packages/index.md
+++ b/doc/packages/index.md
@@ -24,6 +24,7 @@ etc-files.section.md
 nginx.section.md
 opengl.section.md
 shell-helpers.section.md
+python-tree-sitter.section.md
 steam.section.md
 cataclysm-dda.section.md
 urxvt.section.md

--- a/doc/packages/python-tree-sitter.section.md
+++ b/doc/packages/python-tree-sitter.section.md
@@ -1,0 +1,52 @@
+# Python Tree Sitter {#python-tree-sitter}
+
+[Tree Sitter](https://tree-sitter.github.io/tree-sitter/) is a framework for building grammars for programming languages. It generates and uses syntax trees from source files, which are useful for code analysis, tooling, and syntax highlighting.
+
+Python bindings for Tree Sitter grammars are provided through the [py-tree-sitter](https://github.com/tree-sitter/py-tree-sitter) module. The Nix package `python3Packages.tree-sitter-grammars` provides pre-built grammars for various languages.
+
+For example, to experiment with the Rust grammar, you can create a shell environment with the following configuration:
+
+```nix
+{ pkgs ? <nixpkgs> {} }:
+
+pkgs.mkShell {
+  name = "py-tree-sitter-dev-shell";
+
+  buildInputs = with pkgs; [
+    (python3.withPackages (ps: with ps; [
+      tree-sitter
+      tree-sitter-grammars.tree-sitter-rust
+    ]))
+  ];
+}
+```
+
+Once inside the shell, the following Python code demonstrates how to parse a Rust code snippet:
+
+```python
+# Import the Tree Sitter library and Rust grammar
+import tree_sitter
+import tree_sitter_rust
+
+# Load the Rust grammar and initialize the parser
+rust = tree_sitter.Language(tree_sitter_rust.language())
+parser = tree_sitter.Parser(rust)
+
+# Parse a Rust snippet
+tree = parser.parse(
+    bytes(
+        """
+        fn main() {
+          println!("Hello, world!");
+        }
+        """,
+        "utf8"
+    )
+)
+
+# Display the resulting syntax tree
+print(tree.root_node)
+```
+
+The `tree_sitter_rust.language()` function references the Rust grammar loaded in the Nix shell. The resulting tree allows you to inspect the structure of the code programmatically.
+

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -50,6 +50,9 @@
   "chap-packageconfig": [
     "index.html#chap-packageconfig"
   ],
+  "python-tree-sitter": [
+    "index.html#python-tree-sitter"
+  ],
   "sec-allow-broken": [
     "index.html#sec-allow-broken"
   ],

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -622,6 +622,13 @@
     githubId = 1773511;
     name = "Adrien Devresse";
   };
+  adfaure = {
+    email = "adfaure@pm.me";
+    matrix = "@adfaure:matrix.org";
+    github = "adfaure";
+    githubId = 8026586;
+    name = "Adrien Faure";
+  };
   adisbladis = {
     email = "adisbladis@gmail.com";
     matrix = "@adis:blad.is";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -856,6 +856,12 @@
     githubId = 45179933;
     name = "Alex Jackson";
   };
+  a-jay98 = {
+    email = "ali@jamadi.me";
+    github = "A-jay98";
+    githubId = 23138252;
+    name = "Ali Jamadi";
+  };
   ajgon = {
     email = "igor@rzegocki.pl";
     github = "ajgon";

--- a/pkgs/development/python-modules/tree-sitter-grammars/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-grammars/default.nix
@@ -1,0 +1,158 @@
+{
+  lib,
+  buildPythonPackage,
+  pytestCheckHook,
+  tree-sitter,
+  symlinkJoin,
+  writeTextDir,
+  pythonOlder,
+  # `name`: grammar derivation pname in the format of `tree-sitter-<lang>`
+  name,
+  grammarDrv,
+}:
+let
+  inherit (grammarDrv) version;
+
+  snakeCaseName = lib.replaceStrings [ "-" ] [ "_" ] name;
+  drvPrefix = "python-${name}";
+  # If the name of the grammar attribute differs from the grammar's symbol name,
+  # it could cause a symbol mismatch at load time. This manually curated collection
+  # of overrides ensures the binding can find the correct symbol
+  langIdentOverrides = {
+    tree_sitter_org_nvim = "tree_sitter_org";
+  };
+  langIdent = langIdentOverrides.${snakeCaseName} or snakeCaseName;
+in
+buildPythonPackage {
+  inherit version;
+  pname = drvPrefix;
+
+  src = symlinkJoin {
+    name = "${drvPrefix}-source";
+    paths = [
+      (writeTextDir "${snakeCaseName}/__init__.py" ''
+        from ._binding import language
+
+        __all__ = ["language"]
+      '')
+      (writeTextDir "${snakeCaseName}/binding.c" ''
+        #include <Python.h>
+
+        typedef struct TSLanguage TSLanguage;
+
+        TSLanguage *${langIdent}(void);
+
+        static PyObject* _binding_language(PyObject *self, PyObject *args) {
+            return PyLong_FromVoidPtr(${langIdent}());
+        }
+
+        static PyMethodDef methods[] = {
+            {"language", _binding_language, METH_NOARGS,
+            "Get the tree-sitter language for this grammar."},
+            {NULL, NULL, 0, NULL}
+        };
+
+        static struct PyModuleDef module = {
+            .m_base = PyModuleDef_HEAD_INIT,
+            .m_name = "_binding",
+            .m_doc = NULL,
+            .m_size = -1,
+            .m_methods = methods
+        };
+
+        PyMODINIT_FUNC PyInit__binding(void) {
+            return PyModule_Create(&module);
+        }
+      '')
+      (writeTextDir "setup.py" ''
+        from platform import system
+        from setuptools import Extension, setup
+
+
+        setup(
+          packages=["${snakeCaseName}"],
+          ext_package="${snakeCaseName}",
+          ext_modules=[
+            Extension(
+              name="_binding",
+              sources=["${snakeCaseName}/binding.c"],
+              extra_objects = ["${grammarDrv}/parser"],
+              extra_compile_args=(
+                ["-std=c11"] if system() != 'Windows' else []
+              ),
+            )
+          ],
+        )
+      '')
+      (writeTextDir "pyproject.toml" ''
+        [build-system]
+        requires = ["setuptools", "wheel"]
+        build-backend = "setuptools.build_meta"
+
+        [project]
+        name="${snakeCaseName}"
+        description = "${langIdent} grammar for tree-sitter"
+        version = "${version}"
+        keywords = ["parsing", "incremental", "python"]
+        classifiers = [
+          "Development Status :: 4 - Beta",
+          "Intended Audience :: Developers",
+          "License :: OSI Approved :: MIT License",
+          "Topic :: Software Development :: Compilers",
+          "Topic :: Text Processing :: Linguistic",
+        ]
+
+        requires-python = ">=3.8"
+        license.text = "MIT"
+        readme = "README.md"
+
+        [project.optional-dependencies]
+        core = ["tree-sitter~=0.21"]
+
+        [tool.cibuildwheel]
+        build = "cp38-*"
+        build-frontend = "build"
+      '')
+      (writeTextDir "tests/test_language.py" ''
+        from ${snakeCaseName} import language
+        from tree_sitter import Language, Parser
+
+        # This test only checks that the binding can load the grammar from the compiled shared object.
+        # It does not verify the grammar itself; that is tested in
+        # `pkgs/development/tools/parsing/tree-sitter/grammar.nix`.
+
+        def test_language():
+          lang = Language(language())
+          assert lang is not None
+          parser = Parser()
+          parser.language = lang
+          tree = parser.parse(bytes("", "utf-8"))
+          assert tree is not None
+      '')
+    ];
+  };
+
+  preCheck = ''
+    # https://github.com/NixOS/nixpkgs/issues/255262
+    rm -r ${snakeCaseName}
+  '';
+
+  disabled = pythonOlder "3.8";
+
+  nativeCheckInputs = [
+    tree-sitter
+    pytestCheckHook
+  ];
+  pythonImportsCheck = [ snakeCaseName ];
+
+  meta = {
+    description = "Python bindings for ${name}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      a-jay98
+      adfaure
+      mightyiam
+      stepbrobd
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17386,6 +17386,24 @@ self: super: with self; {
     callPackage ../development/python-modules/tree-sitter-embedded-template
       { };
 
+  tree-sitter-grammars = lib.recurseIntoAttrs (
+    lib.mapAttrs
+      (
+        name: grammarDrv:
+        callPackage ../development/python-modules/tree-sitter-grammars { inherit name grammarDrv; }
+      )
+      (
+        # Filtering grammars not compatible with current py-tree-sitter version
+        lib.filterAttrs (
+          name: value:
+          !(builtins.elem name [
+            "tree-sitter-sql"
+            "tree-sitter-templ"
+          ])
+        ) pkgs.tree-sitter.builtGrammars
+      )
+  );
+
   tree-sitter-html = callPackage ../development/python-modules/tree-sitter-html { };
 
   tree-sitter-javascript = callPackage ../development/python-modules/tree-sitter-javascript { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
As request in https://github.com/ngi-nix/projects/issues/2104

This generates a python binding package for each tree-sitter-grammar that exists in `tree-sitter.builtGrammars`. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
