### PR TITLE
yggdrasil-jumper: init at 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17061,6 +17061,12 @@
     github = "jackyliu16";
     githubId = 50787361;
   };
+  one-d-wide = {
+    name = "Remy D. Farley";
+    email = "one-d-wide@protonmail.com";
+    github = "one-d-wide";
+    githubId = 116499566;
+  };
   onemoresuza = {
     name = "Coutinho de Souza";
     email = "dev@onemoresuza.com";

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -49,6 +49,8 @@
 
 - [Omnom](https://github.com/asciimoo/omnom), a webpage bookmarking and snapshotting service. Available as [services.omnom](options.html#opt-services.omnom.enable).
 
+- [Yggdrasil-Jumper](https://github.com/one-d-wide/yggdrasil-jumper) is an independent project that aims to transparently reduce latency of a connection over Yggdrasil network, utilizing NAT traversal to automatically bypass intermediary nodes.
+
 - [Zenoh](https://zenoh.io/), a pub/sub/query protocol with low overhead. The Zenoh router daemon is available as [services.zenohd](options.html#opt-services.zenohd.enable)
 
 - [ytdl-sub](https://github.com/jmbannon/ytdl-sub), a tool that downloads media via yt-dlp and prepares it for your favorite media player, including Kodi, Jellyfin, Plex, Emby, and modern music players. Available as [services.ytdl-sub](options.html#opt-services.ytdl-sub.instances).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1326,6 +1326,7 @@
   ./services/networking/xrdp.nix
   ./services/networking/yggdrasil.nix
   ./services/networking/zapret.nix
+  ./services/networking/yggdrasil-jumper.nix
   ./services/networking/zerobin.nix
   ./services/networking/zenohd.nix
   ./services/networking/zeronet.nix

--- a/nixos/modules/services/networking/yggdrasil-jumper.nix
+++ b/nixos/modules/services/networking/yggdrasil-jumper.nix
@@ -1,0 +1,173 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    escapeShellArgs
+    filter
+    hasPrefix
+    mapAttrsToList
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    ;
+  format = pkgs.formats.toml { };
+in
+{
+  options =
+    let
+      inherit (lib.types)
+        bool
+        enum
+        lines
+        listOf
+        str
+        ;
+    in
+    {
+      services.yggdrasil-jumper = {
+        enable = mkEnableOption "the Yggdrasil Jumper system service";
+
+        retrieveListenAddresses = mkOption {
+          type = bool;
+          default = true;
+          description = ''
+            Automatically retrieve listen addresses from the Yggdrasil router configuration.
+
+            See `yggdrasil_listen` option in Yggdrasil Jumper configuration.
+          '';
+        };
+
+        appendListenAddresses = mkOption {
+          type = bool;
+          default = true;
+          description = ''
+            Append Yggdrasil router configuration with listeners on loopback
+            addresses (`127.0.0.1`) and preselected ports to support peering
+            using client-server protocols like `quic` and `tls`.
+
+            See `Listen` option in Yggdrasil router configuration.
+          '';
+        };
+
+        settings = mkOption {
+          type = format.type;
+          default = { };
+          example = {
+            listen_port = 9999;
+            whitelist = [
+              "<IPv6 address of a remote node>"
+            ];
+          };
+          description = ''
+            Configuration for Yggdrasil Jumper as a Nix attribute set.
+          '';
+        };
+
+        extraConfig = mkOption {
+          type = lines;
+          default = "";
+          example = ''
+            listen_port = 9999;
+            whitelist = [
+              "<IPv6 address of a remote node>"
+            ];
+          '';
+          description = ''
+            Configuration for Yggdrasil Jumper in plaintext.
+          '';
+        };
+
+        package = mkPackageOption pkgs "yggdrasil-jumper" { };
+
+        logLevel = mkOption {
+          type = enum [ "off" "error" "warn" "info" "debug" "trace" ];
+          default = "info";
+          description = ''
+            Set logging verbosity for Yggdrasil Jumper.
+          '';
+        };
+
+        extraArgs = mkOption {
+          type = listOf str;
+          default = [ ];
+          description = ''
+            Extra command line arguments for Yggdrasil Jumper.
+          '';
+        };
+      };
+    };
+
+  config =
+    let
+      cfg = config.services.yggdrasil-jumper;
+
+      # Generate, concatenate and validate config file
+      jumperSettings = format.generate "yggdrasil-jumper-settings" cfg.settings;
+      jumperExtraConfig = pkgs.writeText "yggdrasil-jumper-extra-config" cfg.extraConfig;
+      jumperConfig =
+        pkgs.runCommand
+          "yggdrasil-jumper-config"
+          { }
+          ''
+            cat ${jumperSettings} ${jumperExtraConfig} \
+              | tee $out \
+              | ${cfg.package}/bin/yggdrasil-jumper --validate --config -
+          '';
+    in
+    mkIf cfg.enable {
+      assertions = [{
+        assertion = config.services.yggdrasil.enable;
+        message = "`services.yggdrasil.enable` must be true for `yggdrasil-jumper` to operate";
+      }];
+
+      services.yggdrasil.settings.Listen =
+        let
+          # By default linux dynamically alocates ports in range 32768..60999
+          # `sysctl net.ipv4.ip_local_port_range`
+          # See: https://xkcd.com/221/
+          prot_port = { "tls" = 11814; "quic" = 11814; };
+        in
+        mkIf
+          (cfg.retrieveListenAddresses && cfg.appendListenAddresses)
+          (mapAttrsToList (prot: port: "${prot}://127.0.0.1:${toString port}") prot_port);
+
+      services.yggdrasil-jumper.settings = {
+        yggdrasil_admin_listen = [ "unix:///run/yggdrasil/yggdrasil.sock" ];
+        yggdrasil_listen =
+          mkIf
+            cfg.retrieveListenAddresses
+            (filter (a: !hasPrefix "tcp://" a) config.services.yggdrasil.settings.Listen);
+      };
+
+      systemd.services.yggdrasil-jumper = {
+        description = "Yggdrasil Jumper Service";
+        after = [ "yggdrasil.service" ];
+        unitConfig.BindsTo = [ "yggdrasil.service" ];
+        wantedBy = [ "multi-user.target" ];
+
+        serviceConfig = {
+          User = "yggdrasil";
+          DynamicUser = true;
+
+          # TODO: Remove this delay after support for proper startup notification lands in `yggdrasil-go`
+          ExecStartPre = "${pkgs.coreutils}/bin/sleep 5";
+          ExecStart = escapeShellArgs ([ "${cfg.package}/bin/yggdrasil-jumper" "--loglevel" "${cfg.logLevel}" "--config" "${jumperConfig}" ] ++ cfg.extraArgs);
+          KillSignal = "SIGINT";
+
+          MemoryDenyWriteExecute = true;
+          ProtectControlGroups = true;
+          ProtectHome = "tmpfs";
+          RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6";
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [ "@system-service" "~@privileged" ];
+        };
+      };
+
+      environment.systemPackages = [ cfg.package ];
+    };
+
+  meta.maintainers = with lib.maintainers; [ one-d-wide ];
+}

--- a/pkgs/by-name/yg/yggdrasil-jumper/package.nix
+++ b/pkgs/by-name/yg/yggdrasil-jumper/package.nix
@@ -1,0 +1,36 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, nix-update-script
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "yggdrasil-jumper";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "one-d-wide";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-Op3KBJ911AjB7BIJuV4xR8KHMxBtQj7hf++tC1g7SlM=";
+  };
+
+  cargoHash = "sha256-i4w+cUCTzbXMC76HuVUdKh54ww8T9nPqQkL64YAneos=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "Reduce latency of a connection over Yggdrasil Network";
+    longDescription = ''
+      An independent project that aims to transparently reduce latency
+      of a connection over Yggdrasil network, utilizing NAT traversal to
+      bypass intermediary nodes. It periodically probes for active sessions
+      and automatically establishes direct peerings over internet with
+      remote nodes running Yggdrasil-Jumper without requiring any firewall
+      configuration or port mapping.
+    '';
+    homepage = "https://github.com/one-d-wide/yggdrasil-jumper";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ one-d-wide ];
+  };
+}


### PR DESCRIPTION
Yggdrasil-Jumper is an independent project that aims to transparently reduce latency of a connection over Yggdrasil network, utilizing NAT traversal to bypass intermediary nodes. It periodically probes for active sessions and automatically establishes direct peerings over internet with remote nodes running Yggdrasil-Jumper without requiring any firewall configuration or port mapping.

[Homepage](https://github.com/one-d-wide/yggdrasil-jumper).

## This PR adds

- Yggdrasil Jumper package
- New configuration module

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
