### PR TITLE
lib.systems: do not confuse isStatic with hasSharedLibraries

### DIFF
--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -101,9 +101,28 @@ For example, a package which requires dynamic linking and cannot be linked stati
 ```nix
 {
   meta.platforms = lib.platforms.all;
+  meta.badPlatforms = [{ hasSharedLibraries = false; }];
+}
+```
+
+or
+
+```nix
+{
+  meta.platforms = lib.platforms.all;
   meta.badPlatforms = [ lib.systems.inspect.platformPatterns.isStatic ];
 }
 ```
+
+In the examples above, `lib.systems.inspect.platformPatterns.isStatic` is an alias for `{ isStatic = true; }` platform pattern. The difference between `isStatic` and `hasSharedLibraries` is that:
+
+* isStatic: packages should be statically linked against the dependencies when
+  possible. Dynamic linking may or may not be available.
+
+* hasSharedLibraries: the platform supports dynamic linking. For example, if set
+  to `false`, things like dlopen do not work. If the package *requires* dynamic
+  linking (e.g. must load plugins dynamically), it should be considered
+  unavailable on such platform.
 
 The [`lib.meta.availableOn`](https://github.com/NixOS/nixpkgs/blob/b03ac42b0734da3e7be9bf8d94433a5195734b19/lib/meta.nix#L95-L106) function can be used to test whether or not a package is available (i.e. buildable) on a given platform.
 Some packages use this to automatically detect the maximum set of features with which they can be built.

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -181,7 +181,7 @@ let
          || isDarwin || isSunOS || isOpenBSD || isFreeBSD || isNetBSD  # BSDs
          || isCygwin || isMinGW                                        # Windows
          || isWasm                                                     # WASM
-        ) && !isStatic;
+        ) && !isWasi && !isRedox;
 
       # The difference between `isStatic` and `hasSharedLibraries` is mainly the
       # addition of the `staticMarker` (see make-derivation.nix).  Some

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -164,6 +164,10 @@ rec {
   # apply only to the `parsed` field.
 
   platformPatterns = mapAttrs (_: p: { parsed = {}; } // p) {
+    # Matches platforms that are statically linked. That does not imply that
+    # dynamic linking is not supported.
     isStatic = { isStatic = true; };
+    # Matches platforms that support dynamic linking.
+    hasSharedLibraries = { hasSharedLibraries = true; };
   };
 }

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -160,6 +160,11 @@
 
 - [`lib.options.mkPackageOptionMD`](https://nixos.org/manual/nixpkgs/unstable#function-library-lib.options.mkPackageOptionMD) is now obsolete; use the identical [`lib.options.mkPackageOption`](https://nixos.org/manual/nixpkgs/unstable#function-library-lib.options.mkPackageOption) instead.
 
+- `lib.systems.elaborate` no longer sets `hasSharedLibraries` to `false` if
+  `isStatic = true`. Instead, `hasSharedLibraries` corresponds to the actual
+  platform support for shared libraries, independent of whether the packages
+  are being statically linked with their dependencies.
+
 - To facilitate dependency injection, the `imgui` package now builds a static archive using vcpkg' CMake rules.
   The derivation now installs "impl" headers selectively instead of by a wildcard.
   Use `imgui.src` if you just want to access the unpacked sources.

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -927,6 +927,9 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.linux;
     priority = 10;
     badPlatforms = [
+      # systemd uses dlopen for some features (see above).
+      { hasSharedLibraries = false; }
+      # Upstream is broken due to symbol conflicts when linking.
       # https://github.com/systemd/systemd/issues/20600#issuecomment-912338965
       lib.systems.inspect.platformPatterns.isStatic
     ];

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -433,7 +433,8 @@ let
           [
             "aarch64-linux" # times out on Hydra
 
-            # Static doesn't work on darwin
+            # Darwin requires dynamic linker support that pkgsStatic disables.
+            # TODO: do not disable hasSharedLibraries in pkgsStatic?
             "x86_64-darwin"
             "aarch64-darwin"
           ] {

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -176,8 +176,13 @@ let
   # following package sets are provided:
   #
   # - pkgsCross.<system> where system is a member of lib.systems.examples
+  # - pkgsLLVM
   # - pkgsMusl
   # - pkgsi686Linux
+  # - pkgsx86_64Darwin
+  # - pkgsLinux
+  # - pkgsStatic
+  # - pkgsExtraHardening
   otherPackageSets = self: super: {
     # This maps each entry in lib.systems.examples to its own package
     # set. Each of these will contain all packages cross compiled for
@@ -269,14 +274,15 @@ let
     # Prefer appendOverlays if used repeatedly.
     extend = f: self.appendOverlays [f];
 
-    # Fully static packages.
-    # Currently uses Musl on Linux (couldn’t get static glibc to work).
+    # Fully static packages without shared libraries support.
+    # Currently uses Musl on Linux.
     pkgsStatic = nixpkgsFun ({
       overlays = [ (self': super': {
         pkgsStatic = super';
       })] ++ overlays;
       crossSystem = {
         isStatic = true;
+        hasSharedLibraries = false;
         parsed =
           if stdenv.isLinux
           then makeMuslParsedPlatform stdenv.hostPlatform.parsed


### PR DESCRIPTION
## Description of changes

* isStatic: packages should be statically linked against the dependencies when possible.

* hasSharedLibraries: the platform supports dynamic linking. For example, if set to `false`, things like dlopen do not work. If the package *requires* dynamic linking (e.g. loads plugins), it should be considered unavailable on such platform.

That is, these are two related but distinct concepts. We shouldn’t assume that statically linked system does not support dynamic libraries. For example, GNU/Linux (i.e. glibc) and macOS binaries can be statically linked but have to use dynamic program loader (dyld or ld.so).

Note that it is reasonable to set `hasSharedLibraries = false` on Linux since the entire system is built from source (we can use C library that does not require shared libraries, e.g. musl) and there is a useful subset of packages that works without shared libraries.

This is still a bit ambiguous and naming could be better, but I think it’s a step in the right direction.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
