### PR TITLE
google-cloud-sql-proxy: add passthru.updateScript

### DIFF
--- a/pkgs/tools/misc/google-cloud-sql-proxy/default.nix
+++ b/pkgs/tools/misc/google-cloud-sql-proxy/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildGo122Module
 , fetchFromGitHub
+, nix-update-script
 }:
 
 buildGo122Module rec {
@@ -21,6 +22,8 @@ buildGo122Module rec {
   checkFlags = [
     "-short"
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Utility for ensuring secure connections to Google Cloud SQL instances";


### PR DESCRIPTION
## Description of changes

I confirmed that `nix-update` with default arguments can update the version and hashes of the package properly, so `nix-update-script` with default arguments should too.

## Things done

There's no change to the package itself, so there isn't much to check here.
 
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
