### PR TITLE
yosys: 0.38 -> 0.42

### DIFF
--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -1,6 +1,5 @@
 { stdenv
 , lib
-, abc-verifier
 , bash
 , bison
 , boost
@@ -77,13 +76,27 @@ let
 
 in stdenv.mkDerivation (finalAttrs: {
   pname   = "yosys";
-  version = "0.38";
+  version = "0.42";
 
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo  = "yosys";
     rev   = "refs/tags/${finalAttrs.pname}-${finalAttrs.version}";
-    hash  = "sha256-mzMBhnIEgToez6mGFOvO7zBA+rNivZ9OnLQsjBBDamA=";
+    hash  = "sha256-P0peg81wxCG0Bw2EJEX5WuDYU7GmRqgRw2SyWK/CGNI=";
+    fetchSubmodules = true;
+    leaveDotGit = true;
+    postFetch = ''
+      # set up git hashes as if we used the tarball
+
+      pushd $out
+      git rev-parse HEAD > .gitcommit
+      cd $out/abc
+      git rev-parse HEAD > .gitcommit
+      popd
+
+      # remove .git now that we are through with it
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
   };
 
   enableParallelBuilding = true;
@@ -109,25 +122,13 @@ in stdenv.mkDerivation (finalAttrs: {
     substituteInPlace ./Makefile \
       --replace-fail 'echo UNKNOWN' 'echo ${builtins.substring 0 10 finalAttrs.src.rev}'
 
-    # https://github.com/YosysHQ/yosys/pull/4199
-    substituteInPlace ./tests/various/clk2fflogic_effects.sh \
-      --replace-fail 'tail +3' 'tail -n +3'
-
     chmod +x ./misc/yosys-config.in
     patchShebangs tests ./misc/yosys-config.in
   '';
 
-  preBuild = let
-    shortAbcRev = builtins.substring 0 7 abc-verifier.rev;
-  in ''
+  preBuild = ''
     chmod -R u+w .
     make config-${if stdenv.cc.isClang or false then "clang" else "gcc"}
-    echo 'ABCEXTERNAL = ${abc-verifier}/bin/abc' >> Makefile.conf
-
-    if ! grep -q "ABCREV = ${shortAbcRev}" Makefile; then
-      echo "ERROR: yosys isn't compatible with the provided abc (${shortAbcRev}), failing."
-      exit 1
-    fi
 
     if ! grep -q "YOSYS_VER := $version" Makefile; then
       echo "ERROR: yosys version in Makefile isn't equivalent to version of the nix package (allegedly ${finalAttrs.version}), failing."
@@ -149,16 +150,6 @@ in stdenv.mkDerivation (finalAttrs: {
   checkTarget = "test";
   doCheck = true;
   nativeCheckInputs = [ verilog ];
-
-  # Internally, yosys knows to use the specified hardcoded ABCEXTERNAL binary.
-  # But other tools (like mcy or symbiyosys) can't know how yosys was built, so
-  # they just assume that 'yosys-abc' is available -- but it's not installed
-  # when using ABCEXTERNAL
-  #
-  # add a symlink to fake things so that both variants work the same way. this
-  # is also needed at build time for the test suite.
-  postBuild   = "ln -sfv ${abc-verifier}/bin/abc ./yosys-abc";
-  postInstall = "ln -sfv ${abc-verifier}/bin/abc $out/bin/yosys-abc";
 
   setupHook = ./setup-hook.sh;
 

--- a/pkgs/development/compilers/yosys/fix-clang-build.patch
+++ b/pkgs/development/compilers/yosys/fix-clang-build.patch
@@ -1,14 +1,3 @@
---- a/Makefile
-+++ b/Makefile
-@@ -215,7 +215,7 @@ ABC_ARCHFLAGS += "-DABC_NO_RLIMIT"
- endif
- 
- ifeq ($(CONFIG),clang)
--CXX = clang
-+CXX = clang++
- LD = clang++
- CXXFLAGS += -std=$(CXXSTD) -Os
- ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H -Wno-c++11-narrowing $(ABC_ARCHFLAGS)"
 --- a/tests/cxxrtl/run-test.sh
 +++ b/tests/cxxrtl/run-test.sh
 @@ -5,7 +5,7 @@ set -ex


### PR DESCRIPTION
ABC is now included as a submodule, and we choose to build it like that instead of having to maintain nixpkgs's version, as each version of Yosys is only compatible with one particular version of ABC. The built ABC is available in `$out/bin/yosys-abc` as before.

A little munging is required to present the git hashes as desired.

Additionally, some upstreamed patches are dropped.

Supersedes https://github.com/NixOS/nixpkgs/pull/297531 .

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
