### PR TITLE
lianad: init at 6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16330,6 +16330,12 @@
     githubId = 358550;
     name = "Philip Lykke Carlsen";
   };
+  plebhash = {
+    name = "plebhash";
+    email = "plebhash@proton.me";
+    github = "plebhash";
+    githubId = 147345153;
+  };
   pleshevskiy = {
     email = "dmitriy@pleshevski.ru";
     github = "pleshevskiy";

--- a/pkgs/by-name/li/liana/package.nix
+++ b/pkgs/by-name/li/liana/package.nix
@@ -38,7 +38,7 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "liana";
-  version = "6.0";
+  version = "6.0"; # keep in sync with lianad
 
   src = fetchFromGitHub {
     owner = "wizardsardine";

--- a/pkgs/by-name/li/lianad/package.nix
+++ b/pkgs/by-name/li/lianad/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  udev,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "lianad";
+  version = "6.0"; # keep in sync with liana
+
+  src = fetchFromGitHub {
+    owner = "wizardsardine";
+    repo = "liana";
+    rev = "v${version}";
+    hash = "sha256-LLDgo4GoRTVYt72IT0II7O5wiMDrvJhe0f2yjzxQgsE=";
+  };
+
+  cargoHash = "sha256-a4hLtDXnEeTa0e1LcMkEPKEqGBp5bzWseq5Pe5ZYF1M=";
+
+  buildInputs = [ udev ];
+
+  postInstall = ''
+    install -Dm0644 ./contrib/lianad_config_example.toml $out/etc/liana/config.toml
+  '';
+
+  # bypass broken unit tests
+  doCheck = false;
+
+  meta = {
+    mainProgram = "lianad";
+    description = "Bitcoin wallet leveraging on-chain timelocks for safety and recovery";
+    homepage = "https://wizardsardine.com/liana";
+    license = lib.licenses.bsd3;
+    maintainers = [
+      lib.maintainers.dunxen
+      lib.maintainers.plebhash
+    ];
+    platforms = lib.platforms.linux;
+    broken = stdenv.isAarch64;
+  };
+}


### PR DESCRIPTION
## Description of changes

the `liana` package currently only supports the `liana-gui` executable, while it is desired to also support headless use-cases

this PR adds a `withGui` attribute, which is used to choose between:
- provide `liana-gui` executable if `withGui` is `true`
- provide `lianad` + `liana-cli` executables if `withGui` is `false` (plus a `$out/etc/liana/config.toml` based on [`lianad_config_example.toml`](https://github.com/wizardsardine/liana/blob/master/contrib/lianad_config_example.toml))

cc @dunxen

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
