### PR TITLE
rill: init at 0.46.6

### DIFF
--- a/pkgs/by-name/ri/rill/package.nix
+++ b/pkgs/by-name/ri/rill/package.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenv
+, fetchzip
+, autoPatchelfHook
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rill";
+  version = "0.46.6";
+  src = fetchzip {
+    url = "https://github.com/rilldata/rill/releases/download/v${finalAttrs.version}/rill_linux_amd64.zip";
+    hash = "sha256-lrm7OLO6I16QjQejDjsHQQPAKdJhJPuA2JnWs3i49l8=";
+    stripRoot = false;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+      mkdir -p $out/bin
+      cp rill $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://www.rilldata.com";
+    description = "Effortlessly transforming data sets into powerful, opinionated dashboards using SQL";
+    maintainers = with lib.maintainers; [ ByteSudoer ];
+    platforms = [ "x86_64-linux" ];
+    license = with lib.licenses;[ apsl20 ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "rill";
+  };
+})


### PR DESCRIPTION
## Description of changes
Project description
Dashboards that move as fast as your business. Unlike most BI tools, Rill comes with its own embedded in-memory database. Data and compute are co-located, and queries return in milliseconds. So you can pivot, slice, and drill-down into your data instantly.

Metadata
- homepage URL: https://www.rilldata.com/
- source URL: https://github.com/rilldata/rill
- license: Apache-2.0 license
- platforms: linux

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
