### PR TITLE
rubyfmt: avoid failing upon warning

### DIFF
--- a/pkgs/development/tools/rubyfmt/0003-ignore-warnings.patch
+++ b/pkgs/development/tools/rubyfmt/0003-ignore-warnings.patch
@@ -1,3 +1,15 @@
+diff --git i/librubyfmt/build.rs w/librubyfmt/build.rs
+index 296b749..941a4ca 100644
+--- i/librubyfmt/build.rs
++++ w/librubyfmt/build.rs
+@@ -166,6 +166,7 @@ fn run_configure(ruby_checkout_path: &Path) -> Output {
+         command
+             .arg("--target=aarch64-unknown-linux-gnu")
+             .arg("--host=x86_64")
++            .arg("--disable-werror")
+             .env("CC", "aarch64-linux-gnu-gcc")
+             .env("AR", "aarch64-linux-gnu-ar")
+             .env("RANLIB", "aarch64-linux-gnu-ranlib");
 diff --git i/librubyfmt/src/lib.rs w/librubyfmt/src/lib.rs
 index 9b94b5f..b78e99f 100644
 --- i/librubyfmt/src/lib.rs
@@ -6,3 +18,4 @@ index 9b94b5f..b78e99f 100644
 -#![deny(warnings, missing_copy_implementations)]
  #![allow(clippy::upper_case_acronyms, clippy::enum_variant_names)]
  
+ use serde::de::value;

--- a/pkgs/development/tools/rubyfmt/0003-ignore-warnings.patch
+++ b/pkgs/development/tools/rubyfmt/0003-ignore-warnings.patch
@@ -1,0 +1,8 @@
+diff --git i/librubyfmt/src/lib.rs w/librubyfmt/src/lib.rs
+index 9b94b5f..b78e99f 100644
+--- i/librubyfmt/src/lib.rs
++++ w/librubyfmt/src/lib.rs
+@@ -1,4 +1,3 @@
+-#![deny(warnings, missing_copy_implementations)]
+ #![allow(clippy::upper_case_acronyms, clippy::enum_variant_names)]
+ 

--- a/pkgs/development/tools/rubyfmt/default.nix
+++ b/pkgs/development/tools/rubyfmt/default.nix
@@ -61,6 +61,8 @@ rustPlatform.buildRustPackage rec {
   cargoPatches = [
     # Avoid checking whether ruby gitsubmodule is up-to-date.
     ./0002-remove-dependency-on-git.patch
+    # Avoid failing on unused variable warnings.
+    ./0003-ignore-warnings.patch
   ];
 
   cargoHash = "sha256-QZ26GmsKyENkzdCGg2peie/aJhEt7KQAF/lwsibonDk=";
@@ -76,12 +78,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/fables-tales/rubyfmt";
     license = licenses.mit;
     maintainers = with maintainers; [ bobvanderlinden ];
-    # https://github.com/NixOS/nixpkgs/issues/320722
-    broken = true
-      # = note: Undefined symbols for architecture x86_64:
-      #       "_utimensat", referenced from:
-      #           _utime_internal in librubyfmt-3c969812b3b27083.rlib(file.o)
-      || stdenv.isDarwin && stdenv.isx86_64;
+    broken = stdenv.isDarwin && stdenv.isx86_64;
     mainProgram = "rubyfmt";
   };
 }


### PR DESCRIPTION
## Description of changes

Fixes https://github.com/NixOS/nixpkgs/issues/320722

The build was failing because there were unused variables. These were introduced by upgraded dependencies. We don't want to be bothered by such warnings in the future, so this removes the `#![deny(warnings, missing_copy_implementations)]` annotation.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
