### PR TITLE
glasgow: unstable-2023-09-20 -> unstable-2024-06-28

### DIFF
--- a/pkgs/development/python-modules/amaranth/default.nix
+++ b/pkgs/development/python-modules/amaranth/default.nix
@@ -6,6 +6,7 @@
   pdm-backend,
   pyvcd,
   jinja2,
+  jschon,
   importlib-resources,
   importlib-metadata,
   git,
@@ -20,14 +21,14 @@
 buildPythonPackage rec {
   pname = "amaranth";
   format = "pyproject";
-  version = "0.4.5";
+  version = "0.5.0";
   disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "amaranth-lang";
     repo = "amaranth";
     rev = "refs/tags/v${version}";
-    hash = "sha256-g9dn6gUTdFHz9GMWHERsRLWHoI3E7vjuQDK0usbZO7g=";
+    hash = "sha256-+EV2NgYSuCbYTQKeBUN+/D0attfrJ3cso7U6RjLEIbg=";
   };
 
   nativeBuildInputs = [
@@ -39,6 +40,7 @@ buildPythonPackage rec {
     [
       jinja2
       pyvcd
+      jschon
     ]
     ++ lib.optional (pythonOlder "3.9") importlib-resources
     ++ lib.optional (pythonOlder "3.8") importlib-metadata;

--- a/pkgs/development/python-modules/fx2/default.nix
+++ b/pkgs/development/python-modules/fx2/default.nix
@@ -1,9 +1,10 @@
 {
   lib,
   buildPythonPackage,
-  python,
   fetchFromGitHub,
   sdcc,
+  setuptools,
+  setuptools-scm,
   libusb1,
   crcmod,
 }:
@@ -11,7 +12,7 @@
 buildPythonPackage rec {
   pname = "fx2";
   version = "0.13";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "whitequark";
@@ -20,12 +21,21 @@ buildPythonPackage rec {
     hash = "sha256-PtWxjT+97+EeNMN36zOT1+ost/w3lRRkaON3Cl3dpp4=";
   };
 
-  nativeBuildInputs = [ sdcc ];
+  nativeBuildInputs = [
+    sdcc
+    setuptools
+    setuptools-scm
+  ];
 
   propagatedBuildInputs = [
     libusb1
     crcmod
   ];
+
+  postPatch = ''
+    substituteInPlace software/pyproject.toml \
+      --replace-fail 'setuptools~=67.0' 'setuptools'
+  '';
 
   preBuild = ''
     make -C firmware

--- a/pkgs/development/python-modules/jschon/default.nix
+++ b/pkgs/development/python-modules/jschon/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  rfc3986,
+  setuptools,
+
+  # for tests
+  pytestCheckHook,
+  tox,
+  coverage,
+  hypothesis,
+  pytest-benchmark,
+  pytest-httpserver,
+  requests,
+}:
+
+buildPythonPackage rec {
+  pname = "jschon";
+  pyproject = true;
+  version = "0.11.1";
+
+  src = fetchFromGitHub {
+    owner = "marksparkza";
+    repo = "jschon";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-uOvEIEUEILsoLuV5U9AJCQAlT4iHQhsnSt65gfCiW0k=";
+    fetchSubmodules = true;
+  };
+
+  dependencies = [
+    setuptools
+    rfc3986
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    tox
+    coverage
+    hypothesis
+    pytest-benchmark
+    pytest-httpserver
+    requests
+  ];
+
+  pythonImportsCheck = [ "jschon" ];
+
+  meta = with lib; {
+    description = "Object-oriented JSON Schema implementation for Python";
+    homepage = "https://github.com/marksparkza/jschon";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/tools/misc/glasgow/default.nix
+++ b/pkgs/tools/misc/glasgow/default.nix
@@ -9,19 +9,20 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "glasgow";
-  version = "unstable-2023-09-20";
-  # python -m setuptools_scm
-  realVersion = "0.1.dev1798+g${lib.substring 0 7 src.rev}";
+  version = "unstable-2024-06-28";
+  realVersion = "0.1.dev2085+g${lib.substring 0 7 src.rev}";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "GlasgowEmbedded";
     repo = "glasgow";
-    rev = "e9a9801d5be3dcba0ee188dd8a6e9115e337795d";
-    sha256 = "sha256-ztB3I/jrDSm1gKB1e5igivUVloq+YYhkshDlWg75NMA=";
+    rev = "a599e3caa64c2e445358894fd050e16917f2ee42";
+    sha256 = "sha256-5qg0/j1MgwHMOjySBY5cKuQqlqltV5cXcR/Ap6J9vys=";
   };
 
   nativeBuildInputs = [
-    python3.pkgs.setuptools-scm
+    python3.pkgs.unittestCheckHook
+    python3.pkgs.pdm-backend
     sdcc
   ];
 
@@ -34,6 +35,7 @@ python3.pkgs.buildPythonApplication rec {
     fx2
     libusb1
     packaging
+    platformdirs
     pyvcd
     setuptools
   ];
@@ -46,7 +48,7 @@ python3.pkgs.buildPythonApplication rec {
     make -C firmware LIBFX2=${python3.pkgs.fx2}/share/libfx2
     cp firmware/glasgow.ihex software/glasgow
     cd software
-    export SETUPTOOLS_SCM_PRETEND_VERSION="${realVersion}"
+    export PDM_BUILD_SCM_VERSION="${realVersion}"
   '';
 
   # installCheck tries to build_ext again
@@ -54,16 +56,16 @@ python3.pkgs.buildPythonApplication rec {
 
   postInstall = ''
     mkdir -p $out/etc/udev/rules.d
-    cp $src/config/99-glasgow.rules $out/etc/udev/rules.d
+    cp $src/config/70-cypress.rules $out/etc/udev/rules.d
+    cp $src/config/70-glasgow.rules $out/etc/udev/rules.d
   '';
 
-  checkPhase = ''
+  preCheck = ''
     # tests attempt to cache bitstreams
     # for linux:
     export XDG_CACHE_HOME=$TMPDIR
     # for darwin:
     export HOME=$TMPDIR
-    ${python3.interpreter} -W ignore::DeprecationWarning test.py
   '';
 
   makeWrapperArgs = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6204,6 +6204,8 @@ self: super: with self; {
 
   jschema-to-python = callPackage ../development/python-modules/jschema-to-python { };
 
+  jschon = callPackage ../development/python-modules/jschon { };
+
   jsmin = callPackage ../development/python-modules/jsmin { };
 
   json5 = callPackage ../development/python-modules/json5 { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* Glasgow: https://github.com/GlasgowEmbedded/glasgow/compare/e9a9801d5be3dcba0ee188dd8a6e9115e337795d...a599e3caa64c2e445358894fd050e16917f2ee42
* Updated amaranth to supported version (0.5.0)
  * Added new dependency (jschon)
* Migrated fx2 to pyproject-based build so that version stamping works properly 


pbsds edit: conflicts with and closes https://github.com/NixOS/nixpkgs/pull/322278

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
