### PR TITLE
kdePackages: upstream recommended backports

### DIFF
--- a/pkgs/kde/frameworks/ksvg/default.nix
+++ b/pkgs/kde/frameworks/ksvg/default.nix
@@ -2,9 +2,19 @@
   mkKdeDerivation,
   qtdeclarative,
   qtsvg,
+  fetchpatch,
 }:
 mkKdeDerivation {
   pname = "ksvg";
+
+  patches = [
+    # Backport patch for SVG rendering glitches with fractional scale
+    # FIXME: remove in 6.4
+    (fetchpatch {
+      url = "https://invent.kde.org/frameworks/ksvg/-/commit/74f9f9cbd226407f8cde08c5cd5a711444e2775d.patch";
+      hash = "sha256-i4Wcvo0CkpN2qdlTesnzUyd0mzG1VKbycP5Pd1rHPVg=";
+    })
+  ];
 
   extraBuildInputs = [qtdeclarative qtsvg];
 }

--- a/pkgs/kde/gear/kdenlive/default.nix
+++ b/pkgs/kde/gear/kdenlive/default.nix
@@ -11,6 +11,7 @@
   shared-mime-info,
   libv4l,
   frei0r,
+  fetchpatch,
 }:
 mkKdeDerivation {
   pname = "kdenlive";
@@ -23,6 +24,13 @@ mkKdeDerivation {
         ffmpeg = ffmpeg-full;
       }
     )
+
+    # Backport fix for crash after 5 minutes
+    # FIXME: remove in next release
+    (fetchpatch {
+      url = "https://invent.kde.org/multimedia/kdenlive/-/commit/8be0e826471332bb739344ebe1859298c46e9e0f.patch";
+      hash = "sha256-5hLePH5NlO4Lx8lg9kjBPI4jTmP666RGplaVCmS/9TA=";
+    })
   ];
 
   extraBuildInputs = [


### PR DESCRIPTION
## Description of changes

See https://mail.kde.org/pipermail/distributions/2024-June/thread.html

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
