### PR TITLE
android-studio: stable 2023.3.1.19 -> 2024.1.1.11, beta: 2023.3.1.17 -> 2024.1.1.10, canary, dev: 2024.1.1.4 -> 2024.1.2.7

### DIFF
--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -262,7 +262,7 @@ let
       inherit withSdk;
       sdk = androidSdk;
     };
-    meta = with lib; {
+    meta = {
       description = "Official IDE for Android (${channel} channel)";
       longDescription = ''
         Android Studio is the official IDE for Android app development, based on
@@ -271,7 +271,7 @@ let
       homepage = if channel == "stable"
         then "https://developer.android.com/studio/index.html"
         else "https://developer.android.com/studio/preview/index.html";
-      license = with licenses; [ asl20 unfree ]; # The code is under Apache-2.0, but:
+      license = with lib.licenses; [ asl20 unfree ]; # The code is under Apache-2.0, but:
       # If one selects Help -> Licenses in Android Studio, the dialog shows the following:
       # "Android Studio includes proprietary code subject to separate license,
       # including JetBrains CLion(R) (www.jetbrains.com/clion) and IntelliJ(R)
@@ -280,11 +280,11 @@ let
       # binaries are also distributed as proprietary software (unlike the
       # source-code itself).
       platforms = [ "x86_64-linux" ];
-      maintainers = with maintainers; rec {
-        stable = [ alapshin numinit ];
-        beta = [ alapshin numinit ];
-        canary = [ alapshin numinit ];
-        dev = canary;
+      maintainers = with lib.maintainers; rec {
+        stable = [ alapshin johnrtitor numinit ];
+        beta = stable;
+        canary = stable;
+        dev = stable;
       }."${channel}";
       mainProgram = pname;
     };

--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -10,16 +10,16 @@ let
     inherit tiling_wm;
   };
   stableVersion = {
-    version = "2023.3.1.19"; # "Android Studio Jellyfish | 2023.3.1 Patch 1"
-    sha256Hash = "sha256-FyscJPusmK33UPIexV20GXQ4Z5X8mfNRFPu/2Xeg5ts=";
+    version = "2024.1.1.11"; # "Android Studio Koala | 2024.1.1"
+    sha256Hash = "sha256-2PqOz+QVtEUTNQkBUB4qD0KcoDPPGAUFSxyBbEpwRWU=";
   };
   betaVersion = {
-    version = "2023.3.1.17"; # "Android Studio Jellyfish | 2023.3.1.1 RC 2"
-    sha256Hash = "sha256-zROBKzQiP4V2P67HgOIkHgn8q/M0zy5MkZozVSiQsWU=";
+    version = "2024.1.1.10"; # "Android Studio Koala | 2024.1.1 RC 2"
+    sha256Hash = "sha256-84CpZfoAvJHUCO3ZBJqDbuz9xuGE/5xJfXoetJDXju8=";
   };
   latestVersion = {
-    version = "2024.1.1.4"; # "Android Studio Koala | 2024.1.1 Canary 6"
-    sha256Hash = "sha256-lfig7lFyF7XZowTQKpo6zGeR23VHq/f7vvUDWCs7jeo=";
+    version = "2024.1.2.7"; # "Android Studio Koala Feature Drop | 2024.1.2 Canary 7"
+    sha256Hash = "sha256-opoAKslh8DqS/iS5gw8AxX6x89t2BNX7yaU88XNd2kM=";
   };
 in {
   # Attributes are named by their corresponding release channels


### PR DESCRIPTION

## Description of changes

1. stable 2023.3.1.19 -> 2024.1.1.11
2. beta: 2023.3.1.17 -> 2024.1.1.10
3. canary, dev: 2024.1.1.4 -> 2024.1.2.7


From https://github.com/JetBrains/intellij-sdk-docs/blob/main/topics/_generated/android_studio_releases.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
