### PR TITLE
netdata: 1.45.4 -> 1.46.1

### DIFF
--- a/nixos/modules/services/monitoring/netdata.nix
+++ b/nixos/modules/services/monitoring/netdata.nix
@@ -247,7 +247,8 @@ in {
         ++ lib.optional cfg.python.enable (pkgs.python3.withPackages cfg.python.extraPackages)
         ++ lib.optional config.virtualisation.libvirtd.enable config.virtualisation.libvirtd.package
         ++ lib.optional config.virtualisation.docker.enable config.virtualisation.docker.package
-        ++ lib.optionals config.virtualisation.podman.enable [ pkgs.jq config.virtualisation.podman.package ];
+        ++ lib.optionals config.virtualisation.podman.enable [ pkgs.jq config.virtualisation.podman.package ]
+        ++ lib.optional config.boot.zfs.enabled config.boot.zfs.package;
       environment = {
         PYTHONPATH = "${cfg.package}/libexec/netdata/python.d/python_modules";
         NETDATA_PIPENAME = "/run/netdata/ipc";

--- a/pkgs/tools/system/netdata/dashboard-v2-removal.patch
+++ b/pkgs/tools/system/netdata/dashboard-v2-removal.patch
@@ -1,0 +1,25 @@
+# Original: https://github.com/netdata/netdata/pull/17240
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f37cbd18a..6db4c9f52 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -134,6 +134,7 @@ mark_as_advanced(DEFAULT_FEATURE_STATE)
+ # High-level features
+ option(ENABLE_ACLK "Enable Netdata Cloud support (ACLK)" ${DEFAULT_FEATURE_STATE})
+ option(ENABLE_CLOUD "Enable Netdata Cloud by default at runtime" ${DEFAULT_FEATURE_STATE})
++option(ENABLE_DASHBOARD_V2 "enable dashboard v2" True)
+ option(ENABLE_ML "Enable machine learning features" ${DEFAULT_FEATURE_STATE})
+ option(ENABLE_DBENGINE "Enable dbengine metrics storage" True)
+
+@@ -2946,7 +2947,9 @@ endif()
+ #
+
+ include(src/web/gui/v1/dashboard_v1.cmake)
+-include(src/web/gui/v2/dashboard_v2.cmake)
++if(ENABLE_DASHBOARD_V2)
++        include(src/web/gui/v2/dashboard_v2.cmake)
++endif()
+ include(src/web/gui/gui.cmake)
+
+ function(cat IN_FILE OUT_FILE)

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, pkg-config, makeWrapper
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, makeWrapper
 , CoreFoundation, IOKit, libossp_uuid
 , nixosTests
 , bash, curl, jemalloc, json_c, libuv, zlib, libyaml, libelf, libbpf
@@ -20,7 +20,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.45.4";
+  version = "1.46.1";
   pname = "netdata";
 
   src = fetchFromGitHub {
@@ -28,9 +28,9 @@ stdenv.mkDerivation rec {
     repo = "netdata";
     rev = "v${version}";
     hash = if withCloudUi
-      then "sha256-g/wxKtpNsDw/ZaUokdip39enQHMysJE6pYGsApuL4po="
+      then "sha256-tFjczhJ7bIEUDZx3MxYBu4tGkJhoQn5V79D4sLV2o8U="
       # we delete the v2 GUI after fetching
-      else "sha256-Mkrmvdr19sWzFOkdpt46mcsbA3CNpXy4w8um95xaWlo=";
+      else "sha256-uW3jRiJjFIFSfmmavM3KVF985F8nMKa+lQAgNBZvKyE=";
     fetchSubmodules = true;
 
     # Remove v2 dashboard distributed under NCUL1. Make sure an empty
@@ -60,18 +60,12 @@ stdenv.mkDerivation rec {
     ++ lib.optionals withSsl [ openssl ];
 
   patches = [
+    # Allow ndsudo to use non-hardcoded `PATH`
+    # See https://github.com/netdata/netdata/pull/17377#issuecomment-2183017868
+    #     https://github.com/netdata/netdata/security/advisories/GHSA-pmhq-4cxq-wj93
+    ./ndsudo-fix-path.patch
     # Allow building without non-free v2 dashboard.
-    (fetchpatch {
-      url = "https://github.com/netdata/netdata/pull/17240/commits/b108df72281633234b731b223d99ec99f1d36adf.patch";
-      hash = "sha256-tgsnbNY0pxFU3bz1J1qPaAeVsozsk2bpHV2mNy8A9is=";
-    })
-    # Allow for go.d plugins to access the right directory.
-    # Can be removed once > v1.45.4 is released
-    # https://github.com/netdata/netdata/pull/17661
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/netdata/netdata/pull/17661.patch";
-      sha256 = "sha256-j+mrwkibQio2KO8UnV7sxzCoHmkcsalHNzP+YvrRz74=";
-    })
+    ./dashboard-v2-removal.patch
   ];
 
   # Guard against unused buld-time development inputs in closure. Without
@@ -186,7 +180,7 @@ stdenv.mkDerivation rec {
 
       sourceRoot = "${src.name}/src/go/collectors/go.d.plugin";
 
-      vendorHash = "sha256-KO+xMk6fpZCYRyxxKrsGfOHJ2bwjBaSmkgz1jIUHaZs=";
+      vendorHash = "sha256-fK6pboXgJom77iakb+CJvNuweQjLIrpS7suWRNY/KM4=";
       doCheck = false;
       proxyVendor = true;
 

--- a/pkgs/tools/system/netdata/ndsudo-fix-path.patch
+++ b/pkgs/tools/system/netdata/ndsudo-fix-path.patch
@@ -1,0 +1,16 @@
+# See https://github.com/netdata/netdata/pull/17377#issuecomment-2183017868
+#     https://github.com/netdata/netdata/security/advisories/GHSA-pmhq-4cxq-wj93
+
+diff --git a/src/collectors/plugins.d/ndsudo.c b/src/collectors/plugins.d/ndsudo.c
+index 8b4d76f46..68fa52d38 100644
+--- a/src/collectors/plugins.d/ndsudo.c
++++ b/src/collectors/plugins.d/ndsudo.c
+@@ -357,9 +357,6 @@ int main(int argc, char *argv[]) {
+         return 3;
+     }
+
+-    char new_path[] = "PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin";
+-    putenv(new_path);
+-
+     bool found = false;
+     char filename[FILENAME_MAX];


### PR DESCRIPTION
## Description of changes

This is just a simple version bump, thanks to all the heavy lifting done in https://github.com/NixOS/nixpkgs/pull/298641. Changelog: https://github.com/netdata/netdata/compare/v1.45.4...v1.46.1

- requires https://github.com/NixOS/nixpkgs/pull/321641 to be merged first otherwise the test fails
- the patch to optionally disable dashboard v2 is now outdated in the upstream repo, so I had to bring it back here. 
- the path for `ndsudo` to use non-hardcoded `PATH` env added

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


cc: @rhoriguchi 