### PR TITLE
grafanaPlugins.grafana-oncall-app: 1.5.1 -> 1.7.1

### DIFF
--- a/pkgs/servers/monitoring/grafana/plugins/grafana-oncall-app/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-oncall-app/default.nix
@@ -2,8 +2,9 @@
 
 grafanaPlugin {
   pname = "grafana-oncall-app";
-  version = "1.5.1";
-  zipHash = "sha256-3mC4TJ9ACM9e3e6UKI5vaDwXuW6RjbsOQFJU5v0wjk8=";
+  versionPrefix = "v";
+  version = "1.7.1";
+  zipHash = "sha256-G3QZq26fzv6sJ5j7QKdPPXhEj95iounZO+Ak8cXZDLc=";
   meta = with lib; {
     description = "Developer-friendly incident response for Grafana";
     license = licenses.agpl3Only;

--- a/pkgs/servers/monitoring/grafana/plugins/grafana-plugin.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-plugin.nix
@@ -1,14 +1,14 @@
 { stdenvNoCC, fetchurl, unzip, lib }:
 
-{ pname, version, zipHash, meta ? {}, passthru ? {}, ... }@args:
+{ pname, versionPrefix ? "", version, zipHash, meta ? {}, passthru ? {}, ... }@args:
 let plat = stdenvNoCC.hostPlatform.system; in stdenvNoCC.mkDerivation ({
-  inherit pname version;
+  inherit pname versionPrefix version;
 
   src = if lib.isAttrs zipHash then
     fetchurl {
-      name = "${pname}-${version}-${plat}.zip";
+      name = "${pname}-${versionPrefix}${version}-${plat}.zip";
       hash = zipHash.${plat} or (throw "Unsupported system: ${plat}");
-      url = "https://grafana.com/api/plugins/${pname}/versions/${version}/download" + {
+      url = "https://grafana.com/api/plugins/${pname}/versions/${versionPrefix}${version}/download" + {
         x86_64-linux = "?os=linux&arch=amd64";
         aarch64-linux = "?os=linux&arch=arm64";
         x86_64-darwin = "?os=darwin&arch=amd64";
@@ -17,9 +17,9 @@ let plat = stdenvNoCC.hostPlatform.system; in stdenvNoCC.mkDerivation ({
     }
   else
     fetchurl {
-      name = "${pname}-${version}.zip";
+      name = "${pname}-${versionPrefix}${version}.zip";
       hash = zipHash;
-      url = "https://grafana.com/api/plugins/${pname}/versions/${version}/download";
+      url = "https://grafana.com/api/plugins/${pname}/versions/${versionPrefix}${version}/download";
     }
   ;
 
@@ -38,4 +38,4 @@ let plat = stdenvNoCC.hostPlatform.system; in stdenvNoCC.mkDerivation ({
   meta = {
     homepage = "https://grafana.com/grafana/plugins/${pname}";
   } // meta;
-} // (builtins.removeAttrs args [ "zipHash" "pname" "version" "sha256" "meta" ]))
+} // (builtins.removeAttrs args [ "zipHash" "pname" "versionPrefix" "version" "sha256" "meta" ]))


### PR DESCRIPTION
## Description of changes

- Minor changes to the grafanaPlugins schema, to accommodate versioning schemas with prefixes:
    - Starting with v1.6.2, the plugin `grafana-oncall-app` changed the versioning schema in the upstream grafana plugin repository, adding a prefix "v" to every version. This creates a minor stylistic break in the current `grafanaPlugins` module, since it expects a version with just numbers and decimal points. By adding the versionPrefix arg, we preserve compatibility with other modules, while keeping with nixpkgs conventions.
- Updated `grafana-oncall-app` to version 1.7.1.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
