### PR TITLE
root: 6.32.00 -> 6.32.02

### DIFF
--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -166,7 +166,6 @@ stdenv.mkDerivation rec {
     "-Dmysql=OFF"
     "-Dpgsql=OFF"
     "-Dsqlite=OFF"
-    "-Dtmva-pymva=OFF"
     "-Dvdt=OFF"
   ]
   ++ lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${lib.getDev stdenv.cc.libc}/include"

--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -56,7 +56,7 @@
 
 stdenv.mkDerivation rec {
   pname = "root";
-  version = "6.32.00";
+  version = "6.32.02";
 
   passthru = {
     tests = import ./tests { inherit callPackage; };
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://root.cern.ch/download/root_v${version}.source.tar.gz";
-    hash = "sha256-EvIDaBpZBBxHTOlSN2Hm8OiGGzvueN9feZqNtVGJ5dI=";
+    hash = "sha256-PQ92vwWFfhgHzPssngFPUlvLYl+UojcLRV9LFklhYC0=";
   };
 
   clad_src = fetchgit {

--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -223,6 +223,9 @@ stdenv.mkDerivation rec {
     ]}"
   '';
 
+  # error: aligned allocation function of type 'void *(std::size_t, std::align_val_t)' is only available on macOS 10.13 or newer
+  CXXFLAGS = lib.optional (stdenv.hostPlatform.system == "x86_64-darwin") "-faligned-allocation";
+
   # To use the debug information on the fly (without installation)
   # add the outPath of root.debug into NIX_DEBUG_INFO_DIRS (in PATH-like format)
   # and make sure that gdb from Nixpkgs can be found in PATH.

--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -69,7 +69,9 @@ stdenv.mkDerivation rec {
 
   clad_src = fetchgit {
     url = "https://github.com/vgvassilev/clad";
-    rev = "refs/tags/v1.5"; # Make sure that this is the same tag as in the ROOT build files!
+    # Make sure that this is the same tag as in the ROOT build files!
+    # https://github.com/root-project/root/blob/master/interpreter/cling/tools/plugins/clad/CMakeLists.txt#L76
+    rev = "refs/tags/v1.5";
     hash = "sha256-s0DbHfLthv51ZICnTd30O4qG/DyZPk5tADeu3bBRoOw=";
   };
 


### PR DESCRIPTION
* update ROOT to latest patch release 6.32.02
* don't explicitly set `tmva-pymva=OFF`: building this component of ROOT doesn't require anything that is not
already in the dependencies