### PR TITLE
muscle: compile with GCC for Darwin

### DIFF
--- a/pkgs/applications/science/biology/muscle/default.nix
+++ b/pkgs/applications/science/biology/muscle/default.nix
@@ -1,9 +1,8 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, gccStdenv, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
-  pname   = "muscle";
+gccStdenv.mkDerivation rec {
+  pname = "muscle";
   version = "5.1.0";
-
 
   src = fetchFromGitHub {
     owner = "rcedgar";
@@ -14,15 +13,26 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "${src.name}/src";
 
-  installPhase = ''
-    install -m755 -D Linux/muscle $out/bin/muscle
-  '';
+  patches = [
+    ./muscle-darwin-g++.patch
+  ];
+
+  installPhase =
+    let
+      target =
+        if gccStdenv.isDarwin
+        then "Darwin"
+        else "Linux";
+    in
+    ''
+      install -m755 -D ${target}/muscle $out/bin/muscle
+    '';
 
   meta = with lib; {
     description = "Multiple sequence alignment with top benchmark scores scalable to thousands of sequences";
     mainProgram = "muscle";
-    license     = licenses.gpl3Plus;
-    homepage    = "https://www.drive5.com/muscle/";
+    license = licenses.gpl3Plus;
+    homepage = "https://www.drive5.com/muscle/";
     maintainers = with maintainers; [ unode thyol ];
   };
 }

--- a/pkgs/applications/science/biology/muscle/muscle-darwin-g++.patch
+++ b/pkgs/applications/science/biology/muscle/muscle-darwin-g++.patch
@@ -1,0 +1,15 @@
+
+diff --git a/Makefile b/Makefile
+index df16673..be3bd0d 100644
+--- a/Makefile
++++ b/Makefile
+@@ -20,9 +20,6 @@ OS := $(shell uname)
+ CPPFLAGS := $(CPPFLAGS) -DNDEBUG -pthread
+ 
+ CXX := g++
+-ifeq ($(OS),Darwin)
+-	CXX := g++-11
+-endif
+ 
+ CXXFLAGS := $(CXXFLAGS) -O3 -fopenmp -ffast-math
+ 


### PR DESCRIPTION
## Description of changes

This revision updates `pkgs.muscle` to compile with GCC (`gccStdenv` instead of `stdenv`). This works around issues with OpenMP in the Darwin version of LLVM.

The upstream Makefile assumes that we're compiling with Homebrew or similar and uses `g++-11` instead of `g++`, so this revision also introduces a patch to remove this behavior, allowing the package to compile on Darwin without issue.


## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
