### PR TITLE
key-rack: init at 0.4.0

### DIFF
--- a/pkgs/by-name/ke/key-rack/0001-fix-E0716.patch
+++ b/pkgs/by-name/ke/key-rack/0001-fix-E0716.patch
@@ -1,0 +1,27 @@
+From 0b1d9759c43629dcd3d3a6216ea47b09516a5d84 Mon Sep 17 00:00:00 2001
+From: seth <getchoo@tuta.io>
+Date: Sat, 6 Jul 2024 18:59:50 -0400
+Subject: [PATCH] fix E0716
+
+doesn't seem to have popped up in upstream's CI. maybe this is only an
+issue in rust versions < 1.79?
+---
+ src/data/item.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/data/item.rs b/src/data/item.rs
+index 43dcf6f..985be74 100644
+--- a/src/data/item.rs
++++ b/src/data/item.rs
+@@ -327,7 +327,7 @@ impl ItemSchema {
+             Self::Unknown(schema) => {
+                 let info = crate::utils::AppInfo::new(schema);
+                 if info.is_installed() {
+-                    &format!("{schema}-symbolic")
++                    return format!("{schema}-symbolic");
+                 } else {
+                     "dialog-password-symbolic"
+                 }
+-- 
+2.45.1
+

--- a/pkgs/by-name/ke/key-rack/package.nix
+++ b/pkgs/by-name/ke/key-rack/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  fetchFromGitLab,
+  stdenv,
+  rustPlatform,
+  cargo,
+  rustc,
+  libadwaita,
+  meson,
+  ninja,
+  nix-update-script,
+  pkg-config,
+  python3,
+  wrapGAppsHook4,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "key-rack";
+  version = "0.4.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "sophie-h";
+    repo = "key-rack";
+    rev = finalAttrs.version;
+    hash = "sha256-mthXtTlyrIChaKKwKosTsV1hK9OQ/zLScjrq6D3CRsg=";
+  };
+
+  patches = [ ./0001-fix-E0716.patch ];
+
+  postPatch = ''
+    patchShebangs --build build-aux/{checks.sh,read-manifest.py}
+  '';
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-wCJTm0W+g3+O1t1fR4maqJoxpPM0NeJG7d54MMAH33c=";
+  };
+
+  nativeBuildInputs = [
+    cargo
+    rustc
+    meson
+    ninja
+    pkg-config
+    python3
+    rustPlatform.cargoSetupHook
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [ libadwaita ];
+
+  # Workaround for the gettext-sys issue
+  # https://github.com/Koka/gettext-rs/issues/114
+  env.NIX_CFLAGS_COMPILE = lib.optionalString (
+    stdenv.cc.isClang && lib.versionAtLeast stdenv.cc.version "16"
+  ) "-Wno-error=incompatible-function-pointer-types";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "View and edit your apps’ keys";
+    homepage = "https://gitlab.gnome.org/sophie-h/key-rack";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ getchoo ];
+    mainProgram = "key-rack";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Key Rack allows to view and edit keys, like passwords or tokens, stored by apps. It is meant to eventually replace Seahorse (as explained [here](https://thisweek.gnome.org/posts/2024/06/twig-153/))

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
