### PR TITLE
gvls: init at 20.1

### DIFF
--- a/pkgs/by-name/gv/gvls/package.nix
+++ b/pkgs/by-name/gv/gvls/package.nix
@@ -1,0 +1,86 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  fetchpatch,
+  meson,
+  ninja,
+  pkg-config,
+  glib,
+  vala,
+  jsonrpc-glib,
+  json-glib,
+  gtk3,
+  pango,
+  gtksourceview3,
+  libgee,
+  vala-lint,
+  gobject-introspection,
+  wrapGAppsHook3,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gvls";
+  version = "20.1";
+
+  outputs = [
+    "out"
+    "dev"
+    "devdoc"
+  ];
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "esodan";
+    repo = "gvls";
+    rev = "gvls-${finalAttrs.version}";
+    hash = "sha256-Hpn1osUDxK7+P9Yxcp+3Gw8XJ7jC5C9wRa++0QLp7oM=";
+  };
+
+  nativeBuildInputs = [
+    gobject-introspection
+    meson
+    ninja
+    pkg-config
+    vala
+    wrapGAppsHook3
+  ];
+
+  patches = [
+    # https://gitlab.gnome.org/esodan/gvls/-/merge_requests/14
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/esodan/gvls/-/commit/35930cc5797f3834491dae837d996371a751c7de.patch";
+      hash = "sha256-tDAWLhOCJ+t0UaFEZD9EZKrSI/4FzhE4sZtelx+/wF0=";
+    })
+  ];
+
+  mesonFlags = [ "-Dvapidir=${placeholder "out"}/share" ];
+
+  buildInputs = [
+    glib
+    gtk3
+    gtksourceview3
+    json-glib
+    jsonrpc-glib
+    libgee
+    pango
+  ];
+  # Tests fail, probably they need http support not available inside the
+  # sandbox
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    vala
+    vala-lint
+  ];
+
+  meta = {
+    description = "Language Server Provider for Vala";
+    homepage = "https://gitlab.gnome.org/esodan/gvls";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = (with lib.maintainers; [
+      johnrtitor
+    ]) ++ lib.teams.gnome.members;
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Let's get this done, this has been pending for a long time already. Changes mostly adapted from #83386.

Closes #83118

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
