### PR TITLE
fiji: 20201104-1356 -> 20240614-2117

### DIFF
--- a/pkgs/applications/graphics/fiji/default.nix
+++ b/pkgs/applications/graphics/fiji/default.nix
@@ -75,6 +75,6 @@ stdenv.mkDerivation rec {
       binaryNativeCode
     ];
     license = with lib.licenses; [ gpl2Plus gpl3Plus bsd2 publicDomain ];
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ davisrichard437 ];
   };
 }

--- a/pkgs/applications/graphics/fiji/default.nix
+++ b/pkgs/applications/graphics/fiji/default.nix
@@ -7,19 +7,21 @@
 , makeDesktopItem
 , copyDesktopItems
 , runtimeShell
+, unzip
 }:
+
 stdenv.mkDerivation rec {
   pname = "fiji";
-  version = "20201104-1356";
+  version = "20240614-2117";
 
   src = fetchurl {
-    url = "https://downloads.imagej.net/${pname}/archive/${version}/${pname}-nojre.tar.gz";
-    sha256 = "1jv4wjjkpid5spr2nk5xlvq3hg687qx1n5zh8zlw48y1y09c4q7a";
+    url = "https://downloads.imagej.net/${pname}/archive/${version}/${pname}-nojre.zip";
+    sha256 = "sha256-OCNnN8CYniNEIfKRHRBoJ3Fo+u5AwXoPJAzUCc4P+f0=";
   };
 
   dontBuild = true;
 
-  nativeBuildInputs = [ autoPatchelfHook makeWrapper copyDesktopItems ];
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper copyDesktopItems unzip ];
   buildInputs = [ stdenv.cc.cc.lib ];
 
   desktopItems = [
@@ -46,10 +48,11 @@ stdenv.mkDerivation rec {
     cp -R * $out/fiji
     rm -f $out/fiji/jars/imagej-updater-*.jar
 
-    # Disgusting hack to stop a local desktop entry being created
+    # Don't create a local desktop entry and avoid deprecated garbage
+    # collection option
     cat <<EOF > $out/bin/.fiji-launcher-hack
     #!${runtimeShell}
-    exec \$($out/fiji/ImageJ-linux64 --dry-run "\$@")
+    exec \$($out/fiji/ImageJ-linux64 --default-gc --dry-run "\$@")
     EOF
     chmod +x $out/bin/.fiji-launcher-hack
 

--- a/pkgs/applications/graphics/fiji/default.nix
+++ b/pkgs/applications/graphics/fiji/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   version = "20240614-2117";
 
   src = fetchurl {
-    url = "https://downloads.imagej.net/${pname}/archive/${version}/${pname}-nojre.zip";
+    url = "https://downloads.imagej.net/fiji/archive/${version}/fiji-nojre.zip";
     sha256 = "sha256-OCNnN8CYniNEIfKRHRBoJ3Fo+u5AwXoPJAzUCc4P+f0=";
   };
 


### PR DESCRIPTION
## Description of changes

This PR updates FIJI, a powerful image analysis tool, and adds myself as a maintainer. The previous maintainer orphaned the package 8 months ago and the package hasn't been updated since it was added in 2020. 

A note as well: I am unable to run `nixpkgs-review` on my laptop. Any assistance would be appreciated.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
