### PR TITLE
[Backport release-24.05] teamviewer: 15.49.2 -> 15.54.3

### DIFF
--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -6,11 +6,6 @@
 , makeWrapper
 , xdg-utils
 , dbus
-, qtbase
-, qtwebengine
-, qtx11extras
-, qtquickcontrols2
-, qtgraphicaleffects
 , getconf
 , glibc
 , libXrandr
@@ -23,13 +18,15 @@
 , coreutils
 , wrapQtAppsHook
 , icu63
+, nss
+, minizip
 }:
 
 mkDerivation rec {
   pname = "teamviewer";
   # teamviewer itself has not development files but the dev output removes propagated other dev outputs from runtime
   outputs = [ "out" "dev" ];
-  version = "15.49.2";
+  version = "15.54.3";
 
   src =
     let
@@ -38,11 +35,11 @@ mkDerivation rec {
       {
        x86_64-linux = fetchurl {
           url = "${base_url}/teamviewer_${version}_amd64.deb";
-          sha256 = "sha256-Ag41RQD4lp4Sxuz6wZwiFzVxUalV+M3Zwa2Cug4iNSM=";
+          hash = "sha256-41zVX2svomcRKu2ow1A/EeKojBIpABO4o2EZxappzgo=";
        };
        aarch64-linux = fetchurl {
           url = "${base_url}/teamviewer_${version}_arm64.deb";
-          sha256 = "sha256-JGSmFq4q8TQJVIrS6qQxIxZPNKgor+pFetextLJPHtg=";
+          hash = "sha256-wuQYWeYgXW54/5dpiGzJxZ9JZDlUgFgCKq8Z4xV2HlI=";
        };
       }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
@@ -52,7 +49,7 @@ mkDerivation rec {
   '';
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper wrapQtAppsHook ];
-  buildInputs = [ qtbase qtwebengine qtx11extras qtquickcontrols2 qtgraphicaleffects icu63 ];
+  buildInputs = [ minizip icu63 nss ];
 
   installPhase = ''
     mkdir -p $out/share/teamviewer $out/bin $out/share/applications
@@ -60,27 +57,10 @@ mkDerivation rec {
     rm -R \
       $out/share/teamviewer/logfiles \
       $out/share/teamviewer/config \
-      $out/share/teamviewer/tv_bin/xdg-utils \
       $out/share/teamviewer/tv_bin/script/{teamviewer_setup,teamviewerd.sysv,teamviewerd.service,teamviewerd.*.conf,tv-delayed-start.sh}
 
-    # Teamviewer packages its own qt library files.
-    # Most of them can be replaced by nixpkgs libraries, but the following need to be used beginning at version 15.35.7
-    # because teamviewer will not start without them, either stalling at startup or even segfaulting. In the logfiles, some missing qt libraries
-    # can be observed, although they are present from nixpkgs. AutoPatchelfHook will automatically choose the included libraries, if present.
-    # See https://github.com/NixOS/nixpkgs/pull/202024
-
-    # delete all library files except "qt" folder
-    find $out/share/teamviewer/tv_bin/RTlib -depth  -maxdepth 1 ! -type d -execdir rm -rf {} +
-
-    # remove all other folders except "qml" and "plugins" from the qml directory
-    find $out/share/teamviewer/tv_bin/RTlib/qt -depth -maxdepth 1 -mindepth 1 -type d ! \( -name "qml" -o -name "plugins" \) -execdir rm -rf {} +
-
-    # keep "QtQuick" and "QtQuick.2" directory
-    find $out/share/teamviewer/tv_bin/RTlib/qt/qml -depth -maxdepth 1 -mindepth 1 -type d ! \( -name "QtQuick" -o -name "QtQuick.2" \) -execdir rm -rf {} +
-
-    # delete all folders except "platforms" from the plugins directory
-    # it contains libqxcb.so from qtbase which seems to be incompatible with our nixpkgs version
-    find $out/share/teamviewer/tv_bin/RTlib/qt/plugins -depth -maxdepth 1 -mindepth 1 -type d ! -name "platforms" -execdir rm -rf {} +
+    # Teamviewer packages its own qt library files. So do not use nixpkgs qt files. These will cause issues
+    # See https://github.com/NixOS/nixpkgs/issues/321333
 
     ln -s $out/share/teamviewer/tv_bin/script/teamviewer $out/bin
     ln -s $out/share/teamviewer/tv_bin/teamviewerd $out/bin
@@ -94,11 +74,11 @@ mkDerivation rec {
     install -d "$out/share/dbus-1/services"
     install -m 644 "$in_script_dir/com.teamviewer.TeamViewer.service" "$out/share/dbus-1/services"
     substituteInPlace "$out/share/dbus-1/services/com.teamviewer.TeamViewer.service" \
-      --replace '/opt/teamviewer/tv_bin/TeamViewer' \
+      --replace-fail '/opt/teamviewer/tv_bin/TeamViewer' \
         "$out/share/teamviewer/tv_bin/TeamViewer"
     install -m 644 "$in_script_dir/com.teamviewer.TeamViewer.Desktop.service" "$out/share/dbus-1/services"
     substituteInPlace "$out/share/dbus-1/services/com.teamviewer.TeamViewer.Desktop.service" \
-      --replace '/opt/teamviewer/tv_bin/TeamViewer_Desktop' \
+      --replace-fail '/opt/teamviewer/tv_bin/TeamViewer_Desktop' \
         "$out/share/teamviewer/tv_bin/TeamViewer_Desktop"
 
     install -d "$out/share/dbus-1/system.d"


### PR DESCRIPTION
## Description of changes

- update version to 15.54.3
- remove dependencies to qt, which fixes #321333

backport of #321463

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [x] Tested in a vm

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
