### PR TITLE
ocamlPackages.eqaf: 0.9 → 0.10

### DIFF
--- a/pkgs/development/ocaml-modules/awa/default.nix
+++ b/pkgs/development/ocaml-modules/awa/default.nix
@@ -1,7 +1,7 @@
 { lib, buildDunePackage, fetchurl
 , ppx_sexp_conv
 , mirage-crypto, mirage-crypto-ec, mirage-crypto-rng, mirage-crypto-pk
-, x509, cstruct, cstruct-unix, cstruct-sexp, sexplib, eqaf
+, x509, cstruct, cstruct-unix, cstruct-sexp, sexplib, eqaf-cstruct
 , rresult, mtime, logs, fmt, cmdliner, base64
 , zarith
 }:
@@ -17,11 +17,15 @@ buildDunePackage rec {
     hash = "sha256-VejHFn07B/zoEG4LjLaen24ig9kAXtERl/pRo6UZCQk=";
   };
 
+  postPatch = ''
+    substituteInPlace lib/dune --replace-warn eqaf.cstruct eqaf-cstruct
+  '';
+
   propagatedBuildInputs = [
     mirage-crypto mirage-crypto-ec mirage-crypto-rng mirage-crypto-pk x509
     cstruct cstruct-sexp sexplib mtime
     logs base64 zarith
-    ppx_sexp_conv eqaf
+    ppx_sexp_conv eqaf-cstruct
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/eqaf/cstruct.nix
+++ b/pkgs/development/ocaml-modules/eqaf/cstruct.nix
@@ -1,0 +1,9 @@
+{ buildDunePackage, eqaf, cstruct }:
+
+buildDunePackage {
+  pname = "eqaf-cstruct";
+
+  inherit (eqaf) src version meta;
+
+  propagatedBuildInputs = [ cstruct eqaf ];
+}

--- a/pkgs/development/ocaml-modules/eqaf/default.nix
+++ b/pkgs/development/ocaml-modules/eqaf/default.nix
@@ -1,17 +1,14 @@
-{ lib, fetchurl, buildDunePackage, cstruct }:
+{ lib, fetchurl, buildDunePackage }:
 
 buildDunePackage rec {
   minimalOCamlVersion = "4.07";
-  duneVersion = "3";
   pname = "eqaf";
-  version = "0.9";
+  version = "0.10";
 
   src = fetchurl {
     url = "https://github.com/mirage/eqaf/releases/download/v${version}/eqaf-${version}.tbz";
-    hash = "sha256-7A4oqUasaBf5XVhU8FqZYa46hAi7YQ55z60BubJV3+A=";
+    hash = "sha256-Z9E2nFfE0tFKENAmMtReNVIkq+uYrsCJecC65YQwku4=";
   };
-
-  propagatedBuildInputs = [ cstruct ];
 
   meta = {
     description = "Constant time equal function to avoid timing attacks in OCaml";

--- a/pkgs/development/ocaml-modules/mirage-crypto/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/default.nix
@@ -1,11 +1,10 @@
-{ lib, fetchurl, buildDunePackage, ounit2, cstruct, dune-configurator, eqaf, pkg-config
+{ lib, fetchurl, buildDunePackage, ounit2, dune-configurator, eqaf-cstruct, pkg-config
 , withFreestanding ? false
 , ocaml-freestanding
 }:
 
 buildDunePackage rec {
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
 
   pname = "mirage-crypto";
   version = "0.11.3";
@@ -21,10 +20,15 @@ buildDunePackage rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ dune-configurator  ];
   propagatedBuildInputs = [
-    cstruct eqaf
+    eqaf-cstruct
   ] ++ lib.optionals withFreestanding [
     ocaml-freestanding
   ];
+
+  # Compatibility with eqaf 0.10
+  postPatch = ''
+    substituteInPlace src/dune --replace-warn eqaf.cstruct eqaf-cstruct
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/mirage/mirage-crypto";

--- a/pkgs/development/ocaml-modules/mirage-crypto/pk.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/pk.nix
@@ -1,16 +1,18 @@
 { buildDunePackage, ounit2, randomconv, mirage-crypto, mirage-crypto-rng
-, cstruct, sexplib0, zarith, eqaf, gmp }:
+, cstruct, sexplib0, zarith, eqaf-cstruct, gmp }:
 
 buildDunePackage rec {
   pname = "mirage-crypto-pk";
 
   inherit (mirage-crypto) version src;
 
-  duneVersion = "3";
+  postPatch = ''
+    substituteInPlace pk/dune --replace-warn eqaf.cstruct eqaf-cstruct
+  '';
 
   buildInputs = [ gmp ];
   propagatedBuildInputs = [ cstruct mirage-crypto mirage-crypto-rng
-                            zarith eqaf sexplib0 ];
+                            zarith eqaf-cstruct sexplib0 ];
 
   doCheck = true;
   checkInputs = [ ounit2 randomconv ];

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -466,6 +466,8 @@ let
 
     eqaf = callPackage ../development/ocaml-modules/eqaf { };
 
+    eqaf-cstruct = callPackage ../development/ocaml-modules/eqaf/cstruct.nix { };
+
     erm_xml = callPackage ../development/ocaml-modules/erm_xml { };
 
     erm_xmpp = callPackage ../development/ocaml-modules/erm_xmpp { };


### PR DESCRIPTION
ocamlPackages.eqaf-cstruct: init at 0.10

## Description of changes

https://raw.githubusercontent.com/mirage/eqaf/v0.10/CHANGES.md

Fixes #319835.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
