### PR TITLE
python3Packages.spsdk 2.1.1 -> 2.2.0

### DIFF
--- a/pkgs/development/python-modules/libusbsio/default.nix
+++ b/pkgs/development/python-modules/libusbsio/default.nix
@@ -1,25 +1,26 @@
 {
   lib,
   buildPythonPackage,
+  fetchPypi,
   libusbsio,
 }:
 
 buildPythonPackage rec {
   pname = "libusbsio";
   format = "setuptools";
-  inherit (libusbsio) version;
+  version = "2.1.12";
+  # If the versions come back into sync switch back to inheriting from c lib
+  # inherit (libusbsio) version;
 
-  src = "${libusbsio.src}/python";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-RdUhwilBOwg19ay3Po3zsxqlBV9FTy3btJDbO4YEKS8=";
+  };
 
-  # The source includes both the python module directly and also a source tarball for it.
-  # The direct files lack setup information, the tarball includes unwanted binaries.
-  # This takes only the setup files from the tarball.
-  postUnpack = ''
-    tar -C python --strip-components=1 -xf python/dist/libusbsio-${version}.tar.gz libusbsio-${version}/{setup.py,setup.cfg,pyproject.toml}
-    rm -r python/dist
-  '';
-
+  # The source includes both the python module directly and also prebuilt binaries
+  # Delete the binaries and patch the wrapper to use binary from Nixpkgs instead
   postPatch = ''
+    rm -rf libusbsio/bin
     substituteInPlace libusbsio/libusbsio.py \
         --replace "dllpath = LIBUSBSIO._lookup_dll_path(dfltdir, dllname)" 'dllpath = "${libusbsio}/lib/" + dllname'
   '';
@@ -31,8 +32,8 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "libusbsio" ];
 
   meta = with lib; {
-    description = "NXP Secure Provisioning SDK";
-    homepage = "https://github.com/NXPmicro/spsdk";
+    description = "LIBUSBSIO Host Library for USB Enabled MCUs";
+    homepage = "https://www.nxp.com/design/design-center/software/development-software/libusbsio-host-library-for-usb-enabled-mcus:LIBUSBSIO";
     license = licenses.bsd3;
     maintainers = with maintainers; [
       frogamic

--- a/pkgs/development/python-modules/pyocd/default.nix
+++ b/pkgs/development/python-modules/pyocd/default.nix
@@ -17,7 +17,6 @@
   pylink-square,
   pyusb,
   pyyaml,
-  setuptools,
   setuptools-scm,
   typing-extensions,
   stdenv,
@@ -44,17 +43,11 @@ buildPythonPackage rec {
     })
   ];
 
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "libusb-package>=1.0,<2.0" ""
-  '';
+  pythonRemoveDeps = [ "libusb-package" ];
 
-  nativeBuildInputs = [
-    setuptools
-    setuptools-scm
-  ];
+  build-system = [ setuptools-scm ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     capstone_4
     cmsis-pack-manager
     colorama
@@ -73,6 +66,12 @@ buildPythonPackage rec {
   ] ++ lib.optionals (!stdenv.isLinux) [ hidapi ];
 
   pythonImportsCheck = [ "pyocd" ];
+
+  disabledTests = [
+    # AttributeError: 'not_called' is not a valid assertion
+    # Upstream fix at https://github.com/pyocd/pyOCD/pull/1710
+    "test_transfer_err_not_flushed"
+  ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/spsdk/default.nix
+++ b/pkgs/development/python-modules/spsdk/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   asn1crypto,
-  astunparse,
   bincopy,
   bitstring,
   click,
@@ -17,16 +16,14 @@
   hexdump,
   libusbsio,
   oscrypto,
+  packaging,
   platformdirs,
   prettytable,
-  pylink-square,
   pyocd,
-  pyocd-pemicro,
-  pypemicro,
   pyserial,
   requests,
   ruamel-yaml,
-  setuptools,
+  setuptools-scm,
   sly,
   spsdk,
   testers,
@@ -39,31 +36,30 @@
 
 buildPythonPackage rec {
   pname = "spsdk";
-  version = "2.1.1";
+  version = "2.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nxp-mcuxpresso";
     repo = "spsdk";
     rev = "refs/tags/${version}";
-    hash = "sha256-cWz2zML/gb9l2C5VEBti+nX3ZLyGbLFyLZGjk5GfTJw=";
+    hash = "sha256-2CFxJAP87ysly0i4AfODbwUt5W287+OK7fatdPco7e4=";
   };
 
-  nativeBuildInputs = [
-    setuptools
-  ];
+  build-system = [ setuptools-scm ];
 
   pythonRelaxDeps = [
-    "click"
-    "cryptography"
-    "platformdirs"
     "requests"
+    "packaging"
     "typing-extensions"
   ];
 
-  propagatedBuildInputs = [
+  # Remove unneeded unfree package. pyocd-pemicro is only used when
+  # generating a pyinstaller package, which we don't do.
+  pythonRemoveDeps = [ "pyocd-pemicro" ];
+
+  dependencies = [
     asn1crypto
-    astunparse
     bincopy
     bitstring
     click
@@ -77,12 +73,10 @@ buildPythonPackage rec {
     hexdump
     libusbsio
     oscrypto
+    packaging
     platformdirs
     prettytable
-    pylink-square
     pyocd
-    pyocd-pemicro
-    pypemicro
     pyserial
     requests
     ruamel-yaml
@@ -95,11 +89,6 @@ buildPythonPackage rec {
     pytest-notebook
     pytestCheckHook
     voluptuous
-  ];
-
-  disabledTests = [
-    "test_nxpcrypto_create_signature_algorithm"
-    "test_nxpimage_sb31_kaypair_not_matching"
   ];
 
   pythonImportsCheck = [ "spsdk" ];


### PR DESCRIPTION
## Description of changes

* Update spsdk python module to [2.2.0](https://github.com/nxp-mcuxpresso/spsdk/releases/tag/2.2.0)
    * [Changes](https://github.com/nxp-mcuxpresso/spsdk/compare/2.1.1...2.2.0)
    * Add/remove dependencies accordingly
    * Remove dependency pyocd-pemicro which is non-free due to non-licensed binary files being included. It is still in `requirements.txt` but doesn't seem to be used other than a pyinstaller spec file which afaik is not used in the nix build.
* Update libusbsio python wrapper to [2.1.12](https://pypi.org/project/libusbsio/2.1.12/)
    * Version is no longer in sync with the python wrapper bundled with the binary library, so fetch source from pypi instead.
* Disable a test in `pyocd` that is broken in python 3.12 (upstream fix at pyocd/pyOCD#1710)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
