### PR TITLE
nixos/scion: use RuntimeDirectory instead of StateDirectory

### DIFF
--- a/nixos/modules/services/networking/scion/scion-control.nix
+++ b/nixos/modules/services/networking/scion/scion-control.nix
@@ -12,13 +12,13 @@ let
       reconnect_to_dispatcher = true;
     };
     beacon_db = {
-      connection = "/var/lib/scion-control/control.beacon.db";
+      connection = "/run/scion-control/control.beacon.db";
     };
     path_db = {
-      connection = "/var/lib/scion-control/control.path.db";
+      connection = "/run/scion-control/control.path.db";
     };
     trust_db = {
-      connection = "/var/lib/scion-control/control.trust.db";
+      connection = "/run/scion-control/control.trust.db";
     };
     log.console = {
       level = "info";
@@ -35,7 +35,7 @@ in
       example = literalExpression ''
         {
           path_db = {
-            connection = "/var/lib/scion-control/control.path.db";
+            connection = "/run/scion-control/control.path.db";
           };
           log.console = {
             level = "info";
@@ -62,7 +62,7 @@ in
         DynamicUser = true;
         Restart = "on-failure";
         BindPaths = [ "/dev/shm:/run/shm" ];
-        StateDirectory = "scion-control";
+        RuntimeDirectory = "scion-control";
       };
     };
   };

--- a/nixos/modules/services/networking/scion/scion-daemon.nix
+++ b/nixos/modules/services/networking/scion/scion-daemon.nix
@@ -12,10 +12,10 @@ let
       reconnect_to_dispatcher = true;
     };
     path_db = {
-      connection = "/var/lib/scion-daemon/sd.path.db";
+      connection = "/run/scion-daemon/sd.path.db";
     };
     trust_db = {
-      connection = "/var/lib/scion-daemon/sd.trust.db";
+      connection = "/run/scion-daemon/sd.trust.db";
     };
     log.console = {
       level = "info";
@@ -32,7 +32,7 @@ in
       example = literalExpression ''
         {
           path_db = {
-            connection = "/var/lib/scion-daemon/sd.path.db";
+            connection = "/run/scion-daemon/sd.path.db";
           };
           log.console = {
             level = "info";
@@ -57,7 +57,7 @@ in
         ExecStart = "${pkgs.scion}/bin/scion-daemon --config ${configFile}";
         Restart = "on-failure";
         DynamicUser = true;
-        StateDirectory = "scion-daemon";
+        RuntimeDirectory = "scion-daemon";
       };
     };
   };

--- a/nixos/modules/services/networking/scion/scion-dispatcher.nix
+++ b/nixos/modules/services/networking/scion/scion-dispatcher.nix
@@ -66,7 +66,7 @@ in
         ExecStartPre = "${pkgs.coreutils}/bin/rm -rf /run/shm/dispatcher";
         ExecStart = "${pkgs.scion}/bin/scion-dispatcher --config ${configFile}";
         Restart = "on-failure";
-        StateDirectory = "scion-dispatcher";
+        RuntimeDirectory = "scion-dispatcher";
       };
     };
   };

--- a/nixos/modules/services/networking/scion/scion-router.nix
+++ b/nixos/modules/services/networking/scion/scion-router.nix
@@ -42,7 +42,7 @@ in
         ExecStart = "${pkgs.scion}/bin/scion-router --config ${configFile}";
         Restart = "on-failure";
         DynamicUser = true;
-        StateDirectory = "scion-router";
+        RuntimeDirectory = "scion-router";
       };
     };
   };


### PR DESCRIPTION
## Description of changes

This PR doesn't cause any issues for existing deployments if there are any. It's just a re-routing of where the runtime files are placed, to prevent keeping them persistent on the disk.

It was wrong to use `StateDirectory` to keep the `scion-control` and `scion-router` runtime databases on disk for the next run. I observed that doing this means a reboot, or power outage can corrupt the temporary runtime databases for the next service start, leading `scion ping` and other functionality to stop working permanently, since those files are not managed in an atomic manner by the golang code.

This is supposed to be stateless, which is what `RuntimeDirectory` provides, as those dirs get cleaned up on each service start, leaving nothing behind.

You can see in the following `ls` that I've ended up with a 0 byte file `control.trust.db-wal`:

```
[root@t480:/var/lib/private]# ls -lah scion-*
scion-control:
total 178K
drwxr-xr-x 2 scion-control scion   11 Jun 28 18:02 .
drwx------ 9 root          root     9 Jun 28 18:01 ..
-rw-r--r-- 1 scion-control scion  16K Jun 28 18:02 control.beacon.db
-rw-r--r-- 1 scion-control scion  32K Jun 28 18:12 control.beacon.db-shm
-rw-r--r-- 1 scion-control scion  89K Jun 28 18:12 control.beacon.db-wal
-rw-r--r-- 1 scion-control scion  48K Jun 28 18:02 control.path.db
-rw-r--r-- 1 scion-control scion  32K Jun 28 18:13 control.path.db-shm
-rw-r--r-- 1 scion-control scion 974K Jun 28 18:13 control.path.db-wal
-rw-r--r-- 1 scion-control scion 572K Jun 28 18:02 control.trust.db
-rw-r--r-- 1 scion-control scion  32K Jun 28 18:02 control.trust.db-shm
-rw-r--r-- 1 scion-control scion    0 Jun 28 18:02 control.trust.db-wal
```

Which leads to the following failure log on the next service start:

```
Jun 28 17:55:50 t480 scion-control[1960]: 2024-06-28 16:55:50.093142+0000        ERROR               beaconing/writer.go:324        Unable to register segment        {"debug_id": "49dcfbb8", "seg_type": "down", "addr": "17-ffaa:0:1108,CS", "err": {"msg": "resolving SVC address", "cause": "context deadline exceeded", "stacktrace": ["github.com/scionproto/scion/pkg/grpc.(*QUICDialer).Dial github.com/scionproto/scion/pkg/grpc/dialer.go:148", "github.com/scionproto/scion/control/beaconing/grpc.Registrar.RegisterSegment github.com/scionproto/scion/control/beaconing/grpc/register.go:34", "github.com/scionproto/scion/control/beaconing.(*remoteWriter).startSendSegReg.func1 github.com/scionproto/scion/control/beaconing/writer.go:323"]}}
Jun 28 17:55:50 t480 scion-control[1960]: 2024-06-28 16:55:50.093271+0000        ERROR               beaconing/writer.go:110        Unable to register        {"debug_id": "49dcfbb8", "seg_type": "down", "err": {"msg": "no beacons registered", "stacktrace": ["github.com/scionproto/scion/control/beaconing.(*RemoteWriter).Write github.com/scionproto/scion/control/beaconing/writer.go:191", "github.com/scionproto/scion/control/beaconing.(*WriteScheduler).run github.com/scionproto/scion/control/beaconing/writer.go:124", "github.com/scionproto/scion/control/beaconing.(*WriteScheduler).Run github.com/scionproto/scion/control/beaconing/writer.go:109", "github.com/scionproto/scion/private/periodic.(*Runner).onTick github.com/scionproto/scion/private/periodic/periodic.go:213", "github.com/scionproto/scion/private/periodic.(*Runner).runLoop github.com/scionproto/scion/private/periodic/periodic.go:195", "github.com/scionproto/scion/private/periodic.StartWithMetrics.func1 github.com/scionproto/scion/private/periodic/periodic.go:145"], "candidates": 1}}
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
