### PR TITLE
systemd-netlogd: init at 1.4.2

### DIFF
--- a/pkgs/by-name/sy/systemd-netlogd/package.nix
+++ b/pkgs/by-name/sy/systemd-netlogd/package.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gperf,
+  libcap,
+  meson,
+  ninja,
+  nix-update-script,
+  openssl,
+  pkg-config,
+  pkgsCross,
+  sphinx,
+  systemd,
+  systemdLibs,
+  opensslSupport ? true,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "systemd-netlogd";
+  version = "1.4.2";
+
+  src = fetchFromGitHub {
+    owner = "systemd";
+    repo = "systemd-netlogd";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-FwBwhsnVathlRQjKyrsPpZZlCb2rIpVuHGq9mG3mNsw=";
+  };
+
+  # Fixup a few installation paths
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail "get_option('prefix')" "get_option('bindir')"
+    substituteInPlace doc/meson.build \
+      --replace-fail "'/usr/share/man/man8'" "get_option('mandir') / 'man8'"
+    substituteInPlace units/meson.build \
+      --replace-fail "get_option('prefix') / 'system'" "get_option('libdir') / 'systemd/system'"
+
+    substituteInPlace units/systemd-netlogd.service.in \
+      --replace-fail '@PKGPREFIX@/systemd-netlogd' '${placeholder "out"}/bin/systemd-netlogd'
+  '';
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    gperf
+    meson
+    ninja
+    pkg-config
+    sphinx
+  ];
+
+  buildInputs = [
+    libcap
+    systemdLibs
+  ] ++ lib.optional opensslSupport openssl;
+
+  mesonFlags = [
+    "--sysconfdir=${placeholder "out"}/etc/systemd"
+    (lib.mesonBool "openssl" opensslSupport)
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  passthru = {
+    # Make sure x86_64-linux -> aarch64-linux cross compilation works
+    tests = lib.optionalAttrs (stdenv.buildPlatform.system == "x86_64-linux") {
+      aarch64-cross = pkgsCross.aarch64-multiplatform.systemd-netlogd;
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Forwards messages from the journal to other hosts over the network";
+    homepage = "https://github.com/systemd/systemd-netlogd";
+    changelog = "https://github.com/systemd/systemd-netlogd/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ getchoo ];
+    inherit (systemd.meta) platforms;
+    mainProgram = "systemd-netlogd";
+  };
+})


### PR DESCRIPTION
## Description of changes

fixes #313537

cc @BrainWart for testing

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
