### PR TITLE
linuxKernel: depend exclusively on elfutils

### DIFF
--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -140,8 +140,7 @@ let
     passAsFile = [ "kernelConfig" ];
 
     depsBuildBuild = [ buildPackages.stdenv.cc ];
-    nativeBuildInputs = [ perl gmp libmpc mpfr ]
-      ++ lib.optionals (lib.versionAtLeast version "4.16") [ bison flex ]
+    nativeBuildInputs = [ perl gmp libmpc mpfr bison flex ]
       ++ lib.optional (lib.versionAtLeast version "5.2") pahole
       ++ lib.optionals withRust [ rust-bindgen rustc ]
     ;

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -143,6 +143,8 @@ let
 
       depsBuildBuild = [ buildPackages.stdenv.cc ];
       nativeBuildInputs = [
+        bison
+        flex
         perl
         bc
         nettools
@@ -156,7 +158,6 @@ let
         python3Minimal
         kmod
       ] ++ optional  needsUbootTools ubootTools
-        ++ optionals (lib.versionAtLeast version "4.16") [ bison flex ]
         ++ optionals (lib.versionAtLeast version "5.2")  [ cpio pahole zlib ]
         ++ optionals withRust [ rustc rust-bindgen ];
 

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, buildPackages, runCommand, nettools, bc, bison, flex, perl, rsync, gmp, libmpc, mpfr, openssl
-, libelf, cpio, elfutils, zstd, python3Minimal, zlib, pahole, kmod, ubootTools
+, cpio, elfutils, zstd, python3Minimal, zlib, pahole, kmod, ubootTools
 , fetchpatch
 , rustc, rust-bindgen, rustPlatform
 }:
@@ -120,7 +120,7 @@ let
       moduleBuildDependencies = [
         pahole
         perl
-        libelf
+        elfutils
         # module makefiles often run uname commands to find out the kernel version
         (buildPackages.deterministic-uname.override { inherit modDirVersion; })
       ]
@@ -142,13 +142,23 @@ let
       inherit src;
 
       depsBuildBuild = [ buildPackages.stdenv.cc ];
-      nativeBuildInputs = [ perl bc nettools openssl rsync gmp libmpc mpfr zstd python3Minimal kmod ]
-                          ++ optional  needsUbootTools ubootTools
-                          ++ optional  (lib.versionOlder version "5.8") libelf
-                          ++ optionals (lib.versionAtLeast version "4.16") [ bison flex ]
-                          ++ optionals (lib.versionAtLeast version "5.2")  [ cpio pahole zlib ]
-                          ++ optional  (lib.versionAtLeast version "5.8")  elfutils
-                          ++ optionals withRust [ rustc rust-bindgen ];
+      nativeBuildInputs = [
+        perl
+        bc
+        nettools
+        openssl
+        rsync
+        gmp
+        libmpc
+        mpfr
+        elfutils
+        zstd
+        python3Minimal
+        kmod
+      ] ++ optional  needsUbootTools ubootTools
+        ++ optionals (lib.versionAtLeast version "4.16") [ bison flex ]
+        ++ optionals (lib.versionAtLeast version "5.2")  [ cpio pahole zlib ]
+        ++ optionals withRust [ rustc rust-bindgen ];
 
       RUST_LIB_SRC = lib.optionalString withRust rustPlatform.rustLibSrc;
 
@@ -399,9 +409,6 @@ let
       } // extraMeta;
     };
 in
-
-assert lib.versionOlder version "5.8" -> libelf != null;
-assert lib.versionAtLeast version "5.8" -> elfutils != null;
 
 stdenv.mkDerivation ((drvAttrs config stdenv.hostPlatform.linux-kernel kernelPatches configfile) // {
   inherit pname version;


### PR DESCRIPTION
## Description of changes

Linux kernel versions newer than 5.8 used `elfutils`, but it turns out that the older ones can do so as well.

- #271473 

All the failing packages from the `nixpkgs-review` linked below also fail on master as well.

## Things done

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review): [report.md](https://gist.github.com/philiptaron/2643de9b46de7c3ab2453e640380d0c0)

* 353 packages marked as broken and skipped
* 239 packages failed to build
* 2310 packages built

- [x] Built on x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).