### PR TITLE
lib: deprecate mkPackageOptionMD

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -220,10 +220,10 @@ rec {
           (if isList example then "${pkgsText}." + concatStringsSep "." example else example);
       });
 
-  /* Alias of mkPackageOption. Previously used to create options with markdown
-     documentation, which is no longer required.
+  /* Deprecated alias of mkPackageOption, to be removed in 25.05.
+     Previously used to create options with markdown documentation, which is no longer required.
   */
-  mkPackageOptionMD = mkPackageOption;
+  mkPackageOptionMD = lib.warn "mkPackageOptionMD is deprecated and will be removed in 25.05; please use mkPackageOption." mkPackageOption;
 
   /* This option accepts anything, but it does not produce any result.
 

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -144,6 +144,8 @@
   not the `hare` package, should be added to `nativeBuildInputs` when building
   Hare programs.
 
+- [`lib.options.mkPackageOptionMD`](https://nixos.org/manual/nixpkgs/unstable#function-library-lib.options.mkPackageOptionMD) is now obsolete; use the identical [`lib.options.mkPackageOption`](https://nixos.org/manual/nixpkgs/unstable#function-library-lib.options.mkPackageOption) instead.
+
 - To facilitate dependency injection, the `imgui` package now builds a static archive using vcpkg' CMake rules.
   The derivation now installs "impl" headers selectively instead of by a wildcard.
   Use `imgui.src` if you just want to access the unpacked sources.

--- a/nixos/modules/programs/screen.nix
+++ b/nixos/modules/programs/screen.nix
@@ -9,7 +9,7 @@ in
     programs.screen = {
       enable = lib.mkEnableOption "screen, a basic terminal multiplexer";
 
-      package = lib.mkPackageOptionMD pkgs "screen" { };
+      package = lib.mkPackageOption pkgs "screen" { };
 
       screenrc = lib.mkOption {
         type = lib.types.lines;

--- a/nixos/modules/services/admin/pgadmin.nix
+++ b/nixos/modules/services/admin/pgadmin.nix
@@ -35,7 +35,7 @@ in
       default = 5050;
     };
 
-    package = mkPackageOptionMD pkgs "pgadmin4" { };
+    package = mkPackageOption pkgs "pgadmin4" { };
 
     initialEmail = mkOption {
       description = "Initial email for the pgAdmin account";

--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -8,7 +8,7 @@
   cfg = config.services.desktopManager.plasma6;
 
   inherit (pkgs) kdePackages;
-  inherit (lib) literalExpression mkDefault mkIf mkOption mkPackageOptionMD types;
+  inherit (lib) literalExpression mkDefault mkIf mkOption mkPackageOption types;
 
   activationScript = ''
     # will be rebuilt automatically
@@ -29,7 +29,7 @@ in {
         description = "Enable Qt 5 integration (theming, etc). Disable for a pure Qt 6 system.";
       };
 
-      notoPackage = mkPackageOptionMD pkgs "Noto fonts - used for UI by default" {
+      notoPackage = mkPackageOption pkgs "Noto fonts - used for UI by default" {
         default = ["noto-fonts"];
         example = "noto-fonts-lgc-plus";
       };

--- a/nixos/modules/services/games/armagetronad.nix
+++ b/nixos/modules/services/games/armagetronad.nix
@@ -36,7 +36,7 @@ in
           options = {
             enable = mkEnableOption "armagetronad";
 
-            package = lib.mkPackageOptionMD pkgs "armagetronad-dedicated" {
+            package = lib.mkPackageOption pkgs "armagetronad-dedicated" {
               example = ''
                 pkgs.armagetronad."0.2.9-sty+ct+ap".dedicated
               '';

--- a/nixos/modules/services/games/teeworlds.nix
+++ b/nixos/modules/services/games/teeworlds.nix
@@ -95,7 +95,7 @@ in
     services.teeworlds = {
       enable = mkEnableOption "Teeworlds Server";
 
-      package = mkPackageOptionMD pkgs "teeworlds-server" { };
+      package = mkPackageOption pkgs "teeworlds-server" { };
 
       openPorts = mkOption {
         type = types.bool;

--- a/nixos/modules/services/hardware/auto-epp.nix
+++ b/nixos/modules/services/hardware/auto-epp.nix
@@ -10,7 +10,7 @@ in {
     services.auto-epp = {
       enable = lib.mkEnableOption "auto-epp for amd active pstate";
 
-      package = lib.mkPackageOptionMD pkgs "auto-epp" {};
+      package = lib.mkPackageOption pkgs "auto-epp" {};
 
       settings = mkOption {
         type = types.submodule {

--- a/nixos/modules/services/home-automation/ebusd.nix
+++ b/nixos/modules/services/home-automation/ebusd.nix
@@ -11,7 +11,7 @@ in
   options.services.ebusd = {
     enable = mkEnableOption "ebusd, a daemon for communication with eBUS heating systems";
 
-    package = mkPackageOptionMD pkgs "ebusd" { };
+    package = mkPackageOption pkgs "ebusd" { };
 
     device = mkOption {
       type = types.str;

--- a/nixos/modules/services/home-automation/matter-server.nix
+++ b/nixos/modules/services/home-automation/matter-server.nix
@@ -19,7 +19,7 @@ in
   options.services.matter-server = with types; {
     enable = mkEnableOption "Matter-server";
 
-    package = mkPackageOptionMD pkgs "python-matter-server" { };
+    package = mkPackageOption pkgs "python-matter-server" { };
 
     port = mkOption {
       type = types.port;

--- a/nixos/modules/services/networking/gns3-server.nix
+++ b/nixos/modules/services/networking/gns3-server.nix
@@ -16,7 +16,7 @@ in {
     services.gns3-server = {
       enable = lib.mkEnableOption "GNS3 Server daemon";
 
-      package = lib.mkPackageOptionMD pkgs "gns3-server" { };
+      package = lib.mkPackageOption pkgs "gns3-server" { };
 
       auth = {
         enable = lib.mkEnableOption "password based HTTP authentication to access the GNS3 Server";
@@ -88,17 +88,17 @@ in {
 
       dynamips = {
         enable = lib.mkEnableOption ''Dynamips support'';
-        package = lib.mkPackageOptionMD pkgs "dynamips" { };
+        package = lib.mkPackageOption pkgs "dynamips" { };
       };
 
       ubridge = {
         enable = lib.mkEnableOption ''uBridge support'';
-        package = lib.mkPackageOptionMD pkgs "ubridge" { };
+        package = lib.mkPackageOption pkgs "ubridge" { };
       };
 
       vpcs = {
         enable = lib.mkEnableOption ''VPCS support'';
-        package = lib.mkPackageOptionMD pkgs "vpcs" { };
+        package = lib.mkPackageOption pkgs "vpcs" { };
       };
     };
   };

--- a/nixos/modules/services/networking/xrdp.nix
+++ b/nixos/modules/services/networking/xrdp.nix
@@ -51,11 +51,11 @@ in
 
       enable = mkEnableOption "xrdp, the Remote Desktop Protocol server";
 
-      package = mkPackageOptionMD pkgs "xrdp" { };
+      package = mkPackageOption pkgs "xrdp" { };
 
       audio = {
         enable = mkEnableOption "audio support for xrdp sessions. So far it only works with PulseAudio sessions on the server side. No PipeWire support yet";
-        package = mkPackageOptionMD pkgs "pulseaudio-module-xrdp" {};
+        package = mkPackageOption pkgs "pulseaudio-module-xrdp" {};
       };
 
       port = mkOption {

--- a/nixos/modules/services/search/hound.nix
+++ b/nixos/modules/services/search/hound.nix
@@ -19,7 +19,7 @@ in {
         '';
       };
 
-      package = mkPackageOptionMD pkgs "hound" { };
+      package = mkPackageOption pkgs "hound" { };
 
       user = mkOption {
         default = "hound";

--- a/nixos/modules/services/web-apps/code-server.nix
+++ b/nixos/modules/services/web-apps/code-server.nix
@@ -9,7 +9,7 @@ in {
     services.code-server = {
       enable = lib.mkEnableOption "code-server";
 
-      package = lib.mkPackageOptionMD pkgs "code-server" {
+      package = lib.mkPackageOption pkgs "code-server" {
         example = ''
           pkgs.vscode-with-extensions.override {
             vscode = pkgs.code-server;

--- a/nixos/modules/services/web-apps/invidious.nix
+++ b/nixos/modules/services/web-apps/invidious.nix
@@ -390,7 +390,7 @@ in
         '';
       };
 
-      package = lib.mkPackageOptionMD pkgs "http3-ytproxy" { };
+      package = lib.mkPackageOption pkgs "http3-ytproxy" { };
     };
   };
 

--- a/nixos/modules/services/web-apps/pretalx.nix
+++ b/nixos/modules/services/web-apps/pretalx.nix
@@ -35,7 +35,7 @@ in
   options.services.pretalx = {
     enable = lib.mkEnableOption "pretalx";
 
-    package = lib.mkPackageOptionMD pkgs "pretalx" {};
+    package = lib.mkPackageOption pkgs "pretalx" {};
 
     group = lib.mkOption {
       type = lib.types.str;

--- a/nixos/modules/services/web-apps/silverbullet.nix
+++ b/nixos/modules/services/web-apps/silverbullet.nix
@@ -14,7 +14,7 @@ in
     services.silverbullet = {
       enable = lib.mkEnableOption "Silverbullet, an open-source, self-hosted, offline-capable Personal Knowledge Management (PKM) web application";
 
-      package = lib.mkPackageOptionMD pkgs "silverbullet" { };
+      package = lib.mkPackageOption pkgs "silverbullet" { };
 
       openFirewall = lib.mkOption {
         type = lib.types.bool;

--- a/nixos/modules/services/web-apps/slskd.nix
+++ b/nixos/modules/services/web-apps/slskd.nix
@@ -7,7 +7,7 @@ in {
   options.services.slskd = with lib; with types; {
     enable = mkEnableOption "slskd";
 
-    package = mkPackageOptionMD pkgs "slskd" { };
+    package = mkPackageOption pkgs "slskd" { };
 
     user = mkOption {
       type = types.str;

--- a/nixos/modules/services/web-apps/suwayomi-server.nix
+++ b/nixos/modules/services/web-apps/suwayomi-server.nix
@@ -11,7 +11,7 @@ in
     services.suwayomi-server = {
       enable = mkEnableOption "Suwayomi, a free and open source manga reader server that runs extensions built for Tachiyomi";
 
-      package = lib.mkPackageOptionMD pkgs "suwayomi-server" { };
+      package = lib.mkPackageOption pkgs "suwayomi-server" { };
 
       dataDir = mkOption {
         type = types.path;


### PR DESCRIPTION
## Description of changes

- treewide: replace mkPackageOptionMD with mkPackageOption
- lib: deprecate mkPackageOptionMD

Motivation is that the function is now redundant:
https://github.com/NixOS/nixpkgs/blob/3664857c48feacb35770c00abfdc671e55849be5/lib/options.nix#L223-L226

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
