### PR TITLE
Fix Darwin build on staging-next

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -417,6 +417,9 @@ in with passthru; stdenv.mkDerivation (finalAttrs: {
     (enableFeature enableGIL "gil")
   ] ++ optionals enableOptimizations [
     "--enable-optimizations"
+  ] ++ optionals (stdenv.isDarwin && configd == null) [
+    # Make conditional on Darwin for now to avoid causing Linux rebuilds.
+    "py_cv_module__scproxy=n/a"
   ] ++ optionals (sqlite != null) [
     "--enable-loadable-sqlite-extensions"
   ] ++ optionals (libxcrypt != null) [

--- a/pkgs/development/python-modules/cffi/default.nix
+++ b/pkgs/development/python-modules/cffi/default.nix
@@ -56,7 +56,7 @@ else
           hash = "sha256-H5rFgRRTr27l5S6REo8+7dmPDQW7WXhP4f4DGZjdi+s=";
         })
       ]
-      ++ lib.optionals (stdenv.cc.isClang && (ccVersion == "boot" || lib.versionAtLeast (lib.getVersion stdenv.cc) "13")) [
+      ++ lib.optionals (stdenv.cc.isClang && (ccVersion == "boot" || lib.versionAtLeast ccVersion "13")) [
         # -Wnull-pointer-subtraction is enabled with -Wextra. Suppress it to allow the following tests
         # to run and pass when cffi is built with newer versions of clang (including the bootstrap tools clang on Darwin):
         # - testing/cffi1/test_verify1.py::test_enum_usage

--- a/pkgs/development/python-modules/cffi/default.nix
+++ b/pkgs/development/python-modules/cffi/default.nix
@@ -13,6 +13,9 @@
   pythonAtLeast,
 }:
 
+let
+  ccVersion = lib.getVersion stdenv.cc;
+in
 if isPyPy then
   null
 else
@@ -53,9 +56,9 @@ else
           hash = "sha256-H5rFgRRTr27l5S6REo8+7dmPDQW7WXhP4f4DGZjdi+s=";
         })
       ]
-      ++ lib.optionals (stdenv.cc.isClang && lib.versionAtLeast (lib.getVersion stdenv.cc) "13") [
+      ++ lib.optionals (stdenv.cc.isClang && (ccVersion == "boot" || lib.versionAtLeast (lib.getVersion stdenv.cc) "13")) [
         # -Wnull-pointer-subtraction is enabled with -Wextra. Suppress it to allow the following tests
-        # to run and pass when cffi is built with newer versions of clang:
+        # to run and pass when cffi is built with newer versions of clang (including the bootstrap tools clang on Darwin):
         # - testing/cffi1/test_verify1.py::test_enum_usage
         # - testing/cffi1/test_verify1.py::test_named_pointer_as_argument
         ./clang-pointer-substraction-warning.diff

--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
@@ -59,7 +59,7 @@ appleDerivation' stdenv {
       (cd $dep/include && find . -name '*.h' | copyHierarchy $out/include)
     done
 
-    (cd ${buildPackages.darwin.cctools.dev}/include/mach-o && find . -name '*.h' | copyHierarchy $out/include/mach-o)
+    (cd ${lib.getDev buildPackages.darwin.cctools}/include/mach-o && find . -name '*.h' | copyHierarchy $out/include/mach-o)
 
     for header in pthread.h pthread_impl.h pthread_spis.h sched.h; do
       ln -s "$out/include/pthread/$header" "$out/include/$header"
@@ -142,7 +142,7 @@ appleDerivation' stdenv {
       $out/lib
 
     substituteInPlace $out/lib/libSystem.B.tbd \
-      --replace "/usr/lib/system/" "$out/lib/system/"
+      --replace-fail "/usr/lib/system/" "$out/lib/system/"
     ln -s libSystem.B.tbd $out/lib/libSystem.tbd
 
     # Set up links to pretend we work like a conventional unix (Apple's design, not mine!)

--- a/pkgs/os-specific/darwin/binutils/default.nix
+++ b/pkgs/os-specific/darwin/binutils/default.nix
@@ -1,108 +1,124 @@
-{ lib, stdenv, makeWrapper, binutils-unwrapped, cctools, llvm, clang-unwrapped, dualAs ? false }:
-
-# Make sure both underlying packages claim to have prepended their binaries
-# with the same targetPrefix.
-assert binutils-unwrapped.targetPrefix == cctools.targetPrefix;
+{
+  lib,
+  stdenvNoCC,
+  cctools,
+  clang-unwrapped,
+  llvm,
+  llvm-manpages,
+  makeWrapper,
+  enableManpages ? stdenvNoCC.targetPlatform == stdenvNoCC.hostPlatform,
+}:
 
 let
-  inherit (binutils-unwrapped) targetPrefix;
-  cmds = [
-    "ar" "ranlib" "as" "install_name_tool"
-    "ld" "strip" "otool" "lipo" "nm" "strings" "size"
-    "codesign_allocate"
-  ];
-  isCCToolsLLVM = lib.getName cctools == "cctools-llvm";
-in
+  inherit (stdenvNoCC) targetPlatform hostPlatform;
+  targetPrefix = lib.optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}-";
 
-# TODO: loop over targetPrefixed binaries too
-stdenv.mkDerivation {
-  pname = "${targetPrefix}cctools-binutils-darwin" + lib.optionalString dualAs "-dualas";
+  llvm_cmds = [
+    "addr2line"
+    "ar"
+    "c++filt"
+    "dsymutil"
+    "nm"
+    "objcopy"
+    "objdump"
+    "otool"
+    "size"
+    "strings"
+    "strip"
+  ];
+
+  cctools_cmds = [
+    "codesign_allocate"
+    "gprof"
+    "ranlib"
+    # Use the cctools versions because the LLVM ones can crash or fail when the cctools ones don’t.
+    # Revisit when LLVM is updated to LLVM 18 on Darwin.
+    "lipo"
+    "install_name_tool"
+  ];
+
+  linkManPages =
+    pkg: source: target:
+    lib.optionalString enableManpages ''
+      sourcePath=${pkg}/share/man/man1/${source}.1.gz
+      targetPath=''${!outputMan}/share/man/man1/${target}.1.gz
+
+      if [ -f "$sourcePath" ]; then
+        mkdir -p "$(dirname "$targetPath")"
+        ln -s "$sourcePath" "$targetPath"
+      fi
+    '';
+in
+stdenvNoCC.mkDerivation {
+  pname = "${targetPrefix}cctools-binutils-darwin";
   inherit (cctools) version;
-  outputs = [ "out" "man" ];
+
+  outputs = [ "out" ] ++ lib.optional enableManpages "man";
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
   buildCommand = ''
     mkdir -p $out/bin $out/include
 
-    ln -s ${binutils-unwrapped.out}/bin/${targetPrefix}c++filt $out/bin/${targetPrefix}c++filt
+    for tool in ${toString llvm_cmds}; do
+      # Translate between LLVM and traditional tool names (e.g., `c++filt` versus `cxxfilt`).
+      cctoolsTool=''${tool//-/_}
+      llvmTool=''${tool//++/xx}
 
-    # We specifically need:
-    # - ld: binutils doesn't provide it on darwin
-    # - as: as above
-    # - ar: the binutils one produces .a files that the cctools ld doesn't like
-    # - ranlib: for compatibility with ar
-    # - otool: we use it for some of our name mangling
-    # - install_name_tool: we use it to rewrite stuff in our bootstrap tools
-    # - strip: the binutils one seems to break mach-o files
-    # - lipo: gcc build assumes it exists
-    # - nm: the gnu one doesn't understand many new load commands
-    for i in ${lib.concatStringsSep " " (map (e: targetPrefix + e) cmds)}; do
-      ln -sf "${cctools}/bin/$i" "$out/bin/$i"
+      # Some tools aren’t prefixed (like `dsymutil`).
+      llvmPath="${lib.getBin llvm}/bin"
+      if [ -e "$llvmPath/llvm-$llvmTool" ]; then
+        llvmTool=llvm-$llvmTool
+      elif [ -e "$llvmPath/${targetPrefix}$llvmTool" ]; then
+        llvmTool=${targetPrefix}$llvmTool
+      fi
+
+      # Not all tools are included in the bootstrap tools. Don’t link them if they don’t exist.
+      if [ -e "$llvmPath/$llvmTool" ]; then
+        ln -s "$llvmPath/$llvmTool" "$out/bin/${targetPrefix}$cctoolsTool"
+      fi
+      ${linkManPages llvm-manpages "$llvmTool" "$cctoolsTool"}
     done
 
-    ln -s ${llvm}/bin/dsymutil $out/bin/dsymutil
-
-    ln -s ${binutils-unwrapped.out}/share $out/share
-
-    mkdir -p "$man"/share/man/man{1,5}
-    for i in ${lib.concatStringsSep " " cmds}; do
-      for path in "${cctools.man}"/share/man/man?/$i.*; do
-        dest_path="$man''${path#${cctools.man}}"
-        ln -sv "$path" "$dest_path"
-      done
+    for tool in ${toString cctools_cmds}; do
+      toolsrc="${lib.getBin cctools}/bin/${targetPrefix}$tool"
+      if [ -e "$toolsrc" ]; then
+        ln -s "${lib.getBin cctools}/bin/${targetPrefix}$tool" "$out/bin/${targetPrefix}$tool"
+      fi
+      ${linkManPages (lib.getMan cctools) "$tool" "$tool"}
     done
-  ''
-  + lib.optionalString (!isCCToolsLLVM) (
-    # cctools-port has a `libexec` folder for `as`, but cctools-llvm uses the clang
-    # assembler on both platforms. Only link it when cctools is cctools-port.
-    ''
-      ln -s ${cctools}/libexec $out/libexec
-    ''
-    # cctools-llvm uses the LLVM assembler on both architectures, so use the assembler
-    # from that instead of relinking it.
-    #
-    # On aarch64-darwin we must use clang, because "as" from cctools just doesn't
-    # handle the arch. Proxying calls to clang produces quite a bit of warnings,
-    # and using clang directly here is a better option than relying on cctools.
-    # On x86_64-darwin the Clang version is too old to support this mode.
-    + lib.optionalString stdenv.isAarch64 ''
-      rm $out/bin/${targetPrefix}as
-      makeWrapper "${clang-unwrapped}/bin/clang" "$out/bin/${targetPrefix}as" \
-        --add-flags "-x assembler -integrated-as -c"
-    ''
-    # x86-64 Darwin gnat-bootstrap emits assembly
-    # with MOVQ as the mnemonic for quadword interunit moves
-    # such as `movq %rbp, %xmm0`.
-    # The clang integrated assembler recognises this as valid,
-    # but unfortunately the cctools-port GNU assembler does not;
-    # it instead uses MOVD as the mnemonic.
-    # The assembly that a GCC build emits is determined at build time
-    # and cannot be changed afterwards.
-    #
-    # To build GNAT on x86-64 Darwin, therefore,
-    # we need both the clang _and_ the cctools-port assemblers to be available:
-    # the former to build at least the stage1 compiler,
-    # and the latter at least to be detectable
-    # as the target for the final compiler.
-    #
-    # We choose to match the Aarch64 case above,
-    # wrapping the clang integrated assembler as `as`.
-    # It then seems sensible to wrap the cctools GNU assembler as `gas`.
-    #
-    + lib.optionalString (stdenv.isx86_64 && dualAs) ''
-      mv $out/bin/${targetPrefix}as $out/bin/${targetPrefix}gas
-      makeWrapper "${clang-unwrapped}/bin/clang" "$out/bin/${targetPrefix}as" \
-        --add-flags "-x assembler -integrated-as -c"
-    ''
-  );
+    ${
+      # These unprefixed because some tools expect to invoke them without it when cross-compiling to Darwin:
+      # - clang needs `dsymutil` when building with debug information;
+      # - meson needs `lipo` when cross-compiling to Darwin; and
+      # - meson also needs `install_name_tool` and `otool` when performing rpath cleanup on installation.
+      lib.optionalString (targetPrefix != "") ''
+        for bintool in dsymutil install_name_tool lipo otool; do
+          ln -s "$out/bin/${targetPrefix}$bintool" "$out/bin/$bintool"
+        done
+      ''
+    }
+    # Use the clang-integrated assembler. `as` in cctools is deprecated upstream and no longer built in nixpkgs.
+    makeWrapper "${lib.getBin clang-unwrapped}/bin/clang" "$out/bin/${targetPrefix}as" \
+      --add-flags "-x assembler -integrated-as -c"
 
-  nativeBuildInputs = lib.optionals (!isCCToolsLLVM && (stdenv.isAarch64 || dualAs)) [ makeWrapper ];
+    ln -s '${lib.getBin cctools}/bin/${targetPrefix}ld' "$out/bin/${targetPrefix}ld"
+    ${linkManPages (lib.getMan cctools) "ld" "ld"}
+    # ${linkManPages (lib.getMan cctools) "ld-classic" "ld-classic"}
+    ${linkManPages (lib.getMan cctools) "ld64" "ld64"}
+  '';
+
+  __structuredAttrs = true;
 
   passthru = {
-    inherit targetPrefix;
-    isCCTools = true;
+    inherit cctools_cmds llvm_cmds targetPrefix;
+    isCCTools = true; # The fact ld64 is used instead of lld is why this isn’t `isLLVM`.
   };
 
   meta = {
-    maintainers = with lib.maintainers; [ matthewbauer ];
+    maintainers = with lib.maintainers; [ reckenrode ];
     priority = 10;
   };
 }

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
     sha256 = "0ns12q7vg9yand4dmdsps1917cavfbw67yl5q7bm6kb4ia5kkx13";
   };
 
-  outputs = [ "out" "dev" "man" ];
+  outputs = [ "out" "dev" "gas" "man" ];
 
   nativeBuildInputs = [ autoconf automake libtool autoreconfHook installShellFiles ]
     ++ lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [ memstreamHook ];
@@ -176,6 +176,12 @@ stdenv.mkDerivation {
     install -c -m 444  libsyminfo.h \
       $dev/include/cbt
     popd
+  '';
+
+  postInstall = ''
+    # Move GNU as to its own output to prevent it from being used accidentally.
+    moveToOutput bin/gas "$gas"
+    moveToOutput libexec "$gas"
   '';
 
   passthru = {

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -505,6 +505,8 @@ in
       inherit (prevStage) ccWrapperStdenv
         coreutils gnugrep;
 
+      binutils-unwrapped = builtins.throw "nothing in the bootstrap should depend on GNU binutils";
+
       # Use this stage’s CF to build CMake. It’s required but can’t be included in the stdenv.
       cmake = self.cmakeMinimal;
       cmakeMinimal = super.cmakeMinimal.overrideAttrs (old: {
@@ -1332,8 +1334,6 @@ in
 
       allowedRequisites = (with prevStage; [
         bash
-        binutils.bintools
-        binutils.bintools.lib
         bzip2.bin
         bzip2.out
         cc.expand-response-params
@@ -1433,8 +1433,6 @@ in
           in
           { inherit tools libraries; } // tools // libraries
         );
-
-        inherit (prevStage) binutils binutils-unwrapped;
       };
     };
   })
@@ -1455,5 +1453,10 @@ in
     assert isBuiltByNixpkgsCompiler prevStage.llvmPackages.libllvm;
     assert isBuiltByNixpkgsCompiler prevStage.llvmPackages.libcxx;
     assert isBuiltByNixpkgsCompiler prevStage.llvmPackages.compiler-rt;
+
+    # Make sure these evaluate since they were disabled explicitly in the bootstrap.
+    assert isBuiltByNixpkgsCompiler prevStage.binutils-unwrapped;
+    assert            isFromNixpkgs prevStage.binutils-unwrapped.src;
+
     { inherit (prevStage) config overlays stdenv; })
 ]

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -673,6 +673,11 @@ in
             nixSupport.cc-ldflags = [ "-lSystem" ];
           });
 
+          tools = super.llvmPackages.tools.extend (selfTools: superTools: {
+            # LLVM’s check phase takes a while to run, so disable it in the first LLVM build to speed up the bootstrap.
+            libllvm = superTools.libllvm.override { doCheck = false; };
+          });
+
           libraries = super.llvmPackages.libraries.extend (selfLib: superLib: {
             compiler-rt = null;
             libcxx = superLib.libcxx.override ({
@@ -680,7 +685,7 @@ in
             });
           });
         in
-        { inherit libraries; } // libraries
+        { inherit tools libraries; } // tools // libraries
       );
     };
 

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -233,7 +233,10 @@ in
       # stage should only access the stage that came before it.
       ccWrapperStdenv = self.stdenv;
 
-      bash = bootstrapTools;
+      bash = bootstrapTools // {
+        shellPath = "/bin/bash";
+      };
+
       coreutils = bootstrapTools;
       cpio = bootstrapTools;
       gnugrep = bootstrapTools;
@@ -243,10 +246,6 @@ in
         # Prevent CF from being propagated to the initial stdenv. Packages that require it
         # will have to manually add it to their build inputs.
         CF = null;
-
-        binutils-unwrapped = bootstrapTools // {
-          version = "boot";
-        };
 
         binutils = super.wrapBintoolsWith {
           name = "bootstrap-stage0-binutils-wrapper";
@@ -266,10 +265,98 @@ in
           inherit (selfDarwin) postLinkSignHook signingUtils;
         };
 
-        cctools = bootstrapTools // {
-          targetPrefix = "";
+        binutils-unwrapped = (superDarwin.binutils-unwrapped.overrideAttrs (old: {
           version = "boot";
-          man = bootstrapTools;
+          passthru = (old.passthru or { }) // {
+            isFromBootstrapFiles = true;
+          };
+        })).override { enableManpages = false; };
+
+        cctools = super.stdenv.mkDerivation {
+          pname = "bootstrap-stage0-cctools";
+          version = "boot";
+
+          buildCommand = ''
+            declare -a cctools=(
+              ar
+              bitcode_strip
+              check_dylib
+              checksyms
+              cmpdylib
+              codesign_allocate
+              ctf_insert
+              depinfo
+              diagtest
+              ld
+              gas
+              gprof
+              install_name_tool
+              libtool
+              lipo
+              mtoc
+              mtor
+              nm
+              nmedit
+              otool
+              pagestuff
+              ranlib
+              redo_prebinding
+              seg_addr_table
+              seg_hack
+              segedit
+              size
+              strings
+              strip
+              vtool
+            )
+
+            mkdir -p "$out/bin"
+            for tool in "''${cctools[@]}"; do
+              toolsrc="${bootstrapTools}/bin/$tool"
+              if [ -e "$toolsrc" ]; then
+                ln -s "$toolsrc" "$out/bin"
+              fi
+            done
+
+            # Copy only the required headers to avoid accidentally linking headers that belong to other packages,
+            # which can cause problems when building Libsystem in the source-based SDK.
+            declare -a machohdrs=(
+              arch.h
+              fat.h
+              fixup-chains.h
+              getsect.h
+              ldsyms.h
+              loader.h
+              nlist.h
+              ranlib.h
+              reloc.h
+              stab.h
+              swap.h
+              arm
+              arm64
+              hppa
+              i386
+              i860
+              m68k
+              m88k
+              ppc
+              sparc
+              x86_64
+            )
+
+            mkdir -p "$out/include/mach-o"
+            for header in "''${machohdrs[@]}"; do
+              machosrc="${bootstrapTools}/include-Libsystem/mach-o/$header"
+              if [ -e "$machosrc" ]; then
+                cp -r "$machosrc" "$out/include/mach-o/$header"
+              fi
+            done
+          '';
+
+          passthru = {
+            isFromBootstrapFiles = true;
+            targetPrefix = "";
+          };
         };
 
         locale = self.stdenv.mkDerivation {
@@ -334,19 +421,24 @@ in
                 ];
               };
             };
-            clang-unwrapped = selfTools.libclang;
             libllvm = self.stdenv.mkDerivation {
               name = "bootstrap-stage0-llvm";
               outputs = [ "out" "lib" ];
               buildCommand = ''
                 mkdir -p $out/bin $out/lib
                 ln -s $out $lib
-                ln -s ${bootstrapTools}/bin/strip    $out/bin/llvm-strip
+                for tool in ${toString super.darwin.binutils-unwrapped.llvm_cmds}; do
+                  cctoolsTool=''${tool//-/_}
+                  toolsrc="${bootstrapTools}/bin/$cctoolsTool"
+                  if [ -e "$toolsrc" ]; then
+                    ln -s "$toolsrc" $out/bin/llvm-$tool
+                  fi
+                done
+                ln -s ${bootstrapTools}/bin/dsymutil $out/bin/dsymutil
                 ln -s ${bootstrapTools}/lib/libLLVM* $out/lib
               '';
               passthru.isFromBootstrapFiles = true;
             };
-            llvm = selfTools.libllvm;
           });
           libraries = super.llvmPackages.libraries.extend (_: _: {
             libcxx = self.stdenv.mkDerivation {
@@ -384,19 +476,9 @@ in
     '';
   })
 
-  # This stage is primarily responsible for building the linker and setting up versions of
-  # certain dependencies needed by the rest of the build process. It is necessary to rebuild the
-  # linker because the `compiler-rt` build process checks the version and attempts to manually
-  # run `codesign` if it detects a version of `ld64` it considers too old. If that happens, the
-  # build process will fail for a few different reasons:
-  #  - sigtool is too old and does not accept the `--sign` argument;
-  #  - sigtool is new enough to accept the `--sign` argument, but it aborts when it is invoked on a
-  #    binary that is already signed; or
-  #  - compiler-rt attempts to invoke `codesign` on x86_64-darwin, but `sigtool` is not currently
-  #    part of the x86_64-darwin bootstrap tools.
-  #
-  # This stage also builds CF and Libsystem to simplify assertions and assumptions for later by
-  # making sure both packages are present on x86_64-darwin and aarch64-darwin.
+  # This stage is primarily responsible for setting up versions of certain dependencies needed
+  # by the rest of the build process. This stage also builds CF and Libsystem to simplify assertions
+  # and assumptions for later by making sure both packages are present on x86_64-darwin and aarch64-darwin.
   (prevStage:
     # previous stage0 stdenv:
     assert lib.all isFromBootstrapFiles (
@@ -449,11 +531,13 @@ in
       });
 
       darwin = super.darwin.overrideScope (selfDarwin: superDarwin: {
+        inherit (prevStage.darwin) cctools;
+
         apple_sdk = superDarwin.apple_sdk // {
           inherit (prevStage.darwin.apple_sdk) sdkRoot;
         };
 
-        # Use this stage’s CF to build configd. It’s required but can’t be included in the stdenv.
+        # Use this stage’s CF to build configd. It’s required, but it can’t be included in the stdenv.
         configd = superDarwin.configd.overrideAttrs (old: {
           buildInputs = old.buildInputs or [ ] ++ [ self.darwin.CF ];
         });
@@ -466,6 +550,7 @@ in
           inherit (selfDarwin) sigtool;
         };
 
+        # Rewrap binutils with the real Libsystem
         binutils = superDarwin.binutils.override {
           inherit (self) coreutils;
           inherit (selfDarwin) postLinkSignHook signingUtils;
@@ -476,11 +561,11 @@ in
           runtimeShell = "${bootstrapTools}/bin/bash";
         };
 
+        # Avoid building unnecessary Python dependencies due to building LLVM manpages.
         binutils-unwrapped = superDarwin.binutils-unwrapped.override {
           inherit (selfDarwin) cctools;
+          enableManpages = false;
         };
-
-        cctools = selfDarwin.cctools-port;
       });
 
       llvmPackages = super.llvmPackages // (
@@ -518,20 +603,22 @@ in
     assert lib.all isFromBootstrapFiles (with prevStage; [ coreutils gnugrep ]);
 
     assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
-      autoconf automake bash binutils-unwrapped bison brotli cmake cpio cyrus_sasl db
+      autoconf automake bash bison brotli cmake cpio cyrus_sasl db
       ed expat flex gettext gmp groff icu libedit libffi libiconv libidn2 libkrb5 libssh2
       libtool libunistring libxml2 m4 ncurses nghttp2 ninja openldap openssh openssl
       patchutils pbzx perl pkg-config.pkg-config python3 python3Minimal scons serf sqlite
       subversion texinfo unzip which xz zlib zstd
     ]);
 
+    assert lib.all isFromBootstrapFiles (with prevStage.darwin; [ cctools ]);
     assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [
-      binutils-unwrapped cctools locale libtapi print-reexports rewrite-tbd sigtool
+      locale libtapi print-reexports rewrite-tbd sigtool
     ]);
+
     assert (! useAppleSDKLibs) -> lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [ Libsystem configd ]);
     assert (! useAppleSDKLibs) -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF ]);
     assert    useAppleSDKLibs  -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF Libsystem libobjc]);
-    assert lib.all isFromNixpkgs (with prevStage.darwin; [ dyld launchd xnu ]);
+    assert lib.all isFromNixpkgs (with prevStage.darwin; [ binutils-unwrapped dyld launchd xnu ]);
 
     assert lib.all isFromBootstrapFiles (with prevStage.llvmPackages; [
       clang-unwrapped libclang libllvm llvm compiler-rt libcxx
@@ -611,27 +698,26 @@ in
     assert lib.all isFromBootstrapFiles (with prevStage; [ coreutils gnugrep ]);
 
     assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
-      atf autoconf automake bash binutils-unwrapped bison brotli cmake cpio cyrus_sasl db
+      atf autoconf automake bash bison brotli cmake cpio cyrus_sasl db
       ed expat flex gettext gmp groff icu kyua libedit libffi libiconv libidn2 libkrb5 libssh2
       libtool libunistring libxml2 m4 meson ncurses nghttp2 ninja openldap openssh openssl
       patchutils pbzx perl pkg-config.pkg-config python3 python3Minimal scons serf sqlite
       subversion sysctl.provider texinfo unzip which xz zlib zstd
     ]);
 
+    assert lib.all isFromBootstrapFiles (with prevStage.darwin; [ cctools ]);
     assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [
-      binutils-unwrapped cctools locale libtapi print-reexports rewrite-tbd sigtool
+      locale libtapi print-reexports rewrite-tbd sigtool
     ]);
 
     assert (! useAppleSDKLibs) -> lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [ Libsystem configd ]);
     assert (! useAppleSDKLibs) -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF ]);
     assert    useAppleSDKLibs  -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF Libsystem libobjc ]);
-    assert lib.all isFromNixpkgs (with prevStage.darwin; [ dyld launchd xnu ]);
+    assert lib.all isFromNixpkgs (with prevStage.darwin; [ binutils-unwrapped dyld launchd xnu ]);
 
     assert lib.all isFromBootstrapFiles (with prevStage.llvmPackages; [
       clang-unwrapped libclang libllvm llvm compiler-rt libcxx
     ]);
-
-    assert lib.getVersion prevStage.stdenv.cc.bintools.bintools == lib.getVersion prevStage.darwin.cctools-port;
 
     stageFun prevStage {
     name = "bootstrap-stage-xclang";
@@ -644,8 +730,7 @@ in
         openldap openssh openssl patchutils pbzx perl pkg-config python3 python3Minimal
         scons sed serf sharutils sqlite subversion sysctl texinfo unzip which xz zlib zstd;
 
-      # Switch from cctools-port to cctools-llvm now that LLVM has been built.
-      darwin = super.darwin.overrideScope (_: superDarwin: {
+      darwin = super.darwin.overrideScope (selfDarwin: superDarwin: {
         inherit (prevStage.darwin)
           CF Libsystem configd darwin-stubs dyld launchd libclosure libdispatch libobjc
           locale objc4 postLinkSignHook print-reexports rewrite-tbd signingUtils sigtool;
@@ -654,8 +739,13 @@ in
           inherit (prevStage.darwin.apple_sdk) sdkRoot;
         };
 
+        binutils = superDarwin.binutils.override {
+          inherit (prevStage) expand-response-params;
+          libc = selfDarwin.Libsystem;
+        };
+
         # Avoid building unnecessary Python dependencies due to building LLVM manpages.
-        cctools-llvm = superDarwin.cctools-llvm.override { enableManpages = false; };
+        binutils-unwrapped = superDarwin.binutils-unwrapped.override { enableManpages = false; };
       });
 
       llvmPackages = super.llvmPackages // (
@@ -705,8 +795,8 @@ in
   (prevStage:
     # previous stage-xclang stdenv:
     assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
-      atf autoconf automake bash binutils-unwrapped bison cmake cmakeMinimal coreutils cpio
-      cyrus_sasl db ed expat flex gettext gmp gnugrep groff icu kyua libedit libtool m4 ninja
+      atf autoconf automake bash bison cmake cmakeMinimal coreutils cpio
+      cyrus_sasl db ed expat flex gettext gmp gnugrep groff icu kyua libedit libtool m4 meson ninja
       openbsm openldap openpam openssh patchutils pbzx perl pkg-config.pkg-config python3
       python3Minimal scons serf sqlite subversion sysctl.provider texinfo unzip which xz
     ]);
@@ -717,21 +807,19 @@ in
     ]);
 
     assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [
-      binutils-unwrapped cctools locale libtapi print-reexports rewrite-tbd sigtool
+      cctools locale libtapi print-reexports rewrite-tbd sigtool
     ]);
 
     assert (! useAppleSDKLibs) -> lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [ Libsystem configd ]);
     assert (! useAppleSDKLibs) -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF ]);
     assert    useAppleSDKLibs  -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF Libsystem libobjc ]);
-    assert lib.all isFromNixpkgs (with prevStage.darwin; [ dyld launchd libclosure libdispatch xnu ]);
+    assert lib.all isFromNixpkgs (with prevStage.darwin; [ binutils-unwrapped dyld launchd libclosure libdispatch xnu ]);
 
     assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.llvmPackages; [
       clang-unwrapped libclang libllvm llvm
     ]);
     assert lib.all isBuiltByNixpkgsCompiler (with prevStage.llvmPackages; [ libcxx ]);
     assert prevStage.llvmPackages.compiler-rt == null;
-
-    assert lib.getVersion prevStage.stdenv.cc.bintools.bintools == lib.getVersion prevStage.darwin.cctools-port;
 
     stageFun prevStage {
 
@@ -806,7 +894,7 @@ in
   (prevStage:
     # previous stage2-Libsystem stdenv:
     assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
-      atf autoconf automake binutils-unwrapped bison brotli cmake cmakeMinimal coreutils
+      atf autoconf automake bison brotli cmake cmakeMinimal coreutils
       cpio cyrus_sasl db ed expat flex gettext gmp gnugrep groff icu kyua libedit libidn2
       libkrb5 libssh2 libtool libunistring m4 meson nghttp2 ninja openbsm openldap openpam openssh
       openssl patchutils pbzx perl pkg-config.pkg-config python3 python3Minimal scons serf
@@ -820,22 +908,20 @@ in
     ]);
 
     assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [
-      binutils-unwrapped cctools locale libtapi print-reexports rewrite-tbd sigtool
+      cctools locale libtapi print-reexports rewrite-tbd sigtool
     ]);
 
     assert (! useAppleSDKLibs) -> lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [ configd ]);
     assert (! useAppleSDKLibs) -> lib.all        isBuiltByNixpkgsCompiler (with prevStage.darwin; [ Libsystem ]);
     assert (! useAppleSDKLibs) -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF ]);
     assert    useAppleSDKLibs  -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF Libsystem libobjc ]);
-    assert lib.all isFromNixpkgs (with prevStage.darwin; [ dyld launchd libclosure libdispatch xnu ]);
+    assert lib.all isFromNixpkgs (with prevStage.darwin; [ binutils-unwrapped  dyld launchd libclosure libdispatch xnu ]);
 
     assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.llvmPackages; [
       clang-unwrapped libclang libllvm llvm
     ]);
     assert lib.all isBuiltByNixpkgsCompiler (with prevStage.llvmPackages; [ libcxx ]);
     assert prevStage.llvmPackages.compiler-rt == null;
-
-    assert lib.getVersion prevStage.stdenv.cc.bintools.bintools == lib.getVersion prevStage.darwin.cctools-llvm;
 
     stageFun prevStage {
 
@@ -864,9 +950,6 @@ in
         } // {
           passthru = { inherit (prevStage.bintools.passthru) isFromBootstrapFiles; };
         };
-
-        # Avoid building unnecessary Python dependencies due to building LLVM manpages.
-        cctools-llvm = superDarwin.cctools-llvm.override { enableManpages = false; };
       });
 
       llvmPackages = super.llvmPackages // (
@@ -935,28 +1018,26 @@ in
       subversion sysctl.provider texinfo unzip which xz zstd
     ]);
     assert lib.all isBuiltByNixpkgsCompiler (with prevStage; [
-      bash binutils-unwrapped icu libffi libiconv libxml2 zlib
+      bash icu libffi libiconv libxml2 zlib
     ]);
 
     assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [
       locale print-reexports rewrite-tbd sigtool
     ]);
     assert lib.all isBuiltByNixpkgsCompiler (with prevStage.darwin; [
-      binutils-unwrapped cctools libtapi
+      cctools libtapi
     ]);
 
     assert (! useAppleSDKLibs) -> lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [ configd ]);
     assert (! useAppleSDKLibs) -> lib.all        isBuiltByNixpkgsCompiler (with prevStage.darwin; [ Libsystem ]);
     assert (! useAppleSDKLibs) -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF ]);
     assert    useAppleSDKLibs  -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF Libsystem libobjc ]);
-    assert lib.all isFromNixpkgs (with prevStage.darwin; [ dyld launchd libclosure libdispatch xnu ]);
+    assert lib.all isFromNixpkgs (with prevStage.darwin; [ binutils-unwrapped dyld launchd libclosure libdispatch xnu ]);
 
     assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.llvmPackages; [
       clang-unwrapped libclang libllvm llvm
     ]);
     assert lib.all isBuiltByNixpkgsCompiler (with prevStage.llvmPackages; [ libcxx ]);
-
-    assert lib.getVersion prevStage.stdenv.cc.bintools.bintools == lib.getVersion prevStage.darwin.cctools-llvm;
 
     stageFun prevStage {
 
@@ -978,7 +1059,7 @@ in
 
       darwin = super.darwin.overrideScope (selfDarwin: superDarwin: {
         inherit (prevStage.darwin)
-          CF Libsystem binutils binutils-unwrapped cctools cctools-llvm cctools-port configd
+          CF Libsystem binutils binutils-unwrapped cctools cctools-port configd
           darwin-stubs dyld launchd libclosure libdispatch libobjc libtapi locale objc4
           postLinkSignHook print-reexports rewrite-tbd signingUtils sigtool;
 
@@ -1020,27 +1101,25 @@ in
     ]);
 
     assert lib.all isBuiltByNixpkgsCompiler (with prevStage; [
-      bash binutils-unwrapped icu libffi libiconv libxml2 zlib
+      bash icu libffi libiconv libxml2 zlib
     ]);
 
     assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [
       locale print-reexports rewrite-tbd sigtool
     ]);
     assert lib.all isBuiltByNixpkgsCompiler (with prevStage.darwin; [
-      binutils-unwrapped cctools libtapi
+      cctools libtapi
     ]);
 
     assert (! useAppleSDKLibs) -> lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [ configd ]);
     assert (! useAppleSDKLibs) -> lib.all        isBuiltByNixpkgsCompiler (with prevStage.darwin; [ Libsystem ]);
     assert (! useAppleSDKLibs) -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF ]);
     assert    useAppleSDKLibs  -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF Libsystem libobjc ]);
-    assert lib.all isFromNixpkgs (with prevStage.darwin; [ dyld launchd libclosure libdispatch xnu ]);
+    assert lib.all isFromNixpkgs (with prevStage.darwin; [ binutils-unwrapped dyld launchd libclosure libdispatch xnu ]);
 
     assert lib.all isBuiltByNixpkgsCompiler (with prevStage.llvmPackages; [
       clang-unwrapped libclang libllvm llvm compiler-rt libcxx
     ]);
-
-    assert lib.getVersion prevStage.stdenv.cc.bintools.bintools == lib.getVersion prevStage.darwin.cctools-llvm;
 
     stageFun prevStage {
 
@@ -1078,26 +1157,27 @@ in
           libc = selfDarwin.Libsystem;
         };
 
-        # cctools needs to build the LLVM man pages, which requires sphinx. Sphinx
-        # has hatch-vcs as a transitive dependency, which pulls in git (and curl).
-        # Disabling the tests for hatch-vcs allows the stdenv bootstrap to avoid having
-        # any dependency on curl other than the one provided in the bootstrap tools.
-        cctools-llvm = superDarwin.cctools-llvm.override (old: {
-          llvmPackages =
-            let
-              tools = old.llvmPackages.tools.extend (_: superTools: {
-                llvm-manpages = superTools.llvm-manpages.override {
-                  python3Packages = prevStage.python3Packages.overrideScope (_: superPython: {
-                    hatch-vcs = (superPython.hatch-vcs.override {
-                      git = null;
-                      pytestCheckHook = null;
-                    });
-                  });
-                };
-              });
-              inherit (old.llvmPackages) libraries release_version;
-            in
-            { inherit tools libraries release_version; } // tools // libraries;
+        # binutils-unwrapped needs to build the LLVM man pages, which requires a lot of Python stuff
+        # that ultimately ends up depending on git. Fortunately, the git dependency is only for check
+        # inputs. The following set of overrides allow the LLVM documentation to be built without
+        # pulling curl (and other packages like ffmpeg) into the stdenv bootstrap.
+        binutils-unwrapped = superDarwin.binutils-unwrapped.override (old: {
+          llvm-manpages = super.llvmPackages.llvm-manpages.override {
+            python3Packages = self.python3.pkgs.overrideScope (_: superPython: {
+              hatch-vcs = superPython.hatch-vcs.overrideAttrs {
+                doInstallCheck = false;
+              };
+              markdown-it-py = superPython.markdown-it-py.overrideAttrs {
+                doInstallCheck = false;
+              };
+              mdit-py-plugins = superPython.mdit-py-plugins.overrideAttrs {
+                doInstallCheck = false;
+              };
+              myst-parser = superPython.myst-parser.overrideAttrs {
+                doInstallCheck = false;
+              };
+            });
+          };
         });
       });
 
@@ -1176,20 +1256,20 @@ in
   (prevStage:
     # previous stage4 stdenv:
     assert lib.all isBuiltByNixpkgsCompiler (with prevStage; [
-      bash binutils-unwrapped brotli bzip2 cpio diffutils ed file findutils gawk
+      bash brotli bzip2 cpio diffutils ed file findutils gawk
       gettext gmp gnugrep gnumake gnused gnutar gzip icu libffi libiconv libidn2 libkrb5
       libssh2 libunistring libxml2 libyaml ncurses nghttp2 openbsm openpam openssl patch
       pbzx pcre python3Minimal xar xz zlib zstd
     ]);
 
     assert lib.all isBuiltByNixpkgsCompiler (with prevStage.darwin; [
-      binutils-unwrapped cctools libtapi locale print-reexports rewrite-tbd sigtool
+      cctools libtapi locale print-reexports rewrite-tbd sigtool
     ]);
 
     assert (! useAppleSDKLibs) -> lib.all isBuiltByNixpkgsCompiler (with prevStage.darwin; [ Libsystem configd ]);
     assert (! useAppleSDKLibs) -> lib.all            isFromNixpkgs (with prevStage.darwin; [ CF ]);
     assert    useAppleSDKLibs  -> lib.all            isFromNixpkgs (with prevStage.darwin; [ CF Libsystem libobjc ]);
-    assert lib.all isFromNixpkgs (with prevStage.darwin; [ dyld launchd libclosure libdispatch xnu ]);
+    assert lib.all isFromNixpkgs (with prevStage.darwin; [ binutils-unwrapped dyld launchd libclosure libdispatch xnu ]);
 
     assert lib.all isBuiltByNixpkgsCompiler (with prevStage.llvmPackages; [
       clang-unwrapped libclang libllvm llvm compiler-rt libcxx
@@ -1200,8 +1280,6 @@ in
       libtool m4 meson ninja openldap openssh patchutils perl pkg-config.pkg-config python3 scons
       serf sqlite subversion sysctl.provider texinfo unzip which
     ]);
-
-    assert prevStage.darwin.cctools == prevStage.darwin.cctools-llvm;
 
     let
       doSign = localSystem.isAarch64;
@@ -1311,7 +1389,6 @@ in
       ++ (with prevStage.darwin; [
         CF
         Libsystem
-        cctools-llvm
         cctools-port
         dyld
         libtapi
@@ -1339,7 +1416,7 @@ in
             inherit (prevStage.darwin.apple_sdk) sdkRoot;
           };
         } // lib.optionalAttrs (super.stdenv.targetPlatform == localSystem) {
-          inherit (prevStage.darwin) binutils binutils-unwrapped cctools-llvm cctools-port;
+          inherit (prevStage.darwin) binutils binutils-unwrapped cctools-port;
         });
       } // lib.optionalAttrs (super.stdenv.targetPlatform == localSystem) {
         inherit (prevStage.llvmPackages) clang llvm;
@@ -1366,13 +1443,13 @@ in
   (prevStage:
     # previous final stage stdenv:
     assert isBuiltByNixpkgsCompiler prevStage.darwin.sigtool;
-    assert isBuiltByNixpkgsCompiler prevStage.darwin.binutils-unwrapped;
     assert isBuiltByNixpkgsCompiler prevStage.darwin.print-reexports;
     assert isBuiltByNixpkgsCompiler prevStage.darwin.rewrite-tbd;
     assert isBuiltByNixpkgsCompiler prevStage.darwin.cctools;
 
     assert            isFromNixpkgs prevStage.darwin.CF;
     assert            isFromNixpkgs prevStage.darwin.Libsystem;
+    assert            isFromNixpkgs prevStage.darwin.binutils-unwrapped;
 
     assert isBuiltByNixpkgsCompiler prevStage.llvmPackages.clang-unwrapped;
     assert isBuiltByNixpkgsCompiler prevStage.llvmPackages.libllvm;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1363,7 +1363,7 @@ with pkgs;
 
   fixDarwinDylibNames = makeSetupHook {
     name = "fix-darwin-dylib-names-hook";
-    substitutions = { inherit (binutils) targetPrefix; };
+    substitutions = { inherit (darwin.binutils) targetPrefix; };
     meta.platforms = lib.platforms.darwin;
   } ../build-support/setup-hooks/fix-darwin-dylib-names.sh;
 

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -83,8 +83,8 @@ impure-cmds // appleSourcePackages // chooseLibs // {
   };
 
   binutils-unwrapped = callPackage ../os-specific/darwin/binutils {
-    inherit (pkgs) binutils-unwrapped;
-    inherit (pkgs.llvmPackages) llvm clang-unwrapped;
+    inherit (self) cctools;
+    inherit (pkgs.llvmPackages) clang-unwrapped llvm llvm-manpages;
   };
 
   binutils = pkgs.wrapBintoolsWith {
@@ -114,7 +114,7 @@ impure-cmds // appleSourcePackages // chooseLibs // {
     bintools = self.binutils-unwrapped;
   };
 
-  cctools = self.cctools-llvm;
+  cctools = self.cctools-port;
 
   cctools-apple = callPackage ../os-specific/darwin/cctools/apple.nix {
     stdenv = if stdenv.isDarwin then stdenv else pkgs.libcxxStdenv;

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -95,17 +95,29 @@ impure-cmds // appleSourcePackages // chooseLibs // {
     bintools = self.binutils-unwrapped;
   };
 
-  binutilsDualAs-unwrapped = callPackage ../os-specific/darwin/binutils {
-    inherit (pkgs) binutils-unwrapped;
-    inherit (pkgs.llvmPackages) llvm clang-unwrapped;
-    dualAs = true;
+  # x86-64 Darwin gnat-bootstrap emits assembly
+  # with MOVQ as the mnemonic for quadword interunit moves
+  # such as `movq %rbp, %xmm0`.
+  # The clang integrated assembler recognises this as valid,
+  # but unfortunately the cctools.gas GNU assembler does not;
+  # it instead uses MOVD as the mnemonic.
+  # The assembly that a GCC build emits is determined at build time
+  # and cannot be changed afterwards.
+  #
+  # To build GNAT on x86-64 Darwin, therefore,
+  # we need both the clang _and_ the cctools.gas assemblers to be available:
+  # the former to build at least the stage1 compiler,
+  # and the latter at least to be detectable
+  # as the target for the final compiler.
+  binutilsDualAs-unwrapped = pkgs.buildEnv {
+    name = "${lib.getName self.binutils-unwrapped}-dualas-${lib.getVersion self.binutils-unwrapped}";
+    paths = [
+      self.binutils-unwrapped
+      (lib.getOutput "gas" self.cctools)
+    ];
   };
 
-  binutilsDualAs = pkgs.wrapBintoolsWith {
-    libc =
-      if stdenv.targetPlatform != stdenv.hostPlatform
-      then pkgs.libcCross
-      else pkgs.stdenv.cc.libc;
+  binutilsDualAs = self.binutils.override {
     bintools = self.binutilsDualAs-unwrapped;
   };
 


### PR DESCRIPTION
## Description of changes

Fixes Darwin stdenv build on staging-next https://github.com/NixOS/nixpkgs/pull/322145.

* https://hydra.nixos.org/build/264347232

This PR is a port of some of the work I’ve done preparing for ld64 to drop GNU binutils from the Darwin stdenv, which helps avoid the linked Hydra failure preventing the stdenv from building. I also had to fix Python because `python3Minimal` was still trying to enable the `_scproxy` module in spite of not having configd.

I also included a couple of changes to reduce the time it takes to do a stdenv bootstrap. Python is rebuild fewer times, and the LLVM tests are run only once.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
