### PR TITLE
nodePackages: remove __attrsFailEvaluation in all-packages

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9976,9 +9976,9 @@ with pkgs;
 
   importNpmLock = callPackages ../build-support/node/import-npm-lock { };
 
-  nodePackages_latest = dontRecurseIntoAttrs nodejs_latest.pkgs // { __attrsFailEvaluation = true; };
+  nodePackages_latest = dontRecurseIntoAttrs nodejs_latest.pkgs;
 
-  nodePackages = dontRecurseIntoAttrs nodejs.pkgs // { __attrsFailEvaluation = true; };
+  nodePackages = dontRecurseIntoAttrs nodejs.pkgs;
 
   node2nix = nodePackages.node2nix;
 


### PR DESCRIPTION
## Description of changes

The test (`nix-build pkgs/test/release/default.nix`) continues to pass without this preventative measure.

This line was added in https://github.com/NixOS/nixpkgs/pull/269356.

It adds these paths: https://gist.github.com/philiptaron/911ac3cea7be3236326fb648efd76422

## Things done

- [x] Tested, as applicable:
  - [x] `nix-build pkgs/test/release/default.nix`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).