### PR TITLE
mailpit: implement `passthru.updateScript`

### DIFF
--- a/pkgs/servers/mail/mailpit/default.nix
+++ b/pkgs/servers/mail/mailpit/default.nix
@@ -12,13 +12,15 @@
 }:
 
 let
-  version = "1.15.1";
+  versions = import ./versions.nix;
+
+  version = versions.version;
 
   src = fetchFromGitHub {
     owner = "axllent";
     repo = "mailpit";
     rev = "v${version}";
-    hash = "sha256-5QEn4sEZgtoFrVonZsAtvzhEkxYGDEWwhJOxqwWQJTk=";
+    hash = versions.hash;
   };
 
   # Separate derivation, because if we mix this in buildGoModule, the separate
@@ -30,7 +32,7 @@ let
 
     npmDeps = fetchNpmDeps {
       inherit src;
-      hash = "sha256-5F68ia2V8mw4iPAjSoz0b8z1lplWtAg98BgDXYOmMKs=";
+      hash = versions.npmDepsHash;
     };
 
     env = lib.optionalAttrs (stdenv.isDarwin && stdenv.isx86_64) {
@@ -56,7 +58,7 @@ buildGoModule {
   pname = "mailpit";
   inherit src version;
 
-  vendorHash = "sha256-e2mlOwGDU5NlKZSstHMdTidSfhNeeY6cBgtW+W9nwV8=";
+  vendorHash = versions.vendorHash;
 
   CGO_ENABLED = 0;
 
@@ -69,6 +71,11 @@ buildGoModule {
   passthru.tests.version = testers.testVersion {
     package = mailpit;
     command = "mailpit version";
+  };
+
+  passthru.updateScript = {
+    supportedFeatures = [ "commit" ];
+    command = ./update.sh;
   };
 
   meta = with lib; {

--- a/pkgs/servers/mail/mailpit/update.sh
+++ b/pkgs/servers/mail/mailpit/update.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix coreutils curl jq nix-prefetch-git prefetch-npm-deps
+
+set -x -euo pipefail
+
+OWNER=axllent
+REPO=mailpit
+
+TARGET_VERSION="$(curl https://api.github.com/repos/$OWNER/$REPO/releases/latest | jq -r '.tag_name')"
+
+if [[ "$UPDATE_NIX_OLD_VERSION" == "$TARGET_VERSION" ]]; then
+    # mailpit is up-to-date
+    if [[ -n "$UPDATE_NIX_ATTR_PATH" ]]; then
+        echo "[{}]";
+    fi
+
+    exit 0
+fi
+
+extractVendorHash() {
+    original="${1?original hash missing}"
+    result="$(nix-build -A mailpit.goModules 2>&1 | tail -n3 | grep 'got:' | cut -d: -f2- | xargs echo || true)"
+    [ -z "$result" ] && { echo "$original"; } || { echo "$result"; }
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' exit
+
+NIXPKGS_MAILPIT_PATH=$(cd $(dirname ${BASH_SOURCE[0]}); pwd -P)/
+VERSIONS_NIX="$NIXPKGS_MAILPIT_PATH/versions.nix"
+
+PREFETCH_JSON=$TMP/prefetch.json
+nix-prefetch-git --rev "$TARGET_VERSION" --url https://github.com/$OWNER/$REPO > "$PREFETCH_JSON"
+PREFETCH_HASH="$(jq '.hash' -r < "$PREFETCH_JSON")"
+PREFETCH_PATH="$(jq '.path' -r < "$PREFETCH_JSON")"
+NPM_DEPS_HASH="$(prefetch-npm-deps $PREFETCH_PATH/package-lock.json)"
+
+FAKE_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+cat > $VERSIONS_NIX << EOF
+{
+  version = "$TARGET_VERSION";
+  hash = "$PREFETCH_HASH";
+  npmDepsHash = "$NPM_DEPS_HASH";
+  vendorHash = "$FAKE_HASH";
+}
+EOF
+
+GO_HASH="$(nix-instantiate --eval -A mailpit.vendorHash | tr -d '"')"
+VENDOR_HASH=$(extractVendorHash "$GO_HASH")
+
+cat > $VERSIONS_NIX << EOF
+{
+  version = "$TARGET_VERSION";
+  hash = "$PREFETCH_HASH";
+  npmDepsHash = "$NPM_DEPS_HASH";
+  vendorHash = "$VENDOR_HASH";
+}
+EOF
+
+if [[ -z "$UPDATE_NIX_ATTR_PATH" ]]; then
+    exit 0
+fi
+
+cat <<EOF
+[{
+  "attrPath": "$UPDATE_NIX_ATTR_PATH",
+  "oldVersion": "$UPDATE_NIX_OLD_VERSION",
+  "newVersion": "$TARGET_VERSION",
+  "files": ["$VERSIONS_NIX"]
+}]
+EOF

--- a/pkgs/servers/mail/mailpit/versions.nix
+++ b/pkgs/servers/mail/mailpit/versions.nix
@@ -1,0 +1,6 @@
+{
+version = "v1.19.0";
+hash = "sha256-ios80PGZdp70X3+HFsTS4/DWP89j2TGBfSUvyTx4crQ=";
+npmDepsHash = "sha256-yZFIcU8/WCPjkogk3s4Y/W8agdGhVvQP1Rq+PHd7izo=";
+vendorHash = "sha256-pDMnxXXDtskm9INtlOTRLI6YEOOBIOuuAPnbT3LMhek=";
+}


### PR DESCRIPTION
## Description of changes

Implement `passthru.updateScript` for mailpit package.

Depends on: #323881
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
