### PR TITLE
texlive.pkgs: improve symlinks

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/build-texlive-package.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-texlive-package.nix
@@ -235,15 +235,15 @@ let
       '';
     }
     # each output is just a symlink to the corresponding container
-    # if the container is missing (that is, outputs == [ ]), create a file, to prevent passing the package to .withPackages
+    # if there are no containers (that is, outputs == [ ]), create a file, to forbid passing the package to .withPackages
     ''
-      for outputName in ''${!outputs[@]} ; do
-        if [[ -n ''${outputDrvs[$outputName]} ]] ; then
+      if [[ ''${#outputDrvs[@]} -gt 0 ]] ; then
+        for outputName in ''${!outputs[@]} ; do
           ln -s "''${outputDrvs[$outputName]}" "''${outputs[$outputName]}"
-        else
-          touch "''${outputs[$outputName]}"
-        fi
-      done
+        done
+      else
+        touch "$out"
+      fi
     '';
 in
 if outputs == [ ] then removeAttrs fakeTeX [ "outputSpecified" ] else build // outputDrvs

--- a/pkgs/tools/typesetting/tex/texlive/build-texlive-package.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-texlive-package.nix
@@ -91,6 +91,11 @@ let
     lib.optional hasInfo "info";
   outputDrvs = lib.getAttrs outputs containers;
 
+  # derivation for texlive.pkgs
+  mainDrv = removeAttrs (if outputs == [ ] then fakeTeX else containers.${builtins.head outputs}) [ "outputSpecified" ]
+    # pretend to have all outputs (for use in build-tex-env.nix)
+    // { inherit outputs; };
+
   passthru = {
     # metadata
     inherit pname;
@@ -98,6 +103,8 @@ let
     version = version + extraVersion;
     # containers behave like specified outputs
     outputSpecified = true;
+    # derivation for top level texlivePackages
+    inherit build;
   } // lib.optionalAttrs (args ? deps) { tlDeps = args.deps; }
   // lib.optionalAttrs (args ? fontMaps) { inherit (args) fontMaps; }
   // lib.optionalAttrs (args ? formats) { inherit (args) formats; }
@@ -246,4 +253,4 @@ let
       fi
     '';
 in
-if outputs == [ ] then removeAttrs fakeTeX [ "outputSpecified" ] else build // outputDrvs
+mainDrv


### PR DESCRIPTION
## Description of changes
Improve on #316763. The key difference is that `texlive.pkgs.PKG` is now one of the containers, unlike `texlivePackages.PKG` which is symlinks to the containers. I have also made the symlink creation more robust, hopefully we will catch errors more easily.

This time, I have properly tested it, but against nixpkgs-unstable rather than staging.

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
