### PR TITLE
wootility: implement `NIXOS_OZONE_WL` and add `.desktop` file

### DIFF
--- a/pkgs/tools/misc/wootility/default.nix
+++ b/pkgs/tools/misc/wootility/default.nix
@@ -4,6 +4,7 @@
 , xorg
 , udev
 , wooting-udev-rules
+, makeWrapper
 }:
 
 appimageTools.wrapType2 rec {
@@ -14,6 +15,20 @@ appimageTools.wrapType2 rec {
     url = "https://s3.eu-west-2.amazonaws.com/wooting-update/wootility-lekker-linux-latest/wootility-lekker-${version}.AppImage";
     sha256 = "sha256-JodmF3TThPpXXx1eOnYmYAJ4x5Ylcf35bw3R++5/Buk=";
   };
+
+  extraInstallCommands =
+    let contents = appimageTools.extract { inherit pname version src; };
+    in ''
+      source "${makeWrapper}/nix-support/setup-hook"
+      wrapProgram $out/bin/wootility \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+
+      install -Dm444 ${contents}/wootility-lekker.desktop -t $out/share/applications
+      install -Dm444 ${contents}/wootility-lekker.png -t $out/share/pixmaps
+      substituteInPlace $out/share/applications/wootility-lekker.desktop \
+        --replace-fail 'Exec=AppRun' 'Exec=wootility' \
+        --replace-warn 'Name=wootility-lekker' 'Name=Wootility'
+    '';
 
   profile = ''
     export LC_ALL=C.UTF-8

--- a/pkgs/tools/misc/wootility/default.nix
+++ b/pkgs/tools/misc/wootility/default.nix
@@ -46,7 +46,7 @@ appimageTools.wrapType2 rec {
     homepage = "https://wooting.io/wootility";
     description = "Customization and management software for Wooting keyboards";
     platforms = [ "x86_64-linux" ];
-    license = "unknown";
+    license = licenses.unfree;
     maintainers = with maintainers; [ davidtwco sodiboo ];
     mainProgram = "wootility";
   };

--- a/pkgs/tools/misc/wootility/default.nix
+++ b/pkgs/tools/misc/wootility/default.nix
@@ -32,7 +32,7 @@ appimageTools.wrapType2 rec {
     description = "Customization and management software for Wooting keyboards";
     platforms = [ "x86_64-linux" ];
     license = "unknown";
-    maintainers = with maintainers; [ davidtwco ];
+    maintainers = with maintainers; [ davidtwco sodiboo ];
     mainProgram = "wootility";
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Now, the icon and `.desktop` file for wootility are copied to the output. Additionally, we wrap the main executable with a `makeWraper` that adds ozone platform hints. 

With this change, i can both open wootility from my fuzzel (rather than the terminal) and it works fine on wayland without passing flags manually. I've tested this on my own system and it works great.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
