### PR TITLE
eclipses.plugins: remove __attrsFailEvaluation

### DIFF
--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -241,6 +241,6 @@ in rec {
 
   ### Plugins
 
-  plugins = callPackage ./plugins.nix { } // { __attrsFailEvaluation = true; };
+  plugins = callPackage ./plugins.nix { };
 
 }


### PR DESCRIPTION
## Description of changes

The test (`nix-build pkgs/test/release/default.nix`) continues to pass without this preventative measure.

This line was added in https://github.com/NixOS/nixpkgs/pull/269356.

New paths:

```diff
--- /dev/fd/63	2024-07-01 11:06:41.135488587 -0700
+++ /dev/fd/62	2024-07-01 11:06:41.136488595 -0700
@@ -7129,8 +7129,38 @@
   "eclipses.eclipse-platform",
   "eclipses.eclipse-rcp",
   "eclipses.eclipse-scala-sdk",
   "eclipses.eclipse-sdk",
+  "eclipses.plugins.acejump",
+  "eclipses.plugins.ansi-econsole",
+  "eclipses.plugins.antlr-runtime_4_5",
+  "eclipses.plugins.antlr-runtime_4_7",
+  "eclipses.plugins.anyedittools",
+  "eclipses.plugins.autodetect-encoding",
+  "eclipses.plugins.bytecode-outline",
+  "eclipses.plugins.cdt",
+  "eclipses.plugins.checkstyle",
+  "eclipses.plugins.color-theme",
+  "eclipses.plugins.cup",
+  "eclipses.plugins.drools",
+  "eclipses.plugins.eclemma",
+  "eclipses.plugins.embed-cdt",
+  "eclipses.plugins.findbugs",
+  "eclipses.plugins.freemarker",
+  "eclipses.plugins.gnuarmeclipse",
+  "eclipses.plugins.ivy",
+  "eclipses.plugins.ivyant",
+  "eclipses.plugins.ivyde",
+  "eclipses.plugins.ivyderv",
+  "eclipses.plugins.jdt-codemining",
+  "eclipses.plugins.jsonedit",
+  "eclipses.plugins.rustdt",
+  "eclipses.plugins.scala",
+  "eclipses.plugins.spotbugs",
+  "eclipses.plugins.testng",
+  "eclipses.plugins.vrapper",
+  "eclipses.plugins.yedit",
+  "eclipses.plugins.zest",
   "ecm",
   "ecmtools",
   "ecopcr",
   "ecos",
```

## Things done

- [x] Tested, as applicable:
  - [x] `nix-build pkgs/test/release/default.nix`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).