### PR TITLE
`lib`: Inherit exported builtins from the respective sub-library

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -64,9 +64,9 @@ let
     # linux kernel configuration
     kernel = callLibs ./kernel.nix;
 
-    inherit (builtins) addErrorContext
-      isPath
-      trace;
+    # TODO: For consistency, all builtins should also be available from a sub-library;
+    # these are the only ones that are currently not
+    inherit (builtins) addErrorContext isPath trace;
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
       bitNot boolToString mergeAttrs flip mapNullable inNixShell isFloat min max
       importJSON importTOML warn warnIf warnIfNot throwIf throwIfNot checkListOfEnum

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -65,7 +65,6 @@ let
     kernel = callLibs ./kernel.nix;
 
     inherit (builtins) addErrorContext
-      genericClosure
       isPath
       readFile replaceStrings
       trace;
@@ -75,7 +74,8 @@ let
       info showWarnings nixpkgsVersion version isInOldestRelease
       mod compare splitByAndCompare seq deepSeq lessThan add sub
       functionArgs setFunctionArgs isFunction toFunction mirrorFunctionArgs
-      toHexString toBaseDigits inPureEvalMode isBool isInt pathExists;
+      toHexString toBaseDigits inPureEvalMode isBool isInt pathExists
+      genericClosure;
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions
       composeManyExtensions makeExtensible makeExtensibleWithCustomName;
     inherit (self.attrsets) attrByPath hasAttrByPath setAttrByPath

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -68,12 +68,12 @@ let
       deepSeq elem elemAt genericClosure getAttr
       hasAttr isAttrs isBool isInt isList isPath isString
       pathExists readFile replaceStrings
-      sub trace;
+      trace;
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
       bitNot boolToString mergeAttrs flip mapNullable inNixShell isFloat min max
       importJSON importTOML warn warnIf warnIfNot throwIf throwIfNot checkListOfEnum
       info showWarnings nixpkgsVersion version isInOldestRelease
-      mod compare splitByAndCompare seq lessThan add
+      mod compare splitByAndCompare seq lessThan add sub
       functionArgs setFunctionArgs isFunction toFunction mirrorFunctionArgs
       toHexString toBaseDigits inPureEvalMode;
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -64,7 +64,7 @@ let
     # linux kernel configuration
     kernel = callLibs ./kernel.nix;
 
-    inherit (builtins) add addErrorContext attrNames concatLists
+    inherit (builtins) add addErrorContext attrNames
       deepSeq elem elemAt filter genericClosure genList getAttr
       hasAttr head isAttrs isBool isInt isList isPath isString length
       lessThan listToAttrs pathExists readFile replaceStrings seq
@@ -93,7 +93,7 @@ let
       optional optionals toList range replicate partition zipListsWith zipLists
       reverseList listDfs toposort sort sortOn naturalSort compareLists take
       drop sublist last init crossLists unique allUnique intersectLists
-      subtractLists mutuallyExclusive groupBy groupBy';
+      subtractLists mutuallyExclusive groupBy groupBy' concatLists;
     inherit (self.strings) concatStrings concatMapStrings concatImapStrings
       intersperse concatStringsSep concatMapStringsSep
       concatImapStringsSep concatLines makeSearchPath makeSearchPathOutput

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -65,7 +65,7 @@ let
     kernel = callLibs ./kernel.nix;
 
     inherit (builtins) addErrorContext
-      deepSeq elem elemAt genericClosure getAttr
+      elem elemAt genericClosure getAttr
       hasAttr isAttrs isBool isInt isList isPath isString
       pathExists readFile replaceStrings
       trace;
@@ -73,7 +73,7 @@ let
       bitNot boolToString mergeAttrs flip mapNullable inNixShell isFloat min max
       importJSON importTOML warn warnIf warnIfNot throwIf throwIfNot checkListOfEnum
       info showWarnings nixpkgsVersion version isInOldestRelease
-      mod compare splitByAndCompare seq lessThan add sub
+      mod compare splitByAndCompare seq deepSeq lessThan add sub
       functionArgs setFunctionArgs isFunction toFunction mirrorFunctionArgs
       toHexString toBaseDigits inPureEvalMode;
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -66,7 +66,7 @@ let
 
     inherit (builtins) addErrorContext
       isPath
-      readFile replaceStrings
+      replaceStrings
       trace;
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
       bitNot boolToString mergeAttrs flip mapNullable inNixShell isFloat min max
@@ -75,7 +75,7 @@ let
       mod compare splitByAndCompare seq deepSeq lessThan add sub
       functionArgs setFunctionArgs isFunction toFunction mirrorFunctionArgs
       toHexString toBaseDigits inPureEvalMode isBool isInt pathExists
-      genericClosure;
+      genericClosure readFile;
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions
       composeManyExtensions makeExtensible makeExtensibleWithCustomName;
     inherit (self.attrsets) attrByPath hasAttrByPath setAttrByPath

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -64,7 +64,7 @@ let
     # linux kernel configuration
     kernel = callLibs ./kernel.nix;
 
-    inherit (builtins) add addErrorContext attrNames
+    inherit (builtins) add addErrorContext
       deepSeq elem elemAt filter genericClosure genList getAttr
       hasAttr head isAttrs isBool isInt isList isPath isString length
       lessThan listToAttrs pathExists readFile replaceStrings seq
@@ -79,7 +79,7 @@ let
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions
       composeManyExtensions makeExtensible makeExtensibleWithCustomName;
     inherit (self.attrsets) attrByPath hasAttrByPath setAttrByPath
-      getAttrFromPath attrVals attrValues getAttrs catAttrs filterAttrs
+      getAttrFromPath attrVals attrNames attrValues getAttrs catAttrs filterAttrs
       filterAttrsRecursive foldlAttrs foldAttrs collect nameValuePair mapAttrs
       mapAttrs' mapAttrsToList attrsToList concatMapAttrs mapAttrsRecursive
       mapAttrsRecursiveCond genAttrs isDerivation toDerivation optionalAttrs

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -66,7 +66,7 @@ let
 
     inherit (builtins) addErrorContext
       genericClosure getAttr
-      isBool isInt isList isPath isString
+      isInt isList isPath isString
       pathExists readFile replaceStrings
       trace;
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
@@ -75,7 +75,7 @@ let
       info showWarnings nixpkgsVersion version isInOldestRelease
       mod compare splitByAndCompare seq deepSeq lessThan add sub
       functionArgs setFunctionArgs isFunction toFunction mirrorFunctionArgs
-      toHexString toBaseDigits inPureEvalMode;
+      toHexString toBaseDigits inPureEvalMode isBool;
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions
       composeManyExtensions makeExtensible makeExtensibleWithCustomName;
     inherit (self.attrsets) attrByPath hasAttrByPath setAttrByPath

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -66,7 +66,7 @@ let
 
     inherit (builtins) addErrorContext
       genericClosure getAttr
-      isInt isList isPath isString
+      isList isPath isString
       pathExists readFile replaceStrings
       trace;
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
@@ -75,7 +75,7 @@ let
       info showWarnings nixpkgsVersion version isInOldestRelease
       mod compare splitByAndCompare seq deepSeq lessThan add sub
       functionArgs setFunctionArgs isFunction toFunction mirrorFunctionArgs
-      toHexString toBaseDigits inPureEvalMode isBool;
+      toHexString toBaseDigits inPureEvalMode isBool isInt;
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions
       composeManyExtensions makeExtensible makeExtensibleWithCustomName;
     inherit (self.attrsets) attrByPath hasAttrByPath setAttrByPath

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -65,7 +65,7 @@ let
     kernel = callLibs ./kernel.nix;
 
     inherit (builtins) addErrorContext
-      elem elemAt genericClosure getAttr
+      elemAt genericClosure getAttr
       hasAttr isAttrs isBool isInt isList isPath isString
       pathExists readFile replaceStrings
       trace;
@@ -94,7 +94,7 @@ let
       reverseList listDfs toposort sort sortOn naturalSort compareLists take
       drop sublist last init crossLists unique allUnique intersectLists
       subtractLists mutuallyExclusive groupBy groupBy' concatLists genList
-      length head tail;
+      length head tail elem;
     inherit (self.strings) concatStrings concatMapStrings concatImapStrings
       stringLength substring
       intersperse concatStringsSep concatMapStringsSep

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -66,7 +66,7 @@ let
 
     inherit (builtins) addErrorContext
       genericClosure getAttr
-      isPath isString
+      isPath
       pathExists readFile replaceStrings
       trace;
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
@@ -96,7 +96,7 @@ let
       subtractLists mutuallyExclusive groupBy groupBy' concatLists genList
       length head tail elem elemAt isList;
     inherit (self.strings) concatStrings concatMapStrings concatImapStrings
-      stringLength substring
+      stringLength substring isString
       intersperse concatStringsSep concatMapStringsSep
       concatImapStringsSep concatLines makeSearchPath makeSearchPathOutput
       makeLibraryPath makeIncludePath makeBinPath optionalString

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -65,7 +65,7 @@ let
     kernel = callLibs ./kernel.nix;
 
     inherit (builtins) addErrorContext
-      genericClosure getAttr
+      genericClosure
       isPath
       pathExists readFile replaceStrings
       trace;
@@ -87,7 +87,7 @@ let
       recursiveUpdate matchAttrs mergeAttrsList overrideExisting showAttrPath getOutput
       getBin getLib getDev getMan chooseDevOutputs zipWithNames zip
       recurseIntoAttrs dontRecurseIntoAttrs cartesianProduct cartesianProductOfSets
-      mapCartesianProduct updateManyAttrsByPath listToAttrs hasAttr isAttrs intersectAttrs removeAttrs;
+      mapCartesianProduct updateManyAttrsByPath listToAttrs hasAttr getAttr isAttrs intersectAttrs removeAttrs;
     inherit (self.lists) singleton forEach map foldr fold foldl foldl' imap0 imap1
       filter ifilter0 concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range replicate partition zipListsWith zipLists

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -66,7 +66,7 @@ let
 
     inherit (builtins) addErrorContext
       genericClosure getAttr
-      isList isPath isString
+      isPath isString
       pathExists readFile replaceStrings
       trace;
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
@@ -94,7 +94,7 @@ let
       reverseList listDfs toposort sort sortOn naturalSort compareLists take
       drop sublist last init crossLists unique allUnique intersectLists
       subtractLists mutuallyExclusive groupBy groupBy' concatLists genList
-      length head tail elem elemAt;
+      length head tail elem elemAt isList;
     inherit (self.strings) concatStrings concatMapStrings concatImapStrings
       stringLength substring
       intersperse concatStringsSep concatMapStringsSep

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -67,7 +67,7 @@ let
     inherit (builtins) add addErrorContext
       deepSeq elem elemAt genericClosure getAttr
       hasAttr isAttrs isBool isInt isList isPath isString
-      lessThan listToAttrs pathExists readFile replaceStrings seq
+      lessThan pathExists readFile replaceStrings seq
       sub trace;
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
       bitNot boolToString mergeAttrs flip mapNullable inNixShell isFloat min max
@@ -87,7 +87,7 @@ let
       recursiveUpdate matchAttrs mergeAttrsList overrideExisting showAttrPath getOutput
       getBin getLib getDev getMan chooseDevOutputs zipWithNames zip
       recurseIntoAttrs dontRecurseIntoAttrs cartesianProduct cartesianProductOfSets
-      mapCartesianProduct updateManyAttrsByPath intersectAttrs removeAttrs;
+      mapCartesianProduct updateManyAttrsByPath listToAttrs intersectAttrs removeAttrs;
     inherit (self.lists) singleton forEach map foldr fold foldl foldl' imap0 imap1
       filter ifilter0 concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range replicate partition zipListsWith zipLists

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -66,7 +66,7 @@ let
 
     inherit (builtins) addErrorContext
       genericClosure getAttr
-      hasAttr isAttrs isBool isInt isList isPath isString
+      isAttrs isBool isInt isList isPath isString
       pathExists readFile replaceStrings
       trace;
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
@@ -87,7 +87,7 @@ let
       recursiveUpdate matchAttrs mergeAttrsList overrideExisting showAttrPath getOutput
       getBin getLib getDev getMan chooseDevOutputs zipWithNames zip
       recurseIntoAttrs dontRecurseIntoAttrs cartesianProduct cartesianProductOfSets
-      mapCartesianProduct updateManyAttrsByPath listToAttrs intersectAttrs removeAttrs;
+      mapCartesianProduct updateManyAttrsByPath listToAttrs hasAttr intersectAttrs removeAttrs;
     inherit (self.lists) singleton forEach map foldr fold foldl foldl' imap0 imap1
       filter ifilter0 concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range replicate partition zipListsWith zipLists

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -67,13 +67,13 @@ let
     inherit (builtins) add addErrorContext
       deepSeq elem elemAt genericClosure getAttr
       hasAttr isAttrs isBool isInt isList isPath isString
-      lessThan pathExists readFile replaceStrings
+      pathExists readFile replaceStrings
       sub trace;
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
       bitNot boolToString mergeAttrs flip mapNullable inNixShell isFloat min max
       importJSON importTOML warn warnIf warnIfNot throwIf throwIfNot checkListOfEnum
       info showWarnings nixpkgsVersion version isInOldestRelease
-      mod compare splitByAndCompare seq
+      mod compare splitByAndCompare seq lessThan
       functionArgs setFunctionArgs isFunction toFunction mirrorFunctionArgs
       toHexString toBaseDigits inPureEvalMode;
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -66,7 +66,6 @@ let
 
     inherit (builtins) addErrorContext
       isPath
-      replaceStrings
       trace;
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
       bitNot boolToString mergeAttrs flip mapNullable inNixShell isFloat min max
@@ -96,7 +95,7 @@ let
       subtractLists mutuallyExclusive groupBy groupBy' concatLists genList
       length head tail elem elemAt isList;
     inherit (self.strings) concatStrings concatMapStrings concatImapStrings
-      stringLength substring isString
+      stringLength substring isString replaceStrings
       intersperse concatStringsSep concatMapStringsSep
       concatImapStringsSep concatLines makeSearchPath makeSearchPathOutput
       makeLibraryPath makeIncludePath makeBinPath optionalString

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -68,7 +68,7 @@ let
       deepSeq elem elemAt genericClosure getAttr
       hasAttr head isAttrs isBool isInt isList isPath isString
       lessThan listToAttrs pathExists readFile replaceStrings seq
-      sub substring tail trace;
+      sub substring trace;
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
       bitNot boolToString mergeAttrs flip mapNullable inNixShell isFloat min max
       importJSON importTOML warn warnIf warnIfNot throwIf throwIfNot checkListOfEnum
@@ -94,7 +94,7 @@ let
       reverseList listDfs toposort sort sortOn naturalSort compareLists take
       drop sublist last init crossLists unique allUnique intersectLists
       subtractLists mutuallyExclusive groupBy groupBy' concatLists genList
-      length;
+      length tail;
     inherit (self.strings) concatStrings concatMapStrings concatImapStrings
       stringLength
       intersperse concatStringsSep concatMapStringsSep

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -66,7 +66,7 @@ let
 
     inherit (builtins) add addErrorContext
       deepSeq elem elemAt genericClosure getAttr
-      hasAttr head isAttrs isBool isInt isList isPath isString length
+      hasAttr head isAttrs isBool isInt isList isPath isString
       lessThan listToAttrs pathExists readFile replaceStrings seq
       stringLength sub substring tail trace;
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
@@ -93,7 +93,8 @@ let
       optional optionals toList range replicate partition zipListsWith zipLists
       reverseList listDfs toposort sort sortOn naturalSort compareLists take
       drop sublist last init crossLists unique allUnique intersectLists
-      subtractLists mutuallyExclusive groupBy groupBy' concatLists genList;
+      subtractLists mutuallyExclusive groupBy groupBy' concatLists genList
+      length;
     inherit (self.strings) concatStrings concatMapStrings concatImapStrings
       intersperse concatStringsSep concatMapStringsSep
       concatImapStringsSep concatLines makeSearchPath makeSearchPathOutput

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -64,7 +64,7 @@ let
     # linux kernel configuration
     kernel = callLibs ./kernel.nix;
 
-    inherit (builtins) add addErrorContext
+    inherit (builtins) addErrorContext
       deepSeq elem elemAt genericClosure getAttr
       hasAttr isAttrs isBool isInt isList isPath isString
       pathExists readFile replaceStrings
@@ -73,7 +73,7 @@ let
       bitNot boolToString mergeAttrs flip mapNullable inNixShell isFloat min max
       importJSON importTOML warn warnIf warnIfNot throwIf throwIfNot checkListOfEnum
       info showWarnings nixpkgsVersion version isInOldestRelease
-      mod compare splitByAndCompare seq lessThan
+      mod compare splitByAndCompare seq lessThan add
       functionArgs setFunctionArgs isFunction toFunction mirrorFunctionArgs
       toHexString toBaseDigits inPureEvalMode;
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -67,7 +67,7 @@ let
     inherit (builtins) addErrorContext
       genericClosure
       isPath
-      pathExists readFile replaceStrings
+      readFile replaceStrings
       trace;
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
       bitNot boolToString mergeAttrs flip mapNullable inNixShell isFloat min max
@@ -75,7 +75,7 @@ let
       info showWarnings nixpkgsVersion version isInOldestRelease
       mod compare splitByAndCompare seq deepSeq lessThan add sub
       functionArgs setFunctionArgs isFunction toFunction mirrorFunctionArgs
-      toHexString toBaseDigits inPureEvalMode isBool isInt;
+      toHexString toBaseDigits inPureEvalMode isBool isInt pathExists;
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions
       composeManyExtensions makeExtensible makeExtensibleWithCustomName;
     inherit (self.attrsets) attrByPath hasAttrByPath setAttrByPath

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -66,7 +66,7 @@ let
 
     inherit (builtins) add addErrorContext
       deepSeq elem elemAt genericClosure getAttr
-      hasAttr head isAttrs isBool isInt isList isPath isString
+      hasAttr isAttrs isBool isInt isList isPath isString
       lessThan listToAttrs pathExists readFile replaceStrings seq
       sub substring trace;
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
@@ -94,7 +94,7 @@ let
       reverseList listDfs toposort sort sortOn naturalSort compareLists take
       drop sublist last init crossLists unique allUnique intersectLists
       subtractLists mutuallyExclusive groupBy groupBy' concatLists genList
-      length tail;
+      length head tail;
     inherit (self.strings) concatStrings concatMapStrings concatImapStrings
       stringLength
       intersperse concatStringsSep concatMapStringsSep

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -65,7 +65,7 @@ let
     kernel = callLibs ./kernel.nix;
 
     inherit (builtins) add addErrorContext
-      deepSeq elem elemAt genericClosure genList getAttr
+      deepSeq elem elemAt genericClosure getAttr
       hasAttr head isAttrs isBool isInt isList isPath isString length
       lessThan listToAttrs pathExists readFile replaceStrings seq
       stringLength sub substring tail trace;
@@ -93,7 +93,7 @@ let
       optional optionals toList range replicate partition zipListsWith zipLists
       reverseList listDfs toposort sort sortOn naturalSort compareLists take
       drop sublist last init crossLists unique allUnique intersectLists
-      subtractLists mutuallyExclusive groupBy groupBy' concatLists;
+      subtractLists mutuallyExclusive groupBy groupBy' concatLists genList;
     inherit (self.strings) concatStrings concatMapStrings concatImapStrings
       intersperse concatStringsSep concatMapStringsSep
       concatImapStringsSep concatLines makeSearchPath makeSearchPathOutput

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -68,7 +68,7 @@ let
       deepSeq elem elemAt genericClosure getAttr
       hasAttr head isAttrs isBool isInt isList isPath isString
       lessThan listToAttrs pathExists readFile replaceStrings seq
-      stringLength sub substring tail trace;
+      sub substring tail trace;
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
       bitNot boolToString mergeAttrs flip mapNullable inNixShell isFloat min max
       importJSON importTOML warn warnIf warnIfNot throwIf throwIfNot checkListOfEnum
@@ -96,6 +96,7 @@ let
       subtractLists mutuallyExclusive groupBy groupBy' concatLists genList
       length;
     inherit (self.strings) concatStrings concatMapStrings concatImapStrings
+      stringLength
       intersperse concatStringsSep concatMapStringsSep
       concatImapStringsSep concatLines makeSearchPath makeSearchPathOutput
       makeLibraryPath makeIncludePath makeBinPath optionalString

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -65,7 +65,7 @@ let
     kernel = callLibs ./kernel.nix;
 
     inherit (builtins) addErrorContext
-      elemAt genericClosure getAttr
+      genericClosure getAttr
       hasAttr isAttrs isBool isInt isList isPath isString
       pathExists readFile replaceStrings
       trace;
@@ -94,7 +94,7 @@ let
       reverseList listDfs toposort sort sortOn naturalSort compareLists take
       drop sublist last init crossLists unique allUnique intersectLists
       subtractLists mutuallyExclusive groupBy groupBy' concatLists genList
-      length head tail elem;
+      length head tail elem elemAt;
     inherit (self.strings) concatStrings concatMapStrings concatImapStrings
       stringLength substring
       intersperse concatStringsSep concatMapStringsSep

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -66,7 +66,7 @@ let
 
     inherit (builtins) addErrorContext
       genericClosure getAttr
-      isAttrs isBool isInt isList isPath isString
+      isBool isInt isList isPath isString
       pathExists readFile replaceStrings
       trace;
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
@@ -87,7 +87,7 @@ let
       recursiveUpdate matchAttrs mergeAttrsList overrideExisting showAttrPath getOutput
       getBin getLib getDev getMan chooseDevOutputs zipWithNames zip
       recurseIntoAttrs dontRecurseIntoAttrs cartesianProduct cartesianProductOfSets
-      mapCartesianProduct updateManyAttrsByPath listToAttrs hasAttr intersectAttrs removeAttrs;
+      mapCartesianProduct updateManyAttrsByPath listToAttrs hasAttr isAttrs intersectAttrs removeAttrs;
     inherit (self.lists) singleton forEach map foldr fold foldl foldl' imap0 imap1
       filter ifilter0 concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range replicate partition zipListsWith zipLists

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -68,7 +68,7 @@ let
       deepSeq elem elemAt genericClosure getAttr
       hasAttr isAttrs isBool isInt isList isPath isString
       lessThan listToAttrs pathExists readFile replaceStrings seq
-      sub substring trace;
+      sub trace;
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
       bitNot boolToString mergeAttrs flip mapNullable inNixShell isFloat min max
       importJSON importTOML warn warnIf warnIfNot throwIf throwIfNot checkListOfEnum
@@ -96,7 +96,7 @@ let
       subtractLists mutuallyExclusive groupBy groupBy' concatLists genList
       length head tail;
     inherit (self.strings) concatStrings concatMapStrings concatImapStrings
-      stringLength
+      stringLength substring
       intersperse concatStringsSep concatMapStringsSep
       concatImapStringsSep concatLines makeSearchPath makeSearchPathOutput
       makeLibraryPath makeIncludePath makeBinPath optionalString

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -65,7 +65,7 @@ let
     kernel = callLibs ./kernel.nix;
 
     inherit (builtins) add addErrorContext
-      deepSeq elem elemAt filter genericClosure genList getAttr
+      deepSeq elem elemAt genericClosure genList getAttr
       hasAttr head isAttrs isBool isInt isList isPath isString length
       lessThan listToAttrs pathExists readFile replaceStrings seq
       stringLength sub substring tail trace;
@@ -89,7 +89,7 @@ let
       recurseIntoAttrs dontRecurseIntoAttrs cartesianProduct cartesianProductOfSets
       mapCartesianProduct updateManyAttrsByPath intersectAttrs removeAttrs;
     inherit (self.lists) singleton forEach map foldr fold foldl foldl' imap0 imap1
-      ifilter0 concatMap flatten remove findSingle findFirst any all count
+      filter ifilter0 concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range replicate partition zipListsWith zipLists
       reverseList listDfs toposort sort sortOn naturalSort compareLists take
       drop sublist last init crossLists unique allUnique intersectLists

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -67,13 +67,13 @@ let
     inherit (builtins) add addErrorContext
       deepSeq elem elemAt genericClosure getAttr
       hasAttr isAttrs isBool isInt isList isPath isString
-      lessThan pathExists readFile replaceStrings seq
+      lessThan pathExists readFile replaceStrings
       sub trace;
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
       bitNot boolToString mergeAttrs flip mapNullable inNixShell isFloat min max
       importJSON importTOML warn warnIf warnIfNot throwIf throwIfNot checkListOfEnum
       info showWarnings nixpkgsVersion version isInOldestRelease
-      mod compare splitByAndCompare
+      mod compare splitByAndCompare seq
       functionArgs setFunctionArgs isFunction toFunction mirrorFunctionArgs
       toHexString toBaseDigits inPureEvalMode;
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions


### PR DESCRIPTION
## Description of changes

`lib.*` exports a lot of builtins that are also available in sub-libraries, currently in two ways:
1. `lib.attrValues` -> `lib.attrsets.attrValues` -> `builtins.attrValues`
2. `lib.attrNames` -> `builtins.attrNames` and `lib.attrsets.attrNames` -> `builtins.attrNames`

This PR changes all that use 2. to use the approach from 1. instead, because:
- It's more consistent internally
- In case we ever change anything about the exported symbols, it won't lead to inconsistencies where `lib.attrNames` wouldn't be the same as `lib.attrsets.attrNames` anymore

Ping @roberth

## Things done

Tested that all `lib.*` symbols exist:

```
❯ nix repl -f .
Nix 2.22.1
Type :? for help.
Loading installable ''...
Added 21758 variables.
nix-repl> lib.debug.traceSeqN 1 lib null
...
null
```

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
