### PR TITLE
certmgr: fix kubernetes system certs recreate loop

### DIFF
--- a/pkgs/by-name/ce/certmgr/package.nix
+++ b/pkgs/by-name/ce/certmgr/package.nix
@@ -16,6 +16,8 @@ buildGoModule rec {
 
   vendorHash = null;
 
+  patches = [ ./system-service-certs.patch ];
+
   ldflags = [ "-s" "-w" ];
 
   meta = with lib; {

--- a/pkgs/by-name/ce/certmgr/system-service-certs.patch
+++ b/pkgs/by-name/ce/certmgr/system-service-certs.patch
@@ -1,0 +1,14 @@
+diff --git a/cert/verification.go b/cert/verification.go
+index 39f255c..97fa613 100644
+--- a/cert/verification.go
++++ b/cert/verification.go
+@@ -10,6 +10,9 @@ import (
+
+ // CertificateMatchesHostname checks if the Certificates hosts are the same as the given hosts
+ func CertificateMatchesHostname(hosts []string, cert *x509.Certificate) bool {
++	// kubernetes system certs (i.e. CN=system:kube-proxy)
++	if len(hosts) == 1 && len(cert.DNSNames)+len(cert.IPAddresses) == 0 { return true }
++
+ 	a := make([]string, len(hosts))
+ 	for idx := range hosts {
+ 		// normalize the IPs.


### PR DESCRIPTION
## Avoid unnecessary regeneration of kubernetes system certs

Kubernetes system certs have a CN which is not a vaild DNS name (e.g. system:kube-proxy). The new certmgr has a check that the requested CN and hosts match the DNS names and IP:s of the actual cert on disk. This check always fails for kubernetes system certs, causing them to be regenerated every 30m. This restarts kube-apiserver et al. and causes a lot of noise and service interruption. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Patch certmgr to ignore DNS and IP checks for CN:s with `:` in the name (I will file a PR with the upstream certmgr repo as well).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
