### PR TITLE
pnpm.fetchDeps: Add workspace and custom pnpm config commands support

### DIFF
--- a/pkgs/by-name/as/astro-language-server/package.nix
+++ b/pkgs/by-name/as/astro-language-server/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pnpm_8,
+  nodejs_22,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "astro-language-server";
+  version = "2.10.0";
+
+  src = fetchFromGitHub {
+    owner = "withastro";
+    repo = "language-tools";
+    rev = "@astrojs/language-server@${finalAttrs.version}";
+    hash = "sha256-WdeQQaC9AVHT+/pXLzaC6MZ6ddHsFSpxoDPHqWvqmiQ=";
+  };
+
+  pnpmDeps = pnpm_8.fetchDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      pnpmWorkspace
+      prePnpmInstall
+      ;
+    hash = "sha256-n7HTd/rKxJdQKnty5TeOcyvBU9j/EClQ9IHqbBaEwQE=";
+  };
+
+  nativeBuildInputs = [
+    nodejs_22
+    pnpm_8.configHook
+  ];
+
+  buildInputs = [ nodejs_22 ];
+
+  pnpmWorkspace = "@astrojs/language-server";
+  prePnpmInstall = ''
+    pnpm config set dedupe-peer-dependents false
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm --filter=@astrojs/language-server build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib/astro-language-server}
+    cp -r {packages,node_modules} $out/lib/astro-language-server
+    ln -s $out/lib/astro-language-server/packages/language-server/bin/nodeServer.js $out/bin/astro-ls
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "The Astro language server";
+    homepage = "https://github.com/withastro/language-tools";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pyrox0 ];
+    mainProgram = "astro-ls";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/development/node-packages/aliases.nix
+++ b/pkgs/development/node-packages/aliases.nix
@@ -37,6 +37,7 @@ in
 
 mapAliases {
   "@antora/cli" = pkgs.antora; # Added 2023-05-06
+  "@astrojs/language-server" = pkgs.astro-language-server; # Added 2024-02-12
   "@bitwarden/cli" = pkgs.bitwarden-cli; # added 2023-07-25
   "@emacs-eask/cli" = pkgs.eask; # added 2023-08-17
   "@forge/cli" = throw "@forge/cli was removed because it was broken"; # added 2023-09-20

--- a/pkgs/development/node-packages/main-programs.nix
+++ b/pkgs/development/node-packages/main-programs.nix
@@ -8,7 +8,6 @@
 
   # Packages that provide a single executable.
   "@angular/cli" = "ng";
-  "@astrojs/language-server" = "astro-ls";
   "@babel/cli" = "babel";
   "@commitlint/cli" = "commitlint";
   "@gitbeaker/cli" = "gitbeaker";

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -1,7 +1,6 @@
 [
   "@angular/cli"
 , "@antfu/ni"
-, "@astrojs/language-server"
 , "@babel/cli"
 , "@commitlint/cli"
 , "@commitlint/config-conventional"

--- a/pkgs/development/tools/pnpm/fetch-deps/default.nix
+++ b/pkgs/development/tools/pnpm/fetch-deps/default.nix
@@ -14,6 +14,8 @@
     {
       hash ? "",
       pname,
+      pnpmWorkspace ? "",
+      prePnpmInstall ? "",
       ...
     }@args:
     let
@@ -29,6 +31,7 @@
             outputHash = "";
             outputHashAlgo = "sha256";
           };
+      installFlags = lib.optionalString (pnpmWorkspace != "")  "--filter=${pnpmWorkspace}";
     in
     stdenvNoCC.mkDerivation (finalAttrs: (
       args'
@@ -58,11 +61,14 @@
           pnpm config set side-effects-cache false
           # As we pin pnpm versions, we don't really care about updates
           pnpm config set update-notifier false
+          # Run any additional pnpm configuration commands that users provide.
+          ${prePnpmInstall}
           # pnpm is going to warn us about using --force
           # --force allows us to fetch all dependencies including ones that aren't meant for our host platform
           pnpm install \
               --force \
               --ignore-scripts \
+              ${installFlags} \
               --frozen-lockfile
 
           runHook postInstall

--- a/pkgs/development/tools/pnpm/fetch-deps/default.nix
+++ b/pkgs/development/tools/pnpm/fetch-deps/default.nix
@@ -62,7 +62,7 @@
           # --force allows us to fetch all dependencies including ones that aren't meant for our host platform
           pnpm install \
               --force \
-              --ignore-script \
+              --ignore-scripts \
               --frozen-lockfile
 
           runHook postInstall

--- a/pkgs/development/tools/pnpm/fetch-deps/default.nix
+++ b/pkgs/development/tools/pnpm/fetch-deps/default.nix
@@ -60,7 +60,10 @@
           pnpm config set update-notifier false
           # pnpm is going to warn us about using --force
           # --force allows us to fetch all dependencies including ones that aren't meant for our host platform
-          pnpm install --frozen-lockfile --ignore-script --force
+          pnpm install \
+              --force \
+              --ignore-script \
+              --frozen-lockfile
 
           runHook postInstall
         '';

--- a/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
+++ b/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
@@ -24,7 +24,11 @@ pnpmConfigHook() {
 
     echo "Installing dependencies"
 
-    pnpm install --offline --frozen-lockfile --ignore-script
+    pnpm install \
+        --offline \
+        --ignore-script \
+        --frozen-lockfile
+
 
     echo "Patching scripts"
 

--- a/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
+++ b/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
@@ -26,7 +26,7 @@ pnpmConfigHook() {
 
     pnpm install \
         --offline \
-        --ignore-script \
+        --ignore-scripts \
         --frozen-lockfile
 
 

--- a/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
+++ b/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
@@ -24,9 +24,15 @@ pnpmConfigHook() {
 
     echo "Installing dependencies"
 
+    if [[ -n "$pnpmWorkspace" ]]; then
+        pnpmInstallFlags+=("--filter=$pnpmWorkspace")
+    fi
+    runHook prePnpmInstall
+
     pnpm install \
         --offline \
         --ignore-scripts \
+        "${pnpmInstallFlags[@]}" \
         --frozen-lockfile
 
 


### PR DESCRIPTION
## Description of changes
Adds `pnpmWorkspace` and `extraPnpmCommands` options for pnpm.fetchDeps calls

These can be used to either use a specific pnpm workspace for installation, and to run custom pnpm config commands during dependency fetching. Some packages may need a setting such as `dedupe-peer-dependents` set to a non-default value, and so this allows them to set those when needed.

See the discussion in #309100 (starting at https://github.com/NixOS/nixpkgs/pull/309100#discussion_r1658477855) as to why these are useful.

I've also updated the documentation appropriately.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
