### PR TITLE
deja-dup: 45.2 → 46.1

### DIFF
--- a/pkgs/applications/backup/deja-dup/default.nix
+++ b/pkgs/applications/backup/deja-dup/default.nix
@@ -18,18 +18,19 @@
 , libgpg-error
 , json-glib
 , duplicity
+, rclone
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "deja-dup";
-  version = "45.2";
+  version = "46.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "deja-dup";
     rev = finalAttrs.version;
-    hash = "sha256-nscswpWX6UB1zuv6TXcT3YE1wkREJYDGQrEPryyUYUM=";
+    hash = "sha256-tKVY0wewBDx0AMzmTdko8vGg5bNGfYohgcSDg5Oky30=";
   };
 
   patches = [
@@ -61,8 +62,16 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   mesonFlags = [
-    "-Dduplicity_command=${duplicity}/bin/duplicity"
+    "-Dduplicity_command=${lib.getExe duplicity}"
+    "-Drclone_command=${lib.getExe rclone}"
   ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      # Required by duplicity
+      --prefix PATH : "${lib.makeBinPath [ rclone ]}"
+    )
+  '';
 
   meta = with lib; {
     description = "Simple backup tool";

--- a/pkgs/applications/backup/deja-dup/fix-paths.patch
+++ b/pkgs/applications/backup/deja-dup/fix-paths.patch
@@ -1,11 +1,13 @@
 --- a/libdeja/duplicity/DuplicityInstance.vala
 +++ b/libdeja/duplicity/DuplicityInstance.vala
-@@ -114,7 +114,7 @@ internal class DuplicityInstance : Object
+@@ -114,8 +114,8 @@ internal class DuplicityInstance : Object
      // We already are pretty sure we don't have other duplicities in our
      // archive directories, because we use our own and we ensure we only have
      // one deja-dup running at a time via DBus.
--    Posix.system("/bin/rm -f " + Shell.quote(cache_dir) + "/*/lockfile.lock");
-+    Posix.system("@coreutils@/bin/rm -f " + Shell.quote(cache_dir) + "/*/lockfile.lock");
+     var lockfile_glob = Shell.quote(cache_dir) + "/*/lockfile.lock";
+-    if (Posix.system("/bin/rm -f " + lockfile_glob) != 0)
++    if (Posix.system("@coreutils@/bin/rm -f " + lockfile_glob) != 0)
+       warning("Could not delete '%s'", lockfile_glob);
  
      Process.spawn_async_with_pipes(null, real_argv, real_envp,
                          SpawnFlags.SEARCH_PATH |

--- a/pkgs/tools/backup/duplicity/default.nix
+++ b/pkgs/tools/backup/duplicity/default.nix
@@ -150,6 +150,7 @@ let self = python3.pkgs.buildPythonApplication rec {
     description = "Encrypted bandwidth-efficient backup using the rsync algorithm";
     homepage = "https://duplicity.gitlab.io/duplicity-web/";
     license = licenses.gpl2Plus;
+    mainProgram = "duplicity";
     maintainers = with maintainers; [ corngood ];
   };
 };


### PR DESCRIPTION
## Description of changes

https://gitlab.gnome.org/World/deja-dup/-/compare/45.2...46.beta
https://gitlab.gnome.org/World/deja-dup/-/compare/46.beta...7646f5725ae4500d41e0b18576f317118d04ae66
https://gitlab.gnome.org/World/deja-dup/-/compare/7646f5725ae4500d41e0b18576f317118d04ae66...46.1

https://gitlab.gnome.org/World/deja-dup/-/releases/46.beta
https://gitlab.gnome.org/World/deja-dup/-/releases/46.0
https://gitlab.gnome.org/World/deja-dup/-/releases/46.1

Upgrading since OneDrive support is broken (duplicity requires requests_oauthlib).
The current version uses duplicity-rclone instead which requires rclone on PATH or it will complain: “rclone not found: please install rclone”
https://gitlab.com/duplicity/duplicity/-/blob/e435874ac9667b4b88d032a90312b08555903148/duplicity/backends/rclonebackend.py#L39

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
