### PR TITLE
materialgram: init at 5.4.1.1

### DIFF
--- a/pkgs/by-name/ma/materialgram/package.nix
+++ b/pkgs/by-name/ma/materialgram/package.nix
@@ -1,0 +1,34 @@
+{
+  telegram-desktop,
+  lib,
+  fetchFromGitHub,
+}:
+telegram-desktop.overrideAttrs (
+  finalAttrs: previousAttrs: {
+    pname = "materialgram";
+    version = "5.4.1.1";
+
+    src = fetchFromGitHub {
+      owner = "kukuruzka165";
+      repo = "materialgram";
+      rev = "refs/tags/v${finalAttrs.version}";
+      fetchSubmodules = true;
+      hash = "sha256-enA/8mIXcRTPGyZFgZ5Wg4fWq4fD4rtjH7bm/32FZaE";
+    };
+
+    meta = previousAttrs.meta // {
+      description = "Telegram Desktop fork with material icons and some improvements";
+      longDescription = ''
+        Telegram Desktop fork with Material Design and other improvements,
+        which is based on the Telegram API and the MTProto secure protocol.
+      '';
+      homepage = "https://kukuruzka165.github.io/materialgram/";
+      changelog = "https://github.com/kukuruzka165/materialgram/releases/tag/v${finalAttrs.version}";
+      maintainers = with lib.maintainers; [
+        oluceps
+        aleksana
+      ];
+      mainProgram = "materialgram";
+    };
+  }
+)


### PR DESCRIPTION
## Description of changes
Add https://github.com/kukuruzka165/materialgram

![image](https://github.com/NixOS/nixpkgs/assets/35628088/8bc8dee8-2f04-4870-b002-80ffc993b4db)


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
