### PR TITLE
pymilter: 1.0.5 -> 1.0.6; replace bsddb3 with berkleydb

### DIFF
--- a/pkgs/development/python-modules/pymilter/default.nix
+++ b/pkgs/development/python-modules/pymilter/default.nix
@@ -1,41 +1,36 @@
 {
   lib,
-  python,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   libmilter,
-  bsddb3,
+  berkeleydb,
   pydns,
   iana-etc,
   libredirect,
   pyasyncore,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "pymilter";
-  version = "1.0.5";
-  format = "setuptools";
+  version = "1.0.6";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "sdgathman";
-    repo = pname;
-    rev = "${pname}-${version}";
-    hash = "sha256-gZUWEDVZfDRiOOdG3lpiQldHxm/93l8qYVOHOEpHhzQ=";
+    repo = "pymilter";
+    rev = "refs/tags/pymilter-${version}";
+    hash = "sha256-plaWXwDAIsVzEtrabZuZj7T4WNfz2ntQHgcMCVf5S70=";
   };
 
+  build-system = [
+    setuptools
+  ];
   buildInputs = [ libmilter ];
   nativeCheckInputs = [ pyasyncore ];
-  propagatedBuildInputs = [
-    bsddb3
+  dependencies = [
+    berkeleydb
     pydns
-  ];
-  patches = [
-    (fetchpatch { # https://github.com/sdgathman/pymilter/pull/57
-      name = "Remove-calls-to-the-deprecated-method-assertEquals";
-      url = "https://github.com/sdgathman/pymilter/commit/1ead9028fc63ae3ec6ea3b0c438e6ed088a2b20e.patch";
-      hash = "sha256-/5LlDR15nMR3l7rkVjT3w4FbDTFAAgNdERWlPNL2TVg=";
-    })
   ];
 
   preBuild = ''


### PR DESCRIPTION
Reopening #321446

## Description of changes
Unbreaks pymilter after #311198.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
