### PR TITLE
quarto: 1.4.555 -> 1.4.557

### DIFF
--- a/pkgs/development/libraries/quarto/default.nix
+++ b/pkgs/development/libraries/quarto/default.nix
@@ -19,10 +19,10 @@
 
 stdenv.mkDerivation (final: {
   pname = "quarto";
-  version = "1.4.555";
+  version = "1.4.557";
   src = fetchurl {
     url = "https://github.com/quarto-dev/quarto-cli/releases/download/v${final.version}/quarto-${final.version}-linux-amd64.tar.gz";
-    sha256 = "sha256-uBKKgRsM7kUDeF0kMYbo6RjmiU6wq4EEcE94qqMSzt8=";
+    sha256 = "sha256-RcEkmPMcfNGDmu2bQwUHvlHgM/ySQQwDgf/NpTQMxcI=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

Updated and tested quarto on Ubuntu and macOS, everything seems to be running smoothly.

Closing this one, as two updates got released in very close succession: https://github.com/NixOS/nixpkgs/pull/322787

```
⚠️  The `--unstable` flag is deprecated and will be removed in Deno 2.0. Use granular `--unstable-*` flags instead.
Learn more at: https://docs.deno.com/runtime/manual/tools/unstable_flags
Quarto 1.4.55[7](https://github.com/b-rodrigues/test_nixpkgs/actions/runs/9712441695/job/26807216294#step:6:8)
[✓] Checking versions of quarto binary dependencies...
      Pandoc version 3.1.11: OK
      Dart Sass version 1.77.4: OK
      Deno version 1.44.4: OK
[✓] Checking versions of quarto dependencies......OK
[✓] Checking Quarto installation......OK
      Version: 1.4.557
      Path: /nix/store/0w917zlq2a9y3ijm7acarc0glgr00yw3-quarto-1.4.557/bin
(|) Checking tools....................
[✓] Checking tools....................OK
      TinyTeX: (not installed)
      Chromium: (not installed)
(|) Checking LaTeX....................
[✓] Checking LaTeX....................OK
      Using: Installation From Path
      Path: /nix/store/iwvzdg6y4xpn2sgh0yfs6lc4wi9afj6h-texlive-combined-2023/bin
      Version: undefined
⚠️  The `Deno.dlopen` API was used with `--unstable` flag. The `--unstable` flag is deprecated and will be removed in Deno 2.0. Use granular `--unstable-ffi` instead.
Learn more at: https://docs.deno.com/runtime/manual/tools/unstable_flags
(|) Checking basic markdown render....
[✓] Checking basic markdown render....OK

[✓] Checking Python 3 installation....OK
      Version: 3.11.9
      Path: /nix/store/7rv97767xnrvz0xl9xxjbcyrjczi2dv1-python3-3.11.9-env/bin/python3.11
      Jupyter: 5.7.2
      Kernels: python3
(|) Checking Jupyter engine render....
[✓] Checking Jupyter engine render....OK
(|) Checking R installation...........
[✓] Checking R installation...........OK
      Version: 4.4.1
      Path: /nix/store/rnwcrgsychzvn02g4p2b4xqij50xi9[8](https://github.com/b-rodrigues/test_nixpkgs/actions/runs/9712441695/job/26807216294#step:6:9)z-R-4.4.1/lib/R
      LibPaths:
        - /nix/store/clajc74x[9](https://github.com/b-rodrigues/test_nixpkgs/actions/runs/9712441695/job/26807216294#step:6:10)2qndz6zsz4dwm6zc6fp07r3-r-boot-1.3-30/library
        - /nix/store/isqr1h3xw5i1lkp9y7n8dzdg1mx8lcxn-r-class-7.3-22/library
        - /nix/store/3mxwnaw9cjr5hkjpxscas642amg5k586-r-MASS-7.3-61/library
        - /nix/store/6gbj9fxgavqnr2bqbzd2p0saarka5lzm-r-cluster-2.1.6/library
        - /nix/store/mgha3w3cr0jh6gsm8pf2bb0hz2pgv1hf-r-codetools-0.2-20/library
        - /nix/store/sqkpm5wyv2adhha15p0v1rl0r8851d4s-r-foreign-0.8-86/library
        - /nix/store/s5i04fx0aqqkxzg48rsqa1nb4dj2b1zl-r-KernSmooth-2.23-24/library
        - /nix/store/hk7lr4fiw70dyvmmjz0b3qffvlldxxnp-r-lattice-0.22-6/library
        - /nix/store/kjpaw9cw7myyp4s43nvc0i8ldx5dxc7z-r-Matrix-1.7-0/library
        - /nix/store/v23r4lzfdjgv1br59smv2lkm3h2zyq9v-r-mgcv-1.9-1/library
        - /nix/store/fyalg2a2xsr0kk6p7hvxwmp0nwfpl3aa-r-nlme-3.1-165/library
        - /nix/store/alm3rsm2c1x8f1rmfw9grsilskf92bz9-r-nnet-7.3-19/library
        - /nix/store/1kxf9qkzy8ckhpk7b5k88f1gdc53dnc2-r-rpart-4.1.23/library
        - /nix/store/9pgdl2gws1vcyzla92jbx6kzyj9vdm83-r-spatial-7.3-17/library
        - /nix/store/bvii6sy085ngiyxyy05d1q3d66cbbl2f-r-survival-3.7-0/library
        - /nix/store/0g76f4sadpx7hs5njripx6jm0zx0s6a6-r-rmarkdown-2.27/library
        - /nix/store/[11](https://github.com/b-rodrigues/test_nixpkgs/actions/runs/9712441695/job/26807216294#step:6:12)p01y41vxfij7dyal7bdl8fngsv9w3m-r-bslib-0.7.0/library
        - /nix/store/bd6ps1snz790yr9q3v3f8migp84l4blf-r-base64enc-0.1-3/library
        - /nix/store/ybi4cra2qgzhjl3qxlv2b06wi8v6fld6-r-cachem-1.1.0/library
        - /nix/store/0d3val5phlmjb8z9y1kxvj1zsz678qb2-r-fastmap-1.2.0/library
        - /nix/store/jrwr82c1i96mfkm4qn7kwxagdbaps41i-r-rlang-1.1.4/library
        - /nix/store/6zkshh9zixpw8wjiyyj7qi1s6nx424cl-r-htmltools-0.5.8.1/library
        - /nix/store/3a29v55c4mwymzc42qy0hyqaqh99msy7-r-digest-0.6.35/library
        - /nix/store/qfrkhf5qna2i676zgx3z9ckyz25ni9ij-r-jquerylib-0.1.4/library
        - /nix/store/c1l1x05mjpkji08bml07zhfw3slays5z-r-jsonlite-1.8.8/library
        - /nix/store/cwsw26lmiyxillb356gwwmgfrg3id8i4-r-lifecycle-1.0.4/library
        - /nix/store/sa1xxvxr6x2jnnf30vpyshs9yvn4r6x6-r-cli-3.6.2/library
        - /nix/store/3pwv374bsjwjnxsc9x5cjj78w70pn21z-r-glue-1.7.0/library
        - /nix/store/017rynrml1cig63sfhk96kkb331dwbfp-r-memoise-2.0.1/library
        - /nix/store/6n31km7w1clsbmnzs23xp4hx0naq9r17-r-mime-0.[12](https://github.com/b-rodrigues/test_nixpkgs/actions/runs/9712441695/job/26807216294#step:6:13)/library
        - /nix/store/vfc5qlgfkd1ib3gf9hkarbx2iqcb26ln-r-sass-0.4.9/library
        - /nix/store/mjw7vs7la4z40fpbil5l9snfnir9ydmh-r-fs-1.6.4/library
        - /nix/store/sk92mc5mfqzjxk0yn0fgrbckchddmcfm-r-R6-2.5.1/library
        - /nix/store/p6l1nxpnrqhd7ahcvfz3bkyfiyi68s1w-r-rappdirs-0.3.3/library
        - /nix/store/i6fqf8rmk1a5qccz4v4b88r0q0jqqpix-r-evaluate-0.24.0/library
        - /nix/store/mpxdv3x2qi0yqb57zri3116yd37ps0s9-r-fontawesome-0.5.2/library
        - /nix/store/r204h4wnmcwqwbdaf3260vjafx12kjbd-r-knitr-1.47/library
        - /nix/store/finc34jr485a44yqvinkp9hzcknqd2n3-r-highr-0.11/library
        - /nix/store/3japn02dr622ngb63jpmw2lx0hqjn9pq-r-xfun-0.45/library
        - /nix/store/m4n391sv659gk4dbc0rgmiy71vfzwng1-r-yaml-2.3.8/library
        - /nix/store/qhycvpfwhzwrfr88qgigwzm8bcqjnfs2-r-tinytex-0.51/library
        - /nix/store/ppshshbximmdacgfpvg4bp8gc2k8h4if-r-quarto-1.4/library
        - /nix/store/k0vq1fn323q8mrdv3lwdfmglsf[13](https://github.com/b-rodrigues/test_nixpkgs/actions/runs/9712441695/job/26807216294#step:6:14)6ljf-r-later-1.3.2/library
        - /nix/store/g8mnwf6rdwblxcfjdpchgc64bjcwvc85-r-Rcpp-1.0.12/library
        - /nix/store/lckvr9lnzkm5jyyg55k1r2vh3xdxpsin-r-processx-3.8.4/library
        - /nix/store/4mxkhs8mqrg7s0lkpgnv6279higm2kcs-r-ps-1.7.6/library
        - /nix/store/qr1d2gh5jz7ylvvfjsmm2imc9skpxp81-r-rstudioapi-0.16.0/library
        - /nix/store/dskm6n6z8wvhqp46677nn2s9d80w78ra-r-reticulate-1.37.0/library
        - /nix/store/6nsrp2[15](https://github.com/b-rodrigues/test_nixpkgs/actions/runs/9712441695/job/26807216294#step:6:16)b5n2d91krbyhas10nz2lxwna-r-here-1.0.1/library
        - /nix/store/vw6cijjsh230bsqd06706yk8injjj43g-r-rprojroot-2.0.4/library
        - /nix/store/xhpyzdg3akzkqwf04mvdyv6gc8v7dpvj-r-png-0.1-8/library
        - /nix/store/vfczf1xhaj3wcnzp2r8cda0l6q2r0fz0-r-RcppTOML-0.2.2/library
        - /nix/store/cr3h764zgq6vvschhdwda4w[17](https://github.com/b-rodrigues/test_nixpkgs/actions/runs/9712441695/job/26807216294#step:6:18)fdfqf83-r-withr-3.0.0/library
        - /nix/store/rnwcrgsychzvn02g4p2b4xqij50xi98z-R-4.4.1/lib/R/library
      knitr: 1.47
      rmarkdown: 2.27
(|) Checking Knitr engine render......
[✓] Checking Knitr engine render......OK
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
