### PR TITLE
lib.types: remove __attrsFailEvaluation

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -73,7 +73,6 @@ let
 
   outer_types =
 rec {
-  __attrsFailEvaluation = true;
   isType = type: x: (x._type or "") == type;
 
   setType = typeName: value: value // {


### PR DESCRIPTION
## Description of changes

The test (`nix-build pkgs/test/release/default.nix`) continues to pass without this preventative measure.

This line was added in #269356.

## Things done

- [x] Tested, as applicable:
  - [x] `nix-build pkgs/test/release/default.nix`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
