### PR TITLE
[23.11] openssh: add backported security fix patches

### DIFF
--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -12,7 +12,11 @@ in
       hash = "sha256-kQIRwHJVqMWtZUORtA7lmABxDdgRndU2LeCThap6d3w=";
     };
 
-    extraPatches = [ ./ssh-keysign-8.5.patch ];
+    extraPatches = [
+      ./ssh-keysign-8.5.patch
+      ./openssh-9.6_p1-CVE-2024-6387.patch
+      ./openssh-9.6_p1-chaff-logic.patch
+    ];
     extraMeta.maintainers = with lib.maintainers; [ das_j ];
   };
 

--- a/pkgs/tools/networking/openssh/openssh-9.6_p1-CVE-2024-6387.patch
+++ b/pkgs/tools/networking/openssh/openssh-9.6_p1-CVE-2024-6387.patch
@@ -1,0 +1,19 @@
+https://bugs.gentoo.org/935271
+Backport proposed by upstream at https://marc.info/?l=oss-security&m=171982317624594&w=2.
+--- a/log.c
++++ b/log.c
+@@ -451,12 +451,14 @@ void
+ sshsigdie(const char *file, const char *func, int line, int showfunc,
+     LogLevel level, const char *suffix, const char *fmt, ...)
+ {
++#ifdef SYSLOG_R_SAFE_IN_SIGHAND
+ 	va_list args;
+ 
+ 	va_start(args, fmt);
+ 	sshlogv(file, func, line, showfunc, SYSLOG_LEVEL_FATAL,
+ 	    suffix, fmt, args);
+ 	va_end(args);
++#endif
+ 	_exit(1);
+ }
+ 

--- a/pkgs/tools/networking/openssh/openssh-9.6_p1-chaff-logic.patch
+++ b/pkgs/tools/networking/openssh/openssh-9.6_p1-chaff-logic.patch
@@ -1,0 +1,16 @@
+"Minor logic error in ObscureKeystrokeTiming"
+https://marc.info/?l=oss-security&m=171982317624594&w=2
+--- a/clientloop.c
++++ b/clientloop.c
+@@ -608,8 +608,9 @@ obfuscate_keystroke_timing(struct ssh *ssh, struct timespec *timeout,
+ 		if (timespeccmp(&now, &chaff_until, >=)) {
+ 			/* Stop if there have been no keystrokes for a while */
+ 			stop_reason = "chaff time expired";
+-		} else if (timespeccmp(&now, &next_interval, >=)) {
+-			/* Otherwise if we were due to send, then send chaff */
++		} else if (timespeccmp(&now, &next_interval, >=) &&
++		    !ssh_packet_have_data_to_write(ssh)) {
++			/* If due to send but have no data, then send chaff */
+ 			if (send_chaff(ssh))
+ 				nchaff++;
+ 		}


### PR DESCRIPTION
Fixes a critical security bug allowing remote code execution as root: <https://www.openssh.com/txt/release-9.8>

This may be CVE-2024-6387 (currently embargoed): <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-6387>

Thanks to upstream and Sam James for the backport: <https://github.com/gentoo/gentoo/commit/1633ef45475afb9eea04e9cf27021c9d994af338>

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
