### PR TITLE
recoll: 1.37.5 -> 1.39.1

### DIFF
--- a/pkgs/applications/search/recoll/default.nix
+++ b/pkgs/applications/search/recoll/default.nix
@@ -22,6 +22,8 @@
 , libxslt
 , lyx
 , makeWrapper
+, meson
+, ninja
 , perl
 , perlPackages
 , pkg-config
@@ -66,35 +68,36 @@ let filters = {
       perl = perl.passthru.withPackages (p: [ p.ImageExifTool ]);
     };
     filterPath = lib.makeBinPath (map lib.getBin (builtins.attrValues filters));
+    useInotify = if stdenv.isLinux then "true" else "false";
 in
 
 mkDerivation rec {
   pname = "recoll";
-  version = "1.37.5";
+  version = "1.39.1";
 
   src = fetchurl {
-    url = "https://www.lesbonscomptes.com/${pname}/${pname}-${version}.tar.gz";
-    hash = "sha256-vv2AMt6ufrfxRX2yF28X3E500MYP9hnGfDb3I9RdMVU=";
+    url = "https://www.recoll.org/${pname}-${version}.tar.gz";
+    hash = "sha256-Eeadj/AnuztCb7VIYEy4hKbduH3CzK53tADvI9+PWmQ=";
   };
 
-  configureFlags = [
-    "--enable-recollq"
-    "--disable-webkit"
-    "--without-systemd"
+  mesonFlags = [
+    "-Drecollq=true"
+    "-Dwebkit=false"
+    "-Dsystemd=false"
 
     # this leaks into the final `librecoll-*.so` binary, so we need
     # to be sure it is taken from `pkgs.file` rather than `stdenv`,
     # especially when cross-compiling
-    "--with-file-command=${file}/bin/file"
+    "-Dfile-command=${file}/bin/file"
 
   ] ++ lib.optionals (!withPython) [
-    "--disable-python-module"
-    "--disable-python-chm"
+    "-Dpython-module=false"
+    "-Dpython-chm=false"
   ] ++ lib.optionals (!withGui) [
-    "--disable-qtgui"
-    "--disable-x11mon"
+    "-Dqtgui=false"
+    "-Dx11mon=false"
   ] ++ [
-    (lib.withFeature stdenv.isLinux "inotify")
+    "-Dinotify=${useInotify}"
   ];
 
   env.NIX_CFLAGS_COMPILE = toString [
@@ -111,6 +114,8 @@ mkDerivation rec {
 
   nativeBuildInputs = [
     makeWrapper
+    meson
+    ninja
     pkg-config
     which
   ] ++ lib.optionals withGui [
@@ -174,7 +179,7 @@ mkDerivation rec {
     ln -s ../Applications/recoll.app/Contents/MacOS/recoll $out/bin/recoll
   '';
 
-  enableParallelBuilding = true;
+  enableParallelBuilding = false; # XXX: -j44 tried linking befoire librecoll had been created
 
   meta = with lib; {
     description = "Full-text search tool";
@@ -182,8 +187,8 @@ mkDerivation rec {
       Recoll is an Xapian frontend that can search through files, archive
       members, email attachments.
     '';
-    homepage = "https://www.lesbonscomptes.com/recoll/";
-    changelog = "https://www.lesbonscomptes.com/recoll/pages/release-${versions.majorMinor version}.html";
+    homepage = "https://www.recoll.org";
+    changelog = "https://www.recoll.org/pages/release-history.html";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
     maintainers = with maintainers; [ jcumming ehmry ];


### PR DESCRIPTION
## Description of changes

Address #304490 .

Version bump. Not many features changed, but build system changed. 

https://www.recoll.org/pages/release-history.html

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
