### PR TITLE
mqtt-explorer: init at 0.4.0-beta.6

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -317,6 +317,12 @@ in mkLicense lset) ({
     free = false;
   };
 
+  cc-by-nd-40 = {
+    spdxId = "CC-BY-ND-4.0";
+    fullName = "Creative Commons Attribution-No Derivative Works v4.0";
+    free = false;
+  };
+
   cc-by-sa-10 = {
     spdxId = "CC-BY-SA-1.0";
     fullName = "Creative Commons Attribution Share Alike 1.0";

--- a/pkgs/by-name/mq/mqtt-explorer/package.nix
+++ b/pkgs/by-name/mq/mqtt-explorer/package.nix
@@ -1,0 +1,183 @@
+{
+  lib,
+  stdenv,
+  electron,
+  yarn,
+  fixup-yarn-lock,
+  fetchFromGitHub,
+  fetchYarnDeps,
+  nodejs,
+  typescript,
+  makeWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
+}:
+let
+  electronDist = electron + (if stdenv.isDarwin then "/Applications" else "/libexec/electron");
+in
+# NOTE mqtt-explorer has 3 yarn subpackages and uses relative links
+# between them, which makes it hard to package them via 3 `mkYarnPackage`
+# since the resulting `node_modules` directories don't have the same structure
+# as if they were installed directly. Hence why we opted to use a
+# `stdenv.mkDerivation` instead.
+stdenv.mkDerivation rec {
+  # NOTE official app name is `MQTT-Explorer` but to suffice nixpkgs conventions
+  # we opted to use `mqtt-explorer` instead.
+  pname = "mqtt-explorer";
+  version = "0.4.0-beta.6";
+
+  src = fetchFromGitHub {
+    owner = "thomasnordquist";
+    repo = "MQTT-Explorer";
+    rev = "v${version}";
+    hash = "sha256-oFS4RnuWQoicPemZbPBAp8yQjRbhAyo/jiaw8V0MBAo=";
+  };
+
+  offlineCache = fetchYarnDeps {
+    yarnLock = "${src}/yarn.lock";
+    hash = "sha256-yEL6Vb1Yry3Vns2GF0aagGksRwsCgXR5ZfmrDPxeqos=";
+  };
+
+  offlineCacheApp = fetchYarnDeps {
+    yarnLock = "${src}/app/yarn.lock";
+    hash = "sha256-4oGWBXZHdN+wSpn3fPzTdpaIcywAVdFVYmsOIhcgvUE=";
+  };
+
+  offlineCacheBackend = fetchYarnDeps {
+    yarnLock = "${src}/backend/yarn.lock";
+    hash = "sha256-gg6KrcQz7MdIgFdlbuGiDf/tVd7lSOjwXFIq56tpaTc=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    yarn
+    typescript
+    fixup-yarn-lock
+    makeWrapper
+  ] ++ lib.optionals (!stdenv.isDarwin) [ copyDesktopItems ];
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  # disable code signing on macos
+  # https://github.com/electron-userland/electron-builder/blob/77f977435c99247d5db395895618b150f5006e8f/docs/code-signing.md#how-to-disable-code-signing-during-the-build-process-on-macos
+  postConfigure = lib.optionalString stdenv.isDarwin ''
+    export CSC_IDENTITY_AUTO_DISCOVERY=false
+  '';
+
+  configurePhase = ''
+    runHook preConfigure
+
+    # Yarn writes cache directories etc to $HOME.
+    export HOME=$TMPDIR
+
+    fixup-yarn-lock yarn.lock
+    yarn config --offline set yarn-offline-mirror $offlineCache
+    yarn install --offline --frozen-lockfile --ignore-engines --ignore-scripts --no-progress
+
+    pushd app
+    fixup-yarn-lock yarn.lock
+    yarn config --offline set yarn-offline-mirror $offlineCacheApp
+    yarn install --offline --frozen-lockfile --ignore-engines --ignore-scripts --no-progress
+    popd
+
+    pushd backend
+    fixup-yarn-lock yarn.lock
+    yarn config --offline set yarn-offline-mirror $offlineCacheApp
+    yarn install --offline --frozen-lockfile --ignore-engines --ignore-scripts --no-progress
+    popd
+
+    patchShebangs {node_modules,app/node_modules,backend/node_modules}
+
+    cp -r ${electronDist} electron-dist
+    chmod -R u+w electron-dist
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    tsc && cd app && yarn --offline run build && cd ..
+
+    yarn --offline run electron-builder --dir \
+      -c.electronDist=electron-dist \
+      -c.electronVersion=${electron.version}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    ${lib.optionalString (!stdenv.isDarwin) ''
+      mkdir -p "$out/share/mqtt-explorer"/{app,icons/hicolor}
+
+      cp -r build/*-unpacked/{locales,resources{,.pak}} "$out/share/mqtt-explorer/app"
+
+      for file in res/appx/Square44x44Logo.targetsize-*_altform-unplated.png; do
+
+        size=$(echo "$file" | sed -n 's/.*targetsize-\([0-9]*\)_altform-unplated\.png/\1/p')
+
+        install -Dm644 \
+          "$file" \
+          "$out/share/icons/hicolor/''${size}x''${size}/apps/mqtt-explorer.png"
+      done
+
+      makeWrapper '${electron}/bin/electron' "$out/bin/mqtt-explorer" \
+        --add-flags "$out/share/mqtt-explorer/app/resources/app.asar" \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+        --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
+        --set-default ELECTRON_IS_DEV 0 \
+        --inherit-argv0
+    ''}
+
+    ${lib.optionalString stdenv.isDarwin ''
+      mkdir -p $out/{Applications,bin}
+      mv "build/mac/MQTT Explorer.app" $out/Applications
+
+      makeWrapper "$out/Applications/MQTT Explorer.app/Contents/MacOS/MQTT Explorer" \
+        $out/bin/mqtt-explorer
+    ''}
+
+    runHook postInstall
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    export ELECTRON_OVERRIDE_DIST_PATH=electron-dist/
+
+    yarn test:app --offline
+    yarn test:backend --offline
+
+    unset ELECTRON_OVERRIDE_DIST_PATH
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = meta.mainProgram;
+      icon = "mqtt-explorer";
+      desktopName = "MQTT Explorer";
+      genericName = "MQTT Protocol Client";
+      comment = meta.description;
+      type = "Application";
+      categories = [
+        "Development"
+        "Utility"
+        "Network"
+      ];
+      startupWMClass = "mqtt-explorer";
+    })
+  ];
+
+  meta = with lib; {
+    description = "An all-round MQTT client that provides a structured topic overview";
+    homepage = "https://github.com/thomasnordquist/MQTT-Explorer";
+    changelog = "https://github.com/thomasnordquist/MQTT-Explorer/releases/tag/v${version}";
+    license = licenses.cc-by-nd-40;
+    maintainers = with maintainers; [ tsandrini ];
+    platforms = electron.meta.platforms;
+    mainProgram = "mqtt-explorer";
+  };
+}


### PR DESCRIPTION
## Description of changes

Resolves #312716 by packaging https://github.com/thomasnordquist/MQTT-Explorer directly from source instead of provided AppImage that is, for example, used in NUR.

----

**Notes**:
- Haven't properly tested on `darwin` so I'd appreciate any testing on that part (maybe @sikmir ? :pray: )
- First time packaging electron stuff so I'd be grateful for any feedback on what to improve and such :pray: 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
