### PR TITLE
github-release: 0.10.0 -> 0.10.1-unstable-2024-06-25

### DIFF
--- a/pkgs/development/tools/github/github-release/default.nix
+++ b/pkgs/development/tools/github/github-release/default.nix
@@ -1,34 +1,19 @@
-{ buildGoModule, fetchFromGitHub, fetchpatch, lib, testers, github-release }:
+{ buildGoModule, fetchFromGitHub, lib, testers, github-release }:
 
 buildGoModule rec {
   pname = "github-release";
-  version = "0.10.0";
+  version = "0.10.1-unstable-2024-06-25";
 
   src = fetchFromGitHub {
     owner = "github-release";
     repo = "github-release";
-    rev = "v${version}";
-    hash = "sha256-J5Y0Kvon7DstTueCsoYvw6x4cOH/C1IaVArE0bXtZts=";
+    rev = "d250e89a7bf00d54e823b169c3a4722a55ac67b0";
+    hash = "sha256-QDImy9VNJ3hfGVCpMoJ72Za3CiM3SVNH1D9RFHVM+4I=";
   };
 
   vendorHash = null;
 
-  patches = [
-    # Update version info
-    (fetchpatch {
-      url = "https://github.com/github-release/github-release/commit/ee13bb17b74135bfe646d9be1807a6bc577ba7c6.patch";
-      hash = "sha256-9ZcHwai0HOgapDcpvn3xssrVP9cuNAz9rTgrR4Jfdfg=";
-    })
-
-    # Add Go Modules support.
-    # See https://github.com/Homebrew/homebrew-core/pull/162414.
-    (fetchpatch {
-      url = "https://github.com/github-release/github-release/pull/129/commits/074f4e8e1688642f50a7a3cc92b5777c7b484139.patch";
-      hash = "sha256-OBFbOvNhqcNiuSCP0AfClntj7y5habn+r2eBkmClsgI=";
-    })
-  ];
-
-  ldflags = [ "-s" "-w" ];
+  ldflags = [ "-s" ];
 
   passthru.tests.version = testers.testVersion {
     package = github-release;


### PR DESCRIPTION
## Description of changes

Upgrading to latest main allows dropping both patches.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
