### PR TITLE
jetbrains: build from source code with jbr-no-jcef-17

### DIFF
--- a/pkgs/applications/editors/jetbrains/source/build.nix
+++ b/pkgs/applications/editors/jetbrains/source/build.nix
@@ -30,7 +30,7 @@
 
 let
 
-  jbr = jetbrains.jdk-no-jcef;
+  jbr = jetbrains.jdk-no-jcef-17;
 
   ideaSrc = fetchFromGitHub {
     owner = "jetbrains";

--- a/pkgs/development/compilers/jetbrains-jdk/17.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/17.nix
@@ -1,0 +1,156 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, jetbrains
+, openjdk17
+, openjdk17-bootstrap
+, git
+, autoconf
+, unzip
+, rsync
+, debugBuild ? false
+, withJcef ? true
+
+, libXdamage
+, libXxf86vm
+, libXrandr
+, libXi
+, libXcursor
+, libXrender
+, libX11
+, libXext
+, libxcb
+, nss
+, nspr
+, libdrm
+, mesa
+, wayland
+, udev
+}:
+
+assert debugBuild -> withJcef;
+
+let
+  arch = {
+    "aarch64-linux" = "aarch64";
+    "x86_64-linux" = "x64";
+  }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  cpu = stdenv.hostPlatform.parsed.cpu.name;
+in
+openjdk17.overrideAttrs (oldAttrs: rec {
+  pname = "jetbrains-jdk" + lib.optionalString withJcef "-jcef";
+  javaVersion = "17.0.11";
+  build = "1207.24";
+  # To get the new tag:
+  # git clone https://github.com/jetbrains/jetbrainsruntime
+  # cd jetbrainsruntime
+  # git reset --hard [revision]
+  # git log --simplify-by-decoration --decorate=short --pretty=short | grep "jbr-" --color=never | cut -d "(" -f2 | cut -d ")" -f1 | awk '{print $2}' | sort -t "-" -k 2 -g | tail -n 1 | tr -d ","
+  openjdkTag = "jbr-17.0.8+7";
+  version = "${javaVersion}-b${build}";
+
+  src = fetchFromGitHub {
+    owner = "JetBrains";
+    repo = "JetBrainsRuntime";
+    rev = "jb${version}";
+    hash = "sha256-a7cJF2iCW/1GK0/GmVbaY5pYcn3YtZy5ngFkyAGRhu0=";
+  };
+
+  BOOT_JDK = openjdk17-bootstrap.home;
+  # run `git log -1 --pretty=%ct` in jdk repo for new value on update
+  SOURCE_DATE_EPOCH = 1715809405;
+
+  patches = [ ];
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    ${lib.optionalString withJcef "cp -r ${jetbrains.jcef} jcef_linux_${arch}"}
+
+    sed \
+        -e "s/OPENJDK_TAG=.*/OPENJDK_TAG=${openjdkTag}/" \
+        -e "s/SOURCE_DATE_EPOCH=.*//" \
+        -e "s/export SOURCE_DATE_EPOCH//" \
+        -i jb/project/tools/common/scripts/common.sh
+    sed -i "s/STATIC_CONF_ARGS/STATIC_CONF_ARGS \$configureFlags/" jb/project/tools/linux/scripts/mkimages_${arch}.sh
+    sed \
+        -e "s/create_image_bundle \"jb/#/" \
+        -e "s/echo Creating /exit 0 #/" \
+        -i jb/project/tools/linux/scripts/mkimages_${arch}.sh
+
+    patchShebangs .
+    ./jb/project/tools/linux/scripts/mkimages_${arch}.sh ${build} ${if debugBuild then "fd" else (if withJcef then "jcef" else "nomod")}
+
+    runHook postBuild
+  '';
+
+  installPhase =
+    let
+      buildType = if debugBuild then "fastdebug" else "release";
+      debugSuffix = if debugBuild then "-fastdebug" else "";
+      jcefSuffix = if debugBuild || !withJcef then "" else "_jcef";
+      jbrsdkDir = "jbrsdk${jcefSuffix}-${javaVersion}-linux-${arch}${debugSuffix}-b${build}";
+    in
+    ''
+      runHook preInstall
+
+      mv build/linux-${cpu}-server-${buildType}/images/jdk/man build/linux-${cpu}-server-${buildType}/images/${jbrsdkDir}
+      rm -rf build/linux-${cpu}-server-${buildType}/images/jdk
+      mv build/linux-${cpu}-server-${buildType}/images/${jbrsdkDir} build/linux-${cpu}-server-${buildType}/images/jdk
+    '' + oldAttrs.installPhase + "runHook postInstall";
+
+  postInstall = lib.optionalString withJcef ''
+    chmod +x $out/lib/openjdk/lib/chrome-sandbox
+  '';
+
+  dontStrip = debugBuild;
+
+  postFixup = ''
+    # Build the set of output library directories to rpath against
+    LIBDIRS="${lib.makeLibraryPath [
+      libXdamage libXxf86vm libXrandr libXi libXcursor libXrender libX11 libXext libxcb
+      nss nspr libdrm mesa wayland udev
+    ]}"
+    for output in $outputs; do
+      if [ "$output" = debug ]; then continue; fi
+      LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \+ | sort -u | tr '\n' ':'):$LIBDIRS"
+    done
+    # Add the local library paths to remove dependencies on the bootstrap
+    for output in $outputs; do
+      if [ "$output" = debug ]; then continue; fi
+      OUTPUTDIR=$(eval echo \$$output)
+      BINLIBS=$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)
+      echo "$BINLIBS" | while read i; do
+        patchelf --set-rpath "$LIBDIRS:$(patchelf --print-rpath "$i")" "$i" || true
+        patchelf --shrink-rpath "$i" || true
+      done
+    done
+  '';
+
+  nativeBuildInputs = [ git autoconf unzip rsync ] ++ oldAttrs.nativeBuildInputs;
+
+  meta = with lib; {
+    description = "An OpenJDK fork to better support Jetbrains's products.";
+    longDescription = ''
+      JetBrains Runtime is a runtime environment for running IntelliJ Platform
+      based products on Windows, Mac OS X, and Linux. JetBrains Runtime is
+      based on OpenJDK project with some modifications. These modifications
+      include: Subpixel Anti-Aliasing, enhanced font rendering on Linux, HiDPI
+      support, ligatures, some fixes for native crashes not presented in
+      official build, and other small enhancements.
+      JetBrains Runtime is not a certified build of OpenJDK. Please, use at
+      your own risk.
+    '';
+    homepage = "https://confluence.jetbrains.com/display/JBR/JetBrains+Runtime";
+    inherit (openjdk17.meta) license platforms mainProgram;
+    maintainers = with maintainers; [ edwtjo ];
+
+    broken = stdenv.isDarwin;
+  };
+
+  passthru = oldAttrs.passthru // {
+    home = "${jetbrains.jdk}/lib/openjdk";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31151,6 +31151,9 @@ with pkgs;
       jdk = jdk21;
       withJcef = false;
     };
+    jdk-no-jcef-17 = callPackage ../development/compilers/jetbrains-jdk/17.nix {
+      withJcef = false;
+    };
     jdk = callPackage ../development/compilers/jetbrains-jdk {
       jdk = jdk21;
     };


### PR DESCRIPTION
## Description of changes

Add JBR-17 and use it to build community versions of JetBrains IDEs.
Fixes issues introduced in #318036.

Update: I have checked this on #316185; both the two IDEs were successfully built and able to run.

Fixes https://github.com/NixOS/nixpkgs/issues/320782

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
