### PR TITLE
lomiri.lomiri-calculator-app: init at 4.0.2

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -21,6 +21,7 @@ in {
         history-service
         libusermetrics
         lomiri
+        lomiri-calculator-app
         lomiri-download-manager
         lomiri-filemanager-app
         lomiri-schemas # exposes some required dbus interfaces

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -522,6 +522,7 @@ in {
   lxd-image-server = handleTest ./lxd-image-server.nix {};
   #logstash = handleTest ./logstash.nix {};
   lomiri = handleTest ./lomiri.nix {};
+  lomiri-calculator-app = runTest ./lomiri-calculator-app.nix;
   lomiri-filemanager-app = runTest ./lomiri-filemanager-app.nix;
   lomiri-system-settings = handleTest ./lomiri-system-settings.nix {};
   lorri = handleTest ./lorri/default.nix {};

--- a/nixos/tests/lomiri-calculator-app.nix
+++ b/nixos/tests/lomiri-calculator-app.nix
@@ -1,0 +1,59 @@
+{ pkgs, lib, ... }:
+{
+  name = "lomiri-calculator-app-standalone";
+  meta.maintainers = lib.teams.lomiri.members;
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      imports = [ ./common/x11.nix ];
+
+      services.xserver.enable = true;
+
+      environment = {
+        systemPackages = with pkgs.lomiri; [
+          suru-icon-theme
+          lomiri-calculator-app
+        ];
+        variables = {
+          UITK_ICON_THEME = "suru";
+        };
+      };
+
+      i18n.supportedLocales = [ "all" ];
+
+      fonts.packages = with pkgs; [
+        # Intended font & helps with OCR
+        ubuntu_font_family
+      ];
+    };
+
+  enableOCR = true;
+
+  testScript = ''
+    machine.wait_for_x()
+
+    with subtest("lomiri calculator launches"):
+        machine.execute("lomiri-calculator-app >&2 &")
+        machine.wait_for_text("Calculator")
+        machine.screenshot("lomiri-calculator")
+
+    with subtest("lomiri calculator works"):
+        machine.send_key("tab") # Fix focus
+
+        machine.send_chars("22*16\n")
+        machine.wait_for_text("352")
+        machine.screenshot("lomiri-calculator_caninfactdobasicmath")
+
+    machine.succeed("pkill -f lomiri-calculator-app")
+
+    with subtest("lomiri calculator localisation works"):
+        machine.execute("env LANG=de_DE.UTF-8 lomiri-calculator-app >&2 &")
+        machine.wait_for_text("Rechner")
+        machine.screenshot("lomiri-calculator_localised")
+
+    # History of previous run should have loaded
+    with subtest("lomiri calculator history works"):
+        machine.wait_for_text("352")
+  '';
+}

--- a/pkgs/desktops/lomiri/applications/lomiri-calculator-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-calculator-app/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitLab,
   fetchpatch,
   gitUpdater,
+  nixosTests,
   cmake,
   gettext,
   lomiri-ui-toolkit,
@@ -91,6 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    tests.vm = nixosTests.lomiri-calculator-app;
     updateScript = gitUpdater { rev-prefix = "v"; };
   };
 

--- a/pkgs/desktops/lomiri/applications/lomiri-calculator-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-calculator-app/default.nix
@@ -1,0 +1,106 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  fetchpatch,
+  gitUpdater,
+  cmake,
+  gettext,
+  lomiri-ui-toolkit,
+  pkg-config,
+  qqc2-suru-style,
+  qtbase,
+  wrapQtAppsHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-calculator-app";
+  version = "4.0.2";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/apps/lomiri-calculator-app";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-NyLEis+rIx2ELUiGrGCeFX/tlt43UgPBkb9aUs1tkgk=";
+  };
+
+  patches = [
+    # Remove when version > 4.0.2
+    (fetchpatch {
+      name = "0001-lomiri-calculator-app-Fix-GNUInstallDirs-variable-concatenations.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-calculator-app/-/commit/0bd6ef6c3470bcecf90a88e1e5568a5ce5ad6d06.patch";
+      hash = "sha256-2FCLZ/LY3xTPGDmX+M8LiqlbcNQJu5hulkOf+V+3hWY=";
+    })
+
+    # Remove when version > 4.0.2
+    # Must apply separately because merge has hunk with changes to new file before hunk that inits said file
+    (fetchpatch {
+      name = "0002-lomiri-calculator-app-Migrate-to-C++-app.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-calculator-app/-/commit/035e5b8000ad1c8149a6b024fa8fed2667fbb659.patch";
+      hash = "sha256-2BTFOrH/gjIzXBmnTPMi+mPpUA7e/+6O/E3pdxhjZYQ=";
+    })
+    (fetchpatch {
+      name = "0003-lomiri-calculator-app-Call-i18n.bindtextdomain.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-calculator-app/-/commit/7cb5e56958e41a8f7a51e00d81d9b2bc24de32b0.patch";
+      hash = "sha256-k/Civ0+SCNDDok9bUdb48FKC+LPlM13ASFP6CbBvBVs=";
+    })
+  ];
+
+  postPatch =
+    # We don't want absolute paths in desktop files
+    ''
+      substituteInPlace CMakeLists.txt \
+        --replace-fail 'ICON ''${LOMIRI-CALCULATOR-APP_DIR}/''${ICON_FILE}' 'ICON ''${APP_HARDCODE}' \
+        --replace-fail 'SPLASH ''${LOMIRI-CALCULATOR-APP_DIR}/''${SPLASH_FILE}' 'SPLASH lomiri-app-launch/splash/''${APP_HARDCODE}.svg'
+    ''
+    + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
+      substituteInPlace CMakeLists.txt \
+        --replace-fail 'add_subdirectory(tests)' ""
+    '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qtbase
+
+    # QML
+    lomiri-ui-toolkit
+    qqc2-suru-style
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "CLICK_MODE" false)
+    (lib.cmakeBool "INSTALL_TESTS" false)
+  ];
+
+  # No tests we can actually run (just autopilot)
+  doCheck = false;
+
+  postInstall = ''
+    mkdir -p $out/share/{icons/hicolor/scalable/apps,lomiri-app-launch/splash}
+
+    ln -s $out/share/{lomiri-calculator-app,icons/hicolor/scalable/apps}/lomiri-calculator-app.svg
+    ln -s $out/share/{lomiri-calculator-app/lomiri-calculator-app-splash.svg,lomiri-app-launch/splash/lomiri-calculator-app.svg}
+  '';
+
+  passthru = {
+    updateScript = gitUpdater { rev-prefix = "v"; };
+  };
+
+  meta = {
+    description = "Powerful and easy to use calculator for Ubuntu Touch, with calculations history and formula validation";
+    homepage = "https://gitlab.com/ubports/development/apps/lomiri-calculator-app";
+    changelog = "https://gitlab.com/ubports/development/apps/lomiri-calculator-app/-/blob/v${finalAttrs.version}/ChangeLog";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "lomiri-calculator-app";
+    maintainers = lib.teams.lomiri.members;
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -9,6 +9,7 @@ let
   in {
     #### Core Apps
     lomiri = callPackage ./applications/lomiri { };
+    lomiri-calculator-app = callPackage ./applications/lomiri-calculator-app { };
     lomiri-filemanager-app = callPackage ./applications/lomiri-filemanager-app { };
     lomiri-system-settings-unwrapped = callPackage ./applications/lomiri-system-settings { };
     lomiri-system-settings-security-privacy = callPackage ./applications/lomiri-system-settings/plugins/lomiri-system-settings-security-privacy.nix { };


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[Lomiri Calculator App](https://gitlab.com/ubports/development/apps/lomiri-calculator-app). Self-explanatory. It's a calculator.
![lomiri-calculator](https://github.com/NixOS/nixpkgs/assets/23431373/94ed5bd6-9a1f-43c3-b37f-28321ab47132)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
