### PR TITLE
common-updater-scripts: add allowedVersions parameter

### DIFF
--- a/pkgs/applications/misc/pwsafe/default.nix
+++ b/pkgs/applications/misc/pwsafe/default.nix
@@ -97,7 +97,7 @@ stdenv.mkDerivation rec {
   installFlags = [ "PREFIX=${placeholder "out"}" ];
 
   passthru.updateScript = gitUpdater {
-    ignoredVersions = "^([^1]|1[^.])"; # ignore anything other than 1.x
+    allowedVersions = "^1\\.";
     url = src.gitRepoUrl;
   };
 

--- a/pkgs/by-name/ba/babeltrace/package.nix
+++ b/pkgs/by-name/ba/babeltrace/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     url = "https://git.efficios.com/babeltrace.git";
     rev-prefix = "v";
     # Versions 2.x are packaged independently as babeltrace2
-    ignoredVersions = "^[^1]";
+    allowedVersions = "^1\\.";
   };
 
   meta = {

--- a/pkgs/common-updater/directory-listing-updater.nix
+++ b/pkgs/common-updater/directory-listing-updater.nix
@@ -6,6 +6,7 @@
 { pname ? null
 , version ? null
 , attrPath ? null
+, allowedVersions ? ""
 , ignoredVersions ? ""
 , rev-prefix ? ""
 , odd-unstable ? false
@@ -15,6 +16,6 @@
 }:
 
 genericUpdater {
-  inherit pname version attrPath ignoredVersions rev-prefix odd-unstable patchlevel-unstable;
+  inherit pname version attrPath allowedVersions ignoredVersions rev-prefix odd-unstable patchlevel-unstable;
   versionLister = "${common-updater-scripts}/bin/list-directory-versions ${lib.optionalString (url != null) "--url=${lib.escapeShellArg url}"} ${lib.optionalString (extraRegex != null) "--extra-regex=${lib.escapeShellArg extraRegex}"}";
 }

--- a/pkgs/common-updater/generic-updater.nix
+++ b/pkgs/common-updater/generic-updater.nix
@@ -13,6 +13,7 @@
 , version ? null
 , attrPath ? null
 , versionLister
+, allowedVersions ? ""
 , ignoredVersions ? ""
 , rev-prefix ? ""
 , odd-unstable ? false
@@ -37,10 +38,11 @@ let
     version="$3"
     attr_path="$4"
     version_lister="$5"
-    ignored_versions="$6"
-    rev_prefix="$7"
-    odd_unstable="$8"
-    patchlevel_unstable="$9"
+    allowed_versions="$6"
+    ignored_versions="$7"
+    rev_prefix="$8"
+    odd_unstable="$9"
+    patchlevel_unstable="$${10}"
 
     [[ -n "$name" ]] || name="$UPDATE_NIX_NAME"
     [[ -n "$pname" ]] || pname="$UPDATE_NIX_PNAME"
@@ -52,7 +54,7 @@ let
 
     function version_is_ignored() {
       local tag="$1"
-      [ -n "$ignored_versions" ] && ${grep} -E "$ignored_versions" <<< "$tag"
+      [ -n "$ignored_versions" ] && ${grep} -E -e "$ignored_versions" <<< "$tag"
     }
 
     function version_is_unstable() {
@@ -86,6 +88,9 @@ let
       tags=$(echo "$tags" | ${sed} -e "s,^$rev_prefix,,")
     fi
     tags=$(echo "$tags" | ${grep} "^[0-9]")
+    if [ -n "$allowed_versions" ]; then
+      tags=$(echo "$tags" | ${grep} -E -e "$allowed_versions")
+    fi
 
     # sort the tags in decreasing order
     tags=$(echo "$tags" | ${coreutils}/bin/sort --reverse --version-sort)
@@ -127,7 +132,7 @@ let
 
 in {
   name = "generic-update-script";
-  command = [ updateScript name pname version attrPath versionLister ignoredVersions rev-prefix odd-unstable patchlevel-unstable ];
+  command = [ updateScript name pname version attrPath versionLister allowedVersions ignoredVersions rev-prefix odd-unstable patchlevel-unstable ];
   supportedFeatures = [
     # Stdout must contain output according to the updateScript commit protocol when the update script finishes with a non-zero exit code.
     "commit"

--- a/pkgs/common-updater/git-updater.nix
+++ b/pkgs/common-updater/git-updater.nix
@@ -6,6 +6,7 @@
 { pname ? null
 , version ? null
 , attrPath ? null
+, allowedVersions ? ""
 , ignoredVersions ? ""
 , rev-prefix ? ""
 , odd-unstable ? false
@@ -16,6 +17,6 @@
 }:
 
 genericUpdater {
-  inherit pname version attrPath ignoredVersions rev-prefix odd-unstable patchlevel-unstable;
+  inherit pname version attrPath allowedVersions ignoredVersions rev-prefix odd-unstable patchlevel-unstable;
   versionLister = "${common-updater-scripts}/bin/list-git-tags ${lib.optionalString (url != null) "--url=${url}"}";
 }

--- a/pkgs/common-updater/http-two-levels-updater.nix
+++ b/pkgs/common-updater/http-two-levels-updater.nix
@@ -6,6 +6,7 @@
 { pname ? null
 , version ? null
 , attrPath ? null
+, allowedVersions ? ""
 , ignoredVersions ? ""
 , rev-prefix ? ""
 , odd-unstable ? false
@@ -14,6 +15,6 @@
 }:
 
 genericUpdater {
-  inherit pname version attrPath ignoredVersions rev-prefix odd-unstable patchlevel-unstable;
+  inherit pname version attrPath allowedVersions ignoredVersions rev-prefix odd-unstable patchlevel-unstable;
   versionLister = "${common-updater-scripts}/bin/list-archive-two-levels-versions ${lib.optionalString (url != null) "--url=${lib.escapeShellArg url}"}";
 }

--- a/pkgs/games/minetest/default.nix
+++ b/pkgs/games/minetest/default.nix
@@ -130,7 +130,8 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru.updateScript = gitUpdater {
-    ignoredVersions = "^[^.]+$|.*-android$";
+    allowedVersions = "\\.";
+    ignoredVersions = "-android$";
   };
 
   meta = with lib; {

--- a/pkgs/misc/screensavers/alock/default.nix
+++ b/pkgs/misc/screensavers/alock/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   passthru.updateScript = gitUpdater {
     rev-prefix = "v";
-    ignoredVersions = "^[^.]+$"; # ignore versions without a dot
+    allowedVersions = "\\.";
   };
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

I [said I'd do it](https://discourse.nixos.org/t/generic-git-updater-allowed-versions/47402), so I did it.

By providing a regex in `allowedVersions`, users of `genericUpdater` or `gitUpdater` can exclude versions that don't match the regex. This can be simpler to express than constructing the complement regex in `ignoredVersions`.

There was no documentation for `ignoredVersions` anywhere, so I didn't add any for this either. Woowoowoowoowoowoo!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
