### PR TITLE
libimobiledevice: 1.3.0-date=2023-04-30 -> 1.3.0-unstable-2024-05-20,  libimobiledevice-glue: 1.2.0 -> 1.3.0 

### DIFF
--- a/pkgs/development/libraries/libimobiledevice-glue/default.nix
+++ b/pkgs/development/libraries/libimobiledevice-glue/default.nix
@@ -4,20 +4,23 @@
 , autoreconfHook
 , pkg-config
 , libplist
+, nix-update-script
 }:
 
 stdenv.mkDerivation rec {
   pname = "libimobiledevice-glue";
-  version = "1.2.0";
-
-  outputs = [ "out" "dev" ];
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
     rev = version;
-    hash = "sha256-Rfs1i1Tt8uf3WfR+cDlF4L75nFHg9VypjMhHt0TgkyQ=";
+    hash = "sha256-+poCrn2YHeH8RQCfWDdnlmJB4Nf+unWUVwn7YwILHIs=";
   };
+
+  preAutoreconf = ''
+    export RELEASE_VERSION=${version}
+  '';
 
   nativeBuildInputs = [
     autoreconfHook
@@ -28,9 +31,9 @@ stdenv.mkDerivation rec {
     libplist
   ];
 
-  preAutoreconf = ''
-    export RELEASE_VERSION=${version}
-  '';
+  outputs = [ "out" "dev" ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/libimobiledevice/libimobiledevice-glue";

--- a/pkgs/development/libraries/libimobiledevice/default.nix
+++ b/pkgs/development/libraries/libimobiledevice/default.nix
@@ -12,30 +12,25 @@
 , libimobiledevice-glue
 , SystemConfiguration
 , CoreFoundation
+, unstableGitUpdater
 }:
 
 stdenv.mkDerivation rec {
   pname = "libimobiledevice";
-  version = "1.3.0+date=2023-04-30";
-
-  outputs = [ "out" "dev" ];
+  version = "1.3.0-unstable-2024-05-20";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = "860ffb707af3af94467d2ece4ad258dda957c6cd";
-    hash = "sha256-mIsB+EaGJlGMOpz3OLrs0nAmhOY1BwMs83saFBaejwc=";
+    rev = "9ccc52222c287b35e41625cc282fb882544676c6";
+    hash = "sha256-pNvtDGUlifp10V59Kah4q87TvLrcptrCJURHo+Y+hs4=";
   };
 
-  patches = [
-    # Pull upstream fix for clang-16 and upcoming gcc-14 support:
-    #   https://github.com/libimobiledevice/libimobiledevice/pull/1444
-    (fetchpatch {
-      name = "usleep-decl.patch";
-      url = "https://github.com/libimobiledevice/libimobiledevice/commit/db623184c0aa09c27697f5a2e81025db223075d5.patch";
-      hash = "sha256-TgdgBkEDXzQDSgJxcZc+pZncfmBVXarhHOByGFs6p0Q=";
-    })
-  ];
+  preAutoreconf = ''
+    export RELEASE_VERSION=${version}
+  '';
+
+  configureFlags = [ "--without-cython" ];
 
   nativeBuildInputs = [
     autoreconfHook
@@ -54,11 +49,10 @@ stdenv.mkDerivation rec {
     CoreFoundation
   ];
 
-  preAutoreconf = ''
-    export RELEASE_VERSION=${version}
-  '';
 
-  configureFlags = [ "--without-cython" ];
+  outputs = [ "out" "dev" ];
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = with lib; {
     homepage = "https://github.com/libimobiledevice/libimobiledevice";


### PR DESCRIPTION
## Description of changes

* libimobiledevice: 1.3.0-date=2023-04-30 -> 1.3.0-unstable-2024-05-20
* libimobiledevice-glue: 1.2.0 -> 1.3.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
