### PR TITLE
auto-changelog: move out of node-packages

### DIFF
--- a/pkgs/by-name/au/auto-changelog/package.json
+++ b/pkgs/by-name/au/auto-changelog/package.json
@@ -1,0 +1,100 @@
+{
+  "name": "auto-changelog",
+  "version": "2.4.0",
+  "description": "Command line tool for generating a changelog from git tags and commit history",
+  "main": "./src/index.js",
+  "bin": {
+    "auto-changelog": "./src/index.js"
+  },
+  "engines": {
+    "node": ">=8.3"
+  },
+  "scripts": {
+    "lint": "standard --verbose | snazzy",
+    "lint-fix": "standard --fix",
+    "lint-markdown": "markdownlint README.md test/data/*.md",
+    "test": "cross-env NODE_ENV=test mocha -r @babel/register test",
+    "test-coverage": "cross-env NODE_ENV=test nyc mocha test",
+    "report-coverage": "nyc report --reporter=json && codecov -f coverage/coverage-final.json",
+    "preversion": "npm run lint && npm run test",
+    "version": "node src/index.js --package && git add CHANGELOG.md",
+    "generate-test-data": "cross-env NODE_ENV=test node scripts/generate-test-data.js"
+  },
+  "author": "Pete Cook <pete@cookpete.com> (https://github.com/cookpete)",
+  "homepage": "https://github.com/CookPete/auto-changelog",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/CookPete/auto-changelog.git"
+  },
+  "bugs": {
+    "url": "https://github.com/CookPete/auto-changelog/issues"
+  },
+  "keywords": [
+    "auto",
+    "automatic",
+    "changelog",
+    "change",
+    "log",
+    "generator",
+    "git",
+    "commit",
+    "commits",
+    "history"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "commander": "^7.2.0",
+    "handlebars": "^4.7.7",
+    "node-fetch": "^2.6.1",
+    "parse-github-url": "^1.0.2",
+    "semver": "^7.3.5"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.14.3",
+    "@babel/register": "^7.13.16",
+    "babel-plugin-istanbul": "^6.0.0",
+    "babel-plugin-rewire": "^1.2.0",
+    "chai": "^4.3.4",
+    "codecov": "^3.8.2",
+    "cross-env": "^7.0.3",
+    "markdownlint-cli": "^0.30.0",
+    "mocha": "^9.2.0",
+    "nyc": "^15.1.0",
+    "snazzy": "^9.0.0",
+    "standard": "^16.0.3"
+  },
+  "babel": {
+    "env": {
+      "test": {
+        "plugins": [
+          "istanbul",
+          "rewire"
+        ]
+      }
+    }
+  },
+  "standard": {
+    "ignore": [
+      "test/data/"
+    ]
+  },
+  "nyc": {
+    "all": true,
+    "include": "src",
+    "exclude": "src/index.js",
+    "sourceMap": false,
+    "instrument": false,
+    "report-dir": "./coverage",
+    "temp-dir": "./coverage/.nyc_output",
+    "require": [
+      "@babel/register"
+    ],
+    "reporter": [
+      "text",
+      "html"
+    ]
+  },
+  "auto-changelog": {
+    "breakingPattern": "Breaking change"
+  }
+}

--- a/pkgs/by-name/au/auto-changelog/package.nix
+++ b/pkgs/by-name/au/auto-changelog/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  mkYarnPackage,
+  fetchYarnDeps,
+  fetchFromGitHub
+}: mkYarnPackage rec {
+  pname = "auto-changelog";
+  version = "2.4.0";
+
+  src = fetchFromGitHub {
+    owner = "cookpete";
+    repo = "auto-changelog";
+    rev = "v${version}";
+    hash = "sha256-qgJ/TVyViMhISt/EfCWV7XWQLXKTeZalGHFG905Ma5I=";
+  };
+
+  packageJSON = ./package.json;
+  offlineCache = fetchYarnDeps {
+    yarnLock = "${src}/yarn.lock";
+    hash = "sha256-rP/Xt0txwfEUmGZ0CyHXSEG9zSMtv8wr5M2Na+6PbyQ=";
+  };
+
+  meta = {
+    description = "Command line tool for generating a changelog from git tags and commit history";
+    homepage = "https://github.com/cookpete/auto-changelog";
+    changelog = "https://github.com/cookpete/auto-changelog/blob/master/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "auto-changelog";
+    maintainers = with lib.maintainers; [ pyrox0 ];
+  };
+}

--- a/pkgs/development/node-packages/aliases.nix
+++ b/pkgs/development/node-packages/aliases.nix
@@ -57,6 +57,7 @@ mapAliases {
   alloy = pkgs.titanium-alloy; # added 2023-08-17
   antennas = pkgs.antennas; # added 2023-07-30
   inherit (pkgs) asar; # added 2023-08-26
+  inherit (pkgs) auto-changelog; # added 2024-06-25
   inherit (pkgs) aws-azure-login; # added 2023-09-30
   balanceofsatoshis = pkgs.balanceofsatoshis; # added 2023-07-31
   inherit (pkgs) bash-language-server; # added 2024-06-07

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -21,7 +21,6 @@
 , "alex"
 , "audiosprite"
 , "autoprefixer"
-, "auto-changelog"
 , "aws-cdk"
 , "awesome-lint"
 , "bower"

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -63573,42 +63573,6 @@ in
     bypassCache = true;
     reconstructLock = true;
   };
-  auto-changelog = nodeEnv.buildNodePackage {
-    name = "auto-changelog";
-    packageName = "auto-changelog";
-    version = "2.4.0";
-    src = fetchurl {
-      url = "https://registry.npmjs.org/auto-changelog/-/auto-changelog-2.4.0.tgz";
-      sha512 = "vh17hko1c0ItsEcw6m7qPRf3m45u+XK5QyCrrBFViElZ8jnKrPC1roSznrd1fIB/0vR/zawdECCRJtTuqIXaJw==";
-    };
-    dependencies = [
-      sources."commander-7.2.0"
-      sources."encoding-0.1.13"
-      sources."handlebars-4.7.8"
-      sources."iconv-lite-0.6.3"
-      sources."minimist-1.2.8"
-      sources."neo-async-2.6.2"
-      sources."node-fetch-2.7.0"
-      sources."parse-github-url-1.0.2"
-      sources."safer-buffer-2.1.2"
-      sources."semver-7.6.2"
-      sources."source-map-0.6.1"
-      sources."tr46-0.0.3"
-      sources."uglify-js-3.18.0"
-      sources."webidl-conversions-3.0.1"
-      sources."whatwg-url-5.0.0"
-      sources."wordwrap-1.0.0"
-    ];
-    buildInputs = globalBuildInputs;
-    meta = {
-      description = "Command line tool for generating a changelog from git tags and commit history";
-      homepage = "https://github.com/CookPete/auto-changelog";
-      license = "MIT";
-    };
-    production = true;
-    bypassCache = true;
-    reconstructLock = true;
-  };
   aws-cdk = nodeEnv.buildNodePackage {
     name = "aws-cdk";
     packageName = "aws-cdk";


### PR DESCRIPTION
## Description of changes
Moves the auto-changelog package out of node-packages and into pkgs/by-name. No package update, just the move.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
