### PR TITLE
coqPackages.smtcoq: 2.1 → 2.2

### DIFF
--- a/pkgs/development/coq-modules/smtcoq/default.nix
+++ b/pkgs/development/coq-modules/smtcoq/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, pkgs, mkCoqDerivation, coq, trakt, veriT, zchaff, fetchurl, cvc5, version ? null }:
+{ lib, stdenv, pkgs, mkCoqDerivation, coq, veriT, zchaff, fetchurl, cvc5, version ? null }:
 
 let
   # version of veriT that works with SMTCoq
@@ -15,6 +15,13 @@ mkCoqDerivation {
   pname = "smtcoq";
   owner = "smtcoq";
 
+  release."SMTCoq-2.2+8.19".sha256 = "sha256-9Wv8AXRRyOHG/cjA/V9tSK55R/bofDMLTkDpuwYWkks=";
+  release."SMTCoq-2.2+8.18".sha256 = "sha256-1iJAruI5Qn9nTZcUDjk8t/1Q+eFkYLOe9Ee0DmK03w8=";
+  release."SMTCoq-2.2+8.17".sha256 = "sha256-kaodsyVUl1+QQagzoBTIjxbdD4X3IaaH0x2AsVUL+Z0=";
+  release."SMTCoq-2.2+8.16".sha256 = "sha256-Hwm8IFlw97YiOY6H63HyJlwIXvQHr9lqc1+PgTnBtkw=";
+  release."SMTCoq-2.2+8.15".sha256 = "sha256-+GYOasJ32KJyOfqJlTtFmsJ2exd6gdueKwHdeMPErTo=";
+  release."SMTCoq-2.2+8.14".sha256 = "sha256-jqnF33E/4CqR1HSrLmUmLVCKslw9h3bbWi4YFmFYrhY=";
+  release."SMTCoq-2.2+8.13".sha256 = "sha256-AVpKU/SLaLYnCnx6GOEPGJjwbRrp28Fs5O50kJqdclI=";
   release."SMTCoq-2.1+8.16".rev    = "4996c00b455bfe98400e96c954839ceea93efdf7";
   release."SMTCoq-2.1+8.16".sha256 = "sha256-k53e+frUjwq+ZZKbbOKd/EfVC40QeAzB2nCsGkCKnHA=";
   release."SMTCoq-2.1+8.14".rev    = "e11d9b424b0113f32265bcef0ddc962361da4dae";
@@ -22,14 +29,20 @@ mkCoqDerivation {
   release."SMTCoq-2.1+8.13".rev    = "d02269c43739f4559d83873563ca00daad9faaf1";
   release."SMTCoq-2.1+8.13".sha256 = "sha256-VZetGghdr5uJWDwZWSlhYScoNEoRHIbwqwJKSQyfKKg=";
 
+  releaseRev = v: v;
+
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.version [
-    { case = isEq "8.16"; out = "SMTCoq-2.1+8.16"; }
-    { case = isEq "8.14"; out = "SMTCoq-2.1+8.14"; }
-    { case = isEq "8.13"; out = "SMTCoq-2.1+8.13"; }
+    { case = isEq "8.19"; out = "SMTCoq-2.2+8.19"; }
+    { case = isEq "8.18"; out = "SMTCoq-2.2+8.18"; }
+    { case = isEq "8.17"; out = "SMTCoq-2.2+8.17"; }
+    { case = isEq "8.16"; out = "SMTCoq-2.2+8.16"; }
+    { case = isEq "8.15"; out = "SMTCoq-2.2+8.15"; }
+    { case = isEq "8.14"; out = "SMTCoq-2.2+8.14"; }
+    { case = isEq "8.13"; out = "SMTCoq-2.2+8.13"; }
   ] null;
 
-  propagatedBuildInputs = [ trakt cvc5 veriT' zchaff ] ++ (with coq.ocamlPackages; [ num zarith ]);
+  propagatedBuildInputs = [ cvc5 veriT' zchaff ] ++ (with coq.ocamlPackages; [ findlib num zarith ]);
   mlPlugin = true;
   nativeBuildInputs = (with pkgs; [ gnumake42 ]) ++ (with coq.ocamlPackages; [ ocamlbuild ]);
 


### PR DESCRIPTION
## Description of changes

Support for recent versions of Coq.

Tested there: https://github.com/coq-community/coq-nix-toolbox/pull/232

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
