### PR TITLE
Clean up cross bootstrapping

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -10,15 +10,15 @@
 , stdenvNoCC
 , runtimeShell
 , bintools ? null, libc ? null, coreutils ? null, gnugrep ? null
-, netbsd ? null, netbsdCross ? null
+, netbsd ? null
 , sharedLibraryLoader ?
   if libc == null then
     null
   else if stdenvNoCC.targetPlatform.isNetBSD then
-    if !(targetPackages ? netbsdCross) then
+    if !(targetPackages ? netbsd) then
       netbsd.ld_elf_so
-    else if libc != targetPackages.netbsdCross.headers then
-      targetPackages.netbsdCross.ld_elf_so
+    else if libc != targetPackages.netbsd.headers then
+      targetPackages.netbsd.ld_elf_so
     else
       null
   else

--- a/pkgs/by-name/uc/uclibc-ng/package.nix
+++ b/pkgs/by-name/uc/uclibc-ng/package.nix
@@ -1,5 +1,5 @@
 { lib
-, stdenv
+, stdenvNoLibc
 , buildPackages
 , fetchurl
 , gitUpdater
@@ -9,6 +9,7 @@
 }:
 
 let
+  stdenv = stdenvNoLibc;
   isCross = (stdenv.buildPlatform != stdenv.hostPlatform);
   configParser = ''
     function parseconfig {

--- a/pkgs/development/misc/or1k/newlib.nix
+++ b/pkgs/development/misc/or1k/newlib.nix
@@ -1,6 +1,6 @@
-{ stdenv, texinfo, flex, bison, fetchFromGitHub, crossLibcStdenv, buildPackages }:
+{ stdenv, texinfo, flex, bison, fetchFromGitHub, stdenvNoLibc, buildPackages }:
 
-crossLibcStdenv.mkDerivation {
+stdenvNoLibc.mkDerivation {
   name = "newlib";
   src = fetchFromGitHub {
     owner = "openrisc";

--- a/pkgs/development/misc/vc4/newlib.nix
+++ b/pkgs/development/misc/vc4/newlib.nix
@@ -1,6 +1,6 @@
-{ stdenv, texinfo, flex, bison, fetchFromGitHub, crossLibcStdenv, buildPackages }:
+{ stdenv, texinfo, flex, bison, fetchFromGitHub, stdenvNoLibc, buildPackages }:
 
-crossLibcStdenv.mkDerivation {
+stdenvNoLibc.mkDerivation {
   name = "newlib";
   src = fetchFromGitHub {
     owner = "itszor";

--- a/pkgs/os-specific/bsd/freebsd/default.nix
+++ b/pkgs/os-specific/bsd/freebsd/default.nix
@@ -3,7 +3,6 @@
   makeScopeWithSplicing',
   generateSplicesForMkScope,
   callPackage,
-  crossLibcStdenv,
   attributePathToSplice ? [ "freebsd" ],
   branch ? "release/14.0.0",
 }:
@@ -24,41 +23,30 @@ let
       Branches can be selected by overriding the `branch` attribute on the freebsd package set.
     '';
 
-  # `./package-set.nix` should never know the name of the package set we
-  # are constructing; just this function is allowed to know that. This
-  # is why we:
-  #
-  #  - do the splicing for cross compilation here
-  #
-  #  - construct the *anonymized* `buildFreebsd` attribute to be passed
-  #    to `./package-set.nix`.
-  callFreeBSDWithAttrs =
-    extraArgs:
-    let
-      # we do not include the branch in the splice here because the branch
-      # parameter to this file will only ever take on one value - more values
-      # are provided through overrides.
-      otherSplices = generateSplicesForMkScope attributePathToSplice;
-    in
-    makeScopeWithSplicing' {
-      inherit otherSplices;
-      f =
-        self:
-        {
-          inherit branch;
-        }
-        // callPackage ./package-set.nix (
-          {
-            sourceData = versions.${self.branch} or (throw (badBranchError self.branch));
-            versionData = self.sourceData.version;
-            buildFreebsd = otherSplices.selfBuildHost;
-            patchesRoot = ./patches + "/${self.versionData.revision}";
-          }
-          // extraArgs
-        ) self;
-    };
+  # we do not include the branch in the splice here because the branch
+  # parameter to this file will only ever take on one value - more values
+  # are provided through overrides.
+  otherSplices = generateSplicesForMkScope attributePathToSplice;
 in
-{
-  freebsd = callFreeBSDWithAttrs { };
-  freebsdCross = callFreeBSDWithAttrs { stdenv = crossLibcStdenv; };
+# `./package-set.nix` should never know the name of the package set we
+# are constructing; just this function is allowed to know that. This
+# is why we:
+#
+#  - do the splicing for cross compilation here
+#
+#  - construct the *anonymized* `buildFreebsd` attribute to be passed
+#    to `./package-set.nix`.
+makeScopeWithSplicing' {
+  inherit otherSplices;
+  f =
+    self:
+    {
+      inherit branch;
+    }
+    // callPackage ./package-set.nix ({
+      sourceData = versions.${self.branch} or (throw (badBranchError self.branch));
+      versionData = self.sourceData.version;
+      buildFreebsd = otherSplices.selfBuildHost;
+      patchesRoot = ./patches + "/${self.versionData.revision}";
+    }) self;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   stdenvNoCC,
-  stdenvNoLibs,
+  stdenvNoLibc,
   overrideCC,
   buildPackages,
   versionData,
@@ -28,7 +28,7 @@ lib.makeOverridable (
       if attrs.noCC or false then
         stdenvNoCC
       else if attrs.noLibc or false then
-        stdenvNoLibs
+        stdenvNoLibc
       else if attrs.noLibcxx or false then
         overrideCC stdenv buildPackages.llvmPackages.clangNoLibcxx
       else
@@ -58,12 +58,9 @@ lib.makeOverridable (
 
       HOST_SH = stdenv'.shell;
 
-      # Since STRIP below is the flag
-      STRIPBIN = "${stdenv.cc.bintools.targetPrefix}strip";
-
       makeFlags = [
         "STRIP=-s" # flag to install, not command
-      ] ++ lib.optional (!stdenv.hostPlatform.isFreeBSD) "MK_WERROR=no";
+      ] ++ lib.optional (!stdenv'.hostPlatform.isFreeBSD) "MK_WERROR=no";
 
       # amd64 not x86_64 for this on unlike NetBSD
       MACHINE_ARCH = freebsd-lib.mkBsdArch stdenv';
@@ -91,6 +88,9 @@ lib.makeOverridable (
     // lib.optionalAttrs stdenv'.hasCC {
       # TODO should CC wrapper set this?
       CPP = "${stdenv'.cc.targetPrefix}cpp";
+
+      # Since STRIP below is the flag
+      STRIPBIN = "${stdenv'.cc.bintools.targetPrefix}strip";
     }
     // lib.optionalAttrs stdenv'.isDarwin { MKRELRO = "no"; }
     // lib.optionalAttrs (stdenv'.cc.isClang or false) {

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   stdenvNoCC,
   makeScopeWithSplicing',
@@ -21,7 +20,9 @@ makeScopeWithSplicing' {
 
       defaultMakeFlags = [
         "MKSOFTFLOAT=${
-          if stdenv.hostPlatform.gcc.float or (stdenv.hostPlatform.parsed.abi.float or "hard") == "soft" then
+          if
+            stdenvNoCC.hostPlatform.gcc.float or (stdenvNoCC.hostPlatform.parsed.abi.float or "hard") == "soft"
+          then
             "yes"
           else
             "no"
@@ -36,7 +37,6 @@ makeScopeWithSplicing' {
       # because of the splices.
 
       mkDerivation = self.callPackage ./pkgs/mkDerivation.nix {
-        inherit stdenv stdenvNoCC;
         inherit (buildPackages.netbsd)
           netbsdSetupHook
           makeMinimal
@@ -129,7 +129,7 @@ makeScopeWithSplicing' {
       libpthread-headers = self.callPackage ./pkgs/libpthread/headers.nix { };
 
       csu = self.callPackage ./pkgs/csu.nix {
-        inherit (self) headers sys ld_elf_so;
+        inherit (self) headers sys-headers ld_elf_so;
         inherit (buildPackages.netbsd)
           netbsdSetupHook
           makeMinimal

--- a/pkgs/os-specific/bsd/netbsd/pkgs/csu.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/csu.nix
@@ -16,11 +16,12 @@
   statHook,
   rsync,
   headers,
-  sys,
+  sys-headers,
   ld_elf_so,
 }:
 
 mkDerivation {
+  noLibc = true;
   path = "lib/csu";
   meta.platforms = lib.platforms.netbsd;
   nativeBuildInputs = [
@@ -41,7 +42,7 @@ mkDerivation {
   ];
   buildInputs = [ headers ];
   extraPaths = [
-    sys.path
+    sys-headers.path
     ld_elf_so.path
   ];
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/include.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/include.nix
@@ -15,6 +15,7 @@
 }:
 
 mkDerivation {
+  noLibc = true;
   path = "include";
   nativeBuildInputs = [
     bsdSetupHook

--- a/pkgs/os-specific/bsd/netbsd/pkgs/ld_elf_so.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/ld_elf_so.nix
@@ -6,6 +6,7 @@
 }:
 
 mkDerivation {
+  noLibc = true;
   path = "libexec/ld.elf_so";
   meta.platforms = lib.platforms.netbsd;
   LIBC_PIC = "${libc}/lib/libc_pic.a";

--- a/pkgs/os-specific/bsd/netbsd/pkgs/libc.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/libc.nix
@@ -24,6 +24,7 @@
 }:
 
 mkDerivation {
+  noLibc = true;
   path = "lib/libc";
   USE_FORT = "yes";
   MKPROFILE = "no";
@@ -94,5 +95,8 @@ mkDerivation {
     make -C $BSDSRCDIR/lib/libcrypt $makeFlags
     make -C $BSDSRCDIR/lib/libcrypt $makeFlags install
   '';
-  inherit (librt) postPatch;
+  postPatch = ''
+    sed -i 's,/usr\(/include/sys/syscall.h\),${headers}\1,g' \
+      $BSDSRCDIR/lib/{libc,librt}/sys/Makefile.inc
+  '';
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/librt.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/librt.nix
@@ -9,8 +9,5 @@ mkDerivation {
   path = "lib/librt";
   meta.platforms = lib.platforms.netbsd;
   extraPaths = [ libc.path ] ++ libc.extraPaths;
-  postPatch = ''
-    sed -i 's,/usr\(/include/sys/syscall.h\),${headers}\1,g' \
-      $BSDSRCDIR/lib/{libc,librt}/sys/Makefile.inc
-  '';
+  inherit (libc) postPatch;
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/mkDerivation.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   stdenvNoCC,
-  crossLibcStdenv,
+  stdenvNoLibc,
   runCommand,
   rsync,
   source,
@@ -23,7 +23,13 @@
 lib.makeOverridable (
   attrs:
   let
-    stdenv' = if attrs.noCC or false then stdenvNoCC else stdenv;
+    stdenv' =
+      if attrs.noCC or false then
+        stdenvNoCC
+      else if attrs.noLibc or false then
+        stdenvNoLibc
+      else
+        stdenv;
   in
   stdenv'.mkDerivation (
     rec {

--- a/pkgs/os-specific/bsd/openbsd/default.nix
+++ b/pkgs/os-specific/bsd/openbsd/default.nix
@@ -1,16 +1,17 @@
 {
-  stdenv,
   lib,
-  stdenvNoCC,
   makeScopeWithSplicing',
   generateSplicesForMkScope,
-  pkgs,
   buildPackages,
-  netbsd,
 }:
 
-makeScopeWithSplicing' {
+let
   otherSplices = generateSplicesForMkScope "openbsd";
+  buildOpenbsd = otherSplices.selfBuildHost;
+in
+
+makeScopeWithSplicing' {
+  inherit otherSplices;
   f = (
     self:
     lib.packagesFromDirectoryRecursive {
@@ -19,8 +20,8 @@ makeScopeWithSplicing' {
     }
     // {
       libc = self.callPackage ./pkgs/libc/package.nix {
-        inherit (self) csu include lorder;
-        inherit (buildPackages.openbsd) makeMinimal;
+        inherit (self) csu include;
+        inherit (buildOpenbsd) makeMinimal;
         inherit (buildPackages.netbsd)
           install
           gencat
@@ -30,16 +31,16 @@ makeScopeWithSplicing' {
       };
       makeMinimal = buildPackages.netbsd.makeMinimal.override { inherit (self) make-rules; };
       mkDerivation = self.callPackage ./pkgs/mkDerivation.nix {
-        inherit stdenv;
         inherit (buildPackages.netbsd) install;
+        inherit (buildPackages.buildPackages) rsync;
       };
       include = self.callPackage ./pkgs/include/package.nix {
-        inherit (buildPackages.openbsd) makeMinimal;
+        inherit (buildOpenbsd) makeMinimal;
         inherit (buildPackages.netbsd) install rpcgen mtree;
       };
       csu = self.callPackage ./pkgs/csu.nix {
         inherit (self) include;
-        inherit (buildPackages.openbsd) makeMinimal;
+        inherit (buildOpenbsd) makeMinimal;
         inherit (buildPackages.netbsd) install;
       };
       make-rules = self.callPackage ./pkgs/make-rules/package.nix { };

--- a/pkgs/os-specific/bsd/openbsd/pkgs/csu.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/csu.nix
@@ -9,6 +9,7 @@
 }:
 
 mkDerivation {
+  noLibc = true;
   path = "lib/csu";
   nativeBuildInputs = [
     bsdSetupHook

--- a/pkgs/os-specific/bsd/openbsd/pkgs/libc/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/libc/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  stdenvNoLibc,
   mkDerivation,
   bsdSetupHook,
   openbsdSetupHook,
@@ -10,7 +10,6 @@
   byacc,
   gencat,
   rpcgen,
-  lorder,
   csu,
   include,
   ctags,
@@ -19,7 +18,8 @@
   fetchpatch,
 }:
 
-mkDerivation rec {
+mkDerivation {
+  noLibc = true;
   pname = "libc";
   path = "lib/libc";
   extraPaths = [
@@ -53,7 +53,6 @@ mkDerivation rec {
     gencat
     rpcgen
     ctags
-    lorder
     tsort
   ];
 
@@ -69,7 +68,9 @@ mkDerivation rec {
 
   # Suppress lld >= 16 undefined version errors
   # https://github.com/freebsd/freebsd-src/commit/2ba84b4bcdd6012e8cfbf8a0d060a4438623a638
-  env.NIX_LDFLAGS = lib.optionalString (stdenv.hostPlatform.linker == "lld") "--undefined-version";
+  env.NIX_LDFLAGS = lib.optionalString (
+    stdenvNoLibc.hostPlatform.linker == "lld"
+  ) "--undefined-version";
 
   makeFlags = [
     "STRIP=-s" # flag to install, not command

--- a/pkgs/os-specific/bsd/openbsd/pkgs/lorder.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/lorder.nix
@@ -8,6 +8,7 @@
 }:
 
 mkDerivation {
+  noCC = true;
   path = "usr.bin/lorder";
   nativeBuildInputs = [
     bsdSetupHook

--- a/pkgs/os-specific/bsd/openbsd/pkgs/make-rules/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/make-rules/package.nix
@@ -2,7 +2,6 @@
   fetchpatch,
   lib,
   mkDerivation,
-  stdenv,
 }:
 
 mkDerivation {

--- a/pkgs/os-specific/bsd/openbsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/mkDerivation.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   stdenvNoCC,
+  stdenvNoLibc,
   runCommand,
   rsync,
   source,
@@ -14,7 +15,13 @@
 lib.makeOverridable (
   attrs:
   let
-    stdenv' = if attrs.noCC or false then stdenvNoCC else stdenv;
+    stdenv' =
+      if attrs.noCC or false then
+        stdenvNoCC
+      else if attrs.noLibc or false then
+        stdenvNoLibc
+      else
+        stdenv;
   in
   stdenv'.mkDerivation (
     rec {
@@ -42,9 +49,6 @@ lib.makeOverridable (
       ];
 
       HOST_SH = stdenv'.shell;
-
-      # Since STRIP below is the flag
-      STRIPBIN = "${stdenv.cc.bintools.targetPrefix}strip";
 
       makeFlags = [
         "STRIP=-s" # flag to install, not command
@@ -81,6 +85,9 @@ lib.makeOverridable (
     // lib.optionalAttrs stdenv'.hasCC {
       # TODO should CC wrapper set this?
       CPP = "${stdenv'.cc.targetPrefix}cpp";
+
+      # Since STRIP below is the flag
+      STRIPBIN = "${stdenv'.cc.bintools.targetPrefix}strip";
     }
     // lib.optionalAttrs (attrs.headersOnly or false) {
       installPhase = "includesPhase";

--- a/pkgs/os-specific/windows/default.nix
+++ b/pkgs/os-specific/windows/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, buildPackages
-, newScope, overrideCC, crossLibcStdenv, libcCross
+, newScope, overrideCC, stdenvNoLibc, libcCross
 }:
 
 lib.makeScope newScope (self: with self; {
@@ -14,11 +14,11 @@ lib.makeScope newScope (self: with self; {
   mingw_runtime = mingwrt;
 
   mingw_w64 = callPackage ./mingw-w64 {
-    stdenv = crossLibcStdenv;
+    stdenv = stdenvNoLibc;
   };
 
   # FIXME untested with llvmPackages_16 was using llvmPackages_8
-  crossThreadsStdenv = overrideCC crossLibcStdenv
+  crossThreadsStdenv = overrideCC stdenvNoLibc
     (if stdenv.hostPlatform.useLLVM or false
      then buildPackages.llvmPackages.clangNoLibcxx
      else buildPackages.gccWithoutTargetLibc.override (old: {

--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -3,18 +3,12 @@
 , windows
 , fetchurl
 , autoreconfHook
+, mingw_w64_headers
 }:
 
-let
-  version = "11.0.1";
-in stdenv.mkDerivation {
+stdenv.mkDerivation {
   pname = "mingw-w64";
-  inherit version;
-
-  src = fetchurl {
-    url = "mirror://sourceforge/mingw-w64/mingw-w64-v${version}.tar.bz2";
-    hash = "sha256-P2a84Gnui+10OaGhPafLkaXmfqYXDyExesf1eUYl7hA=";
-  };
+  inherit (mingw_w64_headers) version src meta;
 
   outputs = [ "out" "dev" ];
 
@@ -30,8 +24,4 @@ in stdenv.mkDerivation {
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ windows.mingw_w64_headers ];
   hardeningDisable = [ "stackprotector" "fortify" ];
-
-  meta = {
-    platforms = lib.platforms.windows;
-  };
 }

--- a/pkgs/os-specific/windows/mingw-w64/headers.nix
+++ b/pkgs/os-specific/windows/mingw-w64/headers.nix
@@ -1,11 +1,19 @@
-{ stdenvNoCC, mingw_w64 }:
+{ lib, stdenvNoCC, fetchurl }:
 
-stdenvNoCC.mkDerivation {
-  name = "${mingw_w64.name}-headers";
-  inherit (mingw_w64) src meta;
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "mingw_w64-headers";
+  version = "11.0.1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/mingw-w64/mingw-w64-v${finalAttrs.version}.tar.bz2";
+    hash = "sha256-P2a84Gnui+10OaGhPafLkaXmfqYXDyExesf1eUYl7hA=";
+  };
 
   preConfigure = ''
     cd mingw-w64-headers
   '';
 
-}
+  meta = {
+    platforms = lib.platforms.windows;
+  };
+})

--- a/pkgs/os-specific/windows/mingw-w64/pthreads.nix
+++ b/pkgs/os-specific/windows/mingw-w64/pthreads.nix
@@ -1,8 +1,8 @@
-{ stdenv, mingw_w64 }:
+{ stdenv, mingw_w64_headers }:
 
 stdenv.mkDerivation {
-  name = "${mingw_w64.name}-pthreads";
-  inherit (mingw_w64) src meta;
+  pname = "mingw_w64-pthreads";
+  inherit (mingw_w64_headers) version src meta;
 
   configureFlags = [
     # Rustc require 'libpthread.a' when targeting 'x86_64-pc-windows-gnu'.

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -32,7 +32,11 @@ rec {
 
 
   # Override the compiler in stdenv for specific packages.
-  overrideCC = stdenv: cc: stdenv.override { allowedRequisites = null; cc = cc; };
+  overrideCC = stdenv: cc: stdenv.override {
+    allowedRequisites = null;
+    cc = cc;
+    hasCC = cc != null;
+  };
 
 
   # Add some arbitrary packages to buildInputs for specific packages.

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -41,25 +41,43 @@ in lib.init bootStages ++ [
       if crossSystem.isStatic
       then buildPackages.stdenvAdapters.makeStatic
       else lib.id;
+    stdenvNoCC = adaptStdenv (buildPackages.stdenv.override (old: rec {
+      buildPlatform = localSystem;
+      hostPlatform = crossSystem;
+      targetPlatform = crossSystem;
+
+      # Prior overrides are surely not valid as packages built with this run on
+      # a different platform, and so are disabled.
+      overrides = _: _: {};
+      extraBuildInputs = [ ]; # Old ones run on wrong platform
+      allowedRequisites = null;
+
+      cc = null;
+      hasCC = false;
+
+      extraNativeBuildInputs = old.extraNativeBuildInputs
+        ++ lib.optionals
+             (hostPlatform.isLinux && !buildPlatform.isLinux)
+             [ buildPackages.patchelf ]
+        ++ lib.optional
+             (let f = p: !p.isx86 || builtins.elem p.libc [ "musl" "wasilibc" "relibc" ] || p.isiOS || p.isGenode;
+               in f hostPlatform && !(f buildPlatform) )
+             buildPackages.updateAutotoolsGnuConfigScriptsHook
+        ;
+    }));
   in {
     inherit config;
     overlays = overlays ++ crossOverlays;
     selfBuild = false;
+    inherit stdenvNoCC;
     stdenv = let
-      baseStdenv = adaptStdenv (buildPackages.stdenv.override (old: rec {
-        buildPlatform = localSystem;
-        hostPlatform = crossSystem;
-        targetPlatform = crossSystem;
-
-        # Prior overrides are surely not valid as packages built with this run on
-        # a different platform, and so are disabled.
-        overrides = _: _: {};
+      inherit (stdenvNoCC) hostPlatform targetPlatform;
+      baseStdenv = stdenvNoCC.override {
         extraBuildInputs = [ ] # Old ones run on wrong platform
            ++ lib.optionals hostPlatform.isDarwin [ buildPackages.targetPackages.darwin.apple_sdk.frameworks.CoreFoundation ]
            ;
-        allowedRequisites = null;
 
-        hasCC = !targetPlatform.isGhcjs;
+        hasCC = !stdenvNoCC.targetPlatform.isGhcjs;
 
         cc = if crossSystem.useiOSPrebuilt or false
                then buildPackages.darwin.iosSdkPkgs.clang
@@ -77,16 +95,7 @@ in lib.init bootStages ++ [
                then buildPackages.llvmPackages.clang
              else buildPackages.gcc;
 
-        extraNativeBuildInputs = old.extraNativeBuildInputs
-          ++ lib.optionals
-               (hostPlatform.isLinux && !buildPlatform.isLinux)
-               [ buildPackages.patchelf ]
-          ++ lib.optional
-               (let f = p: !p.isx86 || builtins.elem p.libc [ "musl" "wasilibc" "relibc" ] || p.isiOS || p.isGenode;
-                 in f hostPlatform && !(f buildPlatform) )
-               buildPackages.updateAutotoolsGnuConfigScriptsHook
-          ;
-      }));
+      };
     in if config ? replaceCrossStdenv then config.replaceCrossStdenv { inherit buildPackages baseStdenv; } else baseStdenv;
   })
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -97,6 +97,7 @@ mapAliases ({
   auditBlasHook = throw "'auditBlasHook' has been removed since it never worked"; # Added 2024-04-02
   authy = throw "'authy' has been removed since it reached end of life"; # Added 2024-04-19
   avldrums-lv2 = x42-avldrums; # Added 2020-03-29
+  avrlibcCross = avrlibc; # Added 2024-06-18
   awesome-4-0 = awesome; # Added 2022-05-05
   aws-env = throw "aws-env has been removed as the upstream project was unmaintained"; # Added 2024-06-11
 
@@ -197,6 +198,7 @@ mapAliases ({
   cope = throw "'cope' has been removed, as it is broken in nixpkgs since it was added, and fixing it is not trivial"; # Added 2024-04-12
   cpp-ipfs-api = cpp-ipfs-http-client; # Project has been renamed. Added 2022-05-15
   crispyDoom = crispy-doom; # Added 2023-05-01
+  crossLibcStdenv = stdenvNoLibc; # Added 2024-06-18
   cryptowatch-desktop = throw "Cryptowatch Desktop was sunset on September 30th 2023 and has been removed from nixpkgs"; # Added 2023-12-22
   clash = throw "'clash' has been removed, upstream gone. Consider using 'mihomo' instead."; # added 2023-11-10
   clasp = clingo; # added 2022-12-22
@@ -874,6 +876,7 @@ mapAliases ({
   mpd_clientlib = libmpdclient; # Added 2021-02-11
   mpdevil = plattenalbum; # Added 2024-05-22
   mpg321 = throw "'mpg321' has been removed due to it being unmaintained by upstream. Consider using mpg123 instead."; # Added 2024-05-10
+  msp430NewlibCross = msp430Newlib; # Added 2024-06-18
   mumble_git = throw "'mumble_git' has been renamed to/replaced by 'pkgs.mumble'"; # Converted to throw 2023-09-10
   murmur_git = throw "'murmur_git' has been renamed to/replaced by 'pkgs.murmur'"; # Converted to throw 2023-09-10
   mutt-with-sidebar = mutt; # Added 2022-09-17
@@ -907,6 +910,8 @@ mapAliases ({
   nagiosPluginsOfficial = monitoring-plugins;
   neochat = libsForQt5.kdeGear.neochat; # added 2022-05-10
   neoload = throw "'neoload' has been removed as it is broken and unmaintained"; # Added 2024-03-02
+  newlibCross = newlib; # Added 2024-06-18
+  newlib-nanoCross = newlib-nano; # Added 2024-06-18
   nitrokey-udev-rules = libnitrokey; # Added 2023-03-25
   nix-direnv-flakes = nix-direnv;
   nix-repl = throw (
@@ -1333,6 +1338,8 @@ mapAliases ({
   uade123 = uade; # Added 2022-07-30
   uberwriter = apostrophe; # Added 2020-04-23
   ubootBeagleboneBlack = ubootAmx335xEVM; # Added 2020-01-21
+  uclibc = uclibc-ng; # Added 2022-06-16
+  uclibcCross = uclibc-ng; # Added 2022-06-16
   ue4 = throw "ue4 has been removed, because the package was broken for years"; # Added 2023-11-22
   uhd3_5 = throw "uhd3_5 has been removed, because it was no longer needed"; # Added 2023-10-07
   uhhyou.lv2 = throw "'uhhyou.lv2' has been removed, upstream gone"; # Added 2023-06-21
@@ -1469,6 +1476,10 @@ mapAliases ({
 
   inherit (stdenv.hostPlatform) system; # Added 2021-10-22
   inherit (stdenv) buildPlatform hostPlatform targetPlatform; # Added 2023-01-09
+
+  freebsdCross = freebsd; # Added 2024-06-18
+  netbsdCross = netbsd; # Added 2024-06-18
+  openbsdCross = openbsd; # Added 2024-06-18
 
   # LLVM packages for (integration) testing that should not be used inside Nixpkgs:
   llvmPackages_latest = llvmPackages_18;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31,19 +31,6 @@ with pkgs;
   # it's just the plain stdenv.
   stdenv_32bit = lowPrio (if stdenv.hostPlatform.is32bit then stdenv else multiStdenv);
 
-  stdenvNoCC = stdenv.override (
-    { cc = null; hasCC = false; }
-
-    // lib.optionalAttrs (stdenv.hostPlatform.isDarwin && (stdenv.hostPlatform != stdenv.buildPlatform)) {
-      # TODO: This is a hack to use stdenvNoCC to produce a CF when cross
-      # compiling. It's not very sound. The cross stdenv has:
-      #   extraBuildInputs = [ targetPackages.darwin.apple_sdks.frameworks.CoreFoundation ]
-      # and uses stdenvNoCC. In order to make this not infinitely recursive, we
-      # need to exclude this extraBuildInput.
-      extraBuildInputs = [];
-    }
-  );
-
   mkStdenvNoLibs = stdenv: let
     bintools = stdenv.cc.bintools.override {
       libc = null;
@@ -61,7 +48,7 @@ with pkgs;
   };
 
   stdenvNoLibs =
-    if stdenv.hostPlatform != stdenv.buildPlatform && (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.useLLVM or false)
+    if stdenvNoCC.hostPlatform != stdenvNoCC.buildPlatform
     then
       # We cannot touch binutils or cc themselves, because that will cause
       # infinite recursion. So instead, we just choose a libc based on the
@@ -74,7 +61,17 @@ with pkgs;
       # thing to to create an earlier thing (leading to infinite recursion) and
       # we also would still respect the stage arguments choices for these
       # things.
-      overrideCC stdenv buildPackages.llvmPackages.clangNoCompilerRt
+      (if stdenvNoCC.hostPlatform.isDarwin || stdenvNoCC.hostPlatform.useLLVM or false
+       then overrideCC stdenvNoCC buildPackages.llvmPackages.clangNoCompilerRt
+       else gccCrossLibcStdenv)
+    else mkStdenvNoLibs stdenv;
+
+  stdenvNoLibc =
+    if stdenvNoCC.hostPlatform != stdenvNoCC.buildPlatform
+    then
+      (if stdenvNoCC.hostPlatform.isDarwin || stdenvNoCC.hostPlatform.useLLVM or false
+       then overrideCC stdenvNoCC buildPackages.llvmPackages.clangNoLibc
+       else gccCrossLibcStdenv)
     else mkStdenvNoLibs stdenv;
 
   gccStdenvNoLibs = mkStdenvNoLibs gccStdenv;
@@ -15466,11 +15463,6 @@ with pkgs;
 
   gccCrossLibcStdenv = overrideCC stdenvNoCC buildPackages.gccWithoutTargetLibc;
 
-  crossLibcStdenv =
-    if stdenv.hostPlatform.useLLVM or false || stdenv.hostPlatform.isDarwin
-    then overrideCC stdenv buildPackages.llvmPackages.clangNoLibc
-    else gccCrossLibcStdenv;
-
   # The GCC used to build libc for the target platform. Normal gccs will be
   # built with, and use, that cross-compiled libc.
   gccWithoutTargetLibc = assert stdenv.targetPlatform != stdenv.hostPlatform; let
@@ -17639,9 +17631,8 @@ with pkgs;
 
   h3 = h3_3;
 
-  avrlibc      = callPackage ../development/misc/avr/libc { };
-  avrlibcCross = callPackage ../development/misc/avr/libc {
-    stdenv = crossLibcStdenv;
+  avrlibc = callPackage ../development/misc/avr/libc {
+    stdenv = stdenvNoLibc;
   };
 
   avr8burnomat = callPackage ../development/misc/avr8-burn-omat { };
@@ -17715,10 +17706,7 @@ with pkgs;
 
   msp430GccSupport = callPackage ../development/misc/msp430/gcc-support.nix { };
 
-  msp430Newlib      = callPackage ../development/misc/msp430/newlib.nix { };
-  msp430NewlibCross = callPackage ../development/misc/msp430/newlib.nix {
-    newlib = newlibCross;
-  };
+  msp430Newlib = callPackage ../development/misc/msp430/newlib.nix { };
 
   mspds = callPackage ../development/misc/msp430/mspds { };
   mspds-bin = callPackage ../development/misc/msp430/mspds/binary.nix { };
@@ -20933,14 +20921,14 @@ with pkgs;
   };
 
   muslCross = musl.override {
-    stdenv = crossLibcStdenv;
+    stdenv = stdenvNoLibc;
   };
 
   # These are used when buiding compiler-rt / libgcc, prior to building libc.
   preLibcCrossHeaders = let
     inherit (stdenv.targetPlatform) libc;
   in     if stdenv.targetPlatform.isMinGW then targetPackages.windows.mingw_w64_headers or windows.mingw_w64_headers
-    else if libc == "nblibc" then targetPackages.netbsdCross.headers or netbsdCross.headers
+    else if libc == "nblibc" then targetPackages.netbsd.headers or netbsd.headers
     else if libc == "libSystem" && stdenv.targetPlatform.isAarch64 then targetPackages.darwin.LibsystemCross or darwin.LibsystemCross
     else null;
 
@@ -20951,13 +20939,13 @@ with pkgs;
     /**/ if name == null then null
     else if name == "glibc" then targetPackages.glibcCross or glibcCross
     else if name == "bionic" then targetPackages.bionic or bionic
-    else if name == "uclibc" then targetPackages.uclibcCross or uclibcCross
-    else if name == "avrlibc" then targetPackages.avrlibcCross or avrlibcCross
-    else if name == "newlib" && stdenv.targetPlatform.isMsp430 then targetPackages.msp430NewlibCross or msp430NewlibCross
+    else if name == "uclibc" then targetPackages.uclibc or uclibc
+    else if name == "avrlibc" then targetPackages.avrlibc or avrlibc
+    else if name == "newlib" && stdenv.targetPlatform.isMsp430 then targetPackages.msp430Newlib or msp430Newlib
     else if name == "newlib" && stdenv.targetPlatform.isVc4 then targetPackages.vc4-newlib or vc4-newlib
     else if name == "newlib" && stdenv.targetPlatform.isOr1k then targetPackages.or1k-newlib or or1k-newlib
-    else if name == "newlib" then targetPackages.newlibCross or newlibCross
-    else if name == "newlib-nano" then targetPackages.newlib-nanoCross or newlib-nanoCross
+    else if name == "newlib" then targetPackages.newlib or newlib
+    else if name == "newlib-nano" then targetPackages.newlib-nano or newlib-nano
     else if name == "musl" then targetPackages.muslCross or muslCross
     else if name == "msvcrt" then targetPackages.windows.mingw_w64 or windows.mingw_w64
     else if name == "ucrt" then targetPackages.windows.mingw_w64 or windows.mingw_w64
@@ -20965,9 +20953,9 @@ with pkgs;
       if stdenv.targetPlatform.useiOSPrebuilt
       then targetPackages.darwin.iosSdkPkgs.libraries or darwin.iosSdkPkgs.libraries
       else targetPackages.darwin.LibsystemCross or (throw "don't yet have a `targetPackages.darwin.LibsystemCross for ${stdenv.targetPlatform.config}`")
-    else if name == "fblibc" then targetPackages.freebsdCross.libc or freebsdCross.libc
-    else if name == "oblibc" then targetPackages.openbsdCross.libc or openbsdCross.libc
-    else if name == "nblibc" then targetPackages.netbsdCross.libc or netbsdCross.libc
+    else if name == "fblibc" then targetPackages.freebsd.libc or freebsd.libc
+    else if name == "oblibc" then targetPackages.openbsd.libc or openbsd.libc
+    else if name == "nblibc" then targetPackages.netbsd.libc or netbsd.libc
     else if name == "wasilibc" then targetPackages.wasilibc or wasilibc
     else if name == "relibc" then targetPackages.relibc or relibc
     else throw "Unknown libc ${name}";
@@ -20983,7 +20971,7 @@ with pkgs;
     };
 
   wasilibc = callPackage ../development/libraries/wasilibc {
-    stdenv = crossLibcStdenv;
+    stdenv = stdenvNoLibc;
   };
 
   relibc = callPackage ../development/libraries/relibc { };
@@ -27973,14 +27961,6 @@ with pkgs;
   inherit (callPackage ../misc/barebox {})
     buildBarebox
     bareboxTools;
-
-  uclibc-ng-cross = uclibc-ng.override {
-    stdenv = crossLibcStdenv;
-  };
-
-  # Aliases
-  uclibc = uclibc-ng;
-  uclibcCross = uclibc-ng-cross;
 
   eudev = callPackage ../by-name/eu/eudev/package.nix {
     util-linux = util-linuxMinimal;
@@ -40611,18 +40591,11 @@ with pkgs;
     name = "bsd-setup-hook";
   } ../os-specific/bsd/setup-hook.sh;
 
-  inherit (callPackage ../os-specific/bsd/freebsd { })
-    freebsd freebsdCross;
+  freebsd = callPackage ../os-specific/bsd/freebsd { };
 
   netbsd = callPackage ../os-specific/bsd/netbsd { };
-  netbsdCross = callPackage ../os-specific/bsd/netbsd {
-    stdenv = crossLibcStdenv;
-  };
 
   openbsd = callPackage ../os-specific/bsd/openbsd { };
-  openbsdCross = callPackage ../os-specific/bsd/openbsd {
-    stdenv = crossLibcStdenv;
-  };
 
   powershell = callPackage ../shells/powershell { };
 
@@ -40646,17 +40619,13 @@ with pkgs;
 
   new-session-manager = callPackage ../applications/audio/new-session-manager { };
 
-  newlib = callPackage ../development/misc/newlib { };
-  newlibCross = callPackage ../development/misc/newlib {
-    stdenv = crossLibcStdenv;
+  newlib = callPackage ../development/misc/newlib {
+    stdenv = stdenvNoLibc;
   };
 
   newlib-nano = callPackage ../development/misc/newlib {
+    stdenv = stdenvNoLibc;
     nanoizeNewlib = true;
-  };
-  newlib-nanoCross = callPackage ../development/misc/newlib {
-    nanoizeNewlib = true;
-    stdenv = crossLibcStdenv;
   };
 
   omnisharp-roslyn = callPackage ../development/tools/omnisharp-roslyn { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15464,7 +15464,7 @@ with pkgs;
     dontStrip = true;
   }));
 
-  gccCrossLibcStdenv = overrideCC stdenv buildPackages.gccWithoutTargetLibc;
+  gccCrossLibcStdenv = overrideCC stdenvNoCC buildPackages.gccWithoutTargetLibc;
 
   crossLibcStdenv =
     if stdenv.hostPlatform.useLLVM or false || stdenv.hostPlatform.isDarwin

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -49,6 +49,10 @@ in
 , # The standard environment to use for building packages.
   stdenv
 
+, # `stdenv` without a C compiler. Passing in this helps avoid infinite
+  # recursions, and may eventually replace passing in the full stdenv.
+  stdenvNoCC ? stdenv.override { cc = null; hasCC = false; }
+
 , # This is used because stdenv replacement and the stdenvCross do benefit from
   # the overridden configuration provided by the user, as opposed to the normal
   # bootstrapping stdenvs.
@@ -141,7 +145,7 @@ let
     pkgs = self.pkgsHostTarget;
     targetPackages = self.pkgsTargetTarget;
 
-    inherit stdenv;
+    inherit stdenv stdenvNoCC;
   };
 
   splice = self: super: import ./splice.nix lib self (adjacentPackages != null);


### PR DESCRIPTION
**Contains #320840, will recompute diff once that one is merged.**

This will just be one commit then.

## Description of changes

For a long time, we've had `crossLibcStdenv`, `*Cross` libc attributes, and `*bsdCross` pre-libc package sets. This was always bad because having "cross" things is "not declarative": the naming doesn't reflect what packages *need* but rather how we *provide* something. This is ugly, and creates needless friction between cross and native building.

Now, almost all of these `*Cross` attributes are gone: just these are kept:

- Glibc's and Musl's are kept, because those packages are widely used and I didn't want to risk changing the native builds of those at this time.

- generic `libcCross`, `theadsCross`, and friends, because these relate to the convolulted GCC bootstrap which still needs to be redone.

The BSD and obscure Linux or freestnanding libcs have conversely all been made to use a new `stdenvNoLibc`, which is like the old `crossLibcStdenv` except:

1. It usable for native and cross alike

2. It named according to what it *is* ("a standard environment without libc but with a C compiler"), rather than some non-compositional jargon ("the stdenv used for building libc when cross compiling", yuck).

I should have done this change long ago, but I was stymied because of "infinite recursions". The problem was that in too many cases we are overriding `stdenv` to *remove* things we don't need, and this risks cyles since those more minimal stdenvs are used to build things in the more maximal stdenvs.

The solution is to pass `stage.nix` `stdenvNoCC`, so we can override to *build up* rather than *tear down*. For now, the full `stdenv` is also passed, so I don't need to change the native bootstraps, but I can see this changing as we make things more uniform and clean those up.

Finally, the BSDs also had to be cleaned up, since they have a few pre-libc dependencies, demanding a systematic approach. I realized what @rhelmot did in 6120256 (specify what packages just need `stdenvNoLibc`) is definitely the right approach for this, and adjusted NetBSD and OpenBSD to likewise use it.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
