### PR TITLE
ooklaserver: init at 2.11.1.2

### DIFF
--- a/pkgs/by-name/oo/ooklaserver/package.nix
+++ b/pkgs/by-name/oo/ooklaserver/package.nix
@@ -1,0 +1,53 @@
+{ lib
+, stdenv
+, fetchurl
+, unzip
+}:
+let
+  filenameMapping = {
+    "x86_64-linux" = "OoklaServer-linux-x86_64-static-musl.zip";
+    "aarch64-linux" = "OoklaServer-linux-aarch64-static-musl.zip";
+    # Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
+    "x86_64-darwin" = "OoklaServer-macosx.zip";
+    "aarch64-darwin" = "OoklaServer-macosx.zip";
+    "x86_64-windows" = "OoklaServer-windows64.zip";
+    "i686-windows" = "OoklaServer-windows32.zip";
+    # OoklaServer-linux64-deb9.zip
+    # OoklaServer-freebsd12_64.zip
+    # OoklaServer-freebsd13_64.zip
+  };
+in
+stdenv.mkDerivation rec {
+  version = "2.11.1.2";
+  pname = "ooklaserver";
+
+  src = fetchurl {
+    url = "https://web.archive.org/web/20240703022648/https://install.speedtest.net/ooklaserver/stable/OoklaServer.tgz";
+    hash = "sha256-tctLtTGmrVHs+4pI1PRHrqY+a4ISs6TKvLRKlFdWw88=";
+  };
+  sourceRoot = ".";
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ unzip ];
+
+  installPhase = ''
+    runHook preInstall
+    unzip ${filenameMapping.${stdenv.system}}
+    install -Dm555 OoklaServer${stdenv.hostPlatform.extensions.executable} "$out/bin/OoklaServer"
+    install -Dm444 OoklaServer.properties.default "$out/etc/OoklaServer.properties.default"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Ookla TCP based server daemon that provides standalone testing";
+    homepage = "https://www.speedtest.net";
+    changelog = "https://support.ookla.com/hc/en-us/articles/234578608-Speedtest-Server-Release-Notes";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ neverbehave ];
+    platforms = builtins.attrNames filenameMapping;
+    mainProgram = "OoklaServer";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adding OoklaServer: TCP based server daemon that provides standalone testing, from speedtest.net

OoklaServer version 2.11 (2.11.1.2) build number 2024-02-13.1456.91c4f93

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
