### PR TITLE
scion-apps: init at unstable-2024-04-05

### DIFF
--- a/pkgs/by-name/sc/scion-apps/package.nix
+++ b/pkgs/by-name/sc/scion-apps/package.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, openpam
+}:
+
+buildGoModule {
+  pname = "scion-apps";
+  version = "unstable-2024-04-05";
+
+  src = fetchFromGitHub {
+    owner = "netsec-ethz";
+    repo = "scion-apps";
+    rev = "cb0dc365082788bcc896f0b55c4807b72c2ac338";
+    hash = "sha256-RzWtnUpZfwryOfumgXHV5QMceLY51Zv3KI0K6WLz8rs=";
+  };
+
+  vendorHash = "sha256-bz4vtELxrDfebk+00w9AcEiK/4skO1mE3lBDU1GkOrk=";
+
+  postPatch = ''
+    substituteInPlace webapp/web/tests/health/scmpcheck.sh \
+      --replace-fail "hostname -I" "hostname -i"
+  '';
+
+  postInstall = ''
+    # Add `scion-` prefix to all binaries
+    for f in $out/bin/*; do
+      filename="$(basename "$f")"
+      mv -v $f $out/bin/scion-$filename
+    done
+
+    # Fix nested subpackage names
+    mv -v $out/bin/scion-server $out/bin/scion-ssh-server
+    mv -v $out/bin/scion-client $out/bin/scion-ssh-client
+
+    # Include static website for webapp
+    mkdir -p $out/share
+    cp -r webapp/web $out/share/scion-webapp
+  '';
+
+  buildInputs = [
+    openpam
+  ];
+
+  ldflags = [ "-s" "-w" ];
+
+  meta = with lib; {
+    description = "Public repository for SCION applications";
+    homepage = "https://github.com/netsec-ethz/scion-apps";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ matthewcroughan sarcasticadmin ];
+  };
+}


### PR DESCRIPTION
## Description of changes

So we can actually use scion as outlined in https://docs.scionlab.org/content/apps/

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
