### PR TITLE
nixos/wayfire: fix import file with settings required to start service

### DIFF
--- a/nixos/modules/programs/wayland/wayfire.nix
+++ b/nixos/modules/programs/wayland/wayfire.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ...}:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   cfg = config.programs.wayfire;
 in
@@ -12,7 +17,10 @@ in
 
     plugins = lib.mkOption {
       type = lib.types.listOf lib.types.package;
-      default = with pkgs.wayfirePlugins; [ wcm wf-shell ];
+      default = with pkgs.wayfirePlugins; [
+        wcm
+        wf-shell
+      ];
       defaultText = lib.literalExpression "with pkgs.wayfirePlugins; [ wcm wf-shell ]";
       example = lib.literalExpression ''
         with pkgs.wayfirePlugins; [
@@ -25,32 +33,39 @@ in
         Additional plugins to use with the wayfire window manager.
       '';
     };
-    xwayland.enable = lib.mkEnableOption "XWayland" // { default = true; };
+    xwayland.enable = lib.mkEnableOption "XWayland" // {
+      default = true;
+    };
   };
 
-  config = let
-    finalPackage = pkgs.wayfire-with-plugins.override {
-      wayfire = cfg.package;
-      plugins = cfg.plugins;
-    };
-  in
-  lib.mkIf cfg.enable (lib.mkMerge [{
-    environment.systemPackages = [
-      finalPackage
-    ];
+  config =
+    let
+      finalPackage = pkgs.wayfire-with-plugins.override {
+        wayfire = cfg.package;
+        plugins = cfg.plugins;
+      };
+    in
+    lib.mkIf cfg.enable (
+      lib.mkMerge [
+        {
+          environment.systemPackages = [ finalPackage ];
 
-    services.displayManager.sessionPackages = [ finalPackage ];
+          services.displayManager.sessionPackages = [ finalPackage ];
 
-    xdg.portal = {
-      enable = lib.mkDefault true;
-      wlr.enable = lib.mkDefault true;
-      # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1050914
-      config.wayfire.default = lib.mkDefault [ "wlr" "gtk" ];
-    };
-  }
-  (import ./wayland-session.nix {
-    inherit  lib pkgs;
-    enableXWayland = cfg.xwayland.enable;
-    })
-  ]);
+          xdg.portal = {
+            enable = lib.mkDefault true;
+            wlr.enable = lib.mkDefault true;
+            # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1050914
+            config.wayfire.default = lib.mkDefault [
+              "wlr"
+              "gtk"
+            ];
+          };
+        }
+        (import ./wayland-session.nix {
+          inherit lib pkgs;
+          enableXWayland = cfg.xwayland.enable;
+        })
+      ]
+    );
 }

--- a/nixos/modules/programs/wayland/wayfire.nix
+++ b/nixos/modules/programs/wayland/wayfire.nix
@@ -25,6 +25,7 @@ in
         Additional plugins to use with the wayfire window manager.
       '';
     };
+    xwayland.enable = lib.mkEnableOption "XWayland" // { default = true; };
   };
 
   config = let
@@ -33,7 +34,7 @@ in
       plugins = cfg.plugins;
     };
   in
-  lib.mkIf cfg.enable {
+  lib.mkIf cfg.enable (lib.mkMerge [{
     environment.systemPackages = [
       finalPackage
     ];
@@ -46,5 +47,10 @@ in
       # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1050914
       config.wayfire.default = lib.mkDefault [ "wlr" "gtk" ];
     };
-  };
+  }
+  (import ./wayland-session.nix {
+    inherit  lib pkgs;
+    enableXWayland = cfg.xwayland.enable;
+    })
+  ]);
 }


### PR DESCRIPTION
Wayfire does not start without further configuration, when programs.wayfire.enable is the only wayland wm enabled. When sway or a similar program is also enabled that program imports wayland-session.nix hiding the problem.


Fixes: #322248

## Description of changes


This imports wayland-session.nix into wayfire.nix and adds the option xwayland.enable to pass to the file,
so wayfire works without further configuration when programs.wayfire.enable is true;

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
