### PR TITLE
buildRustCrate: add support for `cargo::rustc-cdylib-link-arg`

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -14,6 +14,7 @@
 , crateLicenseFile
 , crateLinks
 , crateName
+, crateType
 , crateReadme
 , crateRenames
 , crateRepository
@@ -208,6 +209,11 @@ in ''
      EXTRA_LINK_ARGS_LIB=$(sed -n "s/^cargo::\{0,1\}rustc-link-arg-lib=\(.*\)/-C link-arg=\1/p" target/build/${crateName}.opt | tr '\n' ' ')
      EXTRA_LINK_LIBS=$(sed -n "s/^cargo::\{0,1\}rustc-link-lib=\(.*\)/\1/p" target/build/${crateName}.opt | tr '\n' ' ')
      EXTRA_LINK_SEARCH=$(sed -n "s/^cargo::\{0,1\}rustc-link-search=\(.*\)/\1/p" target/build/${crateName}.opt | tr '\n' ' ' | sort -u)
+
+     ${lib.optionalString (lib.elem "cdylib" crateType) ''
+     CRATE_TYPE_IS_CDYLIB="true"
+     EXTRA_CDYLIB_LINK_ARGS=$(sed -n "s/^cargo::\{0,1\}rustc-cdylib-link-arg=\(.*\)/-C link-arg=\1/p" target/build/${crateName}.opt | tr '\n' ' ')
+''}
 
      # We want to read part of every line that has cargo:rustc-env= prefix and
      # export it as environment variables. This turns out tricky if the lines

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -345,7 +345,7 @@ crate_: lib.makeOverridable
 
 
       configurePhase = configureCrate {
-        inherit crateName buildDependencies completeDeps completeBuildDeps crateDescription
+        inherit crateName crateType buildDependencies completeDeps completeBuildDeps crateDescription
           crateFeatures crateRenames libName build workspace_member release libPath crateVersion crateLinks
           extraLinkFlags extraRustcOptsForBuildRs
           crateLicense crateLicenseFile crateReadme crateRepository crateRustVersion

--- a/pkgs/build-support/rust/build-rust-crate/lib.sh
+++ b/pkgs/build-support/rust/build-rust-crate/lib.sh
@@ -114,6 +114,12 @@ setup_link_paths() {
      tr '\n' ' ' < target/link > target/link_
      LINK=$(cat target/link_)
   fi
+
+  # Add "rustc-cdylib-link-arg" as linker arguments
+  # https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-cdylib-link-arg
+  if [[ -n "$CRATE_TYPE_IS_CDYLIB" ]]; then
+    EXTRA_BUILD+=" $EXTRA_CDYLIB_LINK_ARGS"
+  fi
 }
 
 search_for_bin_path() {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Changed lib.sh to add link arguments given through `cargo::rustc-cdylib-link-arg` to the rustc call
- Followed documentation in https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-cdylib-link-arg

Main rationale is that we use napi-rs in our projects, and for macos these build script invocations are made
https://github.com/napi-rs/napi-rs/blob/main/crates/build/src/macos.rs

I was unable to write a proper test, if anyone has ideas for how we could test it would be happy to add it.

Example:

```nix
      cdylibLinkArgs = {
        type = ["cdylib"]; # changing this from cdylib to dylib should remove the link arg
        src = symlinkJoin {
          name = "cdylib-link-arg";
          paths = [
            (mkLib "src/lib.rs")
            (mkFile "build.rs" ''
              fn main() {
                println!("cargo:rustc-cdylib-link-arg=-Wl,-z,stack-size=123");
              }
            '')
          ];
        };
      };
```

Output for cdylib)
```
Building build.rs (cdylibLinkArgs)
Running rustc --crate-name build_script_build build.rs --crate-type bin -C opt-level=3 -C codegen-units=1 --out-dir target/build/cdylibLinkArgs --emit=dep-info,link -L dependency=target/buildDeps --cap-lints allow --color always
Building src/lib.rs (cdylibLinkArgs)
Running rustc --crate-name cdylibLinkArgs src/lib.rs --out-dir target/lib -L dependency=target/deps --cap-lints allow -C opt-level=3 -C codegen-units=1 --remap-path-prefix=/build=/ -C metadata=ca64142ed4 -C extra-filename=-ca64142ed4 \
  --crate-type cdylib -L /build/cdylib-link-arg/target/build/cdylibLinkArgs.out -C link-arg=-Wl,-z,stack-size=123 --color always
```

For dylib:
```
Running rustc --crate-name build_script_build build.rs --crate-type bin -C opt-level=3 -C codegen-units=1 --out-dir target/build/cdylibLinkArgs --emit=dep-info,link -L dependency=target/buildDeps --cap-lints allow --color always
Running phase: buildPhase
Building src/lib.rs (cdylibLinkArgs)
Running rustc --crate-name cdylibLinkArgs src/lib.rs --out-dir target/lib -L dependency=target/deps --cap-lints allow -C opt-level=3 -C codegen-units=1 --remap-path-prefix=/build=/ -C metadata=ca64142ed4 -C extra-filename=-ca64142ed4 \
  --crate-type dylib -L /build/cdylib-link-arg/target/build/cdylibLinkArgs.out --color always
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
