### PR TITLE
nixos/syncthing: prevent enabling overrideFolders and autoAcceptFolders simultaneously

### DIFF
--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -29,6 +29,8 @@ let
     deviceID = device.id;
   }) cfg.settings.devices;
 
+  anyAutoAccept = builtins.any (dev: dev.autoAcceptFolders) devices;
+
   folders = mapAttrsToList (_: folder: folder //
     throwIf (folder?rescanInterval || folder?watch || folder?watchDelay) ''
       The options services.syncthing.settings.folders.<name>.{rescanInterval,watch,watchDelay}
@@ -180,7 +182,12 @@ in {
 
       overrideFolders = mkOption {
         type = types.bool;
-        default = true;
+        default = !anyAutoAccept;
+        defaultText = literalMD ''
+          `true` unless any device has the
+          [autoAcceptFolders](#opt-services.syncthing.settings.devices.<name>.autoAcceptFolders)
+          option set to `true`.
+        '';
         description = ''
           Whether to delete the folders which are not configured via the
           [folders](#opt-services.syncthing.settings.folders) option.
@@ -611,6 +618,15 @@ in {
   ###### implementation
 
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(cfg.overrideFolders && anyAutoAccept);
+        message = ''
+          services.syncthing.overrideFolders will delete auto-accepted folders
+          from the configuration, creating path conflicts.
+        '';
+      }
+    ];
 
     networking.firewall = mkIf cfg.openDefaultPorts {
       allowedTCPPorts = [ 22000 ];

--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -185,7 +185,7 @@ in {
         default = !anyAutoAccept;
         defaultText = literalMD ''
           `true` unless any device has the
-          [autoAcceptFolders](#opt-services.syncthing.settings.devices.<name>.autoAcceptFolders)
+          [autoAcceptFolders](#opt-services.syncthing.settings.devices._name_.autoAcceptFolders)
           option set to `true`.
         '';
         description = ''


### PR DESCRIPTION
## Description of changes

If `services.syncthing.overrideFolders` is set to `true` when syncthing is also configured to auto-accept folders from at least one device, the auto-accepted folders will be deleted from the configuration following a restart, but the actual folders will still be present, creating path conflicts when syncthing attempts to auto-accept the folders again. This PR makes `overrideFolders` default to `false` rather than `true` if any device has `autoAcceptFolders` set to `true`, and raises an assertion if `overrideFolders` is manually set to `true` at the same time as `autoAcceptFolders`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
