### PR TITLE
python3Packages.cyclonedds-python: init at 0.10.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11296,6 +11296,12 @@
     githubId = 11614750;
     name = "Alexander Sharov";
   };
+  kvik = {
+    email = "viktor@a-b.xyz";
+    github = "okvik";
+    githubId = 58425080;
+    name = "Viktor Pocedulić";
+  };
   kwaa = {
     name = "藍+85CD";
     email = "kwa@kwaa.dev";

--- a/pkgs/development/python-modules/cyclonedds-python/default.nix
+++ b/pkgs/development/python-modules/cyclonedds-python/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  cyclonedds,
+  setuptools,
+  rich-click,
+
+  pytestCheckHook,
+  pytest-mock,
+  pytest-cov-stub,
+}:
+
+buildPythonPackage rec {
+  pname = "cyclonedds-python";
+  version = "0.10.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "eclipse-cyclonedds";
+    repo = "cyclonedds-python";
+    rev = "refs/tags/${version}";
+    hash = "sha256-MN3Z5gqsD+cr5Awmsia9+uCHL/a2KQP2uMS13rVc1Hw=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+        --replace-fail "pytest-cov" ""
+  '';
+
+  build-system = [ setuptools ];
+
+  buildInputs = [ cyclonedds ];
+
+  dependencies = [ rich-click ];
+
+  env.CYCLONEDDS_HOME = "${cyclonedds.out}";
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-mock
+    pytest-cov-stub
+  ];
+
+  meta = {
+    description = "Python binding for Eclipse Cyclone DDS";
+    homepage = "https://github.com/eclipse-cyclonedds/cyclonedds-python";
+    changelog = "https://github.com/eclipse-cyclonedds/cyclonedds-python/releases/tag/${version}";
+    license = lib.licenses.epl20;
+    maintainers = with lib.maintainers; [ kvik ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2755,6 +2755,8 @@ self: super: with self; {
 
   cycler = callPackage ../development/python-modules/cycler { };
 
+  cyclonedds-python = callPackage ../development/python-modules/cyclonedds-python { };
+
   cyclonedx-python-lib = callPackage ../development/python-modules/cyclonedx-python-lib { };
 
   cyclopts = callPackage ../development/python-modules/cyclopts { };


### PR DESCRIPTION
## Description of changes

This adds a Python package https://github.com/eclipse-cyclonedds/cyclonedds-python which provides bindings to the CycloneDDS library (already packaged in nixpkgs) as well as some additional CLI tools for inspecting and interacting with a DDS system.

One outstanding issue that's worth noting is that `cyclonedds performance` subcommands do not work with Python 3.11, and the 3.11 support is said by the upstream to be experimental at the moment anyway. The rest of the commands work fine, and since the primary purpose of the package is providing the bindings (which pass the automated tests and additional manual testing of some code of mine) I don't think the issue with the subcommand is a blocker.

If / when this is merged I'd like to backport to release-24.05. Since this is a leaf package it should go without problems.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
