### PR TITLE
py7zr: init at 0.21.1

### DIFF
--- a/pkgs/development/python-modules/inflate64/default.nix
+++ b/pkgs/development/python-modules/inflate64/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
   pname = "inflate64";
   version = "1.0.0";
 
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
@@ -24,11 +24,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "inflate64" ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://codeberg.org/miurahr/inflate64";
     description = "Compress and decompress with Enhanced Deflate compression algorithm";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ ByteSudoer ];
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ ByteSudoer ];
   };
 
 }

--- a/pkgs/development/python-modules/inflate64/default.nix
+++ b/pkgs/development/python-modules/inflate64/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+
+, setuptools
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "inflate64";
+  version = "1.0.0";
+
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+
+    hash = "sha256-MniCe4A88Aah3yUfPhM3TH0m23eeWjMynMEXibgEvC0=";
+  };
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  pythonImportsCheck = [ "inflate64" ];
+
+  meta = with lib; {
+    homepage = "https://codeberg.org/miurahr/inflate64";
+    description = "Compress and decompress with Enhanced Deflate compression algorithm";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ ByteSudoer ];
+  };
+
+}

--- a/pkgs/development/python-modules/multivolumefile/default.nix
+++ b/pkgs/development/python-modules/multivolumefile/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "multivolumefile";
+  version = "0.2.3";
+
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-oGSNCq+8luWRmNXBfprK1+tTGr6lEDXQjOgGDcrXCdY=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  pythonImportsCheck = [ "multivolumefile" ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://codeberg.org/miurahr/multivolume";
+    description = "Library to provide a file-object wrapping multiple files as virtually like as a single file";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ ByteSudoer ];
+  };
+}

--- a/pkgs/development/python-modules/py7zr/default.nix
+++ b/pkgs/development/python-modules/py7zr/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+
+, setuptools
+, setuptools-scm
+
+
+, brotli
+, inflate64
+, multivolumefile
+, psutil
+, pybcj
+, pycryptodomex
+, pyppmd
+, pyzstd
+, texttable
+
+}:
+buildPythonPackage rec {
+  pname = "py7zr";
+  version = "0.21.1";
+
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-3t6O2LezKzWGrEdto6SCtp3UMyKUIL8PYsSVQEtyx5k=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    brotli
+    inflate64
+    multivolumefile
+    psutil
+    pybcj
+    pycryptodomex
+    pyppmd
+    pyzstd
+    texttable
+  ];
+
+  pythonImportsCheck = [ "py7zr" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/miurahr/py7zr";
+    description = "7zip in python3 with ZStandard, PPMd, LZMA2, LZMA1, Delta, BCJ, BZip2";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ ByteSudoer ];
+  };
+}

--- a/pkgs/development/python-modules/pybcj/default.nix
+++ b/pkgs/development/python-modules/pybcj/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, setuptools-scm
+
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "pybcj";
+  version = "1.0.2";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-x/W+9/R3I8U0ION3vGTSVThDvui8rF8K0HarFSR4ABg=";
+  };
+
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+
+  pythonImportsCheck = [ "bcj" "lzma" ];
+
+  meta = with lib; {
+    homepage = "https://codeberg.org/miurahr/pybcj";
+    description = "BCJ(Branch-Call-Jump) filter for python";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ ByteSudoer ];
+  };
+}

--- a/pkgs/development/python-modules/pyppmd/default.nix
+++ b/pkgs/development/python-modules/pyppmd/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+
+, setuptools
+, setuptools-scm
+}:
+
+buildPythonPackage rec{
+  pname = "pyppmd";
+  version = "1.1.0";
+
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-HTjOLkt+uEtTvIpSOAuU9mumw5MouIALMMK1vzFpOXM=";
+  };
+
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+
+  pythonImportsCheck = [ "pyppmd" ];
+
+  meta = with lib; {
+    homepage = "https://codeberg.org/miurahr/pyppmd";
+    description = "PPMd compression/decompression library";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ ByteSudoer ];
+  };
+
+}

--- a/pkgs/development/python-modules/pyzstd/default.nix
+++ b/pkgs/development/python-modules/pyzstd/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "pyzstd";
+  version = "0.16.0";
+
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    repo = "pyzstd";
+    owner = "Rogdham";
+    rev = "${version}";
+    fetchSubmodules = true;
+    hash = "sha256-//SeXs65Qcrbdyj3Ilk8XYUIgpwTej0Eaxv711g+3m8=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  pythonImportsCheck = [ "pyzstd" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/Rogdham/pyzstd";
+    description = "Python bindings to Zstandard (zstd) compression library";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ByteSudoer ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5849,6 +5849,8 @@ self: super: with self; {
 
   infinity = callPackage ../development/python-modules/infinity { };
 
+  inflate64 = callPackage ../development/python-modules/inflate64 { };
+
   inflect = callPackage ../development/python-modules/inflect { };
 
   inflection = callPackage ../development/python-modules/inflection { };
@@ -7900,6 +7902,8 @@ self: super: with self; {
   multiset = callPackage ../development/python-modules/multiset { };
 
   multitasking = callPackage ../development/python-modules/multitasking { };
+
+  multivolumefile = callPackage ../development/python-modules/multivolumefile { };
 
   munch = callPackage ../development/python-modules/munch { };
 
@@ -10037,6 +10041,8 @@ self: super: with self; {
 
   py65 = callPackage ../development/python-modules/py65 { };
 
+  py7zr = callPackage ../development/python-modules/py7zr { };
+
   pyaehw4a1 = callPackage ../development/python-modules/pyaehw4a1 { };
 
   pyatag = callPackage ../development/python-modules/pyatag { };
@@ -10044,6 +10050,8 @@ self: super: with self; {
   pyatem = callPackage ../development/python-modules/pyatem { };
 
   pyatome = callPackage ../development/python-modules/pyatome { };
+
+  pybcj = callPackage ../development/python-modules/pybcj { };
 
   pycketcasts = callPackage ../development/python-modules/pycketcasts { };
 
@@ -10145,6 +10153,8 @@ self: super: with self; {
   pypoint = callPackage ../development/python-modules/pypoint { };
 
   pypoolstation = callPackage ../development/python-modules/pypoolstation { };
+
+  pyppmd = callPackage ../development/python-modules/pyppmd { };
 
   pyrdfa3 = callPackage ../development/python-modules/pyrdfa3 { };
 
@@ -10287,6 +10297,8 @@ self: super: with self; {
   pyzbar = callPackage ../development/python-modules/pyzbar { };
 
   pyzipper = callPackage ../development/python-modules/pyzipper { };
+
+  pyzstd = callPackage ../development/python-modules/pyzstd { };
 
   pkutils = callPackage ../development/python-modules/pkutils { };
 


### PR DESCRIPTION
## Description of changes
py7zr is a library and utility to support 7zip archive compression, decompression, encryption and decryption written by Python programming language.
Metadata
- homepage https://py7zr.readthedocs.io/en/latest/:
- source https://github.com/miurahr/py7zr:
- license: LGPL2.1
### This PR also introduces these packages:
- pyzstd: init at 0.16.0
- pyppmd: init at 1.1.0
- pybcj: init at 1.0.2
- multivolumefile: init at 0.2.3
- inflate64: init at 1.0.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
