### PR TITLE
Revert "trivial: make pkgs.writeText always fixed output"

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -133,14 +133,7 @@ rec {
       pkgs.writeText ${lib.strings.escapeNixString name}: The second argument should be a string, but it's a ${builtins.typeOf text} instead.'';
     lib.warnIf (! lib.isString text) ''
       pkgs.writeText ${lib.strings.escapeNixString name}: The second argument should be a string, but it's a ${builtins.typeOf text} instead, which is deprecated. Use `toString` to convert the value to a string first.''
-    writeTextFile {
-      inherit name text;
-      derivationArgs = rec {
-        outputHashAlgo = "sha256";
-        outputHashMode = "flat";
-        outputHash = builtins.hashString outputHashAlgo (builtins.toString text);
-      };
-    };
+    writeTextFile { inherit name text; };
 
   # See doc/build-helpers/trivial-build-helpers.chapter.md
   # or https://nixos.org/manual/nixpkgs/unstable/#trivial-builder-text-writing


### PR DESCRIPTION
Reverts the last commit of NixOS/nixpkgs#318872

See https://github.com/NixOS/nixpkgs/pull/318872#issuecomment-2196168990