### PR TITLE
emacsPackages: remove __attrsFailEvaluation

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-packages.nix
@@ -121,4 +121,4 @@ self: let
 
   in elpaDevelPackages // { inherit elpaBuild; });
 
-in (generateElpa { }) // { __attrsFailEvaluation = true; }
+in generateElpa { }

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
@@ -210,4 +210,5 @@ self: let
 
   in elpaPackages // { inherit elpaBuild; });
 
-in (generateElpa { }) // { __attrsFailEvaluation = true; }
+in
+generateElpa { }

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -125,6 +125,4 @@ in
   emacsSessionManagement = self.session-management-for-emacs;
   rectMark = self.rect-mark;
   sunriseCommander = self.sunrise-commander;
-
-  __attrsFailEvaluation = true;
 }

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -750,5 +750,4 @@ let
     in lib.mapAttrs (n: v: if lib.hasAttr n overrides then overrides.${n} else v) super);
 
 in
-(generateMelpa { })
-// { __attrsFailEvaluation = true; }
+generateMelpa { }

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-packages.nix
@@ -20,12 +20,12 @@ self: let
     generated ? ./nongnu-generated.nix
   }: let
 
-    imported = (import generated {
+    imported = import generated {
       callPackage = pkgs: args: self.callPackage pkgs (args // {
         # Use custom elpa url fetcher with fallback/uncompress
         fetchurl = buildPackages.callPackage ./fetchelpa.nix { };
       });
-    }) // { __attrsFailEvaluation = true; };
+    };
 
     super = imported;
 


### PR DESCRIPTION
## Description of changes

This adds about 16,100 new packages for consideration by `nix-instantiate --eval --strict --json pkgs/top-level/release-attrpaths-superset.nix -A names`.

The test (`nix-build pkgs/test/release/default.nix`) continues to pass.

These lines were added in https://github.com/NixOS/nixpkgs/pull/269356.

The new packages added are captured here: https://gist.github.com/philiptaron/268b3db85d0004bf929e3cf957678c8b

## Things done

- [x] Tested, as applicable:
  - [x] `nix-build pkgs/test/release/default.nix`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).