### PR TITLE
ghidra: reformat, 11.0.3 -> 11.1.1

### DIFF
--- a/pkgs/tools/security/ghidra/build.nix
+++ b/pkgs/tools/security/ghidra/build.nix
@@ -1,19 +1,20 @@
-{ stdenv
-, fetchFromGitHub
-, lib
-, callPackage
-, gradle_7
-, perl
-, makeBinaryWrapper
-, openjdk17
-, unzip
-, makeDesktopItem
-, copyDesktopItems
-, desktopToDarwinBundle
-, icoutils
-, xcbuild
-, protobuf
-, ghidra-extensions
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  callPackage,
+  gradle_7,
+  perl,
+  makeBinaryWrapper,
+  openjdk17,
+  unzip,
+  makeDesktopItem,
+  copyDesktopItems,
+  desktopToDarwinBundle,
+  icoutils,
+  xcbuild,
+  protobuf,
+  ghidra-extensions,
 }:
 
 let
@@ -76,26 +77,26 @@ let
 
   # Adds a gradle step that downloads all the dependencies to the gradle cache.
   addResolveStep = ''
-    cat >>build.gradle <<HERE
-task resolveDependencies {
-  doLast {
-    project.rootProject.allprojects.each { subProject ->
-      subProject.buildscript.configurations.each { configuration ->
-        resolveConfiguration(subProject, configuration, "buildscript config \''${configuration.name}")
-      }
-      subProject.configurations.each { configuration ->
-        resolveConfiguration(subProject, configuration, "config \''${configuration.name}")
+        cat >>build.gradle <<HERE
+    task resolveDependencies {
+      doLast {
+        project.rootProject.allprojects.each { subProject ->
+          subProject.buildscript.configurations.each { configuration ->
+            resolveConfiguration(subProject, configuration, "buildscript config \''${configuration.name}")
+          }
+          subProject.configurations.each { configuration ->
+            resolveConfiguration(subProject, configuration, "config \''${configuration.name}")
+          }
+        }
       }
     }
-  }
-}
-void resolveConfiguration(subProject, configuration, name) {
-  if (configuration.canBeResolved) {
-    logger.info("Resolving project {} {}", subProject.name, name)
-    configuration.resolve()
-  }
-}
-HERE
+    void resolveConfiguration(subProject, configuration, name) {
+      if (configuration.canBeResolved) {
+        logger.info("Resolving project {} {}", subProject.name, name)
+        configuration.resolve()
+      }
+    }
+    HERE
   '';
 
   # fake build to pre-download deps into fixed-output derivation
@@ -106,7 +107,10 @@ HERE
 
     postPatch = addResolveStep;
 
-    nativeBuildInputs = [ gradle perl ] ++ lib.optional stdenv.isDarwin xcbuild;
+    nativeBuildInputs = [
+      gradle
+      perl
+    ] ++ lib.optional stdenv.isDarwin xcbuild;
     buildPhase = ''
       runHook preBuild
       export HOME="$NIX_BUILD_TOP/home"
@@ -134,9 +138,15 @@ HERE
     outputHashMode = "recursive";
     outputHash = "sha256-nKfJiGoZlDEpbCmYVKNZXz2PYIosCd4nPFdy3MfprHc=";
   };
-
-in stdenv.mkDerivation (finalAttrs: {
-  inherit pname version src patches postPatch;
+in
+stdenv.mkDerivation (finalAttrs: {
+  inherit
+    pname
+    version
+    src
+    patches
+    postPatch
+    ;
 
   desktopItems = [
     (makeDesktopItem {
@@ -150,16 +160,18 @@ in stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  nativeBuildInputs = [
-    gradle
-    unzip
-    makeBinaryWrapper
-    copyDesktopItems
-    protobuf
-  ] ++ lib.optionals stdenv.isDarwin [
-    xcbuild
-    desktopToDarwinBundle
-  ];
+  nativeBuildInputs =
+    [
+      gradle
+      unzip
+      makeBinaryWrapper
+      copyDesktopItems
+      protobuf
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      xcbuild
+      desktopToDarwinBundle
+    ];
 
   dontStrip = true;
 
@@ -211,7 +223,10 @@ in stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     inherit releaseName distroPrefix;
-    inherit (ghidra-extensions.override { ghidra = finalAttrs.finalPackage; }) buildGhidraExtension buildGhidraScripts;
+    inherit (ghidra-extensions.override { ghidra = finalAttrs.finalPackage; })
+      buildGhidraExtension
+      buildGhidraScripts
+      ;
 
     withExtensions = callPackage ./with-extensions.nix { ghidra = finalAttrs.finalPackage; };
   };
@@ -221,14 +236,21 @@ in stdenv.mkDerivation (finalAttrs: {
     description = "Software reverse engineering (SRE) suite of tools";
     mainProgram = "ghidra";
     homepage = "https://ghidra-sre.org/";
-    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
     sourceProvenance = with sourceTypes; [
       fromSource
-      binaryBytecode  # deps
+      binaryBytecode # deps
     ];
     license = licenses.asl20;
-    maintainers = with maintainers; [ roblabla vringar ];
+    maintainers = with maintainers; [
+      roblabla
+      vringar
+    ];
     broken = stdenv.isDarwin && stdenv.isx86_64;
   };
-
 })

--- a/pkgs/tools/security/ghidra/build.nix
+++ b/pkgs/tools/security/ghidra/build.nix
@@ -11,16 +11,17 @@
   makeDesktopItem,
   copyDesktopItems,
   desktopToDarwinBundle,
-  icoutils,
   xcbuild,
   protobuf,
   ghidra-extensions,
+  python3,
+  python3Packages,
 }:
 
 let
   pkg_path = "$out/lib/ghidra";
   pname = "ghidra";
-  version = "11.0.3";
+  version = "11.1.1";
 
   releaseName = "NIX";
   distroPrefix = "ghidra_${version}_${releaseName}";
@@ -28,7 +29,7 @@ let
     owner = "NationalSecurityAgency";
     repo = "Ghidra";
     rev = "Ghidra_${version}_build";
-    hash = "sha256-IiLxaJvfJcK275FDZEsUCGp7haJjp8O2fUIoM4F9H30=";
+    hash = "sha256-t96FcAK3JwO66dOf4OhpOfU8CQfAczfF61Cg7m+B3fA=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -136,7 +137,7 @@ let
     '';
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "sha256-nKfJiGoZlDEpbCmYVKNZXz2PYIosCd4nPFdy3MfprHc=";
+    outputHash = "sha256-66gL4UFlBUo2JIEOXoF6tFvXtBdEX4b2MeSrV1b6Vg4=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -147,6 +148,12 @@ stdenv.mkDerivation (finalAttrs: {
     patches
     postPatch
     ;
+
+  # Don't create .orig files if the patch isn't an exact match.
+  patchFlags = [
+    "--no-backup-if-mismatch"
+    "-p1"
+  ];
 
   desktopItems = [
     (makeDesktopItem {
@@ -167,6 +174,8 @@ stdenv.mkDerivation (finalAttrs: {
       makeBinaryWrapper
       copyDesktopItems
       protobuf
+      python3
+      python3Packages.pip
     ]
     ++ lib.optionals stdenv.isDarwin [
       xcbuild


### PR DESCRIPTION
## Description of changes

Fairly straight-forward update of 11.0.3 to 11.1.1.

The patches still apply just fine, but they have some fuzz, which results in `.orig` files being added into the working directory, this breaks the build due to the IP check (which validates the licenses/copyrights allowed in Ghidra) because the file extension matters for this check. This is pretty undesirable so I add some `patchFlags` to prevent it, to reduce unnecessary churn in the patches.

Tested on `x86_64-linux` and `aarch64-darwin`. Tested loading and upgrading a project to 11.1.1 in code browser. Tested building and running with all Nixpkgs extensions and scripts, and ensuring that they show up as expected.

Upstream changelog: https://htmlpreview.github.io/?https://github.com/NationalSecurityAgency/ghidra/blob/Ghidra_11.1.1_build/Ghidra/Configurations/Public_Release/src/global/docs/ChangeHistory.html

Many improvements were made to the debugger, as well as accessibility in the UI, making it more usable for users who need to navigate with keyboard. The PDB analyzer is now split into multiple parts so that later portions of the analysis can benefit from work done in interim analyzers. Go 1.21 and 1.22 binaries are now supported, as well as AArch64/Apple Silicon Go binaries.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
