### PR TITLE
python311Packages.pyogrio: 0.8.0 → 0.9.0

### DIFF
--- a/pkgs/development/python-modules/pyogrio/default.nix
+++ b/pkgs/development/python-modules/pyogrio/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "pyogrio";
-  version = "0.8.0";
+  version = "0.9.0";
   pyproject = true;
   disabled = pythonOlder "3.8";
 
@@ -25,15 +25,12 @@ buildPythonPackage rec {
     owner = "geopandas";
     repo = "pyogrio";
     rev = "v${version}";
-    hash = "sha256-h4Rv5xOWSJSv0nLbosviz5EiF/IsZO5wzBel9YRd0Bg=";
+    hash = "sha256-HC7+dDehDwEIDQnCMYrsC1jE78AyfHqEhfOZLYSzTIw=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail "versioneer[toml]==0.28" "versioneer[toml]"
-  '' + lib.optionalString (!pythonOlder "3.12") ''
-    substituteInPlace setup.py \
-      --replace-fail "distutils" "setuptools._distutils"
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes
https://github.com/geopandas/pyogrio/releases/tag/v0.9.0

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
