### PR TITLE
catppuccin-gtk: fix inconsistent theme name

### DIFF
--- a/pkgs/by-name/ca/catppuccin-gtk/fix-inconsistent-theme-name.patch
+++ b/pkgs/by-name/ca/catppuccin-gtk/fix-inconsistent-theme-name.patch
@@ -1,0 +1,32 @@
+The theme name uses `default` as fallback for tweaks when they aren't
+set, which not only is not a valid tweak name, but can lead to confusion 
+and inconsistencies (See: https://github.com/catppuccin/nix/pull/261).
+---
+ sources/build/context.py | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/sources/build/context.py b/sources/build/context.py
+index 3d43c01..6167f14 100644
+--- a/sources/build/context.py
++++ b/sources/build/context.py
+@@ -45,7 +45,8 @@ class BuildContext:
+         return f"{self.output_root}/{self.build_id()}"
+ 
+     def build_id(self) -> str:
+-        return f"{self.theme_name}-{self.flavor.identifier}-{self.accent.identifier}-{self.size}+{self.tweaks.id() or 'default'}"
++        tweaks = f"+{self.tweaks.id()}" if self.tweaks.id() != "" else ""
++        return f"{self.theme_name}-{self.flavor.identifier}-{self.accent.identifier}-{self.size}" + tweaks
+ 
+     def apply_suffix(self, suffix: Suffix) -> str:
+         if suffix.test(self):
+@@ -59,6 +60,7 @@ class BuildContext:
+             Subsitution(find=f"\\${key}: {default}", replace=f"${key}: {value}"),
+         )
+ 
++
+ IS_DARK = Suffix(true_value="-Dark", test=lambda ctx: ctx.flavor.dark)
+ IS_LIGHT = Suffix(true_value="-Light", test=lambda ctx: not ctx.flavor.dark)
+ IS_WINDOW_NORMAL = Suffix(
+-- 
+2.45.1
+

--- a/pkgs/by-name/ca/catppuccin-gtk/package.nix
+++ b/pkgs/by-name/ca/catppuccin-gtk/package.nix
@@ -37,6 +37,8 @@ stdenvNoCC.mkDerivation {
     hash = "sha256-q5/VcFsm3vNEw55zq/vcM11eo456SYE5TQA3g2VQjGc=";
   };
 
+  patches = [ ./fix-inconsistent-theme-name.patch ];
+
   nativeBuildInputs = [
     gtk3
     sassc


### PR DESCRIPTION
## Description of changes

The theme name uses `default` as fallback for tweaks when they aren't set, which not only is not a valid tweak name, but can lead to confusion and inconsistencies.

As such, we can either replace `"default"` with `"normal"`, or we can just remove tweaks from the theme name if the list is empty.
The advantage of the second approach is that users won't have to worry about which tweak name they have to specify by default, which also looks cleaner:

```nix
    # before
    gtk.theme.name = "catppuccin-macchiato-pink-compact+default";

    # after
    gtk.theme.name = "catppuccin-macchiato-pink-compact";
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
