### PR TITLE
eudic: init at 13.5.2

### DIFF
--- a/pkgs/by-name/eu/eudic/package.nix
+++ b/pkgs/by-name/eu/eudic/package.nix
@@ -1,0 +1,87 @@
+{ fetchurl
+, stdenv
+, autoPatchelfHook
+, makeWrapper
+, lib
+, copyDesktopItems
+, libnotify
+, libX11
+, libXScrnSaver
+, libXext
+, libXtst
+, libuuid
+, libsecret
+, xdg-utils
+, xdg-utils-cxx
+, at-spi2-atk
+# additional dependencies autoPatchelfHook discovered
+, gtk3
+, alsa-lib
+, e2fsprogs
+, nss
+, libgpg-error
+, libjack2
+, mesa
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "eudic";
+  version = "13.5.2";
+
+  src = fetchurl {
+    url = "https://www.eudic.net/download/eudic.deb?v=${finalAttrs.version}";
+    hash = "sha256-UPkDRaqWF/oydH6AMo3t3PUT5VU961EPLcFb5XwOXVs=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libnotify
+    libX11
+    libXScrnSaver
+    libXext
+    libXtst
+    libuuid
+    libsecret
+    xdg-utils
+    xdg-utils-cxx
+    at-spi2-atk
+    # additional dependencies autoPatchelfHook discovered
+    gtk3
+    alsa-lib
+    e2fsprogs
+    nss
+    libgpg-error
+    libjack2
+    mesa
+  ];
+
+  unpackPhase = ''
+    ar x $src
+    tar xf data.tar.xz
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r usr/* $out/
+
+    makeWrapper $out/share/eusoft-eudic/eudic $out/bin/eudic
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Authoritative English Dictionary Software Essential Tools for English Learners";
+    homepage = "https://www.eudic.net/v4/en/app/eudic";
+    platforms = [ "x86_64-linux" ];
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ onedragon ];
+    mainProgram = "eudic";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Packing a new application [eudic](https://www.eudic.net/v4/en/app/eudic), which is a dictionary software provide for chinese to learn english. (Currently only available in Chinese)

NOTE:
1. I not sure what type of license should be mention, which there havn't define in there desktop item.
2. There is a **pronunciation** problem, but it havn't confirm yet whether it is a general problem in deb packages or a packaging dependency error.
3.  Web rendering in this software **does not seem to support VK fonts**.

```
# control file in deb
Package: eudic
Version: 13.5.2
Installed-Size: 155980
Priority: extra
Section: application
License: unknown
Vendor: EUSOFT<help@eudic.net>
Architecture: amd64
Maintainer: EUSOFT<help@eudic.net>
Depends: libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libuuid1, libsecret-1-0
Homepage: https://www.eudic.net
Description: 欧路软件
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
