### PR TITLE
kodi-horus: init at 1.1.9

### DIFF
--- a/pkgs/applications/video/kodi/addons/horus/default.nix
+++ b/pkgs/applications/video/kodi/addons/horus/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildKodiAddon, fetchzip, kodi-six }:
+
+buildKodiAddon rec {
+  pname = "horus";
+  namespace = "script.module.horus";
+  version = "1.1.9";
+  src = fetchzip {
+    url = "https://github.com/gtkingbuild/Repo-GTKing/raw/master/omega/zips/${namespace}/${namespace}-${version}.zip";
+    hash = "sha256-kbOFChJ0pNT5glz31qyhVofJUwiuXwy9pnevgQer32Q=";
+  };
+
+  propagatedBuildInputs = [ kodi-six ];
+
+  meta = with lib; {
+    homepage = "https://github.com/gtkingbuild/Repo-GTKing";
+    description = "Horus lets you play Acestream links on Kodi";
+    license = licenses.mit;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -63,6 +63,8 @@ let
 
     formula1 = callPackage ../applications/video/kodi/addons/formula1 { };
 
+    horus = callPackage ../applications/video/kodi/addons/horus { };
+
     iagl = callPackage ../applications/video/kodi/addons/iagl { };
 
     invidious = callPackage ../applications/video/kodi/addons/invidious { };


### PR DESCRIPTION
## Description of changes

This adds the Horus Kodi add-on, to be able to watch Acestream with it.

Pinging @aanderse as usual 😉

It needs an Acestream engine to connect to, I'm testing it with a docker container.

Beware: This is not an official nor endorsed add-on.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
