### PR TITLE
Revert "[Backport release 24.05] nixos/snapper: add snapper opts"

### DIFF
--- a/nixos/modules/services/misc/snapper.nix
+++ b/nixos/modules/services/misc/snapper.nix
@@ -78,54 +78,6 @@ let
         Defines whether hourly snapshots should be created.
       '';
     };
-
-    TIMELINE_LIMIT_HOURLY = mkOption {
-      type = types.str;
-      default = "10";
-      description = ''
-        Limits for timeline cleanup.
-      '';
-    };
-
-    TIMELINE_LIMIT_DAILY = mkOption {
-      type = types.str;
-      default = "10";
-      description = ''
-        Limits for timeline cleanup.
-      '';
-    };
-
-    TIMELINE_LIMIT_WEEKLY = mkOption {
-      type = types.str;
-      default = "0";
-      description = ''
-        Limits for timeline cleanup.
-      '';
-    };
-
-    TIMELINE_LIMIT_MONTHLY = mkOption {
-      type = types.str;
-      default = "10";
-      description = ''
-        Limits for timeline cleanup.
-      '';
-    };
-
-    TIMELINE_LIMIT_QUARTERLY = mkOption {
-      type = types.str;
-      default = "0";
-      description = ''
-        Limits for timeline cleanup.
-      '';
-    };
-
-    TIMELINE_LIMIT_YEARLY = mkOption {
-      type = types.str;
-      default = "10";
-      description = ''
-        Limits for timeline cleanup.
-      '';
-    };
   };
 in
 


### PR DESCRIPTION
The change was breaking and should not have been backported, see https://github.com/NixOS/nixpkgs/pull/321237#issuecomment-2202266180. Reverts NixOS/nixpkgs#322217