### PR TITLE
coqPackages.coq-hammer: init at 1.3.2

### DIFF
--- a/pkgs/development/coq-modules/coq-hammer/default.nix
+++ b/pkgs/development/coq-modules/coq-hammer/default.nix
@@ -1,0 +1,19 @@
+{ lib, mkCoqDerivation, coq, coq-hammer-tactics, version ? null }:
+
+mkCoqDerivation {
+  inherit version;
+  pname = "coq-hammer";
+  inherit (coq-hammer-tactics) owner repo defaultVersion release releaseRev;
+
+  buildFlags = [ "plugin" ];
+  installTargets = [ "install-plugin" ];
+  extraInstallFlags = [ "BINDIR=$(out)/bin/" ];
+
+  mlPlugin = true;
+
+  propagatedBuildInputs = [ coq.ocamlPackages.findlib coq-hammer-tactics ];
+
+  meta = coq-hammer-tactics.meta // {
+    description = "General-purpose automated reasoning hammer tool for Coq";
+  };
+}

--- a/pkgs/development/coq-modules/coq-hammer/tactics.nix
+++ b/pkgs/development/coq-modules/coq-hammer/tactics.nix
@@ -1,0 +1,44 @@
+{ lib, mkCoqDerivation, coq, version ? null }:
+
+let
+  owner = "lukaszcz";
+  repo = "coqhammer";
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
+    { case = "8.19"; out = "1.3.2+8.19"; }
+    { case = "8.18"; out = "1.3.2+8.18"; }
+    { case = "8.17"; out = "1.3.2+8.17"; }
+    { case = "8.16"; out = "1.3.2+8.16"; }
+  ] null;
+
+  release = {
+    "1.3.2+8.19".sha256 = "sha256-Zd7piAWlKPAZKEz7HVWxhnzOLbA/eR9C/E0T298MJVY=";
+    "1.3.2+8.18".sha256 = "sha256-D+tQ+1YrSbbqc54U5UlxW1Hhly49TB2pu1LEPL2Eo64=";
+    "1.3.2+8.17".sha256 = "sha256-2fw66z3yFKs5g+zNCeYXiEyxPzjUr+lGDciiQiuuMAs=";
+    "1.3.2+8.16".sha256 = "sha256-+j2Mg9n4heXbhjRaqiTQfgBxRqfw6TPYbIuCdhu8OeE=";
+  };
+
+  releaseRev = v: "refs/tags/v${v}";
+
+in
+
+mkCoqDerivation {
+  inherit version;
+  pname = "coq-hammer-tactics";
+
+  inherit owner repo defaultVersion release releaseRev;
+  passthru = {
+    inherit owner repo defaultVersion release releaseRev;
+  };
+
+  mlPlugin = true;
+
+  buildFlags = [ "tactics" ];
+  installTargets = [ "install-tactics" ];
+
+  meta = {
+    description = "Reconstruction tactics for the hammer for Coq";
+    homepage = "https://github.com/lukaszcz/coqhammer";
+    license = lib.licenses.lgpl21;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -38,6 +38,7 @@ let
       coq-bits = callPackage ../development/coq-modules/coq-bits {};
       coq-elpi = callPackage ../development/coq-modules/coq-elpi {};
       coq-ext-lib = callPackage ../development/coq-modules/coq-ext-lib {};
+      coq-hammer-tactics = callPackage ../development/coq-modules/coq-hammer/tactics.nix { };
       coq-haskell = callPackage ../development/coq-modules/coq-haskell { };
       coq-lsp = callPackage ../development/coq-modules/coq-lsp {};
       coq-record-update = callPackage ../development/coq-modules/coq-record-update { };

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -38,6 +38,7 @@ let
       coq-bits = callPackage ../development/coq-modules/coq-bits {};
       coq-elpi = callPackage ../development/coq-modules/coq-elpi {};
       coq-ext-lib = callPackage ../development/coq-modules/coq-ext-lib {};
+      coq-hammer = callPackage ../development/coq-modules/coq-hammer { };
       coq-hammer-tactics = callPackage ../development/coq-modules/coq-hammer/tactics.nix { };
       coq-haskell = callPackage ../development/coq-modules/coq-haskell { };
       coq-lsp = callPackage ../development/coq-modules/coq-lsp {};


### PR DESCRIPTION
## Description of changes

Fixes #226161
Fixes #320697

cc @Alizter @CohenCyril 

Tested there: https://github.com/coq-community/coq-nix-toolbox/pull/228

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
