### PR TITLE
rubyfmt: mark as broken on aarch64-darwin

### DIFF
--- a/pkgs/development/tools/rubyfmt/default.nix
+++ b/pkgs/development/tools/rubyfmt/default.nix
@@ -73,12 +73,12 @@ rustPlatform.buildRustPackage rec {
     mv $out/bin/rubyfmt{-main,}
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Ruby autoformatter";
     homepage = "https://github.com/fables-tales/rubyfmt";
-    license = licenses.mit;
-    maintainers = with maintainers; [ bobvanderlinden ];
-    broken = stdenv.isDarwin && stdenv.isx86_64;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bobvanderlinden ];
+    broken = stdenv.isDarwin;
     mainProgram = "rubyfmt";
   };
 }


### PR DESCRIPTION
## Description of changes

```
  make[2]: Entering directory '/private/tmp/nix-build-rubyfmt-0.10.0.drv-0/source/librubyfmt/ruby_checkout'
  revision.h unchanged
  config.status: creating ruby-runner.h
  linking ruby
  make[2]: Leaving directory '/private/tmp/nix-build-rubyfmt-0.10.0.drv-0/source/librubyfmt/ruby_checkout'
  make[1]: Leaving directory '/private/tmp/nix-build-rubyfmt-0.10.0.drv-0/source/librubyfmt/ruby_checkout'
  make[1]: Entering directory '/private/tmp/nix-build-rubyfmt-0.10.0.drv-0/source/librubyfmt/ruby_checkout'
  *** Following extensions are not compiled:
  fiddle:
        Could not be configured. It will not be installed.
        /private/tmp/nix-build-rubyfmt-0.10.0.drv-0/source/librubyfmt/ruby_checkout/ext/fiddle/extconf.rb:73: missing libffi. Please install libffi or use --with-libffi-source-dir w>
        Check ext/fiddle/mkmf.log for more details.
  openssl:
        Could not be configured. It will not be installed.
        /private/tmp/nix-build-rubyfmt-0.10.0.drv-0/source/librubyfmt/ruby_checkout/ext/openssl/extconf.rb:101: OpenSSL library could not be found. You might want to use --with-open>
        Check ext/openssl/mkmf.log for more details.
  *** Fix the problems, then remove these directories and try again if you want.
  make[1]: Leaving directory '/private/tmp/nix-build-rubyfmt-0.10.0.drv-0/source/librubyfmt/ruby_checkout'

  --- stderr
  + cp enc/jis/props.h.blt enc/jis/props.h
  parse.c:9130:9: warning: variable 'yynerrs' set but not used [-Wunused-but-set-variable]
      int yynerrs = 0;
          ^
  1 warning generated.
  bigdecimal.c:7161:18: warning: variable 'prec' set but not used [-Wunused-but-set-variable]
      SIGNED_VALUE prec;
                   ^
  ripper.c:10310:9: warning: variable 'yynerrs' set but not used [-Wunused-but-set-variable]
      int yynerrs = 0;
          ^
  1 warning generated.
  1 warning generated.
  thread 'main' panicked at librubyfmt/build.rs:90:5:
  could not extract arch from rbconfig.rb
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
