### PR TITLE
*bsdCross: Remove these package sets

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/default.nix
+++ b/pkgs/os-specific/bsd/freebsd/default.nix
@@ -3,7 +3,6 @@
   makeScopeWithSplicing',
   generateSplicesForMkScope,
   callPackage,
-  crossLibcStdenv,
   attributePathToSplice ? [ "freebsd" ],
   branch ? "release/14.0.0",
 }:
@@ -24,41 +23,30 @@ let
       Branches can be selected by overriding the `branch` attribute on the freebsd package set.
     '';
 
-  # `./package-set.nix` should never know the name of the package set we
-  # are constructing; just this function is allowed to know that. This
-  # is why we:
-  #
-  #  - do the splicing for cross compilation here
-  #
-  #  - construct the *anonymized* `buildFreebsd` attribute to be passed
-  #    to `./package-set.nix`.
-  callFreeBSDWithAttrs =
-    extraArgs:
-    let
-      # we do not include the branch in the splice here because the branch
-      # parameter to this file will only ever take on one value - more values
-      # are provided through overrides.
-      otherSplices = generateSplicesForMkScope attributePathToSplice;
-    in
-    makeScopeWithSplicing' {
-      inherit otherSplices;
-      f =
-        self:
-        {
-          inherit branch;
-        }
-        // callPackage ./package-set.nix (
-          {
-            sourceData = versions.${self.branch} or (throw (badBranchError self.branch));
-            versionData = self.sourceData.version;
-            buildFreebsd = otherSplices.selfBuildHost;
-            patchesRoot = ./patches + "/${self.versionData.revision}";
-          }
-          // extraArgs
-        ) self;
-    };
+  # we do not include the branch in the splice here because the branch
+  # parameter to this file will only ever take on one value - more values
+  # are provided through overrides.
+  otherSplices = generateSplicesForMkScope attributePathToSplice;
 in
-{
-  freebsd = callFreeBSDWithAttrs { };
-  freebsdCross = callFreeBSDWithAttrs { stdenv = crossLibcStdenv; };
+# `./package-set.nix` should never know the name of the package set we
+# are constructing; just this function is allowed to know that. This
+# is why we:
+#
+#  - do the splicing for cross compilation here
+#
+#  - construct the *anonymized* `buildFreebsd` attribute to be passed
+#    to `./package-set.nix`.
+makeScopeWithSplicing' {
+  inherit otherSplices;
+  f =
+    self:
+    {
+      inherit branch;
+    }
+    // callPackage ./package-set.nix ({
+      sourceData = versions.${self.branch} or (throw (badBranchError self.branch));
+      versionData = self.sourceData.version;
+      buildFreebsd = otherSplices.selfBuildHost;
+      patchesRoot = ./patches + "/${self.versionData.revision}";
+    }) self;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
@@ -58,12 +58,9 @@ lib.makeOverridable (
 
       HOST_SH = stdenv'.shell;
 
-      # Since STRIP below is the flag
-      STRIPBIN = "${stdenv.cc.bintools.targetPrefix}strip";
-
       makeFlags = [
         "STRIP=-s" # flag to install, not command
-      ] ++ lib.optional (!stdenv.hostPlatform.isFreeBSD) "MK_WERROR=no";
+      ] ++ lib.optional (!stdenv'.hostPlatform.isFreeBSD) "MK_WERROR=no";
 
       # amd64 not x86_64 for this on unlike NetBSD
       MACHINE_ARCH = freebsd-lib.mkBsdArch stdenv';
@@ -91,6 +88,9 @@ lib.makeOverridable (
     // lib.optionalAttrs stdenv'.hasCC {
       # TODO should CC wrapper set this?
       CPP = "${stdenv'.cc.targetPrefix}cpp";
+
+      # Since STRIP in `makeFlags` has to be a flag, not the binary itself
+      STRIPBIN = "${stdenv'.cc.bintools.targetPrefix}strip";
     }
     // lib.optionalAttrs stdenv'.isDarwin { MKRELRO = "no"; }
     // lib.optionalAttrs (stdenv'.cc.isClang or false) {

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   stdenvNoCC,
   makeScopeWithSplicing',
@@ -21,7 +20,9 @@ makeScopeWithSplicing' {
 
       defaultMakeFlags = [
         "MKSOFTFLOAT=${
-          if stdenv.hostPlatform.gcc.float or (stdenv.hostPlatform.parsed.abi.float or "hard") == "soft" then
+          if
+            stdenvNoCC.hostPlatform.gcc.float or (stdenvNoCC.hostPlatform.parsed.abi.float or "hard") == "soft"
+          then
             "yes"
           else
             "no"
@@ -36,7 +37,6 @@ makeScopeWithSplicing' {
       # because of the splices.
 
       mkDerivation = self.callPackage ./pkgs/mkDerivation.nix {
-        inherit stdenv stdenvNoCC;
         inherit (buildPackages.netbsd)
           netbsdSetupHook
           makeMinimal
@@ -55,12 +55,7 @@ makeScopeWithSplicing' {
         inherit (buildPackages.darwin) cctools-port;
         inherit (buildPackages.buildPackages) rsync;
         inherit (buildPackages.netbsd) makeMinimal;
-        inherit (self)
-          install
-          include
-          libc
-          libutil
-          ;
+        inherit (self) install;
       };
 
       install = self.callPackage ./pkgs/install/package.nix {
@@ -129,7 +124,7 @@ makeScopeWithSplicing' {
       libpthread-headers = self.callPackage ./pkgs/libpthread/headers.nix { };
 
       csu = self.callPackage ./pkgs/csu.nix {
-        inherit (self) headers sys ld_elf_so;
+        inherit (self) headers sys-headers ld_elf_so;
         inherit (buildPackages.netbsd)
           netbsdSetupHook
           makeMinimal

--- a/pkgs/os-specific/bsd/netbsd/pkgs/compat/package.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/compat/package.nix
@@ -6,9 +6,6 @@
   defaultMakeFlags,
   coreutils,
   cctools-port,
-  include,
-  libc,
-  libutil,
   install,
   bsdSetupHook,
   netbsdSetupHook,
@@ -130,12 +127,13 @@ mkDerivation (
           --subst-var-by version ${version}
       '';
     extraPaths = [
-      include.path
-      libc.path
-      libutil.path
+      "common"
+      "include"
+      "lib/libc"
+      "lib/libutil"
       "external/bsd/flex"
-      "sys/sys"
+      "sys"
       "common/include/rpc/types.h"
-    ] ++ libutil.extraPaths ++ _mainLibcExtraPaths;
+    ] ++ _mainLibcExtraPaths;
   }
 )

--- a/pkgs/os-specific/bsd/netbsd/pkgs/csu.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/csu.nix
@@ -16,11 +16,12 @@
   statHook,
   rsync,
   headers,
-  sys,
+  sys-headers,
   ld_elf_so,
 }:
 
 mkDerivation {
+  noLibc = true;
   path = "lib/csu";
   meta.platforms = lib.platforms.netbsd;
   nativeBuildInputs = [
@@ -41,7 +42,7 @@ mkDerivation {
   ];
   buildInputs = [ headers ];
   extraPaths = [
-    sys.path
+    sys-headers.path
     ld_elf_so.path
   ];
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/include.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/include.nix
@@ -15,6 +15,7 @@
 }:
 
 mkDerivation {
+  noLibc = true;
   path = "include";
   nativeBuildInputs = [
     bsdSetupHook

--- a/pkgs/os-specific/bsd/netbsd/pkgs/ld_elf_so.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/ld_elf_so.nix
@@ -6,6 +6,7 @@
 }:
 
 mkDerivation {
+  noLibc = true;
   path = "libexec/ld.elf_so";
   meta.platforms = lib.platforms.netbsd;
   LIBC_PIC = "${libc}/lib/libc_pic.a";

--- a/pkgs/os-specific/bsd/netbsd/pkgs/libc.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/libc.nix
@@ -24,6 +24,7 @@
 }:
 
 mkDerivation {
+  noLibc = true;
   path = "lib/libc";
   USE_FORT = "yes";
   MKPROFILE = "no";
@@ -94,5 +95,8 @@ mkDerivation {
     make -C $BSDSRCDIR/lib/libcrypt $makeFlags
     make -C $BSDSRCDIR/lib/libcrypt $makeFlags install
   '';
-  inherit (librt) postPatch;
+  postPatch = ''
+    sed -i 's,/usr\(/include/sys/syscall.h\),${headers}\1,g' \
+      $BSDSRCDIR/lib/{libc,librt}/sys/Makefile.inc
+  '';
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/librt.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/librt.nix
@@ -9,8 +9,5 @@ mkDerivation {
   path = "lib/librt";
   meta.platforms = lib.platforms.netbsd;
   extraPaths = [ libc.path ] ++ libc.extraPaths;
-  postPatch = ''
-    sed -i 's,/usr\(/include/sys/syscall.h\),${headers}\1,g' \
-      $BSDSRCDIR/lib/{libc,librt}/sys/Makefile.inc
-  '';
+  inherit (libc) postPatch;
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/libutil.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/libutil.nix
@@ -19,8 +19,8 @@ mkDerivation {
   path = "lib/libutil";
   extraPaths = [
     "common"
-    libc.path
-    sys.path
+    "lib/libc"
+    "sys"
   ];
   nativeBuildInputs = [
     bsdSetupHook

--- a/pkgs/os-specific/bsd/netbsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/mkDerivation.nix
@@ -23,7 +23,13 @@
 lib.makeOverridable (
   attrs:
   let
-    stdenv' = if attrs.noCC or false then stdenvNoCC else stdenv;
+    stdenv' =
+      if attrs.noCC or false then
+        stdenvNoCC
+      else if attrs.noLibc or false then
+        crossLibcStdenv
+      else
+        stdenv;
   in
   stdenv'.mkDerivation (
     rec {

--- a/pkgs/os-specific/bsd/openbsd/default.nix
+++ b/pkgs/os-specific/bsd/openbsd/default.nix
@@ -1,16 +1,17 @@
 {
-  stdenv,
   lib,
-  stdenvNoCC,
   makeScopeWithSplicing',
   generateSplicesForMkScope,
-  pkgs,
   buildPackages,
-  netbsd,
 }:
 
-makeScopeWithSplicing' {
+let
   otherSplices = generateSplicesForMkScope "openbsd";
+  buildOpenbsd = otherSplices.selfBuildHost;
+in
+
+makeScopeWithSplicing' {
+  inherit otherSplices;
   f = (
     self:
     lib.packagesFromDirectoryRecursive {
@@ -19,8 +20,8 @@ makeScopeWithSplicing' {
     }
     // {
       libc = self.callPackage ./pkgs/libc/package.nix {
-        inherit (self) csu include lorder;
-        inherit (buildPackages.openbsd) makeMinimal;
+        inherit (self) csu include;
+        inherit (buildOpenbsd) makeMinimal;
         inherit (buildPackages.netbsd)
           install
           gencat
@@ -30,16 +31,16 @@ makeScopeWithSplicing' {
       };
       makeMinimal = buildPackages.netbsd.makeMinimal.override { inherit (self) make-rules; };
       mkDerivation = self.callPackage ./pkgs/mkDerivation.nix {
-        inherit stdenv;
         inherit (buildPackages.netbsd) install;
+        inherit (buildPackages.buildPackages) rsync;
       };
       include = self.callPackage ./pkgs/include/package.nix {
-        inherit (buildPackages.openbsd) makeMinimal;
+        inherit (buildOpenbsd) makeMinimal;
         inherit (buildPackages.netbsd) install rpcgen mtree;
       };
       csu = self.callPackage ./pkgs/csu.nix {
         inherit (self) include;
-        inherit (buildPackages.openbsd) makeMinimal;
+        inherit (buildOpenbsd) makeMinimal;
         inherit (buildPackages.netbsd) install;
       };
       make-rules = self.callPackage ./pkgs/make-rules/package.nix { };

--- a/pkgs/os-specific/bsd/openbsd/pkgs/csu.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/csu.nix
@@ -9,6 +9,7 @@
 }:
 
 mkDerivation {
+  noLibc = true;
   path = "lib/csu";
   nativeBuildInputs = [
     bsdSetupHook

--- a/pkgs/os-specific/bsd/openbsd/pkgs/libc/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/libc/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  crossLibcStdenv,
   mkDerivation,
   bsdSetupHook,
   openbsdSetupHook,
@@ -10,7 +10,6 @@
   byacc,
   gencat,
   rpcgen,
-  lorder,
   csu,
   include,
   ctags,
@@ -19,7 +18,8 @@
   fetchpatch,
 }:
 
-mkDerivation rec {
+mkDerivation {
+  noLibc = true;
   pname = "libc";
   path = "lib/libc";
   extraPaths = [
@@ -53,7 +53,6 @@ mkDerivation rec {
     gencat
     rpcgen
     ctags
-    lorder
     tsort
   ];
 
@@ -69,7 +68,9 @@ mkDerivation rec {
 
   # Suppress lld >= 16 undefined version errors
   # https://github.com/freebsd/freebsd-src/commit/2ba84b4bcdd6012e8cfbf8a0d060a4438623a638
-  env.NIX_LDFLAGS = lib.optionalString (stdenv.hostPlatform.linker == "lld") "--undefined-version";
+  env.NIX_LDFLAGS = lib.optionalString (
+    crossLibcStdenv.hostPlatform.linker == "lld"
+  ) "--undefined-version";
 
   makeFlags = [
     "STRIP=-s" # flag to install, not command

--- a/pkgs/os-specific/bsd/openbsd/pkgs/lorder.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/lorder.nix
@@ -8,6 +8,7 @@
 }:
 
 mkDerivation {
+  noCC = true;
   path = "usr.bin/lorder";
   nativeBuildInputs = [
     bsdSetupHook

--- a/pkgs/os-specific/bsd/openbsd/pkgs/make-rules/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/make-rules/package.nix
@@ -2,7 +2,6 @@
   fetchpatch,
   lib,
   mkDerivation,
-  stdenv,
 }:
 
 mkDerivation {

--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -3,18 +3,12 @@
 , windows
 , fetchurl
 , autoreconfHook
+, mingw_w64_headers
 }:
 
-let
-  version = "11.0.1";
-in stdenv.mkDerivation {
+stdenv.mkDerivation {
   pname = "mingw-w64";
-  inherit version;
-
-  src = fetchurl {
-    url = "mirror://sourceforge/mingw-w64/mingw-w64-v${version}.tar.bz2";
-    hash = "sha256-P2a84Gnui+10OaGhPafLkaXmfqYXDyExesf1eUYl7hA=";
-  };
+  inherit (mingw_w64_headers) version src meta;
 
   outputs = [ "out" "dev" ];
 
@@ -30,8 +24,4 @@ in stdenv.mkDerivation {
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ windows.mingw_w64_headers ];
   hardeningDisable = [ "stackprotector" "fortify" ];
-
-  meta = {
-    platforms = lib.platforms.windows;
-  };
 }

--- a/pkgs/os-specific/windows/mingw-w64/headers.nix
+++ b/pkgs/os-specific/windows/mingw-w64/headers.nix
@@ -1,11 +1,19 @@
-{ stdenvNoCC, mingw_w64 }:
+{ lib, stdenvNoCC, fetchurl }:
 
-stdenvNoCC.mkDerivation {
-  name = "${mingw_w64.name}-headers";
-  inherit (mingw_w64) src meta;
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "mingw_w64-headers";
+  version = "11.0.1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/mingw-w64/mingw-w64-v${finalAttrs.version}.tar.bz2";
+    hash = "sha256-P2a84Gnui+10OaGhPafLkaXmfqYXDyExesf1eUYl7hA=";
+  };
 
   preConfigure = ''
     cd mingw-w64-headers
   '';
 
-}
+  meta = {
+    platforms = lib.platforms.windows;
+  };
+})

--- a/pkgs/os-specific/windows/mingw-w64/pthreads.nix
+++ b/pkgs/os-specific/windows/mingw-w64/pthreads.nix
@@ -1,8 +1,8 @@
-{ stdenv, mingw_w64 }:
+{ stdenv, mingw_w64_headers }:
 
 stdenv.mkDerivation {
-  name = "${mingw_w64.name}-pthreads";
-  inherit (mingw_w64) src meta;
+  pname = "mingw_w64-pthreads";
+  inherit (mingw_w64_headers) version src meta;
 
   configureFlags = [
     # Rustc require 'libpthread.a' when targeting 'x86_64-pc-windows-gnu'.

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -32,7 +32,11 @@ rec {
 
 
   # Override the compiler in stdenv for specific packages.
-  overrideCC = stdenv: cc: stdenv.override { allowedRequisites = null; cc = cc; };
+  overrideCC = stdenv: cc: stdenv.override {
+    allowedRequisites = null;
+    cc = cc;
+    hasCC = cc != null;
+  };
 
 
   # Add some arbitrary packages to buildInputs for specific packages.

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1477,6 +1477,10 @@ mapAliases ({
   inherit (stdenv.hostPlatform) system; # Added 2021-10-22
   inherit (stdenv) buildPlatform hostPlatform targetPlatform; # Added 2023-01-09
 
+  freebsdCross = freebsd; # Added 2024-06-18
+  netbsdCross = netbsd; # Added 2024-06-18
+  openbsdCross = openbsd; # Added 2024-06-18
+
   # LLVM packages for (integration) testing that should not be used inside Nixpkgs:
   llvmPackages_latest = llvmPackages_18;
   llvmPackages_git = recurseIntoAttrs (callPackage ../development/compilers/llvm/git {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -61,7 +61,7 @@ with pkgs;
   };
 
   stdenvNoLibs =
-    if stdenv.hostPlatform != stdenv.buildPlatform && (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.useLLVM or false)
+    if stdenvNoCC.hostPlatform != stdenvNoCC.buildPlatform && (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.useLLVM or false)
     then
       # We cannot touch binutils or cc themselves, because that will cause
       # infinite recursion. So instead, we just choose a libc based on the
@@ -20954,9 +20954,9 @@ with pkgs;
       if stdenv.targetPlatform.useiOSPrebuilt
       then targetPackages.darwin.iosSdkPkgs.libraries or darwin.iosSdkPkgs.libraries
       else targetPackages.darwin.LibsystemCross or (throw "don't yet have a `targetPackages.darwin.LibsystemCross for ${stdenv.targetPlatform.config}`")
-    else if name == "fblibc" then targetPackages.freebsdCross.libc or freebsdCross.libc
-    else if name == "oblibc" then targetPackages.openbsdCross.libc or openbsdCross.libc
-    else if name == "nblibc" then targetPackages.netbsdCross.libc or netbsdCross.libc
+    else if name == "fblibc" then targetPackages.freebsd.libc or freebsd.libc
+    else if name == "oblibc" then targetPackages.openbsd.libc or openbsd.libc
+    else if name == "nblibc" then targetPackages.netbsd.libc or netbsd.libc
     else if name == "wasilibc" then targetPackages.wasilibc or wasilibc
     else if name == "relibc" then targetPackages.relibc or relibc
     else throw "Unknown libc ${name}";
@@ -40585,18 +40585,11 @@ with pkgs;
     name = "bsd-setup-hook";
   } ../os-specific/bsd/setup-hook.sh;
 
-  inherit (callPackage ../os-specific/bsd/freebsd { })
-    freebsd freebsdCross;
+  freebsd = callPackage ../os-specific/bsd/freebsd { };
 
   netbsd = callPackage ../os-specific/bsd/netbsd { };
-  netbsdCross = callPackage ../os-specific/bsd/netbsd {
-    stdenv = crossLibcStdenv;
-  };
 
   openbsd = callPackage ../os-specific/bsd/openbsd { };
-  openbsdCross = callPackage ../os-specific/bsd/openbsd {
-    stdenv = crossLibcStdenv;
-  };
 
   powershell = callPackage ../shells/powershell { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15457,7 +15457,7 @@ with pkgs;
     dontStrip = true;
   }));
 
-  gccCrossLibcStdenv = overrideCC stdenv buildPackages.gccWithoutTargetLibc;
+  gccCrossLibcStdenv = overrideCC stdenvNoCC buildPackages.gccWithoutTargetLibc;
 
   crossLibcStdenv =
     if stdenv.hostPlatform.useLLVM or false || stdenv.hostPlatform.isDarwin


### PR DESCRIPTION
## Description of changes

I realized what @rhelmot did in 61202561d92cf1cd74532fcbd8b9d6662c5bc57b (specify what packages just need `stdenvNoLibc`) is definitely the right approach for this, and adjusted NetBSD and OpenBSD to likewise use it. With that change, we don't need these confusing and ugly `*bsdCross` package sets at all!

We can get rid of a lot more libc-related `*Cross`, and I will do so soon, but this is the first step.

(adapted from commit 51f1ecaa59a3b7c182b24e71a3176c83d6cd601e)

Part of take 2 of https://github.com/NixOS/nixpkgs/pull/320852, without the infra changes. This, unlike the other, is safer to backport.

(They are still kept as deprecated aliases.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
