### PR TITLE
whitakers-words: init at 1.97FC

### DIFF
--- a/pkgs/by-name/wh/whitakers-words/package.nix
+++ b/pkgs/by-name/wh/whitakers-words/package.nix
@@ -1,0 +1,75 @@
+{ stdenvNoCC
+, lib
+, gnat
+, gprbuild
+, fetchFromGitHub
+, writeShellScriptBin
+, symlinkJoin
+}:
+
+let
+  pkg = stdenvNoCC.mkDerivation {
+    pname = "whitakers-words";
+    version = "1.97FC";
+
+    src = fetchFromGitHub {
+      owner = "mk270";
+      repo = "whitakers-words";
+      rev = "9b11477e53f4adfb17d6f6aa563669dc71e0a680";
+      sha256 = "sha256-f/8dQff2min0FivBKTk/kcwwoW5IfajAjsdkALT52xU=";
+    };
+
+    nativeBuildInputs = [
+      gprbuild
+      gnat
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin $out/lib/whitakers-words
+
+      cp -r bin $out/lib/whitakers-words/bin
+      cp -r lib $out/lib/whitakers-words/lib
+      cp *.GEN $out/lib/whitakers-words/
+      cp *.LAT $out/lib/whitakers-words/
+      cp *.SEC $out/lib/whitakers-words/
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "A Latin-English dictionary";
+      longDescription = ''
+        This program, WORDS, takes keyboard input or a file of Latin text lines
+        and provides an analysis of each word individually.
+
+        The dictionary contains over 39000 entries, as would be counted in an
+        ordinary dictionary. This expands to almost twice that number of
+        individual stems and, through additional word construction with hundreds
+        of prefixes and suffixes, may generate more, leading to many hundreds of
+        thousands of ‘words’ that can be formed by declension and
+        conjugation. This version of WORDS provides a tool to help in
+        translations for the Latin student. It is now a large dictionary by any
+        measure and can be helpful to advanced users. The dictionary will
+        continue to grow - slowly.
+      '';
+      homepage = "http://mk270.github.io/whitakers-words";
+      license = lib.licenses.unfreeRedistributable;
+      maintainers = [ lib.maintainers.davisrichard437 ];
+      mainProgram = "words";
+    };
+  };
+
+  script = writeShellScriptBin "words"
+    ''
+      cd ${pkg}/lib/whitakers-words
+      ./bin/words "$@"
+    '';
+
+in
+
+symlinkJoin {
+  inherit (pkg) name meta;
+  paths = [ pkg script ];
+}


### PR DESCRIPTION
http://mk270.github.io/whitakers-words/index.html

## Description of changes

Whitaker's Words is a powerful and extensive interactive Latin-English dictionary that can parse words and conjugations/declinations by their endings. Its homepage is here: <http://mk270.github.io/whitakers-words/index.html>. Try it here: <https://latin-words.com/>.

A couple things worth discussing about this package:

- The license is strange, see [here](https://github.com/mk270/whitakers-words/issues/118) for in-depth discussion. I chose `unfreeRedistributable` because I thought it fit best. What do people think?
- I have never used `symlinkJoin` or `writeShellScriptBin` in a `nixpkgs` PR before. I do not know if what I have done is idiomatic. I felt it was necessary to write a wrapper script because the binary must be run from the same directory as the data files. Please let me know if there is a better way to do this.

And one last note, `nixpkgs-review` was likely too intense for my system so it was unable to complete. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
