### PR TITLE
rust: make pkgsCross.wasi32.rustPlatform.buildRustPackage work

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -353,6 +353,7 @@ rec {
 
   wasi32 = {
     config = "wasm32-unknown-wasi";
+    rustc.config = "wasm32-wasip1";
     useLLVM = true;
   };
 

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -235,6 +235,12 @@ stdenvNoCC.mkDerivation {
         basename=$(basename "$variant")
         wrap $basename ${./ld-wrapper.sh} $variant
       done
+    '' + optionalString targetPlatform.isWasi ''
+      wrap ${targetPrefix}wasm-ld ${./ld-wrapper.sh} $ldPath/${targetPrefix}wasm-ld
+      # clang doesn't properly normalize the target triple[1] before using it as a search path,
+      # and rustc passes wasm32-wasi as `-target`, which gets used as is. Work around.
+      # [1] https://github.com/llvm/llvm-project/blob/ad7aeb0ff58ebd29f68adb85c64e8010639e2a76/clang/lib/Driver/Driver.cpp#L6187
+      ln -s $out/bin/${targetPrefix}wasm-ld $out/bin/wasm32-wasi-wasm-ld
     '';
 
   strictDeps = true;

--- a/pkgs/build-support/rust/lib/default.nix
+++ b/pkgs/build-support/rust/lib/default.nix
@@ -14,18 +14,23 @@ rec {
   # passed on a build=x86_64/host=aarch64 compilation.
   envVars = let
 
-    ccForBuild = "${pkgsBuildHost.stdenv.cc}/bin/${pkgsBuildHost.stdenv.cc.targetPrefix}cc";
-    cxxForBuild = "${pkgsBuildHost.stdenv.cc}/bin/${pkgsBuildHost.stdenv.cc.targetPrefix}c++";
+    # should match pkgs/development/compilers/rust/rustc.nix
+    prefixForStdenv = stdenv: "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}";
+    ccForStdenv = stdenv: "${prefixForStdenv stdenv}${if (stdenv.cc.isClang or false) then "clang" else "gcc"}";
+    cxxForStdenv = stdenv: "${prefixForStdenv stdenv}${if (stdenv.cc.isClang or false) then "clang++" else "g++"}";
 
-    ccForHost = "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc";
-    cxxForHost = "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}c++";
+    ccForBuild = ccForStdenv pkgsBuildHost.stdenv;
+    cxxForBuild = cxxForStdenv pkgsBuildHost.stdenv;
+
+    ccForHost = ccForStdenv stdenv;
+    cxxForHost = cxxForStdenv stdenv;
 
     # Unfortunately we must use the dangerous `pkgsTargetTarget` here
     # because hooks are artificially phase-shifted one slot earlier
     # (they go in nativeBuildInputs, so the hostPlatform looks like
     # a targetPlatform to them).
-    ccForTarget = "${pkgsTargetTarget.stdenv.cc}/bin/${pkgsTargetTarget.stdenv.cc.targetPrefix}cc";
-    cxxForTarget = "${pkgsTargetTarget.stdenv.cc}/bin/${pkgsTargetTarget.stdenv.cc.targetPrefix}c++";
+    ccForTarget = ccForStdenv pkgsTargetTarget.stdenv;
+    cxxForTarget = cxxForStdenv pkgsTargetTarget.stdenv;
 
     rustBuildPlatform = stdenv.buildPlatform.rust.rustcTarget;
     rustBuildPlatformSpec = stdenv.buildPlatform.rust.rustcTargetSpec;

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -84,8 +84,8 @@ in stdenv.mkDerivation (finalAttrs: {
   # Reference: https://github.com/rust-lang/rust/blob/master/src/bootstrap/configure.py
   configureFlags = let
     prefixForStdenv = stdenv: "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}";
-    ccPrefixForStdenv = stdenv: "${prefixForStdenv stdenv}${if (stdenv.cc.isClang or false) then "clang" else "cc"}";
-    cxxPrefixForStdenv = stdenv: "${prefixForStdenv stdenv}${if (stdenv.cc.isClang or false) then "clang++" else "c++"}";
+    ccPrefixForStdenv = stdenv: "${prefixForStdenv stdenv}${if (stdenv.cc.isClang or false) then "clang" else "gcc"}";
+    cxxPrefixForStdenv = stdenv: "${prefixForStdenv stdenv}${if (stdenv.cc.isClang or false) then "clang++" else "g++"}";
     setBuild  = "--set=target.${stdenv.buildPlatform.rust.rustcTarget}";
     setHost   = "--set=target.${stdenv.hostPlatform.rust.rustcTarget}";
     setTarget = "--set=target.${stdenv.targetPlatform.rust.rustcTarget}";

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -225,6 +225,10 @@ in stdenv.mkDerivation (finalAttrs: {
     substituteInPlace compiler/rustc_target/src/spec/*/*.rs \
       --replace-quiet '"rust-lld"' '"lld"'
 
+    # Figuring out when this should be False is a rustc FIXME. Nixpkgs needs it false.
+    substituteInPlace compiler/rustc_target/src/spec/targets/wasm32_wasi*.rs \
+      --replace LinkSelfContainedDefault::True LinkSelfContainedDefault::False
+
     ${optionalString (!withBundledLLVM) "rm -rf src/llvm"}
 
     # Useful debugging parameter

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -167,6 +167,8 @@ in stdenv.mkDerivation (finalAttrs: {
     "${setHost}.musl-root=${pkgsBuildHost.targetPackages.stdenv.cc.libc}"
   ] ++ optionals stdenv.targetPlatform.isMusl [
     "${setTarget}.musl-root=${pkgsBuildTarget.targetPackages.stdenv.cc.libc}"
+  ] ++ optionals stdenv.targetPlatform.isWasi [
+    "${setTarget}.wasi-root=${pkgsBuildTarget.targetPackages.stdenv.cc.libc}"
   ] ++ optionals stdenv.targetPlatform.rust.isNoStdTarget [
     "--disable-docs"
   ] ++ optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
@@ -262,7 +264,7 @@ in stdenv.mkDerivation (finalAttrs: {
   buildInputs = [ openssl ]
     ++ optionals stdenv.hostPlatform.isDarwin [ libiconv Security zlib ]
     ++ optional (!withBundledLLVM) llvmShared.lib
-    ++ optional (useLLVM && !withBundledLLVM) [
+    ++ optional (useLLVM && !withBundledLLVM && !stdenv.targetPlatform.isWasi) [
       llvmPackages.libunwind
       # Hack which is used upstream https://github.com/gentoo/gentoo/blob/master/dev-lang/rust/rust-1.78.0.ebuild#L284
       (runCommandLocal "libunwind-libgcc" {} ''

--- a/pkgs/development/libraries/wasilibc/default.nix
+++ b/pkgs/development/libraries/wasilibc/default.nix
@@ -51,6 +51,11 @@ stdenv.mkDerivation {
 
   preFixup = ''
     ln -s $share/share/undefined-symbols.txt $out/lib/wasi.imports
+    # rustc build expects lib at the path where a make install would put them without the SYSROOT_* overrides
+    TARGET_TRIPLE=wasm32-wasip1
+    ln -s $out/lib/ $out/lib/$TARGET_TRIPLE
+    ln -s $dev/include $dev/include/$TARGET_TRIPLE
+    ln -s $share/share $share/share/$TARGET_TRIPLE
   '';
 
   passthru.tests = {


### PR DESCRIPTION
## Description of changes

This PR makes it possible to e.g. build and run rust packages like `nix shell .#pkgsCross.wasi32.charasay -c charasay.wasm say moo` (assuming you have `wasm32-wasi` in your emulated systems).

Without this PR, building the cross rustc fails with
```
thread 'main' panicked at src/core/build_steps/compile.rs:370:17:
Target "wasm32-unknown-wasi" does not have a "wasi-root" ```
```

I think this is neat, but it admittedly isn't super useful, as a lot of packages fail to compile due to failing C dependencies or some common dependencies assuming that all wasm is for the web. I've tested the 469 rust packages in by-name, and only 60¹ compile. Even those that do compile might fail at runtime, e.g. due to std::thread not being supported and panicking when attempting to create a thread (like alejandra).

I'm only aware of two mildly useful things that work, namely rq and qrtool. But I think it's nice to have this working.

¹ aarch64-esr-decoder, aba, action-validator, adrs, bunbun, cargo-autoinherit, cargo-bloat, cargo-bump, cargo-shear, cargo-swift, catppuccin-whiskers, catppuccinifier-cli, cdwe, circom, clippy-sarif, cmd-wrapped, commitmsgfmt, diesel-cli-ext, dipc, elf-info, emacs-lsp-booster, esbuild-config, french-numbers, galerio, git-upstream, hadolint-sarif, hvm, hyperlink, icnsify, ifrextractor-rs, keedump, kickstart, ldproxy, little_boxes, ludtwig, lutgen, majima, mcumgr-client, mdsh, ndstrim, obsidian-export, okolors, parallel-disk-usage, pdfrip, polylux2pdfpc, preserves-tools, prettypst, protoc-gen-rust-grpc, qrtool, rq, rs-tftpd, rusti-cal, rusty-diceware, sarif-fmt, shellcheck-sarif, tera-cli, thud, toml-cli, typstfmt, unison-fsmonitor, wit-bindgen

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
