### PR TITLE
vscode-js-debug: fix missing jq in postPatch

### DIFF
--- a/pkgs/by-name/vs/vscode-js-debug/package.nix
+++ b/pkgs/by-name/vs/vscode-js-debug/package.nix
@@ -1,7 +1,7 @@
 { lib
 , buildNpmPackage
 , fetchFromGitHub
-, jq
+, buildPackages
 , libsecret
 , pkg-config
 , nodePackages
@@ -23,12 +23,12 @@ buildNpmPackage rec {
 
   npmDepsHash = "sha256-DfeaiqKadTnGzOObK01ctlavwqTMa0tqn59sLZMPvUM=";
 
-  nativeBuildInputs = [ pkg-config nodePackages.node-gyp jq ];
+  nativeBuildInputs = [ pkg-config nodePackages.node-gyp ];
 
   buildInputs = [ libsecret ];
 
   postPatch = ''
-    jq '
+    ${lib.getExe buildPackages.jq} '
       .scripts.postinstall |= empty |             # tries to install playwright, not necessary for build
       .scripts.build |= "gulp dapDebugServer" |   # there is no build script defined
       .bin |= "./dist/src/dapDebugServer.js"      # there is no bin output defined


### PR DESCRIPTION
Fixes #320507.

The `npmConfigHook` used by `buildNpmPackage` does not correctly propagate the `nativeBuildInputs` into its `PATH`, which is why `jq` was not available during the patch phase.

Since this `npmConfigHook` is run as part of a fixed-output derivation (`fetchNpmDeps`), if it had already been realised, unless its hash had changed, a missing `jq` would not be noticed, on a rebuild of `vscode-js-debug`.

The `postPatch` hook is *also* run during `buildNpmPackage`, but there the `nativeBuildInputs` were correctly added to the `PATH`, which is why a rebuild of `vscode-js-debug` with the previous `postPatch` would succeed (if its `npmDeps`'s hash hadn't changed).

## Description of changes

Hard-coded a reference to `jq` using an absolute path into `postPatch`. Specifically, `buildPackages.jq`, which is equivalent to `nativeBuildInputs` from a cross-compilation perspective.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).