### PR TITLE
GNOME updates 2024-06-25

### DIFF
--- a/pkgs/desktops/gnome/games/gnome-sudoku/default.nix
+++ b/pkgs/desktops/gnome/games/gnome-sudoku/default.nix
@@ -21,11 +21,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-sudoku";
-  version = "46.1";
+  version = "46.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-sudoku/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-ObtDHxCjH1Vq9im2aFyG1Qyknymhuv6GIZwgwVUQcKY=";
+    hash = "sha256-K8wzwpHkTVJEj9saRwqKsJ9TxCMEBPbuCoakir8qNGw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/networking/networkmanager/default.nix
+++ b/pkgs/tools/networking/networkmanager/default.nix
@@ -60,11 +60,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "networkmanager";
-  version = "1.48.0";
+  version = "1.48.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/NetworkManager/${lib.versions.majorMinor version}/NetworkManager-${version}.tar.xz";
-    hash = "sha256-/IC5Qt444ylGjm/B37QKrWp40C3fa47DH5rMZGC4cj8=";
+    hash = "sha256-PZBxzGKWTd8OMfXQbwYD4XVouMlRFK4ndwNYGt1ahqE=";
   };
 
   outputs = [ "out" "dev" "devdoc" "man" "doc" ];

--- a/pkgs/tools/networking/networkmanager/openvpn/default.nix
+++ b/pkgs/tools/networking/networkmanager/openvpn/default.nix
@@ -1,30 +1,31 @@
-{ stdenv
-, lib
-, fetchurl
-, substituteAll
-, openvpn
-, gettext
-, libxml2
-, pkg-config
-, file
-, networkmanager
-, libsecret
-, glib
-, gtk3
-, gtk4
-, withGnome ? true
-, gnome
-, kmod
-, libnma
-, libnma-gtk4
+{
+  stdenv,
+  lib,
+  fetchurl,
+  substituteAll,
+  openvpn,
+  gettext,
+  libxml2,
+  pkg-config,
+  file,
+  networkmanager,
+  libsecret,
+  glib,
+  gtk3,
+  gtk4,
+  withGnome ? true,
+  gnome,
+  kmod,
+  libnma,
+  libnma-gtk4,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "NetworkManager-openvpn";
   version = "1.12.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/NetworkManager-openvpn/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/NetworkManager-openvpn/${lib.versions.majorMinor finalAttrs.version}/NetworkManager-openvpn-${finalAttrs.version}.tar.xz";
     sha256 = "kD/UwK69KqescMnYwr7Y35ImVdItdkUUQDVmrom36IY=";
   };
 
@@ -42,17 +43,19 @@ stdenv.mkDerivation rec {
     libxml2
   ];
 
-  buildInputs = [
-    openvpn
-    networkmanager
-    glib
-  ] ++ lib.optionals withGnome [
-    gtk3
-    gtk4
-    libsecret
-    libnma
-    libnma-gtk4
-  ];
+  buildInputs =
+    [
+      openvpn
+      networkmanager
+      glib
+    ]
+    ++ lib.optionals withGnome [
+      gtk3
+      gtk4
+      libsecret
+      libnma
+      libnma-gtk4
+    ];
 
   configureFlags = [
     "--with-gnome=${if withGnome then "yes" else "no"}"
@@ -63,16 +66,18 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = "NetworkManager-openvpn";
       attrPath = "networkmanager-openvpn";
       versionPolicy = "odd-unstable";
     };
     networkManagerPlugin = "VPN/nm-openvpn-service.name";
   };
 
-  meta = with lib; {
+  meta = {
     description = "NetworkManager's OpenVPN plugin";
+    homepage = "https://gitlab.gnome.org/GNOME/NetworkManager-openvpn";
+    changelog = "https://gitlab.gnome.org/GNOME/NetworkManager-openvpn/-/blob/main/NEWS";
     inherit (networkmanager.meta) maintainers platforms;
-    license = licenses.gpl2Plus;
+    license = lib.licenses.gpl2Plus;
   };
-}
+})

--- a/pkgs/tools/networking/networkmanager/openvpn/default.nix
+++ b/pkgs/tools/networking/networkmanager/openvpn/default.nix
@@ -21,11 +21,11 @@
 
 stdenv.mkDerivation rec {
   pname = "NetworkManager-openvpn";
-  version = "1.10.2";
+  version = "1.12.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/NetworkManager-openvpn/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "YvDyqHgiIbkj8hKsKo67wQAu/WqQ7pRdrUrftW0HbSE=";
+    sha256 = "kD/UwK69KqescMnYwr7Y35ImVdItdkUUQDVmrom36IY=";
   };
 
   patches = [


### PR DESCRIPTION
## Description of changes

`adwaita-icon-theme` not updated as it will be done as part of #316416.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
