### PR TITLE
logseq: fix electron version

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5689,8 +5689,8 @@ with pkgs;
   loccount = callPackage ../development/tools/misc/loccount { };
 
   logseq = callPackage ../by-name/lo/logseq/package.nix {
-    # electron version from: https://github.com/logseq/logseq/blob/d8c6ca264bdf9a6a0f03c46dbf3509210367624a/package.json#L116
-    electron = electron_28;
+    # electron version from: https://github.com/logseq/logseq/blob/0.10.9/package.json#L116
+    electron = electron_27;
   };
 
   long-shebang = callPackage ../misc/long-shebang { };


### PR DESCRIPTION
logseq: fix electron version

Fixes: https://github.com/NixOS/nixpkgs/commit/8b7d6f8b0a09f7db74cbce56cf6f1b4bad58d93a#r143643198

CC @RobFisher