### PR TITLE
gnomeExtensions.systemd-manager: package manually

### DIFF
--- a/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
+++ b/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
@@ -11,6 +11,7 @@
   "pidgin@muffinmad" = callPackage ./pidgin-im-integration { };
   "pop-shell@system76.com" = callPackage ./pop-shell { };
   "sound-output-device-chooser@kgshank.net" = callPackage ./sound-output-device-chooser { };
+  "systemd-manager@hardpixel.eu" = callPackage ./systemd-manager { };
   "taskwhisperer-extension@infinicode.de" = callPackage ./taskwhisperer { };
   "tilingnome@rliang.github.com" = callPackage ./tilingnome { };
   "TopIcons@phocean.net" = callPackage ./topicons-plus { };

--- a/pkgs/desktops/gnome/extensions/systemd-manager/default.nix
+++ b/pkgs/desktops/gnome/extensions/systemd-manager/default.nix
@@ -10,7 +10,11 @@
   systemd ? config.systemd.package,
 }:
 
-assert lib.elem allowPolkitPolicy [ "none" "pkexec" "systemctl" ];
+assert lib.elem allowPolkitPolicy [
+  "none"
+  "pkexec"
+  "systemctl"
+];
 
 stdenvNoCC.mkDerivation rec {
   pname = "gnome-shell-extension-systemd-manager";
@@ -27,22 +31,25 @@ stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs = [ glib ];
 
-  postInstall = ''
-    rm systemd-manager@hardpixel.eu/schemas/gschemas.compiled
-    glib-compile-schemas systemd-manager@hardpixel.eu/schemas
+  postInstall =
+    ''
+      rm systemd-manager@hardpixel.eu/schemas/gschemas.compiled
+      glib-compile-schemas systemd-manager@hardpixel.eu/schemas
 
-    mkdir -p $out/share/gnome-shell/extensions
-    mv systemd-manager@hardpixel.eu $out/share/gnome-shell/extensions
-  '' + lib.optionalString (allowPolkitPolicy == "pkexec") ''
-    local bn=org.freedesktop.policykit.pkexec.systemctl.policy
-    mkdir -p $out/share/polkit-1/actions
-    substitute systemd-policies/$bn $out/share/polkit-1/actions/$bn \
-      --replace-fail /usr/bin/systemctl ${lib.getBin systemd}/bin/systemctl
-  '' + lib.optionalString (allowPolkitPolicy == "systemctl") ''
-    install -Dm0644 \
-      systemd-policies/10-service_status.rules \
-      $out/share/polkit-1/rules.d/10-gnome-extension-systemd-manager.rules
-  '';
+      mkdir -p $out/share/gnome-shell/extensions
+      mv systemd-manager@hardpixel.eu $out/share/gnome-shell/extensions
+    ''
+    + lib.optionalString (allowPolkitPolicy == "pkexec") ''
+      local bn=org.freedesktop.policykit.pkexec.systemctl.policy
+      mkdir -p $out/share/polkit-1/actions
+      substitute systemd-policies/$bn $out/share/polkit-1/actions/$bn \
+        --replace-fail /usr/bin/systemctl ${lib.getBin systemd}/bin/systemctl
+    ''
+    + lib.optionalString (allowPolkitPolicy == "systemctl") ''
+      install -Dm0644 \
+        systemd-policies/10-service_status.rules \
+        $out/share/polkit-1/rules.d/10-gnome-extension-systemd-manager.rules
+    '';
 
   passthru = {
     extensionUuid = "systemd-manager@hardpixel.eu";
@@ -53,6 +60,9 @@ stdenvNoCC.mkDerivation rec {
     description = "GNOME Shell extension to manage systemd services";
     homepage = "https://github.com/hardpixel/systemd-manager";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ linsui ];
+    maintainers = with maintainers; [
+      linsui
+      doronbehar
+    ];
   };
 }

--- a/pkgs/desktops/gnome/extensions/systemd-manager/default.nix
+++ b/pkgs/desktops/gnome/extensions/systemd-manager/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  glib,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "gnome-shell-extension-systemd-manager";
+  version = "16";
+
+  # Upstream doesn't post new versions in extensions.gnome.org anymore, see also:
+  # https://github.com/hardpixel/systemd-manager/issues/19
+  src = fetchFromGitHub {
+    owner = "hardpixel";
+    repo = "systemd-manager";
+    rev = "v${version}";
+    hash = "sha256-JecSIRj582jJWdrCQYBWFRkIhosxRhD3BxSAy8/0nVw=";
+  };
+
+  nativeBuildInputs = [ glib ];
+
+  postInstall = ''
+    rm systemd-manager@hardpixel.eu/schemas/gschemas.compiled
+    glib-compile-schemas systemd-manager@hardpixel.eu/schemas
+
+    mkdir -p $out/share/gnome-shell/extensions
+    mv systemd-manager@hardpixel.eu $out/share/gnome-shell/extensions
+  '';
+
+  passthru = {
+    extensionUuid = "systemd-manager@hardpixel.eu";
+    extensionPortalSlug = "systemd-manager";
+  };
+
+  meta = with lib; {
+    description = "GNOME Shell extension to manage systemd services";
+    homepage = "https://github.com/hardpixel/systemd-manager";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ linsui ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/279638
https://github.com/hardpixel/systemd-manager/issues/19

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
