### PR TITLE
chd: init at 0-unstable-2022-02-01

### DIFF
--- a/pkgs/by-name/ch/chd/package.nix
+++ b/pkgs/by-name/ch/chd/package.nix
@@ -1,0 +1,46 @@
+{
+  fetchFromSourcehut,
+  stdenv,
+  lib,
+  installShellFiles,
+}:
+
+stdenv.mkDerivation {
+  pname = "chd";
+  version = "0-unstable-2022-02-01";
+
+  src = fetchFromSourcehut {
+    owner = "~breadbox";
+    repo = "chd";
+    rev = "94c77dbb53fe816be890d9a830cca7fe79076988";
+    hash = "sha256-RxOMAF0JYMmpxIqpiIW7DLia7iUNJ7V8C2vji81N9U8=";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postPatch = ''
+    # allow overriding compiler and flags
+    substituteInPlace Makefile \
+      --replace-fail '=' '?='
+  '';
+
+  dontConfigure = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm555 chd -t $out/bin
+    installManPage chd.1
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Unicode-aware replacement for xxd/hexdump";
+    homepage = "https://www.muppetlabs.com/~breadbox/software/chd.html";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ eclairevoyant ];
+    mainProgram = "chd";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds [chd](https://www.muppetlabs.com/~breadbox/software/chd.html), a Unicode aware xxd/hexdump replacement.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
