### PR TITLE
Kindle Comic Converter (kcc) : 5.5.1 -> 7.3.3

### DIFF
--- a/pkgs/by-name/kc/kcc/package.nix
+++ b/pkgs/by-name/kc/kcc/package.nix
@@ -1,0 +1,60 @@
+{
+  stdenv,
+  lib,
+  qt6,
+  fetchFromGitHub,
+  p7zip,
+  versionCheckHook,
+  nix-update-script,
+  python3,
+  archiveSupport ? true,
+}:
+python3.pkgs.buildPythonApplication rec {
+  pname = "kcc";
+  version = "7.3.3";
+
+  src = fetchFromGitHub {
+    owner = "ciromattia";
+    repo = "kcc";
+    tag = "v${version}";
+    hash = "sha256-6zHUV4s1bOdARsTwNRxFM+s0p+6FLJhqJ9qG5BaBgas=";
+  };
+
+  nativeBuildInputs = [ qt6.wrapQtAppsHook ];
+
+  buildInputs = [ qt6.qtbase ] ++ lib.optionals stdenv.hostPlatform.isLinux [ qt6.qtwayland ];
+  propagatedBuildInputs = with python3.pkgs; [
+    packaging
+    pillow
+    psutil
+    python-slugify
+    raven
+    requests
+    natsort
+    mozjpeg_lossless_optimization
+    distro
+    pyside6
+    numpy
+  ];
+
+  qtWrapperArgs = lib.optionals archiveSupport [ ''--prefix PATH : ${lib.makeBinPath [ p7zip ]}'' ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/kcc-c2e";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Python app to convert comic/manga files or folders to EPUB, Panel View MOBI or E-Ink optimized CBZ";
+    homepage = "https://kcc.iosphe.re";
+    mainProgram = "kcc";
+    changelog = "https://github.com/ciromattia/kcc/releases/tag/v${version}";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [
+      dawidsowa
+      adfaure
+    ];
+  };
+}

--- a/pkgs/development/python-modules/mozjpeg_lossless_optimization/default.nix
+++ b/pkgs/development/python-modules/mozjpeg_lossless_optimization/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  buildPythonPackage,
+  mozjpeg,
+  pytestCheckHook,
+  setuptools,
+  cmake,
+  nix-update-script,
+  cffi,
+}:
+buildPythonPackage rec {
+  pname = "mozjpeg_lossless_optimization";
+  version = "1.1.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "wanadev";
+    repo = "mozjpeg-lossless-optimization";
+    # https://github.com/NixOS/nixpkgs/issues/26302
+    rev = "refs/tags/v${version}";
+    hash = "sha256-OKNt9XtfZ6hhRJN1Asn1T2dVjyXKQAsnFvXKYnrRZ98=";
+    fetchSubmodules = true;
+  };
+
+  # This package needs cmake, but it is not the default builder
+  dontUseCmakeConfigure = true;
+
+  buildInputs = [ mozjpeg ];
+  nativeBuildInputs = [ cmake ];
+  propagatedBuildInputs = [ cffi ];
+
+  # https://github.com/NixOS/nixpkgs/issues/255262
+  preCheck = ''
+    rm -r mozjpeg_lossless_optimization
+  '';
+
+  build-system = [ setuptools ];
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Python library to optimize JPEGs losslessly using MozJPEG";
+    homepage = "https://github.com/wanadev/mozjpeg-lossless-optimization";
+    changelog = "https://github.com/wanadev/mozjpeg-lossless-optimization/releases/tag/v${version}";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.adfaure ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7420,8 +7420,6 @@ with pkgs;
 
   jenkins-job-builder = with python3Packages; toPythonApplication jenkins-job-builder;
 
-  kcc = callPackage ../applications/graphics/kcc { };
-
   kustomize = callPackage ../development/tools/kustomize { };
 
   kustomize_3 = callPackage ../development/tools/kustomize/3.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9154,6 +9154,10 @@ self: super: with self; {
 
   mozilla-django-oidc = callPackage ../development/python-modules/mozilla-django-oidc { };
 
+  mozjpeg_lossless_optimization =
+    callPackage ../development/python-modules/mozjpeg_lossless_optimization
+      { };
+
   mpd2 = callPackage ../development/python-modules/mpd2 { };
 
   mpegdash = callPackage ../development/python-modules/mpegdash { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Update of https://github.com/ciromattia/kcc ([changelog is outdated](https://github.com/ciromattia/kcc/blob/master/CHANGELOG.md)).
  - The pypi package has not beed updated since 2020, so I used the github repository.

- This PR also adds this python package: https://github.com/wanadev/mozjpeg-lossless-optimization, which is a dependency for kcc.

- I added myself as a maintainer. Since I am already involved in another PR (https://github.com/NixOS/nixpkgs/pull/320783) that add my profile as a contributor, I cherry-picked the commit (maybe it is a bad idea :sweat_smile: )

Fixes #219115
Fixes #396679

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
