### PR TITLE
hyprnotify: init at 0.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2665,6 +2665,12 @@
     githubId = 37907;
     name = "Julian Stecklina";
   };
+  bloeckchengrafik = {
+    email = "christian.bergschneider@gmx.de";
+    github = "Bloeckchengrafik";
+    githubId = 37768199;
+    name = "Christian Bergschneider";
+  };
   bloveless = {
     email = "brennon.loveless@gmail.com";
     github = "bloveless";

--- a/pkgs/by-name/hy/hyprnotify/package.nix
+++ b/pkgs/by-name/hy/hyprnotify/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  pkg-config,
+  alsa-lib
+}:
+
+buildGoModule rec {
+  pname = "hyprnotify";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "codelif";
+    repo = "hyprnotify";
+    rev = "v${version}";
+    hash = "sha256-dL+W+iMwRNw9042bs2XUFPMCCqIvDENXOMzhcLh+RL4=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ alsa-lib ];
+
+  vendorHash = "sha256-AZDtaiSNq7em876Q9f+YeDxboqVwA8IE9dDM6zggFXs=";
+
+  meta = {
+    description = "DBus Implementation of Freedesktop Notification spec for 'hyprctl notify'";
+    homepage = "https://github.com/codelif/hyprnotify";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ bloeckchengrafik ];
+    mainProgram = "hyprnotify";
+  };
+}


### PR DESCRIPTION
## Description of changes
This PR adds the package [hyprnotify](https://github.com/codelif/hyprnotify). From the README:
Hyprnotify is a [Freedesktop.org](https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html) compliant notification daemon implementing hyprctl notify as its backend.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md). _i think so at least_

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

As this is my first contribution to nixpkgs, please tell me if i did something wrong! Thanks!

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
