### PR TITLE
sketchybar-app-font: build from source

### DIFF
--- a/pkgs/by-name/sk/sketchybar-app-font/package.nix
+++ b/pkgs/by-name/sk/sketchybar-app-font/package.nix
@@ -1,90 +1,62 @@
-let
-  artifacts = [ "shell" "lua" "font" ];
-in
-{ lib
-, stdenvNoCC
-, fetchurl
-, common-updater-scripts
-, curl
-, jq
-, writeShellScript
-, artifactList ? artifacts
+{
+  fetchFromGitHub,
+  lib,
+  pnpm,
+  stdenvNoCC,
+  nodejs,
+  nix-update-script,
 }:
-lib.checkListOfEnum "sketchybar-app-font: artifacts" artifacts artifactList
-  stdenvNoCC.mkDerivation
-  (finalAttrs:
-  let
-    selectedSources = map (artifact: builtins.getAttr artifact finalAttrs.passthru.sources) artifactList;
-  in
-  {
-    pname = "sketchybar-app-font";
-    version = "2.0.19";
 
-    srcs = selectedSources;
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "sketchybar-app-font";
+  version = "2.0.19";
 
-    unpackPhase = ''
-      runHook preUnpack
+  src = fetchFromGitHub {
+    owner = "kvndrsslr";
+    repo = "sketchybar-app-font";
+    rev = "v2.0.19";
+    hash = "sha256-4D3ONeGSvFYdeD3alzXlDxyLh6EyIC+lr4A6t7YWBaw=";
+  };
 
-      for s in $selectedSources; do
-        b=$(basename $s)
-        cp $s ''${b#*-}
-      done
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-u0Rr086p6gotS+p9365+P8uKEqxDNGnWCsZDCaj8eEE=";
+  };
 
-      runHook postUnpack
+  nativeBuildInputs = [
+    nodejs
+    pnpm.configHook
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm i
+    pnpm run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 dist/sketchybar-app-font.ttf "$out/share/fonts/truetype/sketchybar-app-font.ttf"
+    install -Dm755 dist/icon_map.sh "$out/bin/icon_map.sh"
+    install -Dm644 dist/icon_map.lua "$out/lib/sketchybar-app-font/icon_map.lua"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Ligature-based symbol font and a mapping function for sketchybar";
+    longDescription = ''
+      A ligature-based symbol font and a mapping function for sketchybar, inspired by simple-bar's usage of community-contributed minimalistic app icons.
     '';
-
-    installPhase = ''
-      runHook preInstall
-
-    '' + lib.optionalString (lib.elem "font" artifactList) ''
-      install -Dm644 ${finalAttrs.passthru.sources.font} "$out/share/fonts/truetype/sketchybar-app-font.ttf"
-
-    '' + lib.optionalString (lib.elem "shell" artifactList) ''
-      install -Dm755 ${finalAttrs.passthru.sources.shell} "$out/bin/icon_map.sh"
-
-    '' + lib.optionalString (lib.elem "lua" artifactList) ''
-      install -Dm644 ${finalAttrs.passthru.sources.lua} "$out/lib/sketchybar-app-font/icon_map.lua"
-
-      runHook postInstall
-    '';
-
-    passthru = {
-      sources = {
-        font = fetchurl {
-          url = "https://github.com/kvndrsslr/sketchybar-app-font/releases/download/v${finalAttrs.version}/sketchybar-app-font.ttf";
-          hash = "sha256-AH4Zkaccms1gNt7ZHZRHYPOx/iLpbcA4MiyBStHRDfU=";
-        };
-        lua = fetchurl {
-          url = "https://github.com/kvndrsslr/sketchybar-app-font/releases/download/v${finalAttrs.version}/icon_map.lua";
-          hash = "sha256-AGcHBgOZY2EBR0WEfaQhEsTRdo8QfEawx6Q2rdBuKIg=";
-        };
-        shell = fetchurl {
-          url = "https://github.com/kvndrsslr/sketchybar-app-font/releases/download/v${finalAttrs.version}/icon_map.sh";
-          hash = "sha256-fdKnweYF92zCLVBVXTjLWK9vdzMD8FvOHjEo2vqPbhQ=";
-        };
-      };
-
-      updateScript = writeShellScript "update-sketchybar-app-font" ''
-        set -o errexit
-        export PATH="${lib.makeBinPath [ curl jq common-updater-scripts ]}"
-        NEW_VERSION=$(curl --silent https://api.github.com/repos/kvndrsslr/sketchybar-app-font/releases/latest | jq '.tag_name | ltrimstr("v")' --raw-output)
-        if [[ "${finalAttrs.version}" = "$NEW_VERSION" ]]; then
-            echo "The new version same as the old version."
-            exit 0
-        fi
-        for artifact in ${lib.escapeShellArgs (lib.mapAttrsToList(a: _: a) finalAttrs.passthru.sources)}; do
-          update-source-version "sketchybar-app-font" "$NEW_VERSION" --ignore-same-version --source-key="sources.$artifact"
-        done
-      '';
-    };
-
-    meta = {
-      description = "Ligature-based symbol font and a mapping function for sketchybar";
-      longDescription = ''
-        A ligature-based symbol font and a mapping function for sketchybar, inspired by simple-bar's usage of community-contributed minimalistic app icons.
-      '';
-      homepage = "https://github.com/kvndrsslr/sketchybar-app-font";
-      license = lib.licenses.cc0;
-      maintainers = with lib.maintainers; [ khaneliman ];
-    };
-  })
+    homepage = "https://github.com/kvndrsslr/sketchybar-app-font";
+    license = lib.licenses.cc0;
+    maintainers = with lib.maintainers; [ khaneliman ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes
Now that the pnpmDeps change has been implemented, changing this package to build from source instead of just fetching the artifacts from github releases.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
