### PR TITLE
nixos/xserver: expose services.xserver.displayManager.importedVariables

### DIFF
--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -210,10 +210,14 @@ in
 
       importedVariables = mkOption {
         type = types.listOf (types.strMatching "[a-zA-Z_][a-zA-Z0-9_]*");
-        visible = false;
         description = ''
-          Environment variables to import into the systemd user environment.
+          Environment variables to import into the systemd user environment
+          when starting a graphical session.
         '';
+        example = [
+          "PATH"
+          "XDG_DATA_DIRS"
+        ];
       };
 
     };


### PR DESCRIPTION
## Description of changes

This option allows user to import specific environment variables into systemd user environment, this is useful situations where opening links into another app does not work. This is frequently the case with flatpak apps.

~After this PR, we can utilise this option for example in [sway module](https://github.com/NixOS/nixpkgs/blob/a71e967ef3694799d0c418c98332f7ff4cc5f6af/nixos/modules/programs/wayland/sway.nix#L125) and [hyprland module](https://github.com/NixOS/nixpkgs/blob/a71e967ef3694799d0c418c98332f7ff4cc5f6af/nixos/modules/programs/wayland/hyprland.nix#L66), which employ other mechanisms for importing crucial variables like PATH, into the systemd environment.~

This option only affects XSessions and NOT Wayland.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
