### PR TITLE
hyprland: 0.41.1 -> 0.41.2; hyprutils: 0.1.4 -> 0.1.5; hyprlandPlugins: 0.41.1 -> 0.41.2

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hy3.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hy3.nix
@@ -25,6 +25,9 @@ mkHyprlandPlugin hyprland rec {
     description = "Hyprland plugin for an i3 / sway like manual tiling layout";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ aacebedo ];
+    maintainers = with lib.maintainers; [
+      aacebedo
+      johnrtitor
+    ];
   };
 }

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hy3.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hy3.nix
@@ -7,13 +7,13 @@
 }:
 mkHyprlandPlugin hyprland rec {
   pluginName = "hy3";
-  version = "0.41.1";
+  version = "0.41.2";
 
   src = fetchFromGitHub {
     owner = "outfoxxed";
     repo = "hy3";
-    rev = "hl${version}";
-    hash = "sha256-bRLI+zgfT31LCMW4Pf701ZZx2oFeXoBu1BfYQjX6MPc=";
+    rev = "refs/tags/hl${version}";
+    hash = "sha256-aZuNKBwTwj8EXkDBMWNdRKbHPx647wJLWm55h6jOKbo=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprland-plugins.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprland-plugins.nix
@@ -14,13 +14,13 @@ let
             mkHyprlandPlugin,
           }:
           let
-            version = "0.41.1";
+            version = "0.41.2";
 
             hyprland-plugins-src = fetchFromGitHub {
               owner = "hyprwm";
               repo = "hyprland-plugins";
-              rev = "v${version}";
-              hash = "sha256-Bw3JRBUZg2kmDwxa/UHvD//gGcNjbftTj2MSeLvx1q8=";
+              rev = "refs/tags/v${version}";
+              hash = "sha256-TnlAcO5K2gkab0mpKurP5Co6eWRycP/KbFqWNS2rsMA=";
             };
           in
           mkHyprlandPlugin hyprland {

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprland-plugins.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprland-plugins.nix
@@ -33,7 +33,10 @@ let
               homepage = "https://github.com/hyprwm/hyprland-plugins";
               description = "Hyprland ${description} plugin";
               license = lib.licenses.bsd3;
-              maintainers = with lib.maintainers; [ fufexan ];
+              maintainers = with lib.maintainers; [
+                fufexan
+                johnrtitor
+              ];
               platforms = lib.platforms.linux;
             };
           }

--- a/pkgs/by-name/hy/hyprland/info.json
+++ b/pkgs/by-name/hy/hyprland/info.json
@@ -1,7 +1,7 @@
 {
   "branch": "main",
-  "commit_hash": "9e781040d9067c2711ec2e9f5b47b76ef70762b3",
-  "commit_message": "props: bump version to 0.41.1",
-  "date": "2024-06-13",
-  "tag": "v0.41.1"
+  "commit_hash": "918d8340afd652b011b937d29d5eea0be08467f5",
+  "commit_message": "flake.lock: update",
+  "date": "2024-06-25",
+  "tag": "v0.41.2"
 }

--- a/pkgs/by-name/hy/hyprland/package.nix
+++ b/pkgs/by-name/hy/hyprland/package.nix
@@ -64,14 +64,14 @@ assert lib.assertMsg (!hidpiXWayland) "The option `hidpiXWayland` has been remov
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hyprland" + lib.optionalString debug "-debug";
-  version = "0.41.1";
+  version = "0.41.2";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = finalAttrs.pname;
     fetchSubmodules = true;
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-hLnnNBWP1Qjs1I3fndMgp8rbWJruxdnGTq77A4Rv4R4=";
+    hash = "sha256-JmfnYz+9a4TjNl3mAus1VpoWtTI9d1xkW9MHbkcV0Po=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/hy/hyprland/package.nix
+++ b/pkgs/by-name/hy/hyprland/package.nix
@@ -186,8 +186,9 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Dynamic tiling Wayland compositor that doesn't sacrifice on its looks";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
-      wozeparrot
       fufexan
+      johnrtitor
+      wozeparrot
     ];
     mainProgram = "Hyprland";
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/hy/hyprutils/package.nix
+++ b/pkgs/by-name/hy/hyprutils/package.nix
@@ -5,17 +5,18 @@
   pkg-config,
   pixman,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hyprutils";
-  version = "0.1.4";
+  version = "0.1.5";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "hyprutils";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-CqRZne63BpYlPd/i8lXV0UInUt59oKogiwdVtBRHt60=";
+    hash = "sha256-dmRz128j/lJmMuTYeCYPfSBRHHQO3VeH4PbmoyAhHzw=";
   };
 
   nativeBuildInputs = [
@@ -30,6 +31,8 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = ["out" "dev"];
 
   cmakeBuildType = "RelWithDebInfo";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/hyprwm/hyprutils";


### PR DESCRIPTION
## Description of changes

- Changelog: https://github.com/hyprwm/Hyprland/releases/tag/v0.41.2
- Updates hyprutils: https://github.com/hyprwm/hyprutils/releases/tag/v0.1.5

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
