### PR TITLE
nixos/kubernetes: adds argument to mkCert defaulting to kubernetes group

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/default.nix
+++ b/nixos/modules/services/cluster/kubernetes/default.nix
@@ -61,13 +61,13 @@ let
   etcdEndpoints = ["https://${cfg.masterAddress}:2379"];
 
   mkCert = { name, CN, hosts ? [], fields ? {}, action ? "",
-             privateKeyOwner ? "kubernetes" }: rec {
+             privateKeyOwner ? "kubernetes", privateKeyGroup ? "kubernetes" }: rec {
     inherit name caCert CN hosts fields action;
     cert = secret name;
     key = secret "${name}-key";
     privateKeyOptions = {
       owner = privateKeyOwner;
-      group = "nogroup";
+      group = privateKeyGroup;
       mode = "0600";
       path = key;
     };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds an argument to the `mkCert` function. It allows to use mkCert passing as argument the group name. Previously it had the group hardcoded as nogroup.

With this PR it makes the new default to be the kubernetes group.

For reference, if this contribution is accepted the following issue should be updated: https://github.com/NixOS/nixpkgs/issues/55370


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->


Tested it with:
```bash
nix \
build \
--no-link \
--print-out-paths \
--override-flake \
nixpkgs \
'github:PedroRegisPOAR/nixpkgs/a5deaf9e935f716ed3200c37abc656108c21cfad' \
'nixpkgs#nixosTests.kubernetes.dns-single-node' \
'nixpkgs#nixosTests.kubernetes.dns-multi-node' \
'nixpkgs#nixosTests.kubernetes.rbac-single-node' \
'nixpkgs#nixosTests.kubernetes.rbac-multi-node'
```

Outputs:
```bash
/nix/store/rpxkyqwnwhvqsxvm2aznvdz95y5cgy5k-vm-test-run-kubernetes-dns-multinode
/nix/store/mb9ca1i70xaw52ljc03jqdpb1853m9rw-vm-test-run-kubernetes-dns-singlenode
/nix/store/ndfmpfbbkigqywni4jriv9f62ylka846-vm-test-run-kubernetes-rbac-multinode
/nix/store/8hsa36b5ig42l3ga9hskmlx8sxv5grhq-vm-test-run-kubernetes-rbac-singlenode
```



For local testing:

```bash
nix \
build \
--no-link \
--print-out-paths \
'.#nixosTests.kubernetes.dns-single-node' \
'.#nixosTests.kubernetes.dns-multi-node' \
'.#nixosTests.kubernetes.rbac-single-node' \
'.#nixosTests.kubernetes.rbac-multi-node'
```



## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
