### PR TITLE
monophony: 2.9.0 -> 2.11.0

### DIFF
--- a/pkgs/by-name/mo/monophony/package.nix
+++ b/pkgs/by-name/mo/monophony/package.nix
@@ -11,15 +11,15 @@
 }:
 python3Packages.buildPythonApplication rec {
   pname = "monophony";
-  version = "2.9.0";
-  format = "other";
+  version = "2.11.0";
+  pyproject = false;
 
   sourceRoot = "${src.name}/source";
   src = fetchFromGitLab {
     owner = "zehkira";
     repo = "monophony";
     rev = "v${version}";
-    hash = "sha256-fZ+EQqcHJGOLBwyHZJvML6+SkfFpnt6hb8xHedJ7VSU=";
+    hash = "sha256-OGUj1NNJNerYx/nBtg4g9xMbz6u4YSqKO6HeMNeYpE8=";
   };
 
   pythonPath = with python3Packages; [
@@ -28,8 +28,13 @@ python3Packages.buildPythonApplication rec {
     ytmusicapi
   ];
 
+  build-system = with python3Packages; [
+    pip
+    setuptools
+    wheel
+  ];
+
   nativeBuildInputs = [
-    python3Packages.nuitka
     gobject-introspection
     wrapGAppsHook4
   ];
@@ -44,13 +49,17 @@ python3Packages.buildPythonApplication rec {
     gstreamer
   ]);
 
+  # Makefile only contains `install`
+  dontBuild = true;
+
   installFlags = [ "prefix=$(out)" ];
 
+  dontWrapGApps = true;
+
   preFixup = ''
-    buildPythonPath "$pythonPath"
-    gappsWrapperArgs+=(
-      --prefix PYTHONPATH : "$program_PYTHONPATH"
+    makeWrapperArgs+=(
       --prefix PATH : "${lib.makeBinPath [yt-dlp]}"
+      "''${gappsWrapperArgs[@]}"
     )
   '';
 


### PR DESCRIPTION
*please add backport release-24.05 label*

https://gitlab.com/zehkira/monophony/-/releases/v2.11.0

dropped nuitka, requires pip to build

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
