### PR TITLE
treewide: fix name for appimages

### DIFF
--- a/pkgs/applications/blockchains/trezor-suite/default.nix
+++ b/pkgs/applications/blockchains/trezor-suite/default.nix
@@ -9,7 +9,6 @@
 let
   pname = "trezor-suite";
   version = "24.6.2";
-  name = "${pname}-${version}";
 
   suffix = {
     aarch64-linux = "linux-arm64";
@@ -17,7 +16,7 @@ let
   }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   src = fetchurl {
-    url = "https://github.com/trezor/${pname}/releases/download/v${version}/Trezor-Suite-${version}-${suffix}.AppImage";
+    url = "https://github.com/trezor/trezor-suite/releases/download/v${version}/Trezor-Suite-${version}-${suffix}.AppImage";
     hash = { # curl -Lfs https://github.com/trezor/trezor-suite/releases/download/v${version}/latest-linux{-arm64,}.yml | grep ^sha512 | sed 's/: /-/'
       aarch64-linux = "sha512-fJnka//9DbvTTq7GEN++6thU8f8BL4cHh1J4P/Tu9Eu94KWCHDG2IwFALOXEvZnwLbxFYiu3Cqldp2RIxYFXTA==";
       x86_64-linux  = "sha512-/gRQR1EriiwrDj04BTnhXlsawJgHp6TqgHpgVCMO1r+U2zGiFLdNfwG/SYwARE+55X8Umls5hCt/wuCpTEPkEg==";
@@ -25,16 +24,15 @@ let
   };
 
   appimageContents = appimageTools.extractType2 {
-    inherit name src;
+    inherit pname version src;
   };
 
 in
 
 appimageTools.wrapType2 rec {
-  inherit name src;
+  inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${name} $out/bin/${pname}
     mkdir -p $out/bin $out/share/${pname} $out/share/${pname}/resources
 
     cp -a ${appimageContents}/locales/ $out/share/${pname}

--- a/pkgs/applications/misc/mobilecoin-wallet/default.nix
+++ b/pkgs/applications/misc/mobilecoin-wallet/default.nix
@@ -3,21 +3,18 @@
 let
   pname = "mobilecoin-wallet";
   version = "1.8.0";
-  name = "${pname}-${version}";
   src = fetchurl {
     url = "https://github.com/mobilecoinofficial/desktop-wallet/releases/download/v${version}/MobileCoin.Wallet-${version}.AppImage";
     hash = "sha256-XGU/xxsMhOBAh+MeMtL2S707yH8HnoO9w5l7zqjO6rs=";
   };
-  appimageContents = appimageTools.extractType2 { inherit name src; };
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
 
 in appimageTools.wrapType2 {
-  inherit name src;
+  inherit pname version src;
 
   extraPkgs = pkgs: [ pkgs.libsecret ];
 
   extraInstallCommands = ''
-    mv $out/bin/${name} $out/bin/${pname}
-
     mkdir -p $out/share/${pname}
     cp -a ${appimageContents}/locales $out/share/${pname}
     cp -a ${appimageContents}/resources $out/share/${pname}

--- a/pkgs/applications/networking/cluster/lens/linux.nix
+++ b/pkgs/applications/networking/cluster/lens/linux.nix
@@ -1,20 +1,16 @@
 { pname, version, src, meta, appimageTools, makeWrapper }:
 let
-
-  name = "${pname}-${version}";
-
   appimageContents = appimageTools.extractType2 {
-    inherit name src;
+    inherit pname version src;
   };
 
 in
 
 appimageTools.wrapType2 {
-  inherit name src meta;
+  inherit pname version src meta;
 
   extraInstallCommands =
     ''
-      mv $out/bin/${name} $out/bin/${pname}
       source "${makeWrapper}/nix-support/setup-hook"
       wrapProgram $out/bin/${pname} \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"

--- a/pkgs/applications/networking/instant-messengers/beeper/default.nix
+++ b/pkgs/applications/networking/instant-messengers/beeper/default.nix
@@ -11,7 +11,6 @@
 let
   pname = "beeper";
   version = "3.106.2";
-  name = "${pname}-${version}";
   src = fetchurl {
     url = "https://download.todesktop.com/2003241lzgn20jd/beeper-3.106.2-build-240604xwl5q01pr-x86_64.AppImage";
     hash = "sha256-WbAWJJzk58UVmRN3RHmU/V6zPiLWAb7m7hns4gmP55M=";
@@ -25,7 +24,7 @@ let
   };
 in
 stdenvNoCC.mkDerivation rec {
-  inherit name pname version;
+  inherit pname version;
 
   src = appimage;
 

--- a/pkgs/applications/networking/instant-messengers/ripcord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ripcord/default.nix
@@ -14,7 +14,7 @@ mkDerivation rec {
       name = "${pname}-${version}.AppImage";
     };
   in appimageTools.extract {
-    name = "${pname}-${version}";
+    inherit pname version;
     src = appimage;
   };
 

--- a/pkgs/applications/networking/pcloud/default.nix
+++ b/pkgs/applications/networking/pcloud/default.nix
@@ -48,7 +48,7 @@ let
   };
 
   appimageContents = appimageTools.extractType2 {
-    name = "${pname}-${version}";
+    inherit pname version;
     src = "${src}/pcloud";
   };
 

--- a/pkgs/applications/office/super-productivity/default.nix
+++ b/pkgs/applications/office/super-productivity/default.nix
@@ -11,8 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   appimageContents = appimageTools.extractType2 {
-    name = "${pname}-${version}";
-    inherit src;
+    inherit pname version src;
   };
 
   dontUnpack = true;

--- a/pkgs/applications/video/freetube/default.nix
+++ b/pkgs/applications/video/freetube/default.nix
@@ -12,8 +12,7 @@ stdenv.mkDerivation rec {
   passthru.tests = nixosTests.freetube;
 
   appimageContents = appimageTools.extractType2 {
-    name = "${pname}-${version}";
-    inherit src;
+    inherit pname version src;
   };
 
   dontUnpack = true;

--- a/pkgs/by-name/im/immersed-vr/linux.nix
+++ b/pkgs/by-name/im/immersed-vr/linux.nix
@@ -4,7 +4,6 @@
 , meta
 , appimageTools
 }:
-appimageTools.wrapType2 rec {
+appimageTools.wrapType2 {
   inherit pname version src meta;
-  name = "${pname}-${version}";
 }

--- a/pkgs/by-name/wo/wowup-cf/package.nix
+++ b/pkgs/by-name/wo/wowup-cf/package.nix
@@ -3,19 +3,17 @@
 let
   version = "2.12.0";
   pname = "wowup-cf";
-  name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://github.com/WowUp/WowUp.CF/releases/download/v${version}/WowUp-CF-${version}.AppImage";
     hash = "sha256-uWz/EQBX/d1UBfpc9EL4x+UH72kINd6pqFIvJkV16e8=";
   };
 
-  appimageContents = appimageTools.extractType1 { inherit name src; };
+  appimageContents = appimageTools.extractType1 { inherit pname version src; };
 in appimageTools.wrapType1 {
-  inherit name src;
+  inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${name} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/${pname}.desktop \
       --replace 'Exec=AppRun' 'Exec=${pname}'

--- a/pkgs/os-specific/linux/uhk-agent/default.nix
+++ b/pkgs/os-specific/linux/uhk-agent/default.nix
@@ -21,8 +21,7 @@ let
   };
 
   appimageContents = appimageTools.extract {
-    name = "${pname}-${version}";
-    inherit src;
+    inherit pname version src;
   };
 in
 stdenvNoCC.mkDerivation {


### PR DESCRIPTION
## Description of changes

More followup fixes related to #271071.

Candidates identified with:

```sh
git grep -l --all-match -e appimage --or -e 'name = "\${pname}-\${version}"'
```

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>lens</li>
    <li>mobilecoin-wallet</li>
    <li>trezor-suite</li>
    <li>wowup-cf</li>
  </ul>
</details>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
