### PR TITLE
worldpainter: init at 2.23.2

### DIFF
--- a/pkgs/by-name/wo/worldpainter/package.nix
+++ b/pkgs/by-name/wo/worldpainter/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  jre,
+  makeWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
+  gnused,
+}:
+stdenv.mkDerivation rec {
+  pname = "worldpainter";
+  version = "2.23.2";
+
+  src = fetchurl {
+    url = "https://www.worldpainter.net/files/${pname}_${version}.tar.gz";
+    hash = "sha256-FhrfI2/mBeIZAg26Q8x8T2YU2ANwAkoC3h9Tgw6ggoY=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    copyDesktopItems
+    gnused
+  ];
+
+  outputs = [ "out" ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,lib,.install4j/user}
+
+    install -Dm644 bin/*        "$out/bin/"
+    install -Dm644 lib/*        "$out/lib/"
+    install -Dm644 *.vmoptions  "$out/"
+    install -Dm755 worldpainter "$out/bin"
+    install -Dm755 wpscript     "$out/bin"
+    find .install4j/ -maxdepth 1 -type f -exec install -Dm644 {} "$out/.install4j/" \;
+    find .install4j/user/ -maxdepth 1 -type f -exec install -Dm644 {} "$out/.install4j/user/" \;
+
+    mkdir -p $out/share/{pixmaps,applications}
+    install -Dm644 .install4j/i4j_extf_8_jed6s0_1y6kkxa.png   "$out/share/pixmaps/worldpainter.png"
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    sed -i 's/app_home=\./app_home=../' $out/bin/worldpainter
+    sed -i 's/app_home=\./app_home=../' $out/bin/wpscript
+    wrapProgram $out/bin/worldpainter --prefix PATH : "${jre}/bin"
+    wrapProgram $out/bin/wpscript --prefix PATH : "${jre}/bin"
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      desktopName = pname;
+      exec = pname;
+      icon = pname;
+      terminal = false;
+      type = "Application";
+      startupWMClass = pname;
+      comment = "Paint your own Minecraft worlds";
+      categories = [ "Game" ];
+    })
+  ];
+
+  meta = {
+    homepage = "https://www.worldpainter.net/";
+    description = "Interactive map generator for Minecraft";
+    longDescription = "WorldPainter is an interactive map generator for Minecraft. It allows you to \"paint\" landscapes using similar tools as a regular paint program. Sculpt and mould the terrain, paint materials, trees, snow and ice, etc. onto it, and much more";
+    license = with lib.licenses; [ gpl3 ];
+    maintainers = with lib.maintainers; [ eymeric ];
+    platforms = lib.platforms.linux;
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Packaged world painter

## Things done

Patch world painter runner to add java in $PATH.
Manually make a desktop file.
Inspired a lot by the [aur package](https://aur.archlinux.org/packages/worldpainter)

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
