### PR TITLE
kshutdown: 5.91-beta -> 5.92-beta

### DIFF
--- a/pkgs/by-name/ks/kshutdown/package.nix
+++ b/pkgs/by-name/ks/kshutdown/package.nix
@@ -1,24 +1,24 @@
 { stdenv
 , lib
 , fetchurl
-, extra-cmake-modules
+, cmake
 , unzip
-, libsForQt5
+, kdePackages
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "kshutdown";
-  version = "5.91-beta";
+  version = "5.92-beta";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/kshutdown/KShutdown/${finalAttrs.version}/kshutdown-source-${finalAttrs.version}.zip";
-    hash = "sha256-gWXpVBhoZ57kaQV1C+xCBYc2gZjzJfFViD/SI9D+BRc=";
+    hash = "sha256-EYgb2jeUoLNSPFIzlicnrmsccGc1nvoE5iDVt9x83ns=";
     name = "kshutdown-source-${finalAttrs.version}.zip";
   };
 
-  nativeBuildInputs = [ extra-cmake-modules unzip libsForQt5.wrapQtAppsHook ];
+  nativeBuildInputs = [ cmake unzip kdePackages.wrapQtAppsHook ];
 
-  buildInputs = with libsForQt5; [ qtbase kxmlgui knotifyconfig kidletime ];
+  buildInputs = with kdePackages; [ qtbase kxmlgui knotifyconfig kidletime kstatusnotifieritem ];
 
   meta = with lib; {
     homepage = "https://kshutdown.sourceforge.io/";
@@ -29,4 +29,3 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = platforms.linux;
   };
 })
-


### PR DESCRIPTION
## Description of changes

Updated package kshutdown to 5.92-beta.

## Things done

Updated package kshutdown to 5.92-beta and switched to KF6 because it is now available on kshutdown.
Also stopped using extra-cmake-modules which causes some libs not found

<details>

<summary>Error when using extra-cmake-modules</summary>

```console
Running phase: qtPreHook
Running phase: unpackPhase
unpacking source archive /nix/store/nhrvlwsmb4wj203zxiggk2n1qsjrp8a5-kshutdown-source-5.92-beta.zip
source root is kshutdown-5.92-beta
setting SOURCE_DATE_EPOCH to timestamp 1718646032 of file kshutdown-5.92-beta/tools/test.sh
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
fixing cmake files...
cmake flags: -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DCMAKE_INSTALL_LOCALEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/locale -DCMAKE_INSTALL_LIBEXECDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/libexec -DCMAKE_INSTALL_LIBDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/lib -DCMAKE_INSTALL_DOCDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/doc/kshutdown -DCMAKE_INSTALL_INFODIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/info -DCMAKE_INSTALL_MANDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/man -DCMAKE_INSTALL_OLDINCLUDEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/include -DCMAKE_INSTALL_INCLUDEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/include -DCMAKE_INSTALL_SBINDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/sbin -DCMAKE_INSTALL_BINDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/bin -DCMAKE_INSTALL_NAME_DIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/lib -DCMAKE_POLICY_DEFAULT_CMP0025=NEW -DCMAKE_OSX_SYSROOT= -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_STRIP=/nix/store/mpm3i0sbqc9svfch6a17179fs64dz2kv-gcc-wrapper-13.3.0/bin/strip -DCMAKE_RANLIB=/nix/store/mpm3i0sbqc9svfch6a17179fs64dz2kv-gcc-wrapper-13.3.0/bin/ranlib -DCMAKE_AR=/nix/store/mpm3i0sbqc9svfch6a17179fs64dz2kv-gcc-wrapper-13.3.0/bin/ar -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_INSTALL_PREFIX=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta  -DKDE_INSTALL_EXECROOTDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta -DKDE_INSTALL_BINDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/bin -DKDE_INSTALL_SBINDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/sbin -DKDE_INSTALL_LIBDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/lib -DKDE_INSTALL_LIBEXECDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/libexec -DKDE_INSTALL_CMAKEPACKAGEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/lib/cmake -DKDE_INSTALL_QTPLUGINDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/lib/qt-6/plugins -DKDE_INSTALL_PLUGINDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/lib/qt-6/plugins -DKDE_INSTALL_QMLDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/lib/qt-6/qml -DKDE_INSTALL_INCLUDEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/include -DKDE_INSTALL_LOCALSTATEDIR=/var -DKDE_INSTALL_SHAREDSTATEDIR=/com -DKDE_INSTALL_DATAROOTDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share -DKDE_INSTALL_DATADIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share -DKDE_INSTALL_DOCBUNDLEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/doc/HTML -DKDE_INSTALL_KCFGDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/config.kcfg -DKDE_INSTALL_KCONFUPDATEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/kconf_update -DKDE_INSTALL_KAPPTEMPLATESDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/kdevappwizard/templates -DKDE_INSTALL_KFILETEMPLATESDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/kdevfiletemplates/templates -DKDE_INSTALL_KXMLGUIDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/kxmlgui5 -DKDE_INSTALL_KNOTIFYRCDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/knotifications6 -DKDE_INSTALL_ICONDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/icons -DKDE_INSTALL_LOCALEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/locale -DKDE_INSTALL_SOUNDDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/sounds -DKDE_INSTALL_TEMPLATEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/templates -DKDE_INSTALL_WALLPAPERDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/wallpapers -DKDE_INSTALL_APPDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/applications -DKDE_INSTALL_DESKTOPDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/desktop-directories -DKDE_INSTALL_MIMEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/mime/packages -DKDE_INSTALL_METAINFODIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/appdata -DKDE_INSTALL_QTQCHDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/doc/qch -DKDE_INSTALL_QCHDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/doc/qch -DKDE_INSTALL_MANDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/man -DKDE_INSTALL_INFODIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/info -DKDE_INSTALL_DBUSDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/dbus-1 -DKDE_INSTALL_DBUSINTERFACEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/dbus-1/interfaces -DKDE_INSTALL_DBUSSERVICEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/dbus-1/services -DKDE_INSTALL_DBUSSYSTEMSERVICEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/dbus-1/system-services -DKDE_INSTALL_SYSCONFDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/etc -DKDE_INSTALL_CONFDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/etc/xdg -DKDE_INSTALL_AUTOSTARTDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/etc/xdg/autostart -DKDE_INSTALL_LOGGINGCATEGORIESDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/qlogging-categories6 -DKDE_INSTALL_SYSTEMDUNITDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/lib/systemd -DKDE_INSTALL_SYSTEMDUSERUNITDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/systemd/user -DKDE_INSTALL_EXECROOTDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta -DKDE_INSTALL_BINDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/bin -DKDE_INSTALL_SBINDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/sbin -DKDE_INSTALL_LIBDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/lib -DKDE_INSTALL_LIBEXECDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/libexec -DKDE_INSTALL_CMAKEPACKAGEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/lib/cmake -DKDE_INSTALL_QTPLUGINDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/lib/qt-6/plugins -DKDE_INSTALL_PLUGINDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/lib/qt-6/plugins -DKDE_INSTALL_QMLDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/lib/qt-6/qml -DKDE_INSTALL_INCLUDEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/include -DKDE_INSTALL_LOCALSTATEDIR=/var -DKDE_INSTALL_SHAREDSTATEDIR=/com -DKDE_INSTALL_DATAROOTDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share -DKDE_INSTALL_DATADIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share -DKDE_INSTALL_DOCBUNDLEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/doc/HTML -DKDE_INSTALL_KCFGDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/config.kcfg -DKDE_INSTALL_KCONFUPDATEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/kconf_update -DKDE_INSTALL_KAPPTEMPLATESDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/kdevappwizard/templates -DKDE_INSTALL_KFILETEMPLATESDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/kdevfiletemplates/templates -DKDE_INSTALL_KXMLGUIDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/kxmlgui5 -DKDE_INSTALL_KNOTIFYRCDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/knotifications6 -DKDE_INSTALL_ICONDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/icons -DKDE_INSTALL_LOCALEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/locale -DKDE_INSTALL_SOUNDDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/sounds -DKDE_INSTALL_TEMPLATEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/templates -DKDE_INSTALL_WALLPAPERDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/wallpapers -DKDE_INSTALL_APPDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/applications -DKDE_INSTALL_DESKTOPDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/desktop-directories -DKDE_INSTALL_MIMEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/mime/packages -DKDE_INSTALL_METAINFODIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/appdata -DKDE_INSTALL_QTQCHDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/doc/qch -DKDE_INSTALL_QCHDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/doc/qch -DKDE_INSTALL_MANDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/man -DKDE_INSTALL_INFODIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/info -DKDE_INSTALL_DBUSDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/dbus-1 -DKDE_INSTALL_DBUSINTERFACEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/dbus-1/interfaces -DKDE_INSTALL_DBUSSERVICEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/dbus-1/services -DKDE_INSTALL_DBUSSYSTEMSERVICEDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/dbus-1/system-services -DKDE_INSTALL_SYSCONFDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/etc -DKDE_INSTALL_CONFDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/etc/xdg -DKDE_INSTALL_AUTOSTARTDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/etc/xdg/autostart -DKDE_INSTALL_LOGGINGCATEGORIESDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/qlogging-categories6 -DKDE_INSTALL_SYSTEMDUNITDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/lib/systemd -DKDE_INSTALL_SYSTEMDUSERUNITDIR=/nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta/share/systemd/user 
-- The C compiler identification is GNU 13.3.0
-- The CXX compiler identification is GNU 13.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /nix/store/mpm3i0sbqc9svfch6a17179fs64dz2kv-gcc-wrapper-13.3.0/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /nix/store/mpm3i0sbqc9svfch6a17179fs64dz2kv-gcc-wrapper-13.3.0/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Performing Test HAVE_STDATOMIC
-- Performing Test HAVE_STDATOMIC - Success
-- Found WrapAtomic: TRUE
-- Found OpenGL: /nix/store/a5vcvrkh1c2ng5kr584g3zw3991vnhks-libGL-1.7.0/lib/libOpenGL.so
-- Found WrapOpenGL: TRUE
-- Found XKB: /nix/store/kq90rz7favab185f9lyabzxc6z0z95w8-libxkbcommon-1.7.0/lib/libxkbcommon.so (found suitable version "1.7.0", minimum required is "0.5.0")
-- Found WrapVulkanHeaders: /nix/store/kvnv3yfhwdvmmci261m092llmrwkw2rr-vulkan-headers-1.3.283.0/include
-- Qt 6.x found
Installing in /nix/store/j1h5c51hi4qfqva7lyagiyd30c768nd1-kshutdown-5.92-beta. Run /tmp/nix-build-kshutdown-5.92-beta.drv-0/kshutdown-5.92-beta/build/prefix.sh to set the environment for kshutdown.
-- Looking for __GLIBC__
-- Looking for __GLIBC__ - found
-- Performing Test _OFFT_IS_64BIT
-- Performing Test _OFFT_IS_64BIT - Success
-- Performing Test HAVE_DATE_TIME
-- Performing Test HAVE_DATE_TIME - Success
CMake Error at CMakeLists.txt:50 (find_package):
  By not providing "FindKF6.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "KF6", but
  CMake did not find one.

  Could not find a package configuration file provided by "KF6" with any of
  the following names:

    KF6Config.cmake
    kf6-config.cmake

  Add the installation prefix of "KF6" to CMAKE_PREFIX_PATH or set "KF6_DIR"
  to a directory containing one of the above files.  If "KF6" provides a
  separate development package or SDK, be sure it has been installed.


-- Configuring incomplete, errors occurred!

```

</details>

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
