### PR TITLE
avdump3: init at 8293_stable

### DIFF
--- a/pkgs/by-name/av/avdump3/package.nix
+++ b/pkgs/by-name/av/avdump3/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  dotnet-runtime,
+  zlib,
+  runtimeShell,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "avdump3";
+  version = "8293_stable";
+
+  src = fetchzip {
+    url = "https://cdn.anidb.net/client/avdump3/avdump3_8293_stable.zip";
+    hash = "sha256-H9Sn3I4S9CmymKIMHVagDy+7svHs285S3EJgYQo+ks0=";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/avdump3 $out/bin
+    mv * $out/share/avdump3
+    cat > $out/bin/avdump3 <<EOF
+    #!${runtimeShell}
+    export LD_LIBRARY_PATH="${lib.makeLibraryPath [ zlib ]}:\$LD_LIBRARY_PATH"
+    exec ${dotnet-runtime}/bin/dotnet $out/share/avdump3/AVDump3CL.dll "\$@"
+    EOF
+    chmod +x $out/bin/avdump3
+    runHook postInstall
+  '';
+
+  dontPatchELF = true;
+
+  meta = {
+    mainProgram = "avdump3";
+    description = "Tool for extracting audio/video metadata from media files and uploading it to AniDB";
+    longDescription = ''
+      AVDump is a tool to extract meta information from media files while at the
+      same time calculating multiple hashes. Based on that information reports
+      can be generated in multiple forms. Of particular interest is the ability
+      to send those reports back to AniDB and thereby quickly filling in missing
+      metadata for new files.
+    '';
+    homepage = "https://wiki.anidb.net/Avdump3";
+    sourceProvenance = with lib.sourceTypes; [
+      binaryNativeCode
+      binaryBytecode
+    ];
+    # partial source code available under MIT license at https://github.com/DvdKhl/AVDump3
+    license = with lib.licenses; [
+      mit
+      unfree
+    ];
+    maintainers = with lib.maintainers; [ kini ];
+    # NOTE: aarch64-linux may also work but hasn't been tested; co-maintainers welcome.
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Add `avdump3`, a tool for scanning media files for audio/video metadata / fingerprinting, and usually uploading the resulting analysis to [AniDB](https://anidb.net) (a website for tracking anime).

Home page, such as it is: https://wiki.anidb.net/Avdump3
Partial source code, excluding some proprietary parts: https://github.com/DvdKhl/AVDump3
Repology page: https://repology.org/project/avdump3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
