### PR TITLE
wlr-layout-ui: 1.6.10 -> 1.6.14

### DIFF
--- a/pkgs/by-name/wl/wlr-layout-ui/package.nix
+++ b/pkgs/by-name/wl/wlr-layout-ui/package.nix
@@ -5,23 +5,15 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "wlr-layout-ui";
-  version = "1.6.10";
+  version = "1.6.14";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "fdev31";
     repo = "wlr-layout-ui";
     rev = "refs/tags/${version}";
-    hash = "sha256-UM1p5b5+xJY6BgPUMXjluIC9zQxe388+gBWTbNQPWYQ=";
+    hash = "sha256-Qgg4fdxOVkADDOxmQgQFSF/wgrEQihoRNC9oXeQvaoI=";
   };
-
-  postPatch = ''
-    # The hyprland default.nix patches the version.h of hyprland so that the
-    # version info moves to the commit key.
-    substituteInPlace src/wlr_layout_ui/screens.py \
-      --replace 'json.loads(subprocess.getoutput("hyprctl -j version"))["tag"]'\
-                'json.loads(subprocess.getoutput("hyprctl -j version"))["commit"]'
-  '';
 
   nativeBuildInputs = [
     python3.pkgs.poetry-core


### PR DESCRIPTION
## Description of changes

Version bump from 1.6.10 to 1.6.14
Removed patch, since the hyprland version got fixed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
