### PR TITLE
mkvtoolnix: 84.0 -> 85.0

### DIFF
--- a/pkgs/applications/video/mkvtoolnix/default.nix
+++ b/pkgs/applications/video/mkvtoolnix/default.nix
@@ -8,7 +8,6 @@
 , cmark
 , docbook_xsl
 , expat
-, fetchpatch2
 , file
 , flac
 , fmt
@@ -50,13 +49,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "mkvtoolnix";
-  version = "84.0";
+  version = "85.0";
 
   src = fetchFromGitLab {
     owner = "mbunkus";
     repo = "mkvtoolnix";
     rev = "release-${version}";
-    hash = "sha256-//I++WWnSHnkpTZ0TzS3lhH5+eDD5mazTQ1HVMQS4Ug=";
+    hash = "sha256-E8fULDUkEnh/0W/OIh+peO+JXSecgINPJclOTc5KYVo=";
   };
 
   nativeBuildInputs = [
@@ -94,11 +93,6 @@ stdenv.mkDerivation rec {
   ++ optionals withGUI [ cmark ]
   ++ optionals stdenv.isLinux [ qtwayland ]
   ++ optionals stdenv.isDarwin [ libiconv ];
-
-  patches = [ (fetchpatch2 {
-    url = "https://gitlab.com/mbunkus/mkvtoolnix/-/commit/7e1bea9527616ab6ab38425e7290579f05dd9bb1.patch";
-    hash = "sha256-9UZrfwrzfKwF8XDzqYnuaDgZws7l1YAb5O1O1+nxo0g=";
-  }) ];
 
   # autoupdate is not needed but it silences a ton of pointless warnings
   postPatch = ''


### PR DESCRIPTION
## Description of changes

Routine version bump

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
