### PR TITLE
opendataeditor: init at 1.0.0

### DIFF
--- a/pkgs/by-name/op/open-data-editor/package.nix
+++ b/pkgs/by-name/op/open-data-editor/package.nix
@@ -1,0 +1,72 @@
+{ lib
+, stdenv
+, appimageTools
+, fetchurl
+, makeWrapper
+, pkgs
+}:
+let
+  pname = "opendataeditor";
+  version = "1.0.0";
+
+  src = fetchurl {
+    x86_64-darwin = {
+      url = "https://github.com/okfn/${pname}/releases/download/v${version}/${pname}-mac-${version}.dmg";
+      hash = "sha256-39HzXe7+BKkaP0/x+H4FlolQuy0bkqtLLpTbd7n2TkY=";
+    };
+    x86_64-linux = {
+      url = "https://github.com/okfn/${pname}/releases/download/v${version}/${pname}-linux-${version}.AppImage";
+      hash = "sha256-WTS2dX7j3ovfayu/iBbi5YfLKtLVhK3fFTqqTqQQemk=";
+    };
+  }.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
+
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+
+  meta = with lib; {
+    homepage = "https://opendataeditor.okfn.org/";
+    description = "No-code application to explore and publish all kinds of data";
+    longDescription = ''
+      No-code application to explore and publish all kinds of data: datasets, tables, charts, maps, stories, and more.
+      Forever free and open source project powered by open standards and generative AI.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ ByteSudoer ];
+    platforms = [ "x86_64-darwin" "x86_64-linux" ];
+    mainProgram = "opendataeditor";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+in
+
+if stdenv.isDarwin then
+  stdenv.mkDerivation
+  {
+    inherit pname version src meta;
+
+    sourceRoot = ".";
+
+    nativeBuildInputs = with pkgs; [ undmg ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out/Applications"
+      mv Open\ Data\ Editor.app $out/Applications/
+
+      runHook postInstall
+    '';
+  }
+else
+  appimageTools.wrapType2 {
+    inherit pname version src meta;
+
+    extraPkgs = pkgs: [ pkgs.libxcrypt-legacy ];
+
+    extraInstallCommands = ''
+      mkdir -p $out/share/${pname}
+
+      cp -a ${appimageContents}/{locales,resources} $out/share/${pname}
+      cp -a ${appimageContents}/usr/share/icons $out/share/
+      install -Dm 444 ${appimageContents}/${pname}.desktop -t $out/share/applications
+    '';
+
+  }


### PR DESCRIPTION
## Description of changes
Project description

Open Data Editor by the Open Knowledge Foundation

 > No-code application to explore and publish all kinds of data: datasets, tables, charts, maps, stories, and more. Forever free and open source project powered by open standards and generative AI.

Metadata
- homepage URL: https://opendataeditor.okfn.org/
- source URL: https://github.com/okfn/opendataeditor
- license: mit
- platforms: unix, linux, darwin

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
