### PR TITLE
fix interaction between hardware.printers.ensurePrinters and services.printing.stateless

### DIFF
--- a/nixos/modules/hardware/printers.nix
+++ b/nixos/modules/hardware/printers.nix
@@ -120,6 +120,7 @@ in {
       wantedBy = [ "multi-user.target" ];
       wants = [ "cups.service" ];
       after = [ "cups.service" ];
+      partOf = [ "cups.service" ];
 
       serviceConfig = {
         Type = "oneshot";


### PR DESCRIPTION
ensurePrinters had failed to handle services.printing.stateless=true; and wouldn't rerun even when cups was restarted.

## Description of changes

Use partOf to restart ensure-printers.service whenever cups.service is restarted.

Not able to test at the moment; but the effect of this change seems predictable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
