### PR TITLE
Clean up cross bootstrapping, take 2

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -10,15 +10,15 @@
 , stdenvNoCC
 , runtimeShell
 , bintools ? null, libc ? null, coreutils ? null, gnugrep ? null
-, netbsd ? null, netbsdCross ? null
+, netbsd ? null
 , sharedLibraryLoader ?
   if libc == null then
     null
   else if stdenvNoCC.targetPlatform.isNetBSD then
-    if !(targetPackages ? netbsdCross) then
+    if !(targetPackages ? netbsd) then
       netbsd.ld_elf_so
-    else if libc != targetPackages.netbsdCross.headers then
-      targetPackages.netbsdCross.ld_elf_so
+    else if libc != targetPackages.netbsd.headers then
+      targetPackages.netbsd.ld_elf_so
     else
       null
   else

--- a/pkgs/by-name/uc/uclibc-ng/package.nix
+++ b/pkgs/by-name/uc/uclibc-ng/package.nix
@@ -1,5 +1,5 @@
 { lib
-, stdenv
+, stdenvNoLibc
 , buildPackages
 , fetchurl
 , gitUpdater
@@ -9,6 +9,7 @@
 }:
 
 let
+  stdenv = stdenvNoLibc;
   isCross = (stdenv.buildPlatform != stdenv.hostPlatform);
   configParser = ''
     function parseconfig {

--- a/pkgs/development/misc/or1k/newlib.nix
+++ b/pkgs/development/misc/or1k/newlib.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, crossLibcStdenv, buildPackages }:
+{ stdenv, fetchFromGitHub, stdenvNoLibc, buildPackages }:
 
-crossLibcStdenv.mkDerivation {
+stdenvNoLibc.mkDerivation {
   name = "newlib";
   src = fetchFromGitHub {
     owner = "openrisc";

--- a/pkgs/development/misc/vc4/newlib.nix
+++ b/pkgs/development/misc/vc4/newlib.nix
@@ -1,6 +1,6 @@
-{ stdenv, texinfo, flex, bison, fetchFromGitHub, crossLibcStdenv, buildPackages }:
+{ stdenv, texinfo, flex, bison, fetchFromGitHub, stdenvNoLibc, buildPackages }:
 
-crossLibcStdenv.mkDerivation {
+stdenvNoLibc.mkDerivation {
   name = "newlib";
   src = fetchFromGitHub {
     owner = "itszor";

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   stdenvNoCC,
-  stdenvNoLibs,
+  stdenvNoLibc,
   overrideCC,
   buildPackages,
   stdenvNoLibcxx ? overrideCC stdenv buildPackages.llvmPackages.clangNoLibcxx,
@@ -28,7 +28,7 @@ lib.makeOverridable (
       if attrs.noCC or false then
         stdenvNoCC
       else if attrs.noLibc or false then
-        stdenvNoLibs
+        stdenvNoLibc
       else if attrs.noLibcxx or false then
         stdenvNoLibcxx
       else

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  crossLibcStdenv,
+  stdenvNoLibc,
   stdenvNoCC,
   makeScopeWithSplicing',
   generateSplicesForMkScope,
@@ -37,7 +37,7 @@ makeScopeWithSplicing' {
 
       compatIfNeeded = lib.optional (!stdenvNoCC.hostPlatform.isNetBSD) self.compat;
 
-      stdenvLibcMinimal = crossLibcStdenv.override (old: {
+      stdenvLibcMinimal = stdenvNoLibc.override (old: {
         cc = old.cc.override {
           libc = self.libcMinimal;
           noLibc = false;

--- a/pkgs/os-specific/bsd/netbsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/mkDerivation.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   stdenvNoCC,
-  crossLibcStdenv,
+  stdenvNoLibc,
   stdenvLibcMinimal,
   runCommand,
   rsync,
@@ -28,7 +28,7 @@ lib.makeOverridable (
       if attrs.noCC or false then
         stdenvNoCC
       else if attrs.noLibc or false then
-        crossLibcStdenv
+        stdenvNoLibc
       else if attrs.libcMinimal or false then
         stdenvLibcMinimal
       else

--- a/pkgs/os-specific/bsd/openbsd/default.nix
+++ b/pkgs/os-specific/bsd/openbsd/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  crossLibcStdenv,
+  stdenvNoLibc,
   makeScopeWithSplicing',
   generateSplicesForMkScope,
   buildPackages,
@@ -22,7 +22,7 @@ makeScopeWithSplicing' {
     // {
       version = "7.5";
 
-      stdenvLibcMinimal = crossLibcStdenv.override (old: {
+      stdenvLibcMinimal = stdenvNoLibc.override (old: {
         cc = old.cc.override {
           libc = self.libcMinimal;
           noLibc = false;

--- a/pkgs/os-specific/bsd/openbsd/pkgs/libcMinimal/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/libcMinimal/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  crossLibcStdenv,
+  stdenvNoLibc,
   mkDerivation,
   fetchpatch,
   bsdSetupHook,
@@ -65,7 +65,7 @@ mkDerivation {
   # Suppress lld >= 16 undefined version errors
   # https://github.com/freebsd/freebsd-src/commit/2ba84b4bcdd6012e8cfbf8a0d060a4438623a638
   env.NIX_LDFLAGS = lib.optionalString (
-    crossLibcStdenv.hostPlatform.linker == "lld"
+    stdenvNoLibc.hostPlatform.linker == "lld"
   ) "--undefined-version";
 
   makeFlags = [

--- a/pkgs/os-specific/bsd/openbsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/mkDerivation.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   stdenvNoCC,
-  crossLibcStdenv,
+  stdenvNoLibc,
   stdenvLibcMinimal,
   runCommand,
   rsync,
@@ -22,7 +22,7 @@ lib.makeOverridable (
       if attrs.noCC or false then
         stdenvNoCC
       else if attrs.noLibc or false then
-        crossLibcStdenv
+        stdenvNoLibc
       else if attrs.libcMinimal or false then
         stdenvLibcMinimal
       else

--- a/pkgs/os-specific/windows/default.nix
+++ b/pkgs/os-specific/windows/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, buildPackages
-, newScope, overrideCC, crossLibcStdenv, libcCross
+, newScope, overrideCC, stdenvNoLibc, libcCross
 }:
 
 lib.makeScope newScope (self: with self; {
@@ -14,11 +14,11 @@ lib.makeScope newScope (self: with self; {
   mingw_runtime = mingwrt;
 
   mingw_w64 = callPackage ./mingw-w64 {
-    stdenv = crossLibcStdenv;
+    stdenv = stdenvNoLibc;
   };
 
   # FIXME untested with llvmPackages_16 was using llvmPackages_8
-  crossThreadsStdenv = overrideCC crossLibcStdenv
+  crossThreadsStdenv = overrideCC stdenvNoLibc
     (if stdenv.hostPlatform.useLLVM or false
      then buildPackages.llvmPackages.clangNoLibcxx
      else buildPackages.gccWithoutTargetLibc.override (old: {

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -41,25 +41,44 @@ in lib.init bootStages ++ [
       if crossSystem.isStatic
       then buildPackages.stdenvAdapters.makeStatic
       else lib.id;
+    stdenvNoCC = adaptStdenv (buildPackages.stdenv.override (old: rec {
+      buildPlatform = localSystem;
+      hostPlatform = crossSystem;
+      targetPlatform = crossSystem;
+
+      # Prior overrides are surely not valid as packages built with this run on
+      # a different platform, and so are disabled.
+      overrides = _: _: {};
+      extraBuildInputs = [ ]; # Old ones run on wrong platform
+      allowedRequisites = null;
+
+      cc = null;
+      hasCC = false;
+
+      extraNativeBuildInputs = old.extraNativeBuildInputs
+        ++ lib.optionals
+             (hostPlatform.isLinux && !buildPlatform.isLinux)
+             [ buildPackages.patchelf ]
+        ++ lib.optional
+             (let f = p: !p.isx86 || builtins.elem p.libc [ "musl" "wasilibc" "relibc" ] || p.isiOS || p.isGenode;
+               in f hostPlatform && !(f buildPlatform) )
+             buildPackages.updateAutotoolsGnuConfigScriptsHook
+        ;
+    }));
   in {
     inherit config;
     overlays = overlays ++ crossOverlays;
     selfBuild = false;
+    inherit stdenvNoCC;
     stdenv = let
-      baseStdenv = adaptStdenv (buildPackages.stdenv.override (old: rec {
-        buildPlatform = localSystem;
-        hostPlatform = crossSystem;
-        targetPlatform = crossSystem;
+      inherit (stdenvNoCC) hostPlatform targetPlatform;
+      baseStdenv = stdenvNoCC.override {
+        # Old ones run on wrong platform
+        extraBuildInputs = lib.optionals hostPlatform.isDarwin [
+          buildPackages.targetPackages.darwin.apple_sdk.frameworks.CoreFoundation
+        ];
 
-        # Prior overrides are surely not valid as packages built with this run on
-        # a different platform, and so are disabled.
-        overrides = _: _: {};
-        extraBuildInputs = [ ] # Old ones run on wrong platform
-           ++ lib.optionals hostPlatform.isDarwin [ buildPackages.targetPackages.darwin.apple_sdk.frameworks.CoreFoundation ]
-           ;
-        allowedRequisites = null;
-
-        hasCC = !targetPlatform.isGhcjs;
+        hasCC = !stdenvNoCC.targetPlatform.isGhcjs;
 
         cc = if crossSystem.useiOSPrebuilt or false
                then buildPackages.darwin.iosSdkPkgs.clang
@@ -81,16 +100,7 @@ in lib.init bootStages ++ [
                then buildPackages.arocc
              else buildPackages.gcc;
 
-        extraNativeBuildInputs = old.extraNativeBuildInputs
-          ++ lib.optionals
-               (hostPlatform.isLinux && !buildPlatform.isLinux)
-               [ buildPackages.patchelf ]
-          ++ lib.optional
-               (let f = p: !p.isx86 || builtins.elem p.libc [ "musl" "wasilibc" "relibc" ] || p.isiOS || p.isGenode;
-                 in f hostPlatform && !(f buildPlatform) )
-               buildPackages.updateAutotoolsGnuConfigScriptsHook
-          ;
-      }));
+      };
     in if config ? replaceCrossStdenv then config.replaceCrossStdenv { inherit buildPackages baseStdenv; } else baseStdenv;
   })
 

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -1225,6 +1225,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
 
               # libc++, and libc++abi do not need CoreFoundation. Avoid propagating the CF from prior
               # stages to the final stdenv via rpath by dropping it from `extraBuildInputs`.
+              stdenvNoCC = super.stdenvNoCC.override { extraBuildInputs = [ ]; };
               stdenvNoCF = self.stdenv.override { extraBuildInputs = [ ]; };
 
               libcxxBootstrapStdenv = self.overrideCC stdenvNoCF (
@@ -1543,6 +1544,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
 
         # Don’t link anything in this stage against CF to prevent propagating CF from prior stages to
         # the final stdenv, which happens because of the rpath hook.
+        stdenvNoCC = super.stdenvNoCC.override { extraBuildInputs = [ ]; };
         stdenv =
           let
             stdenvNoCF = super.stdenv.override { extraBuildInputs = [ ]; };

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -138,6 +138,7 @@ mapAliases ({
   auditBlasHook = throw "'auditBlasHook' has been removed since it never worked"; # Added 2024-04-02
   authy = throw "'authy' has been removed since it reached end of life"; # Added 2024-04-19
   avldrums-lv2 = x42-avldrums; # Added 2020-03-29
+  avrlibcCross = avrlibc; # Added 2024-09-06
   awesome-4-0 = awesome; # Added 2022-05-05
   aws-env = throw "aws-env has been removed as the upstream project was unmaintained"; # Added 2024-06-11
   aws-google-auth = throw "aws-google-auth has been removed as the upstream project was unmaintained"; # Added 2024-07-31
@@ -251,6 +252,7 @@ mapAliases ({
   cosmic-tasks = tasks; # Added 2024-07-04
   cpp-ipfs-api = cpp-ipfs-http-client; # Project has been renamed. Added 2022-05-15
   crispyDoom = crispy-doom; # Added 2023-05-01
+  crossLibcStdenv = stdenvNoLibc; # Added 2024-09-06
   cryptowatch-desktop = throw "Cryptowatch Desktop was sunset on September 30th 2023 and has been removed from nixpkgs"; # Added 2023-12-22
   clash = throw "'clash' has been removed, upstream gone. Consider using 'mihomo' instead."; # added 2023-11-10
   clasp = clingo; # added 2022-12-22
@@ -979,6 +981,7 @@ mapAliases ({
   mpd_clientlib = libmpdclient; # Added 2021-02-11
   mpdevil = plattenalbum; # Added 2024-05-22
   mpg321 = throw "'mpg321' has been removed due to it being unmaintained by upstream. Consider using mpg123 instead."; # Added 2024-05-10
+  msp430NewlibCross = msp430Newlib; # Added 2024-09-06
   mumble_git = throw "'mumble_git' has been renamed to/replaced by 'pkgs.mumble'"; # Converted to throw 2023-09-10
   murmur_git = throw "'murmur_git' has been renamed to/replaced by 'pkgs.murmur'"; # Converted to throw 2023-09-10
   mutt-with-sidebar = mutt; # Added 2022-09-17
@@ -1010,6 +1013,8 @@ mapAliases ({
   nagiosPluginsOfficial = monitoring-plugins;
   neochat = libsForQt5.kdeGear.neochat; # added 2022-05-10
   neoload = throw "'neoload' has been removed as it is broken and unmaintained"; # Added 2024-03-02
+  newlibCross = newlib; # Added 2024-09-06
+  newlib-nanoCross = newlib-nano; # Added 2024-09-06
   nitrokey-udev-rules = libnitrokey; # Added 2023-03-25
   nix-direnv-flakes = nix-direnv;
   nix-repl = throw (
@@ -1487,6 +1492,8 @@ mapAliases ({
   uberwriter = apostrophe; # Added 2020-04-23
   ubootBeagleboneBlack = ubootAmx335xEVM; # Added 2020-01-21
   ubuntu_font_family = ubuntu-classic; # Added 2024-02-19
+  uclibc = uclibc-ng; # Added 2022-06-16
+  uclibcCross = uclibc-ng; # Added 2022-06-16
   ue4 = throw "ue4 has been removed, because the package was broken for years"; # Added 2023-11-22
   uefi-firmware-parser = throw "The uefi-firmware-parser package was dropped since it was unmaintained."; # Added 2024-06-21
   uhd3_5 = throw "uhd3_5 has been removed, because it was no longer needed"; # Added 2023-10-07
@@ -1636,9 +1643,9 @@ mapAliases ({
   inherit (stdenv.hostPlatform) system; # Added 2021-10-22
   inherit (stdenv) buildPlatform hostPlatform targetPlatform; # Added 2023-01-09
 
-  freebsdCross = freebsd; # Added 2024-06-18
-  netbsdCross = netbsd; # Added 2024-06-18
-  openbsdCross = openbsd; # Added 2024-06-18
+  freebsdCross = freebsd; # Added 2024-09-06
+  netbsdCross = netbsd; # Added 2024-09-06
+  openbsdCross = openbsd; # Added 2024-09-06
 
   # LLVM packages for (integration) testing that should not be used inside Nixpkgs:
   llvmPackages_latest = llvmPackages_18;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31,19 +31,6 @@ with pkgs;
   # it's just the plain stdenv.
   stdenv_32bit = lowPrio (if stdenv.hostPlatform.is32bit then stdenv else multiStdenv);
 
-  stdenvNoCC = stdenv.override (
-    { cc = null; hasCC = false; }
-
-    // lib.optionalAttrs (stdenv.hostPlatform.isDarwin && (stdenv.hostPlatform != stdenv.buildPlatform)) {
-      # TODO: This is a hack to use stdenvNoCC to produce a CF when cross
-      # compiling. It's not very sound. The cross stdenv has:
-      #   extraBuildInputs = [ targetPackages.darwin.apple_sdks.frameworks.CoreFoundation ]
-      # and uses stdenvNoCC. In order to make this not infinitely recursive, we
-      # need to exclude this extraBuildInput.
-      extraBuildInputs = [];
-    }
-  );
-
   mkStdenvNoLibs = stdenv: let
     bintools = stdenv.cc.bintools.override {
       libc = null;
@@ -61,7 +48,7 @@ with pkgs;
   };
 
   stdenvNoLibs =
-    if stdenvNoCC.hostPlatform != stdenvNoCC.buildPlatform && (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.useLLVM or false)
+    if stdenvNoCC.hostPlatform != stdenvNoCC.buildPlatform
     then
       # We cannot touch binutils or cc themselves, because that will cause
       # infinite recursion. So instead, we just choose a libc based on the
@@ -74,7 +61,17 @@ with pkgs;
       # thing to to create an earlier thing (leading to infinite recursion) and
       # we also would still respect the stage arguments choices for these
       # things.
-      overrideCC stdenv buildPackages.llvmPackages.clangNoCompilerRt
+      (if stdenvNoCC.hostPlatform.isDarwin || stdenvNoCC.hostPlatform.useLLVM or false
+       then overrideCC stdenvNoCC buildPackages.llvmPackages.clangNoCompilerRt
+       else gccCrossLibcStdenv)
+    else mkStdenvNoLibs stdenv;
+
+  stdenvNoLibc =
+    if stdenvNoCC.hostPlatform != stdenvNoCC.buildPlatform
+    then
+      (if stdenvNoCC.hostPlatform.isDarwin || stdenvNoCC.hostPlatform.useLLVM or false
+       then overrideCC stdenvNoCC buildPackages.llvmPackages.clangNoLibc
+       else gccCrossLibcStdenv)
     else mkStdenvNoLibs stdenv;
 
   gccStdenvNoLibs = mkStdenvNoLibs gccStdenv;
@@ -15109,11 +15106,6 @@ with pkgs;
 
   gccCrossLibcStdenv = overrideCC stdenvNoCC buildPackages.gccWithoutTargetLibc;
 
-  crossLibcStdenv =
-    if stdenv.hostPlatform.useLLVM or false || stdenv.hostPlatform.isDarwin
-    then overrideCC stdenv buildPackages.llvmPackages.clangNoLibc
-    else gccCrossLibcStdenv;
-
   # The GCC used to build libc for the target platform. Normal gccs will be
   # built with, and use, that cross-compiled libc.
   gccWithoutTargetLibc = assert stdenv.targetPlatform != stdenv.hostPlatform; let
@@ -17157,9 +17149,8 @@ with pkgs;
 
   h3 = h3_3;
 
-  avrlibc      = callPackage ../development/misc/avr/libc { };
-  avrlibcCross = callPackage ../development/misc/avr/libc {
-    stdenv = crossLibcStdenv;
+  avrlibc = callPackage ../development/misc/avr/libc {
+    stdenv = stdenvNoLibc;
   };
 
   avr8burnomat = callPackage ../development/misc/avr8-burn-omat { };
@@ -17233,10 +17224,7 @@ with pkgs;
 
   msp430GccSupport = callPackage ../development/misc/msp430/gcc-support.nix { };
 
-  msp430Newlib      = callPackage ../development/misc/msp430/newlib.nix { };
-  msp430NewlibCross = callPackage ../development/misc/msp430/newlib.nix {
-    newlib = newlibCross;
-  };
+  msp430Newlib = callPackage ../development/misc/msp430/newlib.nix { };
 
   mspds = callPackage ../development/misc/msp430/mspds { };
   mspds-bin = callPackage ../development/misc/msp430/mspds/binary.nix { };
@@ -20413,14 +20401,14 @@ with pkgs;
   };
 
   muslCross = musl.override {
-    stdenv = crossLibcStdenv;
+    stdenv = stdenvNoLibc;
   };
 
   # These are used when buiding compiler-rt / libgcc, prior to building libc.
   preLibcCrossHeaders = let
     inherit (stdenv.targetPlatform) libc;
   in     if stdenv.targetPlatform.isMinGW then targetPackages.windows.mingw_w64_headers or windows.mingw_w64_headers
-    else if libc == "nblibc" then targetPackages.netbsdCross.headers or netbsdCross.headers
+    else if libc == "nblibc" then targetPackages.netbsd.headers or netbsd.headers
     else if libc == "libSystem" && stdenv.targetPlatform.isAarch64 then targetPackages.darwin.LibsystemCross or darwin.LibsystemCross
     else null;
 
@@ -20431,13 +20419,13 @@ with pkgs;
     /**/ if name == null then null
     else if name == "glibc" then targetPackages.glibcCross or glibcCross
     else if name == "bionic" then targetPackages.bionic or bionic
-    else if name == "uclibc" then targetPackages.uclibcCross or uclibcCross
-    else if name == "avrlibc" then targetPackages.avrlibcCross or avrlibcCross
-    else if name == "newlib" && stdenv.targetPlatform.isMsp430 then targetPackages.msp430NewlibCross or msp430NewlibCross
+    else if name == "uclibc" then targetPackages.uclibc or uclibc
+    else if name == "avrlibc" then targetPackages.avrlibc or avrlibc
+    else if name == "newlib" && stdenv.targetPlatform.isMsp430 then targetPackages.msp430Newlib or msp430Newlib
     else if name == "newlib" && stdenv.targetPlatform.isVc4 then targetPackages.vc4-newlib or vc4-newlib
     else if name == "newlib" && stdenv.targetPlatform.isOr1k then targetPackages.or1k-newlib or or1k-newlib
-    else if name == "newlib" then targetPackages.newlibCross or newlibCross
-    else if name == "newlib-nano" then targetPackages.newlib-nanoCross or newlib-nanoCross
+    else if name == "newlib" then targetPackages.newlib or newlib
+    else if name == "newlib-nano" then targetPackages.newlib-nano or newlib-nano
     else if name == "musl" then targetPackages.muslCross or muslCross
     else if name == "msvcrt" then targetPackages.windows.mingw_w64 or windows.mingw_w64
     else if name == "ucrt" then targetPackages.windows.mingw_w64 or windows.mingw_w64
@@ -20463,7 +20451,7 @@ with pkgs;
     };
 
   wasilibc = callPackage ../development/libraries/wasilibc {
-    stdenv = crossLibcStdenv;
+    stdenv = stdenvNoLibc;
   };
 
   relibc = callPackage ../development/libraries/relibc { };
@@ -27415,14 +27403,6 @@ with pkgs;
   inherit (callPackage ../misc/barebox {})
     buildBarebox
     bareboxTools;
-
-  uclibc-ng-cross = uclibc-ng.override {
-    stdenv = crossLibcStdenv;
-  };
-
-  # Aliases
-  uclibc = uclibc-ng;
-  uclibcCross = uclibc-ng-cross;
 
   eudev = callPackage ../by-name/eu/eudev/package.nix {
     util-linux = util-linuxMinimal;
@@ -39778,17 +39758,13 @@ with pkgs;
 
   new-session-manager = callPackage ../applications/audio/new-session-manager { };
 
-  newlib = callPackage ../development/misc/newlib { };
-  newlibCross = callPackage ../development/misc/newlib {
-    stdenv = crossLibcStdenv;
+  newlib = callPackage ../development/misc/newlib {
+    stdenv = stdenvNoLibc;
   };
 
   newlib-nano = callPackage ../development/misc/newlib {
+    stdenv = stdenvNoLibc;
     nanoizeNewlib = true;
-  };
-  newlib-nanoCross = callPackage ../development/misc/newlib {
-    nanoizeNewlib = true;
-    stdenv = crossLibcStdenv;
   };
 
   omnisharp-roslyn = callPackage ../development/tools/omnisharp-roslyn { };

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -49,6 +49,10 @@ in
 , # The standard environment to use for building packages.
   stdenv
 
+, # `stdenv` without a C compiler. Passing in this helps avoid infinite
+  # recursions, and may eventually replace passing in the full stdenv.
+  stdenvNoCC ? stdenv.override { cc = null; hasCC = false; }
+
 , # This is used because stdenv replacement and the stdenvCross do benefit from
   # the overridden configuration provided by the user, as opposed to the normal
   # bootstrapping stdenvs.
@@ -141,7 +145,7 @@ let
     pkgs = self.pkgsHostTarget;
     targetPackages = self.pkgsTargetTarget;
 
-    inherit stdenv;
+    inherit stdenv stdenvNoCC;
   };
 
   splice = self: super: import ./splice.nix lib self (adjacentPackages != null);


### PR DESCRIPTION
## Description of changes

Take 2 of #320852, without the stdenv change that necessitated the revert in #321435.

Now following up from https://github.com/NixOS/nixpkgs/pull/320852, which got the other part of #320852.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
