### PR TITLE
rocmPackages_6: fix builds by using python311

### DIFF
--- a/pkgs/development/rocm-modules/6/clr/default.nix
+++ b/pkgs/development/rocm-modules/6/clr/default.nix
@@ -21,7 +21,7 @@
 , libGL
 , libxml2
 , libX11
-, python3Packages
+, python311Packages
 }:
 
 let
@@ -65,8 +65,8 @@ in stdenv.mkDerivation (finalAttrs: {
     makeWrapper
     cmake'
     perl
-    python3Packages.python
-    python3Packages.cppheaderparser
+    python311Packages.python
+    python311Packages.cppheaderparser
   ];
 
   buildInputs = [

--- a/pkgs/development/rocm-modules/6/default.nix
+++ b/pkgs/development/rocm-modules/6/default.nix
@@ -4,7 +4,7 @@
 , symlinkJoin
 , fetchFromGitHub
 , cudaPackages
-, python3Packages
+, python311Packages
 , elfutils
 , boost179
 , opencv
@@ -34,7 +34,7 @@ in rec {
     stdenv = llvm.rocmClangStdenv;
   };
 
-  rocm-smi = python3Packages.callPackage ./rocm-smi {
+  rocm-smi = python311Packages.callPackage ./rocm-smi {
     inherit rocmUpdateScript;
     stdenv = llvm.rocmClangStdenv;
   };
@@ -77,7 +77,7 @@ in rec {
     # stdenv = llvm.rocmClangStdenv;
   };
 
-  rocm-docs-core = python3Packages.callPackage ./rocm-docs-core { inherit stdenv; };
+  rocm-docs-core = python311Packages.callPackage ./rocm-docs-core { inherit stdenv; };
 
   hip-common = callPackage ./hip-common {
     inherit rocmUpdateScript;
@@ -187,7 +187,7 @@ in rec {
     stdenv = llvm.rocmClangStdenv;
   };
 
-  tensile = python3Packages.callPackage ./tensile {
+  tensile = python311Packages.callPackage ./tensile {
     inherit rocmUpdateScript rocminfo;
     stdenv = llvm.rocmClangStdenv;
   };

--- a/pkgs/development/rocm-modules/6/llvm/base.nix
+++ b/pkgs/development/rocm-modules/6/llvm/base.nix
@@ -17,7 +17,7 @@
 , mpfr
 , zlib
 , ncurses
-, python3Packages
+, python311Packages
 , buildDocs ? true
 , buildMan ? true
 , buildTests ? true
@@ -86,11 +86,11 @@ in stdenv.mkDerivation (finalAttrs: {
     cmake
     ninja
     git
-    python3Packages.python
+    python311Packages.python
   ] ++ lib.optionals (buildDocs || buildMan) [
     doxygen
     sphinx
-    python3Packages.recommonmark
+    python311Packages.recommonmark
   ] ++ lib.optionals (buildTests && !finalAttrs.passthru.isLLVM) [
     lit
   ] ++ extraNativeBuildInputs;

--- a/pkgs/development/rocm-modules/6/llvm/stage-3/flang.nix
+++ b/pkgs/development/rocm-modules/6/llvm/stage-3/flang.nix
@@ -4,7 +4,7 @@
 , clang-unwrapped
 , mlir
 , graphviz
-, python3Packages
+, python311Packages
 }:
 
 callPackage ../base.nix rec {
@@ -14,7 +14,7 @@ callPackage ../base.nix rec {
 
   extraNativeBuildInputs = [
     graphviz
-    python3Packages.sphinx-markdown-tables
+    python311Packages.sphinx-markdown-tables
   ];
 
   extraBuildInputs = [ mlir ];

--- a/pkgs/development/rocm-modules/6/llvm/stage-3/lldb.nix
+++ b/pkgs/development/rocm-modules/6/llvm/stage-3/lldb.nix
@@ -7,7 +7,7 @@
 , lua5_3
 , graphviz
 , gtest
-, python3Packages
+, python311Packages
 }:
 
 callPackage ../base.nix rec {
@@ -15,7 +15,7 @@ callPackage ../base.nix rec {
   buildTests = false; # FIXME: Bad pathing for clang executable in tests, using relative path most likely
   targetName = "lldb";
   targetDir = targetName;
-  extraNativeBuildInputs = [ python3Packages.sphinx-automodapi ];
+  extraNativeBuildInputs = [ python311Packages.sphinx-automodapi ];
 
   extraBuildInputs = [
     xz

--- a/pkgs/development/rocm-modules/6/migraphx/default.nix
+++ b/pkgs/development/rocm-modules/6/migraphx/default.nix
@@ -26,7 +26,7 @@
 , sphinx
 , docutils
 , ghostscript
-, python3Packages
+, python311Packages
 , buildDocs ? false
 , buildTests ? false
 , gpuTargets ? clr.gpuTargets
@@ -71,15 +71,15 @@ in stdenv.mkDerivation (finalAttrs: {
     rocm-cmake
     clr
     clang-tools-extra
-    python3Packages.python
+    python311Packages.python
   ] ++ lib.optionals buildDocs [
     latex
     doxygen
     sphinx
     docutils
     ghostscript
-    python3Packages.sphinx-rtd-theme
-    python3Packages.breathe
+    python311Packages.sphinx-rtd-theme
+    python311Packages.breathe
   ];
 
   buildInputs = [
@@ -96,8 +96,8 @@ in stdenv.mkDerivation (finalAttrs: {
     oneDNN_2
     blaze
     cppcheck
-    python3Packages.pybind11
-    python3Packages.onnx
+    python311Packages.pybind11
+    python311Packages.onnx
   ];
 
   cmakeFlags = [

--- a/pkgs/development/rocm-modules/6/miopen/default.nix
+++ b/pkgs/development/rocm-modules/6/miopen/default.nix
@@ -28,7 +28,7 @@
 , gtest
 , rocm-comgr
 , roctracer
-, python3Packages
+, python311Packages
 , buildDocs ? false # Needs internet because of rocm-docs-core
 , buildTests ? false
 }:
@@ -156,9 +156,9 @@ in stdenv.mkDerivation (finalAttrs: {
     doxygen
     sphinx
     rocm-docs-core
-    python3Packages.sphinx-rtd-theme
-    python3Packages.breathe
-    python3Packages.myst-parser
+    python311Packages.sphinx-rtd-theme
+    python311Packages.breathe
+    python311Packages.myst-parser
   ] ++ lib.optionals buildTests [
     gtest
     zlib

--- a/pkgs/development/rocm-modules/6/mivisionx/default.nix
+++ b/pkgs/development/rocm-modules/6/mivisionx/default.nix
@@ -23,7 +23,7 @@
 , lmdb
 , rapidjson
 , rocm-docs-core
-, python3Packages
+, python311Packages
 , useOpenCL ? false
 , useCPU ? false
 , buildDocs ? false # Needs internet
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ] ++ lib.optionals buildDocs [
     rocm-docs-core
-    python3Packages.python
+    python311Packages.python
   ];
 
   buildInputs = [
@@ -75,9 +75,9 @@ stdenv.mkDerivation (finalAttrs: {
     libjpeg_turbo
     lmdb
     rapidjson
-    python3Packages.pybind11
-    python3Packages.numpy
-    python3Packages.torchWithRocm
+    python311Packages.pybind11
+    python311Packages.numpy
+    python311Packages.torchWithRocm
   ];
 
   cmakeFlags = [
@@ -121,7 +121,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postBuild = lib.optionalString buildDocs ''
-    python3 -m sphinx -T -E -b html -d _build/doctrees -D language=en ../docs _build/html
+    python311 -m sphinx -T -E -b html -d _build/doctrees -D language=en ../docs _build/html
   '';
 
   postInstall = lib.optionalString (!useOpenCL && !useCPU) ''

--- a/pkgs/development/rocm-modules/6/rocblas/default.nix
+++ b/pkgs/development/rocm-modules/6/rocblas/default.nix
@@ -7,7 +7,7 @@
 , cmake
 , rocm-cmake
 , clr
-, python3
+, python311
 , tensile
 , msgpack
 , libxml2
@@ -15,7 +15,7 @@
 , gfortran
 , openmp
 , amd-blis
-, python3Packages
+, python311Packages
 , buildTensile ? true
 , buildTests ? false
 , buildBenchmarks ? false
@@ -68,12 +68,12 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    python3
+    python311
   ] ++ lib.optionals buildTensile [
     msgpack
     libxml2
-    python3Packages.msgpack
-    python3Packages.joblib
+    python311Packages.msgpack
+    python311Packages.joblib
   ] ++ lib.optionals buildTests [
     gtest
   ] ++ lib.optionals (buildTests || buildBenchmarks) [
@@ -81,13 +81,13 @@ stdenv.mkDerivation (finalAttrs: {
     openmp
     amd-blis
   ] ++ lib.optionals (buildTensile || buildTests || buildBenchmarks) [
-    python3Packages.pyyaml
+    python311Packages.pyyaml
   ];
 
   cmakeFlags = [
     (lib.cmakeFeature "CMAKE_C_COMPILER" "hipcc")
     (lib.cmakeFeature "CMAKE_CXX_COMPILER" "hipcc")
-    (lib.cmakeFeature "python" "python3")
+    (lib.cmakeFeature "python" "python311")
     (lib.cmakeFeature "AMDGPU_TARGETS" (lib.concatStringsSep ";" gpuTargets))
     (lib.cmakeBool "BUILD_WITH_TENSILE" buildTensile)
     (lib.cmakeBool "ROCM_SYMLINK_LIBS" false)

--- a/pkgs/development/rocm-modules/6/rocfft/default.nix
+++ b/pkgs/development/rocm-modules/6/rocfft/default.nix
@@ -5,7 +5,7 @@
 , rocmUpdateScript
 , cmake
 , clr
-, python3
+, python311
 , rocm-cmake
 , sqlite
 , boost
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     clr
-    python3
+    python311
     rocm-cmake
   ];
 
@@ -100,7 +100,7 @@ stdenv.mkDerivation (finalAttrs: {
         boost
         finalAttrs.finalPackage
         openmp
-        (python3.withPackages (ps: with ps; [
+        (python311.withPackages (ps: with ps; [
           pandas
           scipy
         ]))

--- a/pkgs/development/rocm-modules/6/rocgdb/default.nix
+++ b/pkgs/development/rocm-modules/6/rocgdb/default.nix
@@ -13,7 +13,7 @@
 , ncurses
 , expat
 , rocdbgapi
-, python3
+, python311
 , babeltrace
 , sourceHighlight
 }:
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     ncurses
     expat
     rocdbgapi
-    python3
+    python311
     babeltrace
     sourceHighlight
   ];
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-iconv-path=${glibc.bin}"
     "--enable-tui"
     "--with-babeltrace"
-    "--with-python=python3"
+    "--with-python=python311"
     "--with-system-zlib"
     "--enable-64-bit-bfd"
     "--with-gmp=${gmp.dev}"

--- a/pkgs/development/rocm-modules/6/rocminfo/default.nix
+++ b/pkgs/development/rocm-modules/6/rocminfo/default.nix
@@ -6,7 +6,7 @@
 , rocm-cmake
 , rocm-runtime
 , busybox
-, python3
+, python311
 , gnugrep
   # rocminfo requires that the calling user have a password and be in
   # the video group. If we let rocm_agent_enumerator rely upon
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [ rocm-runtime ];
-  propagatedBuildInputs = [ python3 ];
+  propagatedBuildInputs = [ python311 ];
   cmakeFlags = [ "-DROCRTST_BLD_TYPE=Release" ];
 
   prePatch = ''

--- a/pkgs/development/rocm-modules/6/rocmlir/default.nix
+++ b/pkgs/development/rocm-modules/6/rocmlir/default.nix
@@ -13,7 +13,7 @@
 , zstd
 , zlib
 , ncurses
-, python3Packages
+, python311Packages
 , buildRockCompiler ? false
 , buildTests ? false # `argument of type 'NoneType' is not iterable`
 }:
@@ -53,8 +53,8 @@ in stdenv.mkDerivation (finalAttrs: {
     rocm-cmake
     ninja
     clr
-    python3Packages.python
-    python3Packages.tomli
+    python311Packages.python
+    python311Packages.tomli
   ];
 
   buildInputs = [

--- a/pkgs/development/rocm-modules/6/rocprofiler/default.nix
+++ b/pkgs/development/rocm-modules/6/rocprofiler/default.nix
@@ -21,7 +21,7 @@
 , mpi
 , systemd
 , gtest
-, python3Packages
+, python311Packages
 , gpuTargets ? clr.gpuTargets
 }:
 
@@ -73,11 +73,11 @@ in stdenv.mkDerivation (finalAttrs: {
     cmake
     clang
     clr
-    python3Packages.lxml
-    python3Packages.cppheaderparser
-    python3Packages.pyyaml
-    python3Packages.barectf
-    python3Packages.pandas
+    python311Packages.lxml
+    python311Packages.cppheaderparser
+    python311Packages.pyyaml
+    python311Packages.barectf
+    python311Packages.pandas
   ];
 
   buildInputs = [

--- a/pkgs/development/rocm-modules/6/rocsparse/default.nix
+++ b/pkgs/development/rocm-modules/6/rocsparse/default.nix
@@ -11,7 +11,7 @@
 , git
 , gtest
 , boost
-, python3Packages
+, python311Packages
 , buildTests ? false
 , buildBenchmarks ? false # Seems to depend on tests
 , gpuTargets ? [ ]
@@ -49,8 +49,8 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ lib.optionals (buildTests || buildBenchmarks) [
     gtest
     boost
-    python3Packages.python
-    python3Packages.pyyaml
+    python311Packages.python
+    python311Packages.pyyaml
   ];
 
   cmakeFlags = [
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ lib.optionals (buildTests || buildBenchmarks) [
     "-DBUILD_CLIENTS_TESTS=ON"
     "-DCMAKE_MATRICES_DIR=/build/source/matrices"
-    "-Dpython=python3"
+    "-Dpython=python311"
   ] ++ lib.optionals buildBenchmarks [
     "-DBUILD_CLIENTS_BENCHMARKS=ON"
   ];

--- a/pkgs/development/rocm-modules/6/roctracer/default.nix
+++ b/pkgs/development/rocm-modules/6/roctracer/default.nix
@@ -11,7 +11,7 @@
 , gcc-unwrapped
 , libbacktrace
 , rocm-runtime
-, python3Packages
+, python311Packages
 , buildDocs ? false # Nothing seems to be generated, so not making the output
 , buildTests ? false
 }:
@@ -46,8 +46,8 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     libxml2
     libbacktrace
-    python3Packages.python
-    python3Packages.cppheaderparser
+    python311Packages.python
+    python311Packages.cppheaderparser
   ];
 
   cmakeFlags = [

--- a/pkgs/development/rocm-modules/6/rpp/default.nix
+++ b/pkgs/development/rocm-modules/6/rpp/default.nix
@@ -9,7 +9,7 @@
 , clr
 , openmp
 , boost
-, python3Packages
+, python311Packages
 , buildDocs ? false # Needs internet
 , useOpenCL ? false
 , useCPU ? false
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     clr
   ] ++ lib.optionals buildDocs [
     rocm-docs-core
-    python3Packages.python
+    python311Packages.python
   ];
 
   buildInputs = [
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postBuild = lib.optionalString buildDocs ''
-    python3 -m sphinx -T -E -b html -d _build/doctrees -D language=en ../docs _build/html
+    python311 -m sphinx -T -E -b html -d _build/doctrees -D language=en ../docs _build/html
   '';
 
   passthru.updateScript = rocmUpdateScript {


### PR DESCRIPTION
In the attempt to help #322145, see:

https://cache.nixos.org/log/6pb1csgh8d3s23hm4gnn8m9468ziwsis-rocm-llvm-compiler-rt-6.0.2.drv

## Description of changes

- **rocmPackages_6.llvm.compiler-rt: 6.0.2 -> 6.1.2**
- **rocmPackages_6.llvm.compiler-rt: fix build with python3.12**

## Things done

Haven't tested this. Will wait for ofborg..

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

CC @vcunat

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

Fixes #325907 #325909