### PR TITLE
 plex-desktop: init at 1.96.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4866,6 +4866,12 @@
     github = "Detegr";
     githubId = 724433;
   };
+  detroyejr = {
+    name = "Jonathan De Troye";
+    email = "detroyejr@outlook.com";
+    github = "detroyejr";
+    githubId = 12815411;
+  };
   Dettorer = {
     name = "Paul Hervot";
     email = "paul.hervot@dettorer.net";

--- a/pkgs/by-name/pl/plex-desktop/package.nix
+++ b/pkgs/by-name/pl/plex-desktop/package.nix
@@ -128,7 +128,7 @@ buildFHSEnv {
       mkdir -p $out/share/applications $out/share/icons/hicolor/scalable/apps
       install -m 444 -D ${plex-desktop}/meta/gui/plex-desktop.desktop $out/share/applications/plex-desktop.desktop
       substituteInPlace $out/share/applications/plex-desktop.desktop \
-        --replace-warn \
+        --replace-fail \
         'Icon=''${SNAP}/meta/gui/icon.png' \
         'Icon=${plex-desktop}/meta/gui/icon.png' \
         --replace-fail \

--- a/pkgs/by-name/pl/plex-desktop/package.nix
+++ b/pkgs/by-name/pl/plex-desktop/package.nix
@@ -1,0 +1,151 @@
+{ alsa-lib
+, autoPatchelfHook
+, buildFHSEnv
+, dbus
+, elfutils
+, expat
+, extraEnv ? { }
+, fetchFromGitLab
+, fetchurl
+, glib
+, glibc
+, lib
+, libGL
+, libapparmor
+, libbsd
+, libedit
+, libffi_3_3
+, libgcrypt
+, libglvnd
+, makeShellWrapper
+, sqlite
+, squashfsTools
+, stdenv
+, tcp_wrappers
+, udev
+, waylandpp
+, writeShellScript
+, xkeyboard_config
+, xorg
+, xz
+, zstd
+}:
+let
+  pname = "plex-desktop";
+  version = "1.96.0";
+  rev = "69";
+  meta = {
+    homepage = "https://plex.tv/";
+    description = "Streaming media player for Plex";
+    longDescription = ''
+      Plex for Linux is your client for playback on the Linux
+      desktop. It features the point and click interface you see in your browser
+      but uses a more powerful playback engine as well as
+      some other advance features.
+    '';
+    maintainers = with lib.maintainers; [ detroyejr ];
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "plex-desktop";
+  };
+
+  # The latest unstable version isn't compatible with libraries that ship in the snap.
+  libglvnd-1_4_0 = libglvnd.overrideAttrs {
+    src = fetchFromGitLab {
+      domain = "gitlab.freedesktop.org";
+      owner = "glvnd";
+      repo = "libglvnd";
+      rev = "v1.4.0";
+      sha256 = "sha256-Y6JHRygXcZtnrdnqi1Lzyvh/635gwZWnMeW9aRCpxxs";
+    };
+  };
+  plex-desktop = stdenv.mkDerivation {
+    inherit pname version meta;
+
+    src = fetchurl {
+      url = "https://api.snapcraft.io/api/v1/snaps/download/qc6MFRM433ZhI1XjVzErdHivhSOhlpf0_${rev}.snap";
+      hash = "sha512-rECc8rK1ENAL5mXdabO8ynudCaSzz0yygOyg4gMbCtddgqwSOanP24/oguzPLr3zdRMC3VSf9B3hr2BGQ54tzg==";
+    };
+
+    nativeBuildInputs = [ squashfsTools ];
+
+    buildInputs = [
+      alsa-lib
+      autoPatchelfHook
+      dbus
+      elfutils
+      expat
+      glib
+      glibc
+      libGL
+      libapparmor
+      libbsd
+      libedit
+      libffi_3_3
+      libgcrypt
+      makeShellWrapper
+      sqlite
+      squashfsTools
+      stdenv.cc.cc
+      tcp_wrappers
+      udev
+      waylandpp
+      xorg.libXinerama
+      xz
+      zstd
+    ];
+
+    unpackPhase = ''
+      runHook preUnpack
+      unsquashfs "$src"
+      cd squashfs-root
+      runHook postUnpack
+    '';
+
+    dontWrapQtApps = true;
+
+    installPhase =
+      ''
+        runHook preInstall
+
+        cp -r . $out
+
+        ln -s ${libedit}/lib/libedit.so.0 $out/lib/libedit.so.2
+        rm $out/usr/lib/x86_64-linux-gnu/libasound.so.2
+        ln -s ${alsa-lib}/lib/libasound.so.2 $out/usr/lib/x86_64-linux-gnu/libasound.so.2
+        rm $out/usr/lib/x86_64-linux-gnu/libasound.so.2.0.0
+        ln -s ${alsa-lib}/lib/libasound.so.2.0.0 $out/usr/lib/x86_64-linux-gnu/libasound.so.2.0.0
+
+        runHook postInstall
+      '';
+  };
+in
+buildFHSEnv {
+    name = "${pname}-${version}";
+    targetPkgs = pkgs: [ xkeyboard_config ];
+
+    extraInstallCommands = ''
+      mkdir -p $out/share/applications $out/share/icons/hicolor/scalable/apps
+      install -m 444 -D ${plex-desktop}/meta/gui/plex-desktop.desktop $out/share/applications/plex-desktop.desktop
+      substituteInPlace $out/share/applications/plex-desktop.desktop \
+        --replace-warn \
+        'Icon=''${SNAP}/meta/gui/icon.png' \
+        'Icon=${plex-desktop}/meta/gui/icon.png' \
+        --replace-fail \
+        'Exec=plex-desktop' \
+        'Exec=plex-desktop-${version}'
+    '';
+
+    runScript = writeShellScript "plex-desktop.sh" ''
+      # Widevine won't download unless this directory exists.
+      mkdir -p $HOME/.cache/plex/
+      PLEX_USR_PATH=${lib.makeSearchPath "usr/lib/x86_64-linux-gnu"  [ plex-desktop ]}
+
+      set -o allexport
+      LD_LIBRARY_PATH=${lib.makeLibraryPath [ plex-desktop libglvnd-1_4_0 ]}:$PLEX_USR_PATH
+      LIBGL_DRIVERS_PATH=$PLEX_USR_PATH/dri
+      ${lib.toShellVars extraEnv}
+      exec ${plex-desktop}/Plex.sh
+  '';
+}
+

--- a/pkgs/by-name/pl/plex-desktop/update.sh
+++ b/pkgs/by-name/pl/plex-desktop/update.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p curl jq git gnused gnugrep
+
+
+# executing this script without arguments will
+# - find the newest stable plex-desktop version avaiable on snapcraft (https://snapcraft.io/plex-desktop)
+# - read the current plex-desktop version from the current nix expression
+# - update the nix expression if the versions differ
+# - try to build the updated version, exit if that fails
+# - give instructions for upstreaming
+
+# As an optional argument you can specify the snapcraft channel to update to.
+# Default is `stable` and only stable updates should be pushed to nixpkgs. For
+# testing you may specify `candidate` or `edge`.
+
+
+channel="${1:-stable}" # stable/candidate/edge
+nixpkgs="$(git rev-parse --show-toplevel)"
+plex_nix="$nixpkgs/pkgs/by-name/pl/plex-desktop/package.nix"
+
+
+#
+# find the newest stable plex-desktop version avaiable on snapcraft
+#
+
+# create bash array from snap info
+snap_info=($(
+  curl -s -H 'X-Ubuntu-Series: 16' \
+    "https://api.snapcraft.io/api/v1/snaps/details/plex-desktop?channel=$channel" \
+  | jq --raw-output \
+    '.revision,.download_sha512,.version,.last_updated'
+))
+
+# "revision" is the actual version identifier on snapcraft, the "version" is
+# just for human consumption. Revision is just an integer that gets increased
+# by one every (stable or unstable) release.
+revision="${snap_info[0]}"
+# We need to escape the slashes
+hash="$(nix-hash --to-sri --type sha512 ${snap_info[1]} | sed 's|/|\\/|g')"
+upstream_version="${snap_info[2]}"
+last_updated="${snap_info[3]}"
+echo "Latest $channel release is $upstream_version from $last_updated."
+#
+# read the current plex-desktop version from the currently *committed* nix expression
+#
+
+current_version=$(
+  grep 'version\s*=' "$plex_nix" \
+  | sed -Ene 's/.*"(.*)".*/\1/p'
+)
+
+echo "Current version: $current_version"
+
+#
+# update the nix expression if the versions differ
+#
+
+if [[ "$current_version" == "$upstream_version" ]]; then
+  echo "Plex is already up-to-date"
+  exit 0
+fi
+
+echo "Updating from ${current_version} to ${upstream_version}, released on ${last_updated}"
+
+# search-and-replace revision, hash and version
+sed --regexp-extended \
+  -e 's/rev\s*=\s*"[0-9]+"\s*;/rev = "'"${revision}"'";/' \
+  -e 's/hash\s*=\s*"[^"]*"\s*;/hash = "'"${hash}"'";/' \
+  -e 's/version\s*=\s*".*"\s*;/version = "'"${upstream_version}"'";/' \
+  -i "$plex_nix"
+
+#
+# try to build the updated version
+#
+
+if ! nix-build -A plex-desktop "$nixpkgs"; then
+  echo "The updated plex-desktop failed to build."
+  exit 1
+fi
+
+# Commit changes
+git add "$plex_nix"
+git commit -m "plex-desktop: ${current_version} -> ${upstream_version}"


### PR DESCRIPTION
## Description of changes

plex-desktop: init at 1.95.3

Based on the [spotify](https://github.com/NixOS/nixpkgs/blob/d0f207da0e472ca4bd1de8e14f827ab92b1fdcd0/pkgs/applications/audio/spotify/linux.nix) derivation which pulls from the snap store. Also borrowed the excellent update script from there as well.

Fixes https://github.com/NixOS/nixpkgs/issues/252131

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Updated TODO for 2024-07-11:

- [ ] Downloads
- [ ] Investigate Plex & Plex,sh processes hang around after closing the app. Other apps do this so this though, so maybe this isn't specific to Plex.

---

Original Post

Tested this on 3 different NixOS systems and everything generally works.

* Gnome (w/ integrated Intel GPU) - everything works & always launches successfully.
* Hyprland (w/ integrated intel GPU) - sometimes fails to launch for an unknown reason. Messing with `QT_QPA_PLATFORM=xcb` generally works.
* Hyprland (w/ Nvidia) - needs [`nvidia-offload`](https://nixos.wiki/wiki/Nvidia) environment variables set (see below). Works flawlessly.

```
export __NV_PRIME_RENDER_OFFLOAD=1
export __NV_PRIME_RENDER_OFFLOAD_PROVIDER=NVIDIA-G0
export __GLX_VENDOR_LIBRARY_NAME=nvidia
export __VK_LAYER_NV_optimus=NVIDIA_only
```

The steam derivation provide an `extraEnv` option which seems like a reasonable solution. In my own configuration, I just override those as needed for this one particular machine. This is probably what I'll do unless someone someone has a better suggestion.

```
# Override the package passed to programs.steam.package based on the isNvidia flag in my config.
pkgs.steam-small.override
{
  extraEnv =
    if isNvidia
    then {
       __NV_PRIME_RENDER_OFFLOAD = 1;
       __NV_PRIME_RENDER_OFFLOAD_PROVIDER = "NVIDIA-G0";
       __GLX_VENDOR_LIBRARY_NAME = "nvidia";
       __VK_LAYER_NV_optimus = "NVIDIA_only";
    }
    else {};
};
```

I'd appreciate any feedback on this that would make this launch more reliably.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
