### PR TITLE
nixos/bluemap: fix defaults issue with `services.bluemap.host`

### DIFF
--- a/nixos/modules/services/web-servers/bluemap.nix
+++ b/nixos/modules/services/web-servers/bluemap.nix
@@ -71,9 +71,7 @@ in {
 
     host = mkOption {
       type = lib.types.str;
-      default = "bluemap.${config.networking.domain}";
-      defaultText = lib.literalExpression "bluemap.\${config.networking.domain}";
-      description = "Domain to configure nginx for";
+      description = "Domain on which nginx will serve the bluemap webapp";
     };
 
     onCalendar = mkOption {


### PR DESCRIPTION
## Description of changes

The default for the `services.bluemap.host` value depends on `config.networking.domain`, which is typed as `types.nullOr types.str` in [nixos/modules/tasks/network-interfaces.nix](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/tasks/network-interfaces.nix#L609)

As a result, the default for `services.bluemap.host` either has to be `types.nullOr types.str`, or we need to drop the default.

Based on PR feedback, this commit drops the default and requires configuration through the `services.bluemap.host` option.

While this is a breaking change, since the module is [a month old](https://github.com/NixOS/nixpkgs/pull/312518), there should be very few users so far.

I discovered this while testing out https://github.com/NixOS/nixpkgs/pull/313497.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).