### PR TITLE
got-unwrapped: init at 0.100; got: wrap got-unwrapped with ssh

### DIFF
--- a/pkgs/by-name/go/got-unwrapped/package.nix
+++ b/pkgs/by-name/go/got-unwrapped/package.nix
@@ -1,0 +1,78 @@
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, libressl
+, libbsd
+, libevent
+, libuuid
+, libossp_uuid
+, libmd
+, zlib
+, ncurses
+, bison
+, autoPatchelfHook
+, testers
+, got
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "got-unwrapped";
+  version = "0.100";
+
+  src = fetchurl {
+    url = "https://gameoftrees.org/releases/portable/got-portable-${finalAttrs.version}.tar.gz";
+    hash = "sha256-/DqKIGf/aZ09aL/rB7te+AauHmJ+mOTrVEbkqT9WUBI=";
+  };
+
+  patches = [
+    # force got to search for ssh in PATH, to prevent locking in a dependency
+    ./search-for-ssh-in-path.patch
+  ];
+
+  nativeBuildInputs = [ pkg-config bison ]
+    ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+
+  buildInputs = [ libressl libbsd libevent libuuid libmd zlib ncurses ]
+    ++ lib.optionals stdenv.isDarwin [ libossp_uuid ];
+
+  preConfigure = lib.optionalString stdenv.isDarwin ''
+    # The configure script assumes dependencies on Darwin are installed via
+    # Homebrew or MacPorts and hardcodes assumptions about the paths of
+    # dependencies which fails the nixpkgs configurePhase.
+    substituteInPlace configure --replace-fail 'xdarwin' 'xhomebrew'
+  '';
+
+  env.NIX_CFLAGS_COMPILE = toString ([
+    "-DGOT_DIAL_PATH_SSH=\"ssh\""
+    "-DGOT_TAG_PATH_SSH_KEYGEN=\"ssh-keygen\""
+  ] ++ lib.optionals stdenv.isDarwin [
+    # error: conflicting types for 'strmode'
+    "-DHAVE_STRMODE=1"
+    # Undefined symbols for architecture arm64: "_bsd_getopt"
+    "-include getopt.h"
+  ]);
+
+  passthru.tests.version = testers.testVersion {
+    package = got.override { got-unwrapped = finalAttrs.finalPackage; };
+  };
+
+  meta = {
+    changelog = "https://gameoftrees.org/releases/CHANGES";
+    description = "Version control system which prioritizes ease of use and simplicity over flexibility";
+    longDescription = ''
+      Game of Trees (Got) is a version control system which prioritizes
+      ease of use and simplicity over flexibility.
+
+      Got uses Git repositories to store versioned data. Git can be used
+      for any functionality which has not yet been implemented in
+      Got. It will always remain possible to work with both Got and Git
+      on the same repository.
+    '';
+    homepage = "https://gameoftrees.org";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ abbe afh ];
+    mainProgram = "got";
+    platforms = with lib.platforms; darwin ++ linux;
+  };
+})

--- a/pkgs/by-name/go/got-unwrapped/search-for-ssh-in-path.patch
+++ b/pkgs/by-name/go/got-unwrapped/search-for-ssh-in-path.patch
@@ -1,0 +1,13 @@
+--- a/lib/dial.c	1970-01-01 00:00:01.000000000 +0000
++++ b/lib/dial.c	1970-01-01 00:00:01.000000000 +0000
+@@ -316,8 +316,8 @@
+ 			err(1, "dup2");
+ 		if (strlcpy(cmd, command, sizeof(cmd)) >= sizeof(cmd))
+ 			err(1, "snprintf");
+-		if (execv(GOT_DIAL_PATH_SSH, (char *const *)argv) == -1)
+-			err(1, "execv %s", GOT_DIAL_PATH_SSH);
++		if (execvp(GOT_DIAL_PATH_SSH, (char *const *)argv) == -1)
++			err(1, "execvp %s", GOT_DIAL_PATH_SSH);
+ 		abort(); /* not reached */
+ 	} else {
+ 		if (close(pfd[0]) == -1)

--- a/pkgs/by-name/go/got/package.nix
+++ b/pkgs/by-name/go/got/package.nix
@@ -1,69 +1,40 @@
-{ lib
-, stdenv
-, fetchurl
-, pkg-config
-, libressl
-, libbsd
-, libevent
-, libuuid
-, libossp_uuid
-, libmd
-, zlib
-, ncurses
-, bison
-, autoPatchelfHook
-, testers
+{
+  lib,
+  stdenv,
+  got-unwrapped,
+  openssh,
+  makeWrapper,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation {
   pname = "got";
-  version = "0.100";
+  inherit (got-unwrapped) version;
 
-  src = fetchurl {
-    url = "https://gameoftrees.org/releases/portable/got-portable-${finalAttrs.version}.tar.gz";
-    hash = "sha256-/DqKIGf/aZ09aL/rB7te+AauHmJ+mOTrVEbkqT9WUBI=";
-  };
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
 
-  nativeBuildInputs = [ pkg-config bison ]
-    ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+  nativeBuildInputs = [ makeWrapper ];
 
-  buildInputs = [ libressl libbsd libevent libuuid libmd zlib ncurses ]
-    ++ lib.optionals stdenv.isDarwin [ libossp_uuid ];
+  installPhase = ''
+    runHook preInstall
 
-  preConfigure = lib.optionalString stdenv.isDarwin ''
-    # The configure script assumes dependencies on Darwin are installed via
-    # Homebrew or MacPorts and hardcodes assumptions about the paths of
-    # dependencies which fails the nixpkgs configurePhase.
-    substituteInPlace configure --replace-fail 'xdarwin' 'xhomebrew'
+    makeWrapper ${got-unwrapped}/bin/got $out/bin/got \
+      --prefix PATH : ${lib.makeBinPath [ openssh ]}
+
+    runHook postInstall
   '';
 
-  env.NIX_CFLAGS_COMPILE = toString (lib.optionals stdenv.isDarwin [
-    # error: conflicting types for 'strmode'
-    "-DHAVE_STRMODE=1"
-    # Undefined symbols for architecture arm64: "_bsd_getopt"
-    "-include getopt.h"
-  ]);
-
-  passthru.tests.version = testers.testVersion {
-    package = finalAttrs.finalPackage;
-  };
-
   meta = {
-    changelog = "https://gameoftrees.org/releases/CHANGES";
-    description = "Version control system which prioritizes ease of use and simplicity over flexibility";
-    longDescription = ''
-      Game of Trees (Got) is a version control system which prioritizes
-      ease of use and simplicity over flexibility.
-
-      Got uses Git repositories to store versioned data. Git can be used
-      for any functionality which has not yet been implemented in
-      Got. It will always remain possible to work with both Got and Git
-      on the same repository.
-    '';
-    homepage = "https://gameoftrees.org";
-    license = lib.licenses.isc;
-    maintainers = with lib.maintainers; [ abbe afh ];
-    mainProgram = "got";
-    platforms = with lib.platforms; darwin ++ linux;
+    inherit (got-unwrapped.meta)
+      changelog
+      description
+      longDescription
+      homepage
+      license
+      maintainers
+      mainProgram
+      platforms
+      ;
   };
-})
+}


### PR DESCRIPTION
## Description of changes

Created as an alternative to #297154 to prevent superfluous rebuilds.
TBH I'm not a big fan of this approach, a rebuild takes a few seconds, and this increases maintenance burden, but this does address the comments on the previous PR.

Fixes #322043.
Closes #297154.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
