### PR TITLE
spotify: 1.2.17.834.g26ee1129 -> 1.2.38.720.ga4a70a0e

### DIFF
--- a/pkgs/applications/audio/spotify/darwin.nix
+++ b/pkgs/applications/audio/spotify/darwin.nix
@@ -9,17 +9,17 @@
 stdenv.mkDerivation {
   inherit pname;
 
-  version = "1.2.38.720.ga4a70a0e";
+  version = "1.2.40.599.g606b7f29";
 
   src = if stdenv.isAarch64 then (
     fetchurl {
-      url = "https://web.archive.org/web/20240601115919/https://download.scdn.co/SpotifyARM64.dmg";
-      sha256 = "sha256-jQt5lmquxHU6jw1vtEoTsbwryv/6XBZQ2IT7KobKYvk=";
+      url = "https://web.archive.org/web/20240622065234/https://download.scdn.co/SpotifyARM64.dmg";
+      hash = "sha256-mmjxKYmsX0rFlIU19JOfPbNgOhlcZs5slLUhDhlON1c=";
     })
   else (
     fetchurl {
-      url = "https://web.archive.org/web/20240601115919/https://download.scdn.co/Spotify.dmg";
-      sha256 = "sha256-1IVIZpwlwlIjl/UeSyYOQOrQk7sMxrHCQsCkcVMqcfo=";
+      url = "https://web.archive.org/web/20240622065548/https://download.scdn.co/Spotify.dmg";
+      hash = "sha256-hvS0xnmJQoQfNJRFsLBQk8AJjDOzDy+OGwNOq5Ms/O0=";
     });
 
   nativeBuildInputs = [ undmg ];

--- a/pkgs/applications/audio/spotify/darwin.nix
+++ b/pkgs/applications/audio/spotify/darwin.nix
@@ -9,17 +9,17 @@
 stdenv.mkDerivation {
   inherit pname;
 
-  version = "1.2.17.834.g26ee1129";
+  version = "1.2.38.720.ga4a70a0e";
 
   src = if stdenv.isAarch64 then (
     fetchurl {
-      url = "https://web.archive.org/web/20230808124344/https://download.scdn.co/SpotifyARM64.dmg";
-      sha256 = "sha256-u22hIffuCT6DwN668TdZXYedY9PSE7ZnL+ITK78H7FI=";
+      url = "https://web.archive.org/web/20240601115919/https://download.scdn.co/SpotifyARM64.dmg";
+      sha256 = "sha256-jQt5lmquxHU6jw1vtEoTsbwryv/6XBZQ2IT7KobKYvk=";
     })
   else (
     fetchurl {
-      url = "https://web.archive.org/web/20230808124637/https://download.scdn.co/Spotify.dmg";
-      sha256 = "sha256-aaYMbZpa2LvyBeXmEAjrRYfYqbudhJHR/hvCNTsNQmw=";
+      url = "https://web.archive.org/web/20240601115919/https://download.scdn.co/Spotify.dmg";
+      sha256 = "sha256-1IVIZpwlwlIjl/UeSyYOQOrQk7sMxrHCQsCkcVMqcfo=";
     });
 
   nativeBuildInputs = [ undmg ];


### PR DESCRIPTION
## Description of changes

Updating Spotify client for Darwin, old links were down and causing build issues.

Also wanting to backport this as well to 24.05 `backport release-24.05` I seem unable to add this tag myself.

I have modelled this after the a previous PR to update this; #247940 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
