### PR TITLE
gnome.gnome-remote-desktop: re-enable tests

### DIFF
--- a/pkgs/by-name/gn/gnome-remote-desktop/package.nix
+++ b/pkgs/by-name/gn/gnome-remote-desktop/package.nix
@@ -1,32 +1,32 @@
 {
-  stdenv,
-  lib,
-  fetchurl,
-  cairo,
-  meson,
-  ninja,
-  pkg-config,
-  python3,
   asciidoc,
-  wrapGAppsHook3,
+  cairo,
+  fdk_aac,
+  fetchurl,
+  freerdp3,
+  fuse3,
+  gdk-pixbuf,
   glib,
+  gnome,
+  lib,
+  libdrm,
   libei,
   libepoxy,
-  libdrm,
-  nv-codec-headers-11,
-  pipewire,
-  systemd,
-  libsecret,
   libnotify,
   libopus,
+  libsecret,
   libxkbcommon,
-  gdk-pixbuf,
-  freerdp3,
-  fdk_aac,
-  tpm2-tss,
-  fuse3,
-  gnome,
+  meson,
+  ninja,
+  nv-codec-headers-11,
+  pipewire,
+  pkg-config,
   polkit,
+  python3,
+  stdenv,
+  systemd,
+  tpm2-tss,
+  wrapGAppsHook3,
 }:
 
 stdenv.mkDerivation rec {
@@ -39,33 +39,33 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    asciidoc
     meson
     ninja
     pkg-config
     python3
-    asciidoc
     wrapGAppsHook3
   ];
 
   buildInputs = [
     cairo
-    freerdp3
     fdk_aac
-    tpm2-tss
+    freerdp3
     fuse3
     gdk-pixbuf # For libnotify
     glib
+    libdrm
     libei
     libepoxy
-    libdrm
-    nv-codec-headers-11
     libnotify
     libopus
     libsecret
     libxkbcommon
+    nv-codec-headers-11
     pipewire
-    systemd
     polkit # For polkit-gobject
+    systemd
+    tpm2-tss
   ];
 
   mesonFlags = [


### PR DESCRIPTION
## Description of changes

Adds enough build inputs to ensure the built-in tests run.

This partially reverts commits efb08d9060b804c4d8525c42be2b960a53354a0a (#247766) / 1de0e97b3721f5361c738d13308123e02f563515 (#160343).

@bobby285271 @jtojnar This was done as a naive precursor to #266774, and I'm not sure whether there are any additional caveats I'm not aware of beyond the tests being flaky at the time they were disabled.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
