### PR TITLE
Julia 1.10 fixes

### DIFF
--- a/pkgs/development/julia-modules/depot.nix
+++ b/pkgs/development/julia-modules/depot.nix
@@ -56,6 +56,7 @@ runCommand "julia-depot" {
   # See https://github.com/NixOS/nixpkgs/issues/315890
   git config --global --add safe.directory '*'
 
+  # Tell Julia to use the Git binary we provide, rather than internal libgit2.
   export JULIA_PKG_USE_CLI_GIT="true"
 
   # At time of writing, this appears to be the only way to turn precompiling's

--- a/pkgs/development/julia-modules/python/minimal_registry.py
+++ b/pkgs/development/julia-modules/python/minimal_registry.py
@@ -75,7 +75,7 @@ for (uuid, versions) in uuid_to_versions.items():
     os.makedirs(out_path / path)
 
     # Copy some files to the minimal repo unchanged
-    for f in ["Compat.toml", "Deps.toml"]:
+    for f in ["Compat.toml", "Deps.toml", "WeakCompat.toml", "WeakDeps.toml"]:
       if (registry_path / path / f).exists():
         shutil.copy2(registry_path / path / f, out_path / path)
 

--- a/pkgs/development/julia-modules/registry.nix
+++ b/pkgs/development/julia-modules/registry.nix
@@ -3,7 +3,7 @@
 fetchFromGitHub {
   owner = "CodeDownIO";
   repo = "General";
-  rev = "de80ad56e87f222ca6a7a517c69039d35437ab42";
-  sha256 = "0pz1jmmcb2vn854w8w0zlpnihi470649cd8djh1wzgq2i2fy83bl";
-  # date = "2023-12-22T03:28:12+00:00";
+  rev = "998c6da1553dc0776dfff314d2f1bd5af488ed71";
+  sha256 = "sha256-57RiIPTu9895mdk3oSfo7I3PYw7G0BfJG1u+mYkJeLk=";
+  # date = "2024-07-01T12:22:35+00:00";
 }


### PR DESCRIPTION
## Description of changes

This fixes the problems with Julia 1.10 and closes #319149. I also bumped the registry.

I ran the tests on the top 1000 most popular packages (on a branch with this plus my other PR I'm about to open), with these  results:

* Julia 1.9: 98.6% tests passing
* Julia 1.10: 99.2% tests passing

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
