### PR TITLE
nixos/kubernetes: forces etcd to wait for etcd.pem and adds tests

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/apiserver.nix
+++ b/nixos/modules/services/cluster/kubernetes/apiserver.nix
@@ -479,6 +479,7 @@ in
         };
       };
 
+      systemd.services.etcd.unitConfig.ConditionPathExists = "${top.secretsPath}/etcd.pem";
     })
 
   ];

--- a/nixos/tests/kubernetes/dns.nix
+++ b/nixos/tests/kubernetes/dns.nix
@@ -109,6 +109,8 @@ let
 
       # check dns inside the container
       machine1.succeed("kubectl exec probe -- /bin/host redis.default.svc.cluster.local")
+
+      machine1.fail("journalctl --unit etcd.service --boot MESSAGE='Failed to start etcd key-value store.' --grep=.")
     '';
   };
 
@@ -151,6 +153,8 @@ let
 
       # check dns inside the container
       machine1.succeed("kubectl exec probe -- /bin/host redis.default.svc.cluster.local")
+
+      machine1.fail("journalctl --unit etcd.service --boot MESSAGE='Failed to start etcd key-value store.' --grep=.")
     '';
   };
 in {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR forces etcd.service to wait for etcd.pem and adds tests about the journal logs searching for etcd erros. With this PR it starts cleanly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->


The etcd unit was failing a few times, it spams journal logs. It was producing messages like: 

```bash
"Failed to start etcd key-value store."
```


Command to get the massage:
```bash
journalctl --unit etcd.service --boot \
--catalog --no-pager --full --priority=err \
--output="json" --output-fields="MESSAGE"
```

It confuses people (including my self) trying to starting to use kubernetes from/in NixOS. The "classical error" about only etcd pods pending, that can be caused by many things, would be suspected to be etcd faults because of this "Failed to start ..." messages.

### Details 

Tested it with:
```bash
nix \
build \
--no-link \
--print-out-paths \
--override-flake \
nixpkgs \
'github:PedroRegisPOAR/nixpkgs/db15dfcb888dbb9fc02882d16a05a8fb471a4329' \
'nixpkgs#nixosTests.kubernetes.dns-single-node' \
'nixpkgs#nixosTests.kubernetes.dns-multi-node' \
'nixpkgs#nixosTests.kubernetes.rbac-single-node' \
'nixpkgs#nixosTests.kubernetes.rbac-multi-node'
```

Outputs:
```bash
/nix/store/0rgizg8lgflajgz5b2bk7zf95w7p0iq6-vm-test-run-kubernetes-dns-multinode
/nix/store/lrrj8j74jywjz183lla97vfjc9p28xwr-vm-test-run-kubernetes-dns-singlenode
/nix/store/78zvarvyxphhqf8gb5s6ig073nmbiaky-vm-test-run-kubernetes-rbac-multinode
/nix/store/nvpi7wqvda15qy9bj3z9yk85gzdlcarc-vm-test-run-kubernetes-rbac-singlenode
```



For local testing:

```bash
nix \
build \
--no-link \
--print-out-paths \
'.#nixosTests.kubernetes.dns-single-node' \
'.#nixosTests.kubernetes.dns-multi-node' \
'.#nixosTests.kubernetes.rbac-single-node' \
'.#nixosTests.kubernetes.rbac-multi-node'
```



## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
