### PR TITLE
dockerTools: remove __attrsFailEvaluation

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -839,7 +839,7 @@ with pkgs;
 
   dockerTools = callPackage ../build-support/docker {
     writePython3 = buildPackages.writers.writePython3;
-  } // { __attrsFailEvaluation = true; };
+  };
 
   fakeNss = callPackage ../build-support/fake-nss { };
 


### PR DESCRIPTION
## Description of changes

The test (`nix-build pkgs/test/release/default.nix`) continues to pass without this preventative measure.

This line was added in #269356.

It adds these paths: https://gist.github.com/philiptaron/78df3a1b0f9d245c25986552bd1eff26

## Things done

- [x] Tested, as applicable:
  - [x] `nix-build pkgs/test/release/default.nix`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).