### PR TITLE
python311Packages.python-telegram: 0.18.0 -> 0.19.0

### DIFF
--- a/pkgs/development/python-modules/python-telegram/default.nix
+++ b/pkgs/development/python-modules/python-telegram/default.nix
@@ -3,24 +3,26 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  pytestCheckHook,
   pythonOlder,
+  setuptools-scm,
   setuptools,
   tdlib,
   telegram-text,
-  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "python-telegram";
-  version = "0.18.0";
-  format = "setuptools";
-  disabled = pythonOlder "3.6";
+  version = "0.19.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "alexander-akhmetov";
     repo = "python-telegram";
-    rev = version;
-    hash = "sha256-2Q0nUZ2TMVWznd05+fqYojkRn4xfFZJrlqb1PMuBsAY=";
+    rev = "refs/tags/${version}";
+    hash = "sha256-JnU59DZXpnaZXIY/apXQ2gBgiwT12rJIeVqzaP0l7Zk=";
   };
 
   postPatch = ''
@@ -28,12 +30,14 @@ buildPythonPackage rec {
     rm -fr telegram/lib
 
     substituteInPlace telegram/tdjson.py \
-      --replace "ctypes.util.find_library(\"tdjson\")" \
+      --replace-fail "ctypes.util.find_library(\"tdjson\")" \
                 "\"${tdlib}/lib/libtdjson${stdenv.hostPlatform.extensions.sharedLibrary}\""
   '';
 
-  propagatedBuildInputs = [
-    setuptools
+  build-inputs = [ setuptools ];
+
+  dependencies = [
+    setuptools-scm
     telegram-text
   ];
 
@@ -46,6 +50,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python client for the Telegram's tdlib";
     homepage = "https://github.com/alexander-akhmetov/python-telegram";
+    changelog = "https://github.com/alexander-akhmetov/python-telegram/releases/tag/${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ sikmir ];
   };


### PR DESCRIPTION
Diff: https://github.com/alexander-akhmetov/python-telegram/compare/refs/tags/0.18.0...0.19.0

Changelog: https://github.com/alexander-akhmetov/python-telegram/releases/tag/0.19.0

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
