### PR TITLE
python3Packages: clean up toPythonModule

### DIFF
--- a/pkgs/development/python-modules/hoomd-blue/default.nix
+++ b/pkgs/development/python-modules/hoomd-blue/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  buildPythonPackage,
   fetchgit,
   cmake,
   pkgconfig,
@@ -19,9 +19,10 @@ let
   onOffBool = b: if b then "ON" else "OFF";
   withMPI = (mpi != null);
 in
-stdenv.mkDerivation rec {
+buildPythonPackage rec {
   version = "2.3.4";
   pname = "hoomd-blue";
+  pyproject = false; # Built with cmake
 
   src = fetchgit {
     url = "https://bitbucket.org/glotzer/hoomd-blue";

--- a/pkgs/development/python-modules/py3buddy/default.nix
+++ b/pkgs/development/python-modules/py3buddy/default.nix
@@ -1,23 +1,24 @@
 {
   lib,
-  stdenv,
+  buildPythonPackage,
   fetchFromGitHub,
   python,
   pyusb,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+buildPythonPackage rec {
   pname = "py3buddy";
   version = "1.0";
+  pyproject = false; # manually installed
 
   src = fetchFromGitHub {
     owner = "armijnhemel";
     repo = "py3buddy";
-    rev = finalAttrs.version;
+    rev = version;
     hash = "sha256-KJ0xGEXHY6o2074WFZ0u7gATS+wrrjyzanYretckWYk=";
   };
 
-  propagatedBuildInputs = [ pyusb ];
+  dependencies = [ pyusb ];
 
   dontConfigure = true;
   dontBuild = true;
@@ -40,4 +41,4 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ prusnak ];
   };
-})
+}

--- a/pkgs/development/python-modules/pyunbound/default.nix
+++ b/pkgs/development/python-modules/pyunbound/default.nix
@@ -1,11 +1,10 @@
-{ lib, stdenv, unbound, openssl, expat, libevent, swig, pythonPackages }:
+{ lib, buildPythonPackage, unbound, openssl, expat, libevent, swig, python, stdenv }:
 
-let
-  inherit (pythonPackages) python;
-in
-stdenv.mkDerivation rec {
+buildPythonPackage rec {
   pname = "pyunbound";
   inherit (unbound) version src;
+  pyproject = false; # Built with configure script
+
   patches = unbound.patches or null;
 
   nativeBuildInputs = [ swig ];

--- a/pkgs/development/python-modules/segyio/add_missing_cstdint.patch
+++ b/pkgs/development/python-modules/segyio/add_missing_cstdint.patch
@@ -1,0 +1,47 @@
+From 64f06c0643f1f8691a8f2757496b60f1ab98c866 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Sa=C3=AFd=20Benaissa?= <sbenaissa@shearwatergeo.com>
+Date: Fri, 8 Dec 2023 21:51:32 +0100
+Subject: [PATCH] Add include for cstdint, fix segyio build on fedora
+
+---
+ lib/experimental/segyio/segyio.hpp | 1 +
+ python/segyio/segyio.cpp           | 1 +
+ python/setup.py                    | 2 +-
+ 3 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/lib/experimental/segyio/segyio.hpp b/lib/experimental/segyio/segyio.hpp
+index 706f07ff5..7ba3ffb99 100644
+--- a/lib/experimental/segyio/segyio.hpp
++++ b/lib/experimental/segyio/segyio.hpp
+@@ -13,6 +13,7 @@
+ #include <vector>
+ 
+ #include <segyio/segy.h>
++#include <cstdint>
+ 
+ /*
+  * KNOWN ISSUES AND TODOs:
+diff --git a/python/segyio/segyio.cpp b/python/segyio/segyio.cpp
+index 76da965c3..bd8a8622e 100644
+--- a/python/segyio/segyio.cpp
++++ b/python/segyio/segyio.cpp
+@@ -16,6 +16,7 @@
+ #include <cstring>
+ #include <sstream>
+ #include <stdexcept>
++#include <cstdint>
+ 
+ #if PY_MAJOR_VERSION >= 3
+ #define IS_PY3K
+diff --git a/python/setup.py b/python/setup.py
+index 6c6553bc7..654075be9 100644
+--- a/python/setup.py
++++ b/python/setup.py
+@@ -1,6 +1,6 @@
+ import os
+ import sys
+-import skbuild
++import skbuild  # pip install scikit-build
+ import setuptools
+ 
+ long_description = """

--- a/pkgs/development/python-modules/segyio/default.nix
+++ b/pkgs/development/python-modules/segyio/default.nix
@@ -1,18 +1,23 @@
 {
   lib,
-  stdenv,
+  buildPythonPackage,
   fetchFromGitHub,
   cmake,
   ninja,
-  python,
   scikit-build,
   pytest,
   numpy,
 }:
 
-stdenv.mkDerivation rec {
+buildPythonPackage rec {
   pname = "segyio";
   version = "1.9.12";
+  pyproject = false; # Built with cmake
+
+  patches = [
+    # https://github.com/equinor/segyio/pull/570
+    ./add_missing_cstdint.patch
+  ];
 
   postPatch = ''
     # Removing unecessary build dependency
@@ -34,7 +39,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     ninja
-    python
     scikit-build
   ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2560,7 +2560,7 @@ self: super: with self; {
 
   criticality-score = callPackage ../development/python-modules/criticality-score { };
 
-  crocoddyl = toPythonModule (callPackage ../development/libraries/crocoddyl {
+  crocoddyl = toPythonModule (pkgs.crocoddyl.override {
     pythonSupport = true;
     python3Packages = self;
   });
@@ -4880,7 +4880,8 @@ self: super: with self; {
 
   gmpy = callPackage ../development/python-modules/gmpy { };
 
-  gmsh = toPythonModule (callPackage ../applications/science/math/gmsh {
+  gmsh = toPythonModule (pkgs.gmsh.override {
+    inherit (self) python;
     enablePython = true;
   });
 
@@ -6457,6 +6458,7 @@ self: super: with self; {
 
   kmsxx = toPythonModule (pkgs.kmsxx.override {
     withPython = true;
+    python3Packages = self;
   });
 
   knack = callPackage ../development/python-modules/knack { };
@@ -8802,7 +8804,7 @@ self: super: with self; {
 
   neuron-full = pkgs.neuron-full.override { python3 = python; };
 
-  neuronpy = python.pkgs.toPythonModule neuron-full;
+  neuronpy = toPythonModule neuron-full;
 
   nevow = callPackage ../development/python-modules/nevow { };
 
@@ -9616,7 +9618,7 @@ self: super: with self; {
 
   pbs-installer = callPackage ../development/python-modules/pbs-installer { };
 
-  pc-ble-driver-py = toPythonModule (callPackage ../development/python-modules/pc-ble-driver-py { });
+  pc-ble-driver-py = callPackage ../development/python-modules/pc-ble-driver-py { };
 
   pcapy-ng = callPackage ../development/python-modules/pcapy-ng {
     inherit (pkgs) libpcap; # Avoid confusion with python package of the same name
@@ -15299,7 +15301,7 @@ self: super: with self; {
     inherit (pkgs.darwin.apple_sdk.frameworks) Security;
   };
 
-  tokenize-rt = toPythonModule (callPackage ../development/python-modules/tokenize-rt { });
+  tokenize-rt = callPackage ../development/python-modules/tokenize-rt { };
 
   tokenlib = callPackage ../development/python-modules/tokenlib { };
 
@@ -16750,7 +16752,9 @@ self: super: with self; {
 
   vidstab = callPackage ../development/python-modules/vidstab { };
 
-  viennarna = toPythonModule pkgs.viennarna;
+  viennarna = toPythonModule (pkgs.viennarna.override {
+    python3 = self.python;
+  });
 
   viewstate = callPackage ../development/python-modules/viewstate { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5465,9 +5465,7 @@ self: super: with self; {
 
   homepluscontrol = callPackage ../development/python-modules/homepluscontrol { };
 
-  hoomd-blue = toPythonModule (callPackage ../development/python-modules/hoomd-blue {
-    inherit python;
-  });
+  hoomd-blue = callPackage ../development/python-modules/hoomd-blue { };
 
   hopcroftkarp = callPackage ../development/python-modules/hopcroftkarp { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12754,7 +12754,7 @@ self: super: with self; {
     inherit (pkgs) udev;
   };
 
-  pyunbound = toPythonModule (callPackage ../tools/networking/unbound/python.nix { });
+  pyunbound = callPackage ../development/python-modules/pyunbound { };
 
   pyunifi = callPackage ../development/python-modules/pyunifi { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10640,7 +10640,7 @@ self: super: with self; {
 
   py2bit = callPackage ../development/python-modules/py2bit { };
 
-  py3buddy = toPythonModule (callPackage ../development/python-modules/py3buddy { });
+  py3buddy = callPackage ../development/python-modules/py3buddy { };
 
   py3exiv2 = callPackage ../development/python-modules/py3exiv2 { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13792,9 +13792,9 @@ self: super: with self; {
 
   segno = callPackage ../development/python-modules/segno { };
 
-  segyio = toPythonModule (callPackage ../development/python-modules/segyio {
+  segyio = callPackage ../development/python-modules/segyio {
     inherit (pkgs) cmake ninja;
-  });
+  };
 
   selectors2 = callPackage ../development/python-modules/selectors2 { };
 


### PR DESCRIPTION
## Description of changes

Several non-standard behavior have been corrected here.
1. Using `toPythonModule` again for the `buildPythonPackage` package.
2. Not passing `python3Packages = self` or `inherit (self) python`
3. Not using `buildPythonPackage` for packages originally used as python modules
4. `callPackage` again instead of overriding

`pyside2` & `pyside6` stuff and `recursive-pth-loader` are skipped.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
