### PR TITLE
gnome-podcasts: 0.6.1 -> 0.7.1

### DIFF
--- a/pkgs/applications/audio/gnome-podcasts/default.nix
+++ b/pkgs/applications/audio/gnome-podcasts/default.nix
@@ -15,6 +15,7 @@
 , desktop-file-utils
 , dbus
 , openssl
+, glib-networking
 , sqlite
 , gst_all_1
 , wrapGAppsHook4
@@ -22,19 +23,19 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-podcasts";
-  version = "0.6.1";
+  version = "0.7.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "podcasts";
     rev = version;
-    hash = "sha256-LPwCYgAFgUMFQZ0i4ldiuGYGMMWcMqYct3/o7eTIhmU=";
+    hash = "sha256-KCjHT/4AeJ+RXCtawkhs6f4D8NCJotYIPk3tGr5YG9M=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit pname version src;
-    hash = "sha256-n3ZcUhqn1rvvgkBKSKvH0b8wbOCqcBGwpb2OqMe8h0s=";
+    hash = "sha256-XTfKqKs7874ak7Lzscxw8E2qcnJOWMZaaol8TpIB6Vw=";
   };
 
   nativeBuildInputs = [
@@ -56,6 +57,7 @@ stdenv.mkDerivation rec {
     gettext
     dbus
     openssl
+    glib-networking
     sqlite
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
@@ -66,13 +68,13 @@ stdenv.mkDerivation rec {
   # tests require network
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Listen to your favorite podcasts";
     mainProgram = "gnome-podcasts";
     homepage = "https://apps.gnome.org/Podcasts/";
-    license = licenses.gpl3Plus;
-    maintainers = teams.gnome.members;
-    platforms = platforms.unix;
+    license = lib.licenses.gpl3Plus;
+    maintainers = lib.teams.gnome.members;
+    platforms = lib.platforms.unix;
     broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/trunk/gnome-podcasts.x86_64-darwin
   };
 }


### PR DESCRIPTION
## Description of changes

Changelog: https://gitlab.gnome.org/World/podcasts/-/blob/0.7.1/CHANGELOG.md

Diff: https://gitlab.gnome.org/World/podcasts/-/compare/0.6.1...0.7.1


![image](https://github.com/NixOS/nixpkgs/assets/42209822/a4ff5fd0-6fa2-4759-a002-598fdbcd7d54)

Adding `glib-networking` fixes:

```                                                                                                                         
(gnome-podcasts:191149): Adwaita-CRITICAL **: 22:36:45.203: Page 'Command Control Power: Apple Tech Support & Business Talk' is not in the navigation stack
                                                                                                                                                           
 ERROR podcasts_gtk::widgets::player    > gstreamer error: Error from element /GstPlayBin3:playbin3/GstURIDecodeBin3:uridecodebin3/GstURISourceBin:urisourc
ebin0/GstSoupHTTPSrc:souphttpsrc2: GStreamer encountered a general stream error.                                                                           
Internal data stream error.                                                                                                                                
../libs/gst/base/gstbasesrc.c(3177): gst_base_src_loop (): /GstPlayBin3:playbin3/GstURIDecodeBin3:uridecodebin3/GstURISourceBin:urisourcebin0/GstSoupHTTPSr
c:souphttpsrc2:                                                                                                                                            
streaming stopped, reason error (-5) Some(                                                                                                                 
    Structure(                                                                                                                                             
        details {                                                                                                                                          
            flow-return: (gint) -5,
        },
    ),
)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
