### PR TITLE
netbsd.libcMinimal: Cut down on deps, don't build tags

### DIFF
--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -98,7 +98,7 @@ makeScopeWithSplicing' {
         inherit (buildNetbsd) makeMinimal;
       };
 
-      libcMinimal = self.callPackage ./pkgs/libcMinimal.nix {
+      libcMinimal = self.callPackage ./pkgs/libcMinimal/package.nix {
         inherit (self) headers csu;
         inherit (buildNetbsd)
           netbsdSetupHook

--- a/pkgs/os-specific/bsd/netbsd/pkgs/libcMinimal/0001-Allow-building-libc-without-generating-tags.patch
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/libcMinimal/0001-Allow-building-libc-without-generating-tags.patch
@@ -1,0 +1,53 @@
+From 62acd447e36d5009d3008e025df72c08690905d5 Mon Sep 17 00:00:00 2001
+From: John Ericson <John.Ericson@Obsidian.Systems>
+Date: Thu, 20 Jun 2024 15:48:54 -0400
+Subject: [PATCH] Allow building libc without generating tags
+
+When bootstrapping from scratch, it is nice to avoid dependencies (like
+`ctags`/`genassym`/etc.) that are not strictly needed.
+
+This makefile change introduces a new `MK_LIBC_TAGS` variable, defaulted
+to `yes`, to control whether `make all` / `make install` should
+build/install (respectively) the tags.
+
+The underlying rules for tags can still be run regardless of the choice
+of variable.
+---
+ lib/libc/Makefile | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/lib/libc/Makefile b/lib/libc/Makefile
+index f2dab2a090e7..c6aa5e45f959 100644
+--- a/lib/libc/Makefile
++++ b/lib/libc/Makefile
+@@ -132,7 +132,12 @@ MKREPRO_SED=   -e 's;${NETBSDSRCDIR:C/${REGEX_SPECIALS}/\\\\&/g};/usr/src;'
+ .endif
+ 
+ .if !defined(MLIBDIR) && ${RUMPRUN} != "yes"
++realall: ${SRCS}
++
++.if ${MK_LIBC_TAGS:Uyes} == "yes"
+ realall: tags
++.endif
++
+ tags: ${SRCS}
+ 	${_MKTARGET_CREATE}
+ 	-${TOOL_CTAGS} -f ${.TARGET}.tmp -w ${.ALLSRC:M*.c}
+@@ -146,11 +151,14 @@ tags: ${SRCS}
+ .endif
+ 	rm -f ${.TARGET}.tmp
+ 
++.if ${MK_LIBC_TAGS:Uyes} == "yes"
+ FILES=		tags
+ FILESNAME=	libc.tags
+ FILESDIR=	/var/db
+ .endif
+ 
++.endif
++
+ 
+ # workaround for I18N stuffs: build singlebyte setlocale() for libc.a,
+ # multibyte for libc.so.  the quirk should be removed when we support
+-- 
+2.42.0
+


### PR DESCRIPTION
## Description of changes

We have a similar patch for OpenBSD too. FreeBSD didn't need it because they removed a tags special case for libc.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
