### PR TITLE
ktailctl: 0.16.0 -> 0.16.1

### DIFF
--- a/pkgs/applications/networking/ktailctl/default.nix
+++ b/pkgs/applications/networking/ktailctl/default.nix
@@ -10,6 +10,7 @@
 , qtbase
 , qtdeclarative
 , qtsvg
+, qtwayland
 , kconfig
 , kcoreaddons
 , kguiaddons
@@ -18,31 +19,37 @@
 , kirigami-addons
 , knotifications
 , nlohmann_json
+, qqc2-desktop-style
 }:
 
 let
-  version = "0.16.0";
+  version = "0.16.1";
 
   src = fetchFromGitHub {
     owner = "f-koehler";
     repo = "KTailctl";
     rev = "v${version}";
-    hash = "sha256-fIx6XfNGK+jDpeaoCzTKwv3J01yWoHOgWxjbwTGVK1U=";
+    hash = "sha256-rMvFwWTrYWZUAMWd6H/SXE26q5ASjwsa8bD1tFC6yBI=";
   };
 
   goDeps = (buildGoModule {
-    pname = "tailwrap";
+    pname = "ktailctl-go-wrapper";
     inherit src version;
-    modRoot = "tailwrap";
-    vendorHash = "sha256-egTzSdOKrhdEBKarIfROxZUsxbnR9F1JDbdoKzGf9UM=";
+    modRoot = "src/wrapper";
+    vendorHash = "sha256-GD+G+7b8GBwR3OrRPJbGJVom+kLC67VvlGFIA0S7UF8=";
   }).goModules;
 in
 stdenv.mkDerivation {
   pname = "ktailctl";
   inherit version src;
 
+  patches = [
+    # Install libktailctl_config.so https://github.com/f-koehler/KTailctl/pull/212
+    ./install-missing-libraries.diff
+  ];
+
   postPatch = ''
-    cp -r --reflink=auto ${goDeps} tailwrap/vendor
+    cp -r --reflink=auto ${goDeps} src/wrapper/vendor
   '';
 
   # needed for go build to work
@@ -67,13 +74,16 @@ stdenv.mkDerivation {
     qtbase
     qtdeclarative
     qtsvg
+    qtwayland
     kconfig
     kcoreaddons
     kguiaddons
     ki18n
     kirigami
+    kirigami-addons
     knotifications
     nlohmann_json
+    qqc2-desktop-style
   ];
 
   meta = with lib; {
@@ -82,6 +92,6 @@ stdenv.mkDerivation {
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ k900 ];
     mainProgram = "ktailctl";
-    platforms = platforms.all;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/networking/ktailctl/install-missing-libraries.diff
+++ b/pkgs/applications/networking/ktailctl/install-missing-libraries.diff
@@ -1,0 +1,9 @@
+diff --git a/src/config/CMakeLists.txt b/src/config/CMakeLists.txt
+index ed0a64a..970e509 100644
+--- a/src/config/CMakeLists.txt
++++ b/src/config/CMakeLists.txt
+@@ -7,3 +7,4 @@ target_link_libraries(ktailctl_config
+     KF6::ConfigGui
+     ktailctl_wrapper
+ )
++install(TARGETS ktailctl_config)


### PR DESCRIPTION
## Description of changes

Only tested on WSL without GUI but fixed a few missing QML/QT things on that way.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
