### PR TITLE
j-mc-2-obj: init at 126

### DIFF
--- a/pkgs/by-name/jm/jmc2obj/package.nix
+++ b/pkgs/by-name/jm/jmc2obj/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  fetchFromGitHub,
+  jre,
+  makeWrapper,
+  maven,
+}:
+
+maven.buildMavenPackage rec {
+  pname = "j-mc-2-obj";
+  version = "126";
+
+  src = fetchFromGitHub {
+    owner = "jmc2obj";
+    repo = pname;
+    rev = version;
+    hash = "sha256-c0qLryv9Gx9BlKXmwSKkK5/v3Wypny841htNfsNNxpg=";
+  };
+
+  mvnHash = "sha256-ya8E/6tOxyW+AO7v9p0dg72qFpQjWwvntZOw+TEKq0k=";
+
+  mvnParameters = "-Dmaven.gitcommitid.skip=true";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin $out/share/jMc2Obj
+    install -Dm644 JAR/jMc2Obj-${version}.jar $out/share/jMc2Obj
+
+    makeWrapper ${lib.getExe jre} $out/bin/jMc2Obj \
+      --add-flags "-jar $out/share/jMc2Obj/jMc2Obj-${version}.jar"
+    runHook postInstall
+  '';
+
+  meta = {
+    changelog = "https://github.com/jmc2obj/j-mc-2-obj/releases/tag/${version}";
+    description = "Java-based Minecraft-to-OBJ exporter";
+    homepage = "https://github.com/jmc2obj/j-mc-2-obj";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ eymeric ];
+    mainProgram = "jMc2Obj";
+  };
+}


### PR DESCRIPTION
## Description of changes

Add j-mc-2-obj.

## Things done

Packaged j-mc-2-obj

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@Xeon0X please confirm that everything seems to work.
I am also not sure about the name of the app because it is sometime called j-mc-2-obj, sometime jMc2Obj, sometime jMc2Obj-version.
The app also has no license, is it ok to just keep the license field unset? 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
