### PR TITLE
catppuccin-gtk: use vendored colloid-gtk-theme

### DIFF
--- a/pkgs/by-name/ca/catppuccin-gtk/package.nix
+++ b/pkgs/by-name/ca/catppuccin-gtk/package.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , gtk3
 , git
-, colloid-gtk-theme
 , python3
 , sassc
 , nix-update-script
@@ -34,7 +33,8 @@ stdenvNoCC.mkDerivation {
     owner = "catppuccin";
     repo = "gtk";
     rev = "v${version}";
-    hash = "sha256-8KyZtZqVVz5UKuGdLrUsR2djD3nsJDliHMtvFtUVim8=";
+    fetchSubmodules = true;
+    hash = "sha256-q5/VcFsm3vNEw55zq/vcM11eo456SYE5TQA3g2VQjGc=";
   };
 
   nativeBuildInputs = [
@@ -45,12 +45,6 @@ stdenvNoCC.mkDerivation {
     git
     (python3.withPackages (ps: [ ps.catppuccin ]))
   ];
-
-  postUnpack = ''
-    rm -rf source/sources/colloid
-    cp -r ${colloid-gtk-theme.src} source/sources/colloid
-    chmod -R +w source/sources/colloid
-  '';
 
   dontConfigure = true;
   dontBuild = true;


### PR DESCRIPTION
We used to replace vendored colloid-gtk-theme with our nixpkgs version, but catppuccin-gtk has been archived, and its patches cannot be applied on recent version of colloid-gtk-theme, so we dropped it. We may deprecate catppuccin-gtk in favor of the catppuccin flavor of colloid-gtk-theme (which was introduced in 2024-06-18), but still needs some user feedback.

## Description of changes

Fixes https://github.com/NixOS/nixpkgs/pull/315143#issuecomment-2181035329

Related https://github.com/NixOS/nixpkgs/pull/320681

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
