### PR TITLE
slade, sladeUnstable: Fix and update

### DIFF
--- a/pkgs/development/libraries/wxwidgets/wxGTK32.nix
+++ b/pkgs/development/libraries/wxwidgets/wxGTK32.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, curl
 , expat
 , fetchFromGitHub
 , gst_all_1
@@ -70,6 +71,7 @@ stdenv.mkDerivation rec {
     zlib
     pcre2
   ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+    curl
     gtk3
     libSM
     libXinerama
@@ -102,6 +104,7 @@ stdenv.mkDerivation rec {
     "--with-nanosvg"
     "--disable-rpath"
     "--enable-repro-build"
+    "--enable-webrequest"
     (if compat28 then "--enable-compat28" else "--disable-compat28")
     (if compat30 then "--enable-compat30" else "--disable-compat30")
   ] ++ lib.optional unicode "--enable-unicode"
@@ -109,6 +112,9 @@ stdenv.mkDerivation rec {
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     "--with-osx_cocoa"
     "--with-libiconv"
+    "--with-urlsession" # for wxWebRequest
+  ] ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    "--with-libcurl" # for wxWebRequest
   ] ++ lib.optionals withWebKit [
     "--enable-webview"
     "--enable-webviewwebkit"

--- a/pkgs/games/doom-ports/slade/default.nix
+++ b/pkgs/games/doom-ports/slade/default.nix
@@ -20,19 +20,14 @@
 
 stdenv.mkDerivation rec {
   pname = "slade";
-  version = "3.2.5";
+  version = "3.2.6";
 
   src = fetchFromGitHub {
     owner = "sirjuddington";
     repo = "SLADE";
     rev = version;
-    sha256 = "sha256-FBpf1YApwVpWSpUfa2LOrkS1Ef34sKCIZ6ic+Pczs14=";
+    hash = "sha256-pcWmv1fnH18X/S8ljfHxaL1PjApo5jyM8W+WYn+/7zI=";
   };
-
-  postPatch = ''
-    substituteInPlace dist/CMakeLists.txt \
-      --replace "PK3_OUTPUT" "PK3_DESTINATION"
-  '';
 
   nativeBuildInputs = [
     cmake
@@ -57,7 +52,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DwxWidgets_LIBRARIES=${wxGTK}/lib"
-    "-DBUILD_PK3=ON"
   ];
 
   env.NIX_CFLAGS_COMPILE = "-Wno-narrowing";
@@ -71,7 +65,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Doom editor";
     homepage = "http://slade.mancubus.net/";
-    license = licenses.gpl2Plus;
+    license = licenses.gpl2Only; # https://github.com/sirjuddington/SLADE/issues/1754
     platforms = platforms.linux;
     maintainers = with maintainers; [ abbradar ];
   };

--- a/pkgs/games/doom-ports/slade/git.nix
+++ b/pkgs/games/doom-ports/slade/git.nix
@@ -15,29 +15,27 @@
 , glew
 , lua
 , mpg123
+, wrapGAppsHook3
 , unstableGitUpdater
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "slade";
-  version = "3.2.4-unstable-2023-09-30";
+  version = "3.2.6-unstable-2024-11-26";
 
   src = fetchFromGitHub {
     owner = "sirjuddington";
     repo = "SLADE";
-    rev = "d05af4bd3a9a655dfe17d02760bab3542cc0b909";
-    sha256 = "sha256-lzTSE0WH+4fOad9E/pL3LDc4L151W0hFEmD0zsS0gpQ=";
+    rev = "f8ca52edf98e649c6455f6cc32f7aa361e41babe";
+    hash = "sha256-h43kYVLDxr1Z3vKJ+IZaDmvkerUdGJFLzJrPj0b2VUI=";
   };
-
-  postPatch = lib.optionalString (!stdenv.hostPlatform.isx86) ''
-    sed -i '/-msse/d' src/CMakeLists.txt
-  '';
 
   nativeBuildInputs = [
     cmake
     pkg-config
     which
     zip
+    wrapGAppsHook3
   ];
 
   buildInputs = [
@@ -59,6 +57,12 @@ stdenv.mkDerivation rec {
 
   env.NIX_CFLAGS_COMPILE = "-Wno-narrowing";
 
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix GDK_BACKEND : x11
+    )
+  '';
+
   passthru.updateScript = unstableGitUpdater {
     url = "https://github.com/sirjuddington/SLADE.git";
   };
@@ -66,7 +70,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Doom editor";
     homepage = "http://slade.mancubus.net/";
-    license = licenses.gpl2Plus;
+    license = licenses.gpl2Only; # https://github.com/sirjuddington/SLADE/issues/1754
     platforms = platforms.linux;
     maintainers = with maintainers; [ ertes ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17847,14 +17847,7 @@ with pkgs;
   gplates = libsForQt5.callPackage ../applications/science/misc/gplates { };
 
   golly = callPackage ../applications/science/misc/golly {
-    wxGTK = wxGTK32.overrideAttrs (x: {
-      configureFlags = x.configureFlags ++ [
-        "--enable-webrequest"
-      ];
-      buildInputs = x.buildInputs ++ [
-        curl
-      ];
-    });
+    wxGTK = wxGTK32;
   };
 
   megam = callPackage ../applications/science/misc/megam {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16518,16 +16518,7 @@ with pkgs;
   enyo-launcher = libsForQt5.callPackage ../games/doom-ports/enyo-launcher { };
 
   slade = callPackage ../games/doom-ports/slade {
-    wxGTK = (wxGTK32.overrideAttrs {
-      patches = [
-       (fetchpatch { # required to run slade 3.2.4 on wxGTK 3.2.4, see PR #266945
-         url = "https://github.com/wxWidgets/wxWidgets/commit/425d9455e8307c1267a79d47d77e3dafeb4d86de.patch";
-         excludes = [ "docs/changes.txt" ];
-         revert = true;
-         hash = "sha256-6LOYLDLtVCHxNdHAWv3zhlCsljIpi//RJb9XVLGD5hM=";
-       })
-     ];
-    }).override {
+    wxGTK = wxGTK32.override {
       withWebKit = true;
     };
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16524,16 +16524,7 @@ with pkgs;
   };
 
   sladeUnstable = callPackage ../games/doom-ports/slade/git.nix {
-    wxGTK = (wxGTK32.overrideAttrs {
-      patches = [
-       (fetchpatch { # required to run sladeUnstable unstable-2023-09-30 on wxGTK 3.2.4, see PR #266945
-         url = "https://github.com/wxWidgets/wxWidgets/commit/425d9455e8307c1267a79d47d77e3dafeb4d86de.patch";
-         excludes = [ "docs/changes.txt" ];
-         revert = true;
-         hash = "sha256-6LOYLDLtVCHxNdHAWv3zhlCsljIpi//RJb9XVLGD5hM=";
-       })
-     ];
-    }).override {
+    wxGTK = wxGTK32.override {
       withWebKit = true;
     };
   };


### PR DESCRIPTION
## Description of changes

`slade` and `sladeUnstable` currently fail to build following the update of `wxGTK32` from 3.2.4 to 3.2.5 because they apply a patch to `wxGTK32` that fails to apply on 3.2.5. `slade` currently points at SLADE 3.2.5, which contains a fix for the breaking change in `wxGTK32`, making the patch no longer necessary. `sladeUnstable` however is on an earlier version that doesn't have the fix yet. For consistency, this PR updates both packages to the [latest release](https://github.com/sirjuddington/SLADE/releases/tag/3.2.6) and the latest Git commit, respectively.

SLADE 3.2.6 starts using `wxWebRequest`, which is an optional feature in `wxGTK32` that needs to be enable at configure time. I noticed that `golly` enabled it with an override, but in this PR, I enabled the feature in `wxGTK32` directly, in order to reduce the number of variations of `wxGTK32` that need to be built. According to `nix store diff-closures`, this change increases the size of `wxGTK32` by 134.3 KiB. If this is undesirable, let me know and I'll adjust the PR.

This replaces #278799.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (didn't build all downstream dependencies of `wxGTK32`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - I tried, but it takes a long time and I had some failures due to running out of disk space.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

cc @abbradar, @ertes (package maintainers)

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
