### PR TITLE
xfce.xfce4-settings: add integration with colord and fix Upower

### DIFF
--- a/pkgs/desktops/xfce/core/xfce4-settings/default.nix
+++ b/pkgs/desktops/xfce/core/xfce4-settings/default.nix
@@ -13,7 +13,7 @@
 , xfconf
 , xf86inputlibinput
 , colord
-, withColord ? false
+, withColord ? true
 }:
 
 mkXfceDerivation {
@@ -35,15 +35,15 @@ mkXfceDerivation {
     xf86inputlibinput
     xfconf
   ]
-  ++ lib.optional withUpower [ upower.dev ]
-  ++ lib.optional withColord [ colord.dev ];
+  ++ lib.optionals withUpower [ upower ]
+  ++ lib.optionals withColord [ colord ];
 
   configureFlags = [
     "--enable-pluggable-dialogs"
     "--enable-sound-settings"
   ]
-  ++ lib.optional withUpower [ "--enable-upower-glib" ]
-  ++ lib.optional withColord [ "--enable-colord" ];
+  ++ lib.optionals withUpower [ "--enable-upower-glib" ]
+  ++ lib.optionals withColord [ "--enable-colord" ];
 
   meta = with lib; {
     description = "Settings manager for Xfce";

--- a/pkgs/desktops/xfce/core/xfce4-settings/default.nix
+++ b/pkgs/desktops/xfce/core/xfce4-settings/default.nix
@@ -9,8 +9,11 @@
 , libxfce4util
 , libxklavier
 , upower
+, withUpower ? true
 , xfconf
 , xf86inputlibinput
+, colord
+, withColord ? false
 }:
 
 mkXfceDerivation {
@@ -29,15 +32,18 @@ mkXfceDerivation {
     libxfce4ui
     libxfce4util
     libxklavier
-    upower
     xf86inputlibinput
     xfconf
-  ];
+  ]
+  ++ lib.optional withUpower [ upower.dev ]
+  ++ lib.optional withColord [ colord.dev ];
 
   configureFlags = [
     "--enable-pluggable-dialogs"
     "--enable-sound-settings"
-  ];
+  ]
+  ++ lib.optional withUpower [ "--enable-upower-glib" ]
+  ++ lib.optional withColord [ "--enable-colord" ];
 
   meta = with lib; {
     description = "Settings manager for Xfce";


### PR DESCRIPTION
## Description of changes

Add optional colord integration to xfce.xfce4-settings.

While i was at it, I saw that autoconf was not picking up support for Upower despite the fact that is was in buildInputs. So i fixed it and make it optional as well.

## Things done

- Built on platform(s)
  - [x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
