### PR TITLE
`lib`: Re-export expected builtins

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -11,7 +11,7 @@ let
 in
 
 rec {
-  inherit (builtins) attrNames listToAttrs hasAttr isAttrs getAttr removeAttrs;
+  inherit (builtins) attrNames listToAttrs hasAttr isAttrs getAttr removeAttrs intersectAttrs;
 
 
   /**

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -105,7 +105,7 @@ let
       escapeRegex escapeURL escapeXML replaceChars lowerChars
       upperChars toLower toUpper addContextFrom splitString
       removePrefix removeSuffix versionOlder versionAtLeast
-      getName getVersion
+      getName getVersion match
       cmakeOptionType cmakeBool cmakeFeature
       mesonOption mesonBool mesonEnable
       nameFromURL enableFeature enableFeatureAs withFeature

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -87,7 +87,7 @@ let
       recursiveUpdate matchAttrs mergeAttrsList overrideExisting showAttrPath getOutput
       getBin getLib getDev getMan chooseDevOutputs zipWithNames zip
       recurseIntoAttrs dontRecurseIntoAttrs cartesianProduct cartesianProductOfSets
-      mapCartesianProduct updateManyAttrsByPath;
+      mapCartesianProduct updateManyAttrsByPath intersectAttrs;
     inherit (self.lists) singleton forEach map foldr fold foldl foldl' imap0 imap1
       ifilter0 concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range replicate partition zipListsWith zipLists

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -87,7 +87,7 @@ let
       recursiveUpdate matchAttrs mergeAttrsList overrideExisting showAttrPath getOutput
       getBin getLib getDev getMan chooseDevOutputs zipWithNames zip
       recurseIntoAttrs dontRecurseIntoAttrs cartesianProduct cartesianProductOfSets
-      mapCartesianProduct updateManyAttrsByPath intersectAttrs;
+      mapCartesianProduct updateManyAttrsByPath intersectAttrs removeAttrs;
     inherit (self.lists) singleton forEach map foldr fold foldl foldl' imap0 imap1
       ifilter0 concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range replicate partition zipListsWith zipLists

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -105,7 +105,7 @@ let
       escapeRegex escapeURL escapeXML replaceChars lowerChars
       upperChars toLower toUpper addContextFrom splitString
       removePrefix removeSuffix versionOlder versionAtLeast
-      getName getVersion match
+      getName getVersion match split
       cmakeOptionType cmakeBool cmakeFeature
       mesonOption mesonBool mesonEnable
       nameFromURL enableFeature enableFeatureAs withFeature

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -88,7 +88,7 @@ let
       getBin getLib getDev getMan chooseDevOutputs zipWithNames zip
       recurseIntoAttrs dontRecurseIntoAttrs cartesianProduct cartesianProductOfSets
       mapCartesianProduct updateManyAttrsByPath;
-    inherit (self.lists) singleton forEach foldr fold foldl foldl' imap0 imap1
+    inherit (self.lists) singleton forEach map foldr fold foldl foldl' imap0 imap1
       ifilter0 concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range replicate partition zipListsWith zipLists
       reverseList listDfs toposort sort sortOn naturalSort compareLists take


### PR DESCRIPTION
## Description of changes

I've been annoyed for too long about these builtins not being available under `lib.*`! This adds:
- `lib.map` (previously only under `lib.lists`, `builtins` and in the default scope)
- `lib.intersectAttrs` and `lib.attrsets.intersectAttrs` (previously only under `builtins`)
- `lib.removeAttrs` (previously only under `lib.attrsets` and `builtins`)
- `lib.match` (previously only under `lib.strings` and `builtins`)
- `lib.split` (previously only under `lib.strings` and `builtins`)

Ping @roberth

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
