### PR TITLE
spotdl: added patch for `syncedlyrics.utils` build failure

### DIFF
--- a/pkgs/tools/audio/spotdl/default.nix
+++ b/pkgs/tools/audio/spotdl/default.nix
@@ -22,6 +22,9 @@ python3.pkgs.buildPythonApplication rec {
 
   pythonRelaxDeps = true;
 
+  # Remove when https://github.com/spotDL/spotify-downloader/issues/2119 is fixed
+  patches = [ ./is_lrc_valid-failure.patch ];
+
   dependencies = with python3.pkgs; [
     bandcamp-api
     beautifulsoup4

--- a/pkgs/tools/audio/spotdl/is_lrc_valid-failure.patch
+++ b/pkgs/tools/audio/spotdl/is_lrc_valid-failure.patch
@@ -1,0 +1,65 @@
+From 0c1357470450d98b3b7fe5444ac460ba9ee04425 Mon Sep 17 00:00:00 2001
+From: Jeremy Cutler <jerz4lunch@users.noreply.github.com>
+Date: Mon, 17 Jun 2024 02:19:33 -0700
+Subject: [PATCH 1/2] Update lrc.py for updated function in python-syncedlyrics
+
+See syncedlyrics commit: [here](https://github.com/moehmeni/syncedlyrics/commit/64d3f9de3d17bec69cbc3b3b5acd1ab847fde4b2)
+---
+ spotdl/utils/lrc.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/spotdl/utils/lrc.py b/spotdl/utils/lrc.py
+index 726fefbee..e59490b53 100644
+--- a/spotdl/utils/lrc.py
++++ b/spotdl/utils/lrc.py
+@@ -7,7 +7,7 @@
+ from pathlib import Path
+
+ from syncedlyrics import search as syncedlyrics_search
+-from syncedlyrics.utils import is_lrc_valid, save_lrc_file
++from syncedlyrics.utils import has_translation, save_lrc_file
+
+ from spotdl.types.song import Song
+
+@@ -25,7 +25,7 @@ def generate_lrc(song: Song, output_file: Path):
+     - output_file: Path to the output file
+     """
+
+-    if song.lyrics and is_lrc_valid(song.lyrics):
++    if song.lyrics and has_translation(song.lyrics):
+         lrc_data = song.lyrics
+     else:
+         try:
+
+From bfa9456049132e64b5c83655bdeae7c9dcd1b532 Mon Sep 17 00:00:00 2001
+From: Jeremy Cutler <jerz4lunch@users.noreply.github.com>
+Date: Wed, 26 Jun 2024 18:06:59 -0700
+Subject: [PATCH 2/2] Update lrc.py
+
+Seems to have fixed the update of syncedlyrics to 1.0.0
+---
+ spotdl/utils/lrc.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/spotdl/utils/lrc.py b/spotdl/utils/lrc.py
+index e59490b53..cf7478214 100644
+--- a/spotdl/utils/lrc.py
++++ b/spotdl/utils/lrc.py
+@@ -7,7 +7,7 @@
+ from pathlib import Path
+
+ from syncedlyrics import search as syncedlyrics_search
+-from syncedlyrics.utils import has_translation, save_lrc_file
++from syncedlyrics.utils import has_translation, Lyrics
+
+ from spotdl.types.song import Song
+
+@@ -34,7 +34,7 @@ def generate_lrc(song: Song, output_file: Path):
+             lrc_data = None
+
+     if lrc_data:
+-        save_lrc_file(str(output_file.with_suffix(".lrc")), lrc_data)
++        Lyrics.save_lrc_file(str(output_file.with_suffix(".lrc")), lrc_data)
+         logger.debug("Saved lrc file for %s", song.display_name)
+     else:
+         logger.debug("No lrc file found for %s", song.display_name)


### PR DESCRIPTION
## Description of changes

closes https://github.com/NixOS/nixpkgs/issues/323570

fixes the failure experienced in https://github.com/spotDL/spotify-downloader/issues/2119. 

an example of the build error on my machine is:

```
       last 10 log lines:
       > spotdl/console/entry_point.py:10: in <module>
       >     from spotdl.console.download import download
       > spotdl/console/download.py:7: in <module>
       >     from spotdl.download.downloader import Downloader
       > spotdl/download/downloader.py:44: in <module>
       >     from spotdl.utils.lrc import generate_lrc
       > spotdl/utils/lrc.py:10: in <module>
       >     from syncedlyrics.utils import is_lrc_valid, save_lrc_file
       > E   ImportError: cannot import name 'is_lrc_valid' from 'syncedlyrics.utils' (/nix/store/b004zyxjil28rlzc0ykcvk6f9sxwxzcv-python3.11-syncedlyrics-1.0.0/lib/python3.11/site-packages/syncedlyrics/utils.py)
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
