### PR TITLE
python311Packages.webdataset: disable failing tests on darwin

### DIFF
--- a/pkgs/development/python-modules/webdataset/default.nix
+++ b/pkgs/development/python-modules/webdataset/default.nix
@@ -27,12 +27,12 @@ buildPythonPackage rec {
     hash = "sha256-selj7XD7NS831lbPnx/4o46bNpsxuFdSEIIb4S2b7S0=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
     wheel
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     braceexpand
     numpy
     pyyaml
@@ -84,12 +84,20 @@ buildPythonPackage rec {
       "test_webloader_unbatched"
     ];
 
-  meta = with lib; {
+  disabledTestPaths = lib.optionals stdenv.isDarwin [
+    # AttributeError: <module 'torch.distributed' from /nix/store/...
+    "tests/test_wids.py"
+
+    # Issue with creating a temp file in the sandbox
+    "tests/test_wids_mmtar.py"
+  ];
+
+  meta = {
     description = "High-performance Python-based I/O system for large (and small) deep learning problems, with strong support for PyTorch";
     mainProgram = "widsindex";
     homepage = "https://github.com/webdataset/webdataset";
     changelog = "https://github.com/webdataset/webdataset/releases/tag/${version}";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ iynaix ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ iynaix ];
   };
 }


### PR DESCRIPTION
## Description of changes

Disabled the following tests on darwin:
```
=========================== short test summary info ============================
FAILED tests/test_wids.py::TestGz::test_gz - PermissionError: [Errno 13] Permission denied: '/tmp/_wids_cache/testdata%2...
FAILED tests/test_wids_mmtar.py::test_concurrent_access - AssertionError: assert not True
ERROR tests/test_wids.py::TestDistributedChunkedSampler::test_init - AttributeError: <module 'torch.distributed' from '/nix/store/i6m2w8pzmcy84g...
ERROR tests/test_wids.py::TestDistributedChunkedSampler::test_set_epoch - AttributeError: <module 'torch.distributed' from '/nix/store/i6m2w8pzmcy84g...
ERROR tests/test_wids.py::TestDistributedChunkedSampler::test_iter - AttributeError: <module 'torch.distributed' from '/nix/store/i6m2w8pzmcy84g...
ERROR tests/test_wids.py::TestDistributedChunkedSampler::test_iter_no_shuffle - AttributeError: <module 'torch.distributed' from '/nix/store/i6m2w8pzmcy84g...
ERROR tests/test_wids.py::TestDistributedChunkedSampler::test_disjoint_samples - AttributeError: <module 'torch.distributed' from '/nix/store/i6m2w8pzmcy84g...
= 2 failed, 103 passed, 9 skipped, 78 deselected, 1 warning, 5 errors in 59.44s =
```

cc @iynaix 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
