### PR TITLE
nodejs_18: fix build with python312

### DIFF
--- a/pkgs/development/web/nodejs/python312-v18-patches.nix
+++ b/pkgs/development/web/nodejs/python312-v18-patches.nix
@@ -1,0 +1,33 @@
+{ fetchpatch2, buildPackages }:
+[
+  (fetchpatch2 {
+    # Fix build with Python 3.12.
+    # https://github.com/nodejs/node/pull/50582
+    url = "https://github.com/nodejs/node/commit/95534ad82f4e33f53fd50efe633d43f8da70cba6.patch";
+    hash = "sha256-7WRYed2dzOhKhHxsIO7Qv/D1VMJkfUlsyhVVMOBfpTM=";
+  })
+  (fetchpatch2 {
+    # Fix GYP compatibility with Python 3.12.
+    # https://github.com/nodejs/gyp-next/pull/201
+    url = "https://github.com/nodejs/gyp-next/commit/874233e19748f584f73461d636d4ae9f86a88c7b.patch";
+    hash = "sha256-kNDTXEsBJ3KvXnW0Pns5znoxECOSzACAxXYr60j+C0U=";
+    stripLen = 1;
+    extraPrefix = "tools/gyp/";
+    includes = [ "tools/gyp/pylib/gyp/input.py" ];
+  })
+  (fetchpatch2 {
+    # Vendor packaging in GYP for Python 3.12.
+    # https://github.com/nodejs/gyp-next/pull/214
+    url = "https://github.com/nodejs/gyp-next/commit/004c0b0342fd470c9249d1a0f84f7032cd5c8241.patch";
+    hash = "sha256-9Pc2Y3staNq3Cz2b6KTNl9W1RJtBKfG+jjpD0yoRJco=";
+    includes = [ "pylib/*" ];
+    # fetchpatch gets confused by new files and adds extraPrefix to /dev/null
+    # placeholder for the old paths. As a workaround, manually set prefix only
+    # for the new paths. Also note that currently fetchpatch is not using
+    # nativeBuildInputs. See also https://github.com/NixOS/nixpkgs/pull/323824
+    postFetch = ''
+      ${buildPackages.patchutils_0_4_2}/bin/filterdiff --strip=1 --addnewprefix=b/tools/gyp/ -- "$out" >"$tmpfile"
+      mv -- "$tmpfile" "$out"
+    '';
+  })
+]

--- a/pkgs/development/web/nodejs/v18.nix
+++ b/pkgs/development/web/nodejs/v18.nix
@@ -1,4 +1,4 @@
-{ callPackage, lib, overrideCC, pkgs, buildPackages, openssl, python311, fetchpatch2, enableNpm ? true }:
+{ callPackage, lib, overrideCC, pkgs, buildPackages, openssl, python3, fetchpatch2, enableNpm ? true }:
 
 let
   # Clang 16+ cannot build Node v18 due to -Wenum-constexpr-conversion errors.
@@ -14,8 +14,10 @@ let
     inherit openssl;
     stdenv = ensureCompatibleCC pkgs;
     buildPackages = buildPackages // { stdenv = ensureCompatibleCC buildPackages; };
-    python = python311;
+    python = python3;
   };
+
+  python312Patches = callPackage ./python312-v18-patches.nix { };
 in
 buildNodejs {
   inherit enableNpm;
@@ -30,8 +32,10 @@ buildNodejs {
     ./use-correct-env-in-tests.patch
     ./v18-openssl-3.0.14.patch
     (fetchpatch2 {
+      # build: add --skip-tests to test-ci-js target
+      # https://github.com/nodejs/node/pull/53105
       url = "https://github.com/nodejs/node/commit/534c122de166cb6464b489f3e6a9a544ceb1c913.patch";
       hash = "sha256-4q4LFsq4yU1xRwNsM1sJoNVphJCnxaVe2IyL6AeHJ/I=";
     })
-  ];
+  ] ++ python312Patches;
 }


### PR DESCRIPTION
## Description of changes

Fixes Python 3.12 compatibility for Node.js v18.

Split from #262124 (see https://github.com/NixOS/nixpkgs/pull/262124#issuecomment-2206001359).

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
