### PR TITLE
pipewire: fix module-roc-sink explicity specifying sender packet encoding

### DIFF
--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitLab
+, fetchpatch
 , python3
 , meson
 , ninja
@@ -99,6 +100,12 @@ stdenv.mkDerivation(finalAttrs: {
     ./0060-libjack-path.patch
     # Move installed tests into their own output.
     ./0070-installed-tests-path.patch
+    # fix module-roc-sink explicity specifying sender packet encoding
+    # https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/2048
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/6acfb53884c6f3936030fe43a584bfa01c27d3ea.patch";
+      hash = "sha256-UQTWnw2fJ8Sx+eMaUmbJEFopV3HPr63v4xVtk0z3/xM=";
+    })
   ];
 
   strictDeps = true;


### PR DESCRIPTION
pipewire: fix module-roc-sink explicity specifying sender packet encoding

CyberShadow [reports success](https://github.com/NixOS/nixpkgs/pull/320870#issuecomment-2185964928) with this patch. I haven't tested.
Per K900 [comment](https://github.com/NixOS/nixpkgs/pull/322029#issuecomment-2185317650), failing passthru test is assumed to be unrelated.

Fixes regression:
https://github.com/NixOS/nixpkgs/pull/320870#issuecomment-2185279926

Thanks CyberShadow for the fix.

Draft: Needs to target `next-staging`. Because it's a [fix to hydra builds](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#staging). I suppose.