### PR TITLE
tabiew: 0.3.5 -> 0.4.1

### DIFF
--- a/pkgs/by-name/ta/tabiew/package.nix
+++ b/pkgs/by-name/ta/tabiew/package.nix
@@ -5,16 +5,16 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "tabiew";
-  version = "0.3.5";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "shshemi";
     repo = "tabiew";
     rev = "v${version}";
-    hash = "sha256-ObS+8901Uw9mIzMK14D0UgCWJFRNaQ0tOIq5merHYIo=";
+    hash = "sha256-/W6ffanDg+p0g5MFUEF9bjWmYPWjZeCGmHqbruju2hk=";
   };
 
-  cargoHash = "sha256-vOdjHBR/FZjYkLMvPvBZ/xTPKXgchv92BQSLLodymgY=";
+  cargoHash = "sha256-dBk6lfUG7MFJCOdDt+LpkewnYS/awqCLPLUCFSyi5Y8=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
 meta.homepage for tabiew is: https://github.com/shshemi/tabiew
 
 meta.changelog for tabiew is: https://github.com/shshemi/tabiew/releases/tag/v0.4.1
 ###### To inspect upstream changes
 
* [Release on GitHub](https://github.com/shshemi/tabiew/releases/tag/v0.4.1)
 * [Compare changes on GitHub](https://github.com/shshemi/tabiew/compare/v0.3.5...v0.4.1)
 
 
