### PR TITLE
metadata: init at 0.1.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3742,6 +3742,12 @@
     githubId = 848609;
     name = "Michael Bishop";
   };
+  clevor = {
+    email = "myclevorname@gmail.com";
+    github = "myclevorname";
+    githubId = 140354451;
+    name = "Samuel Connelly";
+  };
   clkamp = {
     email = "c@lkamp.de";
     github = "clkamp";

--- a/pkgs/by-name/me/metadata/package.nix
+++ b/pkgs/by-name/me/metadata/package.nix
@@ -1,0 +1,52 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, ffmpeg_7
+, rustPlatform
+, glib
+, installShellFiles
+, asciidoc
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "metadata";
+  version = "0.1.9";
+
+  src = fetchFromGitHub {
+    owner = "zmwangx";
+    repo = "metadata";
+    rev = "v${version}";
+    hash = "sha256-OFWdCV9Msy/mNaSubqoJi4tBiFqL7RuWWQluSnKe4fU=";
+  };
+
+  cargoHash = "sha256-F5jXS/W600nbQtu1FD4+DawrFsO+5lJjvAvTiFKT840=";
+
+  nativeBuildInputs = [
+    pkg-config
+    asciidoc
+    installShellFiles
+    rustPlatform.bindgenHook
+  ];
+
+  postBuild = ''
+    a2x --doctype manpage --format manpage man/metadata.1.adoc
+  '';
+  postInstall = ''
+    installManPage man/metadata.1
+  '';
+
+  buildInputs = [
+    ffmpeg_7
+    glib
+  ];
+
+  env.FFMPEG_DIR = ffmpeg_7.dev;
+
+  meta = {
+    description = "Media metadata parser and formatter designed for human consumption, powered by FFmpeg";
+    maintainers = with lib.maintainers; [ clevor ];
+    license = lib.licenses.mit;
+    homepage = "https://github.com/zmwangx/metadata";
+    mainProgram = "metadata";
+  };
+}


### PR DESCRIPTION
## Description of changes

Info about `metadata` can be found at #322243.

Hopefully, `metadata` should build, but requires libavutil, whose request is #322768.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
