### PR TITLE
Clean calibre packaging

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -26,6 +26,8 @@
 , wrapQtAppsHook
 , xdg-utils
 , wrapGAppsHook3
+, popplerSupport ? true
+, speechSupport ? true
 , unrarSupport ? false
 }:
 
@@ -117,7 +119,6 @@ stdenv.mkDerivation (finalAttrs: {
       regex
       sip
       setuptools
-      speechd
       zeroconf
       jeepney
       pycryptodome
@@ -130,7 +131,7 @@ stdenv.mkDerivation (finalAttrs: {
       # does not support by simply omitting qtwebengine.
       pyqt6-webengine
     ] ++ lib.optional (unrarSupport) unrardll
-  );
+  ) ++ lib.optional (speechSupport) speechd;
 
   installPhase = ''
     runHook preInstall
@@ -171,15 +172,19 @@ stdenv.mkDerivation (finalAttrs: {
   dontWrapQtApps = true;
   dontWrapGApps = true;
 
-  preFixup = ''
-    for program in $out/bin/*; do
-      wrapProgram $program \
-        ''${qtWrapperArgs[@]} \
-        ''${gappsWrapperArgs[@]} \
-        --prefix PYTHONPATH : $PYTHONPATH \
-        --prefix PATH : ${poppler_utils.out}/bin
-    done
-  '';
+  preFixup =
+    let
+      popplerArgs = "--prefix PATH : ${poppler_utils.out}/bin";
+    in
+    ''
+      for program in $out/bin/*; do
+        wrapProgram $program \
+          ''${qtWrapperArgs[@]} \
+          ''${gappsWrapperArgs[@]} \
+          --prefix PYTHONPATH : $PYTHONPATH \
+          ${if popplerSupport then popplerArgs else ""}
+      done
+    '';
 
   meta = {
     homepage = "https://calibre-ebook.com";

--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -21,7 +21,6 @@
 , qmake
 , qtbase
 , qtwayland
-, removeReferencesTo
 , speechd
 , sqlite
 , wrapQtAppsHook
@@ -69,7 +68,6 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
     qmake
-    removeReferencesTo
     wrapGAppsHook3
     wrapQtAppsHook
   ];
@@ -173,13 +171,7 @@ stdenv.mkDerivation (finalAttrs: {
   dontWrapQtApps = true;
   dontWrapGApps = true;
 
-  # Remove some references to shrink the closure size. This reference (as of
-  # 2018-11-06) was a single string like the following:
-  #   /nix/store/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-podofo-0.9.6-dev/include/podofo/base/PdfVariant.h
   preFixup = ''
-    remove-references-to -t ${podofo.dev} \
-      $out/lib/calibre/calibre/plugins/podofo.so
-
     for program in $out/bin/*; do
       wrapProgram $program \
         ''${qtWrapperArgs[@]} \
@@ -188,8 +180,6 @@ stdenv.mkDerivation (finalAttrs: {
         --prefix PATH : ${poppler_utils.out}/bin
     done
   '';
-
-  disallowedReferences = [ podofo.dev ];
 
   meta = {
     homepage = "https://calibre-ebook.com";


### PR DESCRIPTION
## Description of changes

1. This PR remove `removeReferencesTo` since it makes no difference for calibre now, you can check it using `nix path-info -S .#calibre`.
1. This PR avoid wrapping `PYTHONPATH` into program, instead I use `python.withPackages` and let fixupPhase replace `!/usr/bin/env python` to the wrapped python automatically.

   I'll open another PR to build calibre from git source after 7.13 is released. This change ensure `sphinx` won't be regarded as a runtime dependency due to `PYTHONPATH`.

1. This PR add two args (`popplerSupport` and `speechSupport`) for users to override.

   In arch linux repo, `poppler_utils` and `speechd` are optional dependencies, so I add these options. Another reason is that [someone wants the option](https://github.com/NixOS/nixpkgs/pull/289684#issuecomment-1962919157).

1. Format the code using `nixfmt-rfc-style`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
