### PR TITLE
memento: 1.2.2 -> 1.4.0

### DIFF
--- a/pkgs/applications/video/memento/default.nix
+++ b/pkgs/applications/video/memento/default.nix
@@ -2,8 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , cmake
-, qtbase
-, qtx11extras ? null # qt5 only
+, qt6
 , wrapQtAppsHook
 
 # before that => zeal
@@ -15,37 +14,34 @@
 , yt-dlp
 # optional
 , makeWrapper}:
-
-let
-  isQt5 = lib.versions.major qtbase.version == "5";
-
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "memento";
-  version = "1.2.2";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "ripose-jp";
     repo = "Memento";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-55VvT7pHN0/HqxM4vMDQDgUwkVmO/8aOEOye8jcFzgI=";
+    hash = "sha256-/lgjzR2KwlIUMHSz3afBQEy+8kdKAI37kqTuq3r3qMk=";
   };
 
   nativeBuildInputs = [
     cmake
     makeWrapper
+    qt6.qtbase
+    qt6.qtsvg
+    qt6.qtwayland
     wrapQtAppsHook
   ];
 
   buildInputs = [
-    qtbase
     sqlite
     json_c
     libzip
     mecab
-  ] ++ lib.optionals isQt5 [ qtx11extras ];
+  ];
 
-  propagatedBuildInputs = [ mpv  ];
+  propagatedBuildInputs = [ mpv ];
 
   preFixup = ''
      wrapProgram "$out/bin/memento" \

--- a/pkgs/applications/video/memento/default.nix
+++ b/pkgs/applications/video/memento/default.nix
@@ -28,13 +28,13 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     makeWrapper
-    qt6.qtbase
-    qt6.qtsvg
-    qt6.qtwayland
     wrapQtAppsHook
   ];
 
   buildInputs = [
+    qt6.qtbase
+    qt6.qtsvg
+    qt6.qtwayland
     sqlite
     json_c
     libzip

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32791,7 +32791,7 @@ with pkgs;
 
   mailspring = callPackage ../applications/networking/mailreaders/mailspring { };
 
-  memento = libsForQt5.callPackage ../applications/video/memento { };
+  memento = qt6Packages.callPackage ../applications/video/memento { };
 
   mm = callPackage ../applications/networking/instant-messengers/mm { };
 


### PR DESCRIPTION
## Description of changes
- Updates memento to 1.4.0
- Migrates the app to qt6 (see upstream migration commit: https://github.com/ripose-jp/Memento/commit/afea4019a6a1c6bb5daa153490ecfa3ce9494a97)

Based on issue #322167

cc. @teto 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
