### PR TITLE
gerbolyze: unbreak by downgrading resvg

### DIFF
--- a/pkgs/by-name/ge/gerbolyze/package.nix
+++ b/pkgs/by-name/ge/gerbolyze/package.nix
@@ -43,6 +43,22 @@ let
       platforms = platforms.linux;
     };
   };
+
+  # FIXME: check if this downgrade is still required when bumping gerbolyze
+  # https://github.com/jaseg/gerbolyze/issues/47
+  resvg' = resvg.overrideAttrs (old: rec {
+    version = "0.41.0";
+    src = old.src.override {
+      rev = "v${version}";
+      hash = "sha256-plZiyEiBWeV2mwTsNK5Je8Axs/hcHH8aV2VpOix6QCY=";
+    };
+    cargoDeps = old.cargoDeps.overrideAttrs (lib.const {
+      name = "${old.pname}-${version}-vendor.tar.gz";
+      inherit src;
+      outputHash = "sha256-U7xzb9e9wh9XbLvlYQ0ofIjH8FuSzVcrXnrehQmZgww=";
+    });
+  });
+
 in python3Packages.buildPythonApplication rec {
   inherit version src;
   pname = "gerbolyze";
@@ -61,7 +77,7 @@ in python3Packages.buildPythonApplication rec {
     python3Packages.python-slugify
     python3Packages.lxml
     python3Packages.gerbonara
-    resvg
+    resvg'
     svg-flatten
   ];
 
@@ -79,7 +95,7 @@ in python3Packages.buildPythonApplication rec {
 
   pythonImportsCheck = [ "gerbolyze" ];
 
-  nativeCheckInputs = [ python3Packages.pytestCheckHook resvg svg-flatten ];
+  nativeCheckInputs = [ python3Packages.pytestCheckHook resvg' svg-flatten ];
 
   meta = with lib; {
     description = "Directly render SVG overlays into Gerber and Excellon files";


### PR DESCRIPTION
## Description of changes

fixes https://hydra.nixos.org/build/262967152, broken in https://github.com/NixOS/nixpkgs/pull/316461, closes https://github.com/NixOS/nixpkgs/issues/321850

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
