### PR TITLE
cpuinfo: init at 0-unstable-2024-06-02

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15402,6 +15402,12 @@
     githubId = 49961859;
     name = "Pavel Sobolev";
   };
+  pawelchcki = {
+    email = "pawel.chcki@gmail.com";
+    github = "pawelchcki";
+    githubId = 812891;
+    name = "Paweł Chojnacki";
+  };
   pawelpacana = {
     email = "pawel.pacana@gmail.com";
     github = "pawelpacana";

--- a/pkgs/by-name/cp/cpuinfo/package.nix
+++ b/pkgs/by-name/cp/cpuinfo/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  stdenv,
+  gtest,
+  nix-update-script,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cpuinfo";
+  version = "0-unstable-2024-06-02";
+
+  src = fetchFromGitHub {
+    owner = "pytorch";
+    repo = "cpuinfo";
+    rev = "05332fd802d9109a2a151ec32154b107c1e5caf9";
+    hash = "sha256-VhTRHpT+4g97m+amOZ52lJWavHsN5QVnjnEn6wJzE3A=";
+  };
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  checkInputs = [ gtest ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "CPUINFO_BUILD_UNIT_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "CPUINFO_BUILD_MOCK_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "CPUINFO_BUILD_BENCHMARKS" false)
+    (lib.cmakeBool "USE_SYSTEM_LIBS" true)
+  ];
+
+  doCheck = !(stdenv.isLinux && stdenv.isAarch64);
+
+  meta = {
+    description = "Tools and library to detect essential for performance optimization information about host CPU";
+    homepage = "https://github.com/pytorch/cpuinfo";
+    license = lib.licenses.bsd2;
+    mainProgram = "cpu-info";
+    maintainers = with lib.maintainers; [ pawelchcki ];
+    pkgConfigModules = [ "libcpuinfo" ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes

Add libcpuinfo library and associated tools from  https://github.com/pytorch/cpuinfo.

```
cpu-info - gives information about available packages, cores, and logical processors
cache-info - gives detail information about available CPU cache
isa-info - lists available instructions sets
cpuid-dump - dumps raw cpuid information
```



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
