### PR TITLE
java-language-server: use headless jdk to reduce dependencies

### DIFF
--- a/pkgs/development/tools/java/java-language-server/default.nix
+++ b/pkgs/development/tools/java/java-language-server/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub
-, jdk, maven
+, jdk_headless, maven
 , makeWrapper
 }:
 
@@ -25,7 +25,7 @@ maven.buildMavenPackage rec {
   mvnFetchExtraArgs.dontConfigure = true;
   mvnHash = "sha256-2uthmSjFQ43N5lgV11DsxuGce+ZptZsmRLTgjDo0M2w=";
 
-  nativeBuildInputs = [ jdk makeWrapper ];
+  nativeBuildInputs = [ jdk_headless makeWrapper ];
 
   dontConfigure = true;
   preBuild = ''


### PR DESCRIPTION
## Description of changes
```
 ➜ nix store diff-closures ./result-before ./result
command nix store diff-closures ./result-before ./result
ORBit2: 2.14.19 → ∅, -950.3 KiB
acl: 2.3.2 → ∅, -125.2 KiB
at-spi2-core: 2.52.0 → ∅, -2208.8 KiB
attr: 2.5.2 → ∅, -90.6 KiB
audit: 3.1.2 → ∅, -831.0 KiB
avahi: 0.8 → ∅, -1547.5 KiB
bash-interactive: 5.2p26 → ∅, -7042.9 KiB
brotli: 1.1.0 → ∅, -901.4 KiB
bzip2: 1.0.8 → ∅, -146.1 KiB
cairo: 1.18.0 → ∅, -1876.0 KiB
coreutils: 9.5 → ∅, -1434.5 KiB
cracklib: 2.9.11 → ∅, -9743.7 KiB
cryptsetup: 2.7.1 → ∅, -2302.7 KiB
cups: 2.4.8 → ∅, -4742.0 KiB
curl: 8.8.0 → ∅, -895.5 KiB
db: 4.8.30 → ∅, -3542.8 KiB
dbus: 1.14.10 → ∅, -450.0 KiB
dbus-glib: 0.112 → ∅, -255.7 KiB
dconf: 0.40.0 → ∅, -308.5 KiB
dejavu-fonts-minimal: 2.37 → ∅, -742.6 KiB
dns-root-data: 2023-11-27 → ∅
duktape: 2.7.0 → ∅, -1222.1 KiB
elfutils: 0.191 → ∅, -3875.0 KiB
expat: 2.6.2 → ∅, -263.0 KiB
file: 5.45 → ∅, -8532.9 KiB
fontconfig: 2.15.0 → ∅, -2065.4 KiB
freetype: 2.13.2 → ∅, -2040.4 KiB
fribidi: 1.0.13 → ∅, -154.3 KiB
gamin: 0.1.10 → ∅, -192.5 KiB
gconf: 3.2.6 → ∅, -6728.9 KiB
gdk-pixbuf: 2.42.12 → ∅, -2843.5 KiB
getent-glibc: 2.39-52 → ∅
giflib: 5.2.2 → ∅, -397.8 KiB
glib: 2.80.2 → ∅, -14888.6 KiB
glibc: -42.3 KiB
gmp-with-cxx: 6.3.0 → ∅, -1482.1 KiB
gnome-vfs: 2.24.4 → ∅, -4867.3 KiB
gnugrep: 3.11 → ∅, -922.6 KiB
gnupg: 2.4.5 → ∅, -1178.6 KiB
gnutar: 1.35 → ∅, -2737.7 KiB
gnutls: 3.8.5 → ∅, -3187.4 KiB
gobject-introspection: 1.80.1 → ∅, -1106.5 KiB
graphite2: 1.3.14 → ∅, -219.6 KiB
gsettings-desktop-schemas: 46.0 → ∅, -5270.4 KiB
gtk+3: 3.24.42 → ∅, -41618.1 KiB
gzip: 1.13 → ∅, -152.8 KiB
harfbuzz: 8.4.0 → ∅, -3133.7 KiB
icu4c: 73.2 → ∅, -38593.5 KiB
iptables: 1.8.10 → ∅, -2681.5 KiB
iso-codes: 4.16.0 → ∅, -19529.0 KiB
java-language-server: -26.9 KiB
json-c: 0.17 → ∅, -237.9 KiB
json-glib: 1.8.0 → ∅, -620.8 KiB
kbd: 2.6.4 → ∅, -2664.6 KiB
kexec-tools: 2.0.28 → ∅, -254.0 KiB
keyutils: 1.6.3 → ∅, -41.6 KiB
kmod: 31 → ∅, -335.2 KiB
lerc: 4.0.0 → ∅, -832.2 KiB
libGL: 1.7.0 → ∅
libIDL: 0.8.14 → ∅, -241.6 KiB
libX11: 1.8.9 → ∅, -2592.7 KiB
libXau: 1.0.11 → ∅, -23.4 KiB
libXcomposite: 0.4.6 → ∅, -25.2 KiB
libXcursor: 1.2.2 → ∅, -78.2 KiB
libXdamage: 1.1.6 → ∅, -18.1 KiB
libXdmcp: 1.1.5 → ∅, -31.4 KiB
libXext: 1.3.6 → ∅, -94.2 KiB
libXfixes: 6.0.1 → ∅, -38.2 KiB
libXft: 2.3.8 → ∅, -148.3 KiB
libXi: 1.8.1 → ∅, -84.1 KiB
libXinerama: 1.1.5 → ∅, -21.9 KiB
libXrandr: 1.5.4 → ∅, -63.0 KiB
libXrender: 0.9.11 → ∅, -53.5 KiB
libXtst: 1.2.4 → ∅, -121.8 KiB
libapparmor: 3.1.7 → ∅, -431.7 KiB
libargon2: 20190702 → ∅, -141.5 KiB
libassuan: 2.5.7 → ∅, -97.3 KiB
libbpf: 1.4.2 → ∅, -1885.6 KiB
libcap: 2.69 → ∅, -78.0 KiB
libcbor: 0.11.0 → ∅, -79.5 KiB
libdaemon: 0.14 → ∅, -36.9 KiB
libdatrie: 2019-12-20 → ∅, -42.2 KiB
libdeflate: 1.20 → ∅, -421.9 KiB
libepoxy: 1.5.10 → ∅, -1784.1 KiB
libevent: 2.1.12 → ∅, -845.8 KiB
libffi: 3.4.6 → ∅, -71.9 KiB
libfido2: 1.14.0 → ∅, -968.4 KiB
libgcrypt: 1.10.3 → ∅, -1404.7 KiB
libglvnd: 1.7.0 → ∅, -2555.1 KiB
libgpg-error: 1.49 → ∅, -820.0 KiB
libjpeg-turbo: 3.0.3 → ∅, -1969.4 KiB
libkrb5: 1.21.2 → ∅, -2270.5 KiB
libmicrohttpd: 0.9.77 → ∅, -189.0 KiB
libmnl: 1.0.5 → ∅, -42.2 KiB
libnetfilter_conntrack: 1.0.9 → ∅, -191.7 KiB
libnfnetlink: 1.0.2 → ∅, -55.2 KiB
libnftnl: 1.2.6 → ∅, -300.6 KiB
libnl: 3.8.0 → ∅, -1458.0 KiB
libpcap: 1.10.4 → ∅, -1099.0 KiB
libpng-apng: 1.6.43 → ∅, -249.3 KiB
libpsl: 0.21.5 → ∅, -79.6 KiB
libpwquality: 1.4.5 → ∅, -382.7 KiB
libseccomp: 2.5.5 → ∅, -138.9 KiB
libselinux: 3.6 → ∅, -1216.2 KiB
libsoup: 2.74.3, 3.4.4 → ∅, -2336.1 KiB
libssh2: 1.11.0 → ∅, -309.8 KiB
libtasn1: 4.19.0 → ∅, -91.7 KiB
libthai: 0.1.29 → ∅, -627.2 KiB
libtiff: 4.6.0 → ∅, -647.9 KiB
libwebp: 1.4.0 → ∅, -1245.2 KiB
libxcb: 1.17.0 → ∅, -1388.5 KiB
libxcrypt: 4.4.36 → ∅, -128.0 KiB
libxkbcommon: 1.7.0 → ∅, -603.0 KiB
libxml2: 2.12.7 → ∅, -1530.5 KiB
linux-pam: 1.6.1 → ∅, -1900.7 KiB
lvm2: 2.03.23 → ∅, -408.6 KiB
lz4: 1.9.4 → ∅, -231.5 KiB
ncurses: 6.4.20221231 → ∅, -3630.8 KiB
nettle: 3.9.1 → ∅, -698.0 KiB
nghttp2: 1.61.0 → ∅, -219.0 KiB
npth: 1.7 → ∅, -50.3 KiB
openssl: 3.0.13 → ∅, -6330.8 KiB
p11-kit: 0.25.3 → ∅, -4888.6 KiB
pango: 1.52.2 → ∅, -856.6 KiB
pcre2: 10.43 → ∅, -1853.1 KiB
pcsclite: 2.1.0 → ∅, -110.8 KiB
pixman: 0.43.4 → ∅, -802.9 KiB
polkit: 124 → ∅, -547.9 KiB
publicsuffix-list: 0-unstable-2024-01-07 → ∅, -302.5 KiB
qrencode: 4.1.1 → ∅, -58.6 KiB
readline: 8.2p10 → ∅, -459.4 KiB
sqlite: 3.45.3 → ∅, -1507.4 KiB
systemd: 255.6 → ∅, -35797.9 KiB
systemd-minimal: 255.6 → ∅, -14242.8 KiB
systemd-minimal-libs: 255.6 → ∅, -1537.5 KiB
tpm2-tss: 4.1.3 → ∅, -3485.5 KiB
tracker: 3.7.3 → ∅, -5278.8 KiB
unbound: 1.20.0 → ∅, -1092.7 KiB
util-linux-minimal: 2.39.4 → ∅, -2099.9 KiB
wayland: 1.22.0 → ∅, -385.7 KiB
xkeyboard-config: 2.41 → ∅, -6768.8 KiB
xz: 5.4.6 → ∅, -967.3 KiB
zstd: 1.5.6 → ∅, -1498.4 KiB
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
