### PR TITLE
talecast: init at 0.1.39

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4147,6 +4147,12 @@
     githubId = 11145016;
     name = "J.C.";
   };
+  confusedalex = {
+    email = "alex@confusedalex.dev";
+    github = "ConfusedAlex";
+    githubId = 29258035;
+    name = "Alexander Loll";
+  };
   congee = {
     email = "changshengwu@pm.me";
     matrix = "@congeec:matrix.org";

--- a/pkgs/by-name/ta/talecast/package.nix
+++ b/pkgs/by-name/ta/talecast/package.nix
@@ -6,6 +6,7 @@
   pkg-config,
   openssl,
   nix-update-script,
+  stdenv,
   testers,
   talecast
 }:

--- a/pkgs/by-name/ta/talecast/package.nix
+++ b/pkgs/by-name/ta/talecast/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchCrate,
+  darwin,
   rustPlatform,
   pkg-config,
   openssl,
@@ -21,7 +22,9 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-mIzrYlAqHYrK2bb/ZUzqIwhPJKcTQpNpqijpEuwLc5A=";
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ openssl ];
+
+  buildInputs = [ openssl ]
+    + lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.SystemConfiguration ];
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/by-name/ta/talecast/package.nix
+++ b/pkgs/by-name/ta/talecast/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ openssl ]
-    + lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.SystemConfiguration ];
+    ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.SystemConfiguration ];
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/by-name/ta/talecast/package.nix
+++ b/pkgs/by-name/ta/talecast/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  fetchCrate,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  nix-update-script,
+  testers,
+  talecast
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "talecast";
+  version = "0.1.39";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-RwB+X+i3CEcTyKac81he9/cT2aQ4M7AqgqSDBEvhFJU=";
+  };
+
+  cargoHash = "sha256-mIzrYlAqHYrK2bb/ZUzqIwhPJKcTQpNpqijpEuwLc5A=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion { package = talecast; };
+  };
+
+  meta = {
+    description = "Simple CLI podcatcher";
+    homepage = "https://github.com/TBS1996/TaleCast";
+    license = lib.licenses.mit;
+    mainProgram = "talecast";
+    maintainers = with lib.maintainers; [ confusedalex getchoo ];
+  };
+}


### PR DESCRIPTION
## Description of changes
https://github.com/TBS1996/TaleCast
Simple CLI podcatcher

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
