### PR TITLE
pdal: 2.7.1 -> 2.7.2

### DIFF
--- a/pkgs/development/libraries/pdal/default.nix
+++ b/pkgs/development/libraries/pdal/default.nix
@@ -19,6 +19,7 @@
 , pkg-config
 , postgresql
 , proj
+, sqlite
 , tiledb
 , xercesc
 , zlib
@@ -27,13 +28,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pdal";
-  version = "2.7.1";
+  version = "2.7.2";
 
   src = fetchFromGitHub {
     owner = "PDAL";
     repo = "PDAL";
     rev = finalAttrs.version;
-    sha256 = "sha256-JoHBxJ0hCWH7ZhmeJk4huT2k0AK5CzIV58NWCjWj5T0=";
+    sha256 = "sha256-ukBZLr/iyYQ68sv9JWrR4YP0ahHfGhytgcWKPzrF3Ps=";
   };
 
   nativeBuildInputs = [
@@ -52,6 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
     openscenegraph
     postgresql
     proj
+    sqlite
     tiledb
     xercesc
     zlib
@@ -87,12 +89,6 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   disabledTests = [
-    # Failing due to GDAL 3.9 change in coordinates precision.
-    # See: https://github.com/PDAL/PDAL/issues/4403
-    # This test should be re-enabled once https://github.com/PDAL/PDAL/pull/4411
-    # is merged !
-    "pdal_io_ogr_writer_test"
-
     # Tests failing due to TileDB library implementation, disabled also
     # by upstream CI.
     # See: https://github.com/PDAL/PDAL/blob/bc46bc77f595add4a6d568a1ff923d7fe20f7e74/.github/workflows/linux.yml#L81


### PR DESCRIPTION
## Description of changes

Update PDAL to the latest patch version.

Release notes:
https://github.com/PDAL/PDAL/releases/tag/2.7.2


`sqlite` build dependency was added because of following error. Most probably caused by https://github.com/PDAL/PDAL/commit/8a9db9bf9bdadb0613040da210283f397eeebbcc .

```
 CMake Error at /nix/store/ih3wsahlr3d787jc4kzqizp6syq6hy29-cmake-3.29.3/share/cmake-3.29/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find SQLite3 (missing: SQLite3_INCLUDE_DIR SQLite3_LIBRARY)
Call Stack (most recent call first):
  /nix/store/ih3wsahlr3d787jc4kzqizp6syq6hy29-cmake-3.29.3/share/cmake-3.29/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  /nix/store/ih3wsahlr3d787jc4kzqizp6syq6hy29-cmake-3.29.3/share/cmake-3.29/Modules/FindSQLite3.cmake:54 (find_package_handle_standard_args)
  /nix/store/ih3wsahlr3d787jc4kzqizp6syq6hy29-cmake-3.29.3/share/cmake-3.29/Modules/CMakeFindDependencyMacro.cmake:76 (find_package)
  /nix/store/1ql6wsd9v88l3j1qh9y7qi3ybvs9qzqf-proj-9.4.1-dev/lib/cmake/proj/proj-config.cmake:34 (find_dependency)
  cmake/proj.cmake:1 (find_package)
  CMakeLists.txt:102 (include) 
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
