### PR TITLE
sile: 0.14.17 → 0.15.5

### DIFF
--- a/pkgs/tools/typesetting/sile/default.nix
+++ b/pkgs/tools/typesetting/sile/default.nix
@@ -1,47 +1,54 @@
-{ lib
-, stdenv
-, darwin
-, fetchurl
-, makeWrapper
-, pkg-config
-, poppler_utils
-, gitMinimal
-, harfbuzz
-, icu
-, fontconfig
-, lua
-, libiconv
-, makeFontsConf
-, gentium
-, runCommand
-, sile
+{
+  lib,
+  stdenv,
+  darwin,
+  fetchurl,
+  makeWrapper,
+  pkg-config,
+  poppler_utils,
+  gitMinimal,
+  harfbuzz,
+  icu,
+  fontconfig,
+  lua,
+  libiconv,
+  makeFontsConf,
+  gentium,
+  runCommand,
+  sile,
 }:
 
 let
-  luaEnv = lua.withPackages(ps: with ps; [
-    cassowary
-    cldr
-    cosmo
-    fluent
-    linenoise
-    loadkit
-    lpeg
-    lua-zlib
-    lua_cliargs
-    luaepnf
-    luaexpat
-    luafilesystem
-    luarepl
-    luasec
-    luasocket
-    luautf8
-    penlight
-    vstruct
-  ] ++ lib.optionals (lib.versionOlder lua.luaversion "5.2") [
-    bit32
-  ] ++ lib.optionals (lib.versionOlder lua.luaversion "5.3") [
-    compat53
-  ]);
+  luaEnv = lua.withPackages (
+    ps:
+    with ps;
+    [
+      cassowary
+      cldr
+      cosmo
+      fluent
+      linenoise
+      loadkit
+      lpeg
+      lua-zlib
+      lua_cliargs
+      luaepnf
+      luaexpat
+      luafilesystem
+      luarepl
+      luasec
+      luasocket
+      luautf8
+      penlight
+      vstruct
+    ]
+    ++ lib.optionals (lib.versionOlder lua.luaversion "5.2") [
+      bit32
+    ]
+    ++ lib.optionals (lib.versionOlder lua.luaversion "5.3") [
+      compat53
+    ]
+  );
 in
 
 stdenv.mkDerivation (finalAttrs: {
@@ -69,9 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
     icu
     fontconfig
     libiconv
-  ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.AppKit
-  ;
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.AppKit;
   passthru = {
     # So it will be easier to inspect this environment, in comparison to others
     inherit luaEnv;
@@ -79,20 +84,27 @@ stdenv.mkDerivation (finalAttrs: {
     tests.test = lib.optionalAttrs (!(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)) (
       runCommand "sile-test"
         {
-          nativeBuildInputs = [ poppler_utils sile ];
+          nativeBuildInputs = [
+            poppler_utils
+            sile
+          ];
           inherit (finalAttrs) FONTCONFIG_FILE;
-        } ''
-        output=$(mktemp -t selfcheck-XXXXXX.pdf)
-        echo "<sile>foo</sile>" | sile -o $output -
-        pdfinfo $output | grep "SILE v${finalAttrs.version}" > $out
-      '');
+        }
+        ''
+          output=$(mktemp -t selfcheck-XXXXXX.pdf)
+          echo "<sile>foo</sile>" | sile -o $output -
+          pdfinfo $output | grep "SILE v${finalAttrs.version}" > $out
+        ''
+    );
   };
 
-  postPatch = ''
-    patchShebangs build-aux/*.sh
-  '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    sed -i -e 's|@import AppKit;|#import <AppKit/AppKit.h>|' src/macfonts.m
-  '';
+  postPatch =
+    ''
+      patchShebangs build-aux/*.sh
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      sed -i -e 's|@import AppKit;|#import <AppKit/AppKit.h>|' src/macfonts.m
+    '';
 
   NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-framework AppKit";
 
@@ -118,7 +130,12 @@ stdenv.mkDerivation (finalAttrs: {
     done
   '';
 
-  outputs = [ "out" "doc" "man" "dev" ];
+  outputs = [
+    "out"
+    "doc"
+    "man"
+    "dev"
+  ];
 
   meta = with lib; {
     description = "Typesetting system";
@@ -135,7 +152,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://sile-typesetter.org";
     changelog = "https://github.com/sile-typesetter/sile/raw/v${finalAttrs.version}/CHANGELOG.md";
     platforms = platforms.unix;
-    maintainers = with maintainers; [ doronbehar alerque ];
+    maintainers = with maintainers; [
+      doronbehar
+      alerque
+    ];
     license = licenses.mit;
     mainProgram = "sile";
   };


### PR DESCRIPTION
The upstream release is a big change from a pure Lua based CLI to Rust. The Rust CLI still includes a Lua VM that loads the rest of the system and the whole build is still autotools based, so *most* of the current derivation should apply including LuaRock dependencies. The only significant change is the addition of some Rust tooling.

See upstream release notes for [v0.15.0](https://github.com/sile-typesetter/sile/releases/tag/v0.15.0), [v0.15.1](https://github.com/sile-typesetter/sile/releases/tag/v0.15.1), [v0.15.2](https://github.com/sile-typesetter/sile/releases/tag/v0.15.2), [v0.15.3](https://github.com/sile-typesetter/sile/releases/tag/v0.15.3), [v0.15.4](https://github.com/sile-typesetter/sile/releases/tag/v0.15.4), and [v0.15.5](https://github.com/sile-typesetter/sile/releases/tag/v0.15.5).

Most of this is copied from the project's Flake which has adapted to the changes during the development process. The one thing *not* reflected here yet is the ability to change the Lua version by selecting a different package. I wasn't quite sure how to adapt that out of the flake into this derivation.

