### PR TITLE
ocamlPackages.merlin: 4.14-501 → 4.16-501, 5.1-502

### DIFF
--- a/pkgs/development/tools/ocaml/merlin/4.x.nix
+++ b/pkgs/development/tools/ocaml/merlin/4.x.nix
@@ -21,23 +21,26 @@ let
     "4.12.1" = "4.7-412";
     "4.13.0" = "4.7-413";
     "4.13.1" = "4.7-413";
-    "4.14.0" = "4.14-414";
-    "4.14.1" = "4.14-414";
-    "4.14.2" = "4.14-414";
+    "4.14.0" = "4.16-414";
+    "4.14.1" = "4.16-414";
+    "4.14.2" = "4.16-414";
     "5.0.0" = "4.14-500";
-    "5.1.0" = "4.14-501";
-    "5.1.1" = "4.14-501";
+    "5.1.0" = "4.16-501";
+    "5.1.1" = "4.16-501";
+    "5.2.0" = "5.1-502";
   };
 
   hashes = {
     "4.7-412" = "sha256-0U3Ia7EblKULNy8AuXFVKACZvGN0arYJv7BWiBRgT0Y=";
     "4.7-413" = "sha256-aVmGWS4bJBLuwsxDKsng/n0A6qlyJ/pnDTcYab/5gyU=";
-    "4.14-414" = "sha256-eQGMyqN8FQHdXE1c94vDQg1kGx6CRDZimBxUctlzmT0=";
     "4.14-500" = "sha256-7CPzJPh1UgzYiX8wPMbU5ZXz1wAJFNQQcp8WuGrR1w4=";
-    "4.14-501" = "sha256-t+npbpJAWMLOQpZCeIqi45ByDUQeIkU4vPSUplIDopI=";
+    "4.16-414" = "sha256-xekZdfPfVoSeGzBvNWwxcJorE519V2NLjSHkcyZvzy0=";
+    "4.16-501" = "sha256-2lvzCbBAZFwpKuRXLMagpwDb0rz8mWrBPI5cODbCHiY=";
+    "5.1-502" = "sha256-T9gIvCaSnP/MqOoGNEeQFZwQ4+r5yRTPRu956Rf8rhU=";
   };
 
   version = lib.getAttr ocaml.version merlinVersions;
+
 in
 
 if !lib.hasAttr ocaml.version merlinVersions
@@ -47,7 +50,6 @@ else
 buildDunePackage {
   pname = "merlin";
   inherit version;
-  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/ocaml/merlin/releases/download/v${version}/merlin-${version}.tbz";

--- a/pkgs/development/tools/ocaml/merlin/dot-merlin-reader.nix
+++ b/pkgs/development/tools/ocaml/merlin/dot-merlin-reader.nix
@@ -3,8 +3,6 @@
 buildDunePackage rec {
   pname = "dot-merlin-reader";
 
-  duneVersion = "3";
-
   inherit (merlin) version src;
 
   minimalOCamlVersion = "4.06";


### PR DESCRIPTION
## Description of changes

https://github.com/ocaml/merlin/releases/tag/v4.15-414
https://github.com/ocaml/merlin/releases/tag/v4.16-414

Fixes  #312506

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
