### PR TITLE
pebble: 2.4.0 -> 2.6.0 and fix version info

### DIFF
--- a/pkgs/tools/admin/pebble/default.nix
+++ b/pkgs/tools/admin/pebble/default.nix
@@ -7,13 +7,13 @@
 
 buildGoModule rec {
   pname = "pebble";
-  version = "2.4.0";
+  version = "2.6.0";
 
   src = fetchFromGitHub {
     owner = "letsencrypt";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0sh67bzq3hlagk73w2kp45viq15g2rcxm760jk9fqshamq784m6m";
+    hash = "sha256-YPU/bl7h6rOWg+5ut0Thn2UupeKpJ7u4KXc2svIeZEM=";
   };
 
   vendorHash = null;
@@ -28,8 +28,6 @@ buildGoModule rec {
   };
 
   meta = {
-    # ca/ca.go:374:67: 9223372038 (untyped int constant) overflows uint
-    broken = stdenv.hostPlatform.is32bit;
     homepage = "https://github.com/letsencrypt/pebble";
     description = "Small RFC 8555 ACME test server";
     longDescription = "Miniature version of Boulder, Pebble is a small RFC 8555 ACME test server not suited for a production CA";

--- a/pkgs/tools/admin/pebble/default.nix
+++ b/pkgs/tools/admin/pebble/default.nix
@@ -18,6 +18,11 @@ buildGoModule rec {
 
   vendorHash = null;
 
+  ldflags = [
+    "-s" "-w"
+    "-X main.version=${version}"
+  ];
+
   passthru.tests = {
     smoke-test = nixosTests.acme;
   };
@@ -26,8 +31,10 @@ buildGoModule rec {
     # ca/ca.go:374:67: 9223372038 (untyped int constant) overflows uint
     broken = stdenv.hostPlatform.is32bit;
     homepage = "https://github.com/letsencrypt/pebble";
-    description = "Miniature version of Boulder, Pebble is a small RFC 8555 ACME test server not suited for a production CA";
+    description = "Small RFC 8555 ACME test server";
+    longDescription = "Miniature version of Boulder, Pebble is a small RFC 8555 ACME test server not suited for a production CA";
     license = [ lib.licenses.mpl20 ];
+    mainProgram = "pebble";
     maintainers = lib.teams.acme.members;
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* update to 2.6.0
* remove `meta.broken` as 2.6.0 contains a fix for 32-bit system (see [letsencrypt/pebble#388](https://github.com/letsencrypt/pebble/pull/388))
* pass version to `ldflags` to have `pebble -version` show the correct version
* shorten `meta.description`
* add `meta.longDescription`
* add `meta.mainProgram`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
