### PR TITLE
kinfocenter: hardcode paths for additional tools

### DIFF
--- a/pkgs/kde/plasma/kinfocenter/0001-tool-paths.patch
+++ b/pkgs/kde/plasma/kinfocenter/0001-tool-paths.patch
@@ -23,24 +23,168 @@ index 6ae168b5..89d0a2ff 100644
                                                     {QStringLiteral("org.kde.KWin"), QStringLiteral("/KWin"), QStringLiteral("supportInformation")},
                                                     parent);
      }
-diff --git a/kcms/xserver/kcm_xserver.json b/kcms/xserver/kcm_xserver.json
-index b3f1ce24..dc610932 100644
---- a/kcms/xserver/kcm_xserver.json
-+++ b/kcms/xserver/kcm_xserver.json
-@@ -141,7 +141,7 @@
-         "Name[zh_CN]": "X 服务器",
-         "Name[zh_TW]": "X 伺服器"
-     },
--    "TryExec": "xdpyinfo",
-+    "TryExec": "@xdpyinfo@",
-     "X-DocPath": "kinfocenter/graphical.html#xserver",
-     "X-KDE-KInfoCenter-Category": "graphical_information",
-     "X-KDE-Keywords": "X,X-Server,XServer,XFree86,Display,VideoCard,System Information",
+diff --git a/kcms/about-distro/src/dmidecode-helper/helper.cpp b/kcms/about-distro/src/dmidecode-helper/helper.cpp
+index 396b2d74..615e1057 100644
+--- a/kcms/about-distro/src/dmidecode-helper/helper.cpp
++++ b/kcms/about-distro/src/dmidecode-helper/helper.cpp
+@@ -20,13 +20,6 @@ KAuth::ActionReply DMIDecodeHelper::systeminformation(const QVariantMap &args)
+ {
+     Q_UNUSED(args);
+ 
+-    // PATH is super minimal when invoked through dbus
+-    setenv("PATH", "/usr/sbin:/sbin:/usr/local/sbin", 1);
+-    const QString dmidecode = QStandardPaths::findExecutable("dmidecode");
+-    if (dmidecode.isEmpty()) {
+-        return KAuth::ActionReply::HelperErrorReply();
+-    }
+-
+     // NB: Microsoft also outlines a limited set of DMI values to be required for IOT OEM licensing, as such we
+     //   can rely on the same fields to have sound content . Since this only applies to OEMs we still need to filter
+     //   out dummy values though and because of that we can grab more fields, since we'll filter them anyway.
+@@ -38,7 +31,7 @@ KAuth::ActionReply DMIDecodeHelper::systeminformation(const QVariantMap &args)
+                             QStringLiteral("system-version"),
+                             QStringLiteral("system-serial-number")}) {
+         QProcess proc;
+-        proc.start(dmidecode, {QStringLiteral("--string"), key});
++        proc.start("@dmidecode@", {QStringLiteral("--string"), key});
+         proc.waitForFinished();
+         const QByteArray output = proc.readAllStandardOutput().trimmed();
+ 
+diff --git a/kcms/audio_information/main.cpp b/kcms/audio_information/main.cpp
+index adb196fd..9d6c8675 100644
+--- a/kcms/audio_information/main.cpp
++++ b/kcms/audio_information/main.cpp
+@@ -16,7 +16,7 @@ class KCMAudioInformation : public KQuickConfigModule
+     explicit KCMAudioInformation(QObject *parent, const KPluginMetaData &data)
+         : KQuickConfigModule(parent, data)
+     {
+-        m_outputContext = new CommandOutputContext(QStringLiteral("pactl"), {"list"}, parent);
++        m_outputContext = new CommandOutputContext(QStringLiteral("@pactl@"), {"list"}, parent);
+     }
+     CommandOutputContext *outputContext() const
+     {
+diff --git a/kcms/block_devices/main.cpp b/kcms/block_devices/main.cpp
+index 2de923f3..6b14f7fb 100644
+--- a/kcms/block_devices/main.cpp
++++ b/kcms/block_devices/main.cpp
+@@ -20,7 +20,7 @@ class KCMBlockDevices : public KQuickConfigModule
+     {
+         // NOTE: careful when using -o, it tends to incorrectly print multiple mountpoints as a single path
+         // (e.g. when different btrfs subvolumes are mounted at various points in the system it ought to enumerate all mountpoints)
+-        m_outputContext = new CommandOutputContext(u"lsblk"_s, {}, parent);
++        m_outputContext = new CommandOutputContext(u"@lsblk@"_s, {}, parent);
+     }
+     CommandOutputContext *outputContext() const
+     {
+diff --git a/kcms/cpu/main.cpp b/kcms/cpu/main.cpp
+index 608381eb..8fd7914f 100644
+--- a/kcms/cpu/main.cpp
++++ b/kcms/cpu/main.cpp
+@@ -16,7 +16,7 @@ class KCMCPU : public KQuickConfigModule
+     explicit KCMCPU(QObject *parent, const KPluginMetaData &data)
+         : KQuickConfigModule(parent, data)
+     {
+-        m_outputContext = new CommandOutputContext(QStringLiteral("lscpu"), {}, parent);
++        m_outputContext = new CommandOutputContext(QStringLiteral("@lscpu@"), {}, parent);
+     }
+     CommandOutputContext *outputContext() const
+     {
+diff --git a/kcms/egl/main.cpp b/kcms/egl/main.cpp
+index 1a509dac..886a62d8 100644
+--- a/kcms/egl/main.cpp
++++ b/kcms/egl/main.cpp
+@@ -16,7 +16,7 @@ class KCMXServer : public KQuickConfigModule
+     explicit KCMXServer(QObject *parent, const KPluginMetaData &data)
+         : KQuickConfigModule(parent, data)
+     {
+-        m_outputContext = new CommandOutputContext(QStringLiteral("eglinfo"), {}, parent);
++        m_outputContext = new CommandOutputContext(QStringLiteral("@eglinfo@"), {}, parent);
+     }
+     CommandOutputContext *outputContext() const
+     {
+diff --git a/kcms/firmware_security/main.cpp b/kcms/firmware_security/main.cpp
+index 58e25458..890772c8 100644
+--- a/kcms/firmware_security/main.cpp
++++ b/kcms/firmware_security/main.cpp
+@@ -20,7 +20,7 @@ class KCMFirmwareSecurity : public KQuickConfigModule
+         const QString executable = QStandardPaths::locate(QStandardPaths::GenericDataLocation,
+                                                           QStringLiteral("kinfocenter/firmware_security/fwupdmgr.sh"),
+                                                           QStandardPaths::LocateFile);
+-        m_outputContext = new CommandOutputContext({QStringLiteral("fwupdmgr"), QStringLiteral("aha")}, QStringLiteral("/bin/sh"), {executable}, parent);
++        m_outputContext = new CommandOutputContext({QStringLiteral("fwupdmgr"), QStringLiteral("@aha@")}, QStringLiteral("/bin/sh"), {executable}, parent);
+     }
+     CommandOutputContext *outputContext() const
+     {
+diff --git a/kcms/glx/main.cpp b/kcms/glx/main.cpp
+index a7317411..a6c5621d 100644
+--- a/kcms/glx/main.cpp
++++ b/kcms/glx/main.cpp
+@@ -16,7 +16,7 @@ class KCMXServer : public KQuickConfigModule
+     explicit KCMXServer(QObject *parent, const KPluginMetaData &data)
+         : KQuickConfigModule(parent, data)
+     {
+-        m_outputContext = new CommandOutputContext(QStringLiteral("glxinfo"), {}, parent);
++        m_outputContext = new CommandOutputContext(QStringLiteral("@glxinfo@"), {}, parent);
+     }
+     CommandOutputContext *outputContext() const
+     {
+diff --git a/kcms/network/main.cpp b/kcms/network/main.cpp
+index f02577a3..479e18df 100644
+--- a/kcms/network/main.cpp
++++ b/kcms/network/main.cpp
+@@ -18,7 +18,7 @@ class KCMNetwork : public KQuickConfigModule
+     explicit KCMNetwork(QObject *parent, const KPluginMetaData &data)
+         : KQuickConfigModule(parent, data)
+     {
+-        m_outputContext = new CommandOutputContext(u"ip"_s, {u"address"_s}, parent);
++        m_outputContext = new CommandOutputContext(u"@ip@"_s, {u"address"_s}, parent);
+     }
+     CommandOutputContext *outputContext() const
+     {
+diff --git a/kcms/opencl/main.cpp b/kcms/opencl/main.cpp
+index d58728ab..88733d46 100644
+--- a/kcms/opencl/main.cpp
++++ b/kcms/opencl/main.cpp
+@@ -18,7 +18,7 @@ class KCMOpenCL : public KQuickConfigModule
+     explicit KCMOpenCL(QObject *parent, const KPluginMetaData &data)
+         : KQuickConfigModule(parent, data)
+     {
+-        m_outputContext = new CommandOutputContext(QStringLiteral("clinfo"), {}, parent);
++        m_outputContext = new CommandOutputContext(QStringLiteral("@clinfo@"), {}, parent);
+     }
+     CommandOutputContext *outputContext() const
+     {
+diff --git a/kcms/vulkan/main.cpp b/kcms/vulkan/main.cpp
+index 5665d9d2..008f1bf0 100644
+--- a/kcms/vulkan/main.cpp
++++ b/kcms/vulkan/main.cpp
+@@ -16,7 +16,7 @@ class KCMVulkan : public KQuickConfigModule
+     explicit KCMVulkan(QObject *parent, const KPluginMetaData &data)
+         : KQuickConfigModule(parent, data)
+     {
+-        m_outputContext = new CommandOutputContext(QStringLiteral("vulkaninfo"), {}, parent);
++        m_outputContext = new CommandOutputContext(QStringLiteral("@vulkaninfo@"), {}, parent);
+     }
+     CommandOutputContext *outputContext() const
+     {
+diff --git a/kcms/wayland/main.cpp b/kcms/wayland/main.cpp
+index 3a4825c7..2c6a6c43 100644
+--- a/kcms/wayland/main.cpp
++++ b/kcms/wayland/main.cpp
+@@ -16,7 +16,7 @@ class KCMWayland : public KQuickConfigModule
+     explicit KCMWayland(QObject *parent, const KPluginMetaData &data)
+         : KQuickConfigModule(parent, data)
+     {
+-        m_outputContext = new CommandOutputContext(QStringLiteral("wayland-info"), {}, parent);
++        m_outputContext = new CommandOutputContext(QStringLiteral("@waylandinfo@"), {}, parent);
+     }
+     CommandOutputContext *outputContext() const
+     {
 diff --git a/kcms/xserver/main.cpp b/kcms/xserver/main.cpp
-index 6d4d1e25..d39fe19e 100644
+index df9af24a..e5983e22 100644
 --- a/kcms/xserver/main.cpp
 +++ b/kcms/xserver/main.cpp
-@@ -16,7 +16,7 @@ public:
+@@ -16,7 +16,7 @@ class KCMXServer : public KQuickConfigModule
      explicit KCMXServer(QObject *parent, const KPluginMetaData &data)
          : KQuickConfigModule(parent, data)
      {
@@ -49,3 +193,15 @@ index 6d4d1e25..d39fe19e 100644
      }
      CommandOutputContext *outputContext() const
      {
+diff --git a/kcms/pci/CMakeLists.txt b/kcms/pci/CMakeLists.txt
+index 36d82ef8..16ce2703 100644
+--- a/kcms/pci/CMakeLists.txt
++++ b/kcms/pci/CMakeLists.txt
+@@ -19,7 +19,7 @@ else()
+     find_package(lspci)
+     set_package_properties(lspci PROPERTIES TYPE RUNTIME)
+
+-    set(PCI_BACKEND lspci)
++    set(PCI_BACKEND @lspci@)
+     set(PCI_BACKEND_ARGUMENTS "-v")
+ endif()

--- a/pkgs/kde/plasma/kinfocenter/default.nix
+++ b/pkgs/kde/plasma/kinfocenter/default.nix
@@ -1,22 +1,56 @@
 {
+  aha,
+  clinfo,
+  dmidecode,
+  iproute2,
   lib,
-  mkKdeDerivation,
-  substituteAll,
-  qttools,
-  xdpyinfo,
-  systemsettings,
   libusb1,
+  mesa-demos,
+  mkKdeDerivation,
+  pciutils,
+  pulseaudio,
+  qttools,
+  substituteAll,
+  systemsettings,
+  util-linux,
+  vulkan-tools,
+  wayland-utils,
+  xdpyinfo,
 }:
+let
+  tools = {
+    aha = lib.getExe aha;
+    clinfo = lib.getExe clinfo;
+    dmidecode = lib.getExe' dmidecode "dmidecode";
+    eglinfo = lib.getExe' mesa-demos "eglinfo";
+    glxinfo = lib.getExe' mesa-demos "glxinfo";
+    ip = lib.getExe' iproute2 "ip";
+    lsblk = lib.getExe' util-linux "lsblk";
+    lspci = lib.getExe' pciutils "lspci";
+    lscpu = lib.getExe' util-linux "lscpu";
+    pactl = lib.getExe' pulseaudio "pactl";
+    qdbus = lib.getExe' qttools "qdbus";
+    vulkaninfo = lib.getExe' vulkan-tools "vulkaninfo";
+    waylandinfo = lib.getExe wayland-utils;
+    xdpyinfo = lib.getExe xdpyinfo;
+  };
+in
 mkKdeDerivation {
   pname = "kinfocenter";
 
   patches = [
-    (substituteAll {
+    # fwupdmgr is provided through NixOS' module
+    (substituteAll ({
       src = ./0001-tool-paths.patch;
-      qdbus = "${lib.getBin qttools}/bin/qdbus";
-      xdpyinfo = lib.getExe xdpyinfo;
-    })
+    } // tools))
   ];
+
+  postPatch = ''
+    substituteInPlace kcms/firmware_security/fwupdmgr.sh \
+      --replace-fail " aha " " ${lib.getExe aha} "
+  '';
+
+  extraBuildInputs = [libusb1];
 
   # fix wrong symlink of infocenter pointing to a 'systemsettings5' binary in
   # the same directory, while it is actually located in a completely different
@@ -25,6 +59,11 @@ mkKdeDerivation {
     ln -sf ${systemsettings}/bin/systemsettings $out/bin/kinfocenter
   '';
 
-  extraBuildInputs = [libusb1];
+  # Hardcoded as a QString, which is UTF-16 so Nix can't pick it up automatically
+  postFixup = ''
+    mkdir -p $out/nix-support
+    echo "${lib.concatStringsSep ":" (lib.attrValues tools)}" > $out/nix-support/depends
+  '';
+
   meta.mainProgram = "kinfocenter";
 }


### PR DESCRIPTION
## Description of changes

```
 ➜ nix path-info -S ./result-before ./result-after
/nix/store/nq97spkzlchmpk8vlmv81d2kvazd0c0d-kinfocenter-6.1.2    2599908232
/nix/store/50nx7lqwyc88qy0cn2ipmv2dz06jdi4g-kinfocenter-6.1.2    2607244016
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
