### PR TITLE
wootility: Revamp

### DIFF
--- a/pkgs/tools/misc/wootility/default.nix
+++ b/pkgs/tools/misc/wootility/default.nix
@@ -1,20 +1,20 @@
 { appimageTools
 , fetchurl
 , lib
-, xorg
-, udev
-, wooting-udev-rules
 , makeWrapper
 }:
 
-appimageTools.wrapType2 rec {
+let
   pname = "wootility";
   version = "4.6.20";
-
   src = fetchurl {
     url = "https://s3.eu-west-2.amazonaws.com/wooting-update/wootility-lekker-linux-latest/wootility-lekker-${version}.AppImage";
     sha256 = "sha256-JodmF3TThPpXXx1eOnYmYAJ4x5Ylcf35bw3R++5/Buk=";
   };
+in
+
+appimageTools.wrapType2 {
+  inherit pname version src;
 
   extraInstallCommands =
     let contents = appimageTools.extract { inherit pname version src; };
@@ -34,20 +34,16 @@ appimageTools.wrapType2 rec {
     export LC_ALL=C.UTF-8
   '';
 
-  multiPkgs = extraPkgs;
-  extraPkgs =
-    pkgs: (appimageTools.defaultFhsEnvArgs.multiPkgs pkgs) ++ ([
-      udev
-      wooting-udev-rules
-      xorg.libxkbfile
-    ]);
+  extraPkgs = pkgs: with pkgs; ([
+    xorg.libxkbfile
+  ]);
 
-  meta = with lib; {
+  meta = {
     homepage = "https://wooting.io/wootility";
     description = "Customization and management software for Wooting keyboards";
-    platforms = [ "x86_64-linux" ];
-    license = licenses.unfree;
-    maintainers = with maintainers; [ davidtwco sodiboo ];
+    platforms = lib.platforms.linux;
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ davidtwco sodiboo ];
     mainProgram = "wootility";
   };
 }


### PR DESCRIPTION
## Description of changes

Revamps the wootility package:

- ~~Adds a desktop icon (Fixes https://github.com/NixOS/nixpkgs/issues/226338)~~ Fixed by https://github.com/NixOS/nixpkgs/pull/321659
- Removes unnecessary dependencies (wooting-udev-rules has to be installed with services.udev.packages, xorg shouldn't be an input)
- ~~Fixes the license ("unknown" -> unfree (no license))~~ Fixed by https://github.com/NixOS/nixpkgs/pull/321659
- Since AppImages are portable, allows the program to be run on all linux platforms (untested!)
- Removes top-level `rec`
- Removes `with lib; ` in `meta`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
