### PR TITLE
python3Packages.nikola: 8.3.0 -> 8.3.1

### DIFF
--- a/pkgs/development/python-modules/nikola/default.nix
+++ b/pkgs/development/python-modules/nikola/default.nix
@@ -8,7 +8,6 @@
   doit,
   feedparser,
   fetchPypi,
-  fetchpatch2,
   freezegun,
   ghp-import,
   hsluv,
@@ -44,7 +43,7 @@
 
 buildPythonPackage rec {
   pname = "nikola";
-  version = "8.3.0";
+  version = "8.3.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -52,16 +51,8 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "Nikola";
     inherit version;
-    hash = "sha256-VYuhiGLMTHcOZM8/bGZT7Xx5BOHo9gsMPjufYglrBL0=";
+    hash = "sha256-IfJB2Rl3c1MyEiuyNpT3udfpM480VvFD8zosJFDHr7k=";
   };
-
-  patches = [
-    (fetchpatch2 {
-      name = "nikola-pytest8-compat.patch";
-      url = "https://github.com/getnikola/nikola/commit/5f1003f91cd59f62622d379efe9be5fb19a1ed3e.patch";
-      hash = "sha256-2H3125RUnwvN/XgwgfRe1139rhAz/9viMEcUYRGQMPs=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace setup.cfg \


### PR DESCRIPTION
## Description of changes

Flagging as security related as it includes the removal of `polyfill.io` CDN which is now considered to be a bad actor. https://github.com/getnikola/nikola/commit/f7c2e915e6386b89a774e7e1c57290e8a9749f15

Changes:
https://github.com/getnikola/nikola/releases/tag/v8.3.1
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>python311Packages.nikola</li>
    <li>python311Packages.nikola.dist</li>
    <li>python312Packages.nikola</li>
    <li>python312Packages.nikola.dist</li>
  </ul>
</details>
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
