### PR TITLE
flutterPackages-source: disable old version sources, fix update hashes

### DIFF
--- a/pkgs/development/compilers/flutter/engine/constants.nix
+++ b/pkgs/development/compilers/flutter/engine/constants.nix
@@ -1,41 +1,46 @@
-{ lib, targetPlatform }:
-rec {
-  os =
-    if targetPlatform.isLinux then
-      "linux"
-    else if targetPlatform.isDarwin then
-      "macos"
-    else if targetPlatform.isWindows then
-      "windows"
-    else
-      throw "Unsupported OS \"${targetPlatform.parsed.kernel.name}\"";
+{ lib, platform }:
+let
+  self = {
+    os =
+      if platform.isLinux then
+        "linux"
+      else if platform.isDarwin then
+        "macos"
+      else if platform.isWindows then
+        "windows"
+      else
+        throw "Unsupported OS \"${platform.parsed.kernel.name}\"";
 
-  arch =
-    if targetPlatform.isx86_64 then
-      "amd64"
-    else if targetPlatform.isx86 && targetPlatform.is32bit then
-      "386"
-    else if targetPlatform.isAarch64 then
-      "arm64"
-    else if targetPlatform.isMips && targetPlatform.parsed.cpu.significantByte == "littleEndian" then
-      "mipsle"
-    else if targetPlatform.isMips64 then
-      "mips64${lib.optionalString (targetPlatform.parsed.cpu.significantByte == "littleEndian") "le"}"
-    else if targetPlatform.isPower64 then
-      "ppc64${lib.optionalString (targetPlatform.parsed.cpu.significantByte == "littleEndian") "le"}"
-    else if targetPlatform.isS390x then
-      "s390x"
-    else
-      throw "Unsupported CPU \"${targetPlatform.parsed.cpu.name}\"";
+    alt-os = if platform.isDarwin then "mac" else self.os;
 
-  alt-arch =
-    if targetPlatform.isx86_64 then
-      "x64"
-    else if targetPlatform.isAarch64 then
-      "arm64"
-    else
-      targetPlatform.parsed.cpu.name;
+    arch =
+      if platform.isx86_64 then
+        "amd64"
+      else if platform.isx86 && platform.is32bit then
+        "386"
+      else if platform.isAarch64 then
+        "arm64"
+      else if platform.isMips && platform.parsed.cpu.significantByte == "littleEndian" then
+        "mipsle"
+      else if platform.isMips64 then
+        "mips64${lib.optionalString (platform.parsed.cpu.significantByte == "littleEndian") "le"}"
+      else if platform.isPower64 then
+        "ppc64${lib.optionalString (platform.parsed.cpu.significantByte == "littleEndian") "le"}"
+      else if platform.isS390x then
+        "s390x"
+      else
+        throw "Unsupported CPU \"${platform.parsed.cpu.name}\"";
 
-  platform = "${os}-${arch}";
-  alt-platform = "${os}-${alt-arch}";
-}
+    alt-arch =
+      if platform.isx86_64 then
+        "x64"
+      else if platform.isAarch64 then
+        "arm64"
+      else
+        platform.parsed.cpu.name;
+
+    platform = "${self.os}-${self.arch}";
+    alt-platform = "${self.os}-${self.alt-arch}";
+  };
+in
+self

--- a/pkgs/development/compilers/flutter/engine/package.nix
+++ b/pkgs/development/compilers/flutter/engine/package.nix
@@ -5,10 +5,11 @@
   symlinkJoin,
   targetPlatform,
   hostPlatform,
+  buildPlatform,
   darwin,
   clang,
   llvm,
-  tools ? callPackage ./tools.nix { inherit hostPlatform; },
+  tools ? callPackage ./tools.nix { hostPlatform = buildPlatform; },
   stdenv,
   stdenvNoCC,
   dart,
@@ -53,7 +54,7 @@ let
 
   expandDeps = deps: flatten (map expandSingleDep deps);
 
-  constants = callPackage ./constants.nix { inherit targetPlatform; };
+  constants = callPackage ./constants.nix { platform = targetPlatform; };
 
   src = callPackage ./source.nix {
     inherit
@@ -61,6 +62,8 @@ let
       version
       hashes
       url
+      targetPlatform
+      hostPlatform
       ;
   };
 
@@ -324,5 +327,7 @@ stdenv.mkDerivation (finalAttrs: {
       "x86_64-darwin"
       "aarch64-darwin"
     ];
+  } // lib.optionalAttrs (lib.versionOlder flutterVersion "3.22") {
+    hydraPlatforms = [];
   };
 })

--- a/pkgs/development/compilers/flutter/engine/tools.nix
+++ b/pkgs/development/compilers/flutter/engine/tools.nix
@@ -29,7 +29,7 @@
   },
 }:
 let
-  constants = callPackage ./constants.nix { targetPlatform = hostPlatform; };
+  constants = callPackage ./constants.nix { platform = hostPlatform; };
 in
 {
   depot_tools = fetchgit {

--- a/pkgs/development/compilers/flutter/update/get-engine-hashes.nix.in
+++ b/pkgs/development/compilers/flutter/update/get-engine-hashes.nix.in
@@ -11,6 +11,7 @@ let
   derivations = builtins.map
     (systemPlatform: callPackage "${nixpkgsRoot}/pkgs/development/compilers/flutter/engine/source.nix" {
       targetPlatform = lib.systems.elaborate systemPlatform;
+      hostPlatform = lib.systems.elaborate systemPlatform;
       version = engineVersion;
       url = "https://github.com/flutter/engine.git@${engineVersion}";
       hashes."${systemPlatform}" = lib.fakeSha256;

--- a/pkgs/development/compilers/flutter/versions/3_13/data.json
+++ b/pkgs/development/compilers/flutter/versions/3_13/data.json
@@ -6,7 +6,7 @@
   "channel": "stable",
   "engineHashes": {
     "aarch64-linux": "sha256-+MIGPmKHkcn3TlFYu6jXv8KBRqdECgtGSqAKQE33iAM=",
-    "x86_64-linux": "sha256-+MIGPmKHkcn3TlFYu6jXv8KBRqdECgtGSqAKQE33iAM="
+    "x86_64-linux": "sha256-JnoFiKaMhJA/eAHv9Qi1lAqZfLW0K3qalEo8Oe923Jo="
   },
   "dartVersion": "3.1.4",
   "dartHash": {


### PR DESCRIPTION
## Description of changes

Fixes the hash mismatches found on Hydra for `x86_64-linux`. We also disable using the engine on old Flutter versions as they might be dropped soon.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
