### PR TITLE
mopidy-spotify: adopt; modernize; 4.1.1-unstable-2024-02-27 -> 5.0.0a2

### DIFF
--- a/pkgs/applications/audio/mopidy/spotify.nix
+++ b/pkgs/applications/audio/mopidy/spotify.nix
@@ -6,26 +6,45 @@
   nix-update-script,
 }:
 
-pythonPackages.buildPythonApplication {
+pythonPackages.buildPythonApplication rec {
   pname = "mopidy-spotify";
-  version = "4.1.1-unstable-2024-02-27";
+  version = "5.0.0a2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mopidy";
     repo = "mopidy-spotify";
-    rev = "112d4abbb3f5b6477dab796f2824fa42196bfa0a";
-    hash = "sha256-RkXDzAbOOll3uCNZ2mFRnjqMkT/NkXOGjywLRTC9i60=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-QeABG9rQKJ8sIoK38R74N0s5rRG+zws7AZR0xPysdcY=";
   };
 
   build-system = [ pythonPackages.setuptools ];
 
   dependencies = [
     mopidy
-    pythonPackages.responses
+    pythonPackages.pykka
+    pythonPackages.requests
   ];
 
-  nativeCheckInputs = [ pythonPackages.pytestCheckHook ];
+  optional-dependencies = {
+    lint = with pythonPackages; [
+      black
+      check-manifest
+      flake8
+      flake8-bugbear
+      isort
+    ];
+
+    test = with pythonPackages; [
+      pytest
+      pytest-cov
+      responses
+    ];
+
+    dev = optional-dependencies.lint ++ optional-dependencies.test ++ [ pythonPackages.tox ];
+  };
+
+  nativeCheckInputs = [ pythonPackages.pytestCheckHook ] ++ optional-dependencies.test;
 
   pythonImportsCheck = [ "mopidy_spotify" ];
 
@@ -36,6 +55,7 @@ pythonPackages.buildPythonApplication {
   meta = {
     description = "Mopidy extension for playing music from Spotify";
     homepage = "https://github.com/mopidy/mopidy-spotify";
+    changelog = "https://github.com/mopidy/mopidy-spotify/releases/tag/v${version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ getchoo ];
   };

--- a/pkgs/applications/audio/mopidy/spotify.nix
+++ b/pkgs/applications/audio/mopidy/spotify.nix
@@ -32,6 +32,6 @@ pythonPackages.buildPythonApplication rec {
     homepage = "https://github.com/mopidy/mopidy-spotify";
     description = "Mopidy extension for playing music from Spotify";
     license = licenses.asl20;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ getchoo ];
   };
 }

--- a/pkgs/applications/audio/mopidy/spotify.nix
+++ b/pkgs/applications/audio/mopidy/spotify.nix
@@ -6,9 +6,10 @@
   unstableGitUpdater,
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication {
   pname = "mopidy-spotify";
   version = "4.1.1-unstable-2024-02-27";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mopidy";
@@ -17,21 +18,23 @@ pythonPackages.buildPythonApplication rec {
     hash = "sha256-RkXDzAbOOll3uCNZ2mFRnjqMkT/NkXOGjywLRTC9i60=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ pythonPackages.setuptools ];
+
+  dependencies = [
     mopidy
     pythonPackages.responses
   ];
 
-  nativeBuildInputs = [ pythonPackages.pytestCheckHook ];
+  nativeCheckInputs = [ pythonPackages.pytestCheckHook ];
 
   pythonImportsCheck = [ "mopidy_spotify" ];
 
   passthru.updateScript = unstableGitUpdater { tagPrefix = "v"; };
 
-  meta = with lib; {
-    homepage = "https://github.com/mopidy/mopidy-spotify";
+  meta = {
     description = "Mopidy extension for playing music from Spotify";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ getchoo ];
+    homepage = "https://github.com/mopidy/mopidy-spotify";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ getchoo ];
   };
 }

--- a/pkgs/applications/audio/mopidy/spotify.nix
+++ b/pkgs/applications/audio/mopidy/spotify.nix
@@ -1,4 +1,10 @@
-{ lib, fetchFromGitHub, pythonPackages, mopidy, unstableGitUpdater }:
+{
+  lib,
+  fetchFromGitHub,
+  pythonPackages,
+  mopidy,
+  unstableGitUpdater,
+}:
 
 pythonPackages.buildPythonApplication rec {
   pname = "mopidy-spotify";
@@ -16,15 +22,11 @@ pythonPackages.buildPythonApplication rec {
     pythonPackages.responses
   ];
 
-  nativeBuildInputs = [
-    pythonPackages.pytestCheckHook
-  ];
+  nativeBuildInputs = [ pythonPackages.pytestCheckHook ];
 
   pythonImportsCheck = [ "mopidy_spotify" ];
 
-  passthru.updateScript = unstableGitUpdater {
-    tagPrefix = "v";
-  };
+  passthru.updateScript = unstableGitUpdater { tagPrefix = "v"; };
 
   meta = with lib; {
     homepage = "https://github.com/mopidy/mopidy-spotify";

--- a/pkgs/applications/audio/mopidy/spotify.nix
+++ b/pkgs/applications/audio/mopidy/spotify.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   pythonPackages,
   mopidy,
-  unstableGitUpdater,
+  nix-update-script,
 }:
 
 pythonPackages.buildPythonApplication {
@@ -29,7 +29,9 @@ pythonPackages.buildPythonApplication {
 
   pythonImportsCheck = [ "mopidy_spotify" ];
 
-  passthru.updateScript = unstableGitUpdater { tagPrefix = "v"; };
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Mopidy extension for playing music from Spotify";


### PR DESCRIPTION
## Description of changes

Upstream has been using the v5 alpha as the default version to install [for a while now](https://github.com/mopidy/mopidy-spotify/commit/6e7f95330a17dd36e990650fd3f63b27ad46f215), so I think it's time we do here as well. See the changelog of [v5.0.0a1](https://github.com/mopidy/mopidy-spotify/releases/tag/v5.0.0a1) for a better list of all the changes here, but for our purposes this should only be a breakage in dependencies rather than anything user facing

The biggest dependency change is the addition of `spotifyaudiosrc` from `gst-plugins-rs`. This should already be covered in mopidy itself [here](https://github.com/NixOS/nixpkgs/blob/26d9cafa3461c8ec55a6aa7e76ec0f8db0737ff9/pkgs/applications/audio/mopidy/mopidy.nix#L24), so I don't imagine we should need to wrap it here as well

Testing would be appreciated, but in any case I'll be trying this on my own machine in a few days

Diff: https://github.com/mopidy/mopidy-spotify/compare/v4.1.1...v5.0.0a2
Changelog: https://github.com/mopidy/mopidy-spotify/releases/tag/v5.0.0a2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
