### PR TITLE
gaphor: 2.8.2 -> 2.25.1; better-exceptions: init at 0.3.3

### DIFF
--- a/pkgs/development/python-modules/better-exceptions/default.nix
+++ b/pkgs/development/python-modules/better-exceptions/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "better_exceptions";
+  version = "0.3.3";
+
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-5Oa8GERNXwTm6JSxA4Hl6SHT1UQkBBgWLH21fp6zRTs=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  meta = with lib; {
+    description = "Pretty and helpful exceptions, automatically";
+    homepage = "https://github.com/qix-/better-exceptions";
+    license = licenses.mit;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/tools/misc/gaphor/default.nix
+++ b/pkgs/tools/misc/gaphor/default.nix
@@ -1,52 +1,66 @@
 { lib
+, babel
+, better-exceptions
 , buildPythonApplication
-, fetchPypi
 , copyDesktopItems
-, gobject-introspection
-, poetry-core
-, wrapGAppsHook3
-, gtksourceview4
-, pango
+, defusedxml
+, dulwich
+, fetchPypi
 , gaphas
 , generic
-, jedi
-, pycairo
-, pygobject3
-, tinycss2
+, gobject-introspection
 , gtk3
+, gtksourceview5
+, jedi
+, libadwaita
 , librsvg
 , makeDesktopItem
+, pango
+, pillow
+, poetry-core
+, pycairo
+, pydot
+, pygobject3
 , python
+, tinycss2
+, wrapGAppsHook4
 }:
 
 buildPythonApplication rec {
   pname = "gaphor";
-  version = "2.8.2";
+  version = "2.25.1";
 
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-+qqsSLjdY2I19fxdfkOEQ9DhTTHccUDll4O5yqtLiz0=";
+    sha256 = "sha256-9PNgU1/9RL6QXba0gn4zHCAtSV3iY0HOY1Rf6bkyzxY=";
   };
 
   nativeBuildInputs = [
     copyDesktopItems
     gobject-introspection
     poetry-core
-    wrapGAppsHook3
+    wrapGAppsHook4
   ];
 
   buildInputs = [
-    gtksourceview4
+    gtksourceview5
     pango
   ];
 
   propagatedBuildInputs = [
+    babel
+    better-exceptions
+    defusedxml
+    dulwich
     gaphas
     generic
     jedi
+    libadwaita
+    pillow
     pycairo
+    pydot
     pygobject3
     tinycss2
   ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1534,6 +1534,8 @@ self: super: with self; {
 
   betamax-serializers = callPackage ../development/python-modules/betamax-serializers { };
 
+  better-exceptions = callPackage ../development/python-modules/better-exceptions { };
+
   betterproto = callPackage ../development/python-modules/betterproto { };
 
   beziers = callPackage ../development/python-modules/beziers { };


### PR DESCRIPTION
## Motivation for this change
#291281 

## Description of changes
Bumped version number and added/updated dependencies as needed.

Added better-exceptions as a new package because it is a dependency of gaphor.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
