### PR TITLE
rust: Write config.toml not config

### DIFF
--- a/pkgs/build-support/rust/fetch-cargo-tarball/default.nix
+++ b/pkgs/build-support/rust/fetch-cargo-tarball/default.nix
@@ -73,7 +73,7 @@ in stdenv.mkDerivation ({
 
     ${cargoUpdateHook}
 
-    # Override the `http.cainfo` option usually specified in `.cargo/config`.
+    # Override the `http.cainfo` option usually specified in `.cargo/config.toml`.
     export CARGO_HTTP_CAINFO=${cacert}/etc/ssl/certs/ca-bundle.crt
 
     if grep '^source = "git' Cargo.lock; then
@@ -96,7 +96,7 @@ in stdenv.mkDerivation ({
 
     # Packages with git dependencies generate non-default cargo configs, so
     # always install it rather than trying to write a standard default template.
-    install -D $CARGO_CONFIG $name/.cargo/config;
+    install -D $CARGO_CONFIG $name/.cargo/config.toml;
 
     runHook postBuild
   '';

--- a/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
@@ -22,7 +22,7 @@ cargoSetupPostUnpackHook() {
         mkdir .cargo
     fi
 
-    config="$cargoDepsCopy/.cargo/config";
+    config="$cargoDepsCopy/.cargo/config.toml";
     if [[ ! -e $config ]]; then
       config=@defaultConfig@
     fi;
@@ -30,9 +30,9 @@ cargoSetupPostUnpackHook() {
     tmp_config=$(mktemp)
     substitute $config $tmp_config \
       --subst-var-by vendor "$cargoDepsCopy"
-    cat ${tmp_config} >> .cargo/config
+    cat ${tmp_config} >> .cargo/config.toml
 
-    cat >> .cargo/config <<'EOF'
+    cat >> .cargo/config.toml <<'EOF'
     @cargoConfig@
 EOF
 

--- a/pkgs/build-support/rust/import-cargo-lock.nix
+++ b/pkgs/build-support/rust/import-cargo-lock.nix
@@ -226,7 +226,7 @@ let
       else "cp $lockFileContentsPath $out/Cargo.lock"
     }
 
-    cat > $out/.cargo/config <<EOF
+    cat > $out/.cargo/config.toml <<EOF
 [source.crates-io]
 replace-with = "vendored-sources"
 
@@ -237,7 +237,7 @@ EOF
     declare -A keysSeen
 
     for registry in ${toString (builtins.attrNames extraRegistries)}; do
-      cat >> $out/.cargo/config <<EOF
+      cat >> $out/.cargo/config.toml <<EOF
 
 [source."$registry"]
 registry = "$registry"
@@ -253,7 +253,7 @@ EOF
         key=$(sed 's/\[source\."\(.*\)"\]/\1/; t; d' < "$crate/.cargo-config")
         if [[ -z ''${keysSeen[$key]} ]]; then
           keysSeen[$key]=1
-          cat "$crate/.cargo-config" >> $out/.cargo/config
+          cat "$crate/.cargo-config" >> $out/.cargo/config.toml
         fi
       fi
     done

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -215,7 +215,7 @@ in stdenv.mkDerivation (finalAttrs: {
     export JEMALLOC_SYS_WITH_LG_VADDR=48
   '' + lib.optionalString (!(finalAttrs.src.passthru.isReleaseTarball or false)) ''
     mkdir .cargo
-    cat > .cargo/config <<\EOF
+    cat > .cargo/config.toml <<\EOF
     [source.crates-io]
     replace-with = "vendored-sources"
     [source.vendored-sources]

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -326,7 +326,7 @@ in
       rustc.unwrapped
     ];
     preBuild = ''
-      cat ../.cargo/config > ext/fast_mmaped_file_rs/.cargo/config.toml
+      cat ../.cargo/config.toml > ext/fast_mmaped_file_rs/.cargo/config.toml
       sed -i "s|cargo-vendor-dir|$PWD/../cargo-vendor-dir|" ext/fast_mmaped_file_rs/.cargo/config.toml
     '';
     postInstall = ''


### PR DESCRIPTION
## Description of changes

Changes the rust infra to write cargo config to .cargo/config.toml insted of .cargo/config since the latter is deprecated (since 1.38?) and is now warning on stderr.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
