### PR TITLE
protoc-gen-swift: init at 1.28.2

### DIFF
--- a/pkgs/by-name/pr/protoc-gen-swift/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-swift/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  fetchFromGitHub,
+  swiftPackages,
+  swift,
+  swiftpm,
+  nix-update-script,
+}:
+let
+  stdenv = swiftPackages.stdenv;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "protoc-gen-swift";
+  version = "1.28.2";
+
+  src = fetchFromGitHub {
+    owner = "apple";
+    repo = "swift-protobuf";
+    rev = "${finalAttrs.version}";
+    hash = "sha256-YOEr73xDjNrc4TTkIBY8AdAUX2MBtF9ED1UF2IjTu44=";
+  };
+
+  nativeBuildInputs = [
+    swift
+    swiftpm
+  ];
+
+  # Not needed for darwin, as `apple-sdk` is implicit and part of the stdenv
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    swiftPackages.Foundation
+    swiftPackages.Dispatch
+  ];
+
+  # swiftpm fails to found libdispatch.so on Linux
+  LD_LIBRARY_PATH = lib.optionalString stdenv.hostPlatform.isLinux (
+    lib.makeLibraryPath [
+      swiftPackages.Dispatch
+    ]
+  );
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 .build/release/protoc-gen-swift $out/bin/protoc-gen-swift
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Protobuf plugin for generating Swift code";
+    homepage = "https://github.com/apple/swift-protobuf";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ matteopacini ];
+    mainProgram = "protoc-gen-swift";
+    inherit (swift.meta) platforms badPlatforms;
+  };
+})


### PR DESCRIPTION
## Description of changes

Protobuf plugin for generating Swift code.

https://github.com/apple/swift-protobuf

Extra notes:
- This cannot be backported because the Swift version on `release-24.05` is too old to support this package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
