### PR TITLE
treewide: use cmakeCudaArchitecturesString

### DIFF
--- a/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
@@ -24,7 +24,7 @@
 assert enableCuda -> singlePrec;
 
 let
-  inherit (cudaPackages.cudaFlags) cudaCapabilities dropDot;
+  inherit (cudaPackages.flags) cmakeCudaArchitecturesString;
 
   # Select reasonable defaults for all major platforms
   # The possible values are defined in CMakeLists.txt:
@@ -111,10 +111,10 @@ in stdenv.mkDerivation rec {
      ]
   ) ++ lib.optionals enableCuda [
     "-DGMX_GPU=CUDA"
-    (lib.cmakeFeature "CMAKE_CUDA_ARCHITECTURES" (builtins.concatStringsSep ";" (map dropDot cudaCapabilities)))
+    (lib.cmakeFeature "CMAKE_CUDA_ARCHITECTURES" cmakeCudaArchitecturesString)
 
     # Gromacs seems to ignore and override the normal variables, so we add this ad hoc:
-    (lib.cmakeFeature "GMX_CUDA_TARGET_COMPUTE" (builtins.concatStringsSep ";" (map dropDot cudaCapabilities)))
+    (lib.cmakeFeature "GMX_CUDA_TARGET_COMPUTE" cmakeCudaArchitecturesString)
   ];
 
   postInstall = ''

--- a/pkgs/by-name/ll/llama-cpp/package.nix
+++ b/pkgs/by-name/ll/llama-cpp/package.nix
@@ -122,12 +122,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     (cmakeBool "LLAMA_VULKAN" vulkanSupport)
   ]
       ++ optionals cudaSupport [
-        (
-          with cudaPackages.flags;
-          cmakeFeature "CMAKE_CUDA_ARCHITECTURES" (
-            builtins.concatStringsSep ";" (map dropDot cudaCapabilities)
-          )
-        )
+        (cmakeFeature "CMAKE_CUDA_ARCHITECTURES" cudaPackages.flags.cmakeCudaArchitecturesString)
       ]
       ++ optionals rocmSupport [
         (cmakeFeature "CMAKE_C_COMPILER" "hipcc")

--- a/pkgs/by-name/ma/maa-assistant-arknights/fastdeploy-ppocr.nix
+++ b/pkgs/by-name/ma/maa-assistant-arknights/fastdeploy-ppocr.nix
@@ -14,10 +14,6 @@
 
 let
   effectiveStdenv = if cudaSupport then cudaPackages.backendStdenv else inputs.stdenv;
-  cudaCapabilities = cudaPackages.cudaFlags.cudaCapabilities;
-  # E.g. [ "80" "86" "90" ]
-  cudaArchitectures = (builtins.map cudaPackages.cudaFlags.dropDot cudaCapabilities);
-  cudaArchitecturesString = lib.strings.concatStringsSep ";" cudaArchitectures;
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "fastdeploy-ppocr";
@@ -65,7 +61,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
       (lib.cmakeBool "BUILD_SHARED_LIBS" true)
     ]
     ++ lib.optionals cudaSupport [
-      (lib.cmakeFeature "CMAKE_CUDA_ARCHITECTURES" cudaArchitecturesString)
+      (lib.cmakeFeature "CMAKE_CUDA_ARCHITECTURES" cudaPackages.flags.cmakeCudaArchitecturesString)
     ];
 
   postInstall = ''

--- a/pkgs/development/libraries/onnxruntime/default.nix
+++ b/pkgs/development/libraries/onnxruntime/default.nix
@@ -29,10 +29,7 @@ let
   stdenv = throw "Use effectiveStdenv instead";
   effectiveStdenv = if cudaSupport then cudaPackages.backendStdenv else inputs.stdenv;
 
-  cudaCapabilities = cudaPackages.cudaFlags.cudaCapabilities;
-  # E.g. [ "80" "86" "90" ]
-  cudaArchitectures = (builtins.map cudaPackages.cudaFlags.dropDot cudaCapabilities);
-  cudaArchitecturesString = lib.strings.concatStringsSep ";" cudaArchitectures;
+  cudaArchitecturesString = cudaPackages.flags.cmakeCudaArchitecturesString;
 
   howard-hinnant-date = fetchFromGitHub {
     owner = "HowardHinnant";

--- a/pkgs/development/libraries/science/math/faiss/default.nix
+++ b/pkgs/development/libraries/science/math/faiss/default.nix
@@ -29,8 +29,7 @@ let
   pname = "faiss";
   version = "1.7.4";
 
-  inherit (cudaPackages) cudaFlags backendStdenv;
-  inherit (cudaFlags) cudaCapabilities dropDot;
+  inherit (cudaPackages) flags backendStdenv;
 
   stdenv = if cudaSupport then backendStdenv else inputs.stdenv;
 
@@ -93,7 +92,7 @@ stdenv.mkDerivation {
     "-DFAISS_ENABLE_PYTHON=${if pythonSupport then "ON" else "OFF"}"
     "-DFAISS_OPT_LEVEL=${optLevel}"
   ] ++ lib.optionals cudaSupport [
-    "-DCMAKE_CUDA_ARCHITECTURES=${builtins.concatStringsSep ";" (map dropDot cudaCapabilities)}"
+    "-DCMAKE_CUDA_ARCHITECTURES=${flags.cmakeCudaArchitecturesString}"
     "-DCUDAToolkit_INCLUDE_DIR=${cudaJoined}/include"
   ];
 

--- a/pkgs/development/libraries/science/math/magma/generic.nix
+++ b/pkgs/development/libraries/science/math/magma/generic.nix
@@ -41,8 +41,7 @@ let
     then cudaPackages_11
     else cudaPackages;
 
-  inherit (effectiveCudaPackages) cudaAtLeast cudaFlags cudaOlder;
-  inherit (cudaFlags) cudaCapabilities;
+  inherit (effectiveCudaPackages) cudaAtLeast flags cudaOlder;
 
   # move to newer ROCm version once supported
   rocmPackages = rocmPackages_5;
@@ -52,7 +51,7 @@ let
   #   lists.subtractLists a b = b - a
 
   # For ROCm
-  # NOTE: The hip.gpuTargets are prefixed with "gfx" instead of "sm" like cudaFlags.realArches.
+  # NOTE: The hip.gpuTargets are prefixed with "gfx" instead of "sm" like flags.realArches.
   #   For some reason, Magma's CMakeLists.txt file does not handle the "gfx" prefix, so we must
   #   remove it.
   rocmArches = lists.map (x: strings.removePrefix "gfx" x) rocmPackages.clr.gpuTargets;
@@ -83,12 +82,11 @@ let
       throw "No GPU targets specified"
   );
 
-  # E.g. [ "80" "86" "90" ]
-  cudaArchitectures = (builtins.map cudaFlags.dropDot cudaCapabilities);
-
-  cudaArchitecturesString = strings.concatStringsSep ";" cudaArchitectures;
+  cudaArchitecturesString = flags.cmakeCudaArchitecturesString;
   minArch =
     let
+      # E.g. [ "80" "86" "90" ]
+      cudaArchitectures = (builtins.map flags.dropDot flags.cudaCapabilities);
       minArch' = builtins.head (builtins.sort strings.versionOlder cudaArchitectures);
     in
     # "75" -> "750"  Cf. https://bitbucket.org/icl/magma/src/f4ec79e2c13a2347eff8a77a3be6f83bc2daec20/CMakeLists.txt#lines-273

--- a/pkgs/development/libraries/science/math/tiny-cuda-nn/default.nix
+++ b/pkgs/development/libraries/science/math/tiny-cuda-nn/default.nix
@@ -11,7 +11,7 @@
   which,
 }: let
   inherit (lib) lists strings;
-  inherit (cudaPackages) backendStdenv cudaFlags;
+  inherit (cudaPackages) backendStdenv flags;
 
   cuda-common-redist = with cudaPackages; [
     cuda_cudart.dev # cuda_runtime.h
@@ -89,9 +89,7 @@ in
     doCheck = false;
 
     preConfigure = ''
-      export TCNN_CUDA_ARCHITECTURES="${
-        strings.concatStringsSep ";" (lists.map cudaFlags.dropDot cudaFlags.cudaCapabilities)
-      }"
+      export TCNN_CUDA_ARCHITECTURES="${flags.cmakeCudaArchitecturesString}"
       export CUDA_HOME="${cuda-native-redist}"
       export LIBRARY_PATH="${cuda-native-redist}/lib/stubs:$LIBRARY_PATH"
       export CC="${backendStdenv.cc}/bin/cc"


### PR DESCRIPTION
## Description of changes

`cmakeCudaArchitecturesString` was introduced in e77b24b15926bf690a6e69d2fb805edce0f4f4b1. There are seven packages that still have redundant code that computes the same thing. This commit simplifies all of them.

This change also replaces `cudaPackages.cudaFlags` with `cudaPackages.flags` in these packages, since my understanding is that the former is deprecated.

Note that there is one instance of a package with a very similar expression: https://github.com/NixOS/nixpkgs/blob/a5f040459a99b8bbc373d5f04ba7e6ce467b98d1/pkgs/development/libraries/dlib/default.nix#L41
It uses `,` instead of `;`, so it is not equivalent to `cmakeCudaArchitecturesString`.

@NixOS/cuda-maintainers

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
