### PR TITLE
python3Packages.qiskit: 1.0.1 -> 1.1.1

### DIFF
--- a/pkgs/development/python-modules/qiskit/default.nix
+++ b/pkgs/development/python-modules/qiskit/default.nix
@@ -1,67 +1,86 @@
 {
   lib,
   pythonOlder,
+  pythonAtLeast,
   buildPythonPackage,
   fetchFromGitHub,
+  rustPlatform,
 
   # build-system
   setuptools,
+  setuptools-rust,
+  rustc,
+  cargo,
 
   # Python Inputs
-  qiskit-aer,
-  qiskit-ibmq-provider,
-  qiskit-ignis,
-  qiskit-terra,
+  rustworkx,
+  numpy,
+  scipy,
+  sympy,
+  dill,
+  python-dateutil,
+  stevedore,
+  symengine,
+
   # Optional inputs
-  withOptionalPackages ? true,
-  qiskit-finance,
-  qiskit-machine-learning,
-  qiskit-nature,
-  qiskit-optimization,
   # Check Inputs
-  pytestCheckHook,
+  hypothesis,
+  ddt,
+  coverage,
+  stestr,
+  threadpoolctl,
 }:
 
-let
-  optionalQiskitPackages = [
-    qiskit-finance
-    qiskit-machine-learning
-    qiskit-nature
-    qiskit-optimization
-  ];
-in
 buildPythonPackage rec {
   pname = "qiskit";
-  # NOTE: This version denotes a specific set of subpackages. See https://qiskit.org/documentation/release_notes.html#version-history
-  version = "1.0.1";
+  version = "1.1.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.6";
+  # disabled in sync with openstackdocstheme,
+  # It that is not disabled anymore, try building for a newer python version
+  # Can possibly be excluded somewhere in the dependency tree, but I could not
+  # find where
+  disabled = pythonOlder "3.6" || pythonAtLeast "3.12";
 
   src = fetchFromGitHub {
     owner = "Qiskit";
     repo = "qiskit";
     rev = "refs/tags/${version}";
-    hash = "sha256-Cjfn+9h8W08FcAlVC7b7O8Z+VGx5UeHosSgYJin/evE=";
+    hash = "sha256-kPYXM37CygY2VpmbE8q9bMXx/m1ni0CiYEUPPCQs2NA=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  nativeBuildInputs = [
+    setuptools
+    setuptools-rust
+    rustc
+    cargo
+    rustPlatform.cargoSetupHook
+  ];
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-O3mZb2f8NNlpReiLE7lEX83QNTCxdayu+zxBmG0PSXg=";
+  };
 
-  propagatedBuildInputs = [
-    qiskit-aer
-    qiskit-ibmq-provider
-    qiskit-ignis
-    qiskit-terra
-  ] ++ lib.optionals withOptionalPackages optionalQiskitPackages;
+  # these are taken from requirements-dev.txt test section
+  nativeCheckInputs = [
+    hypothesis
+    ddt
+    coverage
+    stestr
+    threadpoolctl
+  ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
-
-  pythonImportsCheck = [
-    "qiskit"
-    "qiskit.circuit"
-    "qiskit.ignis"
-    "qiskit.providers.aer"
-    "qiskit.providers.ibmq"
+  pythonImportsCheck = [ "qiskit" ];
+  dependencies = [
+    rustworkx
+    numpy
+    scipy
+    sympy
+    dill
+    python-dateutil
+    stevedore
+    symengine
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Qiskit has seen some major changes, here is the blog post for [1.0](https://docs.quantum.ibm.com/api/qiskit/release-notes/1.0#100).

The previous build strategy had to be updated. Due to a limitation in one of the dependencies, this derivation does not currently build on Python 3.12.

A Github issue for this is open at https://github.com/NixOS/nixpkgs/issues/306328.



## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
