### PR TITLE
btc-rpc-explorer: mark broken

### DIFF
--- a/pkgs/tools/misc/btc-rpc-explorer/default.nix
+++ b/pkgs/tools/misc/btc-rpc-explorer/default.nix
@@ -43,5 +43,7 @@ buildNpmPackage rec {
     license = lib.licenses.mit;
     mainProgram = "btc-rpc-explorer";
     maintainers = with lib.maintainers; [ d-xo ];
+    broken = true; # At 2024-06-29
+                   # https://hydra.nixos.org/build/264232177/nixlog/1
   };
 }


### PR DESCRIPTION
btc-rpc-explorer: mark broken

https://hydra.nixos.org/build/264232177/nixlog/1

CC @d-xo