### PR TITLE
sddm-astronaut: init at 1.0

### DIFF
--- a/pkgs/data/themes/sddm-astronaut/default.nix
+++ b/pkgs/data/themes/sddm-astronaut/default.nix
@@ -1,0 +1,38 @@
+{ pkgs, lib, stdenvNoCC, themeConfig ? null }:
+stdenvNoCC.mkDerivation rec {
+  pname = "sddm-astronaut";
+  version = "1.0";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "Keyitdev";
+    repo = "sddm-astronaut-theme";
+    rev = "48ea0a792711ac0c58cc74f7a03e2e7ba3dc2ac0";
+    hash = "sha256-kXovz813BS+Mtbk6+nNNdnluwp/7V2e3KJLuIfiWRD0=";
+  };
+
+  dontWrapQtApps = true;
+  propagatedBuildInputs = with pkgs.kdePackages; [ qt5compat qtsvg ];
+
+  installPhase =
+    let
+      iniFormat = pkgs.formats.ini { };
+      configFile = iniFormat.generate "" { General = themeConfig; };
+
+      basePath = "$out/share/sddm/themes/sddm-astronaut-theme";
+    in
+    ''
+      mkdir -p ${basePath}
+      cp -r $src/* ${basePath}
+    '' + lib.optionalString (themeConfig != null) ''
+      ln -sf ${configFile} ${basePath}/theme.conf.user
+    '';
+
+  meta = {
+    description = "Modern looking qt6 sddm theme";
+    homepage = "https://github.com/${src.owner}/${pname}";
+    license = lib.licenses.gpl3;
+
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ danid3v ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27627,6 +27627,8 @@ with pkgs;
 
   schedtool = callPackage ../os-specific/linux/schedtool { };
 
+  sddm-astronaut = qt6Packages.callPackage ../data/themes/sddm-astronaut { };
+
   sddm-chili-theme = libsForQt5.callPackage ../data/themes/chili-sddm { };
 
   sddm-sugar-dark = libsForQt5.callPackage ../data/themes/sddm-sugar-dark { };


### PR DESCRIPTION
## Description of changes

Added the sddm-theme [sddm-astronaut](https://github.com/Keyitdev/sddm-astronaut-theme)

To use this in your configuration.nix
```nix
services.displayManager.sddm = {
  enable = true;
  package = pkgs.kdePackages.sddm; # this is not the default!!! (pkgs.plasma5Packages.sddm is but that doesn't work with a qt6 theme)
  
  theme = "sddm-astronaut-theme";
  extraPackages = [ pkgs.sddm-astronaut ];
};
```
and
```nix
environment.systemPackages = [ pkgs.sddm-astronaut ];
```

You need to globally install it because the sddm module [sets the ThemeDir](https://github.com/NixOS/nixpkgs/blob/09b3443ecb2c6a897a867ab421ba8234b939d6e3/nixos/modules/services/display-managers/sddm.nix#L56) to `/run/current-system/sw/share/sddm/themes`.
Packages in `sddm.extraPackages` won't end up there. We should probably change the `theme` string option to accept a derivation instead. This is a different issue tho. I might PR this is in the near future.

(If you know a better way to do this feel free to correct me)

### TODO:
- [ ] Decide whether to rename this package to sddm-astronaut-theme because that's what you need to set the theme string to.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
