### PR TITLE
nix-channel: do not set empty nix-path when disabling channels

### DIFF
--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -116,6 +116,55 @@ It has two modes:
 
 : The `lychee` package to use.
 
+## `shellcheck` {#tester-shellcheck}
+
+Runs files through `shellcheck`, a static analysis tool for shell scripts.
+
+:::{.example #ex-shellcheck}
+# Run `testers.shellcheck`
+
+A single script
+
+```nix
+testers.shellcheck {
+  name = "shellcheck";
+  src = ./script.sh;
+}
+```
+
+Multiple files
+
+```nix
+let
+  inherit (lib) fileset;
+in
+testers.shellcheck {
+  name = "shellcheck";
+  src = fileset.toSource {
+    root = ./.;
+    fileset = fileset.unions [
+      ./lib.sh
+      ./nixbsd-activate
+    ];
+  };
+}
+```
+
+:::
+
+### Inputs {#tester-shellcheck-inputs}
+
+[`src` (path or string)]{#tester-shellcheck-param-src}
+
+: The path to the shell script(s) to check.
+  This can be a single file or a directory containing shell files.
+  All files in `src` will be checked, so you may want to provide `fileset`-based source instead of a whole directory.
+
+### Return value {#tester-shellcheck-return}
+
+A derivation that runs `shellcheck` on the given script(s).
+The build will fail if `shellcheck` finds any issues.
+
 ## `testVersion` {#tester-testVersion}
 
 Checks that the output from running a command contains the specified version string in it as a whole word.

--- a/nixos/modules/config/nix-channel.nix
+++ b/nixos/modules/config/nix-channel.nix
@@ -101,23 +101,25 @@ in
 
     system.activationScripts.no-nix-channel = mkIf (!cfg.channel.enable)
       (stringAfter [ "etc" "users" ] ''
+        explainChannelWarning=0
         if [ -e "/root/.nix-defexpr/channels" ]; then
-            echo "WARNING: /root/.nix-defexpr/channels exists, but channels have been disabled." 1>&2
-            echo "Due to https://github.com/NixOS/nix/issues/9574, Nix may still use these channels when NIX_PATH is unset." 1>&2
-            echo "Delete the above directory to prevent this." 1>&2
+            warn '/root/.nix-defexpr/channels exists, but channels have been disabled.'
+            explainChannelWarning=1
         fi
         if [ -e "/nix/var/nix/profiles/per-user/root/channels" ]; then
-            echo "WARNING: /nix/var/nix/profiles/per-user/root/channels exists, but channels have been disabled." 1>&2
-            echo "Due to https://github.com/NixOS/nix/issues/9574, Nix may still use these channels when NIX_PATH is unset." 1>&2
-            echo "Delete the above directory to prevent this." 1>&2
+            warn "/nix/var/nix/profiles/per-user/root/channels exists, but channels have been disabled."
+            explainChannelWarning=1
         fi
         getent passwd | while IFS=: read -r _ _ _ _ _ home _ ; do
             if [ -n  "$home" -a -e "$home/.nix-defexpr/channels" ]; then
-                echo "WARNING: $home/.nix-defexpr/channels exists, but channels have been disabled." 1>&2
-                echo "Due to https://github.com/NixOS/nix/issues/9574, Nix may still use these channels when NIX_PATH is unset." 1>&2
-                echo "Delete the above directory to prevent this." 1>&2
+                warn "$home/.nix-defexpr/channels exists, but channels have been disabled." 1>&2
+                explainChannelWarning=1
             fi
         done
+        if [ $explainChannelWarning -eq 1 ]; then
+            echo "Due to https://github.com/NixOS/nix/issues/9574, Nix may still use these channels when NIX_PATH is unset." 1>&2
+            echo "Delete the above directory or directories to prevent this." 1>&2
+        fi
       '');
   };
 }

--- a/nixos/modules/config/nix-channel.nix
+++ b/nixos/modules/config/nix-channel.nix
@@ -100,26 +100,6 @@ in
     ];
 
     system.activationScripts.no-nix-channel = mkIf (!cfg.channel.enable)
-      (stringAfter [ "etc" "users" ] ''
-        explainChannelWarning=0
-        if [ -e "/root/.nix-defexpr/channels" ]; then
-            warn '/root/.nix-defexpr/channels exists, but channels have been disabled.'
-            explainChannelWarning=1
-        fi
-        if [ -e "/nix/var/nix/profiles/per-user/root/channels" ]; then
-            warn "/nix/var/nix/profiles/per-user/root/channels exists, but channels have been disabled."
-            explainChannelWarning=1
-        fi
-        getent passwd | while IFS=: read -r _ _ _ _ _ home _ ; do
-            if [ -n  "$home" -a -e "$home/.nix-defexpr/channels" ]; then
-                warn "$home/.nix-defexpr/channels exists, but channels have been disabled." 1>&2
-                explainChannelWarning=1
-            fi
-        done
-        if [ $explainChannelWarning -eq 1 ]; then
-            echo "Due to https://github.com/NixOS/nix/issues/9574, Nix may still use these channels when NIX_PATH is unset." 1>&2
-            echo "Delete the above directory or directories to prevent this." 1>&2
-        fi
-      '');
+      (stringAfter [ "etc" "users" ] (builtins.readFile ./nix-channel/activation-check.sh));
   };
 }

--- a/nixos/modules/config/nix-channel/activation-check.sh
+++ b/nixos/modules/config/nix-channel/activation-check.sh
@@ -1,0 +1,21 @@
+# shellcheck shell=bash
+
+explainChannelWarning=0
+if [[ -e "/root/.nix-defexpr/channels" ]]; then
+    warn '/root/.nix-defexpr/channels exists, but channels have been disabled.'
+    explainChannelWarning=1
+fi
+if [[ -e "/nix/var/nix/profiles/per-user/root/channels" ]]; then
+    warn "/nix/var/nix/profiles/per-user/root/channels exists, but channels have been disabled."
+    explainChannelWarning=1
+fi
+while IFS=: read -r _ _ _ _ _ home _ ; do
+    if [[ -n  "$home" && -e "$home/.nix-defexpr/channels" ]]; then
+        warn "$home/.nix-defexpr/channels exists, but channels have been disabled." 1>&2
+        explainChannelWarning=1
+    fi
+done < <(getent passwd)
+if [[ $explainChannelWarning -eq 1 ]]; then
+    echo "Due to https://github.com/NixOS/nix/issues/9574, Nix may still use these channels when NIX_PATH is unset." 1>&2
+    echo "Delete the above directory or directories to prevent this." 1>&2
+fi

--- a/nixos/modules/config/nix-channel/test.nix
+++ b/nixos/modules/config/nix-channel/test.nix
@@ -1,0 +1,19 @@
+# Run:
+#   nix-build -A nixosTests.nix-channel
+{ lib, testers }:
+let
+  inherit (lib) fileset;
+
+  runShellcheck = testers.shellcheck {
+    src = fileset.toSource {
+      root = ./.;
+      fileset = fileset.unions [
+        ./activation-check.sh
+      ];
+    };
+  };
+
+in
+lib.recurseIntoAttrs {
+  inherit runShellcheck;
+}

--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -33,6 +33,8 @@ let
     ''
       #!${pkgs.runtimeShell}
 
+      source ${./lib/lib.sh}
+
       systemConfig='@out@'
 
       export PATH=/empty

--- a/nixos/modules/system/activation/lib/lib.sh
+++ b/nixos/modules/system/activation/lib/lib.sh
@@ -1,0 +1,5 @@
+# shellcheck shell=bash
+
+warn() {
+    printf "\033[1;35mwarning:\033[0m %s\n" "$*" >&2
+}

--- a/nixos/modules/system/activation/lib/test.nix
+++ b/nixos/modules/system/activation/lib/test.nix
@@ -1,0 +1,36 @@
+# Run:
+#   nix-build -A nixosTests.activation-lib
+{ lib, stdenv, testers }:
+let
+  inherit (lib) fileset;
+
+  runTests = stdenv.mkDerivation {
+    name = "tests-activation-lib";
+    src = fileset.toSource {
+      root = ./.;
+      fileset = fileset.unions [
+        ./lib.sh
+        ./test.sh
+      ];
+    };
+    buildPhase = ":";
+    doCheck = true;
+    postUnpack = ''
+      patchShebangs --build .
+    '';
+    checkPhase = ''
+      ./test.sh
+    '';
+    installPhase = ''
+      touch $out
+    '';
+  };
+
+  runShellcheck = testers.shellcheck {
+    src = runTests.src;
+  };
+
+in
+lib.recurseIntoAttrs {
+  inherit runTests runShellcheck;
+}

--- a/nixos/modules/system/activation/lib/test.sh
+++ b/nixos/modules/system/activation/lib/test.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Run:
+#   ./test.sh
+# or:
+#   nix-build -A nixosTests.activation-lib
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+set -euo pipefail
+
+# report failure
+onerr() {
+  set +e
+  # find failed statement
+  echo "call trace:"
+  local i=0
+  while t="$(caller $i)"; do
+    line="${t%% *}"
+    file="${t##* }"
+    echo "  $file:$line" >&2
+    ((i++))
+  done
+  # red
+  printf "\033[1;31mtest failed\033[0m\n" >&2
+  exit 1
+}
+trap onerr ERR
+
+source ./lib.sh
+
+(warn hi, this works >/dev/null) 2>&1 | grep -E $'.*warning:.* hi, this works' >/dev/null
+
+# green
+printf "\033[1;32mok\033[0m\n"

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -610,6 +610,7 @@ in {
   nbd = handleTest ./nbd.nix {};
   ncdns = handleTest ./ncdns.nix {};
   ndppd = handleTest ./ndppd.nix {};
+  nix-channel = pkgs.callPackage ../modules/config/nix-channel/test.nix { };
   nebula = handleTest ./nebula.nix {};
   netbird = handleTest ./netbird.nix {};
   nimdow = handleTest ./nimdow.nix {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -296,6 +296,7 @@ in {
   esphome = handleTest ./esphome.nix {};
   etc = pkgs.callPackage ../modules/system/etc/test.nix { inherit evalMinimalConfig; };
   activation = pkgs.callPackage ../modules/system/activation/test.nix { };
+  activation-lib = pkgs.callPackage ../modules/system/activation/lib/test.nix { };
   activation-var = runTest ./activation/var.nix;
   activation-nix-channel = runTest ./activation/nix-channel.nix;
   activation-etc-overlay-mutable = runTest ./activation/etc-overlay-mutable.nix;

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -392,6 +392,7 @@ let
       #   - the "backdoor" shell is not a proper session and does not have `NIX_PATH=""` set
       #   - seeing no nix path settings at all, Nix loads its hardcoded default value,
       #     which is unfortunately non-empty
+      # Or maybe it's the new default NIX_PATH?? :(
       # with subtest("builtins.nixPath is now empty"):
       #   target.succeed("""
       #     (

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -350,7 +350,32 @@ let
         """)
 
       with subtest("Switch to flake based config"):
-        target.succeed("nixos-rebuild switch --flake /root/my-config#xyz")
+        target.succeed("nixos-rebuild switch --flake /root/my-config#xyz 2>&1 | tee activation-log >&2")
+
+        target.succeed("""
+          cat -n activation-log >&2
+        """)
+
+        target.succeed("""
+          grep -F '/root/.nix-defexpr/channels exists, but channels have been disabled.' activation-log
+        """)
+        target.succeed("""
+          grep -F '/nix/var/nix/profiles/per-user/root/channels exists, but channels have been disabled.' activation-log
+        """)
+        target.succeed("""
+          grep -F '/root/.nix-defexpr/channels exists, but channels have been disabled.' activation-log
+        """)
+        target.succeed("""
+          grep -F 'Due to https://github.com/NixOS/nix/issues/9574, Nix may still use these channels when NIX_PATH is unset.' activation-log
+        """)
+        target.succeed("rm activation-log")
+
+        # Perform the suggested cleanups we've just seen in the log
+        # TODO after https://github.com/NixOS/nix/issues/9574: don't remove them yet
+        target.succeed("""
+          rm -rf /root/.nix-defexpr/channels /nix/var/nix/profiles/per-user/root/channels /root/.nix-defexpr/channels
+        """)
+
 
       target.shutdown()
 
@@ -361,10 +386,19 @@ let
 
       # Note that the channel profile is still present on disk, but configured
       # not to be used.
-      with subtest("builtins.nixPath is now empty"):
-        target.succeed("""
-          [[ "[ ]" == "$(nix-instantiate builtins.nixPath --eval --expr)" ]]
-        """)
+      # TODO after issue https://github.com/NixOS/nix/issues/9574: re-enable this assertion
+      # I believe what happens is
+      #   - because of the issue, we've removed the `nix-path =` line from nix.conf
+      #   - the "backdoor" shell is not a proper session and does not have `NIX_PATH=""` set
+      #   - seeing no nix path settings at all, Nix loads its hardcoded default value,
+      #     which is unfortunately non-empty
+      # with subtest("builtins.nixPath is now empty"):
+      #   target.succeed("""
+      #     (
+      #       set -x;
+      #       [[ "[ ]" == "$(nix-instantiate builtins.nixPath --eval --expr)" ]];
+      #     )
+      #   """)
 
       with subtest("<nixpkgs> does not resolve"):
         target.succeed("""
@@ -378,12 +412,16 @@ let
         target.succeed("""
           (
             exec 1>&2
-            rm -v /root/.nix-channels
+            rm -vf /root/.nix-channels
             rm -vrf ~/.nix-defexpr
             rm -vrf /nix/var/nix/profiles/per-user/root/channels*
           )
         """)
-        target.succeed("nixos-rebuild switch --flake /root/my-config#xyz")
+        target.succeed("nixos-rebuild switch --flake /root/my-config#xyz | tee activation-log >&2")
+        target.succeed("cat -n activation-log >&2")
+        target.succeed("! grep -F '/root/.nix-defexpr/channels' activation-log")
+        target.succeed("! grep -F 'but channels have been disabled' activation-log")
+        target.succeed("! grep -F 'https://github.com/NixOS/nix/issues/9574' activation-log")
 
       target.shutdown()
     '';

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -151,4 +151,6 @@
   hasPkgConfigModules = callPackage ./hasPkgConfigModules/tester.nix { };
 
   testMetaPkgConfig = callPackage ./testMetaPkgConfig/tester.nix { };
+
+  shellcheck = callPackage ./shellcheck/tester.nix { };
 }

--- a/pkgs/build-support/testers/shellcheck/example.sh
+++ b/pkgs/build-support/testers/shellcheck/example.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo $@

--- a/pkgs/build-support/testers/shellcheck/tester.nix
+++ b/pkgs/build-support/testers/shellcheck/tester.nix
@@ -1,0 +1,28 @@
+# Dependencies (callPackage)
+{ lib, stdenv, shellcheck }:
+
+# testers.shellcheck function
+# Docs: doc/build-helpers/testers.chapter.md
+# Tests: ./tests.nix
+{ src }:
+let
+  inherit (lib) fileset pathType isPath;
+in
+stdenv.mkDerivation {
+  name = "run-shellcheck";
+  src =
+    if isPath src && pathType src == "regular" # note that for strings this would have been IFD, which we prefer to avoid
+    then fileset.toSource { root = dirOf src; fileset = src; }
+    else src;
+  nativeBuildInputs = [ shellcheck ];
+  doCheck = true;
+  dontConfigure = true;
+  dontBuild = true;
+  checkPhase = ''
+    find . -type f -print0 \
+      | xargs -0 shellcheck
+  '';
+  installPhase = ''
+    touch $out
+  '';
+}

--- a/pkgs/build-support/testers/shellcheck/tests.nix
+++ b/pkgs/build-support/testers/shellcheck/tests.nix
@@ -1,0 +1,38 @@
+# Run:
+#   nix-build -A tests.testers.shellcheck
+
+{ lib, testers, runCommand }:
+let
+  inherit (lib) fileset;
+in
+lib.recurseIntoAttrs {
+
+  example-dir = runCommand "test-testers-shellcheck-example-dir" {
+    failure = testers.testBuildFailure
+      (testers.shellcheck {
+        src = fileset.toSource {
+          root = ./.;
+          fileset = fileset.unions [
+            ./example.sh
+          ];
+        };
+      });
+  } ''
+    log="$failure/testBuildFailure.log"
+    echo "Checking $log"
+    grep SC2068 "$log"
+    touch $out
+  '';
+
+  example-file = runCommand "test-testers-shellcheck-example-file" {
+    failure = testers.testBuildFailure
+      (testers.shellcheck {
+        src = ./example.sh;
+      });
+  } ''
+    log="$failure/testBuildFailure.log"
+    echo "Checking $log"
+    grep SC2068 "$log"
+    touch $out
+  '';
+}

--- a/pkgs/build-support/testers/test/default.nix
+++ b/pkgs/build-support/testers/test/default.nix
@@ -16,6 +16,8 @@ lib.recurseIntoAttrs {
 
   hasPkgConfigModules = pkgs.callPackage ../hasPkgConfigModules/tests.nix { };
 
+  shellcheck = pkgs.callPackage ../shellcheck/tests.nix { };
+
   runNixOSTest-example = pkgs-with-overlay.testers.runNixOSTest ({ lib, ... }: {
     name = "runNixOSTest-test";
     nodes.machine = { pkgs, ... }: {


### PR DESCRIPTION
## Description of changes

Continuation of https://github.com/NixOS/nixpkgs/pull/273170.

An empty nix-path in nix.conf will disable NIX_PATH environment variable entirely, which is not necessarily implied by users who want to disable nix channels. NIX_PATH also has some usages in tools like nixos-rebuild or just as user aliases.

That change is surprising and debatable, and also caused breakages in nixpkgs-review and user configs.

See:
- https://github.com/NixOS/nixpkgs/pull/242098/files#r1269891427
- https://github.com/Mic92/nixpkgs-review/issues/343
- https://github.com/NixOS/nix/pull/10998

Changes since https://github.com/NixOS/nixpkgs/pull/273170: implements @roberth's suggestion to warn when channel data still exists, as Nix (in the absence of a `NIX_PATH`) will still use it.

In this circumstance, Nix will now complain:

```
warning: Nix search path entry '/root/.nix-defexpr/channels' does not exist, ignoring
warning: Nix search path entry '/nix/var/nix/profiles/per-user/root/channels' does not exist, ignoring
```

It is a little annoying, but also in a way reassuring.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
