### PR TITLE
tinyfugue: darwin support

### DIFF
--- a/pkgs/games/tinyfugue/001-darwin-fixes.patch
+++ b/pkgs/games/tinyfugue/001-darwin-fixes.patch
@@ -1,0 +1,27 @@
+diff --git a/src/malloc.h b/src/malloc.h
+index cc4d3bf..bbf78cd 100644
+--- a/src/malloc.h
++++ b/src/malloc.h
+@@ -34,6 +34,10 @@ extern int low_memory_warning;
+ # define realloc(ptr, size)		mrealloc(NULL, ptr, size)
+ # define free(ptr)			mfree(NULL, ptr)
+ #else
++#ifdef __APPLE__
++    #include <stdlib.h>
++    #include <sys/types.h>
++#endif
+ # define mmalloc(md, size)		malloc(size)
+ # define mcalloc(md, size)		calloc(size)
+ # define mrealloc(md, ptr, size)	realloc(ptr, size)
+diff --git a/src/tfio.c b/src/tfio.c
+index 2cd2103..8640f2b 100644
+--- a/src/tfio.c
++++ b/src/tfio.c
+@@ -70,6 +70,7 @@ static void fileputs(const char *str, FILE *fp);
+ static void filenputs(const char *str, int n, FILE *fp);
+ static void queueputline(conString *line, TFILE *file);
+ 
++extern void    main_loop(void);
+ 
+ void init_tfio(void)
+ {

--- a/pkgs/games/tinyfugue/default.nix
+++ b/pkgs/games/tinyfugue/default.nix
@@ -1,6 +1,11 @@
-{ lib, stdenv, fetchurl, ncurses, zlib
-, openssl ? null
-, sslSupport ? true
+{
+  lib,
+  stdenv,
+  fetchurl,
+  ncurses,
+  zlib,
+  openssl,
+  sslSupport ? true,
 }:
 
 assert sslSupport -> openssl != null;
@@ -24,11 +29,16 @@ stdenv.mkDerivation rec {
     sha256 = "12fra2fdwqj6ilv9wdkc33rkj343rdcf5jyff4yiwywlrwaa2l1p";
   };
 
+  patches = [
+    ./001-darwin-fixes.patch
+  ];
+
   configureFlags = optional (!sslSupport) "--disable-ssl";
 
-  buildInputs =
-    [ ncurses zlib ]
-    ++ optional sslSupport openssl;
+  buildInputs = [
+    ncurses
+    zlib
+  ] ++ optional sslSupport openssl;
 
   # Workaround build failure on -fno-common toolchains like upstream
   # gcc-10. Otherwise build fails as:
@@ -45,7 +55,7 @@ stdenv.mkDerivation rec {
       with any type of text MUD.
     '';
     license = licenses.gpl2;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.KibaFox ];
   };
 }


### PR DESCRIPTION
## Description of changes

Fixes  #321611.

Didn't touch the derivation too much as quite outdated, but happy to reformat and modernise it if required.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
