### PR TITLE
realvnc-vnc-viewer: revert changes caused by captcha

### DIFF
--- a/pkgs/tools/admin/realvnc-vnc-viewer/darwin.nix
+++ b/pkgs/tools/admin/realvnc-vnc-viewer/darwin.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenvNoCC
-, requireFile
+, fetchurl
 , undmg
 , pname
 , version
@@ -9,17 +9,10 @@
 stdenvNoCC.mkDerivation (finalAttrs: {
   inherit pname version meta;
 
-  src = requireFile rec {
+  src = fetchurl rec {
       name = "VNC-Viewer-${finalAttrs.version}-MacOSX-universal.dmg";
       url = "https://downloads.realvnc.com/download/file/viewer.files/${name}";
       sha256 = "0k72fdnx1zmyi9z5n3lazc7s70gcddxq0s73akp0al0y9hzq9prh";
-      message= ''
-        vnc-viewer can be downloaded from ${url},
-        but the download link require captcha, thus if you wish to use this application,
-        you need to download it manually and use follow command to add downloaded files into nix-store
-
-        $ nix-prefetch-url --type sha256 file:///path/to/${name}
-      '';
   };
   sourceRoot = ".";
 

--- a/pkgs/tools/admin/realvnc-vnc-viewer/default.nix
+++ b/pkgs/tools/admin/realvnc-vnc-viewer/default.nix
@@ -17,7 +17,6 @@ let
     };
     maintainers = with maintainers; [ emilytrau onedragon ];
     platforms = [ "x86_64-linux" ] ++ platforms.darwin;
-    hydraPlatforms = [];
     mainProgram = "vncviewer";
   };
 in

--- a/pkgs/tools/admin/realvnc-vnc-viewer/linux.nix
+++ b/pkgs/tools/admin/realvnc-vnc-viewer/linux.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, requireFile
+, fetchurl
 , autoPatchelfHook
 , rpmextract
 , libX11
@@ -13,18 +13,11 @@
 stdenv.mkDerivation (finalAttrs: {
   inherit pname version;
 
-  src = {
-    "x86_64-linux" = requireFile rec {
+  src = rec {
+    "x86_64-linux" = fetchurl rec {
       name = "VNC-Viewer-${finalAttrs.version}-Linux-x64.rpm";
       url = "https://downloads.realvnc.com/download/file/viewer.files/${name}";
       sha256 = "sha256-Ull9iNi8NxB12YwEThWE0P9k1xOV2LZnebuRrVH/zwI=";
-      message= ''
-        vnc-viewer can be downloaded from ${url},
-        but the download link require captcha, thus if you wish to use this application,
-        you need to download it manually and use follow command to add downloaded files into nix-store
-
-        $ nix-prefetch-url --type sha256 file:///path/to/${name}
-      '';
     };
   }.${stdenv.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 


### PR DESCRIPTION
## Description of changes

Based on the latest information in #303675,

After manual inspection, it was found that the corresponding captcha had been cancelled, so the previous changes were rolled back to the state before #304058.

<del>However, based on the consideration that the verification code may still appear, the original changes will not be deleted for the time being.</del>

## Things done

different between two commit: https://fars.ee/WcYT
generate via: `git diff  4c5b023 a99b271 -- pkgs/tools/admin/realvnc-vnc-viewer/ | curl -F "c=@-" "https://fars.ee/"`

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
