### PR TITLE
nix-web: 0.3.0 -> 0.4.2

### DIFF
--- a/pkgs/by-name/ni/nix-web/package.nix
+++ b/pkgs/by-name/ni/nix-web/package.nix
@@ -15,23 +15,16 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "nix-web";
-  version = "0.3.0";
+  version = "0.4.2";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "gorgon";
     repo = "gorgon";
     rev = "nix-web-v${version}";
-    hash = "sha256-/tjcin3p+nE9Y7bhTCj7D4lpjKEFGM1bRqKE8T6igJE=";
-
-    # Various unit tests contain /nix/store/* paths. This breaks the fetcher in a very funny way:
-    #   error: illegal path references in fixed-output derivation '/nix/store/52nmkc6v9qhdyzszlvbncndxyrcdfjn3-source.drv'
-    nativeBuildInputs = [ nukeReferences ];
-    postFetch = ''
-      find $out -name "*.rs" -print0 | xargs -0 nuke-refs
-    '';
+    hash = "sha256-lAk2VfhclHswsctA0RQgEj5oEX1fowh8TCaKykGEioY=";
   };
-  cargoHash = "sha256-5pPn6APz0kdxuBdz9pgqvECTk6KhXnW/YTjxKgiuD9Q=";
+  cargoHash = "sha256-romL/RALr/pmwUA8/SN4AOwc+Vndspd1Yrqs0AHPYRY=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = lib.optional (!stdenv.isDarwin) openssl
@@ -47,11 +40,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoBuildFlags = cargoFlags;
   cargoTestFlags = cargoFlags;
-  checkFlags = [
-    # Skip tests that rely on store paths nuked by `nuke-refs`.
-    "--skip=test_env_value_to_html_store_path_subpath"
-    "--skip=test_env_value_to_html_store_path"
-  ];
 
   NIX_WEB_BUILD_NIX_CLI_PATH = "${nixPackage}/bin/nix";
 

--- a/pkgs/by-name/ni/nix-web/package.nix
+++ b/pkgs/by-name/ni/nix-web/package.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = lib.optional (!stdenv.isDarwin) openssl
-    ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
+    ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Security SystemConfiguration ]);
 
   postPatch = ''
     substituteInPlace nix-web/nix-web.service \


### PR DESCRIPTION
## Description of changes

https://codeberg.org/gorgon/gorgon/releases/tag/nix-web-v0.4.2

## Things done

Updated `nix-web` from v0.3.0 to v0.4.2.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
