### PR TITLE
grafana: 11.0.0 -> 11.1.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -29,6 +29,8 @@
 
 - `androidenv.androidPkgs_9_0` has been removed, and replaced with `androidenv.androidPkgs` for a more complete Android SDK including support for Android 9 and later.
 
+- `grafana` has been updated to version 11.1. This version doesn't support setting `http_addr` to a hostname anymore, an IP address is expected.
+
 - `wstunnel` has had a major version upgrade that entailed rewriting the program in Rust.
   The module was updated to accommodate for breaking changes.
   Breaking changes to the module API were minimised as much as possible,

--- a/nixos/modules/services/monitoring/grafana.nix
+++ b/nixos/modules/services/monitoring/grafana.nix
@@ -105,7 +105,7 @@ let
       };
       url = mkOption {
         type = types.str;
-        default = "localhost";
+        default = "";
         description = "Url of the datasource.";
       };
       editable = mkOption {

--- a/nixos/tests/grafana/basic.nix
+++ b/nixos/tests/grafana/basic.nix
@@ -10,7 +10,7 @@ let
         analytics.reporting_enabled = false;
 
         server = {
-          http_addr = "localhost";
+          http_addr = "::1";
           domain = "localhost";
         };
 
@@ -47,7 +47,7 @@ let
 
     postgresql = {
       services.grafana.settings.database = {
-        host = "127.0.0.1:5432";
+        host = "[::1]:5432";
         user = "grafana";
       };
       services.postgresql = {
@@ -91,9 +91,9 @@ in {
 
     with subtest("Declarative plugins installed"):
         declarativePlugins.wait_for_unit("grafana.service")
-        declarativePlugins.wait_for_open_port(3000)
+        declarativePlugins.wait_for_open_port(3000, addr="::1")
         declarativePlugins.succeed(
-            "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/plugins | grep grafana-clock-panel"
+            "curl -sSfN -u testadmin:snakeoilpwd http://[::1]:3000/api/plugins | grep grafana-clock-panel"
         )
         declarativePlugins.shutdown()
 
@@ -101,10 +101,10 @@ in {
         sqlite.wait_for_unit("grafana.service")
         sqlite.wait_for_open_port(3000)
         print(sqlite.succeed(
-            "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/org/users -i"
+            "curl -sSfN -u testadmin:snakeoilpwd http://[::1]:3000/api/org/users -i"
         ))
         sqlite.succeed(
-            "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/org/users | grep admin\@localhost"
+            "curl -sSfN -u testadmin:snakeoilpwd http://[::1]:3000/api/org/users | grep admin\@localhost"
         )
         sqlite.shutdown()
 
@@ -112,10 +112,10 @@ in {
         socket.wait_for_unit("grafana.service")
         socket.wait_for_open_port(80)
         print(socket.succeed(
-            "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1/api/org/users -i"
+            "curl -sSfN -u testadmin:snakeoilpwd http://[::1]/api/org/users -i"
         ))
         socket.succeed(
-            "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1/api/org/users | grep admin\@localhost"
+            "curl -sSfN -u testadmin:snakeoilpwd http://[::1]/api/org/users | grep admin\@localhost"
         )
         socket.shutdown()
 
@@ -125,7 +125,7 @@ in {
         postgresql.wait_for_open_port(3000)
         postgresql.wait_for_open_port(5432)
         postgresql.succeed(
-            "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/org/users | grep admin\@localhost"
+            "curl -sSfN -u testadmin:snakeoilpwd http://[::1]:3000/api/org/users | grep admin\@localhost"
         )
         postgresql.shutdown()
 
@@ -135,7 +135,7 @@ in {
         mysql.wait_for_open_port(3000)
         mysql.wait_for_open_port(3306)
         mysql.succeed(
-            "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/org/users | grep admin\@localhost"
+            "curl -sSfN -u testadmin:snakeoilpwd http://[::1]:3000/api/org/users | grep admin\@localhost"
         )
         mysql.shutdown()
   '';

--- a/nixos/tests/grafana/provision/default.nix
+++ b/nixos/tests/grafana/provision/default.nix
@@ -11,7 +11,7 @@ let
         analytics.reporting_enabled = false;
 
         server = {
-          http_addr = "localhost";
+          http_addr = "::1";
           domain = "localhost";
         };
 
@@ -177,41 +177,41 @@ in {
     for description, machine in [nodeNix, nodeYaml, nodeYamlDir]:
         with subtest(f"Should start provision node: {description}"):
             machine.wait_for_unit("grafana.service")
-            machine.wait_for_open_port(3000)
+            machine.wait_for_open_port(3000, addr="::1")
 
         with subtest(f"Successful datasource provision with {description}"):
             machine.succeed(
-                "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/datasources/uid/test_datasource | grep Test\ Datasource"
+                "curl -sSfN -u testadmin:snakeoilpwd http://[::1]:3000/api/datasources/uid/test_datasource | grep Test\ Datasource"
             )
 
         with subtest(f"Successful dashboard provision with {description}"):
             machine.succeed(
-                "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/dashboards/uid/test_dashboard | grep Test\ Dashboard"
+                "curl -sSfN -u testadmin:snakeoilpwd http://[::1]:3000/api/dashboards/uid/test_dashboard | grep Test\ Dashboard"
             )
 
         with subtest(f"Successful rule provision with {description}"):
             machine.succeed(
-                "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/v1/provisioning/alert-rules/test_rule | grep Test\ Rule"
+                "curl -sSfN -u testadmin:snakeoilpwd http://[::1]:3000/api/v1/provisioning/alert-rules/test_rule | grep Test\ Rule"
             )
 
         with subtest(f"Successful contact point provision with {description}"):
             machine.succeed(
-                "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/v1/provisioning/contact-points | grep Test\ Contact\ Point"
+                "curl -sSfN -u testadmin:snakeoilpwd http://[::1]:3000/api/v1/provisioning/contact-points | grep Test\ Contact\ Point"
             )
 
         with subtest(f"Successful policy provision with {description}"):
             machine.succeed(
-                "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/v1/provisioning/policies | grep Test\ Contact\ Point"
+                "curl -sSfN -u testadmin:snakeoilpwd http://[::1]:3000/api/v1/provisioning/policies | grep Test\ Contact\ Point"
             )
 
         with subtest(f"Successful template provision with {description}"):
             machine.succeed(
-                "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/v1/provisioning/templates | grep Test\ Template"
+                "curl -sSfN -u testadmin:snakeoilpwd http://[::1]:3000/api/v1/provisioning/templates | grep Test\ Template"
             )
 
         with subtest("Successful mute timings provision with {description}"):
             machine.succeed(
-                "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/v1/provisioning/mute-timings | grep Test\ Mute\ Timing"
+                "curl -sSfN -u testadmin:snakeoilpwd http://[::1]:3000/api/v1/provisioning/mute-timings | grep Test\ Mute\ Timing"
             )
   '';
 })

--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -3,7 +3,7 @@
 , yarn, nodejs, python3, cacert
 , jq, moreutils
 , nix-update-script, nixosTests, xcbuild
-, util-linux
+, faketty
 }:
 
 let
@@ -77,7 +77,8 @@ buildGoModule rec {
 
   proxyVendor = true;
 
-  nativeBuildInputs = [ wire yarn jq moreutils removeReferencesTo python3 ] ++ lib.optionals stdenv.isDarwin [ xcbuild.xcbuild ];
+  nativeBuildInputs = [ wire yarn jq moreutils removeReferencesTo python3 faketty ]
+    ++ lib.optionals stdenv.isDarwin [ xcbuild.xcbuild ];
 
   postPatch = ''
     ${patchGoVersion}
@@ -113,7 +114,7 @@ buildGoModule rec {
     # After having built all the Go code, run the JS builders now.
 
     # Workaround for https://github.com/nrwl/nx/issues/22445
-    ${util-linux}/bin/script -c 'yarn run build' /dev/null
+    faketty yarn run build
     yarn run plugins:build-bundled
   '';
 
@@ -154,8 +155,5 @@ buildGoModule rec {
     maintainers = with maintainers; [ offline fpletz willibutz globin ma27 Frostman ];
     platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
     mainProgram = "grafana-server";
-    # requires util-linux to work around https://github.com/nrwl/nx/issues/22445
-    # `script` doesn't seem to be part of util-linux on Darwin though.
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -7,22 +7,18 @@
 }:
 
 let
-  # We need dev dependencies to run webpack, but patch away
-  # `cypress` (and @grafana/e2e which has a direct dependency on cypress).
-  # This attempts to download random blobs from the Internet in
-  # postInstall. Also, it's just a testing framework, so not worth the hassle.
-  patchAwayGrafanaE2E = ''
-    find . -name package.json | while IFS=$'\n' read -r pkg_json; do
-      <"$pkg_json" jq '. + {
-        "devDependencies": .devDependencies | del(."@grafana/e2e") | del(.cypress)
-      }' | sponge "$pkg_json"
-    done
-    rm -r packages/grafana-e2e
+  # Grafana seems to just set it to the latest version available
+  # nowadays.
+  patchGoVersion = ''
+    substituteInPlace go.{mod,work} pkg/build/wire/go.mod \
+      --replace-fail "go 1.22.4" "go 1.22.3"
+    substituteInPlace Makefile \
+      --replace-fail "GO_VERSION = 1.22.4" "GO_VERSION = 1.22.3"
   '';
 in
 buildGoModule rec {
   pname = "grafana";
-  version = "11.0.0";
+  version = "11.1.0";
 
   subPackages = [ "pkg/cmd/grafana" "pkg/cmd/grafana-server" "pkg/cmd/grafana-cli" ];
 
@@ -30,11 +26,13 @@ buildGoModule rec {
     owner = "grafana";
     repo = "grafana";
     rev = "v${version}";
-    hash = "sha256-cC1dpgb8IiyPIqlVvn8Qi1l7j6lLtQF+BOOO+DQCp4E=";
+    hash = "sha256-iTTT10YN8jBT4/ukGXNK1QHcyzXnAqg2LiFtNiwnENw=";
   };
 
   # borrowed from: https://github.com/NixOS/nixpkgs/blob/d70d9425f49f9aba3c49e2c389fe6d42bac8c5b0/pkgs/development/tools/analysis/snyk/default.nix#L20-L22
-  env = lib.optionalAttrs (stdenv.isDarwin && stdenv.isx86_64) {
+  env = {
+    CYPRESS_INSTALL_BINARY = 0;
+  } // lib.optionalAttrs (stdenv.isDarwin && stdenv.isx86_64) {
     # Fix error: no member named 'aligned_alloc' in the global namespace.
     # Occurs while building @esfx/equatable@npm:1.0.2 on x86_64-darwin
     NIX_CFLAGS_COMPILE = "-D_LIBCPP_HAS_NO_LIBRARY_ALIGNED_ALLOCATION=1";
@@ -49,7 +47,7 @@ buildGoModule rec {
     # @esfx/equatable@npm:1.0.2 fails to build on darwin as it requires `xcbuild`
     ] ++ lib.optionals stdenv.isDarwin [ xcbuild.xcbuild ];
     postPatch = ''
-      ${patchAwayGrafanaE2E}
+      ${patchGoVersion}
     '';
     buildPhase = ''
       runHook preBuild
@@ -66,23 +64,23 @@ buildGoModule rec {
     dontFixup = true;
     outputHashMode = "recursive";
     outputHash = rec {
-      x86_64-linux = "sha256-+Udq8oQSIAHku55VKnrfgHHevzBels0QiOZwnwuts8k=";
+      x86_64-linux = "sha256-2VnhZBWLdYQhqKCxM63fCAwQXN4Zrh2wCdPBLCCUuvg=";
       aarch64-linux = x86_64-linux;
-      aarch64-darwin = "sha256-m3jtZNz0J2nZwFHXVp3ApgDfnGBOJvFeUpqOPQqv200=";
+      aarch64-darwin = "sha256-MZE3/PHynL6SHOxJgOG41pi2X8XeutruAOyUFY9Lmsc=";
       x86_64-darwin = aarch64-darwin;
     }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   };
 
   disallowedRequisites = [ offlineCache ];
 
-  vendorHash = "sha256-kcdW6RQghyAOZUDmIo9G6YBC+YaLHdafvj+fCd+dcDE=";
+  vendorHash = "sha256-Ny/SoelFVPvBBn50QpHcLTuVY3ynKbCegM1uQkJzB9Y=";
 
   proxyVendor = true;
 
   nativeBuildInputs = [ wire yarn jq moreutils removeReferencesTo python3 ] ++ lib.optionals stdenv.isDarwin [ xcbuild.xcbuild ];
 
   postPatch = ''
-    ${patchAwayGrafanaE2E}
+    ${patchGoVersion}
   '';
 
   postConfigure = ''


### PR DESCRIPTION
## Description of changes
ChangeLog: https://github.com/grafana/grafana/releases/tag/v11.1.0

A few additional changes were necessary:

* Grafana now refuses to listen on non-IP values and aborts with

    Error: ✗ *apiserver.service run error: invalid IP address: localhost

* packages/grafana-e2e doesn't exist anymore, so the build fixes for
  that could be removed.

* Make sure we always compile the binary parts of cypress.

* Grafana tends to set the minimum Go version to the latest Go version
  available now[1].

* The `url` of a datasource was set to `localhost` by default. I don't
  expect anybody to have not set it when needed, also Grafana aborts now
  if `url` is non-empty for a random walk datasource (which broke the VM
  tests).

[1] grafana/grafana#88794 (comment)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
