### PR TITLE
libe57format: 2.2.0 -> 3.1.1

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -79,6 +79,8 @@
   for `stateVersion` ≥ 24.11. (It was previously using SQLite for structured
   data and the filesystem for blobs).
 
+- `libe57format` has been updated to `>= 3.0.0`, which contains some backward-incompatible API changes. See the [release note](https://github.com/asmaloney/libE57Format/releases/tag/v3.0.0) for more details.
+
 - `zx` was updated to v8, which introduces several breaking changes.
   See the [v8 changelog](https://github.com/google/zx/releases/tag/8.0.0) for more information.
 

--- a/pkgs/development/libraries/libe57format/default.nix
+++ b/pkgs/development/libraries/libe57format/default.nix
@@ -1,34 +1,44 @@
 {
   lib, stdenv,
   cmake,
-  fetchpatch,
   fetchFromGitHub,
-  boost,
+  fetchpatch,
   xercesc,
-  icu,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libe57format";
-  version = "2.2.0";
+  version = "3.1.1";
 
   src = fetchFromGitHub {
     owner = "asmaloney";
     repo = "libE57Format";
-    rev = "v${version}";
-    sha256 = "15l23spjvak5h3n7aj3ggy0c3cwcg8mvnc9jlbd9yc2ra43bx7bp";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-bOuWh9Nkxva2v0M6+vnAya8EW/G3WQePxHakQt8T9NE=";
+    fetchSubmodules = true; # for submodule-vendored libraries such as `gtest`
   };
 
-  patches = [
-    # gcc11 header fix
-    (fetchpatch {
-      url = "https://github.com/asmaloney/libE57Format/commit/13f6a16394ce3eb50ea4cd21f31f77f53294e8d0.patch";
-      sha256 = "sha256-4vVhKrCxnWO106DSAk+xxo4uk6zC89m9VQAPaDJ8Ed4=";
-    })
-  ];
+  # Repository of E57 files used for testing.
+  libE57Format-test-data_src = fetchFromGitHub {
+    owner = "asmaloney";
+    repo = "libE57Format-test-data";
+    rev = "4960564a732c6444c50dfae5b2273e68837399cd";
+    hash = "sha256-k26yVbYSQJ3EMgcpjm35N1OAxarFmfMvzfTN2Hdyu8c=";
+  };
+
   CXXFLAGS = [
     # GCC 13: error: 'int16_t' has not been declared in 'std'
     "-include cstdint"
+  ];
+
+  patches = [
+    # TODO: Remove with the next release: https://github.com/asmaloney/libE57Format/pull/299
+    (fetchpatch {
+      name = "libE57Format-Dont-force-warnings-as-errors-when-building-self.patch"; # https://github.com/apache/thrift/pull/2726
+      url = "https://github.com/asmaloney/libE57Format/commit/66bb5af15937b4c10a7f412ca4d1673f42bbad28.patch";
+      hash = "sha256-2cNURjMLP0TijYY5gbuWLE7H/PlMW936wAeOqJ/w9C0=";
+    })
+
   ];
 
   nativeBuildInputs = [
@@ -36,15 +46,22 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    boost
-    icu
-  ];
-
-  propagatedBuildInputs = [
-    # Necessary for projects that try to find libE57Format via CMake
-    # due to the way that libe57format's CMake config is written.
     xercesc
   ];
+
+  cmakeFlags = [
+    # See https://github.com/asmaloney/libE57Format/blob/9372bdea8db2cc0c032a08f6d655a53833d484b8/test/README.md
+    (if finalAttrs.doCheck
+      then "-DE57_TEST_DATA_PATH=${finalAttrs.libE57Format-test-data_src}"
+      else "-DE57_BUILD_TEST=OFF"
+    )
+  ];
+
+  doCheck = true;
+
+  postCheck = ''
+    ./testE57
+  '';
 
   # The build system by default builds ONLY static libraries, and with
   # `-DE57_BUILD_SHARED=ON` builds ONLY shared libraries, see:
@@ -70,4 +87,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ chpatrick nh2 ];
     platforms = platforms.linux; # because of the .so buiding in `postInstall` above
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Replaces #240934.

New version: https://github.com/asmaloney/libE57Format/releases/tag/v3.0.0

* Tests now run during the build by default.
* The dependency on `boost` was removed: https://github.com/asmaloney/libE57Format/commit/cf46a9d3c82fa218507712f5de925887876542ba
* `xercesc` is now an official dependency: https://github.com/asmaloney/libE57Format/commit/
7569757cacfbf744be809a2c47df454adaf3bbfd

Minor upgrade: https://github.com/asmaloney/libE57Format/releases/tag/v3.1.0


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Further:

* Tested that `pdal` builds.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
