### PR TITLE
Revert #320852: Clean up cross bootstrapping

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -10,15 +10,15 @@
 , stdenvNoCC
 , runtimeShell
 , bintools ? null, libc ? null, coreutils ? null, gnugrep ? null
-, netbsd ? null
+, netbsd ? null, netbsdCross ? null
 , sharedLibraryLoader ?
   if libc == null then
     null
   else if stdenvNoCC.targetPlatform.isNetBSD then
-    if !(targetPackages ? netbsd) then
+    if !(targetPackages ? netbsdCross) then
       netbsd.ld_elf_so
-    else if libc != targetPackages.netbsd.headers then
-      targetPackages.netbsd.ld_elf_so
+    else if libc != targetPackages.netbsdCross.headers then
+      targetPackages.netbsdCross.ld_elf_so
     else
       null
   else

--- a/pkgs/by-name/uc/uclibc-ng/package.nix
+++ b/pkgs/by-name/uc/uclibc-ng/package.nix
@@ -1,5 +1,5 @@
 { lib
-, stdenvNoLibc
+, stdenv
 , buildPackages
 , fetchurl
 , gitUpdater
@@ -9,7 +9,6 @@
 }:
 
 let
-  stdenv = stdenvNoLibc;
   isCross = (stdenv.buildPlatform != stdenv.hostPlatform);
   configParser = ''
     function parseconfig {

--- a/pkgs/development/misc/or1k/newlib.nix
+++ b/pkgs/development/misc/or1k/newlib.nix
@@ -1,6 +1,6 @@
-{ stdenv, texinfo, flex, bison, fetchFromGitHub, stdenvNoLibc, buildPackages }:
+{ stdenv, texinfo, flex, bison, fetchFromGitHub, crossLibcStdenv, buildPackages }:
 
-stdenvNoLibc.mkDerivation {
+crossLibcStdenv.mkDerivation {
   name = "newlib";
   src = fetchFromGitHub {
     owner = "openrisc";

--- a/pkgs/development/misc/vc4/newlib.nix
+++ b/pkgs/development/misc/vc4/newlib.nix
@@ -1,6 +1,6 @@
-{ stdenv, texinfo, flex, bison, fetchFromGitHub, stdenvNoLibc, buildPackages }:
+{ stdenv, texinfo, flex, bison, fetchFromGitHub, crossLibcStdenv, buildPackages }:
 
-stdenvNoLibc.mkDerivation {
+crossLibcStdenv.mkDerivation {
   name = "newlib";
   src = fetchFromGitHub {
     owner = "itszor";

--- a/pkgs/os-specific/bsd/freebsd/default.nix
+++ b/pkgs/os-specific/bsd/freebsd/default.nix
@@ -3,6 +3,7 @@
   makeScopeWithSplicing',
   generateSplicesForMkScope,
   callPackage,
+  crossLibcStdenv,
   attributePathToSplice ? [ "freebsd" ],
   branch ? "release/14.0.0",
 }:
@@ -23,30 +24,41 @@ let
       Branches can be selected by overriding the `branch` attribute on the freebsd package set.
     '';
 
-  # we do not include the branch in the splice here because the branch
-  # parameter to this file will only ever take on one value - more values
-  # are provided through overrides.
-  otherSplices = generateSplicesForMkScope attributePathToSplice;
+  # `./package-set.nix` should never know the name of the package set we
+  # are constructing; just this function is allowed to know that. This
+  # is why we:
+  #
+  #  - do the splicing for cross compilation here
+  #
+  #  - construct the *anonymized* `buildFreebsd` attribute to be passed
+  #    to `./package-set.nix`.
+  callFreeBSDWithAttrs =
+    extraArgs:
+    let
+      # we do not include the branch in the splice here because the branch
+      # parameter to this file will only ever take on one value - more values
+      # are provided through overrides.
+      otherSplices = generateSplicesForMkScope attributePathToSplice;
+    in
+    makeScopeWithSplicing' {
+      inherit otherSplices;
+      f =
+        self:
+        {
+          inherit branch;
+        }
+        // callPackage ./package-set.nix (
+          {
+            sourceData = versions.${self.branch} or (throw (badBranchError self.branch));
+            versionData = self.sourceData.version;
+            buildFreebsd = otherSplices.selfBuildHost;
+            patchesRoot = ./patches + "/${self.versionData.revision}";
+          }
+          // extraArgs
+        ) self;
+    };
 in
-# `./package-set.nix` should never know the name of the package set we
-# are constructing; just this function is allowed to know that. This
-# is why we:
-#
-#  - do the splicing for cross compilation here
-#
-#  - construct the *anonymized* `buildFreebsd` attribute to be passed
-#    to `./package-set.nix`.
-makeScopeWithSplicing' {
-  inherit otherSplices;
-  f =
-    self:
-    {
-      inherit branch;
-    }
-    // callPackage ./package-set.nix ({
-      sourceData = versions.${self.branch} or (throw (badBranchError self.branch));
-      versionData = self.sourceData.version;
-      buildFreebsd = otherSplices.selfBuildHost;
-      patchesRoot = ./patches + "/${self.versionData.revision}";
-    }) self;
+{
+  freebsd = callFreeBSDWithAttrs { };
+  freebsdCross = callFreeBSDWithAttrs { stdenv = crossLibcStdenv; };
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   stdenvNoCC,
-  stdenvNoLibc,
+  stdenvNoLibs,
   overrideCC,
   buildPackages,
   versionData,
@@ -28,7 +28,7 @@ lib.makeOverridable (
       if attrs.noCC or false then
         stdenvNoCC
       else if attrs.noLibc or false then
-        stdenvNoLibc
+        stdenvNoLibs
       else if attrs.noLibcxx or false then
         overrideCC stdenv buildPackages.llvmPackages.clangNoLibcxx
       else
@@ -58,9 +58,12 @@ lib.makeOverridable (
 
       HOST_SH = stdenv'.shell;
 
+      # Since STRIP below is the flag
+      STRIPBIN = "${stdenv.cc.bintools.targetPrefix}strip";
+
       makeFlags = [
         "STRIP=-s" # flag to install, not command
-      ] ++ lib.optional (!stdenv'.hostPlatform.isFreeBSD) "MK_WERROR=no";
+      ] ++ lib.optional (!stdenv.hostPlatform.isFreeBSD) "MK_WERROR=no";
 
       # amd64 not x86_64 for this on unlike NetBSD
       MACHINE_ARCH = freebsd-lib.mkBsdArch stdenv';
@@ -88,9 +91,6 @@ lib.makeOverridable (
     // lib.optionalAttrs stdenv'.hasCC {
       # TODO should CC wrapper set this?
       CPP = "${stdenv'.cc.targetPrefix}cpp";
-
-      # Since STRIP in `makeFlags` has to be a flag, not the binary itself
-      STRIPBIN = "${stdenv'.cc.bintools.targetPrefix}strip";
     }
     // lib.optionalAttrs stdenv'.isDarwin { MKRELRO = "no"; }
     // lib.optionalAttrs (stdenv'.cc.isClang or false) {

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   lib,
   stdenvNoCC,
   makeScopeWithSplicing',
@@ -20,9 +21,7 @@ makeScopeWithSplicing' {
 
       defaultMakeFlags = [
         "MKSOFTFLOAT=${
-          if
-            stdenvNoCC.hostPlatform.gcc.float or (stdenvNoCC.hostPlatform.parsed.abi.float or "hard") == "soft"
-          then
+          if stdenv.hostPlatform.gcc.float or (stdenv.hostPlatform.parsed.abi.float or "hard") == "soft" then
             "yes"
           else
             "no"
@@ -37,6 +36,7 @@ makeScopeWithSplicing' {
       # because of the splices.
 
       mkDerivation = self.callPackage ./pkgs/mkDerivation.nix {
+        inherit stdenv stdenvNoCC;
         inherit (buildPackages.netbsd)
           netbsdSetupHook
           makeMinimal
@@ -129,7 +129,7 @@ makeScopeWithSplicing' {
       libpthread-headers = self.callPackage ./pkgs/libpthread/headers.nix { };
 
       csu = self.callPackage ./pkgs/csu.nix {
-        inherit (self) headers sys-headers ld_elf_so;
+        inherit (self) headers sys ld_elf_so;
         inherit (buildPackages.netbsd)
           netbsdSetupHook
           makeMinimal

--- a/pkgs/os-specific/bsd/netbsd/pkgs/csu.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/csu.nix
@@ -16,12 +16,11 @@
   statHook,
   rsync,
   headers,
-  sys-headers,
+  sys,
   ld_elf_so,
 }:
 
 mkDerivation {
-  noLibc = true;
   path = "lib/csu";
   meta.platforms = lib.platforms.netbsd;
   nativeBuildInputs = [
@@ -42,7 +41,7 @@ mkDerivation {
   ];
   buildInputs = [ headers ];
   extraPaths = [
-    sys-headers.path
+    sys.path
     ld_elf_so.path
   ];
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/include.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/include.nix
@@ -15,7 +15,6 @@
 }:
 
 mkDerivation {
-  noLibc = true;
   path = "include";
   nativeBuildInputs = [
     bsdSetupHook

--- a/pkgs/os-specific/bsd/netbsd/pkgs/ld_elf_so.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/ld_elf_so.nix
@@ -6,7 +6,6 @@
 }:
 
 mkDerivation {
-  noLibc = true;
   path = "libexec/ld.elf_so";
   meta.platforms = lib.platforms.netbsd;
   LIBC_PIC = "${libc}/lib/libc_pic.a";

--- a/pkgs/os-specific/bsd/netbsd/pkgs/libc.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/libc.nix
@@ -24,7 +24,6 @@
 }:
 
 mkDerivation {
-  noLibc = true;
   path = "lib/libc";
   USE_FORT = "yes";
   MKPROFILE = "no";
@@ -95,8 +94,5 @@ mkDerivation {
     make -C $BSDSRCDIR/lib/libcrypt $makeFlags
     make -C $BSDSRCDIR/lib/libcrypt $makeFlags install
   '';
-  postPatch = ''
-    sed -i 's,/usr\(/include/sys/syscall.h\),${headers}\1,g' \
-      $BSDSRCDIR/lib/{libc,librt}/sys/Makefile.inc
-  '';
+  inherit (librt) postPatch;
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/librt.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/librt.nix
@@ -9,5 +9,8 @@ mkDerivation {
   path = "lib/librt";
   meta.platforms = lib.platforms.netbsd;
   extraPaths = [ libc.path ] ++ libc.extraPaths;
-  inherit (libc) postPatch;
+  postPatch = ''
+    sed -i 's,/usr\(/include/sys/syscall.h\),${headers}\1,g' \
+      $BSDSRCDIR/lib/{libc,librt}/sys/Makefile.inc
+  '';
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/mkDerivation.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   stdenvNoCC,
-  stdenvNoLibc,
+  crossLibcStdenv,
   runCommand,
   rsync,
   source,
@@ -23,13 +23,7 @@
 lib.makeOverridable (
   attrs:
   let
-    stdenv' =
-      if attrs.noCC or false then
-        stdenvNoCC
-      else if attrs.noLibc or false then
-        stdenvNoLibc
-      else
-        stdenv;
+    stdenv' = if attrs.noCC or false then stdenvNoCC else stdenv;
   in
   stdenv'.mkDerivation (
     rec {

--- a/pkgs/os-specific/bsd/openbsd/pkgs/csu.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/csu.nix
@@ -9,7 +9,6 @@
 }:
 
 mkDerivation {
-  noLibc = true;
   path = "lib/csu";
   nativeBuildInputs = [
     bsdSetupHook

--- a/pkgs/os-specific/bsd/openbsd/pkgs/libc/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/libc/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenvNoLibc,
+  stdenv,
   mkDerivation,
   bsdSetupHook,
   openbsdSetupHook,
@@ -10,6 +10,7 @@
   byacc,
   gencat,
   rpcgen,
+  lorder,
   csu,
   include,
   ctags,
@@ -18,8 +19,7 @@
   fetchpatch,
 }:
 
-mkDerivation {
-  noLibc = true;
+mkDerivation rec {
   pname = "libc";
   path = "lib/libc";
   extraPaths = [
@@ -53,6 +53,7 @@ mkDerivation {
     gencat
     rpcgen
     ctags
+    lorder
     tsort
   ];
 
@@ -68,9 +69,7 @@ mkDerivation {
 
   # Suppress lld >= 16 undefined version errors
   # https://github.com/freebsd/freebsd-src/commit/2ba84b4bcdd6012e8cfbf8a0d060a4438623a638
-  env.NIX_LDFLAGS = lib.optionalString (
-    stdenvNoLibc.hostPlatform.linker == "lld"
-  ) "--undefined-version";
+  env.NIX_LDFLAGS = lib.optionalString (stdenv.hostPlatform.linker == "lld") "--undefined-version";
 
   makeFlags = [
     "STRIP=-s" # flag to install, not command

--- a/pkgs/os-specific/bsd/openbsd/pkgs/lorder.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/lorder.nix
@@ -8,7 +8,6 @@
 }:
 
 mkDerivation {
-  noCC = true;
   path = "usr.bin/lorder";
   nativeBuildInputs = [
     bsdSetupHook

--- a/pkgs/os-specific/bsd/openbsd/pkgs/make-rules/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/make-rules/package.nix
@@ -2,6 +2,7 @@
   fetchpatch,
   lib,
   mkDerivation,
+  stdenv,
 }:
 
 mkDerivation {

--- a/pkgs/os-specific/bsd/openbsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/mkDerivation.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   stdenvNoCC,
-  stdenvNoLibc,
   runCommand,
   rsync,
   source,
@@ -15,13 +14,7 @@
 lib.makeOverridable (
   attrs:
   let
-    stdenv' =
-      if attrs.noCC or false then
-        stdenvNoCC
-      else if attrs.noLibc or false then
-        stdenvNoLibc
-      else
-        stdenv;
+    stdenv' = if attrs.noCC or false then stdenvNoCC else stdenv;
   in
   stdenv'.mkDerivation (
     rec {
@@ -49,6 +42,9 @@ lib.makeOverridable (
       ];
 
       HOST_SH = stdenv'.shell;
+
+      # Since STRIP below is the flag
+      STRIPBIN = "${stdenv.cc.bintools.targetPrefix}strip";
 
       makeFlags = [
         "STRIP=-s" # flag to install, not command
@@ -85,9 +81,6 @@ lib.makeOverridable (
     // lib.optionalAttrs stdenv'.hasCC {
       # TODO should CC wrapper set this?
       CPP = "${stdenv'.cc.targetPrefix}cpp";
-
-      # Since STRIP in `makeFlags` has to be a flag, not the binary itself
-      STRIPBIN = "${stdenv'.cc.bintools.targetPrefix}strip";
     }
     // lib.optionalAttrs (attrs.headersOnly or false) {
       installPhase = "includesPhase";

--- a/pkgs/os-specific/windows/default.nix
+++ b/pkgs/os-specific/windows/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, buildPackages
-, newScope, overrideCC, stdenvNoLibc, libcCross
+, newScope, overrideCC, crossLibcStdenv, libcCross
 }:
 
 lib.makeScope newScope (self: with self; {
@@ -14,11 +14,11 @@ lib.makeScope newScope (self: with self; {
   mingw_runtime = mingwrt;
 
   mingw_w64 = callPackage ./mingw-w64 {
-    stdenv = stdenvNoLibc;
+    stdenv = crossLibcStdenv;
   };
 
   # FIXME untested with llvmPackages_16 was using llvmPackages_8
-  crossThreadsStdenv = overrideCC stdenvNoLibc
+  crossThreadsStdenv = overrideCC crossLibcStdenv
     (if stdenv.hostPlatform.useLLVM or false
      then buildPackages.llvmPackages.clangNoLibcxx
      else buildPackages.gccWithoutTargetLibc.override (old: {

--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -3,12 +3,18 @@
 , windows
 , fetchurl
 , autoreconfHook
-, mingw_w64_headers
 }:
 
-stdenv.mkDerivation {
+let
+  version = "11.0.1";
+in stdenv.mkDerivation {
   pname = "mingw-w64";
-  inherit (mingw_w64_headers) version src meta;
+  inherit version;
+
+  src = fetchurl {
+    url = "mirror://sourceforge/mingw-w64/mingw-w64-v${version}.tar.bz2";
+    hash = "sha256-P2a84Gnui+10OaGhPafLkaXmfqYXDyExesf1eUYl7hA=";
+  };
 
   outputs = [ "out" "dev" ];
 
@@ -24,4 +30,8 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ windows.mingw_w64_headers ];
   hardeningDisable = [ "stackprotector" "fortify" ];
+
+  meta = {
+    platforms = lib.platforms.windows;
+  };
 }

--- a/pkgs/os-specific/windows/mingw-w64/headers.nix
+++ b/pkgs/os-specific/windows/mingw-w64/headers.nix
@@ -1,19 +1,11 @@
-{ lib, stdenvNoCC, fetchurl }:
+{ stdenvNoCC, mingw_w64 }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
-  pname = "mingw_w64-headers";
-  version = "11.0.1";
-
-  src = fetchurl {
-    url = "mirror://sourceforge/mingw-w64/mingw-w64-v${finalAttrs.version}.tar.bz2";
-    hash = "sha256-P2a84Gnui+10OaGhPafLkaXmfqYXDyExesf1eUYl7hA=";
-  };
+stdenvNoCC.mkDerivation {
+  name = "${mingw_w64.name}-headers";
+  inherit (mingw_w64) src meta;
 
   preConfigure = ''
     cd mingw-w64-headers
   '';
 
-  meta = {
-    platforms = lib.platforms.windows;
-  };
-})
+}

--- a/pkgs/os-specific/windows/mingw-w64/pthreads.nix
+++ b/pkgs/os-specific/windows/mingw-w64/pthreads.nix
@@ -1,8 +1,8 @@
-{ stdenv, mingw_w64_headers }:
+{ stdenv, mingw_w64 }:
 
 stdenv.mkDerivation {
-  pname = "mingw_w64-pthreads";
-  inherit (mingw_w64_headers) version src meta;
+  name = "${mingw_w64.name}-pthreads";
+  inherit (mingw_w64) src meta;
 
   configureFlags = [
     # Rustc require 'libpthread.a' when targeting 'x86_64-pc-windows-gnu'.

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -32,11 +32,7 @@ rec {
 
 
   # Override the compiler in stdenv for specific packages.
-  overrideCC = stdenv: cc: stdenv.override {
-    allowedRequisites = null;
-    cc = cc;
-    hasCC = cc != null;
-  };
+  overrideCC = stdenv: cc: stdenv.override { allowedRequisites = null; cc = cc; };
 
 
   # Add some arbitrary packages to buildInputs for specific packages.

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -98,7 +98,6 @@ mapAliases ({
   auditBlasHook = throw "'auditBlasHook' has been removed since it never worked"; # Added 2024-04-02
   authy = throw "'authy' has been removed since it reached end of life"; # Added 2024-04-19
   avldrums-lv2 = x42-avldrums; # Added 2020-03-29
-  avrlibcCross = avrlibc; # Added 2024-06-18
   awesome-4-0 = awesome; # Added 2022-05-05
   aws-env = throw "aws-env has been removed as the upstream project was unmaintained"; # Added 2024-06-11
 
@@ -199,7 +198,6 @@ mapAliases ({
   cope = throw "'cope' has been removed, as it is broken in nixpkgs since it was added, and fixing it is not trivial"; # Added 2024-04-12
   cpp-ipfs-api = cpp-ipfs-http-client; # Project has been renamed. Added 2022-05-15
   crispyDoom = crispy-doom; # Added 2023-05-01
-  crossLibcStdenv = stdenvNoLibc; # Added 2024-06-18
   cryptowatch-desktop = throw "Cryptowatch Desktop was sunset on September 30th 2023 and has been removed from nixpkgs"; # Added 2023-12-22
   clash = throw "'clash' has been removed, upstream gone. Consider using 'mihomo' instead."; # added 2023-11-10
   clasp = clingo; # added 2022-12-22
@@ -879,7 +877,6 @@ mapAliases ({
   mpd_clientlib = libmpdclient; # Added 2021-02-11
   mpdevil = plattenalbum; # Added 2024-05-22
   mpg321 = throw "'mpg321' has been removed due to it being unmaintained by upstream. Consider using mpg123 instead."; # Added 2024-05-10
-  msp430NewlibCross = msp430Newlib; # Added 2024-06-18
   mumble_git = throw "'mumble_git' has been renamed to/replaced by 'pkgs.mumble'"; # Converted to throw 2023-09-10
   murmur_git = throw "'murmur_git' has been renamed to/replaced by 'pkgs.murmur'"; # Converted to throw 2023-09-10
   mutt-with-sidebar = mutt; # Added 2022-09-17
@@ -913,8 +910,6 @@ mapAliases ({
   nagiosPluginsOfficial = monitoring-plugins;
   neochat = libsForQt5.kdeGear.neochat; # added 2022-05-10
   neoload = throw "'neoload' has been removed as it is broken and unmaintained"; # Added 2024-03-02
-  newlibCross = newlib; # Added 2024-06-18
-  newlib-nanoCross = newlib-nano; # Added 2024-06-18
   nitrokey-udev-rules = libnitrokey; # Added 2023-03-25
   nix-direnv-flakes = nix-direnv;
   nix-repl = throw (
@@ -1338,8 +1333,6 @@ mapAliases ({
   uade123 = uade; # Added 2022-07-30
   uberwriter = apostrophe; # Added 2020-04-23
   ubootBeagleboneBlack = ubootAmx335xEVM; # Added 2020-01-21
-  uclibc = uclibc-ng; # Added 2022-06-16
-  uclibcCross = uclibc-ng; # Added 2022-06-16
   ue4 = throw "ue4 has been removed, because the package was broken for years"; # Added 2023-11-22
   uhd3_5 = throw "uhd3_5 has been removed, because it was no longer needed"; # Added 2023-10-07
   uhhyou.lv2 = throw "'uhhyou.lv2' has been removed, upstream gone"; # Added 2023-06-21
@@ -1476,10 +1469,6 @@ mapAliases ({
 
   inherit (stdenv.hostPlatform) system; # Added 2021-10-22
   inherit (stdenv) buildPlatform hostPlatform targetPlatform; # Added 2023-01-09
-
-  freebsdCross = freebsd; # Added 2024-06-18
-  netbsdCross = netbsd; # Added 2024-06-18
-  openbsdCross = openbsd; # Added 2024-06-18
 
   # LLVM packages for (integration) testing that should not be used inside Nixpkgs:
   llvmPackages_latest = llvmPackages_18;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31,6 +31,19 @@ with pkgs;
   # it's just the plain stdenv.
   stdenv_32bit = lowPrio (if stdenv.hostPlatform.is32bit then stdenv else multiStdenv);
 
+  stdenvNoCC = stdenv.override (
+    { cc = null; hasCC = false; }
+
+    // lib.optionalAttrs (stdenv.hostPlatform.isDarwin && (stdenv.hostPlatform != stdenv.buildPlatform)) {
+      # TODO: This is a hack to use stdenvNoCC to produce a CF when cross
+      # compiling. It's not very sound. The cross stdenv has:
+      #   extraBuildInputs = [ targetPackages.darwin.apple_sdks.frameworks.CoreFoundation ]
+      # and uses stdenvNoCC. In order to make this not infinitely recursive, we
+      # need to exclude this extraBuildInput.
+      extraBuildInputs = [];
+    }
+  );
+
   mkStdenvNoLibs = stdenv: let
     bintools = stdenv.cc.bintools.override {
       libc = null;
@@ -48,7 +61,7 @@ with pkgs;
   };
 
   stdenvNoLibs =
-    if stdenvNoCC.hostPlatform != stdenvNoCC.buildPlatform
+    if stdenv.hostPlatform != stdenv.buildPlatform && (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.useLLVM or false)
     then
       # We cannot touch binutils or cc themselves, because that will cause
       # infinite recursion. So instead, we just choose a libc based on the
@@ -61,17 +74,7 @@ with pkgs;
       # thing to to create an earlier thing (leading to infinite recursion) and
       # we also would still respect the stage arguments choices for these
       # things.
-      (if stdenvNoCC.hostPlatform.isDarwin || stdenvNoCC.hostPlatform.useLLVM or false
-       then overrideCC stdenvNoCC buildPackages.llvmPackages.clangNoCompilerRt
-       else gccCrossLibcStdenv)
-    else mkStdenvNoLibs stdenv;
-
-  stdenvNoLibc =
-    if stdenvNoCC.hostPlatform != stdenvNoCC.buildPlatform
-    then
-      (if stdenvNoCC.hostPlatform.isDarwin || stdenvNoCC.hostPlatform.useLLVM or false
-       then overrideCC stdenvNoCC buildPackages.llvmPackages.clangNoLibc
-       else gccCrossLibcStdenv)
+      overrideCC stdenv buildPackages.llvmPackages.clangNoCompilerRt
     else mkStdenvNoLibs stdenv;
 
   gccStdenvNoLibs = mkStdenvNoLibs gccStdenv;
@@ -15456,7 +15459,12 @@ with pkgs;
     dontStrip = true;
   }));
 
-  gccCrossLibcStdenv = overrideCC stdenvNoCC buildPackages.gccWithoutTargetLibc;
+  gccCrossLibcStdenv = overrideCC stdenv buildPackages.gccWithoutTargetLibc;
+
+  crossLibcStdenv =
+    if stdenv.hostPlatform.useLLVM or false || stdenv.hostPlatform.isDarwin
+    then overrideCC stdenv buildPackages.llvmPackages.clangNoLibc
+    else gccCrossLibcStdenv;
 
   # The GCC used to build libc for the target platform. Normal gccs will be
   # built with, and use, that cross-compiled libc.
@@ -17624,8 +17632,9 @@ with pkgs;
 
   h3 = h3_3;
 
-  avrlibc = callPackage ../development/misc/avr/libc {
-    stdenv = stdenvNoLibc;
+  avrlibc      = callPackage ../development/misc/avr/libc { };
+  avrlibcCross = callPackage ../development/misc/avr/libc {
+    stdenv = crossLibcStdenv;
   };
 
   avr8burnomat = callPackage ../development/misc/avr8-burn-omat { };
@@ -17699,7 +17708,10 @@ with pkgs;
 
   msp430GccSupport = callPackage ../development/misc/msp430/gcc-support.nix { };
 
-  msp430Newlib = callPackage ../development/misc/msp430/newlib.nix { };
+  msp430Newlib      = callPackage ../development/misc/msp430/newlib.nix { };
+  msp430NewlibCross = callPackage ../development/misc/msp430/newlib.nix {
+    newlib = newlibCross;
+  };
 
   mspds = callPackage ../development/misc/msp430/mspds { };
   mspds-bin = callPackage ../development/misc/msp430/mspds/binary.nix { };
@@ -20914,14 +20926,14 @@ with pkgs;
   };
 
   muslCross = musl.override {
-    stdenv = stdenvNoLibc;
+    stdenv = crossLibcStdenv;
   };
 
   # These are used when buiding compiler-rt / libgcc, prior to building libc.
   preLibcCrossHeaders = let
     inherit (stdenv.targetPlatform) libc;
   in     if stdenv.targetPlatform.isMinGW then targetPackages.windows.mingw_w64_headers or windows.mingw_w64_headers
-    else if libc == "nblibc" then targetPackages.netbsd.headers or netbsd.headers
+    else if libc == "nblibc" then targetPackages.netbsdCross.headers or netbsdCross.headers
     else if libc == "libSystem" && stdenv.targetPlatform.isAarch64 then targetPackages.darwin.LibsystemCross or darwin.LibsystemCross
     else null;
 
@@ -20932,13 +20944,13 @@ with pkgs;
     /**/ if name == null then null
     else if name == "glibc" then targetPackages.glibcCross or glibcCross
     else if name == "bionic" then targetPackages.bionic or bionic
-    else if name == "uclibc" then targetPackages.uclibc or uclibc
-    else if name == "avrlibc" then targetPackages.avrlibc or avrlibc
-    else if name == "newlib" && stdenv.targetPlatform.isMsp430 then targetPackages.msp430Newlib or msp430Newlib
+    else if name == "uclibc" then targetPackages.uclibcCross or uclibcCross
+    else if name == "avrlibc" then targetPackages.avrlibcCross or avrlibcCross
+    else if name == "newlib" && stdenv.targetPlatform.isMsp430 then targetPackages.msp430NewlibCross or msp430NewlibCross
     else if name == "newlib" && stdenv.targetPlatform.isVc4 then targetPackages.vc4-newlib or vc4-newlib
     else if name == "newlib" && stdenv.targetPlatform.isOr1k then targetPackages.or1k-newlib or or1k-newlib
-    else if name == "newlib" then targetPackages.newlib or newlib
-    else if name == "newlib-nano" then targetPackages.newlib-nano or newlib-nano
+    else if name == "newlib" then targetPackages.newlibCross or newlibCross
+    else if name == "newlib-nano" then targetPackages.newlib-nanoCross or newlib-nanoCross
     else if name == "musl" then targetPackages.muslCross or muslCross
     else if name == "msvcrt" then targetPackages.windows.mingw_w64 or windows.mingw_w64
     else if name == "ucrt" then targetPackages.windows.mingw_w64 or windows.mingw_w64
@@ -20946,9 +20958,9 @@ with pkgs;
       if stdenv.targetPlatform.useiOSPrebuilt
       then targetPackages.darwin.iosSdkPkgs.libraries or darwin.iosSdkPkgs.libraries
       else targetPackages.darwin.LibsystemCross or (throw "don't yet have a `targetPackages.darwin.LibsystemCross for ${stdenv.targetPlatform.config}`")
-    else if name == "fblibc" then targetPackages.freebsd.libc or freebsd.libc
-    else if name == "oblibc" then targetPackages.openbsd.libc or openbsd.libc
-    else if name == "nblibc" then targetPackages.netbsd.libc or netbsd.libc
+    else if name == "fblibc" then targetPackages.freebsdCross.libc or freebsdCross.libc
+    else if name == "oblibc" then targetPackages.openbsdCross.libc or openbsdCross.libc
+    else if name == "nblibc" then targetPackages.netbsdCross.libc or netbsdCross.libc
     else if name == "wasilibc" then targetPackages.wasilibc or wasilibc
     else if name == "relibc" then targetPackages.relibc or relibc
     else throw "Unknown libc ${name}";
@@ -20964,7 +20976,7 @@ with pkgs;
     };
 
   wasilibc = callPackage ../development/libraries/wasilibc {
-    stdenv = stdenvNoLibc;
+    stdenv = crossLibcStdenv;
   };
 
   relibc = callPackage ../development/libraries/relibc { };
@@ -27952,6 +27964,14 @@ with pkgs;
   inherit (callPackage ../misc/barebox {})
     buildBarebox
     bareboxTools;
+
+  uclibc-ng-cross = uclibc-ng.override {
+    stdenv = crossLibcStdenv;
+  };
+
+  # Aliases
+  uclibc = uclibc-ng;
+  uclibcCross = uclibc-ng-cross;
 
   eudev = callPackage ../by-name/eu/eudev/package.nix {
     util-linux = util-linuxMinimal;
@@ -40579,11 +40599,18 @@ with pkgs;
     name = "bsd-setup-hook";
   } ../os-specific/bsd/setup-hook.sh;
 
-  freebsd = callPackage ../os-specific/bsd/freebsd { };
+  inherit (callPackage ../os-specific/bsd/freebsd { })
+    freebsd freebsdCross;
 
   netbsd = callPackage ../os-specific/bsd/netbsd { };
+  netbsdCross = callPackage ../os-specific/bsd/netbsd {
+    stdenv = crossLibcStdenv;
+  };
 
   openbsd = callPackage ../os-specific/bsd/openbsd { };
+  openbsdCross = callPackage ../os-specific/bsd/openbsd {
+    stdenv = crossLibcStdenv;
+  };
 
   powershell = callPackage ../shells/powershell { };
 
@@ -40607,13 +40634,17 @@ with pkgs;
 
   new-session-manager = callPackage ../applications/audio/new-session-manager { };
 
-  newlib = callPackage ../development/misc/newlib {
-    stdenv = stdenvNoLibc;
+  newlib = callPackage ../development/misc/newlib { };
+  newlibCross = callPackage ../development/misc/newlib {
+    stdenv = crossLibcStdenv;
   };
 
   newlib-nano = callPackage ../development/misc/newlib {
-    stdenv = stdenvNoLibc;
     nanoizeNewlib = true;
+  };
+  newlib-nanoCross = callPackage ../development/misc/newlib {
+    nanoizeNewlib = true;
+    stdenv = crossLibcStdenv;
   };
 
   omnisharp-roslyn = callPackage ../development/tools/omnisharp-roslyn { };

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -49,10 +49,6 @@ in
 , # The standard environment to use for building packages.
   stdenv
 
-, # `stdenv` without a C compiler. Passing in this helps avoid infinite
-  # recursions, and may eventually replace passing in the full stdenv.
-  stdenvNoCC ? stdenv.override { cc = null; hasCC = false; }
-
 , # This is used because stdenv replacement and the stdenvCross do benefit from
   # the overridden configuration provided by the user, as opposed to the normal
   # bootstrapping stdenvs.
@@ -145,7 +141,7 @@ let
     pkgs = self.pkgsHostTarget;
     targetPackages = self.pkgsTargetTarget;
 
-    inherit stdenv stdenvNoCC;
+    inherit stdenv;
   };
 
   splice = self: super: import ./splice.nix lib self (adjacentPackages != null);


### PR DESCRIPTION
It rebuilt stdenv on *-darwin; we can't do that in nixpkgs master.

This reverts commit 2f20501c5f188ab0c4c430519ce77bc6b988202b, reversing changes made to fd469c24af2e16aad2c2b4fc90fc8c74af36e773.

_The usual checklist doesn't really apply here._