### PR TITLE
openai-whisper-cpp: 1.5.4 -> 1.6.2

### DIFF
--- a/pkgs/tools/audio/openai-whisper-cpp/default.nix
+++ b/pkgs/tools/audio/openai-whisper-cpp/default.nix
@@ -25,13 +25,13 @@ let
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "whisper-cpp";
-  version = "1.5.4";
+  version = "1.6.2";
 
   src = fetchFromGitHub {
     owner = "ggerganov";
     repo = "whisper.cpp";
     rev = "refs/tags/v${finalAttrs.version}" ;
-    hash = "sha256-9H2Mlua5zx2WNXbz2C5foxIteuBgeCNALdq5bWyhQCk=";
+    hash = "sha256-hIEIu7feOZWqxRskf6Ej7l653/9KW8B3cnpPLoCRBAc=";
   };
 
   # The upstream download script tries to download the models to the
@@ -80,6 +80,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   env = lib.optionalAttrs stdenv.isDarwin {
     WHISPER_COREML = "1";
     WHISPER_COREML_ALLOW_FALLBACK = "1";
+    WHISPER_METAL_EMBED_LIBRARY = "1";
   } // lib.optionalAttrs cudaSupport {
     WHISPER_CUBLAS = "1";
   };
@@ -98,15 +99,6 @@ effectiveStdenv.mkDerivation (finalAttrs: {
 
     wrapProgram $out/bin/whisper-cpp-download-ggml-model \
       --prefix PATH : ${lib.makeBinPath [wget]}
-
-    ${lib.optionalString stdenv.isDarwin ''
-      install -Dt $out/share/whisper-cpp ggml-metal.metal
-
-      for bin in whisper-cpp whisper-cpp-stream whisper-cpp-command; do
-        wrapProgram $out/bin/$bin \
-          --set-default GGML_METAL_PATH_RESOURCES $out/share/whisper-cpp
-      done
-    ''}
 
     runHook postInstall
   '';

--- a/pkgs/tools/audio/openai-whisper-cpp/download-models.patch
+++ b/pkgs/tools/audio/openai-whisper-cpp/download-models.patch
@@ -1,51 +1,53 @@
+diff --git a/models/download-ggml-model.sh b/models/download-ggml-model.sh
+index 1f1075b..7476c8e 100755
 --- a/models/download-ggml-model.sh
 +++ b/models/download-ggml-model.sh
-@@ -9,18 +9,6 @@
- src="https://huggingface.co/ggerganov/whisper.cpp"
- pfx="resolve/main/ggml"
+@@ -12,18 +12,6 @@ pfx="resolve/main/ggml"
+ BOLD="\033[1m"
+ RESET='\033[0m'
  
 -# get the path of this script
--function get_script_path() {
+-get_script_path() {
 -    if [ -x "$(command -v realpath)" ]; then
--        echo "$(dirname "$(realpath "$0")")"
+-        dirname "$(realpath "$0")"
 -    else
--        local ret="$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)"
--        echo "$ret"
+-        _ret="$(cd -- "$(dirname "$0")" >/dev/null 2>&1 || exit ; pwd -P)"
+-        echo "$_ret"
 -    fi
 -}
 -
 -models_path="${2:-$(get_script_path)}"
 -
  # Whisper models
- models=(
-     "tiny.en"
-@@ -56,8 +44,8 @@ function list_models {
+ models="tiny
+ tiny.en
+@@ -64,8 +52,8 @@ list_models() {
      printf "\n\n"
  }
  
 -if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
--    printf "Usage: $0 <model> [models_path]\n"
+-    printf "Usage: %s <model> [models_path]\n" "$0"
 +if [ "$#" -ne 1 ]; then
-+    printf "Usage: $0 <model>\n"
++    printf "Usage: %s <model>\n" "$0"
      list_models
+     printf "___________________________________________________________\n"
+     printf "${BOLD}.en${RESET} = english-only ${BOLD}-q5_[01]${RESET} = quantized ${BOLD}-tdrz${RESET} = tinydiarize\n"
+@@ -94,8 +82,6 @@ echo "$model" | grep -q '^"tdrz"*$'
  
-     exit 1
-@@ -82,8 +70,6 @@ fi
+ printf "Downloading ggml model %s from '%s' ...\n" "$model" "$src"
  
- printf "Downloading ggml model $model from '$src' ...\n"
- 
--cd "$models_path"
+-cd "$models_path" || exit
 -
  if [ -f "ggml-$model.bin" ]; then
-     printf "Model $model already exists. Skipping download.\n"
+     printf "Model %s already exists. Skipping download.\n" "$model"
      exit 0
-@@ -105,7 +91,7 @@ if [ $? -ne 0 ]; then
+@@ -116,7 +102,7 @@ if [ $? -ne 0 ]; then
      exit 1
  fi
  
--printf "Done! Model '$model' saved in '$models_path/ggml-$model.bin'\n"
-+printf "Done! Model '$model' saved in 'ggml-$model.bin'\n"
+-printf "Done! Model '%s' saved in '%s/ggml-%s.bin'\n" "$model" "$models_path" "$model"
++printf "Done! Model '%s' saved in 'ggml-%s.bin'\n" "$model" "$model"
  printf "You can now use it like this:\n\n"
--printf "  $ ./main -m $models_path/ggml-$model.bin -f samples/jfk.wav\n"
-+printf "  $ whisper-cpp -m ggml-$model.bin -f samples/jfk.wav\n"
+-printf "  $ ./main -m %s/ggml-%s.bin -f samples/jfk.wav\n" "$models_path" "$model"
++printf "  $ whisper-cpp -m ggml-%s.bin -f samples/jfk.wav\n" "$model"
  printf "\n"


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Changelogs](https://github.com/ggerganov/whisper.cpp/releases)

* Bumped sources from 1.5.4 to 1.6.2 
* Updated the `download-models` patch to handle changes to upstream script
* For darwin, replaced `wrapProgram` that sets `GGML_METAL_PATH_RESOURCES` with `WHISPER_METAL_EMBED_LIBRARY` build option.

Note: `openai-whisper-cpp` has `ffmpeg` support now, but that would require switching to `CMake`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Tested model download script and both the Metal and CoreML backends for the main `whisper-cpp` binary.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
