### PR TITLE
vscode-extensions.ms-dotnettools: update extensions

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csdevkit/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csdevkit/default.nix
@@ -14,7 +14,7 @@ let
     {
       x86_64-linux = {
         arch = "linux-x64";
-        hash = "sha256-7m85Zl9oV40le3nkNPzoKu/AAf8XhQpI8sBMsQXmBg8=";
+        hash = "sha256-lpMwA5jMr10uV4uIjq9VNOKjqduxXuDZVIIszVIXSGw=";
         binaries = [
           "components/vs-green-server/platforms/linux-x64/node_modules/@microsoft/servicehub-controller-net60.linux-x64/Microsoft.ServiceHub.Controller"
           "components/vs-green-server/platforms/linux-x64/node_modules/@microsoft/visualstudio-code-servicehost.linux-x64/Microsoft.VisualStudio.Code.ServiceHost"
@@ -24,7 +24,7 @@ let
       };
       aarch64-linux = {
         arch = "linux-arm64";
-        hash = "sha256-39D55EdwE4baDYbHc9GD/1XoxGbQkUkS1H2uysJHlxw=";
+        hash = "sha256-OaA3uNvKwbRGqMQqg6YozQF6AXxisO9ndDAFBj7wUEM=";
         binaries = [
           "components/vs-green-server/platforms/linux-arm64/node_modules/@microsoft/servicehub-controller-net60.linux-arm64/Microsoft.ServiceHub.Controller"
           "components/vs-green-server/platforms/linux-arm64/node_modules/@microsoft/visualstudio-code-servicehost.linux-arm64/Microsoft.VisualStudio.Code.ServiceHost"
@@ -34,7 +34,7 @@ let
       };
       x86_64-darwin = {
         arch = "darwin-x64";
-        hash = "sha256-gfhJX07R+DIw9FbzaEE0JZwEmDeifiq4vHyMHZZ1udM=";
+        hash = "sha256-o6B6eA4LqoLw1aGvUI95aK3pChyFXK3jUOH5Fpp4/IM=";
         binaries = [
           "components/vs-green-server/platforms/darwin-x64/node_modules/@microsoft/servicehub-controller-net60.darwin-x64/Microsoft.ServiceHub.Controller"
           "components/vs-green-server/platforms/darwin-x64/node_modules/@microsoft/visualstudio-code-servicehost.darwin-x64/Microsoft.VisualStudio.Code.ServiceHost"
@@ -44,7 +44,7 @@ let
       };
       aarch64-darwin = {
         arch = "darwin-arm64";
-        hash = "sha256-vogstgCWvI9csNF9JfJ41XPR1POy842g2yhWqIDoHLw=";
+        hash = "sha256-cDv1l57C73UEtSJhTO+xb2sSX8xwepzJYxYuGsNq+r4=";
         binaries = [
           "components/vs-green-server/platforms/darwin-arm64/node_modules/@microsoft/servicehub-controller-net60.darwin-arm64/Microsoft.ServiceHub.Controller"
           "components/vs-green-server/platforms/darwin-arm64/node_modules/@microsoft/visualstudio-code-servicehost.darwin-arm64/Microsoft.VisualStudio.Code.ServiceHost"
@@ -59,7 +59,7 @@ buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "csdevkit";
     publisher = "ms-dotnettools";
-    version = "1.4.28";
+    version = "1.7.27";
     inherit (extInfo) hash arch;
   };
   sourceRoot = "extension"; # This has more than one folder.

--- a/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csharp/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csharp/default.nix
@@ -29,22 +29,22 @@ let
     {
       x86_64-linux = {
         arch = "linux-x64";
-        hash = "sha256-si4HKGVIHu44QNlNI2WEnMff9+QZOMWiBfWQaaFGyQE=";
+        hash = "sha256-Y+Re3tDX8HQrWo045JxdX8Jt4jomm1/C9T+BU2/hE+g=";
         binaries = linuxBins;
       };
       aarch64-linux = {
         arch = "linux-arm64";
-        hash = "sha256-1IXkSRgCHOLD4VeCdqyy54MXCBUX5RDDb3pf7GQH5jA=";
+        hash = "sha256-nFCFK2GVLljMqmxJnlma6kAXHc9qN/DnnRiWrkjmLmo=";
         binaries = linuxBins;
       };
       x86_64-darwin = {
         arch = "darwin-x64";
-        hash = "sha256-AAbYjZ+YYyGEXSLkiFfluLf7P4OzPhmHzK44N5XT9UI=";
+        hash = "sha256-hC1ZJdBKJR3om9xuxEBhaBtQXEin1R0t7BFVdOUu6X8=";
         binaries = darwinBins;
       };
       aarch64-darwin = {
         arch = "darwin-arm64";
-        hash = "sha256-1m47kX0Jo+UvthNfgdoPdBBOcDyCA8DfP+zRk3SicR0=";
+        hash = "sha256-mIZJXgACvJmhrJzOtKcF2DKeBkLSjKehE1xEwtp1X+E=";
         binaries = darwinBins ++ [
           ".debugger/arm64/vsdbg-ui"
           ".debugger/arm64/vsdbg"
@@ -57,7 +57,7 @@ buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "csharp";
     publisher = "ms-dotnettools";
-    version = "2.22.3";
+    version = "2.34.12";
     inherit (extInfo) hash arch;
   };
 


### PR DESCRIPTION
## Description of changes

Updates C# DevKit and C# extensions to their latest stable version.
Didn't do these in separate PRs because the changes are small and the C# DevKit extension depends on the C# extension.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
