### PR TITLE
python3Packages.listparser: init at 0.20

### DIFF
--- a/pkgs/development/python-modules/listparser/default.nix
+++ b/pkgs/development/python-modules/listparser/default.nix
@@ -1,0 +1,55 @@
+{
+  fetchFromGitHub,
+  lib,
+  lxml,
+  nix-update-script,
+  poetry-core,
+  pypaBuildHook,
+  pypaInstallHook,
+  pytestCheckHook,
+  requests,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "listparser";
+  version = "0.20";
+
+  src = fetchFromGitHub {
+    owner = "kurtmckee";
+    repo = "listparser";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-eg9TrjDgvHsYt/0JQ7MK/uGc3KK3uGr3jRxzG0FlySg=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+    pypaBuildHook
+    pypaInstallHook
+  ];
+
+  propagatedBuildInputs = [
+    requests
+    lxml
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "listparser"
+  ];
+
+  doCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "Parse OPML subscription lists in Python";
+    homepage = "https://github.com/kurtmckee/listparser";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.colinsane ];
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6943,6 +6943,8 @@ self: super: with self; {
     python3 = python;
   });
 
+  listparser = toPythonModule (callPackage ../development/python-modules/listparser { });
+
   lit = callPackage ../development/python-modules/lit { };
 
   litellm = callPackage ../development/python-modules/litellm { };


### PR DESCRIPTION
this package was previously available via `gnome-feeds.passthru.listparser` but was [removed](https://github.com/NixOS/nixpkgs/pull/320801/files) when no longer needed by gnome-feeds. make it available as a standalone package, because the OPML lists it works with are usable by many (other) feed readers.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
