### PR TITLE
pidginPackages: move __attrsFailEvaluation to allow deeper evaluation

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/default.nix
@@ -14,7 +14,8 @@ lib.makeScope newScope (self:
       plugins = [];
     };
 
-    pidginPackages = self;
+    # Prevent `pkgs/top-level/release-attrpaths-superset.nix` from recursing here.
+    pidginPackages = self // { pidginPackages = self.pidginPackages // { __attrsFailEvaluation = true; }; };
 
     pidgin-indicator = callPackage ./pidgin-indicator { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33436,10 +33436,7 @@ with pkgs;
 
   picosnitch = callPackage ../tools/networking/picosnitch { };
 
-  pidginPackages =
-    let pidgin-plugins =
-          recurseIntoAttrs (callPackage ../applications/networking/instant-messengers/pidgin/pidgin-plugins { });
-    in pidgin-plugins // { pidginPackages = pidgin-plugins.pidginPackages // { __attrsFailEvaluation = true; }; };
+  pidginPackages = callPackage ../applications/networking/instant-messengers/pidgin/pidgin-plugins { };
 
   inherit (pidginPackages) pidgin;
 


### PR DESCRIPTION
## Description of changes

The test (`nix-build pkgs/test/release/default.nix`) test continues to pass.

These lines were added in https://github.com/NixOS/nixpkgs/pull/269356.

New derivations reported:

```diff
--- /dev/fd/63	2024-07-04 10:21:33.667962671 -0700
+++ /dev/fd/62	2024-07-04 10:21:33.667962671 -0700
@@ -51996,8 +51996,34 @@
   "pidginPackages.pidgin-sipe",
   "pidginPackages.pidgin-skypeweb",
   "pidginPackages.pidgin-window-merge",
   "pidginPackages.pidgin-xmpp-receipts",
+  "pidginPackages.pidginPackages.pidgin",
+  "pidginPackages.pidginPackages.pidgin-carbons",
+  "pidginPackages.pidginPackages.pidgin-indicator",
+  "pidginPackages.pidginPackages.pidgin-latex",
+  "pidginPackages.pidginPackages.pidgin-mra",
+  "pidginPackages.pidginPackages.pidgin-msn-pecan",
+  "pidginPackages.pidginPackages.pidgin-opensteamworks",
+  "pidginPackages.pidginPackages.pidgin-osd",
+  "pidginPackages.pidginPackages.pidgin-otr",
+  "pidginPackages.pidginPackages.pidgin-sipe",
+  "pidginPackages.pidginPackages.pidgin-skypeweb",
+  "pidginPackages.pidginPackages.pidgin-window-merge",
+  "pidginPackages.pidginPackages.pidgin-xmpp-receipts",
+  "pidginPackages.pidginPackages.purple-discord",
+  "pidginPackages.pidginPackages.purple-facebook",
+  "pidginPackages.pidginPackages.purple-googlechat",
+  "pidginPackages.pidginPackages.purple-hangouts",
+  "pidginPackages.pidginPackages.purple-lurch",
+  "pidginPackages.pidginPackages.purple-matrix",
+  "pidginPackages.pidginPackages.purple-mm-sms",
+  "pidginPackages.pidginPackages.purple-plugin-pack",
+  "pidginPackages.pidginPackages.purple-signald",
+  "pidginPackages.pidginPackages.purple-slack",
+  "pidginPackages.pidginPackages.purple-vk-plugin",
+  "pidginPackages.pidginPackages.purple-xmpp-http-upload",
+  "pidginPackages.pidginPackages.tdlib-purple",
   "pidginPackages.purple-discord",
   "pidginPackages.purple-facebook",
   "pidginPackages.purple-googlechat",
   "pidginPackages.purple-hangouts",
```

## Things done

- [x] Tested, as applicable:
  - [x] `nix-build pkgs/test/release/default.nix`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).