### PR TITLE
viber: 16.1.0.37 -> 21.8.0.11 

### DIFF
--- a/pkgs/applications/networking/instant-messengers/viber/default.nix
+++ b/pkgs/applications/networking/instant-messengers/viber/default.nix
@@ -1,7 +1,34 @@
-{fetchurl, lib, stdenv, dpkg, makeWrapper,
- alsa-lib, cups, curl, dbus, expat, fontconfig, freetype, glib, gst_all_1,
- harfbuzz, libcap, libGL, libGLU, libpulseaudio, libxkbcommon, libxml2, libxslt,
- nspr, nss, openssl_1_1, systemd, wayland, xorg, zlib, ...
+{
+  fetchurl,
+  lib,
+  stdenv,
+  dpkg,
+  makeWrapper,
+  alsa-lib,
+  cups,
+  curl,
+  dbus,
+  expat,
+  fontconfig,
+  freetype,
+  glib,
+  gst_all_1,
+  harfbuzz,
+  libcap,
+  libGL,
+  libGLU,
+  libpulseaudio,
+  libxkbcommon,
+  libxml2,
+  libxslt,
+  nspr,
+  nss,
+  openssl_1_1,
+  systemd,
+  wayland,
+  xorg,
+  zlib,
+  ...
 }:
 
 stdenv.mkDerivation {
@@ -20,51 +47,51 @@ stdenv.mkDerivation {
   dontUnpack = true;
 
   libPath = lib.makeLibraryPath [
-      alsa-lib
-      cups
-      curl
-      dbus
-      expat
-      fontconfig
-      freetype
-      glib
-      gst_all_1.gst-plugins-base
-      gst_all_1.gstreamer
-      harfbuzz
-      libcap
-      libGLU libGL
-      libpulseaudio
-      libxkbcommon
-      libxml2
-      libxslt
-      nspr
-      nss
-      openssl_1_1
-      stdenv.cc.cc
-      systemd
-      wayland
-      zlib
+    alsa-lib
+    cups
+    curl
+    dbus
+    expat
+    fontconfig
+    freetype
+    glib
+    gst_all_1.gst-plugins-base
+    gst_all_1.gstreamer
+    harfbuzz
+    libcap
+    libGLU
+    libGL
+    libpulseaudio
+    libxkbcommon
+    libxml2
+    libxslt
+    nspr
+    nss
+    openssl_1_1
+    stdenv.cc.cc
+    systemd
+    wayland
+    zlib
 
-      xorg.libICE
-      xorg.libSM
-      xorg.libX11
-      xorg.libxcb
-      xorg.libXcomposite
-      xorg.libXcursor
-      xorg.libXdamage
-      xorg.libXext
-      xorg.libXfixes
-      xorg.libXi
-      xorg.libXrandr
-      xorg.libXrender
-      xorg.libXScrnSaver
-      xorg.libXtst
-      xorg.xcbutilimage
-      xorg.xcbutilkeysyms
-      xorg.xcbutilrenderutil
-      xorg.xcbutilwm
-  ]
-  ;
+    xorg.libICE
+    xorg.libSM
+    xorg.libX11
+    xorg.libxcb
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXScrnSaver
+    xorg.libXtst
+    xorg.xcbutilimage
+    xorg.xcbutilkeysyms
+    xorg.xcbutilrenderutil
+    xorg.xcbutilwm
+  ];
 
   installPhase = ''
     dpkg-deb -x $src $out

--- a/pkgs/applications/networking/instant-messengers/viber/default.nix
+++ b/pkgs/applications/networking/instant-messengers/viber/default.nix
@@ -5,6 +5,7 @@
   dpkg,
   makeWrapper,
   alsa-lib,
+  brotli,
   cups,
   curl,
   dbus,
@@ -14,31 +15,40 @@
   glib,
   gst_all_1,
   harfbuzz,
+  lcms,
   libcap,
+  libevent,
   libGL,
   libGLU,
+  libkrb5,
+  libopus,
   libpulseaudio,
   libxkbcommon,
+  libxkbfile,
   libxml2,
   libxslt,
+  libwebp,
+  mesa,
   nspr,
   nss,
-  openssl_1_1,
+  openssl,
+  snappy,
   systemd,
   wayland,
   xorg,
   zlib,
+  zstd,
   ...
 }:
 
 stdenv.mkDerivation {
   pname = "viber";
-  version = "16.1.0.37";
+  version = "21.8.0.11";
 
   src = fetchurl {
     # Official link: https://download.cdn.viber.com/cdn/desktop/Linux/viber.deb
-    url = "https://web.archive.org/web/20211119123858/https://download.cdn.viber.com/cdn/desktop/Linux/viber.deb";
-    sha256 = "sha256-hOz+EQc2OOlLTPa2kOefPJMUyWvSvrgqgPgBKjWE3p8=";
+    url = "https://download.cdn.viber.com/cdn/desktop/Linux/viber.deb";
+    hash = "sha256-RrObmN21QOm5nk0R2avgCH0ulrfiUIo2PnyYWvQaGVw=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -48,6 +58,7 @@ stdenv.mkDerivation {
 
   libPath = lib.makeLibraryPath [
     alsa-lib
+    brotli
     cups
     curl
     dbus
@@ -58,20 +69,29 @@ stdenv.mkDerivation {
     gst_all_1.gst-plugins-base
     gst_all_1.gstreamer
     harfbuzz
+    lcms
     libcap
+    libevent
     libGLU
     libGL
+    libkrb5
+    libopus
     libpulseaudio
     libxkbcommon
+    libxkbfile
     libxml2
     libxslt
+    libwebp
+    mesa
     nspr
     nss
-    openssl_1_1
+    openssl
+    snappy
     stdenv.cc.cc
     systemd
     wayland
     zlib
+    zstd
 
     xorg.libICE
     xorg.libSM


### PR DESCRIPTION
## Description of changes
Updates this package to the latest version, which also removes the dependency on openssl 1.1. There were a few more that needed to be added, but nothing major. There's no upstream changelog as far as I can see, so I can't link to one.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
