### PR TITLE
python3Packages.pydantic-core: fix cargoDeps hash

### DIFF
--- a/pkgs/development/python-modules/pydantic-core/default.nix
+++ b/pkgs/development/python-modules/pydantic-core/default.nix
@@ -33,7 +33,7 @@ let
     cargoDeps = rustPlatform.fetchCargoTarball {
       inherit src;
       name = "${pname}-${version}";
-      hash = "sha256-m0xP4fIFgInkUeAy4HqfTKHEiqmWpYO8CgKzxg+WXiU=";
+      hash = "sha256-g+vqjR6objN1LwqBJ0BAiCFlgPLrJH+aKoLMD9e89zw=";
     };
 
     nativeBuildInputs = [


### PR DESCRIPTION
python3Packages.pydantic-core: fix hash

![image](https://github.com/NixOS/nixpkgs/assets/5861043/e4c1f005-bd20-49dd-991e-be4ea632d9ff)

Found this problem at [libimobiledevice build](https://github.com/NixOS/nixpkgs/pull/321723#issuecomment-2184693488).

I don't know yet why hash changed. But this fixes builds for other packages.