### PR TITLE
buildRubyGem: do not override fixupPhase

### DIFF
--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -251,19 +251,15 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
     done
     ''}
 
-    runHook postInstall
-  '';
-
-  # For Ruby-generated binstubs, shebang paths are already in Nix store but for
-  # ruby used to build the package. Update them to match the host system. Note
-  # that patchShebangsAuto ignores scripts where shebang line is already in Nix
-  # store.
-  fixupPhase = attrs.fixupPhase or ''
-    runHook preFixup
-    if [[ -d $out/${ruby.gemPath}/bin ]]; then
-      patchShebangs --update --host $out/${ruby.gemPath}/bin
+    # For Ruby-generated binstubs, shebang paths are already in Nix store but for
+    # ruby used to build the package. Update them to match the host system. Note
+    # that patchShebangsAuto ignores scripts where shebang line is already in Nix
+    # store.
+    if [[ -d $GEM_HOME/bin ]]; then
+      patchShebangs --update --host -- "$GEM_HOME"/bin
     fi
-    runHook postFixup
+
+    runHook postInstall
   '';
 
   propagatedBuildInputs = gemPath ++ propagatedBuildInputs;


### PR DESCRIPTION
## Description of changes

Oops, looks like we were overriding stdenv’s fixupPhase that runs fixupOutputHooks, including patchShebangsAuto.

See https://github.com/NixOS/nixpkgs/pull/270242#issuecomment-2198531800

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
