### PR TITLE
hyprlandPlugins: init upstream hyprland-plugins at 0.41.1, hy3: 0.41.0 -> 0.41.1

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
@@ -1,50 +1,34 @@
-{ lib
-, callPackage
-, pkg-config
-, stdenv
-, hyprland
+{
+  lib,
+  callPackage,
+  pkg-config,
+  stdenv,
+  hyprland,
 }:
 let
-  mkHyprlandPlugin = hyprland:
+  mkHyprlandPlugin =
+    hyprland:
     args@{ pluginName, ... }:
-    stdenv.mkDerivation (args // {
-      pname = "${pluginName}";
-      nativeBuildInputs = [ pkg-config ] ++ args.nativeBuildInputs or [ ];
-      buildInputs = [ hyprland ]
-        ++ hyprland.buildInputs
-        ++ (args.buildInputs or [ ]);
-      meta = args.meta // {
-        description = args.meta.description or "";
-        longDescription = (args.meta.longDescription or "") +
-          "\n\nPlugins can be installed via a plugin entry in the Hyprland NixOS or Home Manager options.";
-      };
-    });
+    stdenv.mkDerivation (
+      args
+      // {
+        pname = "${pluginName}";
+        nativeBuildInputs = [ pkg-config ] ++ args.nativeBuildInputs or [ ];
+        buildInputs = [ hyprland ] ++ hyprland.buildInputs ++ (args.buildInputs or [ ]);
+        meta = args.meta // {
+          description = args.meta.description or "";
+          longDescription =
+            (args.meta.longDescription or "")
+            + "\n\nPlugins can be installed via a plugin entry in the Hyprland NixOS or Home Manager options.";
+        };
+      }
+    );
 
   plugins = {
-    hy3 = { fetchFromGitHub, cmake, hyprland }:
-      mkHyprlandPlugin hyprland rec {
-        pluginName = "hy3";
-        version = "0.41.0";
-
-        src = fetchFromGitHub {
-          owner = "outfoxxed";
-          repo = "hy3";
-          rev = "hl${version}";
-          hash = "sha256-gEEWWlQRvejSR2RRg78Lubz6siIgknqj6CslveyyIP4=";
-        };
-
-        nativeBuildInputs = [ cmake ];
-
-        dontStrip = true;
-
-        meta = {
-          homepage = "https://github.com/outfoxxed/hy3";
-          description = "Hyprland plugin for an i3 / sway like manual tiling layout";
-          license = lib.licenses.gpl3;
-          platforms = lib.platforms.linux;
-          maintainers = with lib.maintainers; [ aacebedo ];
-        };
-      };
+    hy3 = import ./hy3.nix;
   };
 in
-(lib.mapAttrs (name: plugin: callPackage plugin { }) plugins) // { inherit mkHyprlandPlugin; }
+(lib.mapAttrs (name: plugin: callPackage plugin { inherit mkHyprlandPlugin; }) plugins)
+// {
+  inherit mkHyprlandPlugin;
+}

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
@@ -24,9 +24,10 @@ let
       }
     );
 
-  plugins = {
-    hy3 = import ./hy3.nix;
-  };
+  plugins = lib.mergeAttrsList [
+    { hy3 = import ./hy3.nix; }
+    (import ./hyprland-plugins.nix)
+  ];
 in
 (lib.mapAttrs (name: plugin: callPackage plugin { inherit mkHyprlandPlugin; }) plugins)
 // {

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hy3.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hy3.nix
@@ -7,13 +7,13 @@
 }:
 mkHyprlandPlugin hyprland rec {
   pluginName = "hy3";
-  version = "0.41.0";
+  version = "0.41.1";
 
   src = fetchFromGitHub {
     owner = "outfoxxed";
     repo = "hy3";
     rev = "hl${version}";
-    hash = "sha256-gEEWWlQRvejSR2RRg78Lubz6siIgknqj6CslveyyIP4=";
+    hash = "sha256-bRLI+zgfT31LCMW4Pf701ZZx2oFeXoBu1BfYQjX6MPc=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hy3.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hy3.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  cmake,
+  fetchFromGitHub,
+  hyprland,
+  mkHyprlandPlugin,
+}:
+mkHyprlandPlugin hyprland rec {
+  pluginName = "hy3";
+  version = "0.41.0";
+
+  src = fetchFromGitHub {
+    owner = "outfoxxed";
+    repo = "hy3";
+    rev = "hl${version}";
+    hash = "sha256-gEEWWlQRvejSR2RRg78Lubz6siIgknqj6CslveyyIP4=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  dontStrip = true;
+
+  meta = {
+    homepage = "https://github.com/outfoxxed/hy3";
+    description = "Hyprland plugin for an i3 / sway like manual tiling layout";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ aacebedo ];
+  };
+}

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprland-plugins.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprland-plugins.nix
@@ -1,0 +1,51 @@
+let
+  # shared src for upstream hyprland-plugins repo
+  # function generating derivations for all plugins in hyprland-plugins
+  hyprland-plugins =
+    builtins.mapAttrs
+      (
+        name: description:
+        (
+          {
+            lib,
+            cmake,
+            fetchFromGitHub,
+            hyprland,
+            mkHyprlandPlugin,
+          }:
+          let
+            version = "0.41.1";
+
+            hyprland-plugins-src = fetchFromGitHub {
+              owner = "hyprwm";
+              repo = "hyprland-plugins";
+              rev = "v${version}";
+              hash = "sha256-Bw3JRBUZg2kmDwxa/UHvD//gGcNjbftTj2MSeLvx1q8=";
+            };
+          in
+          mkHyprlandPlugin hyprland {
+            pluginName = name;
+            inherit version;
+
+            src = "${hyprland-plugins-src}/${name}";
+            nativeBuildInputs = [ cmake ];
+            meta = {
+              homepage = "https://github.com/hyprwm/hyprland-plugins";
+              description = "Hyprland ${description} plugin";
+              license = lib.licenses.bsd3;
+              maintainers = with lib.maintainers; [ fufexan ];
+              platforms = lib.platforms.linux;
+            };
+          }
+        )
+      )
+      {
+        borders-plus-plus = "multiple borders";
+        csgo-vulkan-fix = "CS:GO/CS2 Vulkan fix";
+        hyprbars = "window title";
+        hyprexpo = "workspaces overview";
+        hyprtrails = "smooth trails behind moving windows";
+        hyprwinwrap = "xwinwrap-like";
+      };
+in
+hyprland-plugins


### PR DESCRIPTION
## Description of changes

Adds [hyprland-plugins](https://github.com/hyprwm/hyprland-plugins). Should greatly simplify using plugins on versioned Hyprland, as this eliminates inconsistencies between Nixpkgs/compiler/headers.

The plugins are simple, thus I've made a helper function to generate a derivation for each of them.

These plugins will have to be updated with Hyprland. Hopefully I can get vaxry to create tags for future releases.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
