### PR TITLE
abuild: fix build

### DIFF
--- a/pkgs/development/tools/abuild/default.nix
+++ b/pkgs/development/tools/abuild/default.nix
@@ -11,6 +11,7 @@
 , busybox
 , apk-tools
 , perl
+, findutils
 }:
 
 stdenv.mkDerivation rec {
@@ -44,6 +45,7 @@ stdenv.mkDerivation rec {
     scdoc
     makeWrapper
     file
+    findutils
   ];
 
   patchPhase = ''


### PR DESCRIPTION
abuild: fix build

Errors as:
> find: unrecognized: -printf

Log: https://termbin.com/j3w1

Builds with `gnu find`.
I don't know how to fix this with `busybox find`. (Tricky?)
Would this be acceptable? (Question!)

CC @onny @jopejoe1

* Hydra build: https://hydra.nixos.org/build/262910068