### PR TITLE
oscar: init at 1.5.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15752,6 +15752,12 @@
     githubId = 817039;
     name = "Paulo Casaretto";
   };
+  pcboy = {
+    email = "david@joynetiks.com";
+    github = "pcboy";
+    githubId = 943430;
+    name = "David Hagege";
+  };
   pedrohlc = {
     email = "root@pedrohlc.com";
     github = "PedroHLC";

--- a/pkgs/by-name/os/oscar/package.nix
+++ b/pkgs/by-name/os/oscar/package.nix
@@ -1,0 +1,64 @@
+{ stdenv
+, fetchFromGitLab
+, qt5
+, libGLU
+, bash
+, lib
+, ...
+}:
+stdenv.mkDerivation (final: {
+  pname = "oscar";
+  version = "1.5.3";
+
+  src = fetchFromGitLab {
+    owner = "pholy";
+    repo = "OSCAR-code";
+    rev = "${final.version}";
+    sha256 = "sha256-ukd2pni4qEwWxG4lr8KUliZO/R2eziTTuSvDo8uigxQ=";
+  };
+
+  buildInputs = with qt5;
+    [
+      qtbase
+      qttools
+      qtserialport
+      libGLU
+    ]
+    ++ lib.optionals stdenv.isLinux [ qtwayland ];
+
+  nativeBuildInputs = with qt5; [
+    wrapQtAppsHook
+  ];
+
+  postPatch =
+    let
+      lrelease = lib.getExe' (lib.getDev qt5.qttools) "lrelease";
+    in
+    ''
+      substituteInPlace oscar/oscar.pro --replace-fail '$$LRELEASE' '${lrelease}'
+      substituteInPlace oscar/oscar.pro --replace-fail /bin/bash '${lib.getExe bash}'
+    '';
+
+  buildPhase = ''
+    mkdir build
+    cd build
+    qmake ../OSCAR_QT.pro
+    make -j$NIX_BUILD_CORES
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin/
+    mkdir -p $out/shared/
+    cp -r oscar $out/shared/
+    makeWrapper $out/shared/oscar/OSCAR $out/bin/oscar
+  '';
+
+  meta = {
+    homepage = "https://www.sleepfiles.com/OSCAR/";
+    description = "The Open Source CPAP Analysis Reporter";
+    mainProgram = "oscar";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ pcboy ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description of changes

Adding OSCAR. It's an Open Source CPAP Analysis Reporter (maybe the most famous one) for people suffering from sleep apnea.

https://www.sleepfiles.com/OSCAR/

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


