### PR TITLE
idris2Packages.buildIdris: better lib ergonomics

### DIFF
--- a/doc/languages-frameworks/idris2.section.md
+++ b/doc/languages-frameworks/idris2.section.md
@@ -19,7 +19,7 @@ let lspLibPkg = idris2Packages.buildIdris {
   };
   idrisLibraries = [ ];
 };
-in lspLibPkg.library
+in lspLibPkg.library { withSource = true; }
 ```
 
 The above results in a derivation with the installed library results (with sourcecode).
@@ -30,6 +30,7 @@ A slightly more involved example of a fully packaged executable would be the [`i
 
 # Assuming the previous example lives in `lsp-lib.nix`:
 let lspLib = callPackage ./lsp-lib.nix { };
+    inherit (idris2Packages) idris2Api;
     lspPkg = idris2Packages.buildIdris {
       ipkgName = "idris2-lsp";
       src = fetchFromGitHub {
@@ -38,10 +39,9 @@ let lspLib = callPackage ./lsp-lib.nix { };
          rev = "main";
          hash = "sha256-vQTzEltkx7uelDtXOHc6QRWZ4cSlhhm5ziOqWA+aujk=";
       };
-      idrisLibraries = [(idris2Packages.idris2Api { }) (lspLib { })];
+      idrisLibraries = [idris2Api lspLib];
     };
 in lspPkg.executable
 ```
 
-The above uses the default value of `withSource = false` for both of the two required Idris libraries that the `idris2-lsp` executable depends on. `idris2Api` in the above derivation comes built in with `idris2Packages`. This library exposes many of the otherwise internal APIs of the Idris2 compiler.
-
+The above uses the default value of `withSource = false` for the `idris2Api` but could be modified to include that library's source by passing `(idris2Api { withSource = true; })` to `idrisLibraries` instead. `idris2Api` in the above derivation comes built in with `idris2Packages`. This library exposes many of the otherwise internal APIs of the Idris2 compiler.

--- a/pkgs/development/compilers/idris2/idris2-lsp.nix
+++ b/pkgs/development/compilers/idris2/idris2-lsp.nix
@@ -11,8 +11,8 @@ let
   ];
   globalLibrariesPath = builtins.concatStringsSep ":" globalLibraries;
 
-  idris2Api = idris2Packages.idris2Api { };
-  lspLib = (idris2Packages.buildIdris {
+  inherit (idris2Packages) idris2Api;
+  lspLib = idris2Packages.buildIdris {
     ipkgName = "lsp-lib";
     version = "2024-01-21";
     src = fetchFromGitHub {
@@ -22,7 +22,7 @@ let
      hash = "sha256-ICW9oOOP70hXneJFYInuPY68SZTDw10dSxSPTW4WwWM=";
     };
     idrisLibraries = [ ];
-  }).library { };
+  };
 
   lspPkg = idris2Packages.buildIdris {
     ipkgName = "idris2-lsp";


### PR DESCRIPTION
## Description of changes

In short, this makes it much easier to work with the output of the `buildIdris` function if you are going to use the result as a dependency in another Idris package.

Before:
```nix
let myLib = buildIdris { ... };
in buildIdris {
  ...
  idrisLibraries = [ (myLib.library {}) ];
}
```

After:
```nix
let myLib = buildIdris { ... };
in buildIdris {
  ...
  idrisLibraries = [ myLib ];
}
```

This doesn't remove support for the existing way of passing the library; that helps with backwards compatibility, but even more importantly there is still a use-case for explicitly calling the `library` function: to include the dependency's source code in its build artifacts.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
