### PR TITLE
elpa: mark broken

### DIFF
--- a/pkgs/development/libraries/elpa/default.nix
+++ b/pkgs/development/libraries/elpa/default.nix
@@ -101,5 +101,7 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl3Only;
     platforms = platforms.linux;
     maintainers = [ maintainers.markuskowa ];
+    broken = true;  # At 2024-06-25. 49 unit tests fail.
+                    # https://hydra.nixos.org/build/263906391/nixlog/1
   };
 }


### PR DESCRIPTION
elpa: mark broken

* https://hydra.nixos.org/build/263906391/nixlog/1

CC Maintainer @markuskowa
