### PR TITLE
nixos/boot: add boot.tmp.useZram option

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1807,6 +1807,7 @@
   ./system/boot/uki.nix
   ./system/boot/unl0kr.nix
   ./system/boot/uvesafb.nix
+  ./system/boot/zram-as-tmp.nix
   ./system/etc/etc-activation.nix
   ./tasks/auto-upgrade.nix
   ./tasks/bcache.nix

--- a/nixos/modules/system/boot/zram-as-tmp.nix
+++ b/nixos/modules/system/boot/zram-as-tmp.nix
@@ -1,0 +1,105 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.boot.tmp;
+in
+{
+  options = {
+    boot.tmp = {
+      useZram = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        example = true;
+        description = ''
+          Whether to mount a zram device on {file}`/tmp` during boot.
+
+          ::: {.note}
+          Large Nix builds can fail if the mounted zram device is not large enough.
+          In such a case either increase the zramSettings.zram-size or disable this option.
+          :::
+        '';
+      };
+
+      zramSettings = {
+        zram-size = lib.mkOption {
+          type = lib.types.str;
+          default = "ram * 0.5";
+          example = "min(ram / 2, 4096)";
+          description = ''
+            The size of the zram device, as a function of MemTotal, both in MB.
+            For example, if the machine has 1 GiB, and zram-size=ram/4,
+            then the zram device will have 256 MiB.
+            Fractions in the range 0.1–0.5 are recommended
+
+            See: https://github.com/systemd/zram-generator/blob/main/zram-generator.conf.example
+          '';
+        };
+
+        compression-algorithm = lib.mkOption {
+          type = lib.types.str;
+          default = "zstd";
+          example = "lzo-rle";
+          description = ''
+            The compression algorithm to use for the zram device.
+
+            See: https://github.com/systemd/zram-generator/blob/main/zram-generator.conf.example
+          '';
+        };
+
+        fs-type = lib.mkOption {
+          type = lib.types.str;
+          default = "ext4";
+          example = "ext2";
+          description = ''
+            The file system to put on the device.
+
+            See: https://github.com/systemd/zram-generator/blob/main/zram-generator.conf.example
+          '';
+        };
+
+        options = lib.mkOption {
+          type = lib.types.str;
+          default = "X-mount.mode=1777,discard";
+          description = ''
+            By default, file systems and swap areas are trimmed on-the-go
+            by setting "discard".
+            Setting this to the empty string clears the option.
+
+            See: https://github.com/systemd/zram-generator/blob/main/zram-generator.conf.example
+          '';
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf (cfg.useZram) {
+    assertions = [
+      {
+        assertion = !cfg.useTmpfs;
+        message = "boot.tmp.useTmpfs is unnecessary if useZram=true";
+      }
+    ];
+
+    services.zram-generator.enable = true;
+    services.zram-generator.settings =
+      let
+        cfgz = cfg.zramSettings;
+      in
+      {
+        "zram${toString (if config.zramSwap.enable then config.zramSwap.swapDevices else 0)}" = {
+          mount-point = "/tmp";
+          zram-size = cfgz.zram-size;
+          compression-algorithm = cfgz.compression-algorithm;
+          options = cfgz.options;
+          fs-type = cfgz.fs-type;
+        };
+      };
+    systemd.services."systemd-zram-setup@".path = [ pkgs.util-linux ] ++ config.system.fsPackages;
+
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR provides an alternative option for the `boot.tmp.useTmpfs` setting, allowing a **zram device to be used directly as /tmp**.
In certain scenarios, this choice can be more effective than using zram as swap and waiting for tmpfs to trigger swap due to memory pressure. After all, the conditions for triggering swap are unrelated to the compression ratio of the content. In situations where it can be presupposed that the contents of the /tmp directory will have a higher compression ratio, the option provided by this PR will be an excellent solution.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Provide an option named `boot.tmp.useZram`, and related options named `boot.tmp.zramSettings.*`

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
