### PR TITLE
buildDotnetModule: convert makeWrapperArgs to an array

### DIFF
--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-fixup-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-fixup-hook.sh
@@ -1,3 +1,12 @@
+# For compatibility, convert makeWrapperArgs to an array unless we are using
+# structured attributes. That is, we ensure that makeWrapperArgs is always an
+# array.
+# See https://github.com/NixOS/nixpkgs/blob/858f4db3048c5be3527e183470e93c1a72c5727c/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-fixup-hook.sh#L1-L3
+# and https://github.com/NixOS/nixpkgs/pull/313005#issuecomment-2175482920
+if [[ -z $__structuredAttrs ]]; then
+    makeWrapperArgs=( ${makeWrapperArgs-} )
+fi
+
 # First argument is the executable you want to wrap,
 # the second is the destination for the wrapper.
 wrapDotnetProgram() {
@@ -17,10 +26,8 @@ dotnetFromEnv'
 
     if [[ -n $__structuredAttrs ]]; then
         local -r dotnetRuntimeDepsArray=( "${dotnetRuntimeDeps[@]}" )
-        local -r makeWrapperArgsArray=( "${makeWrapperArgs[@]}" )
     else
         local -r dotnetRuntimeDepsArray=($dotnetRuntimeDeps)
-        local -r makeWrapperArgsArray=($makeWrapperArgs)
     fi
 
     local dotnetRuntimeDepsFlags=()
@@ -49,7 +56,7 @@ dotnetFromEnv'
         "${dotnetRuntimeDepsFlags[@]}" \
         "${dotnetRootFlagsArray[@]}" \
         "${gappsWrapperArgs[@]}" \
-        "${makeWrapperArgsArray[@]}"
+        "${makeWrapperArgs[@]}"
 
     echo "installed wrapper to "$2""
 }


### PR DESCRIPTION
## Description of changes

Fixes a regression introduced in https://github.com/NixOS/nixpkgs/pull/313005#issuecomment-2175482920: dotnetFixupHook should be converting makeWrapperArgs to an array unless we are already using structured attributes.

That is, the previous PR removed the following piece of code assuming that it was no-op, but some packages actually rely on makeWrapperArgs being an array without structured attributes.
https://github.com/NixOS/nixpkgs/blob/858f4db3048c5be3527e183470e93c1a72c5727c/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-fixup-hook.sh#L1-L3

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
