### PR TITLE
python3Packages.awslambdaric: 2.0.11 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/awslambdaric/default.nix
+++ b/pkgs/development/python-modules/awslambdaric/default.nix
@@ -3,7 +3,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   isPy27,
   pytestCheckHook,
   autoconf271,
@@ -11,14 +10,14 @@
   cmake,
   gcc,
   libtool,
+  parameterized,
   perl,
   setuptools,
   simplejson,
 }:
-
 buildPythonPackage rec {
   pname = "awslambdaric";
-  version = "2.0.11";
+  version = "2.1.0";
   pyproject = true;
 
   disabled = isPy27;
@@ -27,21 +26,8 @@ buildPythonPackage rec {
     owner = "aws";
     repo = "aws-lambda-python-runtime-interface-client";
     rev = "refs/tags/${version}";
-    sha256 = "sha256-9DiUpgeL4bY7G3b5R06FjpN0st03F84fj0bhp70moKo=";
+    sha256 = "sha256-FHZ7ZTCOzElW/DM07TScp6bfOOFe4b307q/ALVX1fWQ=";
   };
-
-  patches = [
-    (fetchpatch {
-      # https://github.com/aws/aws-lambda-python-runtime-interface-client/pull/58
-      url = "https://github.com/aws/aws-lambda-python-runtime-interface-client/commit/162c3c0051bb9daa92e4a2a4af7e90aea60ee405.patch";
-      sha256 = "09qqq5x6npc9jw2qbhzifqn5sqiby4smiin1aw30psmlp21fv7j8";
-    })
-  ];
-
-  postPatch = ''
-    substituteInPlace requirements/base.txt \
-      --replace 'simplejson==3' 'simplejson~=3'
-  '';
 
   propagatedBuildInputs = [ simplejson ];
 
@@ -58,11 +44,9 @@ buildPythonPackage rec {
 
   dontUseCmakeConfigure = true;
 
-  nativeCheckInputs = [ pytestCheckHook ];
-
-  disabledTests = [
-    # Test fails with: Assertion error
-    "test_handle_event_request_fault_exception_logging_syntax_error"
+  nativeCheckInputs = [
+    parameterized
+    pytestCheckHook
   ];
 
   pythonImportsCheck = [
@@ -71,7 +55,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64);
+    broken = stdenv.isLinux && stdenv.isAarch64;
     description = "AWS Lambda Runtime Interface Client for Python";
     homepage = "https://github.com/aws/aws-lambda-python-runtime-interface-client";
     license = licenses.asl20;


### PR DESCRIPTION
## Description of changes

Updates to latest and fixes https://github.com/NixOS/nixpkgs/issues/323226.

https://github.com/aws/aws-lambda-python-runtime-interface-client/compare/2.0.10...2.1.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc