### PR TITLE
xcodeenv: accept version & perform runtime checks

### DIFF
--- a/pkgs/development/mobile/xcodeenv/compose-xcodewrapper.nix
+++ b/pkgs/development/mobile/xcodeenv/compose-xcodewrapper.nix
@@ -1,19 +1,41 @@
-{ stdenv, lib }:
-{ version ? "11.1"
-, allowHigher ? false
-, xcodeBaseDir ? "/Applications/Xcode.app" }:
+{ lib,
+  stdenv,
+  writeShellScriptBin }:
+{ versions ? [ ] , xcodeBaseDir ? "/Applications/Xcode.app" }:
 
 assert stdenv.isDarwin;
+let
+  xcodebuildPath = "${xcodeBaseDir}/Contents/Developer/usr/bin/xcodebuild";
 
+  xcodebuildWrapper = writeShellScriptBin "xcodebuild" ''
+    currentVer="$(${xcodebuildPath} -version | awk 'NR==1{print $2}')"
+    wrapperVers=(${lib.concatStringsSep " " versions})
+
+    for ver in "''${wrapperVers[@]}"; do
+      if [[ "$currentVer" == "$ver" ]]; then
+        # here exec replaces the shell without creating a new process
+        # https://www.gnu.org/software/bash/manual/bash.html#index-exec
+        exec "${xcodebuildPath}" "$@"
+      fi
+    done
+
+    echo "The installed Xcode version ($currentVer) does not match any of the allowed versions: ${lib.concatStringsSep ", " versions}"
+    echo "Please update your local Xcode installation to match one of the allowed versions"
+    exit 1
+  '';
+in
 stdenv.mkDerivation {
-  pname = "xcode-wrapper${lib.optionalString allowHigher "-plus"}";
-  inherit version;
+  name = "xcode-wrapper-impure";
   # Fails in sandbox. Use `--option sandbox relaxed` or `--option sandbox false`.
   __noChroot = true;
   buildCommand = ''
     mkdir -p $out/bin
     cd $out/bin
-    ln -s /usr/bin/xcode-select
+    ${if versions == [ ] then ''
+    ln -s "${xcodebuildPath}"
+    '' else ''
+    ln -s "${xcodebuildWrapper}/bin/xcode-select"
+    ''}
     ln -s /usr/bin/security
     ln -s /usr/bin/codesign
     ln -s /usr/bin/xcrun
@@ -22,23 +44,9 @@ stdenv.mkDerivation {
     ln -s /usr/bin/lipo
     ln -s /usr/bin/file
     ln -s /usr/bin/rev
-    ln -s "${xcodeBaseDir}/Contents/Developer/usr/bin/xcodebuild"
     ln -s "${xcodeBaseDir}/Contents/Developer/Applications/Simulator.app/Contents/MacOS/Simulator"
 
     cd ..
     ln -s "${xcodeBaseDir}/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs"
-
-    # Check if we have the xcodebuild version that we want
-    currVer=$($out/bin/xcodebuild -version | head -n1)
-    ${if allowHigher then ''
-    if [ -z "$(printf '%s\n' "${version}" "$currVer" | sort -V | head -n1)""" != "${version}" ]
-    '' else ''
-    if [ -z "$(echo $currVer | grep -x 'Xcode ${version}')" ]
-    ''}
-    then
-        echo "We require xcodebuild version${if allowHigher then " or higher" else ""}: ${version}"
-        echo "Instead what was found: $currVer"
-        exit 1
-    fi
   '';
 }


### PR DESCRIPTION
## Description of changes

- xcodewrapper nix derivation has been updated to now accept a list of acceptable versions.
- allowHigher is now removed
- this matches closely to what we use for building react-native with nix at status-mobile repo
ref -> https://github.com/status-im/status-mobile/blob/develop/nix/pkgs/xcodeenv/compose-xcodewrapper.nix
- The key change done here is that now xcodewrapper checks Xcode versions at runtime instead of build time. This helps us to show warning messages when underlying environment does not have the Xcode version we want to support.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
