### PR TITLE
connectome-workbench: init at 2.0.0

### DIFF
--- a/pkgs/by-name/co/connectome-workbench/package.nix
+++ b/pkgs/by-name/co/connectome-workbench/package.nix
@@ -1,0 +1,65 @@
+{ lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  libGL,
+  libGLU,
+  libsForQt5,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "connectome-workbench";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "Washington-University";
+    repo = "workbench";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-d0J5bXp6mJlUQBmInxPXPkd5P5H+3F6fE9fc8pD1fUc=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/src";
+
+  patches = [
+    # remove after next release:
+    (fetchpatch {
+      name = "fix-missing-includes-in-CZIlib";
+      url = "https://github.com/Washington-University/workbench/commit/7ba3345d161d567a4b628ceb02ab4471fc96cb20.diff";
+      hash = "sha256-DMrJOr/2Wr4o4Z3AuhWfMZTX8f/kOYWwZQzBUwIrTd8=";
+      relative = "src";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt  \
+      --replace-fail "ADD_SUBDIRECTORY ( Tests )" ""  \
+      --replace-fail "ENABLE_TESTING()" ""
+  '';
+  # tests are minimal and test_driver fails to link (also -DBUILD_TESTING=... is ignored):
+  # ld: ../Brain/libBrain.a(BrainOpenGLVolumeObliqueSliceDrawing.cxx.o): undefined reference to symbol 'glGetFloatv'
+  # ld: /nix/store/a5vcvrkh1c2ng5kr584g3zw3991vnhks-libGL-1.7.0/lib/libGL.so.1: error adding symbols: DSO missing from command line
+
+  nativeBuildInputs = [
+    cmake
+    libsForQt5.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    libGL
+    libGLU
+  ] ++ (with libsForQt5; [
+    qtbase
+  ]);
+  # note: we should be able to unvendor a few libs (ftgl, quazip, qwt) but they aren't detected properly
+
+  meta = {
+    description = "Visualization and discovery tool used to map neuroimaging data";
+    homepage = "https://www.humanconnectome.org/software/connectome-workbench";
+    license = with lib.licenses; [ gpl2Plus gpl3Plus mit ];
+    changelog = "https://github.com/Washington-University/workbench/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ bcdarwin ];
+    mainProgram = "wb_command";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Init `connectome-workbench`, a [package for processing and visualization of neuroimaging data](https://www.humanconnectome.org/software/connectome-workbench).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
