### PR TITLE
sageWithDoc: python 3.12 fixes

### DIFF
--- a/pkgs/applications/science/math/sage/patches/gap-element-crash.patch
+++ b/pkgs/applications/science/math/sage/patches/gap-element-crash.patch
@@ -1,0 +1,18 @@
+diff --git a/src/sage/libs/gap/element.pyx b/src/sage/libs/gap/element.pyx
+index b2b0681c052..b2e5807392c 100644
+--- a/src/sage/libs/gap/element.pyx
++++ b/src/sage/libs/gap/element.pyx
+@@ -35,6 +35,13 @@ from sage.structure.coerce cimport coercion_model as cm
+ ### helper functions to construct lists and records ########################
+ ############################################################################
+ 
++
++cdef extern from *:
++    """
++    #pragma GCC optimize("O1")
++    """
++
++
+ cdef Obj make_gap_list(sage_list) except NULL:
+     """
+     Convert Sage lists into Gap lists

--- a/pkgs/applications/science/math/sage/sage-env.nix
+++ b/pkgs/applications/science/math/sage/sage-env.nix
@@ -5,6 +5,7 @@
 , sage-docbuild
 , env-locations
 , gfortran
+, ninja
 , bash
 , coreutils
 , gnused
@@ -63,6 +64,7 @@ let
     "@sage-local@/build"
     pythonEnv
     gfortran # for inline fortran
+    ninja # for inline fortran via numpy.f2py
     stdenv.cc # for cython
     bash
     coreutils

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -61,19 +61,9 @@ stdenv.mkDerivation rec {
       hash = "sha256-uCXchYx26DdxTjR1k2748KCEHPnekKS2fAM7SpyhNvM=";
     })
 
-    # https://github.com/sagemath/sage/pull/37763, landed in 10.4.beta2
-    (fetchpatch {
-      name = "scipy-fault-tolerance.patch";
-      url = "https://github.com/sagemath/sage/commit/551139c09f26a5da96b1187c3f0dd17b8d80ef84.diff";
-      hash = "sha256-PR4przrZ3ieHaW2nSY7l7VhNfrUupu9yCIrXpeyoAgg=";
-    })
-
-    # first two commits from https://github.com/sagemath/sage/pull/38100
-    (fetchpatch {
-      name = "sphinx-7.3-update.patch";
-      url = "https://github.com/sagemath/sage/compare/10.4.beta7...d2932e142991b442a3eee5dc4f8949e3f7e6fe5c.patch";
-      hash = "sha256-g6w0ImE0d2ocKnbGMQikcz9eI9r3/gESlA1NrQfGimk=";
-    })
+    # compile libs/gap/element.pyx with -O1
+    # a more conservative version of https://github.com/sagemath/sage/pull/37951
+    ./patches/gap-element-crash.patch
   ];
 
   # Patches needed because of package updates. We could just pin the versions of
@@ -83,11 +73,39 @@ stdenv.mkDerivation rec {
   # should come from or be proposed to upstream. This list will probably never
   # be empty since dependencies update all the time.
   packageUpgradePatches = [
-    # https://github.com/sagemath/sage/pull/37492
+    # https://github.com/sagemath/sage/pull/37763, landed in 10.4.beta2
+    (fetchpatch {
+      name = "scipy-fault-tolerance.patch";
+      url = "https://github.com/sagemath/sage/commit/551139c09f26a5da96b1187c3f0dd17b8d80ef84.diff";
+      hash = "sha256-PR4przrZ3ieHaW2nSY7l7VhNfrUupu9yCIrXpeyoAgg=";
+    })
+
+    # https://github.com/sagemath/sage/pull/37492, landed in 10.4.beta5
     (fetchpatch {
       name = "singular-4.3.2p14-upgrade.patch";
       url = "https://github.com/sagemath/sage/commit/a0c56816b051e97da44ac0a4e4d4f6915cf7fa0f.diff";
       sha256 = "sha256-WGMmPeBoj2LUC+2qxWuaJL89QUuGt6axGvxWkpM9LYg=";
+    })
+
+    # https://github.com/sagemath/sage/pull/37949, landed in 10.4.beta6
+    (fetchpatch {
+      name = "conway-polynomials-new-len.patch";
+      url = "https://github.com/sagemath/sage/commit/c9f5b45179e92ea0de1e0dbe0f47464010902851.diff";
+      hash = "sha256-DwN2UIX8dxfxjIiqVvMdGbIxJ7CR/Ag2XUmS5vUKFTs=";
+    })
+
+    # https://github.com/sagemath/sage/pull/37967, landed in 10.4.beta6
+    (fetchpatch {
+      name = "conway-polynomials-ell-point.patch";
+      url = "https://github.com/sagemath/sage/commit/4e0bbaf90262a42f8ea14d5bcfed65f9d1787f54.diff";
+      hash = "sha256-9gXydi1A+n7+K8YpH0PB8l/OMexhgO2F5NccU0cK+ls=";
+    })
+
+    # https://github.com/sagemath/sage/pull/38100, landed in 10.4.beta8
+    (fetchpatch {
+      name = "sphinx-7.3-update.patch";
+      url = "https://github.com/sagemath/sage/commit/e1b22690db42885423be5049246eb71ff52bdfef.diff";
+      hash = "sha256-04KAyz8+0pJbRV8Ld0bNX1OoEx/35gIh3Nff+6n8QUU=";
     })
   ];
 

--- a/pkgs/applications/science/math/sage/sagelib.nix
+++ b/pkgs/applications/science/math/sage/sagelib.nix
@@ -6,6 +6,7 @@
 , perl
 , pkg-config
 , sage-setup
+, setuptools
 , gd
 , iml
 , libpng
@@ -62,6 +63,7 @@
 , lrcalc-python
 , matplotlib
 , memory-allocator
+, meson-python
 , mpmath
 , networkx
 , numpy
@@ -78,7 +80,6 @@
 , sphinx
 , sympy
 , typing-extensions
-, nbclassic
 }:
 
 assert (!blas.isILP64) && (!lapack.isILP64);
@@ -102,6 +103,7 @@ buildPythonPackage rec {
     pip # needed to query installed packages
     pkg-config
     sage-setup
+    setuptools
   ];
 
   pythonRelaxDeps = [
@@ -171,6 +173,7 @@ buildPythonPackage rec {
     lrcalc-python
     matplotlib
     memory-allocator
+    meson-python
     mpmath
     networkx
     numpy
@@ -187,8 +190,6 @@ buildPythonPackage rec {
     sphinx
     sympy
     typing-extensions
-
-    nbclassic
   ];
 
   preBuild = ''


### PR DESCRIPTION
## Description of changes

gcc 13.3.0 seems to exploit some undefined behaviour around setjmp/longjmp to do some optimizations that completely break Sage's GAP interface, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114872 for the upstream investigation and https://trofi.github.io/posts/312-the-sagemath-saga.html for @trofi's analysis. This only affects Python 3.12.

Unfortunately, the minimal upstream patch at https://github.com/sagemath/sage/pull/37951, which was supposed to address the issue, is not enough to fix the issue on Nixpkgs: GCC still emits code in which an always-null pointer is dereferenced with no null checks. Arch [is also seeing crashes even with the upstream patch applied](https://github.com/sagemath/sage/issues/37026#issuecomment-2131373734). As a stopgap, we compile the relevant file with `-O1` (see `gap-element-crash.patch`)

I also tried other patches similar to https://github.com/sagemath/sage/pull/37951, like having volatile `v0`, `v1` and `v2` variables and populating the relevant variables in the 1-arg, 2-arg and 3-arg cases (see [here](https://github.com/NixOS/nixpkgs/blob/beacd5135b73bebbf6bd6efc9cc6a6839805e415/pkgs/applications/science/math/sage/patches/gap-element-crash.patch)), but that makes crashes *more* frequent, presumably GCC can then easily infer that  `__pyx_t_4`  (a temporary used in Cython-generated code to hold expressions of the form `<GapElement>a[i]`) is always non-null when jumping to the error handling cleanup code without longjmp. It then removes the null check, but it also performs other optimizations which notice that `__pyx_t_4` is always zero. The case where we jump to the error handling code after longjmp, which is what Sage tests, is undefined behaviour and leads to a crash.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
