### PR TITLE
pkgs/top-level: stop permitting openssl 1.1

### DIFF
--- a/pkgs/top-level/release-python.nix
+++ b/pkgs/top-level/release-python.nix
@@ -12,12 +12,6 @@
   nixpkgsArgs ? { config = {
     allowUnfree = false;
     inHydra = true;
-    permittedInsecurePackages = [
-      # Keep evaluating home-assistant, which is transitively affected
-      # by home-assistant-chip-core consuming OpenSSL 1.1. Affects roughly
-      # 800 jobs.
-      "openssl-1.1.1w"
-    ];
   }; }
 }:
 

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -29,14 +29,6 @@
 , nixpkgsArgs ? { config = {
     allowUnfree = false;
     inHydra = true;
-    permittedInsecurePackages = [
-      # *Exceptionally*, those packages will be cached with their *secure* dependents
-      # because they will reach EOL in the middle of the 23.05 release
-      # and it will be too much painful for our users to recompile them
-      # for no real reason.
-      # Remove them for 23.11.
-      "openssl-1.1.1w"
-    ];
   }; }
 
   # This flag, if set to true, will inhibit the use of `mapTestOn`


### PR DESCRIPTION
A year has passed and a limited number of packages still rely on this, so it is probably safe to remove these.

- pkgs/games/runescape-launcher/default.nix (@GRBurst)
- pkgs/development/ruby-modules/gem-config/default.nix
- pkgs/tools/security/pcsc-safenet/default.nix (@wldhx)
- pkgs/tools/system/osquery/default.nix (@znewman01 @nlewo)
- pkgs/by-name/aw/aws-workspaces/package.nix (@mausch @dylanmtaylor)
- pkgs/top-level/php-packages.nix (php-spx)
- pkgs/tools/archivers/quickbms/default.nix
- pkgs/applications/networking/instant-messengers/viber/default.nix (@jagajaga)
- pkgs/by-name/we/wechat-uos/package.nix (@pokon548 
- pkgs/development/python-modules/paddlepaddle/default.nix (@happysalada)
- pkgs/applications/editors/sublime/4/common.nix (@jtojnar)

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
