### PR TITLE
python3Packages.joblib: update and fix lscpu warning

### DIFF
--- a/pkgs/development/python-modules/joblib/default.nix
+++ b/pkgs/development/python-modules/joblib/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   pythonOlder,
-  fetchPypi,
+  fetchFromGitHub,
   pythonAtLeast,
   stdenv,
 
@@ -22,18 +22,20 @@
 buildPythonPackage rec {
   pname = "joblib";
   version = "1.4.2";
-  format = "pyproject";
+  pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-I4LFgWsmNvvSCgng9Ona1HNnZf37fcpYKUO5wTZrPw4=";
+  src = fetchFromGitHub {
+    owner = "joblib";
+    repo = "joblib";
+    rev = version;
+    hash = "sha256-/II5E97u7UkfQ87DU+TWQ2IdsmQf24QRCfgSwUtgSBI=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     lz4
     psutil
   ];
@@ -65,6 +67,6 @@ buildPythonPackage rec {
     description = "Lightweight pipelining: using Python functions as pipeline jobs";
     homepage = "https://joblib.readthedocs.io/";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ dsuetin ];
   };
 }

--- a/pkgs/development/python-modules/joblib/default.nix
+++ b/pkgs/development/python-modules/joblib/default.nix
@@ -33,6 +33,11 @@ buildPythonPackage rec {
     hash = "sha256-/II5E97u7UkfQ87DU+TWQ2IdsmQf24QRCfgSwUtgSBI=";
   };
 
+  patches = [
+    # Ignore phys core information in sandbox env, and consider NIX_BUILD_CORES
+    ./nix_build_env.patch
+  ];
+
   build-system = [ setuptools ];
 
   dependencies = [

--- a/pkgs/development/python-modules/joblib/nix_build_env.patch
+++ b/pkgs/development/python-modules/joblib/nix_build_env.patch
@@ -1,0 +1,28 @@
+diff --git a/joblib/externals/loky/backend/context.py b/joblib/externals/loky/backend/context.py
+index d0f5903..a3310f0 100644
+--- a/joblib/externals/loky/backend/context.py
++++ b/joblib/externals/loky/backend/context.py
+@@ -126,6 +126,11 @@ def cpu_count(only_physical_cores=False):
+         # Respect user setting
+         return max(cpu_count_user, 1)
+ 
++    if sys.platform == "linux" and not os.path.exists("/sys/devices/system/cpu/possible"):
++        # lscpu which used on linux, uses /sys/devices/system/cpu/possible
++        # which is not availble in nix sandbox environment
++        return aggregate_cpu_count
++
+     cpu_count_physical, exception = _count_physical_cores()
+     if cpu_count_physical != "not found":
+         return cpu_count_physical
+@@ -226,7 +231,10 @@ def _cpu_count_user(os_cpu_count):
+     # User defined soft-limit passed as a loky specific environment variable.
+     cpu_count_loky = int(os.environ.get("LOKY_MAX_CPU_COUNT", os_cpu_count))
+ 
+-    return min(cpu_count_affinity, cpu_count_cgroup, cpu_count_loky)
++    # If used inside nix build, consider NIX_BUILD_CORES as well
++    cpu_count_nix = int(os.environ.get("NIX_BUILD_CORES", os_cpu_count))
++
++    return min(cpu_count_affinity, cpu_count_cgroup, cpu_count_loky, cpu_count_nix)
+ 
+ 
+ def _count_physical_cores():


### PR DESCRIPTION
## Description of changes

While reviewing another PR (#289823). I got a warning during `nix-build` that `lscpu` is missing.
I decided to add it as a dependency. Since `propagatedBuildInputs` didn't work, I then tried substituting full `lscpu` path in source, but then got another warning that `lscpu` returned 0 cores, which is likely due to isolation in derivation build environment.
So I decided to patch the package to ignore trying to fetch physical core information if `NIX_BUILD_TOP` is set, and also to consider `NIX_BUILD_CORES` if exists.

I am not sure if the story is different in darwin, but I think it might be a good idea to use nix information about cores if the package is executed in derivation build environment.
Feel free to suggest a different idea how to fix this.


Since it's required mass rebuild, I also updated the package and did a bit of refactoring to use new style separated dependencies.

Also, there was no maintainer, so I added myself.

`lz4` and `psutil` are stated as optional dependencies in upstream, so ideally they can be moved to `optional-dependencies`, but it will probably break other packages, and will end up requiring to modify a bunch of them, so I guess it's better to do it in a separate PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc