### PR TITLE
budgie.budgie-desktop: 10.9.1 -> 10.9.2

### DIFF
--- a/pkgs/desktops/budgie/budgie-desktop/default.nix
+++ b/pkgs/desktops/budgie/budgie-desktop/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch2
 , accountsservice
 , alsa-lib
 , budgie-screensaver
@@ -38,39 +37,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "budgie-desktop";
-  version = "10.9.1";
+  version = "10.9.2";
 
   src = fetchFromGitHub {
     owner = "BuddiesOfBudgie";
     repo = "budgie-desktop";
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-H+J/zFUjiXbr5ynDkkjrRsEbyO4LPOhqe8DdG60ikRw=";
+    hash = "sha256-lDsQlUAa79gnM8wC5pwyquvFyEiayH4W4gD/uyC5Koo=";
   };
 
   patches = [
     ./plugins.patch
-
-    # Fix workspace applet window icon click not performing workspace switch
-    # https://github.com/BuddiesOfBudgie/budgie-desktop/issues/524
-    (fetchpatch2 {
-      url = "https://github.com/BuddiesOfBudgie/budgie-desktop/commit/9b775d613ad0c324db628ed5a32d3fccc90f82d6.patch";
-      hash = "sha256-QtPviPW7pJYZIs28CYwE3N8vcDswqnjD6d0WVPFchL4=";
-    })
-
-    # Work around even more SNI noncompliance
-    # https://github.com/BuddiesOfBudgie/budgie-desktop/issues/539
-    (fetchpatch2 {
-      url = "https://github.com/BuddiesOfBudgie/budgie-desktop/commit/84269e2fcdcac6d737ee5100881e8b306eaae570.patch";
-      hash = "sha256-1Uj+6GZ9/oDQOt+5P8UYiVP3P0BrsJe3HqXVLkWCkAM=";
-    })
-
-    # vapi: Update libxfce4windowing to 4.19.3
-    # https://github.com/BuddiesOfBudgie/budgie-desktop/issues/546
-    (fetchpatch2 {
-      url = "https://github.com/BuddiesOfBudgie/budgie-desktop/commit/a040ccb96094f1d3a1ee81a6733c9434722bdf6c.patch";
-      hash = "sha256-9eMYB5Zyn3BDYvAwORXTHaPGYDP7LnqHAwp+6Wy6XLk=";
-    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://github.com/BuddiesOfBudgie/budgie-desktop/compare/v10.9.1...v10.9.2

![](https://github.com/NixOS/nixpkgs/assets/20080233/b3d5d473-fd28-48f0-b93a-070f37829ec2)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

