### PR TITLE
lomiri.lomiri-clock-app: init at 4.0.3

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -22,6 +22,7 @@ in {
         libusermetrics
         lomiri
         lomiri-calculator-app
+        lomiri-clock-app
         lomiri-download-manager
         lomiri-filemanager-app
         lomiri-polkit-agent

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -525,6 +525,7 @@ in {
   #logstash = handleTest ./logstash.nix {};
   lomiri = handleTest ./lomiri.nix {};
   lomiri-calculator-app = runTest ./lomiri-calculator-app.nix;
+  lomiri-clock-app = runTest ./lomiri-clock-app.nix;
   lomiri-filemanager-app = runTest ./lomiri-filemanager-app.nix;
   lomiri-system-settings = handleTest ./lomiri-system-settings.nix {};
   lorri = handleTest ./lorri/default.nix {};

--- a/nixos/tests/lomiri-clock-app.nix
+++ b/nixos/tests/lomiri-clock-app.nix
@@ -1,0 +1,48 @@
+{ pkgs, lib, ... }:
+{
+  name = "lomiri-clock-app-standalone";
+  meta.maintainers = lib.teams.lomiri.members;
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      imports = [ ./common/x11.nix ];
+
+      services.xserver.enable = true;
+
+      environment = {
+        systemPackages = with pkgs.lomiri; [
+          suru-icon-theme
+          lomiri-clock-app
+        ];
+        variables = {
+          UITK_ICON_THEME = "suru";
+        };
+      };
+
+      i18n.supportedLocales = [ "all" ];
+
+      fonts.packages = with pkgs; [
+        # Intended font & helps with OCR
+        ubuntu_font_family
+      ];
+    };
+
+  enableOCR = true;
+
+  testScript = ''
+    machine.wait_for_x()
+
+    with subtest("lomiri clock launches"):
+        machine.execute("lomiri-clock-app >&2 &")
+        machine.wait_for_text(r"(clock.ubports|City|Alarms)")
+        machine.screenshot("lomiri-clock_open")
+
+    machine.succeed("pkill -f lomiri-clock-app")
+
+    with subtest("lomiri clock localisation works"):
+        machine.execute("env LANG=de_DE.UTF-8 lomiri-clock-app >&2 &")
+        machine.wait_for_text(r"(Stadt|Weckzeiten)")
+        machine.screenshot("lomiri-clock_localised")
+  '';
+}

--- a/pkgs/desktops/lomiri/applications/lomiri-clock-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-clock-app/default.nix
@@ -1,0 +1,219 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  fetchpatch,
+  gitUpdater,
+  cmake,
+  content-hub,
+  geonames,
+  gettext,
+  libusermetrics,
+  lomiri-sounds,
+  lomiri-ui-toolkit,
+  makeWrapper,
+  pkg-config,
+  qtbase,
+  qtdeclarative,
+  qtmultimedia,
+  qtpositioning,
+  qtsystems,
+  runtimeShell,
+  u1db-qt,
+  wrapQtAppsHook,
+  xvfb-run,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-clock-app";
+  version = "4.0.3";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/apps/lomiri-clock-app";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-q/hdnwHO97bhL0W3VsdHwjPvGs6GhWbDiVLCx4NiR50=";
+  };
+
+  patches = [
+    # Fix dispatching to clock app via LUD
+    # Remove when version > 4.0.3
+    (fetchpatch {
+      name = "0001-lomiri-clock-app-Fix-non-click-lomiri-url-dispatcher-support.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/commit/493888b41489b360415d1a0d0e431754afdee2b0.patch";
+      hash = "sha256-sI7YDrWjV0bSAq0vdSvNcWCLhmEEb10T7jd2kYfSfZU=";
+    })
+
+    # Fix GNUInstallDirs variables usage
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/merge_requests/215 merged & in release
+    (fetchpatch {
+      name = "0002-lomiri-clock-app-Fix-GNUInstallDirs-variable-concatenations-in-CMake.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/commit/33c62d0382f69462de0567628d7a6ef162944e12.patch";
+      hash = "sha256-JEoRjc6RugtznNtgJsXz9wnAL/7fkoog40EVl7uu2pc=";
+    })
+
+    # Fix installation of splash icon
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/merge_requests/216 merged & in release
+    (fetchpatch {
+      name = "0003-lomiri-clock-app-Fix-splash-file-installation-in-non-clock-mode.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/commit/97fd6fd91ee787dfe107bd36bc895f2ff234b5e3.patch";
+      hash = "sha256-g9eR6yYgKFDohuZMs1Ub0TwPM2AWbwWLDvZMrT4gMls=";
+    })
+
+    # Port from qmlscene to dedicated C++ entry, and apply abunch of fixes that this move enables
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/merge_requests/217 merged & in release
+    (fetchpatch {
+      name = "0004-lomiri-clock-app-Migrate-to-C++-app.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/commit/c690d65baf2d28f99364dec2244f8d4ebdb09178.patch";
+      hash = "sha256-JCQFlHFAXbgiSGNtEsq/khblhAD/3BdE68Qctn7j5T0=";
+    })
+    (fetchpatch {
+      name = "0005-lomiri-clock-app-Call-i18n.bindtextdomain-and-fix-app-icon-load.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/commit/0619730ca639228b1c0a3403082a6a13e2fe3ff3.patch";
+      hash = "sha256-NQQYvJ141fU2iQ+xzYoNkuuzvqQg1BGZNGq24u8i1is=";
+    })
+    (fetchpatch {
+      name = "0006-lomiri-clock-app-Pass-through-project-version.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/commit/ae1467fe44813eef2fc6cc4b9d6ddc02edee7640.patch";
+      hash = "sha256-E6yk5H+YVH4oSg6AIAJ+Rynu0HFkNomX7sTjM/x37PU=";
+    })
+    (fetchpatch {
+      name = "0007-lomiri-clock-app-Fix-tests-after-module-changes.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/commit/40cbd7847c4a850184e553ac5b8981672b7deed0.patch";
+      hash = "sha256-AA4KRYZNBQ0/Nk65kyzzDFhs/zWO7fb5f2Toy1diPBg=";
+    })
+
+    # Don't ignore PATH when looking for qmltestrunner, saves us a patch for hardcoded fallback
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/merge_requests/218 merged & in release
+    (fetchpatch {
+      name = "0008-lomiri-clock-app-tests-Drop-NO_DEFAULT_PATH.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/commit/190ef47e2efaaf139920d0556e0522f95479ea95.patch";
+      hash = "sha256-jy4E+VfVyRu99eGqbhlYi/xjDgPajozHPSlqEcGVOA4=";
+    })
+
+    # Make tests honour BUILD_TESTING
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/merge_requests/219 merged & in release
+    (fetchpatch {
+      name = "0009-lomiri-clock-app-tests-Honour-BUILD_TESTING.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/commit/b0ca583238f011e23a99286a1d2b61f2dcd85303.patch";
+      hash = "sha256-TyM5Y8BRAqinvZiZ5TEXd5caVesFluPi6iGmTS1wRlI=";
+    })
+  ];
+
+  postPatch = ''
+    # Part of 493888b41489b360415d1a0d0e431754afdee2b0 patch, but neither fetchpatch nor fetchpatch2 can handle a rename-only change to a file
+    # Remove when version > 4.0.3
+    mv clock.ubports_clock.url-dispatcher lomiri-clock-app.url-dispatcher
+
+    # QT_IMPORTS_DIR returned by qmake -query is broken
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'qmake -query QT_INSTALL_QML' 'echo ''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}' \
+
+    # We don't want absolute paths in desktop files
+    substituteInPlace lomiri-clock-app.desktop.in.in \
+      --replace-fail '@ICON@' 'lomiri-clock-app' \
+      --replace-fail '@SPLASH@' 'lomiri-app-launch/splash/lomiri-clock-app.svg'
+
+    # Path to alarm sounds
+    # TODO maybe change to /run/current-system/sw instead to pick up all installed sounds?
+    substituteInPlace app/alarm/AlarmSound.qml backend/modules/Alarm/sound.cpp \
+      --replace-fail '/usr' '${lomiri-sounds}'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    makeWrapper
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    geonames
+    qtbase
+
+    # QML
+    content-hub
+    libusermetrics
+    lomiri-ui-toolkit
+    qtdeclarative
+    qtmultimedia
+    qtpositioning
+    qtsystems
+    u1db-qt
+  ];
+
+  nativeCheckInputs = [
+    qtdeclarative # qmltestrunner
+    xvfb-run
+  ];
+
+  dontWrapGApps = true;
+
+  cmakeFlags = [
+    (lib.cmakeBool "CLICK_MODE" false)
+    (lib.cmakeBool "INSTALL_TESTS" false)
+    (lib.cmakeBool "USE_XVFB" true)
+    (lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" (
+      lib.concatStringsSep ";" [
+        # Exclude tests
+        "-E"
+        (lib.strings.escapeShellArg "(${
+          lib.concatStringsSep "|" [
+            # Runs into ShapeMaterial codepath in lomiri-ui-toolkit which needs OpenGL, see LUITK for details
+            "^AlarmLabel"
+            "^AlarmRepeat"
+            "^AlarmSound"
+          ]
+        })")
+      ]
+    ))
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  preCheck =
+    let
+      listToQtVar = suffix: lib.makeSearchPathOutput "bin" suffix;
+    in
+    ''
+      export QT_PLUGIN_PATH=${listToQtVar qtbase.qtPluginPrefix [ qtbase ]}
+      export QML2_IMPORT_PATH=${
+        listToQtVar qtbase.qtQmlPrefix (
+          [
+            content-hub
+            lomiri-ui-toolkit
+            qtmultimedia
+            u1db-qt
+          ]
+          ++ lomiri-ui-toolkit.propagatedBuildInputs
+        )
+      }
+    '';
+
+  # Parallelism breaks xvfb-run usage
+  enableParallelChecking = false;
+
+  postInstall = ''
+    mkdir -p $out/share/{icons/hicolor/scalable/apps,lomiri-app-launch/splash}
+
+    ln -s $out/share/lomiri-clock-app/clock-app.svg $out/share/icons/hicolor/scalable/apps/lomiri-clock-app.svg
+    ln -s $out/share/lomiri-clock-app/clock-app-splash.svg $out/share/lomiri-app-launch/splash/lomiri-clock-app.svg
+  '';
+
+  passthru = {
+    updateScript = gitUpdater { rev-prefix = "v"; };
+  };
+
+  meta = {
+    description = "Simple and easy to use clock for Ubuntu Touch, with time zone support for cities and timer and count down functions";
+    homepage = "https://gitlab.com/ubports/development/apps/lomiri-clock-app";
+    changelog = "https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/blob/v${finalAttrs.version}/ChangeLog";
+    license = lib.licenses.gpl3Only;
+    maintainers = lib.teams.lomiri.members;
+    mainProgram = "lomiri-clock-app";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/desktops/lomiri/applications/lomiri-clock-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-clock-app/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitLab,
   fetchpatch,
   gitUpdater,
+  nixosTests,
   cmake,
   content-hub,
   geonames,
@@ -204,6 +205,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    tests.vm = nixosTests.lomiri-clock-app;
     updateScript = gitUpdater { rev-prefix = "v"; };
   };
 

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -10,6 +10,7 @@ let
     #### Core Apps
     lomiri = callPackage ./applications/lomiri { };
     lomiri-calculator-app = callPackage ./applications/lomiri-calculator-app { };
+    lomiri-clock-app = callPackage ./applications/lomiri-clock-app { };
     lomiri-filemanager-app = callPackage ./applications/lomiri-filemanager-app { };
     lomiri-system-settings-unwrapped = callPackage ./applications/lomiri-system-settings { };
     lomiri-system-settings-security-privacy = callPackage ./applications/lomiri-system-settings/plugins/lomiri-system-settings-security-privacy.nix { };


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[Lomiri Clock App](https://gitlab.com/ubports/development/apps/lomiri-clock-app). Self-explanatory. Tick Tock.
![Bildschirmfoto_2024-06-29_23-36-09](https://github.com/NixOS/nixpkgs/assets/23431373/ae444d0e-3824-4378-b466-6e4803ea0f22)

Leftover issues:
- I haven't been able to get any alarm sounds working, but I *think* the actual sound output might get dispatched to another service?
- ~~Crashes when dispatched from `ayatana-indicator-datetime`'s clock link from within Lomiri. Down to a bug in `qtsystems`, will fix that in separate PR.~~ #323485
- On launch, prints:
  ```
  - WARNING: alarm manager "eds" not installed, using "memory"
  ```
  Message is from [`lomiri-ui-toolkit`](https://gitlab.com/ubports/development/core/lomiri-ui-toolkit/-/blob/556828a7c96fc692fd35c24f75a1efdff4cc5226/src/LomiriToolkit/adapters/alarmsadapter_organizer.cpp#L36-41), about [`qtorganiser-eds`](https://gitlab.com/ubports/development/core/qtorganizer-eds), which needs [`address-book-service`](https://gitlab.com/ubports/development/core/lomiri-address-book-service)… Or maybe [`evolution-data-server-lomiri`](https://gitlab.com/ubports/development/core/evolution-data-server-lomiri), which extracts the relevant bits from the former… Or maybe this gets replaced at some point, from what I've caught on Telegram? Not sure, and don't think it's *super* critical for our non-phone usecase if this isn't working 100% right now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
