### PR TITLE
python3Packages.python-redis-lock: Fix tests

### DIFF
--- a/pkgs/development/python-modules/python-redis-lock/default.nix
+++ b/pkgs/development/python-modules/python-redis-lock/default.nix
@@ -2,8 +2,10 @@
   lib,
   stdenv,
   buildPythonPackage,
+  setuptools,
   eventlet,
   fetchPypi,
+  fetchpatch,
   gevent,
   pkgs,
   process-tests,
@@ -17,7 +19,9 @@
 buildPythonPackage rec {
   pname = "python-redis-lock";
   version = "4.0.0";
-  format = "setuptools";
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   disabled = pythonOlder "3.7";
 
@@ -26,7 +30,16 @@ buildPythonPackage rec {
     hash = "sha256-Sr0Lz0kTasrWZye/VIbdJJQHjKVeSe+mk/eUB3MZCRo=";
   };
 
-  propagatedBuildInputs = [ redis ] ++ lib.optionals withDjango [ django-redis ];
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/ionelmc/python-redis-lock/pull/119.diff";
+      hash = "sha256-Fo43+pCtnrEMxMdEEdo0YfJGkBlhhH0GjYNgpZeHF3U=";
+    })
+
+    ./test_signal_expiration_increase_sleep.patch
+  ];
+
+  dependencies = [ redis ] ++ lib.optionals withDjango [ django-redis ];
 
   nativeCheckInputs = [
     eventlet

--- a/pkgs/development/python-modules/python-redis-lock/test_signal_expiration_increase_sleep.patch
+++ b/pkgs/development/python-modules/python-redis-lock/test_signal_expiration_increase_sleep.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/test_redis_lock.py b/tests/test_redis_lock.py
+index ac9e3ef..331ab41 100644
+--- a/tests/test_redis_lock.py
++++ b/tests/test_redis_lock.py
+@@ -552,7 +552,7 @@ def test_signal_expiration(conn, signal_expire, method):
+         lock.release()
+     elif method == 'reset_all':
+         reset_all(conn)
+-    time.sleep(0.5)
++    time.sleep(0.6)
+     assert conn.exists('lock-signal:signal_expiration')
+     time.sleep((signal_expire - 500) / 1000.0)
+     assert conn.llen('lock-signal:signal_expiration') == 0


### PR DESCRIPTION
## Description of changes

python3Packages.python-redis-lock: Fix tests

I Had to patch `process-tests` https://github.com/NixOS/nixpkgs/pull/324348
and another small patch for bigger sleep time during `signal_expiration` test  

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
