### PR TITLE
nixos/cloudflare-warp: init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20545,6 +20545,12 @@
     githubId = 1312290;
     name = "Trevor Joynson";
   };
+  treyfortmuller = {
+    email = "treyunofficial@gmail.com";
+    github = "treyfortmuller";
+    githubId = 5715025;
+    name = "Trey Fortmuller";
+  };
   tricktron = {
     email = "tgagnaux@gmail.com";
     github = "tricktron";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -973,6 +973,7 @@
   ./services/networking/clatd.nix
   ./services/networking/cloudflare-dyndns.nix
   ./services/networking/cloudflared.nix
+  ./services/networking/cloudflare-warp.nix
   ./services/networking/cntlm.nix
   ./services/networking/connman.nix
   ./services/networking/consul.nix

--- a/nixos/modules/services/networking/cloudflare-warp.nix
+++ b/nixos/modules/services/networking/cloudflare-warp.nix
@@ -1,0 +1,91 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.cloudflare-warp;
+in
+{
+  options.services.cloudflare-warp = {
+    enable = lib.mkEnableOption "Cloudflare Zero Trust client daemon";
+
+    package = lib.mkPackageOption pkgs "cloudflare-warp" { };
+
+    rootDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/cloudflare-warp";
+      description = ''
+        Working directory for the warp-svc daemon.
+      '';
+    };
+
+    udpPort = lib.mkOption {
+      type = lib.types.port;
+      default = 2408;
+      description = ''
+        The UDP port to open in the firewall. Warp uses port 2408 by default, but fallback ports can be used
+        if that conflicts with another service. See the [firewall documentation](https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp/deployment/firewall#warp-udp-ports)
+        for the pre-configured available fallback ports.
+      '';
+    };
+
+    openFirewall = lib.mkEnableOption "opening UDP ports in the firewall" // {
+      default = true;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedUDPPorts = [ cfg.udpPort ];
+    };
+
+    systemd.tmpfiles.rules = [
+      "d ${cfg.rootDir}    - root root"
+      "z ${cfg.rootDir}    - root root"
+    ];
+
+    systemd.services.cloudflare-warp = {
+      enable = true;
+      description = "Cloudflare Zero Trust Client Daemon";
+
+      # lsof is used by the service to determine which UDP port to bind to
+      # in the case that it detects collisions.
+      path = [ pkgs.lsof ];
+      requires = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig =
+        let
+          caps = [
+            "CAP_NET_ADMIN"
+            "CAP_NET_BIND_SERVICE"
+            "CAP_SYS_PTRACE"
+          ];
+        in
+        {
+          Type = "simple";
+          ExecStart = "${cfg.package}/bin/warp-svc";
+          ReadWritePaths = [ "${cfg.rootDir}" "/etc/resolv.conf" ];
+          CapabilityBoundingSet = caps;
+          AmbientCapabilities = caps;
+          Restart = "always";
+          RestartSec = 5;
+          Environment = [ "RUST_BACKTRACE=full" ];
+          WorkingDirectory = cfg.rootDir;
+
+          # See the systemd.exec docs for the canonicalized paths, the service
+          # makes use of them for logging, and account state info tracking.
+          # https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#RuntimeDirectory=
+          StateDirectory = "cloudflare-warp";
+          RuntimeDirectory = "cloudflare-warp";
+          LogsDirectory = "cloudflare-warp";
+
+          # The service needs to write to /etc/resolv.conf to configure DNS, so that file would have to
+          # be world read/writable to run as anything other than root.
+          User = "root";
+          Group = "root";
+        };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ treyfortmuller ];
+}


### PR DESCRIPTION
## Description of changes

Cloudflare warp is a VPN service which uses Cloudflare's network built on WireGuard. Warp has free plans and there's a thing called WARP+ (which I haven't used personally) which is a paid subscription. The derivations for the warp tooling are already in `nixpkgs` as `pkgs.cloudflare-warp`. 

Here's the homepage and docs/downloads: 
* https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp/download-warp/
* https://pkg.cloudflareclient.com/

This is my first nixpkgs PR so looking for feedback! Especially around tests for a service like this, a basic `nixosTest` which enables the service and checks that its up would be easy to do, but I imagine we wouldn't want tests actually attempting to register as VPN user.

Some background:
* looks like there was an attempt to get a module in for this service before: https://github.com/NixOS/nixpkgs/pull/168092 this fizzled and was closed after some back and forth on the PR
* an open issue with a request for this module: https://github.com/NixOS/nixpkgs/issues/213177

I've been using this module for a few weeks without issue at work so I'm confident in the basic functionality. I attempted some `DynamicUser` configuration as a hardening step but the service reads/writes to `/etc/resolv.conf` so I've only been able to make this service work as intended while running as root.

I tested this manually by building a VM of my workstation off of my fork of nixpkgs and enabling `services.cloudflare-warp`. `warp-cli` is added to `systemPackages` and I used that to verify registration flows:

```
[nixosvmtest@kearsarge:~]$ warp-cli registration show
NOTICE:

Cloudflare only collects limited DNS query and traffic data (excluding payload)
that is sent to our network when you have the app enabled on your device. We
will not sell, rent, share, or otherwise disclose your personal information to
anyone, except as otherwise described in this Policy, without first providing
you with notice and the opportunity to consent. All information is handled in
accordance with our Privacy Policy.

More information is available at:
- https://www.cloudflare.com/application/terms/
- https://www.cloudflare.com/application/privacypolicy/

Accept Terms of Service and Privacy Policy? [y/N] y

Account type: Free
Device ID: 2914ecbd-ef6f-4db8-8397-d50453606e6a
Public key: beea6273fa27f78eb68ea092fc6aac776b1d5ea3aa06cf859587635dd442a62e
Account ID: 72a780f901b7416ca06bb2894e9086c5
License: X4a65S8U-60we45No-t1f89B0x

[nixosvmtest@kearsarge:~]$ warp-cli status
Status update: Connected
Success

[nixosvmtest@kearsarge:~]$ systemctl status cloudflare-warp.service
● cloudflare-warp.service - Cloudflare Zero Trust Client Daemon
     Loaded: loaded (/etc/systemd/system/cloudflare-warp.service; enabled; preset: enabled)
     Active: active (running) since Thu 2024-06-20 01:25:59 BST; 1min 56s ago
   Main PID: 692 (.warp-svc-wrapp)
         IP: 91.3K in, 27.1K out
         IO: 48.0K read, 140.0K written
      Tasks: 18 (limit: 2338)
     Memory: 61.9M (peak: 65.9M)
        CPU: 311ms
     CGroup: /system.slice/cloudflare-warp.service
             └─692 /nix/store/x6f7y11maam9gx6lx35anfx7knhg64ap-cloudflare-warp-2024.4.133/bin/warp-svc
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
