### PR TITLE
progress-tracker: init at 1.5.1

### DIFF
--- a/pkgs/by-name/pr/progress-tracker/package.nix
+++ b/pkgs/by-name/pr/progress-tracker/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  catch2_3,
+  cmake,
+  fetchFromGitHub,
+  gtkmm4,
+  libadwaita,
+  pcre2,
+  pkg-config,
+  stdenv,
+  tinyxml-2,
+  wrapGAppsHook4,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "progress-tracker";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "smolBlackCat";
+    repo = "progress-tracker";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-0FpWUNsXYIQRn6ciLoRbKBuEZT739sAAIfSBxFqfEpk=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    catch2_3
+    gtkmm4
+    libadwaita
+    pcre2
+    tinyxml-2
+  ];
+
+  postPatch = ''
+    substituteInPlace src/CMakeLists.txt \
+      --replace-fail "/usr/bin/" "${placeholder "out"}/bin/"
+
+    substituteInPlace po/CMakeLists.txt \
+      --replace-fail "/usr/share/" "${placeholder "out"}/share/"
+
+    substituteInPlace data/CMakeLists.txt \
+      --replace-fail "/usr/share/" "${placeholder "out"}/share/"
+  '';
+
+  meta = {
+    description = "Simple kanban-style task organiser";
+    homepage = "https://github.com/smolBlackCat/progress-tracker";
+    license = lib.licenses.mit;
+    mainProgram = "progress";
+    maintainers = with lib.maintainers; [ Guanran928 ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Simple kanban-style task organiser
https://flathub.org/apps/io.github.smolblackcat.Progress
https://github.com/smolBlackCat/progress-tracker

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
