### PR TITLE
radicle-httpd: init at 0.11.0

### DIFF
--- a/pkgs/by-name/ra/radicle-httpd/package.nix
+++ b/pkgs/by-name/ra/radicle-httpd/package.nix
@@ -1,0 +1,79 @@
+{
+  asciidoctor,
+  darwin,
+  fetchgit,
+  git,
+  installShellFiles,
+  lib,
+  makeWrapper,
+  man-db,
+  rustPlatform,
+  stdenv,
+  xdg-utils,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "radicle-httpd";
+  version = "0.11.0";
+  env.RADICLE_VERSION = version;
+
+  src = fetchgit {
+    url = "https://seed.radicle.xyz/z4V1sjrXqjvFdnCUbxPFqd5p4DtH5.git";
+    rev = "refs/namespaces/z6MkkfM3tPXNPrPevKr3uSiQtHPuwnNhu2yUVjgd2jXVsVz5/refs/tags/v${version}";
+    hash = "sha256-XMEO+L362uaPUr25YUkMh41a2BcKEy8bgXfwKlvBtnQ=";
+    sparseCheckout = [ "radicle-httpd" ];
+  };
+  sourceRoot = "${src.name}/radicle-httpd";
+  cargoHash = "sha256-WdgPL6X3FMxHW6OVoTkrbo0azAxp35UzGMcTJ5pNnkI=";
+
+  nativeBuildInputs = [
+    asciidoctor
+    installShellFiles
+    makeWrapper
+  ];
+  nativeCheckInputs = [ git ];
+  buildInputs = lib.optionals stdenv.buildPlatform.isDarwin [ darwin.apple_sdk.frameworks.Security ];
+
+  doCheck = stdenv.hostPlatform.isLinux;
+
+  postInstall = ''
+    for page in $(find -name '*.adoc'); do
+      asciidoctor -d manpage -b manpage $page
+      installManPage ''${page::-5}
+    done
+  '';
+
+  postFixup = ''
+    for program in $out/bin/* ;
+    do
+      wrapProgram "$program" \
+        --prefix PATH : "${
+          lib.makeBinPath [
+            git
+            man-db
+            xdg-utils
+          ]
+        }"
+    done
+  '';
+
+  meta = {
+    description = "Radicle JSON HTTP API Daemon";
+    longDescription = ''
+      A Radicle HTTP daemon exposing a JSON HTTP API that allows someone to browse local
+      repositories on a Radicle node via their web browser.
+    '';
+    homepage = "https://radicle.xyz";
+    # cargo.toml says MIT and asl20, LICENSE file says GPL3
+    license = with lib.licenses; [
+      gpl3Only
+      mit
+      asl20
+    ];
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      gador
+      lorenzleutgeb
+    ];
+    mainProgram = "radicle-httpd";
+  };
+}


### PR DESCRIPTION
## Description of changes

Since the version bump to 1.0.0-rc.11 of radicle in #321299 `radicle-httpd` and `rad-web` have been phased out to an external repo [radicle-explorer](https://app.radicle.xyz/nodes/seed.radicle.garden/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5). 

This PR packages the phased out part, which will be needed by the nixos service #314440

@lorenzleutgeb and @ju1m 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
