### PR TITLE
dmenu: allow config file argument

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -71,6 +71,12 @@
     github = "0b11stan";
     githubId = 27831931;
   };
+  _0david0mp = {
+    email = "davidmrpr@proton.me";
+    github = "0david0mp";
+    githubId = 54892055;
+    name = "David mp";
+  };
   _0nyr = {
     email = "onyr.maintainer@gmail.com";
     github = "0nyr";

--- a/pkgs/applications/misc/dmenu/default.nix
+++ b/pkgs/applications/misc/dmenu/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchurl, libX11, libXinerama, libXft, zlib, patches ? null
-# update script dependencies
-, gitUpdater
-}:
+{ lib, stdenv, fetchurl, libX11, libXinerama, libXft, zlib, writeText
+, conf ? null, patches ? null
+  # update script dependencies
+, gitUpdater }:
 
 stdenv.mkDerivation rec {
   pname = "dmenu";
@@ -16,9 +16,15 @@ stdenv.mkDerivation rec {
 
   inherit patches;
 
-  postPatch = ''
+  postPatch = let
+    configFile = if lib.isDerivation conf || builtins.isPath conf then
+      conf
+    else
+      writeText "config.def.h" conf;
+  in ''
     sed -ri -e 's!\<(dmenu|dmenu_path|stest)\>!'"$out/bin"'/&!g' dmenu_run
     sed -ri -e 's!\<stest\>!'"$out/bin"'/&!g' dmenu_path
+    ${lib.optionalString (conf != null) "cp ${configFile} config.def.h"}
   '';
 
   preConfigure = ''
@@ -27,15 +33,14 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "CC:=$(CC)" ];
 
-  passthru.updateScript = gitUpdater {
-    url = "git://git.suckless.org/dmenu";
-  };
+  passthru.updateScript = gitUpdater { url = "git://git.suckless.org/dmenu"; };
 
   meta = with lib; {
-    description = "Generic, highly customizable, and efficient menu for the X Window System";
+    description =
+      "Generic, highly customizable, and efficient menu for the X Window System";
     homepage = "https://tools.suckless.org/dmenu";
     license = licenses.mit;
-    maintainers = with maintainers; [ pSub globin qusic ];
+    maintainers = with maintainers; [ pSub globin qusic _0david0mp ];
     platforms = platforms.all;
     mainProgram = "dmenu";
   };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Just allowing for a config file as arg (like in [slstatus](https://github.com/NixOS/nixpkgs/blob/88470d6246d6e6673f17961772f889fee3504e04/pkgs/applications/misc/slstatus/default.nix#L30) or [dwm](https://github.com/NixOS/nixpkgs/blob/88470d6246d6e6673f17961772f889fee3504e04/pkgs/applications/window-managers/dwm/default.nix#L27))

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
