### PR TITLE
nicstat: init at 0-unstable-2018-05-09

### DIFF
--- a/pkgs/by-name/ni/nicstat/package.nix
+++ b/pkgs/by-name/ni/nicstat/package.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, installShellFiles
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nicstat";
+  version = "0-unstable-2018-05-09";
+
+  src = fetchFromGitHub {
+    owner = "scotte";
+    repo = "nicstat";
+    rev = "1fbe28198b49a2062b0c928554f93db33cb288c3";
+    hash = "sha256-7+11K9636dGeW0HaaH6OJF5Wy4CXYXfoaZOVfhHK6kg=";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    $CC -O2 nicstat.c -o nicstat
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -d "$out/bin"
+    install -m 755 nicstat "$out/bin"
+
+    installManPage nicstat.1
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Network traffic statistics utility for Solaris and Linux";
+    homepage = "https://github.com/scotte/nicstat";
+    changelog = "https://github.com/scotte/nicstat/blob/${finalAttrs.src.rev}/ChangeLog.txt";
+    license = lib.licenses.artistic2;
+    maintainers = with lib.maintainers; [ juliusrickert ];
+    mainProgram = "nicstat";
+    platforms = lib.platforms.unix;
+    broken = stdenv.isDarwin;
+  };
+})


### PR DESCRIPTION
# Project description

nicstat is a tool similar to iostat, but for network interfaces.
Originally written by [Brendan Gregg](https://www.brendangregg.com/) for Solaris. Ported to [Linux by Tim Cook](https://web.archive.org/web/20160331125836/https://blogs.oracle.com/timc/entry/nicstat_the_solaris_and_linux).

Closes https://github.com/NixOS/nixpkgs/issues/324060

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
