### PR TITLE
release-cuda: build with config.cudaSupport

### DIFF
--- a/pkgs/top-level/release-cuda.nix
+++ b/pkgs/top-level/release-cuda.nix
@@ -1,60 +1,147 @@
 /*
     Test CUDA packages.
 
-    This release file will not be tested on hydra.nixos.org
-    because it requires unfree software.
+    This release file is currently not tested on hydra.nixos.org
+    because it requires unfree software, but it is tested by
+    https://hydra.nix-community.org/jobset/nixpkgs/cuda-nixos-unstable.
+
+    Cf. https://github.com/nix-community/infra/pull/1335
 
     Test for example like this:
 
-        $ hydra-eval-jobs pkgs/top-level/release-cuda.nix --option restrict-eval false -I foo=. --arg nixpkgs '{ outPath = ./.; revCount = 0; shortRev = "aabbcc"; }'
-
+        $ hydra-eval-jobs pkgs/top-level/release-cuda.nix -I .
 */
 
-{ # The platforms for which we build Nixpkgs.
+{
+  # The platforms for which we build Nixpkgs.
   supportedSystems ? [
     "x86_64-linux"
-  ]
-, # Attributes passed to nixpkgs.
-  nixpkgsArgs ? { config = { allowUnfree = true; inHydra = true; }; }
+    "aarch64-linux"
+  ],
+  variant ? "cuda",
+  # Attributes passed to nixpkgs.
+  nixpkgsArgs ? {
+    config = {
+      "${variant}Support" = true;
+      allowUnfree = true;
+      inHydra = true;
+    };
+  },
 }:
 
+assert builtins.elem variant [
+  "cuda"
+  "rocm"
+  null
+];
+
 let
-  release-lib = import ./release-lib.nix {
-    inherit supportedSystems nixpkgsArgs;
-  };
+  release-lib = import ./release-lib.nix { inherit supportedSystems nixpkgsArgs; };
 
-  inherit (release-lib) linux mapTestOn packagePlatforms pkgs;
+  inherit (release-lib) lib;
+  inherit (release-lib)
+    linux
+    mapTestOn
+    packagePlatforms
+    pkgs
+    ;
 
-  inherit (release-lib.lib) genAttrs;
-
-  # Package sets to evaluate
-  packageSets = [
-    "cudaPackages_10_0"
-    "cudaPackages_10_1"
-    "cudaPackages_10_2"
-    "cudaPackages_10"
-    "cudaPackages_11_0"
-    "cudaPackages_11_1"
-    "cudaPackages_11_2"
-    "cudaPackages_11_3"
-    "cudaPackages_11_4"
-    "cudaPackages_11_5"
-    "cudaPackages_11_6"
-    "cudaPackages_11"
-    "cudaPackages"
-  ];
-
+  # Package sets to evaluate whole
+  packageSets = builtins.filter (lib.strings.hasPrefix "cudaPackages") (builtins.attrNames pkgs);
   evalPackageSet = pset: mapTestOn { ${pset} = packagePlatforms pkgs.${pset}; };
 
-  jobs = (mapTestOn ({
-    # Packages to evaluate
-    python3.pkgs.caffeWithCuda = linux;
-    python3.pkgs.jaxlibWithCuda = linux;
-    python3.pkgs.libgpuarray = linux;
-    python3.pkgs.tensorflowWithCuda = linux;
-    python3.pkgs.pyrealsense2WithCuda = linux;
-    python3.pkgs.torchWithCuda = linux;
-    python3.pkgs.jaxlib = linux;
-  }) // (genAttrs packageSets evalPackageSet));
+  jobs =
+    mapTestOn {
+      blas = linux;
+      blender = linux;
+      faiss = linux;
+      lapack = linux;
+      magma = linux;
+      mpich = linux;
+      openmpi = linux;
+      ucx = linux;
 
-in jobs
+      opencv = linux;
+      cctag = linux; # Failed in https://github.com/NixOS/nixpkgs/pull/233581
+
+      cholmod-extra = linux;
+      colmap = linux;
+      ctranslate2 = linux;
+      deepin.image-editor = linux;
+      ffmpeg-full = linux;
+      gimp = linux;
+      gpu-screen-recorder = linux;
+      gst_all_1.gst-plugins-bad = linux;
+      lightgbm = linux;
+      llama-cpp = linux;
+      meshlab = linux;
+      monado = linux; # Failed in https://github.com/NixOS/nixpkgs/pull/233581
+      noisetorch = linux;
+      obs-studio-plugins.obs-backgroundremoval = linux;
+      ollama = linux;
+      onnxruntime = linux;
+      openmvg = linux;
+      openmvs = linux;
+      opentrack = linux;
+      openvino = linux;
+      pixinsight = linux; # Failed in https://github.com/NixOS/nixpkgs/pull/233581
+      qgis = linux;
+      rtabmap = linux;
+      saga = linux;
+      suitesparse = linux;
+      truecrack-cuda = linux;
+      tts = linux;
+      ueberzugpp = linux; # Failed in https://github.com/NixOS/nixpkgs/pull/233581
+      wyoming-faster-whisper = linux;
+      xgboost = linux;
+
+      python3Packages = {
+        boxx = linux;
+        bpycv = linux;
+        caffe = linux;
+        catboost = linux;
+        chainer = linux;
+        cupy = linux;
+        faiss = linux;
+        faster-whisper = linux;
+        flax = linux;
+        gpt-2-simple = linux;
+        grad-cam = linux;
+        jaxlib = linux;
+        jax = linux;
+        Keras = linux;
+        kornia = linux;
+        libgpuarray = linux;
+        mmcv = linux;
+        mxnet = linux;
+        numpy = linux; # Only affected by MKL?
+        onnx = linux;
+        openai-triton = linux;
+        openai-whisper = linux;
+        opencv4 = linux;
+        opensfm = linux;
+        pycuda = linux;
+        pymc = linux;
+        pyrealsense2WithCuda = linux;
+        pytorch-lightning = linux;
+        pytorch = linux;
+        scikitimage = linux;
+        scikit-learn = linux; # Only affected by MKL?
+        scipy = linux; # Only affected by MKL?
+        spacy-transformers = linux;
+        tensorflow = linux;
+        tensorflow-probability = linux;
+        tesserocr = linux;
+        Theano = linux;
+        tiny-cuda-nn = linux;
+        torchaudio = linux;
+        torch = linux;
+        torchvision = linux;
+        transformers = linux;
+        ttstokenizer = linux;
+        vidstab = linux;
+      };
+    }
+    // (lib.genAttrs packageSets evalPackageSet);
+in
+jobs

--- a/pkgs/top-level/release-cuda.nix
+++ b/pkgs/top-level/release-cuda.nix
@@ -12,6 +12,22 @@
         $ hydra-eval-jobs pkgs/top-level/release-cuda.nix -I .
 */
 
+let
+  ensureList = x: if builtins.isList x then x else [ x ];
+  allowUnfreePredicate =
+    p:
+    builtins.all (
+      license:
+      license.free
+      || license.redistributable
+      || builtins.elem license.shortName [
+        "CUDA EULA"
+        "cuDNN EULA"
+        "NVidia OptiX EULA"
+      ]
+    ) (ensureList p.meta.license);
+in
+
 {
   # The platforms for which we build Nixpkgs.
   supportedSystems ? [
@@ -22,8 +38,8 @@
   # Attributes passed to nixpkgs.
   nixpkgsArgs ? {
     config = {
+      inherit allowUnfreePredicate;
       "${variant}Support" = true;
-      allowUnfree = true;
       inHydra = true;
     };
   },


### PR DESCRIPTION
## Description of changes

The NixOS Hydra still doesn't build CUDA and unfree packages (except for when we misspecify the licenses, like for PyPi wheels which may or may not include hidden CUDA and MKL bits), but https://hydra.nix-community.org/jobset/nixpkgs/cuda-nixos-unstable might: thanks to https://github.com/nix-community/infra/pull/1335.

CC @zimbatm @NixOS/cuda-maintainers

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
