### PR TITLE
rsync: fix missing ipv6 support (again)

### DIFF
--- a/pkgs/applications/networking/sync/rsync/configure.ac-fix-failing-IPv6-check.patch
+++ b/pkgs/applications/networking/sync/rsync/configure.ac-fix-failing-IPv6-check.patch
@@ -1,0 +1,12 @@
+diff -rup rsync-3.2.7/configure.sh rsync-3.2.7-fixed/configure.sh
+--- rsync-3.2.7/configure.sh	2022-10-20 17:57:22
++++ rsync-3.2.7-fixed/configure.sh	2024-01-01 19:51:58
+@@ -7706,7 +7706,7 @@ else $as_nop
+ #include <stdlib.h>
+ #include <sys/types.h>
+ #include <sys/socket.h>
+-main()
++int main()
+ {
+    if (socket(AF_INET6, SOCK_STREAM, 0) < 0)
+      exit(1);

--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -31,6 +31,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook perl ];
 
+  patches = [
+    # https://github.com/WayneD/rsync/pull/558
+    ./configure.ac-fix-failing-IPv6-check.patch
+  ];
+
   buildInputs = [ libiconv zlib popt ]
     ++ lib.optional enableACLs acl
     ++ lib.optional enableZstd zstd


### PR DESCRIPTION
## Description of changes

The patch was removed in 21604e8d2bf4 despite not being included in rsync v3.3.0, which broke IPv6 on at least darwin again.

cc @kashw2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
