### PR TITLE
grist-core: init package and module

### DIFF
--- a/pkgs/by-name/gr/grist-core/grist-run.sh.in
+++ b/pkgs/by-name/gr/grist-core/grist-run.sh.in
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eu
+
+export PATH=@path@
+# export GRIST_SANDBOX_FLAVOR=gvisor
+# export GVISOR_FLAGS="-unprivileged -ignore-cgroups"
+
+# export GRIST_INST_DIR=/tmp/grist
+# export GRIST_DATA_DIR=/tmp/grist/docs
+# export TYPEORM_DATABASE=/tmp/grist/db.sqlite3
+
+cd @gristOut@
+exec ./sandbox/run.sh

--- a/pkgs/by-name/gr/grist-core/package.nix
+++ b/pkgs/by-name/gr/grist-core/package.nix
@@ -1,0 +1,72 @@
+{ lib, stdenv, fetchFromGitHub, fetchYarnDeps, mkYarnPackage, mkYarnModules
+, yarn, python3, sqlite, nodejs, gvisor, coreutils
+}: let
+
+  pname = "grist-core";
+  version = "1.1.15";
+
+  src = fetchFromGitHub {
+    owner = "gristlabs";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-pEcH0skMf/3/dckcPNG8VM/QMwrkKjkU8FllpJjXkQs=";
+  };
+
+  offlineCache = fetchYarnDeps {
+    yarnLock = src + "/yarn.lock";
+    hash = "sha256-TxyQdI/tP7q6kevMQJbnXmaVhBiFOK+9C10feNupGxs=";
+  };
+
+in stdenv.mkDerivation {
+
+  inherit pname version src;
+  nativeBuildInputs = [
+    yarn nodejs python3
+    ## for @gristlabs/sqlite3
+    nodejs.pkgs.node-pre-gyp
+  ];
+  buildInputs = [
+    ## for @gristlabs/sqlite3
+    sqlite
+  ];
+
+  preUnpack = ''
+    export HOME=$NIX_BUILD_TOP/yarn_home
+  '';
+
+  patchPhase = ''
+    patchShebangs buildtools/*
+    # Do not look up in the registry, but in the offline cache.
+    # TODO: Ask upstream to fix this mess. see yarn2nix-moretea
+    sed -i -E '/resolved /{s|https://registry.yarnpkg.com/||;s|[@/:-]|_|g}' yarn.lock
+    rm .yarnrc
+  '';
+
+  configurePhase = ''
+    yarn config --offline set yarn-offline-mirror ${offlineCache}
+  '';
+
+  buildPhase = ''
+    yarn install --offline --frozen-lockfile --ignore-scripts
+    patchShebangs node_modules/*/bin/*
+    ( cd node_modules/@gristlabs/sqlite3
+      CPPFLAGS="-I${nodejs}/include/node" node-pre-gyp install \
+        --prefer-offline --build-from-source \
+        --nodedir=${nodejs}/include/node --sqlite=${sqlite.dev}
+      rm -r build-tmp-napi-v6 )
+    yarn --offline build:prod
+  '';
+  ## FIXME cannot prune despite 300M savings:
+  ## Error: Cannot find module 'chokidar'
+  # npm prune --omit=dev
+
+  installPhase = ''
+    mkdir -p $out/libexec $out/bin
+    cp -R . $out/libexec/grist
+    substitute ${./grist-run.sh.in} $out/bin/grist-run \
+      --subst-var-by gristOut $out/libexec/grist \
+      --subst-var-by path ${lib.makeBinPath [ nodejs coreutils gvisor ]}
+    chmod +x $out/bin/grist-run
+  '';
+
+}

--- a/pkgs/by-name/gr/grist-core/package.nix
+++ b/pkgs/by-name/gr/grist-core/package.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchFromGitHub, fetchYarnDeps, mkYarnPackage, mkYarnModules
-, yarn, python3, sqlite, nodejs, gvisor, coreutils
+{ lib, stdenv, fetchFromGitHub, fetchYarnDeps
+, yarn, python3, sqlite, nodejs, coreutils
 }: let
 
   pname = "grist-core";
@@ -16,6 +16,21 @@
     yarnLock = src + "/yarn.lock";
     hash = "sha256-TxyQdI/tP7q6kevMQJbnXmaVhBiFOK+9C10feNupGxs=";
   };
+
+  gristPython = python3.withPackages (pkgs: with pkgs; [
+    ## see ${src}/sandbox/requirements3.in
+    friendly-traceback
+    openpyxl
+    astroid
+    roman
+    chardet
+    iso8601
+    phonenumbers
+    python-dateutil
+    six
+    sortedcontainers
+    unittest-xml-reporting
+  ]);
 
 in stdenv.mkDerivation {
 
@@ -65,7 +80,7 @@ in stdenv.mkDerivation {
     cp -R . $out/libexec/grist
     substitute ${./grist-run.sh.in} $out/bin/grist-run \
       --subst-var-by gristOut $out/libexec/grist \
-      --subst-var-by path ${lib.makeBinPath [ nodejs coreutils gvisor ]}
+      --subst-var-by path ${lib.makeBinPath [ nodejs coreutils gristPython ]}
     chmod +x $out/bin/grist-run
   '';
 

--- a/pkgs/development/python-modules/friendly-traceback/default.nix
+++ b/pkgs/development/python-modules/friendly-traceback/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  isPyPy,
+  pytestCheckHook,
+  asttokens,
+  executing,
+  pure-eval,
+  stack-data,
+  six,
+}:
+
+buildPythonPackage rec {
+  pname = "friendly-traceback";
+  version = "0.7.61";
+
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-jKFJ6k7/oRSp1DVAeNAlLbxT4pHNzGPyPjS4+2W6FfM=";
+  };
+
+  propagatedBuildInputs = [
+    asttokens
+    executing
+    pure-eval
+    stack-data
+    six
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "Friendlier Python tracebacks";
+    homepage = "https://github.com/friendly-traceback/friendly-traceback";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bendlas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4590,6 +4590,8 @@ self: super: with self; {
 
   frida-python = callPackage ../development/python-modules/frida-python { };
 
+  friendly-traceback = callPackage ../development/python-modules/friendly-traceback { };
+
   frigidaire = callPackage ../development/python-modules/frigidaire { };
 
   frilouz = callPackage ../development/python-modules/frilouz { };


### PR DESCRIPTION
## Description of changes

Packages grist-core, see https://github.com/NixOS/nixpkgs/issues/295228

Until nixos module is implemented, you can test with

```console
TYPEORM_DATABASE=/tmp/grist/db.sqlite3 GRIST_INST_DIR=/tmp/grist GRIST_DATA_DIR=/tmp/grist/docs $(nix-build . -A grist-core --no-out-link)/bin/grist-run
```

## Things done

- Packaging Tasks
  - [x] Package node / yarn package
  - [x] Package python dependencies (unsandboxed)
  - [ ] Implement sandbox based on gvisor
  - [ ] Implement nixos module
  - [ ] Add nixos release notes
    - [ ] Add support for redis
    - [ ] Add support for minio

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
