### PR TITLE
lib/modules: lib fix and tidying

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -66,7 +66,7 @@ let
 
     # TODO: For consistency, all builtins should also be available from a sub-library;
     # these are the only ones that are currently not
-    inherit (builtins) addErrorContext isPath trace;
+    inherit (builtins) addErrorContext isPath trace typeOf unsafeGetAttrPos;
     inherit (self.trivial) id const pipe concat or and xor bitAnd bitOr bitXor
       bitNot boolToString mergeAttrs flip mapNullable inNixShell isFloat min max
       importJSON importTOML warn warnIf warnIfNot throwIf throwIfNot checkListOfEnum

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -2,6 +2,7 @@
 
 let
   inherit (lib)
+    addErrorContext
     all
     any
     attrByPath
@@ -265,9 +266,9 @@ let
               let
                 optText = showOption (prefix ++ firstDef.prefix);
                 defText =
-                  builtins.addErrorContext
+                  addErrorContext
                     "while evaluating the error message for definitions for `${optText}', which is an option that does not exist"
-                    (builtins.addErrorContext
+                    (addErrorContext
                       "while evaluating a definition from `${firstDef.file}'"
                       ( showDefs [ firstDef ])
                     );
@@ -503,8 +504,8 @@ let
       # not their values.  The values are forwarding the result of the
       # evaluation of the option.
       context = name: ''while evaluating the module argument `${name}' in "${key}":'';
-      extraArgs = builtins.mapAttrs (name: _:
-        builtins.addErrorContext (context name)
+      extraArgs = mapAttrs (name: _:
+        addErrorContext (context name)
           (args.${name} or config._module.args.${name})
       ) (lib.functionArgs f);
 
@@ -806,7 +807,7 @@ let
           "The type `types.${opt.type.name}' of option `${showOption loc}' defined in ${showFiles opt.declarations} is deprecated. ${opt.type.deprecationMessage}";
 
     in warnDeprecation opt //
-      { value = builtins.addErrorContext "while evaluating the option `${showOption loc}':" value;
+      { value = addErrorContext "while evaluating the option `${showOption loc}':" value;
         inherit (res.defsFinal') highestPrio;
         definitions = map (def: def.value) res.defsFinal;
         files = map (def: def.file) res.defsFinal;
@@ -822,7 +823,7 @@ let
       let
         # Process mkMerge and mkIf properties.
         defs' = concatMap (m:
-          map (value: { inherit (m) file; inherit value; }) (builtins.addErrorContext "while evaluating definitions from `${m.file}':" (dischargeProperties m.value))
+          map (value: { inherit (m) file; inherit value; }) (addErrorContext "while evaluating definitions from `${m.file}':" (dischargeProperties m.value))
         ) defs;
 
         # Process mkOverride properties.

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -14,6 +14,7 @@ let
     elem
     filter
     foldl'
+    functionArgs
     getAttrFromPath
     head
     id
@@ -507,7 +508,7 @@ let
       extraArgs = mapAttrs (name: _:
         addErrorContext (context name)
           (args.${name} or config._module.args.${name})
-      ) (lib.functionArgs f);
+      ) (functionArgs f);
 
       # Note: we append in the opposite order such that we can add an error
       # context on the explicit arguments of "args" too. This update

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -485,10 +485,10 @@ let
         config = addFreeformType (removeAttrs m ["_class" "_file" "key" "disabledModules" "require" "imports" "freeformType"]);
       };
 
-  applyModuleArgsIfFunction = key: f: args@{ config, options, lib, ... }:
+  applyModuleArgsIfFunction = key: f: args@{ config, ... }:
     if isFunction f then applyModuleArgs key f args else f;
 
-  applyModuleArgs = key: f: args@{ config, options, lib, ... }:
+  applyModuleArgs = key: f: args@{ config, ... }:
     let
       # Module arguments are resolved in a strict manner when attribute set
       # deconstruction is used.  As the arguments are now defined with the

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -94,6 +94,8 @@ checkConfigOutput '^true$' config.result ./module-argument-default.nix
 # gvariant
 checkConfigOutput '^true$' config.assertion ./gvariant.nix
 
+checkConfigOutput '"ok"' config.result ./specialArgs-lib.nix
+
 # https://github.com/NixOS/nixpkgs/pull/131205
 # We currently throw this error already in `config`, but throwing in `config.wrong1` would be acceptable.
 checkConfigError 'It seems as if you.re trying to declare an option by placing it into .config. rather than .options.' config.wrong1 ./error-mkOption-in-config.nix

--- a/lib/tests/modules/specialArgs-lib.nix
+++ b/lib/tests/modules/specialArgs-lib.nix
@@ -1,0 +1,28 @@
+{ config, lib, ... }:
+
+{
+  options = {
+    result = lib.mkOption { };
+    weird = lib.mkOption {
+      type = lib.types.submoduleWith {
+        # I generally recommend against overriding lib, because that leads to
+        # slightly incompatible dialects of the module system.
+        # Nonetheless, it's worth guarding the property that the module system
+        # evaluates with a completely custom lib, as a matter of separation of
+        # concerns.
+        specialArgs.lib = { };
+        modules = [ ];
+      };
+    };
+  };
+  config.weird = args@{ ... /* note the lack of a `lib` argument */ }:
+  assert args.lib == { };
+  assert args.specialArgs == { lib = { }; };
+  {
+    options.foo = lib.mkOption { };
+    config.foo = lib.mkIf true "alright";
+  };
+  config.result =
+    assert config.weird.foo == "alright";
+    "ok";
+}


### PR DESCRIPTION
## Description of changes

- Fix a potential problem (first commit)
- Tidy up
- Reduce attribute lookups
- Reduce env size (`applyModuleArgs`)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
