### PR TITLE
mercurial: fix cargoDeps hash

### DIFF
--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -37,7 +37,7 @@ let
     cargoDeps = if rustSupport then rustPlatform.fetchCargoTarball {
       inherit src;
       name = "mercurial-${version}";
-      hash = "sha256-FRa7frX2z9jQGFBXS2TpOUANs0+xwegNETUAQIU0S4o=";
+      hash = "sha256-Fjsh8ZWU3j8g/YxJCfSpgwDXuZmp17f5p7051SoWvK8=";
       sourceRoot = "mercurial-${version}/rust";
     } else null;
     cargoRoot = if rustSupport then "rust" else null;


### PR DESCRIPTION
mercurial: fix cargoDeps hash

![image](https://github.com/NixOS/nixpkgs/assets/5861043/98127f75-6eae-475d-a8c8-5354cc12a566)

Found this problem at [libimobiledevice build](https://github.com/NixOS/nixpkgs/pull/321723#issuecomment-2184693488).

I don't know yet why cargoDeps hash changed. But this fixes builds for other packages.

Current best guess:

* https://github.com/NixOS/nixpkgs/pull/321960#issuecomment-2185099697