### PR TITLE
python312Packages.hdmedians: modernize, fix testing, adopt

### DIFF
--- a/pkgs/development/python-modules/hdmedians/default.nix
+++ b/pkgs/development/python-modules/hdmedians/default.nix
@@ -1,40 +1,65 @@
 {
   lib,
   buildPythonPackage,
+  pythonOlder,
   fetchPypi,
-  nose,
   cython,
+  oldest-supported-numpy,
+  setuptools,
   numpy,
+  nose,
 }:
 
 buildPythonPackage rec {
-  version = "0.14.2";
-  format = "setuptools";
   pname = "hdmedians";
+  version = "0.14.2";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "b47aecb16771e1ba0736557255d80ae0240b09156bff434321de559b359ac2d6";
   };
 
-  # nose was specified in setup.py as a build dependency...
-  buildInputs = [
-    cython
-    nose
-  ];
-  propagatedBuildInputs = [ numpy ];
-
-  # cannot resolve path for packages in tests
-  doCheck = false;
-
-  checkPhase = ''
-    nosetests
+  # nose was marked as a build-time dependency, but is only used for testing
+  postPatch = ''
+    substituteInPlace setup.py \
+        --replace-fail "'nose>=1.0', " ""
   '';
 
-  meta = with lib; {
+  build-system = [
+    cython
+    oldest-supported-numpy
+    setuptools
+  ];
+
+  dependencies = [ numpy ];
+
+  # nose no longer builds on python >=3.12
+  doCheck = pythonOlder "3.12";
+
+  nativeCheckInputs = [ nose ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    # force python to resolve the package from $out, where the cython ext files actually exist
+    mv hdmedians/tests tests
+    rm -r hdmedians
+
+    nosetests tests
+
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [
+    "hdmedians"
+    "hdmedians.geomedian" # ext
+  ];
+
+  meta = {
     homepage = "https://github.com/daleroberts/hdmedians";
     description = "High-dimensional medians";
-    license = licenses.gpl3;
-    maintainers = [ ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ tomasajt ];
   };
 }


### PR DESCRIPTION
## Description of changes

This PR refactors the `hdmedians` python package to use the more modern python packaging methods.

The testing logic was not workign previously, this PR addresses that also.
Note: `pynose` is used in place of `nose`, since `pynose` has python >=3.12 support.

Also, the license of the project changed in 2007, but hasn't been updated to reflect that inside nixpkgs. This was corrected in this PR.

I added myself to the maintainer list, since I maintain another package depending on this package.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
