### PR TITLE
ponyc: 0.54.0 -> 0.58.5

### DIFF
--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation (rec {
   pname = "ponyc";
-  version = "0.54.0";
+  version = "0.58.5";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = pname;
     rev = version;
-    hash = "sha256-qFPubqGfK0WCun6QA1OveyDJj7Wf6SQpky7pEb7qsf4=";
+    hash = "sha256-ZJ8iBZ8T9H/Ds7/uTqdAuXQhZRZl8o3T+NVpPu9OvSw=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/compilers/ponyc/disable-tests.patch
+++ b/pkgs/development/compilers/ponyc/disable-tests.patch
@@ -1,8 +1,8 @@
 diff --git a/packages/net/_test.pony b/packages/net/_test.pony
-index 9044dfb1..f0ea10f7 100644
+index ea24992d..7e54f4a3 100644
 --- a/packages/net/_test.pony
 +++ b/packages/net/_test.pony
-@@ -26,11 +26,6 @@ actor \nodoc\ Main is TestList
+@@ -21,11 +21,6 @@ actor \nodoc\ Main is TestList
        test(_TestTCPThrottle)
      end
  

--- a/pkgs/development/compilers/ponyc/make-safe-for-sandbox.patch
+++ b/pkgs/development/compilers/ponyc/make-safe-for-sandbox.patch
@@ -1,14 +1,5 @@
-From e26ae067644ea780f050fb900bd850027bb86456 Mon Sep 17 00:00:00 2001
-From: superherointj <5861043+superherointj@users.noreply.github.com>
-Date: Tue, 7 Mar 2023 14:59:31 -0300
-Subject: [PATCH] make-safe-for-sandbox.patch
-
----
- lib/CMakeLists.txt | 80 ++--------------------------------------------
- 1 file changed, 2 insertions(+), 78 deletions(-)
-
 diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
-index 129e26e6..d25bdf9d 100644
+index 8d853b4b..9a9f46bf 100644
 --- a/lib/CMakeLists.txt
 +++ b/lib/CMakeLists.txt
 @@ -32,14 +32,14 @@ endif()
@@ -34,7 +25,7 @@ index 129e26e6..d25bdf9d 100644
  
 -find_package(Git)
 -
--set(LLVM_DESIRED_HASH "1f9140064dfbfb0bbda8e51306ea51080b2f7aac")
+-set(LLVM_DESIRED_HASH "8dfdcc7b7bf66834a761bd8de445840ef68e4d1a")
 -set(PATCHES_DESIRED_HASH "3e16c097794cb669a8f6a0bd7600b440205ac5c29a6135750c2e83263eb16a95")
 -
 -if(GIT_FOUND)
@@ -111,6 +102,3 @@ index 129e26e6..d25bdf9d 100644
  message("Building targets: ${LLVM_TARGETS_TO_BUILD}")
  
  set(LLVM_ENABLE_BINDINGS OFF CACHE BOOL "ponyc specific override of LLVM cache entry")
--- 
-2.39.2
-


### PR DESCRIPTION
Release: https://github.com/ponylang/ponyc/releases/tag/0.58.5

## Description of changes
This fixes #281592 (the initial error reported, at least) which for me is occurring when using ponyc in flake either on 24.05 or unstable, not just musl. It does resolve the error on musl, but another occurs down the line.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
