### PR TITLE
treewide: remove Mesa from more closures by replacing full xorgserver with xvfb

### DIFF
--- a/pkgs/applications/window-managers/herbstluftwm/default.nix
+++ b/pkgs/applications/window-managers/herbstluftwm/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, cmake, pkg-config, python3, libX11, libXext, libXinerama, libXrandr, libXft, libXrender, libXdmcp, libXfixes, freetype, asciidoc
-, xdotool, xorgserver, xsetroot, xterm, runtimeShell
+, xdotool, xorg, xsetroot, xterm, runtimeShell
 , fetchpatch
 , nixosTests }:
 
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
   nativeCheckInputs = [
     (python3.withPackages (ps: with ps; [ ewmh pytest xlib ]))
     xdotool
-    xorgserver
+    xorg.xvfb
     xsetroot
     xterm
     python3.pkgs.pytestCheckHook

--- a/pkgs/applications/window-managers/i3/default.nix
+++ b/pkgs/applications/window-managers/i3/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, lib, stdenv, pkg-config, makeWrapper, meson, ninja, installShellFiles, libxcb, xcbutilkeysyms
 , xcbutil, xcbutilwm, xcbutilxrm, libstartup_notification, libX11, pcre2, libev
 , yajl, xcb-util-cursor, perl, pango, perlPackages, libxkbcommon
-, xorgserver, xvfb-run
+, xvfb-run
 , asciidoc, xmlto, docbook_xml_dtd_45, docbook_xsl, findXMLCatalogs
 }:
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     libstartup_notification libX11 pcre2 libev yajl xcb-util-cursor perl pango
     perlPackages.AnyEventI3 perlPackages.X11XCB perlPackages.IPCRun
     perlPackages.ExtUtilsPkgConfig perlPackages.InlineC
-    xorgserver xvfb-run
+    xvfb-run
   ];
 
   configureFlags = [ "--disable-builddir" ];

--- a/pkgs/by-name/no/normcap/package.nix
+++ b/pkgs/by-name/no/normcap/package.nix
@@ -75,7 +75,7 @@ ps.buildPythonApplication rec {
     ps.toml
   ] ++ lib.optionals stdenv.isLinux [
     ps.pytest-xvfb
-    xorg.xorgserver
+    xorg.xvfb
   ];
 
   preCheck = ''

--- a/pkgs/development/libraries/libxkbcommon/default.nix
+++ b/pkgs/development/libraries/libxkbcommon/default.nix
@@ -13,7 +13,7 @@
 , libX11
   # To enable the "interactive-wayland" subcommand of xkbcli. This is the
   # wayland equivalent of `xev` on X11.
-, xorgserver # for Xvfb in tests
+, xorg
 , withWaylandTools ? stdenv.isLinux
 , wayland
 , wayland-protocols
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [ "out" "dev" "doc" ];
 
   depsBuildBuild = [ pkg-config ];
-  nativeBuildInputs = [ meson ninja pkg-config bison doxygen xorgserver ]
+  nativeBuildInputs = [ meson ninja pkg-config bison doxygen xorg.xvfb ]
     ++ lib.optional withWaylandTools wayland-scanner;
   buildInputs = [ xkeyboard_config libxcb libxml2 ]
     ++ lib.optionals withWaylandTools [ wayland wayland-protocols ];

--- a/pkgs/development/python-modules/i3ipc/default.nix
+++ b/pkgs/development/python-modules/i3ipc/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  xorgserver,
+  xorg,
   pytest,
   pytest-xvfb,
   i3,
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     pytest
     xdpyinfo
     pytest-xvfb
-    xorgserver
+    xorg.xvfb
     i3
   ];
 

--- a/pkgs/development/python-modules/xcffib/default.nix
+++ b/pkgs/development/python-modules/xcffib/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     xorg.xeyes
-    xorg.xorgserver
+    xorg.xvfb
   ];
 
   preCheck = ''

--- a/pkgs/development/python-modules/xlib/default.nix
+++ b/pkgs/development/python-modules/xlib/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     nose
     util-linux
     xorg.xauth
-    xorg.xorgserver
+    xorg.xvfb
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/xvfbwrapper/default.nix
+++ b/pkgs/development/python-modules/xvfbwrapper/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  xorgserver,
+  xorg,
   mock,
 }:
 
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "097wxhvp01ikqpg1z3v8rqhss6f1vwr399zpz9a05d2135bsxx5w";
   };
-  propagatedBuildInputs = [ xorgserver ];
+  propagatedBuildInputs = [ xorg.xvfb ];
 
   # See: https://github.com/cgoldberg/xvfbwrapper/issues/30
   doCheck = false;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -905,6 +905,33 @@ self: super:
         };
       }));
 
+  # xvfb is used by a bunch of things to run tests
+  # and doesn't support hardware accelerated rendering
+  # so remove it from the rebuild heavy path for mesa
+  xvfb = super.xorgserver.overrideAttrs(old: {
+    configureFlags = [
+      "--enable-xvfb"
+      "--disable-xorg"
+      "--disable-xquartz"
+      "--disable-xwayland"
+      "--disable-glamor"
+      "--disable-glx"
+      "--disable-dri"
+      "--disable-dri2"
+      "--disable-dri3"
+      "--with-xkb-bin-directory=${xorg.xkbcomp}/bin"
+      "--with-xkb-path=${xorg.xkeyboardconfig}/share/X11/xkb"
+      "--with-xkb-output=$out/share/X11/xkb/compiled"
+    ];
+
+    buildInputs = old.buildInputs ++ (with xorg; [
+      pixman
+      libXfont2
+      xtrans
+      libxcvt
+    ]);
+  });
+
   lndir = super.lndir.overrideAttrs (attrs: {
     buildInputs = [];
     nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];

--- a/pkgs/tools/misc/xvfb-run/default.nix
+++ b/pkgs/tools/misc/xvfb-run/default.nix
@@ -2,7 +2,7 @@
 , stdenvNoCC
 , fetchFromGitHub
 , makeWrapper
-, xorgserver
+, xorg
 , getopt
 , xauth
 , util-linux
@@ -39,7 +39,7 @@ stdenvNoCC.mkDerivation rec {
     patchShebangs $out/bin/xvfb-run
     wrapProgram $out/bin/xvfb-run \
       --set-default FONTCONFIG_FILE "${fontsConf}" \
-      --prefix PATH : ${lib.makeBinPath [ getopt xorgserver xauth which util-linux gawk coreutils ]}
+      --prefix PATH : ${lib.makeBinPath [ getopt xorg.xvfb xauth which util-linux gawk coreutils ]}
   '';
 
   doInstallCheck = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14659,20 +14659,6 @@ with pkgs;
 
   xvfb-run = callPackage ../tools/misc/xvfb-run {
     inherit (texFunctions) fontsConf;
-
-    # xvfb-run is used by a bunch of things to run tests
-    # and doesn't support hardware accelerated rendering
-    # so remove it from the rebuild heavy path for mesa
-    xorgserver = xorg.xorgserver.overrideAttrs(old: {
-      buildInputs = lib.filter (pkg: lib.getName pkg != "mesa") old.buildInputs;
-      configureFlags = old.configureFlags ++ [
-        "--disable-glamor"
-        "--disable-glx"
-        "--disable-dri"
-        "--disable-dri2"
-        "--disable-dri3"
-      ];
-    });
   };
 
   xvkbd = callPackage ../tools/X11/xvkbd { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17285,9 +17285,7 @@ self: super: with self; {
 
   xtensor-python = callPackage ../development/python-modules/xtensor-python { };
 
-  xvfbwrapper = callPackage ../development/python-modules/xvfbwrapper {
-    inherit (pkgs.xorg) xorgserver;
-  };
+  xvfbwrapper = callPackage ../development/python-modules/xvfbwrapper {};
 
   xxhash = callPackage ../development/python-modules/xxhash { };
 


### PR DESCRIPTION
## Description of changes

Should save us some more rebuilds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
