### PR TITLE
nixos/ec2-data: skip unrecognized keys in print-host-keys

### DIFF
--- a/nixos/modules/virtualisation/ec2-data.nix
+++ b/nixos/modules/virtualisation/ec2-data.nix
@@ -80,7 +80,7 @@ with lib;
             # ec2-get-console-output.
             echo "-----BEGIN SSH HOST KEY FINGERPRINTS-----" > /dev/console
             for i in /etc/ssh/ssh_host_*_key.pub; do
-                ${config.programs.ssh.package}/bin/ssh-keygen -l -f $i > /dev/console
+                ${config.programs.ssh.package}/bin/ssh-keygen -l -f $i || true > /dev/console
             done
             echo "-----END SSH HOST KEY FINGERPRINTS-----" > /dev/console
           '';


### PR DESCRIPTION
## Description of changes

The recent move to strip out DSS support from the openssh package means that older key formats cause the key-printing command to fail. Rather than causing the entire unit to fail, we should instead skip those keys - while still letting the error through to the console - and continue to print other keys the loop may find.

I caught this when upgrading a server to 24.05 from an older installation. The error this causes looks like this when invoking `nixos-rebuild`:


```
Starting Print SSH Host Key...
/etc/ssh/ssh_host_dsa_key.pub is not a public key file.
Main process exited, code=exited, status=255/EXCEPTION
print-host-key.service: Failed with result 'exit-code'.
Failed to start Print SSH Host Key.
```

With these changes:

```
Starting Print SSH Host Key...
/etc/ssh/ssh_host_dsa_key.pub is not a public key file.
256 SHA256:<snip> (ECDSA)
256 SHA256:<snip> (ED25519)
3072 SHA256:<snip> (RSA)
Finished Print SSH Host Key.
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
