### PR TITLE
nixos/wordpress: update .htaccess for httpd

### DIFF
--- a/nixos/modules/services/web-apps/wordpress.nix
+++ b/nixos/modules/services/web-apps/wordpress.nix
@@ -426,6 +426,7 @@ in
             # standard wordpress .htaccess contents
             <IfModule mod_rewrite.c>
               RewriteEngine On
+              RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
               RewriteBase /
               RewriteRule ^index\.php$ - [L]
               RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
Update standard wordpress .htaccess content if using httpd according to [1] (as of 2024-06-26)

[1]: https://developer.wordpress.org/advanced-administration/server/web-server/httpd/

## Description of changes

small httpd config change

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
