### PR TITLE
brother-dcpl2550dw: init at 4.0.0-1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15313,6 +15313,14 @@
     github = "p3psi-boo";
     githubId = 43925055;
   };
+  p4p4j0hn = {
+    name = "John Schmidt";
+    email = "john@schmidthaus.rocks";
+    matrix = "@p4p4j0hn:gnulinux.club";
+    github = "p4p4j0hn";
+    githubId = 119713522;
+    keys = [ { fingerprint = "A792 08BD 70D0 2F18 19AB  0AFD 1972 A1A7 296A 2156"; } ];
+  };
   pabloaul = {
     email = "contact@nojus.org";
     github = "pabloaul";

--- a/pkgs/by-name/br/brother-dcpl2550dw/fix-perm.patch
+++ b/pkgs/by-name/br/brother-dcpl2550dw/fix-perm.patch
@@ -1,0 +1,10 @@
+--- a/opt/brother/Printers/DCPL2550DW/cupswrapper/lpdwrapper	2017-07-17 18:34:39.000000000 -0700
++++ b/opt/brother/Printers/DCPL2550DW/cupswrapper/lpdwrapper	2024-03-22 09:25:37.967798025 -0700
+@@ -379,6 +379,7 @@
+ 
+ 
+ `cp  $basedir/inf/br${PRINTER}rc  $TEMPRC`;
++`chmod 666  $TEMPRC`;
+ $ENV{BRPRINTERRCFILE} = $TEMPRC;
+ 
+ logprint( 0 , "TEMPRC    = $TEMPRC\n");

--- a/pkgs/by-name/br/brother-dcpl2550dw/package.nix
+++ b/pkgs/by-name/br/brother-dcpl2550dw/package.nix
@@ -1,0 +1,124 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  makeWrapper,
+  perl,
+  gnused,
+  ghostscript,
+  file,
+  coreutils,
+  gnugrep,
+  which,
+}:
+
+let
+
+  arches = [
+    "x86_64"
+    "i686"
+    "armv7l"
+  ];
+
+  runtimeDeps = [
+    ghostscript
+    file
+    gnused
+    gnugrep
+    coreutils
+    which
+  ];
+
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "brother-dcpl2550dw";
+  version = "4.0.0-1";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf103577/dcpl2550dwpdrv-${finalAttrs.version}.i386.deb";
+    hash = "sha256-gGW8KDXlmYSMxvI29pfXd/lusg4rd4HaXiGkbBnUuQY=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+    autoPatchelfHook
+  ];
+  buildInputs = [ perl ];
+
+  patches = [
+    # The brother lpdwrapper uses a temporary file to convey the printer settings.
+    # The original settings file will be copied with "400" permissions and the "brprintconflsr3"
+    # binary cannot alter the temporary file later on. This fixes the permissions so the can be modified.
+    # Since this is all in briefly in the temporary directory of systemd-cups and not accessible by others,
+    # it shouldn't be a security concern.
+    ./fix-perm.patch
+  ];
+
+  installPhase =
+    ''
+      runHook preInstall
+      mkdir -p $out
+      cp -ar opt $out/opt
+      # delete unnecessary files for the current architecture
+    ''
+    + lib.concatMapStrings (arch: ''
+      echo Deleting files for ${arch}
+      rm -r "$out/opt/brother/Printers/DCPL2550DW/lpd/${arch}"
+    '') (builtins.filter (arch: arch != stdenv.hostPlatform.linuxArch) arches)
+    + ''
+      # bundled scripts don't understand the arch subdirectories for some reason
+      ln -s \
+        "$out/opt/brother/Printers/DCPL2550DW/lpd/${stdenv.hostPlatform.linuxArch}/"* \
+        "$out/opt/brother/Printers/DCPL2550DW/lpd/"
+
+      # Fix global references and replace auto discovery mechanism with hardcoded values
+      substituteInPlace $out/opt/brother/Printers/DCPL2550DW/lpd/lpdfilter \
+        --replace-fail "my \$BR_PRT_PATH =" "my \$BR_PRT_PATH = \"$out/opt/brother/Printers/DCPL2550DW\"; #" \
+        --replace-fail "PRINTER =~" "PRINTER = \"DCPL2550DW\"; #"
+      substituteInPlace $out/opt/brother/Printers/DCPL2550DW/cupswrapper/lpdwrapper \
+        --replace-fail "my \$basedir = C" "my \$basedir = \"$out/opt/brother/Printers/DCPL2550DW\" ; #" \
+        --replace-fail "PRINTER =~" "PRINTER = \"DCPL2550DW\"; #"
+
+      # Make sure all executables have the necessary runtime dependencies available
+      find "$out" -executable -and -type f | while read file; do
+        wrapProgram "$file" --prefix PATH : "${lib.makeBinPath runtimeDeps}"
+      done
+
+      # Symlink filter and ppd into a location where CUPS will discover it
+      mkdir -p $out/lib/cups/filter
+      mkdir -p $out/share/cups/model
+      mkdir -p $out/etc/opt/brother/Printers/DCPL2550DW/inf
+
+      ln -s $out/opt/brother/Printers/DCPL2550DW/inf/brDCPL2550DWrc \
+        $out/etc/opt/brother/Printers/DCPL2550DW/inf/brDCPL2550DWrc
+      ln -s \
+        $out/opt/brother/Printers/DCPL2550DW/cupswrapper/lpdwrapper \
+        $out/lib/cups/filter/brother_lpdwrapper_DCPL2550DW
+      ln -s \
+        $out/opt/brother/Printers/DCPL2550DW/cupswrapper/brother-DCPL2550DW-cups-en.ppd \
+        $out/share/cups/model/
+      runHook postInstall
+    '';
+
+  meta = with lib; {
+    homepage = "http://www.brother.com/";
+    description = "Brother DCPL2550DW printer driver";
+    longDescription = ''
+      Install this with printing services:
+      ```
+      ...
+        services.printing.enable = true;
+        services.printing.drivers = [
+          pkgs.brother-dcpl2550dw
+        ];
+      ...
+      ```
+    '';
+    license = licenses.unfree;
+    platforms = builtins.map (arch: "${arch}-linux") arches;
+    maintainers = [ maintainers.p4p4j0hn ];
+  };
+})


### PR DESCRIPTION
## Description of changes

This adds the printer driver for the Brother DCPL2550DW.
It combines the cups-wrapper and the driver in one file which allows
sharing common variables.

## Things done

Currently using these packages on my laptop.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
