### PR TITLE
doc: Update note under `buildDotnetModule` to reflect actual behaviour

### DIFF
--- a/doc/languages-frameworks/dotnet.section.md
+++ b/doc/languages-frameworks/dotnet.section.md
@@ -142,9 +142,7 @@ in buildDotnetModule rec {
   src = ./.;
 
   projectFile = "src/project.sln";
-  # File generated with `nix-build -A package.passthru.fetch-deps`.
-  # To run fetch-deps when this file does not yet exist, set nugetDeps to null
-  nugetDeps = ./deps.nix;
+  nugetDeps = ./deps.nix; # see "Generating and updating NuGet dependencies" section for details
 
   projectReferences = [ referencedProject ]; # `referencedProject` must contain `nupkg` in the folder structure.
 
@@ -220,6 +218,12 @@ buildDotnetGlobalTool {
 ```
 ## Generating and updating NuGet dependencies {#generating-and-updating-nuget-dependencies}
 
+When writing a new expression, you can use the generated `fetch-deps` script to initialise the lockfile.
+After creating a blank `deps.nix` and pointing `nugetDeps` to it,
+build the script with `nix-build -A package.fetch-deps` and then run the result.
+(When the root attr is your package, it's simply `nix-build -A fetch-deps`.)
+
+There is also a manual method:
 First, restore the packages to the `out` directory, ensure you have cloned
 the upstream repository and you are inside it.
 
@@ -255,6 +259,5 @@ Finally, you move the `deps.nix` file to the appropriate location to be used by 
 If you ever need to update the dependencies of a package, you instead do
 
 * `nix-build -A package.fetch-deps` to generate the update script for `package`
-* Run `./result deps.nix` to regenerate the lockfile to `deps.nix`, keep in mind if a location isn't provided, it will write to a temporary path instead
-* Finally, move the file where needed and look at its contents to confirm it has updated the dependencies.
-
+* Run `./result` to regenerate the lockfile to the path passed for `nugetDeps` (keep in mind if it can't be resolved to a local path, the script will write to `$1` or a temporary path instead)
+* Finally, ensure the correct file was written and the derivation can be built.


### PR DESCRIPTION
## Description of changes

~~Per https://github.com/NixOS/nixpkgs/issues/179136#issuecomment-1898496798.
`nugetDeps = null;` behaves as though the attr was omitted, it must be `nugetDeps = "";`.~~
Thanks to @corngood for pointing out that a blank file also works. That method has the added benefit of writing straight to the file, meaning you don't have to remember to copy from `/tmp`. I've rewritten this PR to use that method. In the process I noticed the other section in the docs, so I'm updating that and pointing readers to it, rather than only changing the sample expression.

Fixes #179136.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
