### PR TITLE
julia.withPackages: fix for overrides not in a registry

### DIFF
--- a/pkgs/development/julia-modules/python/minimal_registry.py
+++ b/pkgs/development/julia-modules/python/minimal_registry.py
@@ -56,7 +56,8 @@ for (uuid, versions) in uuid_to_versions.items():
       # Write nothing in Compat.toml, because we've already resolved everything
     with open(out_path / path / Path("Deps.toml"), "w") as f:
       f.write('["%s"]\n' % info["version"])
-      toml.dump(project["deps"], f)
+      if "deps" in project:
+        toml.dump(project["deps"], f)
     with open(out_path / path / Path("Versions.toml"), "w") as f:
       f.write('["%s"]\n' % info["version"])
       f.write('git-tree-sha1 = "%s"\n' % info["treehash"])

--- a/pkgs/development/julia-modules/tests/julia-top-n/app/Main.hs
+++ b/pkgs/development/julia-modules/tests/julia-top-n/app/Main.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -19,7 +20,7 @@ import qualified Data.Aeson.KeyMap          as HM
 import qualified Data.ByteString.Lazy.Char8 as BL8
 import qualified Data.List as L
 import Data.String.Interpolate
-import Data.Text as T
+import Data.Text as T hiding (count)
 import qualified Data.Vector as V
 import qualified Data.Yaml as Yaml
 import GHC.Generics
@@ -60,34 +61,55 @@ julia = Label
 main :: IO ()
 main = do
   clo <- parseCommandLineArgs argsParser (return ())
-  let Args {..} = optUserOptions clo
+  let args@(Args {..}) = optUserOptions clo
 
   namesAndCounts :: [NameAndCount] <- Yaml.decodeFileEither countFilePath >>= \case
     Left err -> throwIO $ userError ("Couldn't decode names and counts YAML file: " <> show err)
     Right x -> pure x
 
-  runSandwichWithCommandLineArgs' defaultOptions argsParser $
+  runSandwichWithCommandLineArgs' defaultOptions argsParser $ do
+    miscTests args
+
     describe ("Building environments for top " <> show topN <> " Julia packages") $
       parallelN parallelism $
         forM_ (L.take topN namesAndCounts) $ \(NameAndCount {..}) ->
-          introduce' (defaultNodeOptions { nodeOptionsVisibilityThreshold = 0 }) (T.unpack name) julia (newMVar Nothing) (const $ return ()) $ do
-            it "Builds" $ do
-              let cp = proc "nix" ["build", "--impure", "--no-link", "--json", "--expr"
-                                  , [i|with import ../../../../. {}; #{juliaAttr}.withPackages ["#{name}"]|]
-                                  ]
-              output <- readCreateProcessWithLogging cp ""
-              juliaPath <- case A.eitherDecode (BL8.pack output) of
-                Right (A.Array ((V.!? 0) -> Just (A.Object (aesonLookup "outputs" -> Just (A.Object (aesonLookup "out" -> Just (A.String t))))))) -> pure (JuliaPath ((T.unpack t) </> "bin" </> "julia"))
-                x -> expectationFailure ("Couldn't parse output: " <> show x)
+          testExpr args name [i|#{juliaAttr}.withPackages ["#{name}"]|]
 
-              getContext julia >>= flip modifyMVar_ (const $ return (Just juliaPath))
+miscTests :: Args -> SpecFree ctx IO ()
+miscTests args@(Args {..}) = describe "Misc tests" $ do
+  describe "works for a package outside the General registry" $ do
+    testExpr args "HelloWorld" [iii|(#{juliaAttr}.withPackages.override {
+                                      packageOverrides = {
+                                        "HelloWorld" = pkgs.fetchFromGitHub {
+                                          owner = "codedownio";
+                                          repo = "HelloWorld.jl";
+                                          rev = "9b41c55df76eb87830dd3bd0b5601ee2582a37c6";
+                                          sha256 = "sha256-G+xpMRb0RopW/xWA8KCFF/S8wuHTQbpj0qwm9CihfSc=";
+                                        };
+                                      };
+                                    }) [ "HelloWorld" ]|]
 
-            it "Uses" $ do
-              getContext julia >>= readMVar >>= \case
-                Nothing -> expectationFailure "Build step failed."
-                Just (JuliaPath juliaPath) -> do
-                  let cp = proc juliaPath ["-e", "using " <> T.unpack name]
-                  createProcessWithLogging cp >>= waitForProcess >>= (`shouldBe` ExitSuccess)
+-- * Low-level
 
-aesonLookup :: Text -> HM.KeyMap v -> Maybe v
-aesonLookup = HM.lookup . A.fromText
+testExpr :: Args -> Text -> String -> SpecFree ctx IO ()
+testExpr _args name expr = do
+  introduce' (defaultNodeOptions { nodeOptionsVisibilityThreshold = 0 }) (T.unpack name) julia (newMVar Nothing) (const $ return ()) $ do
+    it "Builds" $ do
+      let cp = proc "nix" ["build", "--impure", "--no-link", "--json", "--expr", [i|with import ../../../../. {}; #{expr}|]]
+      output <- readCreateProcessWithLogging cp ""
+      juliaPath <- case A.eitherDecode (BL8.pack output) of
+        Right (A.Array ((V.!? 0) -> Just (A.Object (aesonLookup "outputs" -> Just (A.Object (aesonLookup "out" -> Just (A.String t))))))) -> pure (JuliaPath ((T.unpack t) </> "bin" </> "julia"))
+        x -> expectationFailure ("Couldn't parse output: " <> show x)
+
+      getContext julia >>= flip modifyMVar_ (const $ return (Just juliaPath))
+
+    it "Uses" $ do
+      getContext julia >>= readMVar >>= \case
+        Nothing -> expectationFailure "Build step failed."
+        Just (JuliaPath juliaPath) -> do
+          let cp = proc juliaPath ["-e", "using " <> T.unpack name]
+          createProcessWithLogging cp >>= waitForProcess >>= (`shouldBe` ExitSuccess)
+
+  where
+    aesonLookup :: Text -> HM.KeyMap v -> Maybe v
+    aesonLookup = HM.lookup . A.fromText


### PR DESCRIPTION
## Description of changes

This is a fix for #279853, making it possible to use a package in the `packageOverrides` even if that package doesn't appear in the registry.

I'm not sure if it's a totally comprehensive solution, but I added a test to the test suite for the case presented in the issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
