### PR TITLE
workflows/check-by-name: link to githubstatus

### DIFF
--- a/.github/workflows/check-by-name.yml
+++ b/.github/workflows/check-by-name.yml
@@ -58,7 +58,7 @@ jobs:
 
             if [[ "$mergeable" == "null" ]]; then
               if (( retryCount == 0 )); then
-                echo "Not retrying anymore, probably GitHub is having internal issues"
+                echo "Not retrying anymore. It's likely that GitHub is having internal issues: check https://www.githubstatus.com/"
                 exit 1
               else
                 (( retryCount -= 1 )) || true


### PR DESCRIPTION
GitHub is currently having some problems with actions: https://www.githubstatus.com/

Let's include a link to that from the `pkgs/by-name` check action.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
