### PR TITLE
jetbrains: prevent download of unpatched jetbrains jdk

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/linux.nix
+++ b/pkgs/applications/editors/jetbrains/bin/linux.nix
@@ -110,7 +110,7 @@ with stdenv; lib.makeOverridable mkDerivation (rec {
       --set-default JDK_HOME "$jdk" \
       --set-default ANDROID_JAVA_HOME "$jdk" \
       --set-default JAVA_HOME "$jdk" \
-      --set-default JETBRAINSCLIENT_JDK "$jdk" \
+      --set-default JETBRAINS_CLIENT_JDK "$jdk" \
       --set-default ${hiName}_JDK "$jdk" \
       --set-default ${hiName}_VM_OPTIONS ${vmoptsFile}
 


### PR DESCRIPTION
## Description of changes

It looks like recent changes to `jetbrains_client.sh` prevent devcontainers from starting.
I experienced the following errors (unveiled by [increasing log level](https://www.jetbrains.com/help/idea/faq-about-dev-containers.html#logs)):

```txt
2024-06-19 12:46:54,007 [ 168013]   INFO - #c.i.r.d.CodeWithMeClientDownloader - GUEST OUTPUT: Could not start dynamically linked executable: /home/mloeper/.cache/JetBrains/JetBrainsClientDist/JetBrainsClient-242.16677.12.tar.gz-1c24b25903.ide.d/JetBrainsClient-242.16677.12/jbr/bin/java

2024-06-19 12:46:54,007 [ 168013]   INFO - #c.i.r.d.CodeWithMeClientDownloader - GUEST OUTPUT: NixOS cannot run dynamically linked executables intended for generic

2024-06-19 12:46:54,007 [ 168013]   INFO - #c.i.r.d.CodeWithMeClientDownloader - GUEST OUTPUT: linux environments out of the box. For more information, see:

2024-06-19 12:46:54,007 [ 168013]   INFO - #c.i.r.d.CodeWithMeClientDownloader - GUEST OUTPUT: https://nix.dev/permalink/stub-ld
```

It looks like the breaking change is related to a simple renaming from `JETBRAINSCLIENT_JDK` to `JETBRAINS_CLIENT_JDK` by the jetbrains team in `jetbrains_client.sh` which is downloaded on-demand.

The renaming of the env var in the script leads to a new jdk being downloaded which is not patched.
We usually want the script to run the jetbrains.jdk instead of the unpatched one which is downloaded on-demand.

One thing to consider: Since the `jetbrains_client.sh` is downloaded on-demand, it might be that users have an older version in their `<home>/.cache` folder. To prevent breaking things, we might keep the old `JETBRAINSCLIENT_JDK` and defer its removal.

The discourse which pointed me into the right direction for this fix is: https://discourse.nixos.org/t/jetbrains-gateway-client-support-on-nixos/18108/18

Side note: This is my first nixpkgs contribution. Feel free to point our any missing information etc.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
