### PR TITLE
python312Packages.ipython-genutils: remove nose test dependency

### DIFF
--- a/pkgs/development/python-modules/ipython-genutils/default.nix
+++ b/pkgs/development/python-modules/ipython-genutils/default.nix
@@ -2,10 +2,9 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  fetchpatch,
   setuptools,
-  nose,
   pytestCheckHook,
-  pythonAtLeast,
 }:
 
 buildPythonPackage rec {
@@ -13,19 +12,23 @@ buildPythonPackage rec {
   version = "0.2.0";
   pyproject = true;
 
-  # uses the imp module, upstream says "DO NOT USE"
-  disabled = pythonAtLeast "3.12";
-
   src = fetchPypi {
     pname = "ipython_genutils";
     inherit version;
     hash = "sha256-6y4RbnXs751NIo/cZq9UJpr6JqtEYwQuM3hbiHxii6g=";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "ipython_genutils-denose.patch";
+      url = "https://build.opensuse.org/public/source/devel:languages:python:jupyter/python-ipython_genutils/denose.patch?rev=9";
+      hash = "sha256-At0aq6rLw/L64Own069m0p/WQm7iDa24fm0SPLLRBdE=";
+    })
+  ];
+
   nativeBuildInputs = [ setuptools ];
 
   nativeCheckInputs = [
-    nose
     pytestCheckHook
   ];
 


### PR DESCRIPTION
## Description of changes

This package was disabled because upstream said "DO NOT USE" on PyPI, and because it depends on the unmaintained `nose` test framework. There's some nuance to the first point, however. As you can see by looking at the [repository README](https://github.com/ipython/ipython_genutils), the full recommendation is that "no packages outside IPython/Jupyter should depend on it". Unfortunately, nbclassic is an actively maintained part of Jupyter [which depends on ipython-genutils](https://github.com/jupyter/nbclassic/blob/main/setup.cfg#L31), so we have to keep it alive for now.

The options to do so are either to keep `nose` alive ([as Arch does](https://gitlab.archlinux.org/archlinux/packaging/packages/python-nose/-/blob/main/python-nose-py312.patch?ref_type=heads)) or to migrate `nose` tests to `pytest` ([as openSUSE does](https://build.opensuse.org/projects/devel:languages:python:jupyter/packages/python-ipython_genutils/files/denose.patch)). I picked the latter option and imported the openSUSE patch. Three and a half years ago, openSUSE devs notified upstream at https://github.com/ipython/ipython_genutils/issues/17, but upstream thought fully eliminating ipython-genutils was in the near future; it hasn't happened so far.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
