### PR TITLE
vmctl: init at v0.99-unstable-2024-05-14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15207,6 +15207,12 @@
     githubId = 79252025;
     name = "Nicolas Benes";
   };
+  panky = {
+    email = "dev@pankajraghav.com";
+    github = "Panky-codes";
+    githubId = 33182938;
+    name = "Pankaj";
+  };
   paperdigits = {
     email = "mica@silentumbrella.com";
     github = "paperdigits";

--- a/pkgs/by-name/vm/vmctl/package.nix
+++ b/pkgs/by-name/vm/vmctl/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  openssh,
+  socat,
+  gawk,
+  cloud-utils,
+  cdrtools,
+  qemu,
+  qemu-utils,
+  coreutils,
+  getopt,
+  makeWrapper,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "vmctl";
+  version = "v0.99-unstable-2024-05-14";
+
+  src = fetchFromGitHub {
+    owner = "SamsungDS";
+    repo = "vmctl";
+    rev = "5b6b7084b8cba06b474c0e020df965237f2c832c";
+    hash = "sha256-yDgaY2RJXBjWkMSQb4JaJzMGLFzowfOGixSRzzv2iIk=";
+  };
+
+  dontBuild = true;
+
+  postPatch = ''
+    substituteInPlace vmctl \
+      --replace 'BASEDIR="$(dirname "$(readlink -f "''${BASH_SOURCE[0]}")")"' 'BASEDIR="${placeholder "out"}"'
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm555 vmctl -t "$out/bin"
+    wrapProgram "$out/bin/vmctl" \
+      --set PATH "${
+        lib.makeBinPath [
+          openssh
+          socat
+          gawk
+          cloud-utils
+          cdrtools
+          qemu
+          qemu-utils
+          coreutils
+          getopt
+        ]
+      }"
+    cp -r {cmd,common,contrib,lib} $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Command line tool focused on NVMe testing in QEMU";
+    homepage = "https://github.com/SamsungDS/vmctl";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ panky ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Vmctl is a command line tool focused on NVMe testing in QEMU. vmctl provides easy config options to test different NVMe configurations easily in QEMU.

Github: https://github.com/SamsungDS/vmctl
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
