### PR TITLE
pysolfc: 2.21.0 -> 3.0.0

### DIFF
--- a/pkgs/games/pysolfc/default.nix
+++ b/pkgs/games/pysolfc/default.nix
@@ -1,31 +1,57 @@
-{ lib
-, fetchzip
-, buildPythonApplication
-, python3Packages
-, desktop-file-utils
-, freecell-solver
+{
+  lib,
+  stdenv,
+  fetchzip,
+  python311Packages,
+  desktop-file-utils,
+  freecell-solver,
+  black-hole-solver,
+  _experimental-update-script-combinators,
+  gitUpdater,
 }:
 
-buildPythonApplication rec {
+python311Packages.buildPythonApplication rec {
   pname = "pysolfc";
-  version = "2.21.0";
+  version = "3.0.0";
 
   src = fetchzip {
     url = "mirror://sourceforge/pysolfc/PySolFC-${version}.tar.xz";
-    hash = "sha256-Deye7KML5G6RZkth2veVgPOWZI8gnusEvszlrPTAhag=";
+    hash = "sha256-LPOm83K4bdzmmQskmAnSyYpz+5y9ktQAhYCkXpODYKI=";
   };
 
-  cardsets = fetchzip {
-    url = "mirror://sourceforge/pysolfc/PySolFC-Cardsets-2.2.tar.bz2";
-    hash = "sha256-mWJ0l9rvn9KeZ9rCWy7VjngJzJtSQSmG8zGcYFE4yM0=";
+  cardsets = stdenv.mkDerivation rec {
+    pname = "pysol-cardsets";
+    version = "3.0";
+
+    src = fetchzip {
+      url = "mirror://sourceforge/pysolfc/PySolFC-Cardsets-${version}.tar.bz2";
+      hash = "sha256-UP0dQjoZJg+iSKVOrWbkLj1KCzMWws8ZBVSBLly1a/Y=";
+    };
+
+    installPhase = ''
+      runHook preInstall
+      cp -r $src $out
+      runHook postInstall
+    '';
   };
 
-  music = fetchzip {
-    url = "mirror://sourceforge/pysolfc/pysol-music-4.50.tar.xz";
-    hash = "sha256-sOl5U98aIorrQHJRy34s0HHaSW8hMUE7q84FMQAj5Yg=";
+  music = stdenv.mkDerivation rec {
+    pname = "pysol-music";
+    version = "4.50";
+
+    src = fetchzip {
+      url = "mirror://sourceforge/pysolfc/pysol-music-${version}.tar.xz";
+      hash = "sha256-sOl5U98aIorrQHJRy34s0HHaSW8hMUE7q84FMQAj5Yg=";
+    };
+
+    installPhase = ''
+      runHook preInstall
+      cp -r $src $out
+      runHook postInstall
+    '';
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  propagatedBuildInputs = with python311Packages; [
     tkinter
     six
     random2
@@ -36,12 +62,11 @@ buildPythonApplication rec {
     # optional :
     pygame
     freecell-solver
+    black-hole-solver
     pillow
   ];
 
-  patches = [
-    ./pysolfc-datadir.patch
-  ];
+  patches = [ ./pysolfc-datadir.patch ];
 
   nativeBuildInputs = [ desktop-file-utils ];
   postPatch = ''
@@ -57,6 +82,24 @@ buildPythonApplication rec {
 
   # No tests in archive
   doCheck = false;
+
+  passthru.updateScript = _experimental-update-script-combinators.sequence (
+    # Needed in order to work around requirement that only one updater with features enabled is in sequence
+    map (updater: updater.command) [
+      (gitUpdater {
+        url = "https://github.com/shlomif/PySolFC.git";
+        rev-prefix = "pysolfc-";
+      })
+      (gitUpdater {
+        url = "https://github.com/shlomif/PySolFC-CardSets.git";
+        attrPath = "pysolfc.cardsets";
+      })
+      (gitUpdater {
+        url = "https://github.com/shlomif/pysol-music.git";
+        attrPath = "pysolfc.music";
+      })
+    ]
+  );
 
   meta = with lib; {
     description = "A collection of more than 1000 solitaire card games";


### PR DESCRIPTION
## Description of changes

- Update `pysolfc` from `2.21.0` -> `3.0.0`
  - Changes: https://pysolfc.sourceforge.io/doc/news.html (Relevant entry is 31, March, 2024)
- Update cardsets to `3.0`
- Add `black-hole-solver`as an optional dependency
- Added `passthru.updateScript`, which required significant refactoring of the cardsets and music derivations.

I would like to note that there is currently an issue where sound effects play, but the music does not in at least both versions `2.21.0` and `3.0.0`. I could not fix this and I am not even sure if this is a NixOS issue or a PySolFC issue.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
