### PR TITLE
roc-toolkit: 0.3.0 -> 0.4.0

### DIFF
--- a/pkgs/development/libraries/audio/roc-toolkit/default.nix
+++ b/pkgs/development/libraries/audio/roc-toolkit/default.nix
@@ -16,12 +16,14 @@
   opensslSupport ? true,
   openssl,
   soxSupport ? true,
-  sox
+  sox,
+  libsndfileSupport ? true,
+  libsndfile
 }:
 
 stdenv.mkDerivation rec {
   pname = "roc-toolkit";
-  version = "0.3.0";
+  version = "0.4.0";
 
   outputs = [ "out" "dev" ];
 
@@ -29,7 +31,7 @@ stdenv.mkDerivation rec {
     owner = "roc-streaming";
     repo = "roc-toolkit";
     rev = "v${version}";
-    hash = "sha256-tC0rjb3eDtEciUk0NmVye+N//Y/RFsi5d3kFS031y8I=";
+    hash = "sha256-53irDq803dTg0YqtC1SOXmYNGypSMAEK+9HJ65pR5PA=";
   };
 
   nativeBuildInputs = [
@@ -46,7 +48,8 @@ stdenv.mkDerivation rec {
     ++ lib.optional libunwindSupport libunwind
     ++ lib.optional pulseaudioSupport libpulseaudio
     ++ lib.optional opensslSupport openssl
-    ++ lib.optional soxSupport sox;
+    ++ lib.optional soxSupport sox
+    ++ lib.optional libsndfileSupport libsndfile;
 
   sconsFlags =
     [ "--build=${stdenv.buildPlatform.config}"
@@ -56,6 +59,7 @@ stdenv.mkDerivation rec {
     lib.optional (!soxSupport) "--disable-sox" ++
     lib.optional (!libunwindSupport) "--disable-libunwind" ++
     lib.optional (!pulseaudioSupport) "--disable-pulseaudio" ++
+    lib.optional (!libsndfileSupport) "--disable-sndfile" ++
     (if (!openfecSupport)
        then ["--disable-openfec"]
        else [ "--with-libraries=${openfec}/lib"


### PR DESCRIPTION
## Description of changes
Update `roc-toolkit` from 0.3.0 to 0.4.0:
+ [GitHub Release](https://github.com/roc-streaming/roc-toolkit/releases/tag/v0.4.0)
+ [Changelog](https://roc-streaming.org/toolkit/docs/development/changelog.html#version-0-4-0-jun-14-2024)
+ [Git Diff](https://github.com/roc-streaming/roc-toolkit/compare/v0.3.0..v0.4.0)

Changes:
+ Bump version and update hash.
+ Added libsndfile.

Testing:
+ Built and ran main binaries.
+ Built and ran pipewire with roc module.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
