### PR TITLE
androidStudioPackages: add update script

### DIFF
--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -257,10 +257,12 @@ let
     passthru = let
       withSdk = androidSdk: mkAndroidStudioWrapper { inherit androidStudio androidSdk; };
     in {
+      inherit version;
       unwrapped = androidStudio;
       full = withSdk androidenv.androidPkgs.androidsdk;
       inherit withSdk;
       sdk = androidSdk;
+      updateScript = [ ./update.sh "${channel}" ];
     };
     meta = {
       description = "Official IDE for Android (${channel} channel)";

--- a/pkgs/applications/editors/android-studio/update.sh
+++ b/pkgs/applications/editors/android-studio/update.sh
@@ -1,0 +1,70 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -I nixpkgs=./. -i bash -p python3Packages.yq nix-prefetch-scripts
+
+set -euo pipefail
+
+DEFAULT_NIX="$(realpath "./pkgs/applications/editors/android-studio/default.nix")"
+RELEASES_XML="$(curl -v --silent https://raw.githubusercontent.com/JetBrains/intellij-sdk-docs/main/topics/_generated/android_studio_releases.xml 2>/dev/null)"
+
+# Available channels: Release/Patch (stable), Beta, Canary
+getLatest() {
+    local attribute="$1"
+    local channel="$2"
+    [[ "$channel" = "stable" ]] && channel="release" # Our naming convention is different
+    local result="$(echo "$RELEASES_XML" \
+        | xq -r ".[].item[] | select(.channel == \"${channel^}\") | .${attribute}" \
+        | sort --version-sort \
+        | tail -n 1)"
+
+    if [[ -n "$result" ]]; then
+        echo "$result"
+    else
+        echo "could not find the latest $attribute for $channel"
+        exit 1
+    fi
+}
+
+updateChannel() {
+    local channel="$1"
+    local latestVersion="$(getLatest "version" "$channel")"
+    if [[ "$channel" = "stable" ]]; then
+        # Sometimes the latest stable version is published under the `patch` channel instead of `release`,
+        # so we need to check if the latest version of the release channel isnt older than the patch channel
+        local latestPatchVersion="$(getLatest "version" "patch")"
+        if [[ "$(nix eval --expr "with import ./default.nix {}; lib.versionOlder \"${latestVersion}\" \"${latestPatchVersion}\"" --impure)" = "true" ]]; then
+            latestVersion="$latestPatchVersion"
+        fi
+    fi
+
+    local localVersion="$(nix eval --raw --file . androidStudioPackages."${channel}".version)"
+    if [[ "${latestVersion}" == "${localVersion}" ]]; then
+        echo "$channel is already up to date!"
+        return 0
+    fi
+    echo "updating $channel from $localVersion to $latestVersion"
+
+    local latestHash="$(nix-prefetch-url --quiet "https://dl.google.com/dl/android/studio/ide-zips/${latestVersion}/android-studio-${latestVersion}-linux.tar.gz")"
+    local localHash="$(nix eval --raw --file . androidStudioPackages."${channel}".unwrapped.src.drvAttrs.outputHash)"
+    sed -i "s/${localHash}/${latestHash}/g" "${DEFAULT_NIX}"
+
+    # Match the formatting of default.nix: `version = "2021.3.1.14"; # "Android Studio Dolphin (2021.3.1) Beta 5"`
+    local versionString="${latestVersion}\"; # \"$(getLatest "name" "${channel}")\""
+    sed -i "s/${localVersion}.*/${versionString}/g" "${DEFAULT_NIX}"
+    echo "updated ${channel} to ${latestVersion}"
+}
+
+if (( $# == 0 )); then
+    for channel in "beta" "canary" "stable"; do
+        updateChannel "$channel"
+    done
+else
+    while (( "$#" )); do
+        case "$1" in
+            beta|canary|stable)
+                updateChannel "$1" ;;
+            *)
+                echo "unknown channel: $1" && exit 1 ;;
+        esac
+        shift 1
+    done
+fi

--- a/pkgs/applications/editors/android-studio/update.sh
+++ b/pkgs/applications/editors/android-studio/update.sh
@@ -1,19 +1,24 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -I nixpkgs=./. -i bash -p python3Packages.yq nix-prefetch-scripts
+#! nix-shell -I nixpkgs=./. -i bash -p jq nix-prefetch-scripts
 
 set -euo pipefail
 
 DEFAULT_NIX="$(realpath "./pkgs/applications/editors/android-studio/default.nix")"
-RELEASES_XML="$(curl -v --silent https://raw.githubusercontent.com/JetBrains/intellij-sdk-docs/main/topics/_generated/android_studio_releases.xml 2>/dev/null)"
+RELEASES_JSON="$(curl --silent -L https://jb.gg/android-studio-releases-list.json)"
 
 # Available channels: Release/Patch (stable), Beta, Canary
 getLatest() {
     local attribute="$1"
     local channel="$2"
-    [[ "$channel" = "stable" ]] && channel="release" # Our naming convention is different
-    local result="$(echo "$RELEASES_XML" \
-        | xq -r ".[].item[] | select(.channel == \"${channel^}\") | .${attribute}" \
+    case "$channel" in
+        "stable") local select='.channel == "Release" or .channel == "Patch"' ;;
+        "beta") local select='.channel == "Beta" or .channel == "RC"' ;;
+        *) local select=".channel == \"${channel^}\"" ;;
+    esac
+    local result="$(echo "$RELEASES_JSON" \
+        | jq -r ".content.item[] | select(${select}) | [.version, .${attribute}] | join(\" \")" \
         | sort --version-sort \
+        | cut -d' ' -f 2- \
         | tail -n 1)"
 
     if [[ -n "$result" ]]; then
@@ -27,29 +32,22 @@ getLatest() {
 updateChannel() {
     local channel="$1"
     local latestVersion="$(getLatest "version" "$channel")"
-    if [[ "$channel" = "stable" ]]; then
-        # Sometimes the latest stable version is published under the `patch` channel instead of `release`,
-        # so we need to check if the latest version of the release channel isnt older than the patch channel
-        local latestPatchVersion="$(getLatest "version" "patch")"
-        if [[ "$(nix eval --expr "with import ./default.nix {}; lib.versionOlder \"${latestVersion}\" \"${latestPatchVersion}\"" --impure)" = "true" ]]; then
-            latestVersion="$latestPatchVersion"
-        fi
-    fi
 
-    local localVersion="$(nix eval --raw --file . androidStudioPackages."${channel}".version)"
+    local localVersion="$(nix --extra-experimental-features nix-command eval --raw --file . androidStudioPackages."${channel}".version)"
     if [[ "${latestVersion}" == "${localVersion}" ]]; then
-        echo "$channel is already up to date!"
+        echo "$channel is already up to date at $latestVersion"
         return 0
     fi
     echo "updating $channel from $localVersion to $latestVersion"
 
-    local latestHash="$(nix-prefetch-url --quiet "https://dl.google.com/dl/android/studio/ide-zips/${latestVersion}/android-studio-${latestVersion}-linux.tar.gz")"
-    local localHash="$(nix eval --raw --file . androidStudioPackages."${channel}".unwrapped.src.drvAttrs.outputHash)"
-    sed -i "s/${localHash}/${latestHash}/g" "${DEFAULT_NIX}"
+    local latestHash="$(nix-prefetch-url "https://dl.google.com/dl/android/studio/ide-zips/${latestVersion}/android-studio-${latestVersion}-linux.tar.gz")"
+    local latestSri="$(nix --extra-experimental-features nix-command hash to-sri --type sha256 "$latestHash")"
+    local localHash="$(nix --extra-experimental-features nix-command eval --raw --file . androidStudioPackages."${channel}".unwrapped.src.drvAttrs.outputHash)"
+    sed -i "s~${localHash}~${latestSri}~g" "${DEFAULT_NIX}"
 
     # Match the formatting of default.nix: `version = "2021.3.1.14"; # "Android Studio Dolphin (2021.3.1) Beta 5"`
     local versionString="${latestVersion}\"; # \"$(getLatest "name" "${channel}")\""
-    sed -i "s/${localVersion}.*/${versionString}/g" "${DEFAULT_NIX}"
+    sed -i "s~${localVersion}.*~${versionString}~g" "${DEFAULT_NIX}"
     echo "updated ${channel} to ${latestVersion}"
 }
 


### PR DESCRIPTION
## Description of changes

This adds an update script for all branches of Android Studio, with the latest information being fetched from jetbrains https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html 

Closes #182128

cc @kirillrdy 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
