### PR TITLE
gnome-pass-search-provider: init at 1.4.0

### DIFF
--- a/pkgs/by-name/gn/gnome-pass-search-provider/package.nix
+++ b/pkgs/by-name/gn/gnome-pass-search-provider/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  python3Packages,
+  wrapGAppsHook3,
+  gtk3,
+  gobject-introspection,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gnome-pass-search-provider";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "jle64";
+    repo = "gnome-pass-search-provider";
+    rev = finalAttrs.version;
+    hash = "sha256-PDR8fbDoT8IkHiTopQp0zd4DQg7JlacA6NdKYKYmrWw=";
+  };
+
+  nativeBuildInputs = [
+    python3Packages.wrapPython
+    wrapGAppsHook3
+  ];
+
+  propagatedBuildInputs = [
+    python3Packages.dbus-python
+    python3Packages.pygobject3
+    python3Packages.fuzzywuzzy
+    python3Packages.levenshtein
+
+    gtk3
+    gobject-introspection
+  ];
+
+  env = {
+    LIBDIR = placeholder "out" + "/lib";
+    DATADIR = placeholder "out" + "/share";
+  };
+
+  postPatch = ''
+    substituteInPlace  conf/org.gnome.Pass.SearchProvider.service.{dbus,systemd} \
+      --replace-fail "/usr/lib" "$LIBDIR"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    bash ./install.sh
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    makeWrapperArgs=( "''${gappsWrapperArgs[@]}" )
+    wrapPythonProgramsIn "$out/lib" "$out $propagatedBuildInputs"
+  '';
+
+  meta = {
+    description = "Pass password manager search provider for gnome-shell";
+    homepage = "https://github.com/jle64/gnome-pass-search-provider";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ lelgenio ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Repository: https://github.com/jle64/gnome-pass-search-provider

Tested copying password, other fields and OTP.

Sample configuration for usage:

```nix
{ pkgs, ... }: {
  programs.gnupg.agent = {
    enable = true;
    pinentryPackage = pkgs.pinentry-gnome3;
  };
  programs.gpaste.enable = true;
  environment.systemPackages =  with pkgs; [
    gnome-pass-search-provider
  ];
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
