### PR TITLE
deface: 1.4.0 -> 1.5.0

### DIFF
--- a/pkgs/applications/video/deface/default.nix
+++ b/pkgs/applications/video/deface/default.nix
@@ -8,21 +8,23 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "deface";
-  version = "1.4.0";
-  format = "pyproject";
+  version = "1.5.0";
+  pyproject = true;
+
+  disabled = python3.pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "ORB-HD";
     repo = "deface";
-    rev = "v${version}";
-    hash = "sha256-tLNTgdnKKmyYHVajz0dHIb7cvC1by5LQ5CFIbMvPEYk=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-/mXWeL6OSgW4BMXtAZD/3UxQUGt7UE5ZvH8CXNCueJo=";
   };
 
-  nativeBuildInputs = with python3.pkgs; [
+  build-system = with python3.pkgs; [
     setuptools-scm
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  dependencies = with python3.pkgs; [
     imageio
     imageio-ffmpeg
     numpy
@@ -38,17 +40,21 @@ python3.pkgs.buildPythonApplication rec {
     ''--prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ pkgs.onnxruntime ]}"''
   ];
 
-  patchPhase = ''
-    substituteInPlace pyproject.toml requirements.txt --replace "opencv-python" "opencv"
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "opencv-python" "opencv"
   '';
 
   pythonImportsCheck = [ "deface" "onnx" "onnxruntime" ];
 
-  meta = with lib; {
+  meta = {
     description = "Video anonymization by face detection";
     homepage = "https://github.com/ORB-HD/deface";
-    license = licenses.mit;
-    maintainers = with maintainers; [ lurkki ];
+    changelog = "https://github.com/ORB-HD/deface/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ lurkki ];
     mainProgram = "deface";
+    # terminate called after throwing an instance of 'onnxruntime::OnnxRuntimeException'
+    broken = stdenv.hostPlatform.system == "aarch64-linux";
   };
 }


### PR DESCRIPTION
## Description of changes

Also, marked it as broken on `aarch64-linux` (because of an `OnnxRuntimeException`).
Changelog: https://github.com/ORB-HD/deface/releases/tag/v1.5.0

cc @Lurkki14 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
