### PR TITLE
vcpkg{,-tool}: miscellaneous fixups

### DIFF
--- a/doc/packages/index.md
+++ b/doc/packages/index.md
@@ -24,6 +24,7 @@ shell-helpers.section.md
 steam.section.md
 cataclysm-dda.section.md
 urxvt.section.md
+vcpkg.section.md
 weechat.section.md
 xorg.section.md
 ```

--- a/doc/packages/vcpkg.section.md
+++ b/doc/packages/vcpkg.section.md
@@ -1,0 +1,24 @@
+# VCPKG {#sec-vcpkg}
+
+The `vcpkg-tool` package  has a wrapper around the `vcpkg` executable to avoid writing to the nix store.
+The wrapper will also be present in `vcpkg`, unless you specify `vcpkg.override { vcpkg-tool = vcpkg-tool-unwrapped; }`
+
+The wrapper has been made in a way so that it will provide default cli arguments, but tries not to interfere if the user provides the same arguments.
+The arguments also have corresponding environment variables that can be used as an alternative way of overriding these paths.
+
+Run the wrapper with the environment variable `NIX_VCPKG_DEBUG_PRINT_ENVVARS=true` to get a full list of corresponding environment variables.
+
+## Nix specific environment variables {#sec-vcpkg-nix-envvars}
+
+The wrapper also provides some new nix-specific environment variables that lets you control some of the wrapper functionality.
+
+- `NIX_VCPKG_WRITABLE_PATH = <path>`
+
+   Set this environment variable to specify the path where `vcpkg` will store buildtime artifacts.
+   This will become the base path for all of the other paths.
+
+- `NIX_VCPKG_DEBUG_PRINT_ENVVARS = true | false`
+
+   Set this to `true` for the wrapper to print the corresponding environment variables for the arguments that will be provided to the unwrapped executable.
+   The list of variables will be printed right before invoking `vcpkg`.
+   This can be useful if you suspect that the wrapper for some reason was unable to prioritize user-provided cli args over its default ones, or for fixing other issues like typos or unexpanded environment variables.

--- a/pkgs/by-name/vc/vcpkg-tool/package.nix
+++ b/pkgs/by-name/vc/vcpkg-tool/package.nix
@@ -5,6 +5,7 @@
 , cacert
 , cmake
 , cmakerc
+, curl
 , fmt
 , git
 , gzip
@@ -12,6 +13,7 @@
 , ninja
 , openssh
 , python3
+, unzip
 , zip
 , zstd
 , extraRuntimeDeps ? []
@@ -55,12 +57,14 @@ stdenv.mkDerivation (finalAttrs: {
     runtimeDeps = [
       cacert
       cmake
+      curl
       git
       gzip
       meson
       ninja
       openssh
       python3
+      unzip
       zip
       zstd
     ] ++ extraRuntimeDeps;

--- a/pkgs/by-name/vc/vcpkg-tool/package.nix
+++ b/pkgs/by-name/vc/vcpkg-tool/package.nix
@@ -183,7 +183,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/microsoft/vcpkg-tool";
     changelog = "https://github.com/microsoft/vcpkg-tool/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ guekka gracicot ];
+    maintainers = with lib.maintainers; [ guekka gracicot h7x4 ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/vc/vcpkg-tool/package.nix
+++ b/pkgs/by-name/vc/vcpkg-tool/package.nix
@@ -181,6 +181,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Components of microsoft/vcpkg's binary";
     mainProgram = "vcpkg";
     homepage = "https://github.com/microsoft/vcpkg-tool";
+    changelog = "https://github.com/microsoft/vcpkg-tool/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ guekka gracicot ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/vc/vcpkg/package.nix
+++ b/pkgs/by-name/vc/vcpkg/package.nix
@@ -51,7 +51,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     mainProgram = "vcpkg";
     homepage = "https://vcpkg.io/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ guekka gracicot ];
+    maintainers = with lib.maintainers; [ guekka gracicot h7x4 ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/vc/vcpkg/package.nix
+++ b/pkgs/by-name/vc/vcpkg/package.nix
@@ -21,14 +21,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   installPhase = ''
       runHook preInstall
 
-      mkdir -p $out/bin $out/share/vcpkg/scripts/buildsystems
-      cp --preserve=mode -r ./{docs,ports,triplets,scripts,.vcpkg-root,versions,LICENSE.txt} $out/share/vcpkg/
+      mkdir -p "$out/bin" "$out/share/vcpkg/scripts/buildsystems"
+      cp --preserve=mode -r ./{docs,ports,triplets,scripts,.vcpkg-root,versions,LICENSE.txt} "$out/share/vcpkg/"
 
       makeWrapper "${vcpkg-tool}/bin/vcpkg" "$out/bin/vcpkg" \
         --set-default VCPKG_ROOT "$out/share/vcpkg"
 
-      ln -s $out/bin/vcpkg $out/share/vcpkg/vcpkg
-      touch $out/share/vcpkg/vcpkg.disable-metrics
+      ln -s "$out/bin/vcpkg" "$out/share/vcpkg/vcpkg"
+      touch "$out/share/vcpkg/vcpkg.disable-metrics"
 
       runHook postInstall
     '';

--- a/pkgs/by-name/vc/vcpkg/package.nix
+++ b/pkgs/by-name/vc/vcpkg/package.nix
@@ -18,6 +18,16 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  postPatch = ''
+    substituteInPlace scripts/toolchains/linux.cmake \
+      --replace-fail "aarch64-linux-gnu-as"  "aarch64-unknown-linux-gnu-as" \
+      --replace-fail "aarch64-linux-gnu-gcc" "aarch64-unknown-linux-gnu-gcc" \
+      --replace-fail "aarch64-linux-gnu-g++" "aarch64-unknown-linux-gnu-g++" \
+      --replace-fail "arm-linux-gnueabihf-as"  "armv7l-unknown-linux-gnueabihf-as" \
+      --replace-fail "arm-linux-gnueabihf-gcc" "armv7l-unknown-linux-gnueabihf-gcc" \
+      --replace-fail "arm-linux-gnueabihf-g++" "armv7l-unknown-linux-gnueabihf-g++"
+  '';
+
   installPhase = ''
       runHook preInstall
 

--- a/pkgs/by-name/vc/vcpkg/package.nix
+++ b/pkgs/by-name/vc/vcpkg/package.nix
@@ -3,6 +3,7 @@
 , lib
 , vcpkg-tool
 , makeWrapper
+, doWrap ? true
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -34,8 +35,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       mkdir -p "$out/bin" "$out/share/vcpkg/scripts/buildsystems"
       cp --preserve=mode -r ./{docs,ports,triplets,scripts,.vcpkg-root,versions,LICENSE.txt} "$out/share/vcpkg/"
 
-      makeWrapper "${vcpkg-tool}/bin/vcpkg" "$out/bin/vcpkg" \
-        --set-default VCPKG_ROOT "$out/share/vcpkg"
+      ${lib.optionalString doWrap ''
+        makeWrapper "${vcpkg-tool}/bin/vcpkg" "$out/bin/vcpkg" \
+          --set-default VCPKG_ROOT "$out/share/vcpkg"
+      ''}
 
       ln -s "$out/bin/vcpkg" "$out/share/vcpkg/vcpkg"
       touch "$out/share/vcpkg/vcpkg.disable-metrics"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19595,6 +19595,8 @@ with pkgs;
 
   qcachegrind = libsForQt5.callPackage ../development/tools/analysis/qcachegrind { };
 
+  vcpkg-tool-unwrapped = callPackage ../by-name/vc/vcpkg-tool/package.nix { doWrap = false; };
+
   visualvm = callPackage ../development/tools/java/visualvm { };
 
   volta = callPackage ../development/tools/volta { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

**Summary:**

- Moved most of the wrapper from vcpkg to vcpkg-tool directly (so you can rely on vcpkg-tool with an external VCPKG_ROOT and not have to repeat the patches)
- Ensure all of the arguments in the (now) vcpkg-tool wrapper is overridable, using envvars prefixed with `NIX` to communicate that these are nix specific.
- Patch some of the vcpkg cmake scripts, to conform the compiler detection to the executable names used in `pkgsCross`.
- Add some missing runtime deps for vcpkg-tool (these are listed as direct dependencies at https://github.com/microsoft/vcpkg/blob/101cc9a69a1061969caf4b73579a34873fdd60fe/scripts/bootstrap.sh#L88-L91 as well as https://github.com/microsoft/vcpkg/blob/101cc9a69a1061969caf4b73579a34873fdd60fe/scripts/azure-pipelines/linux/provision-image.sh#L27)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
