### PR TITLE
lib/licenses: fix fullName case for ncbiPd

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -910,7 +910,7 @@ in mkLicense lset) ({
 
   ncbiPd = {
     spdxId = "NCBI-PD";
-    fullname = "NCBI Public Domain Notice";
+    fullName = "NCBI Public Domain Notice";
     # Due to United States copyright law, anything with this "license" does not have a copyright in the
     # jurisdiction of the United States. However, other jurisdictions may assign the United States
     # government copyright to the work, and the license explicitly states that in such a case, no license


### PR DESCRIPTION
Currently that is the only license with "fullname" (all lowercase) attribute name instead of "fullName" ("N" uppercase).

`fullname` in `meta.license` for `sratoolkit` (currently the only package with this license):
```nix
# nix eval --expr "let pkgs = import <nixpkgs> {}; in pkgs.sratoolkit.meta.license" --impure
{
  deprecated = false;
  free = false;
  fullname = "NCBI Public Domain Notice";
  redistributable = false;
  shortName = "ncbiPd";
  spdxId = "NCBI-PD";
  url = "https://spdx.org/licenses/NCBI-PD.html";
}
```

`fullName` in `meta.license` for other packages:
```nix
# nix eval --expr "let pkgs = import <nixpkgs> {}; in pkgs.hello.meta.license" --impure
{
  deprecated = false;
  free = true;
  fullName = "GNU General Public License v3.0 or later";
  redistributable = true;
  shortName = "gpl3Plus";
  spdxId = "GPL-3.0-or-later";
  url = "https://spdx.org/licenses/GPL-3.0-or-later.html";
}
```

ncbiPd license was added in:
https://github.com/NixOS/nixpkgs/pull/311696

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
