### PR TITLE
yaml-language-server: drop dev dependencies to reduce closure size

### DIFF
--- a/pkgs/development/tools/language-servers/yaml-language-server/default.nix
+++ b/pkgs/development/tools/language-servers/yaml-language-server/default.nix
@@ -1,10 +1,14 @@
 { lib
-, mkYarnPackage
-, fetchYarnDeps
 , fetchFromGitHub
+, fetchYarnDeps
+, fixup-yarn-lock
+, makeWrapper
+, nodejs
+, stdenv
+, yarn
 }:
 
-mkYarnPackage rec {
+stdenv.mkDerivation rec {
   pname = "yaml-language-server";
   version = "1.15.0";
 
@@ -15,19 +19,52 @@ mkYarnPackage rec {
     hash = "sha256-Y3Q/y9UIiy7US8Jl4vxT0Pfw8h3hiXK+Cu9TEQHyAaA=";
   };
 
-  packageJSON = ./package.json;
   offlineCache = fetchYarnDeps {
     yarnLock = "${src}/yarn.lock";
     hash = "sha256-zHcxZ4VU6CGux72Nsy0foU4gFshK1wO/LTfnwOoirmg=";
   };
 
+  nativeBuildInputs = [
+    makeWrapper
+    fixup-yarn-lock
+    yarn
+  ];
+
+  buildInputs = [
+    nodejs
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    export HOME=$(mktemp -d)
+    yarn config --offline set yarn-offline-mirror "$offlineCache"
+    fixup-yarn-lock yarn.lock
+    yarn --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive install
+    patchShebangs node_modules
+
+    runHook postConfigure
+  '';
+
   buildPhase = ''
     runHook preBuild
 
-    export HOME=$(mktemp -d)
-    yarn --offline build
+    yarn --offline compile
+    yarn --offline build:libs
 
     runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    yarn --offline --production install
+
+    mkdir -p $out/bin $out/lib/node_modules/yaml-language-server
+    cp -r . $out/lib/node_modules/yaml-language-server
+    ln -s $out/lib/node_modules/yaml-language-server/bin/yaml-language-server $out/bin/
+
+    runHook postInstall
   '';
 
   meta = {


### PR DESCRIPTION
## Description of changes

 ➜ nix path-info -hS ./result-before
/nix/store/ghv9p5gvafyma394gxacv8jjazy9k0ia-yaml-language-server-1.15.0  439.6 MiB

 ➜ nix path-info -hS ./result-after
/nix/store/lsxjzg66pcz4g8lrc9a5zyzbc0pf28yp-yaml-language-server-1.15.0  181.2 MiB

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
