### PR TITLE
vimPlugins.aw-watcher-vim: init at 2023-10-09

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22732,7 +22732,7 @@
     githubId = 332418;
   };
   tsandrini = {
-    email = "tomas.sandrini@seznam.cz";
+    email = "t@tsandrini.sh";
     name = "Tomáš Sandrini";
     github = "tsandrini";
     githubId = 21975189;

--- a/pkgs/applications/editors/vim/plugins/generated.nix
+++ b/pkgs/applications/editors/vim/plugins/generated.nix
@@ -1037,6 +1037,18 @@ final: prev:
     meta.homepage = "https://github.com/yetone/avante.nvim/";
   };
 
+  aw-watcher-vim = buildVimPlugin {
+    pname = "aw-watcher-vim";
+    version = "2023-10-09";
+    src = fetchFromGitHub {
+      owner = "ActivityWatch";
+      repo = "aw-watcher-vim";
+      rev = "4ba86d05a940574000c33f280fd7f6eccc284331";
+      sha256 = "0kzpr2dgn80lcqbbf9ig6vx7azz6vbvadi31mxb0qyd91fyiidi3";
+    };
+    meta.homepage = "https://github.com/ActivityWatch/aw-watcher-vim/";
+  };
+
   awesome-vim-colorschemes = buildVimPlugin {
     pname = "awesome-vim-colorschemes";
     version = "2024-05-18";

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -258,6 +258,15 @@ in
     }
   );
 
+  aw-watcher-vim = super.aw-watcher-vim.overrideAttrs {
+    patches = [
+      (substituteAll {
+        src = ./patches/aw-watcher-vim/program_paths.patch;
+        curl = lib.getExe curl;
+      })
+    ];
+  };
+
   bamboo-nvim = super.bamboo-nvim.overrideAttrs {
     nvimSkipModule = [
       # Requires config table

--- a/pkgs/applications/editors/vim/plugins/patches/aw-watcher-vim/program_paths.patch
+++ b/pkgs/applications/editors/vim/plugins/patches/aw-watcher-vim/program_paths.patch
@@ -1,0 +1,13 @@
+diff --git a/plugin/activitywatch.vim b/plugin/activitywatch.vim
+index 6986553..7462b02 100644
+--- a/plugin/activitywatch.vim
++++ b/plugin/activitywatch.vim
+@@ -29,7 +29,7 @@ let s:heartbeat_apiurl = printf('%s/heartbeat?pulsetime=30', s:bucket_apiurl)
+ let s:http_response_code = {}
+ 
+ function! HTTPPostJson(url, data)
+-    let l:req = ['curl', '-s', a:url,
++    let l:req = ['@curl@', '-s', a:url,
+         \ '-H', 'Content-Type: application/json',
+         \ '-X', 'POST',
+         \ '-d', json_encode(a:data),


### PR DESCRIPTION
## Description of changes

https://github.com/ActivityWatch/aw-watcher-vim provides vim bindings for the https://github.com/ActivityWatch/activitywatch, the Open Source private activity time tracker (which is already present in nixpkgs)

---

**Note**: Hopefully this is the correct way to add vimPlugins, I ran the `update.py add "ActivityWatch/aw-watcher-vim"`, checked the build and checked that the `$out/plugin/activitywatch.vim` file is parsed correctly and sends the expected info to activitywatch.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
