### PR TITLE
haskellPackages: wrap up loose ends in js context

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghcjs-8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs-8.x.nix
@@ -24,6 +24,11 @@ self: super:
     aeson = self.aeson_1_5_6_0;
   });
 
+  # Some Hackage packages reference this attribute, which exists only in the
+  # GHCJS package set. We provide a dummy version here to fix potential
+  # evaluation errors.
+  ghcjs-prim = null;
+
   # GHCJS does not ship with the same core packages as GHC.
   # https://github.com/ghcjs/ghcjs/issues/676
   stm = doJailbreak self.stm_2_5_3_1;

--- a/pkgs/development/haskell-modules/configuration-ghcjs-8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs-8.x.nix
@@ -29,6 +29,8 @@ self: super:
   # evaluation errors.
   ghcjs-prim = null;
 
+  ghcjs-websockets = markUnbroken super.ghcjs-websockets;
+
   # GHCJS does not ship with the same core packages as GHC.
   # https://github.com/ghcjs/ghcjs/issues/676
   stm = doJailbreak self.stm_2_5_3_1;

--- a/pkgs/development/haskell-modules/configuration-ghcjs-8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs-8.x.nix
@@ -24,9 +24,7 @@ self: super:
     aeson = self.aeson_1_5_6_0;
   });
 
-  # Some Hackage packages reference this attribute, which exists only in the
-  # GHCJS package set. We provide a dummy version here to fix potential
-  # evaluation errors.
+  # Included in ghcjs itself
   ghcjs-prim = null;
 
   ghcjs-websockets = markUnbroken super.ghcjs-websockets;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -1999,6 +1999,7 @@ broken-packages:
   - ghcjs-fetch # timeout
   - ghcjs-promise # failure in job https://hydra.nixos.org/build/233243985 at 2023-09-02
   - ghcjs-xhr # failure in job https://hydra.nixos.org/build/233235693 at 2023-09-02
+  - ghcjs-websockets # Does not work on the js backend added in 9.6+, only on ghcjs, where we markUnbroken
   - ghc-justdoit # failure in job https://hydra.nixos.org/build/233221884 at 2023-09-02
   - ghclive # failure in job https://hydra.nixos.org/build/233231592 at 2023-09-02
   - ghc-man-completion # failure in job https://hydra.nixos.org/build/233245740 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -791,6 +791,7 @@ supported-platforms:
   geomancy:                                     [ platforms.x86 ] # x86 intrinsics
   geomancy-layout:                              [ platforms.x86 ] # x86 intrinsics
   gi-gtkosxapplication:                         [ platforms.darwin ]
+  ghcjs-base:                                   [ javascript-ghcjs ]
   ghcjs-dom-javascript:                         [ javascript-ghcjs ]
   gtk-mac-integration:                          [ platforms.darwin ]
   gtk3-mac-integration:                         [ platforms.darwin ]


### PR DESCRIPTION
## Description of changes

## ghcjs-base
```
$ nix-build -A pkgsCross.ghcjs.haskell.packages.ghc98.ghcjs-base
/nix/store/j82sxhz433yv9nik8knw4wd4jwlv1168-ghcjs-base-0.8.0.1

$ nix-build -A haskell.packages.ghc96.ghcjs-base 
...
Running phase: installPhase
Error: Setup: No executables and no library found. Nothing to do.
``` 
Guess it started failing after [removing](https://github.com/NixOS/nixpkgs/pull/309650/files#diff-06cdf278a2cf7f0e7793a4a8d19cbdd6e6a3a3722482708833ef9270b65d7d56L277-L281) `ghcjs-base = null`. 
Since it's [only buildable on JS](https://github.com/ghcjs/ghcjs-base/blob/31a85c618a97ce3af3d91bbceb7b0891b0fdab94/ghcjs-base.cabal#L146-L147), I set it as the only supported platform.

Related, turns out the `ghcjs-prim = null` removal broke old ghcjs eval
```
$ nix-build -A haskell.packages.ghcjs810.ghcjs-base
...
error: function 'anonymous lambda' called without required argument 'ghcjs-prim'
```

so I added that back in ghcjs-8.x only.

That fixes the eval errors, but I can't seem to actually build as linking fails on hspec-discover
``` 
Linking dist/build/hspec-discover/hspec-discover.jsexe (Main,Paths_hspec_discover)
Running phase: checkPhase
Running 1 test suites...
Test suite spec: RUNNING...
uncaught exception in Haskell main thread: ReferenceError: h$CLOCK_MONOTONIC is not defined
ReferenceError: h$CLOCK_MONOTONIC is not defined
    at h$hspeczmmetazm2zi7zi8zmKLEyatGv3WyFnEfi1EAvPBZCTestziHspecziCoreziClockzigetMonotonicTime2_e (/build/hspec-discover-2.7.10/dist/build/spec/spec:182124:102)
    at h$runThreadSlice (/build/hspec-discover-2.7.10/dist/build/spec/spec:7492:11)
    at h$runThreadSliceCatch (/build/hspec-discover-2.7.10/dist/build/spec/spec:7468:12)
    at h$mainLoop (/build/hspec-discover-2.7.10/dist/build/spec/spec:7463:9)
    at /build/hspec-discover-2.7.10/dist/build/spec/spec:7956:13
    at h$handleErrnoC (/build/hspec-discover-2.7.10/dist/build/spec/spec:5460:9)
    at /build/hspec-discover-2.7.10/dist/build/spec/spec:22758:13
    at FSReqCallback.oncomplete (node:fs:204:21)
```
Happens on master as well though

## ghcjs-websockets

https://hackage.haskell.org/package/ghcjs-websockets was last updated 8 years ago and is deprecated in favor of https://github.com/ghcjs/ghcjs-base/blob/31a85c618a97ce3af3d91bbceb7b0891b0fdab94/JavaScript/Web/WebSocket.hs .
Its only reverse dependency on hackage is acme-everything, so I flagged it as broken by default and unmarked on ghcjs-8.x only. I don't think the compile time errors under new js backend will ever be fixed:

```
$ nix-build -A pkgsCross.ghcjs.haskell.packages.ghc98.ghcjs-websockets
...
Building library for ghcjs-websockets-0.3.0.5..
[1 of 5] Compiling JavaScript.Blob  ( src/JavaScript/Blob.hs, dist/build/JavaScript/Blob.o )

src/JavaScript/Blob.hs:16:27: error: [GHC-61689]
    Module ‘GHCJS.Foreign’ does not export ‘bufferByteString’.
   |
16 | import GHCJS.Foreign     (bufferByteString)
   |                           ^^^^^^^^^^^^^^^^
[2 of 5] Compiling JavaScript.NoGHCJS ( src/JavaScript/NoGHCJS.hs, dist/build/JavaScript/NoGHCJS.o )
[3 of 5] Compiling JavaScript.WebSockets.FFI ( src/JavaScript/WebSockets/FFI.hs, dist/build/JavaScript/WebSockets/FFI.o )

src/JavaScript/WebSockets/FFI.hs:28:28: error: [GHC-61689]
    Module ‘GHCJS.Types’ does not export ‘JSArray’.
   |
28 | import GHCJS.Types (JSRef, JSArray, JSString, JSObject, JSBool)
   |                            ^^^^^^^

src/JavaScript/WebSockets/FFI.hs:28:47: error: [GHC-61689]
    Module ‘GHCJS.Types’ does not export ‘JSObject’.
   |
28 | import GHCJS.Types (JSRef, JSArray, JSString, JSObject, JSBool)
   |                                               ^^^^^^^^

src/JavaScript/WebSockets/FFI.hs:28:57: error: [GHC-61689]
    Module ‘GHCJS.Types’ does not export ‘JSBool’.
   |
28 | import GHCJS.Types (JSRef, JSArray, JSString, JSObject, JSBool)
   |                                                         ^^^^^^
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
