### PR TITLE
fetchFromGitHub: use the API tarball endpoint for `private`

### DIFF
--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -74,15 +74,16 @@ let
       # Use the archive URI for non-private repos, as the API endpoint has
       # relatively restrictive rate limits for unauthenticated users.
       url =
-        let
-          endpoint = "/repos/${owner}/${repo}/tarball/${revWithTag}";
-        in
-        if private
-        then
-          if githubBase == "github.com"
-          then "https://api.github.com${endpoint}"
-          else "https://${githubBase}/api/v3${endpoint}"
-        else "${baseUrl}/archive/${revWithTag}.tar.gz";
+        if private then
+          let
+            endpoint = "/repos/${owner}/${repo}/tarball/${revWithTag}";
+          in
+          if githubBase == "github.com" then
+            "https://api.github.com${endpoint}"
+          else
+            "https://${githubBase}/api/v3${endpoint}"
+        else
+          "${baseUrl}/archive/${revWithTag}.tar.gz";
       extension = "tar.gz";
 
       passthru = {

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -43,17 +43,19 @@ let
     else if fetchzip ? override then fetchzip.override { withUnzip = false; }
     else fetchzip;
   privateAttrs = lib.optionalAttrs private {
-    netrcPhase = ''
-      if [ -z "''$${varBase}USERNAME" -o -z "''$${varBase}PASSWORD" ]; then
-        echo "Error: Private fetchFromGitHub requires the nix building process (nix-daemon in multi user mode) to have the ${varBase}USERNAME and ${varBase}PASSWORD env vars set." >&2
-        exit 1
-      fi
-      cat > netrc <<EOF
-      machine ${githubBase}
-              login ''$${varBase}USERNAME
-              password ''$${varBase}PASSWORD
-      EOF
-    '';
+    netrcPhase =
+      let machineName = if githubBase == "github.com" then "api.github.com" else githubBase;
+      in ''
+        if [ -z "''$${varBase}USERNAME" -o -z "''$${varBase}PASSWORD" ]; then
+          echo "Error: Private fetchFromGitHub requires the nix building process (nix-daemon in multi user mode) to have the ${varBase}USERNAME and ${varBase}PASSWORD env vars set." >&2
+          exit 1
+        fi
+        cat > netrc <<EOF
+        machine ${machineName}
+                login ''$${varBase}USERNAME
+                password ''$${varBase}PASSWORD
+        EOF
+      '';
     netrcImpureEnvVars = [ "${varBase}USERNAME" "${varBase}PASSWORD" ];
   };
 
@@ -66,7 +68,22 @@ let
       inherit tag rev deepClone fetchSubmodules sparseCheckout fetchLFS; url = gitRepoUrl;
     } // lib.optionalAttrs (leaveDotGit != null) { inherit leaveDotGit; }
     else {
-      url = "${baseUrl}/archive/${revWithTag}.tar.gz";
+      # Use the API endpoint for private repos, as the archive URI doesn't
+      # support access with GitHub's fine-grained access tokens.
+      #
+      # Use the archive URI for non-private repos, as the API endpoint has
+      # relatively restrictive rate limits for unauthenticated users.
+      url =
+        let
+          endpoint = "/repos/${owner}/${repo}/tarball/${revWithTag}";
+        in
+        if private
+        then
+          if githubBase == "github.com"
+          then "https://api.github.com${endpoint}"
+          else "https://${githubBase}/api/v3${endpoint}"
+        else "${baseUrl}/archive/${revWithTag}.tar.gz";
+      extension = "tar.gz";
 
       passthru = {
         inherit gitRepoUrl;


### PR DESCRIPTION
GitHub currently has two kinds of personal access token: "classic" and "fine-grained".  Fine-grained personal access tokens, as the name suggests, allow much more control over what the token can and cannot do, and in particular allow users to specify which repositories the token should provide access to.

Unfortunately, fine-grained tokens don't allow access to repository archive tarballs for private repositories at (say) https://github.com/me-and/private-demo/archive/HEAD.tar.gz. Fortunately, the GitHub API endpoint does provide this access, and also works with classic tokens and -- for public repositories -- no token at all.

Fixes #321481

## Description of changes

Change `pkgs.fetchFromGitHub` to use the GitHub API for downloading packages.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
