### PR TITLE
STC: init at 4.2

### DIFF
--- a/pkgs/by-name/st/STC/package.nix
+++ b/pkgs/by-name/st/STC/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "stclib";
     repo = "STC";
-    rev = "refs/tags/v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-vbFv1jPVeMQC58fVjoNlbB5w3EM/v4NGKqx0XvaJuns=";
   };
 
@@ -27,12 +27,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   installPhase =
     let
-      pc = rec {
-        name = "${finalAttrs.pname}.pc";
+      pc = {
+        name = "stc.pc";
         file = writeText name ''
           includedir=@PREFIX@/include
 
-          Name: ${finalAttrs.pname}
+          Name: stc
           Description: Smart Template Containers
           URL: https://github.com/stclib/STC
           Version: ${finalAttrs.version}

--- a/pkgs/by-name/st/STC/package.nix
+++ b/pkgs/by-name/st/STC/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  writeText,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "stc";
+  version = "4.2";
+
+  src = fetchFromGitHub {
+    owner = "stclib";
+    repo = "STC";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-vbFv1jPVeMQC58fVjoNlbB5w3EM/v4NGKqx0XvaJuns=";
+  };
+
+  dontBuild = true;
+
+  dontFixup = true;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  installPhase =
+    let
+      pc = rec {
+        name = "${finalAttrs.pname}.pc";
+        file = writeText name ''
+          includedir=@PREFIX@/include
+
+          Name: ${finalAttrs.pname}
+          Description: Smart Template Containers
+          URL: https://github.com/stclib/STC
+          Version: ${finalAttrs.version}
+          Cflags: -I''${includedir}
+        '';
+      };
+    in
+    ''
+      runHook preInstall
+
+      mkdir -p $out
+      mkdir -p $dev/lib/pkgconfig
+
+      cp -rf $src/include $out
+
+      cp ${pc.file} $dev/lib/pkgconfig/${pc.name}
+
+      substituteInPlace $dev/lib/pkgconfig/${pc.name} \
+          --replace-fail '@PREFIX@' $out
+
+      runHook postInstall
+    '';
+
+  meta = {
+    description = "Smart Template Containers";
+    longDescription = ''
+      A modern, user friendly, generic, type-safe and fast C99 container library:
+      String, Vector, Sorted and Unordered Map and Set, Deque, Forward List, Smart Pointers, Bitset and Random numbers.
+    '';
+    homepage = "https://github.com/stclib/STC";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ steve-chavez ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
STC is a header-only library for C99. It provides Smart Template Containers.

See https://github.com/stclib/STC.

This package adds a `.pc` file so STC can be used with `pkg-config`.

```
pkg-config --cflags stc
```

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
