### PR TITLE
haskellPackages.libmpd: Remove unnecessary patch

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -144,15 +144,6 @@ self: super: {
       })
     super.ascii-numbers;
 
-  # Fix ghc-9.6.x build errors.
-  libmpd = appendPatch
-    # https://github.com/vimus/libmpd-haskell/pull/138
-    (pkgs.fetchpatch { url = "https://github.com/vimus/libmpd-haskell/compare/95d3b3bab5858d6d1f0e079d0ab7c2d182336acb...5737096a339edc265a663f51ad9d29baee262694.patch";
-                       name = "vimus-libmpd-haskell-pull-138.patch";
-                       sha256 = "sha256-CvvylXyRmoCoRJP2MzRwL0SBbrEzDGqAjXS+4LsLutQ=";
-                     })
-    super.libmpd;
-
   # Apply patch from PR with mtl-2.3 fix.
   ConfigFile = overrideCabal (drv: {
     editedCabalFile = null;


### PR DESCRIPTION
The patch was merged in https://github.com/vimus/libmpd-haskell/pull/138 and this version is on hackage now

This fixes the `xmonad` and `xmonad-extras` build failures in https://github.com/NixOS/nixpkgs/pull/321948

``` console
$ nix-build ./ -A haskellPackages.libmpd
/nix/store/blwsajaa1xbv1qdnpv19ixbiqkvss08r-libmpd-0.10.0.1

$ nix-build ./ -A haskellPackages.xmonad-extras
/nix/store/z9hq49xrsl75znh55mcnxq7h482h8w3v-xmonad-extras-0.17.1

$ nix-build ./ -A haskellPackages.xmonad
/nix/store/4bdr209if7175dc7cm0kprz32jc4harf-xmonad-0.17.2
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)

  `nix-shell -p nixpkgs-review --run "nixpkgs-review pr https://github.com/NixOS/nixpkgs/pull/324308"` reports:

  ```
  Link to currently reviewing PR: https://github.com/NixOS/nixpkgs/pull/324308

  1 package built:
  xmobar
  ```

  (I don't know why it does not try to at least build `xmonad-extras`)

- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
