### PR TITLE
[Backport release-24.05] klee: make llvmPackages and uclibc overridable

### DIFF
--- a/pkgs/applications/science/logic/klee/default.nix
+++ b/pkgs/applications/science/logic/klee/default.nix
@@ -11,6 +11,7 @@
 , sqlite
 , gtest
 , lit
+, nix-update-script
 
 # Build KLEE in debug mode. Defaults to false.
 , debug ? false

--- a/pkgs/applications/science/logic/klee/default.nix
+++ b/pkgs/applications/science/logic/klee/default.nix
@@ -1,10 +1,8 @@
 { lib
-, stdenv
+, llvmPackages
 , callPackage
 , fetchFromGitHub
 , cmake
-, clang
-, llvm
 , python3
 , z3
 , stp
@@ -30,19 +28,35 @@
 # Enable runtime asserts. Default false.
 , runtimeAsserts ? false
 
-# Extra klee-uclibc config.
+# Klee uclibc. Defaults to the bundled version.
+, kleeuClibc ? null
+
+# Extra klee-uclibc config for the default klee-uclibc.
 , extraKleeuClibcConfig ? {}
 }:
 
+# Klee supports these LLVM versions.
 let
+  llvmVersion = llvmPackages.llvm.version;
+  inherit (lib.strings) versionAtLeast versionOlder;
+in
+assert versionAtLeast llvmVersion "11" && versionOlder llvmVersion "17";
+
+let
+  # The chosen version of klee-uclibc.
+  chosenKleeuClibc =
+    if kleeuClibc == null then
+      callPackage ./klee-uclibc.nix {
+        llvmPackages = llvmPackages;
+        inherit extraKleeuClibcConfig debugRuntime runtimeAsserts;
+      }
+    else
+      kleeuClibc;
+
   # Python used for KLEE tests.
   kleePython = python3.withPackages (ps: with ps; [ tabulate ]);
-
-  # The klee-uclibc derivation.
-  kleeuClibc = callPackage ./klee-uclibc.nix {
-    inherit stdenv clang llvm extraKleeuClibcConfig debugRuntime runtimeAsserts;
-  };
-in stdenv.mkDerivation rec {
+in
+llvmPackages.stdenv.mkDerivation rec {
   pname = "klee";
   version = "3.1";
 
@@ -54,14 +68,16 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
+
   buildInputs = [
+    llvmPackages.llvm
     cryptominisat
     gperftools
-    llvm
     sqlite
     stp
     z3
   ];
+
   nativeCheckInputs = [
     gtest
 
@@ -77,10 +93,10 @@ in stdenv.mkDerivation rec {
     onOff = val: if val then "ON" else "OFF";
   in [
     "-DKLEE_RUNTIME_BUILD_TYPE=${if debugRuntime then "Debug" else "Release"}"
-    "-DLLVMCC=${clang}/bin/clang"
-    "-DLLVMCXX=${clang}/bin/clang++"
+    "-DLLVMCC=${llvmPackages.clang}/bin/clang"
+    "-DLLVMCXX=${llvmPackages.clang}/bin/clang++"
     "-DKLEE_ENABLE_TIMESTAMP=${onOff false}"
-    "-DKLEE_UCLIBC_PATH=${kleeuClibc}"
+    "-DKLEE_UCLIBC_PATH=${chosenKleeuClibc}"
     "-DENABLE_KLEE_ASSERTS=${onOff asserts}"
     "-DENABLE_POSIX_RUNTIME=${onOff true}"
     "-DENABLE_UNIT_TESTS=${onOff true}"
@@ -94,17 +110,21 @@ in stdenv.mkDerivation rec {
   env.NIX_CFLAGS_COMPILE = toString ["-Wno-macro-redefined"];
 
   prePatch = ''
-    patchShebangs .
+    patchShebangs --build .
   '';
 
   # https://github.com/klee/klee/issues/1690
   hardeningDisable = [ "fortify" ];
 
+  enableParallelBuilding = true;
   doCheck = true;
 
   passthru = {
-    # Let the user depend on `klee.uclibc` for klee-uclibc
-    uclibc = kleeuClibc;
+    updateScript = nix-update-script {
+      extraArgs = [ "--version-regex" "v(\d\.\d)" ];
+    };
+    # Let the user access the chosen uClibc outside the derivation.
+    uclibc = chosenKleeuClibc;
   };
 
   meta = with lib; {
@@ -128,7 +148,7 @@ in stdenv.mkDerivation rec {
       that matches a computed test input, including setting up files, pipes,
       environment variables, and passing command line arguments.
     '';
-    homepage = "https://klee.github.io/";
+    homepage = "https://klee.github.io";
     license = licenses.ncsa;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ numinit ];

--- a/pkgs/applications/science/logic/klee/default.nix
+++ b/pkgs/applications/science/logic/klee/default.nix
@@ -129,7 +129,8 @@ llvmPackages.stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    description = "A symbolic virtual machine built on top of LLVM";
+    mainProgram = "klee";
+    description = "Symbolic virtual machine built on top of LLVM";
     longDescription = ''
       KLEE is a symbolic virtual machine built on top of the LLVM compiler
       infrastructure. Currently, there are two primary components:

--- a/pkgs/applications/science/logic/klee/klee-uclibc.nix
+++ b/pkgs/applications/science/logic/klee/klee-uclibc.nix
@@ -6,6 +6,7 @@
 , python3
 , curl
 , which
+, nix-update-script
 , debugRuntime ? true
 , runtimeAsserts ? false
 , extraKleeuClibcConfig ? {}
@@ -88,6 +89,10 @@ llvmPackages.stdenv.mkDerivation rec {
   makeFlags = ["HAVE_DOT_CONFIG=y"];
 
   enableParallelBuilding = true;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex" "v(\d\.\d)" ];
+  };
 
   meta = with lib; {
     description = "A modified version of uClibc for KLEE.";

--- a/pkgs/applications/science/logic/klee/klee-uclibc.nix
+++ b/pkgs/applications/science/logic/klee/klee-uclibc.nix
@@ -1,13 +1,11 @@
 { lib
-, stdenv
+, llvmPackages
 , fetchurl
 , fetchFromGitHub
-, which
 , linuxHeaders
-, clang
-, llvm
 , python3
 , curl
+, which
 , debugRuntime ? true
 , runtimeAsserts ? false
 , extraKleeuClibcConfig ? {}
@@ -24,21 +22,22 @@ let
     "RUNTIME_PREFIX" = "/";
     "DEVEL_PREFIX" = "/";
   });
-in stdenv.mkDerivation rec {
+in
+llvmPackages.stdenv.mkDerivation rec {
   pname = "klee-uclibc";
   version = "1.4";
   src = fetchFromGitHub {
     owner = "klee";
     repo = "klee-uclibc";
     rev = "klee_uclibc_v${version}";
-    sha256 = "sha256-sogQK5Ed0k5tf4rrYwCKT4YRKyEovgT25p0BhGvJ1ok=";
+    hash = "sha256-sogQK5Ed0k5tf4rrYwCKT4YRKyEovgT25p0BhGvJ1ok=";
   };
 
   nativeBuildInputs = [
-    clang
-    curl
-    llvm
+    llvmPackages.clang
+    llvmPackages.llvm
     python3
+    curl
     which
   ];
 
@@ -47,11 +46,11 @@ in stdenv.mkDerivation rec {
 
   # HACK: needed for cross-compile.
   # See https://www.mail-archive.com/klee-dev@imperial.ac.uk/msg03141.html
-  KLEE_CFLAGS = "-idirafter ${clang}/resource-root/include";
+  KLEE_CFLAGS = "-idirafter ${llvmPackages.clang}/resource-root/include";
 
   prePatch = ''
-    patchShebangs ./configure
-    patchShebangs ./extra
+    patchShebangs --build ./configure
+    patchShebangs --build ./extra
   '';
 
   # klee-uclibc configure does not support --prefix, so we override configurePhase entirely
@@ -88,13 +87,15 @@ in stdenv.mkDerivation rec {
 
   makeFlags = ["HAVE_DOT_CONFIG=y"];
 
+  enableParallelBuilding = true;
+
   meta = with lib; {
     description = "A modified version of uClibc for KLEE.";
     longDescription = ''
       klee-uclibc is a bitcode build of uClibc meant for compatibility with the
       KLEE symbolic virtual machine.
     '';
-    homepage = "https://klee.github.io/";
+    homepage = "https://github.com/klee/klee-uclibc";
     license = licenses.lgpl3;
     maintainers = with maintainers; [ numinit ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32154,11 +32154,9 @@ with pkgs;
 
   klayout = libsForQt5.callPackage ../applications/misc/klayout { };
 
-  klee = callPackage ../applications/science/logic/klee (with llvmPackages_13; {
-    clang = clang;
-    llvm = llvm;
-    stdenv = stdenv;
-  });
+  klee = callPackage ../applications/science/logic/klee {
+    llvmPackages = llvmPackages_13;
+  };
 
   kmetronome = qt6Packages.callPackage ../applications/audio/kmetronome { };
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Backport from #304204 allowing LLVM to be overridden in klee. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
