### PR TITLE
magnetic-catppuccin-gtk: init at 0-unstable-2024-06-27

### DIFF
--- a/pkgs/by-name/ma/magnetic-catppuccin-gtk/package.nix
+++ b/pkgs/by-name/ma/magnetic-catppuccin-gtk/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gtk-engine-murrine,
+  jdupes,
+  sassc,
+  accent ? ["default"],
+  shade ? "dark",
+  size ? "standard",
+  tweaks ? [],
+}: let
+  validAccents = ["default" "purple" "pink" "red" "orange" "yellow" "green" "teal" "grey" "all"];
+  validShades = ["light" "dark"];
+  validSizes = ["standard" "compact"];
+  validTweaks = ["frappe" "macchiato" "black" "float" "outline" "macos"];
+
+  single = x: lib.optional (x != null) x;
+  pname = "Catppuccin-GTK";
+in
+  lib.checkListOfEnum "${pname} Valid theme accent(s)" validAccents accent
+  lib.checkListOfEnum "${pname} Valid shades" validShades (single shade)
+  lib.checkListOfEnum "${pname} Valid sizes" validSizes (single size)
+  lib.checkListOfEnum "${pname} Valid tweaks" validTweaks tweaks
+
+  stdenv.mkDerivation {
+    pname = "magnetic-${lib.toLower pname}";
+    version = "0-unstable-2024-06-27";
+
+    src = fetchFromGitHub {
+      owner = "Fausto-Korpsvart";
+      repo = "Catppuccin-GTK-Theme";
+      rev = "0bd2869e7f0fdb36c720a4fb873d4fed361b0606";
+      hash = "sha256-oFVsYrJ27hYGY+x9+Z4SxVCp3w6PiLYTZaxmGhnpVHQ=";
+    };
+
+    nativeBuildInputs = [jdupes sassc];
+
+    propagatedUserEnvPkgs = [gtk-engine-murrine];
+
+    postPatch = ''
+      find -name "*.sh" -print0 | while IFS= read -r -d ''' file; do
+        patchShebangs "$file"
+      done
+    '';
+
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share/themes
+
+      ./themes/install.sh \
+        --name ${pname} \
+        ${toString (map (x: "--theme " + x) accent)} \
+        ${lib.optionalString (shade != null) ("--color " + shade)} \
+        ${lib.optionalString (size != null) ("--size " + size)} \
+        ${toString (map (x: "--tweaks " + x) tweaks)} \
+        --dest $out/share/themes
+
+      jdupes --quiet --link-soft --recurse $out/share
+
+      runHook postInstall
+    '';
+
+    meta = with lib; {
+      description = "GTK Theme with Catppuccin colour scheme";
+      homepage = "https://github.com/Fausto-Korpsvart/Catppuccin-GTK-Theme";
+      license = licenses.gpl3Only;
+      maintainers = with maintainers; [ icy-thought ];
+      platforms = platforms.all;
+    };
+  }


### PR DESCRIPTION
## Description of changes

Considering how [catppuccin/gtk](https://github.com/catppuccin/gtk) has become an archived project, I thought I should put some effort into pushing a new alternative that could be used as a replacement.

Solves: https://github.com/Fausto-Korpsvart/Catppuccin-GTK-Theme/issues/12

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
