### PR TITLE
linuxPackages.nvidiaPackages.latest: 550.54.14 -> 555.58

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -42,12 +42,12 @@ rec {
   };
 
   latest = selectHighestVersion production (generic {
-    version = "550.54.14";
-    sha256_64bit = "sha256-jEl/8c/HwxD7h1FJvDD6pP0m0iN7LLps0uiweAFXz+M=";
-    sha256_aarch64 = "sha256-sProBhYziFwk9rDAR2SbRiSaO7RMrf+/ZYryj4BkLB0=";
-    openSha256 = "sha256-F+9MWtpIQTF18F2CftCJxQ6WwpA8BVmRGEq3FhHLuYw=";
-    settingsSha256 = "sha256-m2rNASJp0i0Ez2OuqL+JpgEF0Yd8sYVCyrOoo/ln2a4=";
-    persistencedSha256 = "sha256-XaPN8jVTjdag9frLPgBtqvO/goB5zxeGzaTU0CdL6C4=";
+    version = "555.58";
+    sha256_64bit = "sha256-bXvcXkg2kQZuCNKRZM5QoTaTjF4l2TtrsKUvyicj5ew=";
+    sha256_aarch64 = "sha256-7XswQwW1iFP4ji5mbRQ6PVEhD4SGWpjUJe1o8zoXYRE=";
+    openSha256 = "sha256-hEAmFISMuXm8tbsrB+WiUcEFuSGRNZ37aKWvf0WJ2/c=";
+    settingsSha256 = "sha256-vWnrXlBCb3K5uVkDFmJDVq51wrCoqgPF03lSjZOuU8M=";
+    persistencedSha256 = "sha256-lyYxDuGDTMdGxX3CaiWUh1IQuQlkI2hPEs5LI20vEVw=";
   });
 
   beta = selectHighestVersion latest (generic {


### PR DESCRIPTION
~No releases for settings/persistenced yet.~

## Description of changes

Highlights since R555 2nd Beta Release, 555.52.04

- Minor bug fixes and improvements

Highlights from R555 2nd Beta Release, 555.52.04

- Fixed a segmentation fault when running multi-threaded NvFBC applications.
- Temporarily disabled the GLX_EXT_buffer_age extension on Xwayland to work around a bug that could cause corruption.
- Fixed a bug that could cause corruption when the GLX_EXT_buffer_age extension is used on X.org with PRIME render offloading.
- Fixed a bug that could cause the X server to crash when graphics applications requested single-buffered drawables while certain features (such as Vulkan sharpening) are enabled.
- Fixed a bug that could lead to a kernel panic, due to a failure to release a spinlock under some conditions.
- Fixed a race condition which could lead to crashes when Xid errors occur concurrently on multiple GPUs.

Highlights from R555 Beta Release, 555.42.02

- The GSP firmware is now used by default on all GPUs which support it. It can be disabled by setting the kernel module parameter `NVreg_EnableGpuFirmware=0`.
- Added support for the linux-drm-syncobj-v1 protocol for Wayland explicit sync in EGL.
- Removed support for Base Mosaic on GeForce, which was previously available only on select GPU boards with some motherboards, and limited to five display devices.
- Fixed a bug that caused "Failed to apply atomic modeset" and "Flip event timeout" messages to be printed to the system log when a DRM client such as ddcutil drops "master" permissions while a framebuffer console is being initialized.
- Fixed a bug, when nvidia-drm is loaded with the fbdev=1 module parameter on some kernels, that caused incorrect colors to be displayed.
- Changed the minimum required Linux kernel version from 3.10 to 4.15.
- Added immediate presentation mode support to Vulkan Wayland WSI. This presentation mode instructs the compositors not to wait for a vertical blanking period to update the application's surface content, which may result in tearing.
- Enabled HDMI 10 bits per component support by default; disable by loading nvidia-modeset with `hdmi_deepcolor=0`.
- Fixed a regression that led to Xid errors when loading the NVIDIA driver on some notebook systems with RTX 4xxx series GPUs.
- Fixed a bug that caused driver build failure when using separate kernel source and output directories on Linux v6.6 and later.
- Added an interactive prompt to nvidia-installer to allow selecting between the proprietary and open kernel modules, on systems where both kernel module types are supported.
- Fixed a bug that incorrectly allowed `nvidia-smi -r` to reset the primary GPU when using the open kernel modules.
- Fixed a bug that caused vkGetPhysicalDeviceSurfaceSupportKHR to incorrectly report support for Wayland surfaces when nvidia-drm is not loaded with modeset=1.
- Fixed a bug that could cause the display to lock up when suspending on a kernel with CONFIG_FRAMEBUFFER_CONSOLE_DEFERRED_TAKEOVER enabled with nvidia-drm loaded with modeset=1 and fbdev=1.
- Added support for using EGL instead of GLX as the OpenGL ICD for NvFBC.
- Fixed a bug that could lead to a system hang and "Idling display engine timed out" messages when VT switching on an HDMI Fixed Rate Link (FRL) display.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
