### PR TITLE
gnomeExtensions.guillotine: package manually

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8263,6 +8263,13 @@
     githubId = 6109326;
     name = "David Hummel";
   };
+  husky = {
+    email = "husky@husky.sh";
+    github = "huskyistaken";
+    githubId = 20684258;
+    name = "Luna Perego";
+    keys = [ { fingerprint = "09E4 B981 9B93 5B0C 0B91  1274 0578 7332 9217 08FF"; } ];
+  };
   huyngo = {
     email = "huyngo@disroot.org";
     github = "Huy-Ngo";

--- a/pkgs/desktops/gnome/extensions/guillotine/default.nix
+++ b/pkgs/desktops/gnome/extensions/guillotine/default.nix
@@ -1,0 +1,55 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  glib,
+}:
+# We package this manually because upstream stopped updating the package to
+# extensions.gnome.org. See:
+# https://gitlab.com/ente76/guillotine/-/issues/17
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gnome-shell-extension-guillotine";
+  version = "24";
+
+  src = fetchFromGitLab {
+    owner = "ente76";
+    repo = "guillotine";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-eNhK3h9luPGXHR3lPkfu/mUN9+ixma64rbCk0cjF4Fc=";
+  };
+
+  nativeBuildInputs = [ glib ];
+
+  passthru = {
+    extensionUuid = "guillotine@fopdoodle.net";
+    extensionPortalSlug = "guillotine";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+    rm schemas/gschemas.compiled
+    glib-compile-schemas schemas
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/gnome-shell/extensions/guillotine@fopdoodle.net
+    cp -R schemas "$out/share/gnome-shell/extensions/guillotine@fopdoodle.net"
+    cp default.json $out/share/gnome-shell/extensions/guillotine@fopdoodle.net
+    cp extension.js "$out/share/gnome-shell/extensions/guillotine@fopdoodle.net"
+    cp guillotine-symbolic.svg "$out/share/gnome-shell/extensions/guillotine@fopdoodle.net"
+    cp LICENSE "$out/share/gnome-shell/extensions/guillotine@fopdoodle.net"
+    cp metadata.json "$out/share/gnome-shell/extensions/guillotine@fopdoodle.net"
+    cp README.md "$out/share/gnome-shell/extensions/guillotine@fopdoodle.net"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A gnome extension designed for efficiently carrying out executions of commands from a customizable menu";
+    homepage = "https://gitlab.com/ente76/guillotine/";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ husky ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
+++ b/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
@@ -6,6 +6,7 @@
   "drop-down-terminal@gs-extensions.zzrough.org" = callPackage ./drop-down-terminal { };
   "EasyScreenCast@iacopodeenosee.gmail.com" = callPackage ./EasyScreenCast { };
   "gsconnect@andyholmes.github.io" = callPackage ./gsconnect { };
+  "guillotine@fopdoodle.net" = callPackage ./guillotine { };
   "impatience@gfxmonk.net" = callPackage ./impatience { };
   "no-title-bar@jonaspoehler.de" = callPackage ./no-title-bar { };
   "pidgin@muffinmad" = callPackage ./pidgin-im-integration { };


### PR DESCRIPTION

## Description of changes
Starting from version 19 guillotine is no longer updated on https://extensions.gnome.org.
Notably Gnome 46 compatibility is introduced in version 22.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
