### PR TITLE
steam-tui: 0.1.0 -> 0.3.0

### DIFF
--- a/pkgs/games/steam-tui/default.nix
+++ b/pkgs/games/steam-tui/default.nix
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage rec {
     description = "Rust TUI client for steamcmd";
     homepage = "https://github.com/dmadisetti/steam-tui";
     license = licenses.mit;
-    maintainers = with maintainers; [ lom ];
+    maintainers = with maintainers; [ lom dmadisetti ];
     # steam only supports that platform
     platforms = [ "x86_64-linux" ];
     mainProgram = "steam-tui";

--- a/pkgs/games/steam-tui/default.nix
+++ b/pkgs/games/steam-tui/default.nix
@@ -1,28 +1,35 @@
-{ lib
-, rustPlatform
-, steamcmd
-, fetchFromGitHub
-, steam-run
-, runtimeShell
-, withWine ? false
-, wine
+{
+  lib,
+  rustPlatform,
+  steamcmd,
+  fetchFromGitHub,
+  steam-run,
+  openssl,
+  pkg-config,
+  runtimeShell,
+  withWine ? false,
+  wine,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "steam-tui";
-  version = "0.1.0";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "dmadisetti";
     repo = pname;
     rev = version;
-    sha256 = "sha256-UTXYlPecv0MVonr9zZwfwopfC/Fdch/ZSCxqgUsem40=";
+    sha256 = "sha256-3vBIpPIsh+7PjTuNNqp7e/pdciOYnzuGkjb/Eks6QJw=";
   };
 
-  cargoSha256 = "sha256-VYBzwDLSV4N4qt2dNgIS399T2HIbPTdQ2rDIeheLlfo=";
+  cargoSha256 = "sha256-poNPdrMguV79cwo2Eq1dGVUN0E4yG84Q63kU9o+eABo=";
 
-  buildInputs = [ steamcmd ]
-    ++ lib.optional withWine wine;
+  nativeBuildInputs = [
+    openssl
+    pkg-config
+  ];
+
+  buildInputs = [ steamcmd ] ++ lib.optional withWine wine;
 
   preFixup = ''
     mv $out/bin/steam-tui $out/bin/.steam-tui-unwrapped
@@ -34,11 +41,18 @@ rustPlatform.buildRustPackage rec {
     chmod +x $out/bin/steam-tui
   '';
 
+  checkFlags = [ "--skip=impure" ];
+
+  PKG_CONFIG_PATH = "${openssl.dev}/lib/pkgconfig";
+
   meta = with lib; {
     description = "Rust TUI client for steamcmd";
     homepage = "https://github.com/dmadisetti/steam-tui";
     license = licenses.mit;
-    maintainers = with maintainers; [ lom dmadisetti ];
+    maintainers = with maintainers; [
+      lom
+      dmadisetti
+    ];
     # steam only supports that platform
     platforms = [ "x86_64-linux" ];
     mainProgram = "steam-tui";


### PR DESCRIPTION
## Description of changes

Updated steam-tui to most recent release. Closes https://github.com/dmadisetti/steam-tui/issues/70

## Things done

 - Update to 0.3.0
 - Add dmadisetti as maintainer
 - Exclude "impure" tests explicitly as done in the flake.
 - ran `nixfmt`

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
