### PR TITLE
nixos/gdm: Fix fingerprint auth rules

### DIFF
--- a/nixos/modules/services/desktops/gnome/gnome-keyring.nix
+++ b/nixos/modules/services/desktops/gnome/gnome-keyring.nix
@@ -35,15 +35,7 @@ in
 
     xdg.portal.extraPortals = [ pkgs.gnome-keyring ];
 
-    security.pam.services = lib.mkMerge [
-      {
-        login.enableGnomeKeyring = true;
-      }
-      (lib.mkIf config.services.xserver.displayManager.gdm.enable {
-        gdm-password.enableGnomeKeyring = true;
-        gdm-autologin.enableGnomeKeyring = true;
-      })
-    ];
+    security.pam.services.login.enableGnomeKeyring = true;
 
     security.wrappers.gnome-keyring-daemon = {
       owner = "root";

--- a/nixos/modules/services/desktops/gnome/gnome-keyring.nix
+++ b/nixos/modules/services/desktops/gnome/gnome-keyring.nix
@@ -43,9 +43,6 @@ in
         gdm-password.enableGnomeKeyring = true;
         gdm-autologin.enableGnomeKeyring = true;
       })
-      (lib.mkIf (config.services.xserver.displayManager.gdm.enable && config.services.fprintd.enable) {
-        gdm-fingerprint.enableGnomeKeyring = true;
-      })
     ];
 
     security.wrappers.gnome-keyring-daemon = {

--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -6,6 +6,7 @@ let
 
   cfg = config.services.xserver.displayManager;
   gdm = pkgs.gnome.gdm;
+  pamCfg = config.security.pam.services;
   settingsFormat = pkgs.formats.ini { };
   configFile = settingsFormat.generate "custom.conf" cfg.gdm.settings;
 
@@ -331,7 +332,10 @@ in
         auth       requisite                   pam_faillock.so      preauth
         auth       required                    ${pkgs.fprintd}/lib/security/pam_fprintd.so
         auth       required                    pam_env.so
-        auth       [success=ok default=1]      ${pkgs.gnome.gdm}/lib/security/pam_gdm.so
+        ${lib.optionalString pamCfg.login.enableGnomeKeyring ''
+          auth       [success=ok default=1]      ${pkgs.gnome.gdm}/lib/security/pam_gdm.so
+          auth       optional                    ${pkgs.gnome-keyring}/lib/security/pam_gnome_keyring.so
+        ''}
 
         account    include                     login
 

--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -321,13 +321,15 @@ in
         session   include       login
       '';
 
+      # This would block password prompt when included by gdm-password.
+      # GDM will instead run gdm-fingerprint in parallel.
       login.fprintAuth = mkIf config.services.fprintd.enable false;
+
       gdm-fingerprint.text = mkIf config.services.fprintd.enable ''
         auth       required                    pam_shells.so
         auth       requisite                   pam_nologin.so
         auth       requisite                   pam_faillock.so      preauth
         auth       required                    ${pkgs.fprintd}/lib/security/pam_fprintd.so
-        auth       optional                    pam_permit.so
         auth       required                    pam_env.so
         auth       [success=ok default=1]      ${pkgs.gnome.gdm}/lib/security/pam_gdm.so
 


### PR DESCRIPTION
## Description of changes

We introduced the gdm-fingerprint.pam in 9d41fe6fcc4df838a56b1cfb2512b65e5e655958.

We used the [upstream Arch config] as a template, which contains an extended control field that jumps over **one** immediately-following `auth` rule unless `pam_gdm.so` succeeds.

But we decided to not include `pam_gnome_keyring.so` so there was no rule to skip over, resulting in a broken control flow and the PAM module failing with “PAM bad jump in stack”, breaking the fingerprint authentication in GDM.

Let’s actually add `pam_gnome_keyring.so`, like the Arch config does. Because we are creating the PAM file using the `text` option, `security.pam.services.gdm-fingerprint.enableGnomeKeyring` does not do anything so we need to do it manually.

For the case where gnome-keyring is not enabled, we could add a no-op rule like `optional pam_permit.so` after `pam_gdm.so` so that the branching always has something to jump over but it will be simpler to just make the both conditional. There are no further `auth` rules that could benefit from `pam_gdm.so` doing something so it should be fine.

Unlike in Arch, we are not going to invoke `pam_gnome_keyring.so` in a `session` rule since that is already done by the included `login` module.

Let’s also add a comment about disabling `fprintAuth`, remove no-op `optional pam_permit.so` rule and revert parts of https://github.com/NixOS/nixpkgs/pull/315874 that do not do anything.

[upstream Arch config]: https://gitlab.gnome.org/GNOME/gdm/-/blob/81ee658c11381912131dd4a29e84190f7f9cd039/data/pam-arch/gdm-fingerprint.pam


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
