### PR TITLE
iwleeprom

### DIFF
--- a/pkgs/os-specific/linux/firmware/iwleeprom/default.nix
+++ b/pkgs/os-specific/linux/firmware/iwleeprom/default.nix
@@ -1,0 +1,46 @@
+{
+  stdenv,
+  pkgs,
+  lib,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation {
+  name = "iwleeprom";
+  version = "unstable-2024-05-02";
+  src = fetchFromGitHub {
+    owner = "abajk";
+    repo = "iwleeprom";
+    rev = "1030c95fbeb1fa5f45db1c2b96f2e93a3ce1c1a0";
+    sha256 = "sha256-3U+VdVXqA/261zB6rKGU1ZivYzjl1ri8NqFnU3di8+A=";
+  };
+
+  nativeBuildInputs = with pkgs; [ gzip ];
+
+  buildPhase = ''
+    mkdir obj
+    $CC -Wall  -c -o obj/iwlio.o iwlio.c
+    $CC -Wall  -c -o obj/ath5kio.o ath5kio.c
+    $CC -Wall  -c -o obj/ath9kio.o ath9kio.c
+    $CC -Wall  -c -o obj/iwleeprom.o iwleeprom.c
+    $CC -Wall  -o iwleeprom obj/iwleeprom.o obj/iwlio.o obj/ath5kio.o obj/ath9kio.o
+    rm -r obj
+    gzip -c iwleeprom.8 > iwleeprom.8.gz
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/man/man8
+    install -m 755 iwleeprom $out/bin
+    install -m 644 iwleeprom.8.gz $out/share/man/man8
+  '';
+
+  meta = with lib; {
+    description = "EEPROM reader/writer for Intel and Atheros wifi cards";
+    longDescription = "EEPROM reader/writer for Intel (iwlio) and Atheros (ath5k, ath9k) wifi cards. May require iomem=relaxed";
+    homepage = "https://code.google.com/archive/p/iwleeprom/";
+    changelog = "https://code.google.com/archive/p/iwleeprom/source/default/commits";
+    license = licenses.gpl2;
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
EEPROM reader/writer for Intel and Atheros wifi cards
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [v] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [v] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [v] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
