### PR TITLE
CuboCore.coreterminal: mark broken

### DIFF
--- a/pkgs/applications/misc/cubocore-packages/coreterminal/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/coreterminal/default.nix
@@ -41,5 +41,7 @@ mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ dan4ik605743 ];
     platforms = platforms.linux;
+    broken = true; # At 2024-06-29
+                   # https://hydra.nixos.org/build/264686032/nixlog/1
   };
 }


### PR DESCRIPTION
CuboCore.coreterminal: mark broken

https://hydra.nixos.org/build/264686032/nixlog/1

CC @dan4ik605743