### PR TITLE
ear2ctl: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8953,6 +8953,11 @@
     githubId = 3874017;
     name = "Jappie Klooster";
   };
+  jaredmontoya = {
+    name = "Jared Montoya";
+    github = "jaredmontoya";
+    githubId = 49511278;
+  };
   jasoncarr = {
     email = "jcarr250@gmail.com";
     github = "jasoncarr0";
@@ -14002,11 +14007,6 @@
     github = "nbren12";
     githubId = 1386642;
     name = "Noah Brenowitz";
-  };
-  jaredmontoya = {
-    name = "Jared Montoya";
-    github = "jaredmontoya";
-    githubId = 49511278;
   };
   nbsp = {
     email = "aoife@enby.space";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14003,6 +14003,11 @@
     githubId = 1386642;
     name = "Noah Brenowitz";
   };
+  jaredmontoya = {
+    name = "Jared Montoya";
+    github = "jaredmontoya";
+    githubId = 49511278;
+  };
   nbsp = {
     email = "aoife@enby.space";
     matrix = "@nbsp:enby.space";

--- a/pkgs/by-name/ea/ear2ctl/package.nix
+++ b/pkgs/by-name/ea/ear2ctl/package.nix
@@ -1,0 +1,27 @@
+{ lib, rustPlatform, fetchFromGitLab, pkg-config, dbus }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "ear2ctl";
+  version = "0.1.0";
+
+  src = fetchFromGitLab {
+    owner = "bharadwaj-raju";
+    repo = pname;
+    rev = version;
+    hash = "sha256-xaxl4opLMw9KEDpmNcgR1fBGUqO4BP5a/U52Kz+GAvc=";
+  };
+
+  cargoHash = "sha256-ax+/lvdEOjLnwE3Gvji7aaeF9KXjoOXdlTvxYDo8wGI=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ dbus ];
+
+  meta = with lib; {
+    description = "Controls for the Nothing Ear (2)";
+    homepage = "https://gitlab.com/bharadwaj-raju/ear2ctl";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    mainProgram = "ear2ctl";
+  };
+}

--- a/pkgs/by-name/ea/ear2ctl/package.nix
+++ b/pkgs/by-name/ea/ear2ctl/package.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ dbus ];
 
   meta = with lib; {
-    description = "Controls for the Nothing Ear (2)";
+    description = "Linux controller for the Nothing Ear (2)";
     homepage = "https://gitlab.com/bharadwaj-raju/ear2ctl";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;

--- a/pkgs/by-name/ea/ear2ctl/package.nix
+++ b/pkgs/by-name/ea/ear2ctl/package.nix
@@ -6,7 +6,7 @@ rustPlatform.buildRustPackage rec {
 
   src = fetchFromGitLab {
     owner = "bharadwaj-raju";
-    repo = pname;
+    repo = "ear2ctl";
     rev = version;
     hash = "sha256-xaxl4opLMw9KEDpmNcgR1fBGUqO4BP5a/U52Kz+GAvc=";
   };

--- a/pkgs/by-name/ea/ear2ctl/package.nix
+++ b/pkgs/by-name/ea/ear2ctl/package.nix
@@ -17,11 +17,11 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ dbus ];
 
-  meta = with lib; {
+  meta = {
     description = "Linux controller for the Nothing Ear (2)";
     homepage = "https://gitlab.com/bharadwaj-raju/ear2ctl";
-    license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
     mainProgram = "ear2ctl";
   };
 }

--- a/pkgs/by-name/ea/ear2ctl/package.nix
+++ b/pkgs/by-name/ea/ear2ctl/package.nix
@@ -20,6 +20,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Linux controller for the Nothing Ear (2)";
     homepage = "https://gitlab.com/bharadwaj-raju/ear2ctl";
+    maintainers = with lib.maintainers; [ jaredmontoya ];
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     mainProgram = "ear2ctl";


### PR DESCRIPTION
## Description of changes
Added ear2ctl package, a cli tool for controlling Nothing ear earbuds over bluetooth.

I used `nix-init` to generate this package and checked it with `nixpkgs-fmt`.
Then built with `nix run nixpkgs#nixpkgs-review rev HEAD` on my x86_64-linux machine and ran the resulting executable with the --help flag.

The maintainer list is not set because I don't want to block this package's updates made by someone else in case I do not respond to the ping in the future. If this is a requirement, I will fill it out.

This is my first contribution to nixpkgs. If I made any mistakes please kindly point me to them.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
