### PR TITLE
easytag: fix ogg corruption, darwin build, add maintainer

### DIFF
--- a/pkgs/applications/audio/easytag/default.nix
+++ b/pkgs/applications/audio/easytag/default.nix
@@ -1,18 +1,27 @@
 { lib, stdenv, fetchurl, pkg-config, intltool, gtk3, glib, libid3tag, id3lib, taglib
 , libvorbis, libogg, opusfile, flac, itstool, libxml2, gsettings-desktop-schemas
-, gnome, wrapGAppsHook3
+, gnome, wrapGAppsHook3, fetchpatch
 }:
 
-let
+stdenv.mkDerivation rec {
   pname = "easytag";
   version = "2.4.3";
-in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1mbxnqrw1fwcgraa1bgik25vdzvf97vma5pzknbwbqq5ly9fwlgw";
+    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    hash = "sha256-/FHukqcF48WXnf8WVfdJbv+2i5jxraBUfoy7wDO2fdU=";
   };
+
+  patches = [
+    # https://gitlab.gnome.org/GNOME/easytag/-/merge_requests/8
+    # Borrowed from Gentoo
+    (
+      fetchpatch {
+        url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-sound/easytag/files/easytag-2.4.3-ogg-corruption.patch";
+        hash = "sha256-z75dYTEVp1raSFROjpakLeBjF96sgWBxxRB6ut9wYXw=";
+      }
+    )
+  ];
 
   NIX_LDFLAGS = "-lid3tag -lz";
 
@@ -36,7 +45,7 @@ in stdenv.mkDerivation rec {
     mainProgram = "easytag";
     homepage = "https://gitlab.gnome.org/GNOME/easytag";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ ];
-    platforms = platforms.linux;
+    maintainers = with maintainers; [ matteopacini ];
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/applications/audio/easytag/default.nix
+++ b/pkgs/applications/audio/easytag/default.nix
@@ -1,6 +1,24 @@
-{ lib, stdenv, fetchurl, pkg-config, intltool, gtk3, glib, libid3tag, id3lib, taglib
-, libvorbis, libogg, opusfile, flac, itstool, libxml2, gsettings-desktop-schemas
-, gnome, wrapGAppsHook3, fetchpatch
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  intltool,
+  gtk3,
+  glib,
+  libid3tag,
+  id3lib,
+  taglib,
+  libvorbis,
+  libogg,
+  opusfile,
+  flac,
+  itstool,
+  libxml2,
+  gsettings-desktop-schemas,
+  gnome,
+  wrapGAppsHook3,
+  fetchpatch,
 }:
 
 stdenv.mkDerivation rec {
@@ -15,20 +33,33 @@ stdenv.mkDerivation rec {
   patches = [
     # https://gitlab.gnome.org/GNOME/easytag/-/merge_requests/8
     # Borrowed from Gentoo
-    (
-      fetchpatch {
-        url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-sound/easytag/files/easytag-2.4.3-ogg-corruption.patch";
-        hash = "sha256-z75dYTEVp1raSFROjpakLeBjF96sgWBxxRB6ut9wYXw=";
-      }
-    )
+    (fetchpatch {
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-sound/easytag/files/easytag-2.4.3-ogg-corruption.patch";
+      hash = "sha256-z75dYTEVp1raSFROjpakLeBjF96sgWBxxRB6ut9wYXw=";
+    })
   ];
 
   NIX_LDFLAGS = "-lid3tag -lz";
 
-  nativeBuildInputs = [ pkg-config intltool itstool libxml2 wrapGAppsHook3 ];
+  nativeBuildInputs = [
+    pkg-config
+    intltool
+    itstool
+    libxml2
+    wrapGAppsHook3
+  ];
   buildInputs = [
-    gtk3 glib libid3tag id3lib taglib libvorbis libogg opusfile flac
-    gsettings-desktop-schemas gnome.adwaita-icon-theme
+    gtk3
+    glib
+    libid3tag
+    id3lib
+    taglib
+    libvorbis
+    libogg
+    opusfile
+    flac
+    gsettings-desktop-schemas
+    gnome.adwaita-icon-theme
   ];
 
   doCheck = false; # fails 1 out of 9 tests


### PR DESCRIPTION
## Description of changes

- Modernised the derivation a bit
- Borrowed a patch from Gentoo that prevents [easytag from corrupting Ogg Vorbis files](https://gitlab.gnome.org/GNOME/easytag/-/issues/8)
- Builds and works on Darwin too now (tested on `aarch64-darwin`)
- Added myself as maintainer (derivation has none)
- Formatted the derivation with `nixfmt-rfc-style` (in a separate commit)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
