### PR TITLE
python312Packages.hatch-regex-commit: init at 0.0.3, python312Packages.pyloadapi: init at 1.2.0

### DIFF
--- a/pkgs/development/python-modules/hatch-regex-commit/default.nix
+++ b/pkgs/development/python-modules/hatch-regex-commit/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatch-regex-commit,
+  hatchling,
+  pythonOlder,
+}:
+
+buildPythonPackage rec {
+  pname = "hatch-regex-commit";
+  version = "0.0.3";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "frankie567";
+    repo = "hatch-regex-commit";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-E0DIBBaDmTCsZQ41NcjcbzgJ16BwhdexlrGWBdf77oA=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'dynamic = ["version"]' 'version = "${version}"' \
+      --replace-fail ', "hatch-regex-commit"' "" \
+      --replace-fail " --cov-report=term-missing --cov-config=pyproject.toml --cov=hatch_regex_commit --cov=tests" ""
+  '';
+
+  build-system = [ hatchling ];
+
+  dependencies = [ hatchling ];
+
+  # Module has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "hatch_regex_commit" ];
+
+  meta = with lib; {
+    description = "Hatch plugin to create a commit and tag when bumping version";
+    homepage = "https://github.com/frankie567/hatch-regex-commit";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pyloadapi/default.nix
+++ b/pkgs/development/python-modules/pyloadapi/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  aiohttp,
+  aioresponses,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatch-regex-commit,
+  hatchling,
+  pytest-asyncio,
+  pytestCheckHook,
+  python-dotenv,
+  pythonOlder,
+}:
+
+buildPythonPackage rec {
+  pname = "pyloadapi";
+  version = "1.2.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.12";
+
+  src = fetchFromGitHub {
+    owner = "tr4nt0r";
+    repo = "pyloadapi";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-uOgqc1RqmEk0Lqz/ixlChKTZva7+0v4V8KutLSgPKEE=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "--cov=src/pyloadapi/ --cov-report=term-missing" ""
+  '';
+
+  build-system = [
+    hatch-regex-commit
+    hatchling
+  ];
+
+  dependencies = [ aiohttp ];
+
+  nativeCheckInputs = [
+    aioresponses
+    pytest-asyncio
+    pytestCheckHook
+    python-dotenv
+  ];
+
+  pythonImportsCheck = [ "pyloadapi" ];
+
+  meta = with lib; {
+    description = "Simple wrapper for pyLoad's API";
+    homepage = "https://github.com/tr4nt0r/pyloadapi";
+    changelog = "https://github.com/tr4nt0r/pyloadapi/blob/${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5365,6 +5365,8 @@ self: super: with self; {
 
   hatch-nodejs-version = callPackage ../development/python-modules/hatch-nodejs-version { };
 
+  hatch-regex-commit = callPackage ../development/python-modules/hatch-regex-commit { };
+
   hatch-requirements-txt = callPackage ../development/python-modules/hatch-requirements-txt { };
 
   haversine = callPackage ../development/python-modules/haversine { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10087,6 +10087,8 @@ self: super: with self; {
 
   pylddwrap = callPackage ../development/python-modules/pylddwrap { };
 
+  pyloadapi = callPackage ../development/python-modules/pyloadapi { };
+
   pyngo = callPackage ../development/python-modules/pyngo { };
 
   pyngrok = callPackage ../development/python-modules/pyngrok { };


### PR DESCRIPTION
## Description of changes

Simple wrapper for pyLoad's API

https://github.com/tr4nt0r/pyloadapi

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
