### PR TITLE
bleep: init at 0.0.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10802,6 +10802,12 @@
     githubId = 4032;
     name = "Kristoffer Thømt Ravneberg";
   };
+  kristianan = {
+    email = "kristian@krined.no";
+    github = "KristianAN";
+    githubId = 80984519;
+    name = "Kristian Alvestad Nedevold-Hansen";
+  };
   kristian-brucaj = {
     email = "kbrucaj@gmail.com";
     github = "Flameslice";

--- a/pkgs/by-name/bl/bleep/package.nix
+++ b/pkgs/by-name/bl/bleep/package.nix
@@ -1,0 +1,75 @@
+{
+  stdenvNoCC,
+  fetchzip,
+  autoPatchelfHook,
+  installShellFiles,
+  makeWrapper,
+  lib,
+  zlib,
+}:
+let
+  platform =
+    {
+      x86_64-linux = "x86_64-pc-linux";
+      x86_64-darwin = "x86_64-apple-darwin";
+      aarch64-darwin = "arm64-apple-darwin";
+    }
+    ."${stdenvNoCC.system}" or (throw "unsupported system ${stdenvNoCC.hostPlatform.system}");
+
+  hash =
+    {
+      x86_64-linux = "sha256-dB8reN5rTlY5czFH7BaRya7qBa6czAIH2NkFWZh81ek=";
+      x86_64-darwin = "sha256-tpUcduCPCbVVaYZZOhWdPlN6SW3LGZPWSO9bDStVDms=";
+      aarch64-darwin = "sha256-V8QGF3Dpuy9I6CqKsJRHBHRdaLhc4XKZkv/rI7zs+qQ=";
+    }
+    ."${stdenvNoCC.system}" or (throw "unsupported system ${stdenvNoCC.hostPlatform.system}");
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "bleep";
+  version = "0.0.7";
+
+  src = fetchzip {
+    url = "https://github.com/oyvindberg/bleep/releases/download/v${finalAttrs.version}/bleep-${platform}.tar.gz";
+    hash = hash;
+  };
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ] ++ lib.optional stdenvNoCC.isLinux autoPatchelfHook;
+
+  buildInputs = [ zlib ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 bleep -t $out/bin/
+    runHook postInstall
+  '';
+
+  dontAutoPatchelf = true;
+
+  postFixup =
+    lib.optionalString stdenvNoCC.isLinux ''
+      autoPatchelf $out
+    ''
+    + ''
+      export PATH=$PATH:$out/bin
+      installShellCompletion --cmd bleep \
+        --bash <(bleep install-tab-completions-bash --stdout) \
+        --zsh <(bleep install-tab-completions-zsh --stdout) \
+    '';
+
+  meta = {
+    homepage = "https://bleep.build/";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    license = lib.licenses.mit;
+    description = "Bleeping fast scala build tool";
+    mainProgram = "bleep";
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    maintainers = with lib.maintainers; [ kristianan ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Added new package: Bleep - A fast modern build tool for Scala with a declarative configuration: https://bleep.build

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Add a 👍 [reaction](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to [issues you find important](https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc).
