### PR TITLE
nix-folder2channel: init

### DIFF
--- a/pkgs/by-name/ni/nix-folder2channel/package.nix
+++ b/pkgs/by-name/ni/nix-folder2channel/package.nix
@@ -1,0 +1,31 @@
+{ stdenv, writeScriptBin, buildEnv, git, busybox }:
+let
+  nix-folder2channel-script = writeScriptBin "nix-folder2channel" ''
+    #!${stdenv.shell}
+    if ! [ -f flake.nix ]; then
+      echo Please run at root of nixpkgs
+      exit 1
+    fi
+
+    HASH=$(nix-build nixos/release.nix -A channel --arg nixpkgs  '{ outPath = ./. ; revCount = "'$(${git}/bin/git rev-list HEAD | ${busybox}/bin/wc -l)'"; shortRev = "'$(${git}/bin/git rev-parse --short HEAD)'"; }' | ${busybox}/bin/awk -F'/' '{print $4}')
+    TARBAL_NAME=`echo $HASH | ${busybox}/bin/sed -e 's/.*-//'`
+
+    nix-channel --remove nixos
+    nix-channel --add file:///nix/store/$HASH/tarballs/nixos-$TARBAL_NAME.tar.xz nixos
+    nix-channel --update
+
+    echo "nix-channel change to current folder"
+    nix-channel --list
+  '';
+
+in {
+  nix-folder2channel = buildEnv {
+    name = "nix-folder2channel";
+    paths = [ nix-folder2channel-script ];
+    meta = with stdenv.lib; {
+      description = "Help developers set nixos channel from source code";
+      maintainers = with maintainers; [ yanganto SuperSandro2000 ];
+      platforms = platforms.unix;
+    };
+  };
+}


### PR DESCRIPTION
add nix-folder2channel script to make the nixpkgs into a channel in developing nix packages.

###### Motivation for this change
Some developers and I are confusing about make the source code into a channel when developing nix packages.
It is trival, but friendly for a new developer to contribute on the nix.
I lack of deep knowledge about nix, and am willing to get any better suggestion and take time to work on this.  
If you have any comment or suggestion on this script, I am appreciated.
Fix #14698

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Related issue:
#101524
