### PR TITLE
pcsx2: 1.7.5779 -> 1.7.5919

### DIFF
--- a/pkgs/by-name/pc/pcsx2/linux.nix
+++ b/pkgs/by-name/pc/pcsx2/linux.nix
@@ -7,7 +7,6 @@
   cubeb,
   curl,
   extra-cmake-modules,
-  fetchpatch,
   ffmpeg,
   libaio,
   libbacktrace,
@@ -38,8 +37,8 @@ let
   pcsx2_patches = fetchFromGitHub {
     owner = "PCSX2";
     repo = "pcsx2_patches";
-    rev = "b3a788e16ea12efac006cbbe1ece45b6b9b34326";
-    sha256 = "sha256-Uvpz2Gpj533Sr6wLruubZxssoXefQDey8GHIDKWhW3s=";
+    rev = "9e71956797332471010e563a4b75a5934bef9d4e";
+    sha256 = "sha256-jpaRpvJox78zRGyrVIGYVoSEo/ICBlBfw3dTMz9QGuU=";
   };
   inherit (qt6)
     qtbase
@@ -55,23 +54,12 @@ llvmPackages_17.stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "PCSX2";
     repo = "pcsx2";
-    fetchSubmodules = true;
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-WiwnP5yoBy8bRLUPuCZ7z4nhIzrY8P29KS5ZjErM/A4=";
+    # NOTE: Don't forget to change the hash in shaderc-patched.nix as well.
+    sha256 = "sha256-cDugEbbz40uLPW64bcDGxfo1Y3ahYnEVaalfMp/J95s=";
   };
 
-  patches = [
-    ./define-rev.patch
-    # Backport patches to fix random crashes on startup
-    (fetchpatch {
-      url = "https://github.com/PCSX2/pcsx2/commit/e47bcf8d80df9a93201eefbaf169ec1a0673a833.patch";
-      sha256 = "sha256-7CL1Kpu+/JgtKIenn9rQKAs3A+oJ40W5XHlqSg77Q7Y=";
-    })
-    (fetchpatch {
-      url = "https://github.com/PCSX2/pcsx2/commit/92b707db994f821bccc35d6eef67727ea3ab496b.patch";
-      sha256 = "sha256-HWJ8KZAY/qBBotAJerZg6zi5QUHuTD51zKH1rAtZ3tc=";
-    })
-  ];
+  patches = [ ./define-rev.patch ];
 
   cmakeFlags = [
     (lib.cmakeBool "DISABLE_ADVANCE_SIMD" true)
@@ -122,7 +110,13 @@ llvmPackages_17.stdenv.mkDerivation (finalAttrs: {
 
   qtWrapperArgs =
     let
-      libs = lib.makeLibraryPath ([ vulkan-loader ] ++ cubeb.passthru.backendLibs);
+      libs = lib.makeLibraryPath (
+        [
+          vulkan-loader
+          shaderc-patched
+        ]
+        ++ cubeb.passthru.backendLibs
+      );
     in
     [ "--prefix LD_LIBRARY_PATH : ${libs}" ];
 

--- a/pkgs/by-name/pc/pcsx2/package.nix
+++ b/pkgs/by-name/pc/pcsx2/package.nix
@@ -5,7 +5,7 @@
 }:
 let
   pname = "pcsx2";
-  version = "1.7.5779";
+  version = "1.7.5919";
   meta = with lib; {
     description = "Playstation 2 emulator";
     longDescription = ''

--- a/pkgs/by-name/pc/pcsx2/shaderc-patched.nix
+++ b/pkgs/by-name/pc/pcsx2/shaderc-patched.nix
@@ -1,20 +1,35 @@
 {
+  lib,
+  fetchFromGitHub,
   fetchpatch,
   pcsx2,
   shaderc,
 }:
 
+let
+  version = "2024.1";
+in
 shaderc.overrideAttrs (old: {
+  inherit version;
   pname = "shaderc-patched-for-pcsx2";
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "shaderc";
+    rev = "v${version}";
+    hash = "sha256-2L/8n6KLVZWXt6FrYraVlZV5YqbPHD7rzXPCkD0d4kg=";
+  };
   patches = (old.patches or [ ]) ++ [
     (fetchpatch {
       url = "file://${pcsx2.src}/.github/workflows/scripts/common/shaderc-changes.patch";
-      hash = "sha256-Ps/D+CdSbjVWg3ZGOEcgbpQbCNkI5Nuizm4E5qiM9Wo=";
+      hash = "sha256-/qX2yD0RBuPh4Cf7n6OjVA2IyurpaCgvCEsIX/hXFdQ=";
       excludes = [
-        "CHANGES"
-        "CMakeLists.txt"
         "libshaderc/CMakeLists.txt"
+        "third_party/CMakeLists.txt"
       ];
     })
+  ];
+  cmakeFlags = (old.cmakeFlags or [ ]) ++ [
+    (lib.cmakeBool "SHADERC_SKIP_EXAMPLES" true)
+    (lib.cmakeBool "SHADERC_SKIP_TESTS" true)
   ];
 })


### PR DESCRIPTION
## Description of changes

Diff: https://github.com/PCSX2/pcsx2/compare/v1.7.5779...v1.7.5919

Also pinned Shaderc (didn't do it in a separate commit because I'd first have to pin it to 2024.0, then update it).
Upstream decided that Shaderc is now a dynamic library.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
