### PR TITLE
stdenvBootstrapTools: update aarch64 gnu

### DIFF
--- a/pkgs/stdenv/linux/bootstrap-files/aarch64-unknown-linux-gnu.nix
+++ b/pkgs/stdenv/linux/bootstrap-files/aarch64-unknown-linux-gnu.nix
@@ -1,11 +1,25 @@
+#
+# Files came from this Hydra build:
+#
+#   https://hydra.nixos.org/build/262871650
+#
+# …which used nixpkgs revision a9858885e197f984d92d7fe64e9fff6b2e488d40
+# to instantiate:
+#
+#   /nix/store/nxyvqvf7l9hvlkg3ca56gy3jkr5pqrn2-stdenv-bootstrap-tools.drv
+#
+# …and then built:
+#
+#   /nix/store/dk28gq49ckmgwpnx36709ff0hxnkmqpk-stdenv-bootstrap-tools
+#
 {
   busybox = import <nix/fetchurl.nix> {
-    url = "http://tarballs.nixos.org/stdenv-linux/aarch64/21ec906463ea8f11abf3f9091ddd4c3276516e58/busybox";
+    url = "http://tarballs.nixos.org/stdenv-linux/aarch64/a9858885e197f984d92d7fe64e9fff6b2e488d40/busybox";
     executable = true;
-    hash = "sha256-0MuIeQlBUaeisqoFSu8y+8oB6K4ZG5Lhq8RcS9JqkFQ=";
+    hash = "sha256-8areJJa2A0xauz5XqwZTgkHSb3qSdi7rTiCI05SaS0Y=";
   };
   bootstrapTools = import <nix/fetchurl.nix> {
-    url = "http://tarballs.nixos.org/stdenv-linux/aarch64/21ec906463ea8f11abf3f9091ddd4c3276516e58/bootstrap-tools.tar.xz";
-    hash = "sha256-aJvtsWeuQHbb14BGZ2EiOKzjQn46h3x3duuPEawG0eE=";
+    url = "http://tarballs.nixos.org/stdenv-linux/aarch64/a9858885e197f984d92d7fe64e9fff6b2e488d40/bootstrap-tools.tar.xz";
+    hash = "sha256-Ag5/vwGqv8q9SwdJYmmcvtqcLJjVYNwhgcqQ0BHTTdg=";
   };
 }


### PR DESCRIPTION
## Description of changes

I needed to update the aarch64 gnu bootstrap in order to check if the combinaison of musl / static / aarch64 was still broken when enabling PIE (https://github.com/NixOS/nixpkgs/pull/252310).

In order to that I followed the same approach than in ea67e455d3d59fd80c20169051475f5b84193b8d.

Files came from this Hydra build:

  https://hydra.nixos.org/build/262861772

…which used nixpkgs revision a9858885e197f984d92d7fe64e9fff6b2e488d40 to instantiate:

  `/nix/store/rqhq21qxwyhd633wgc53269jzp19y75m-stdenv-bootstrap-tools.drv`

…and then built:

  `/nix/store/z3sgi7wh8c5pnm3xm2s3kcbwqbw0d5dp-stdenv-bootstrap-tools`

I downloaded these files from Hydra and prefetched them into the Nix store with the following commands:

```
  STOREPATH=dk28gq49ckmgwpnx36709ff0hxnkmqpk-stdenv-bootstrap-tools
  OPTIONS="--option binary-caches https://cache.nixos.org --option trusted-public-keys cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
  nix --extra-experimental-features nix-command store prefetch-file \
    file://$(nix --extra-experimental-features nix-command store add-file --name bootstrap-tools.tar.xz  $(nix-store ${OPTIONS} -r /nix/store/${STOREPATH})/on-server/bootstrap-tools.tar.xz)
  nix --extra-experimental-features nix-command store prefetch-file --executable \
    file://$(nix --extra-experimental-features nix-command store add-path --name busybox $(nix-store ${OPTIONS} -r /nix/store/${STOREPATH})/on-server/busybox)
```

These commands produced the following output:

```
  copying path '/nix/store/dk28gq49ckmgwpnx36709ff0hxnkmqpk-stdenv-bootstrap-tools' from 'https://cache.nixos.org'...
  warning: you did not specify '--add-root'; the result might be removed by the garbage collector
  Downloaded 'file:///nix/store/rpsfzw2ixbdrd5nm4l00y9sjq8h9lg5k-bootstrap-tools.tar.xz' to '/nix/store/ax259maqg6nfdrxznv49as902j1fzhhr-rpsfzw2ixbdrd5nm4l00y9sjq8h9lg5k-bootstrap-tools.tar.xz' (hash 'sha256-Ag5/vwGqv8q9SwdJYmmcvtqcLJjVYNwhgcqQ0BHTTdg=').
  warning: you did not specify '--add-root'; the result might be removed by the garbage collector
  Downloaded 'file:///nix/store/7p38lg5jh4rvgq6aaxqs5sw0gy357z6s-busybox' to '/nix/store/y9bhy7662zdsacn6hr6zp81mzdyb7vzf-7p38lg5jh4rvgq6aaxqs5sw0gy357z6s-busybox' (hash 'sha256-8areJJa2A0xauz5XqwZTgkHSb3qSdi7rTiCI05SaS0Y=').
```

The sha256sums of all the on-server components:

```
  $ sha256sum /nix/store/${STOREPATH}/on-server/*
  020e7fbf01aabfcabd4b074962699cbeda9c2c98d560dc2181ca90d011d34dd8  /nix/store/dk28gq49ckmgwpnx36709ff0hxnkmqpk-stdenv-bootstrap-tools/on-server/bootstrap-tools.tar.xz
  8f4e1b1cafbfd3cc1517f477870f3b54170934f09b4c19ae2257acea557fbbca  /nix/store/dk28gq49ckmgwpnx36709ff0hxnkmqpk-stdenv-bootstrap-tools/on-server/busybox
```
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
