### PR TITLE
hydra-menu: init at 0-unstable-2024-06-18

### DIFF
--- a/pkgs/by-name/hy/hydra-menu/package.nix
+++ b/pkgs/by-name/hy/hydra-menu/package.nix
@@ -1,4 +1,8 @@
-{ stdenv, lib, fetchFromGitHub }:
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+}:
 
 stdenv.mkDerivation rec {
   name = "hydra-menu";
@@ -8,7 +12,7 @@ stdenv.mkDerivation rec {
     owner = "emad-elsaid";
     repo = "hydra";
     rev = "92d59e3a440eb9ebe098551ba972c894b1601f7f";
-    sha256 = "dSwxIiFqfNp5OhTWl1OCc1XYgMG3pqYfXtQM7thvGOQ=";
+    hash = "sha256-dSwxIiFqfNp5OhTWl1OCc1XYgMG3pqYfXtQM7thvGOQ=";
   };
 
   makeFlags = [
@@ -17,9 +21,9 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    description = "A C implementation of Emacs Hydra to be used in the terminal.";
+    description = "C implementation of Emacs Hydra to be used in the terminal";
     homepage = "https://hydra.emadelsaid.com/";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     platforms = platforms.all;
     maintainers = with maintainers; [ edrex ];
   };

--- a/pkgs/by-name/hy/hydra-menu/package.nix
+++ b/pkgs/by-name/hy/hydra-menu/package.nix
@@ -1,4 +1,5 @@
 { stdenv, lib, fetchFromGitHub }:
+
 stdenv.mkDerivation rec {
   name = "hydra-menu";
   version = "0-unstable-2024-06-18";

--- a/pkgs/by-name/hy/hydra-menu/package.nix
+++ b/pkgs/by-name/hy/hydra-menu/package.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, fetchFromGitHub }:
+stdenv.mkDerivation rec {
+  name = "hydra-menu";
+  version = "0-unstable-2024-06-18";
+
+  src = fetchFromGitHub {
+    owner = "emad-elsaid";
+    repo = "hydra";
+    rev = "92d59e3a440eb9ebe098551ba972c894b1601f7f";
+    sha256 = "dSwxIiFqfNp5OhTWl1OCc1XYgMG3pqYfXtQM7thvGOQ=";
+  };
+
+  makeFlags = [
+    "DESTDIR=${placeholder "out"}"
+    "prefix="
+  ];
+
+  meta = with lib; {
+    description = "A C implementation of Emacs Hydra to be used in the terminal.";
+    homepage = "https://hydra.emadelsaid.com/";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ edrex ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds [hydra](https://github.com/emad-elsaid/hydra) console menu (clone of emacs hydra) as *hydra-menu*. Similar functionality to existing package tydra but that one isn't currently maintained. 

No release yet ~~so this is a draft~~ using unstable version.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @emad-elsaid
