### PR TITLE
fcitx5-pinyin-{minecraft,moegirl,zhwiki}: init

### DIFF
--- a/pkgs/by-name/fc/fcitx5-pinyin-minecraft/package.nix
+++ b/pkgs/by-name/fc/fcitx5-pinyin-minecraft/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  fetchurl,
+  nix-update-script,
+  stdenvNoCC,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "fcitx5-pinyin-minecraft";
+  version = "0.1.20240629";
+
+  src = fetchurl {
+    url = "https://github.com/oldherl/fcitx5-pinyin-minecraft/releases/download/${finalAttrs.version}/minecraft-cn.dict";
+    hash = "sha256-uD/ADL+JGdSYiNz6XIqJB0Y0IU6Jf56q5g7xG2o3a+E=";
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 $src $out/share/fcitx5/pinyin/dictionaries/minecraft.dict
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fcitx 5 pinyin dictionary from zh.minecraft.wiki";
+    homepage = "https://github.com/oldherl/fcitx5-pinyin-minecraft";
+    license = with lib.licenses; [ unlicense cc-by-nc-sa-30 ];
+    maintainers = with lib.maintainers; [ Guanran928 ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/fc/fcitx5-pinyin-moegirl/package.nix
+++ b/pkgs/by-name/fc/fcitx5-pinyin-moegirl/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  fetchurl,
+  nix-update-script,
+  stdenvNoCC,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "fcitx5-pinyin-moegirl";
+  version = "20240609";
+
+  src = fetchurl {
+    url = "https://github.com/outloudvi/mw2fcitx/releases/download/${finalAttrs.version}/moegirl.dict";
+    hash = "sha256-dXFV0kVr8hgT17Jmr28PiYTiELm8kS/KM71igHXA6hs=";
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 $src $out/share/fcitx5/pinyin/dictionaries/moegirl.dict
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fcitx 5 pinyin dictionary from zh.moegirl.org.cn";
+    homepage = "https://github.com/outloudvi/mw2fcitx";
+    license = with lib.licenses; [ unlicense cc-by-nc-sa-30 ];
+    maintainers = with lib.maintainers; [ Guanran928 ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/fc/fcitx5-pinyin-zhwiki/package.nix
+++ b/pkgs/by-name/fc/fcitx5-pinyin-zhwiki/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  fetchurl,
+  stdenvNoCC,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "fcitx5-pinyin-zhwiki";
+  version = "0.2.5";
+  date = "20240509";
+
+  src = fetchurl {
+    url = "https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/${finalAttrs.version}/zhwiki-${finalAttrs.date}.dict";
+    hash = "sha256-uRpKPq+/xJ8akKB8ol/JRF79VfDIQ8L4SxLDXzpfPxg=";
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 $src $out/share/fcitx5/pinyin/dictionaries/zhwiki.dict
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Fcitx 5 pinyin dictionary from zh.wikipedia.org";
+    homepage = "https://github.com/felixonmars/fcitx5-pinyin-zhwiki";
+    license = with lib.licenses; [ unlicense cc-by-sa-40 ];
+    maintainers = with lib.maintainers; [ Guanran928 ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes

Adds 3 Fcitx5 dictionary files. 
- https://github.com/oldherl/fcitx5-pinyin-minecraft
- https://github.com/outloudvi/mw2fcitx
- https://github.com/felixonmars/fcitx5-pinyin-zhwiki

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
