### PR TITLE
lmstudio: 0.2.25 -> 0.2.27

### DIFF
--- a/pkgs/by-name/lm/lmstudio/darwin.nix
+++ b/pkgs/by-name/lm/lmstudio/darwin.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://releases.lmstudio.ai/mac/arm64/${version}/latest/LM-Studio-${version}-arm64.dmg";
-    hash = "sha256-byS0LNJQjs/+sf2anhTAdsXUWad9HujxmLx5uEfdlo8=";
+    hash = "sha256-zLbkb33Fmz2b+cloEINJybuj+i3ya+EVxb5CPWo/iXk=";
   };
 
   nativeBuildInputs = [ undmg ];

--- a/pkgs/by-name/lm/lmstudio/linux.nix
+++ b/pkgs/by-name/lm/lmstudio/linux.nix
@@ -8,7 +8,7 @@
 let
   src = fetchurl {
     url = "https://releases.lmstudio.ai/linux/x86/${version}/beta/LM_Studio-${version}.AppImage";
-    hash = "sha256-2a3ac+0m3C/YyPM0Waia+x2Q/lodfbyHNvlbB2AHT78=";
+    hash = "sha256-Mui9QxK7UDnt6cWpYzsoy4hp7P46kx/53+em7Alu1BA=";
   };
 
   appimageContents = appimageTools.extractType2 { inherit pname version src; };

--- a/pkgs/by-name/lm/lmstudio/package.nix
+++ b/pkgs/by-name/lm/lmstudio/package.nix
@@ -5,7 +5,7 @@
 }:
 let
   pname = "lmstudio";
-  version = "0.2.25";
+  version = "0.2.27";
   meta = {
     description = "LM Studio is an easy to use desktop app for experimenting with local and open-source Large Language Models (LLMs)";
     homepage = "https://lmstudio.ai/";


### PR DESCRIPTION
## Description of changes

**0.2.27**

⚙️ Improved performance for Google's Gemma 2 models:
  - Gemma `9B` and `27B` performance is now **much** improved.
    - 🙏 This is thanks to `llama.cpp` devs: [abetlen](https://github.com/abetlen), [ngxson](https://github.com/ngxson), [slaren](https://github.com/slaren), [ggerganov](https://github.com/ggerganov) and others.
  - Download Gemma from the LM Studio Community page on Hugging Face. [Gemma 9B](https://huggingface.co/lmstudio-community/gemma-2-9b-it-GGUF), [Gemma 27B](https://huggingface.co/lmstudio-community/gemma-2-27b-it-GGUF).

🐛 Bug fixes
  - [lmstudio.js] Fixed "invalid creation parameter" bug [issue #45](https://github.com/lmstudio-ai/lmstudio.js/issues/45)
  - If you've been seeing a new message about no GPU support, see advanced information below

🧠 Advanced Information:
  - Updated `llama.cpp` commit ID: `d08c20eddedb24515a3212e2de66bdff41a26b8c`
  - `OpenCL` backend is now again bundled with LM Studio for both Windows and Linux. 
     - NOTE: Gemma 2 is NOT supported for OpenCL.
  - AMD ROCm user on Windows? See [instructions for how to update your ROCm extension pack](https://github.com/lmstudio-ai/configs/blob/main/Extension-Pack-Instructions.md#amd-rocm). Linux ROCm ext pack is still on the way.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
