### PR TITLE
libliftoff_0_4: backport gcc-14 build fix

### DIFF
--- a/pkgs/development/libraries/libliftoff/default.nix
+++ b/pkgs/development/libraries/libliftoff/default.nix
@@ -1,9 +1,17 @@
-{ callPackage, fetchFromGitLab, ... }:
+{
+  callPackage,
+  fetchFromGitLab,
+  fetchpatch,
+}:
 let
   mkVariant =
-    version: hash:
+    {
+      version,
+      hash,
+      patches ? [ ],
+    }:
     callPackage ./generic.nix {
-      inherit version;
+      inherit version patches;
       src = fetchFromGitLab {
         domain = "gitlab.freedesktop.org";
         owner = "emersion";
@@ -14,6 +22,21 @@ let
     };
 in
 {
-  libliftoff_0_4 = mkVariant "0.4.1" "sha256-NPwhsd6IOQ0XxNQQNdaaM4kmwoLftokV86WYhoa5csY=";
-  libliftoff_0_5 = mkVariant "0.5.0" "sha256-PcQY8OXPqfn8C30+GAYh0Z916ba5pik8U0fVpZtFb5g=";
+  libliftoff_0_4 = mkVariant {
+    version = "0.4.1";
+    hash = "sha256-NPwhsd6IOQ0XxNQQNdaaM4kmwoLftokV86WYhoa5csY=";
+    patches = [
+      # Pull gcc-14 fix:
+      #   https://gitlab.freedesktop.org/emersion/libliftoff/-/merge_requests/78
+      (fetchpatch {
+        name = "libliftoff-gcc-14-calloc.patch";
+        url = "https://gitlab.freedesktop.org/emersion/libliftoff/-/commit/29a06add8ef184f85e37ff8abdc34fbaa2f4ee1e.patch";
+        hash = "sha256-Y8x1RK3o/I9bs/ZOLeC4t9AIK78l0QnlBWHhiVC+sz8=";
+      })
+    ];
+  };
+  libliftoff_0_5 = mkVariant {
+    version = "0.5.0";
+    hash = "sha256-PcQY8OXPqfn8C30+GAYh0Z916ba5pik8U0fVpZtFb5g=";
+  };
 }

--- a/pkgs/development/libraries/libliftoff/generic.nix
+++ b/pkgs/development/libraries/libliftoff/generic.nix
@@ -3,11 +3,12 @@
 , libdrm
 , version
 , src
+, patches
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libliftoff";
-  inherit version src;
+  inherit version src patches;
 
   nativeBuildInputs = [ meson pkg-config ninja ];
 


### PR DESCRIPTION
Without the change `gcc-14` build fails as:

    $ nix build --impure --expr 'with import ./. {}; libliftoff_0_4.override { stdenv = gcc14Stdenv; }'
    ...
    libliftoff> ../layer.c: In function 'liftoff_layer_create':
    libliftoff> ../layer.c:20:48: error: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
    libliftoff>    20 |         layer->candidate_planes = calloc(sizeof(layer->candidate_planes[0]),
    libliftoff>       |                                                ^

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
