### PR TITLE
krun: init at 0-unstable-2024-06-18

### DIFF
--- a/pkgs/by-name/kr/krun/package.nix
+++ b/pkgs/by-name/kr/krun/package.nix
@@ -1,0 +1,70 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, rustPlatform
+, libiconv
+, libkrun
+, makeWrapper
+, passt
+, sommelier
+, mesa
+, opengl-driver ? mesa.drivers
+, withSommelier ? false
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "krun";
+  version = "0-unstable-2024-06-18";
+
+  src = fetchFromGitHub {
+    owner = "slp";
+    repo = pname;
+    rev = "912afa5c6525b7c8f83dffd65ec4b1425b3f7521";
+    hash = "sha256-rDuxv3UakAemDnj4Nsbpqsykts2IcseuQmDwO24L+u8=";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/slp/krun/pull/39.diff";
+      hash = "sha256-CV69L+VDDLRcWgpgDCAYKLlTU9ytFcHhzNgOibWD8KY=";
+    })
+    (fetchpatch {
+      url = "https://github.com/slp/krun/pull/38.diff";
+      hash = "sha256-cK3iDhh+33H16V65lWUXahjmpSxI1HhiLUmkjfkRB7A=";
+    })
+  ];
+
+  cargoHash = "sha256-NahnigxJaY2QwWnySCRrnf3JyqZ+7jRA1CpE7ON0OOE=";
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    (libkrun.override {
+      withGpu = true;
+      withNet = true;
+    })
+  ];
+
+  # Allow for sommelier to be disabled as it can cause problems.
+  wrapArgs = [
+    "--prefix PATH : ${lib.makeBinPath (lib.optional withSommelier [ sommelier ] ++ [ passt ])}"
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/krun $wrapArgs \
+      --set-default OPENGL_DRIVER ${opengl-driver}
+  '';
+
+  meta = {
+    description = "Run programs from your system in a microVM";
+    homepage = "https://github.com/slp/krun";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ RossComputerGuy ];
+    platforms = libkrun.meta.platforms;
+    mainProgram = "krun";
+  };
+}

--- a/pkgs/development/libraries/libkrun/default.nix
+++ b/pkgs/development/libraries/libkrun/default.nix
@@ -6,54 +6,72 @@
 , pkg-config
 , glibc
 , openssl
+, libepoxy
+, libdrm
+, pipewire
+, virglrenderer
 , libkrunfw
+, llvmPackages
 , rustc
+, withGpu ? false
+, withSound ? false
+, withNet ? false
 , sevVariant ? false
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libkrun";
   version = "1.9.3";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "libkrun";
-    rev = "refs/tags/v${version}";
+    rev = "refs/tags/v${finalAttrs.version}";
     hash = "sha256-LIp2/794gbHPweBJcHCjbF0m+bJAs0SPF7WivW7fxLI=";
   };
 
+  outputs = [ "out" "dev" ];
+
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit pname version src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-g4ceYi16mjEgvWTAQEW8ShT/e5IKnlgLgk49Mg0N2fQ=";
   };
 
   nativeBuildInputs = [
+    llvmPackages.clang
     rustPlatform.cargoSetupHook
     cargo
     rustc
-  ] ++ lib.optionals sevVariant [
-    pkg-config
-  ];
+  ] ++ lib.optional (sevVariant || withGpu) pkg-config;
 
   buildInputs = [
     (libkrunfw.override { inherit sevVariant; })
     glibc
     glibc.static
-  ] ++ lib.optionals sevVariant [
-    openssl
-  ];
+  ] ++ lib.optionals withGpu [ libepoxy libdrm virglrenderer ]
+    ++ lib.optional withSound pipewire
+    ++ lib.optional sevVariant openssl;
+
+  env.LIBCLANG_PATH = "${llvmPackages.clang-unwrapped.lib}/lib/libclang.so";
 
   makeFlags = [
     "PREFIX=${placeholder "out"}"
-  ] ++ lib.optionals sevVariant [
-    "SEV=1"
-  ];
+  ] ++ lib.optional withGpu "GPU=1"
+    ++ lib.optional withSound "SND=1"
+    ++ lib.optional withNet "NET=1"
+    ++ lib.optional sevVariant "SEV=1";
+
+  postInstall = ''
+    mkdir -p $dev/lib/pkgconfig
+    mv $out/lib64/pkgconfig $dev/lib/pkgconfig
+    mv $out/include $dev/include
+  '';
 
   meta = with lib; {
     description = "Dynamic library providing Virtualization-based process isolation capabilities";
     homepage = "https://github.com/containers/libkrun";
     license = licenses.asl20;
-    maintainers = with maintainers; [ nickcao ];
+    maintainers = with maintainers; [ nickcao RossComputerGuy ];
     platforms = libkrunfw.meta.platforms;
   };
-}
+})

--- a/pkgs/development/libraries/libkrunfw/default.nix
+++ b/pkgs/development/libraries/libkrunfw/default.nix
@@ -5,25 +5,27 @@
 , flex
 , bison
 , bc
+, cpio
+, perl
 , elfutils
 , python3
 , sevVariant ? false
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libkrunfw";
-  version = "4.0.0";
+  version = "4.0.0-unstable-2024-06-10";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "libkrunfw";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-9oVl4mlJE7QHeehG86pbh7KdShZNUGwlnO75k/F/PQ0=";
+    rev = "12236fa4caa42423ff3081b6179aa0a5f37c67c9";
+    hash = "sha256-Vcbg2zBVMQsiAQF/cEEIRMqppMBVGnqUBlDquGzRBsc=";
   };
 
   kernelSrc = fetchurl {
-    url = "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.4.7.tar.xz";
-    hash = "sha256-3hQ8th3Kp1bAX1b/NRRDFtgQYVgZUYoz40dU8GTEp9g=";
+    url = "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.6.32.tar.xz";
+    hash = "sha256-qqgk6vB/YZEdIrdf8JCkA8PdC9c+I5M+C7qLWXFDbOE=";
   };
 
   postPatch = ''
@@ -35,6 +37,8 @@ stdenv.mkDerivation rec {
     flex
     bison
     bc
+    cpio
+    perl
     python3
     python3.pkgs.pyelftools
   ];
@@ -49,13 +53,16 @@ stdenv.mkDerivation rec {
     "SEV=1"
   ];
 
+  # Fixes https://github.com/containers/libkrunfw/issues/55
+  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.targetPlatform.isAarch64 "-march=armv8-a+crypto";
+
   enableParallelBuilding = true;
 
   meta = with lib; {
     description = "Dynamic library bundling the guest payload consumed by libkrun";
     homepage = "https://github.com/containers/libkrunfw";
     license = with licenses; [ lgpl2Only lgpl21Only ];
-    maintainers = with maintainers; [ nickcao ];
-    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ nickcao RossComputerGuy ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Updates `libkrun` and `libkrunfw`, adds `krun`. Good way to test is `NIXOS_CURRENT_SYSTEM=$(readlink -e /run/current-system/) ./result/bin/krun bash`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
