### PR TITLE
deepsource-cli: init at 0.8.6

### DIFF
--- a/pkgs/by-name/de/deepsource-cli/package.nix
+++ b/pkgs/by-name/de/deepsource-cli/package.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+
+, installShellFiles
+
+}:
+buildGoModule rec {
+  pname = "deepsource-cli";
+  version = "0.8.6";
+
+  src = fetchFromGitHub {
+    repo = "cli";
+    owner = "DeepSourceCorp";
+    rev = "v${version}";
+    hash = "sha256-6uNb4cQVerrlW/eUkjmlO1i1YKYX3qaVdo0i5cczt+I=";
+  };
+
+  vendorHash = "sha256-SsMq4ngq3sSOL28ysHTxTF4CT9sIcCIW7yIhBxIPrNs=";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  excludedPackages = [
+    # This test expects some content to be copied and written to and from /tmp directory
+    "command/report/tests"
+  ];
+
+  postInstall = ''
+    installShellCompletion --cmd deepsource \
+    --bash <($out/bin/deepsource completion bash) \
+    --fish <($out/bin/deepsource completion fish) \
+    --zsh <($out/bin/deepsource completion zsh)
+  '';
+
+
+  meta = with lib; {
+    homepage = "https://github.com/DeepSourceCorp/cli";
+    description = "Command line interface to DeepSource ";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ ByteSudoer ];
+    mainProgram = "deepsource";
+  };
+}


### PR DESCRIPTION
## Description of changes
Deepsource is static analysis and AI

Metadata
- homepage URL: https://deepsource.com/
- source URL: https://github.com/DeepSourceCorp/cli
- license: bsd
- platforms: unix, linux, darwin, windows

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
