### PR TITLE
linux: multiple outputs for kernel targets

### DIFF
--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -1,3 +1,12 @@
+let
+  # Map of images representations to legacy Makefile targets.
+  defaultMapKernelToInstallTargets = {
+    "uImage" = "uinstall";
+    "zImage" = "zinstall";
+    "Image.gz" = "zinstall";
+    "vmlinuz.efi" = "zinstall";
+  };
+in
 { buildPackages
 , callPackage
 , perl
@@ -70,6 +79,12 @@ lib.makeOverridable ({ # The kernel source tarball.
 # easy overrides to stdenv.hostPlatform.linux-kernel members
 , autoModules ? stdenv.hostPlatform.linux-kernel.autoModules
 , preferBuiltin ? stdenv.hostPlatform.linux-kernel.preferBuiltin or false
+, kernelTargets ?
+    if stdenv.hostPlatform.isAarch64 then
+      ["Image" "vmlinuz.efi"]
+    else
+      [stdenv.hostPlatform.linux-kernel.target]
+, installTargets ? lib.unique (map (target: defaultMapKernelToInstallTargets.${target} or "install") kernelTargets)
 , kernelArch ? stdenv.hostPlatform.linuxArch
 , kernelTests ? []
 
@@ -214,7 +229,7 @@ let
   }; # end of configfile derivation
 
   kernel = (callPackage ./manual-config.nix { inherit lib stdenv buildPackages; }) (basicArgs // {
-    inherit kernelPatches randstructSeed extraMakeFlags extraMeta configfile modDirVersion;
+    inherit kernelPatches randstructSeed extraMakeFlags extraMeta configfile modDirVersion kernelTargets installTargets;
     pos = builtins.unsafeGetAttrPos "version" args;
 
     config = {

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -33,6 +33,13 @@ in lib.makeOverridable ({
   src,
   # a list of { name=..., patch=..., extraConfig=...} patches
   kernelPatches ? [],
+  # kernel image build targets like Image, bzImage, Image.gz, vmlinuz.efi
+  kernelTargets ? [],
+  # a list of install targets, e.g. :
+  # - uinstall for uImage, U-Boot wrapped image
+  # - zinstall for zImage, self-extracting images
+  # - install, the generic binary image
+  installTargets ? [],
   # The kernel .config file
   configfile,
   # Manually specified nixexpr representing the config
@@ -64,7 +71,9 @@ let
   # Shadow the un-defaulted parameter; don't want null.
   modDirVersion = modDirVersion_;
   inherit (lib)
-    hasAttr getAttr optional optionals optionalString optionalAttrs maintainers platforms;
+    hasAttr getAttr optional optionals optionalString optionalAttrs genAttrs replaceStrings maintainers platforms;
+
+  targetsToOutput = genAttrs kernelTargets (target: replaceStrings ["."] ["-"] target);
 
   drvAttrs = config_: kernelConf: kernelPatches: configfile:
     let
@@ -128,10 +137,10 @@ let
       ++ optionals withRust [ rustc rust-bindgen ]
       ;
 
-    in (optionalAttrs isModular { outputs = [ "out" "dev" ]; }) // {
+    in (optionalAttrs isModular { outputs = [ "out" "dev" ] ++ (lib.attrValues targetsToOutput); }) // {
       passthru = rec {
         inherit version modDirVersion config kernelPatches configfile
-          moduleBuildDependencies stdenv;
+          moduleBuildDependencies stdenv targetsToOutput;
         inherit isZen isHardened isLibre withRust;
         isXen = lib.warn "The isXen attribute is deprecated. All Nixpkgs kernels that support it now have Xen enabled." true;
         baseVersion = lib.head (lib.splitString "-rc" version);
@@ -242,7 +251,7 @@ let
 
       buildFlags = [
         "KBUILD_BUILD_VERSION=1-NixOS"
-        kernelConf.target
+      ] ++ kernelTargets ++ [
         "vmlinux"  # for "perf" and things like that
       ] ++ optional isModular "modules"
         ++ optionals buildDTBs ["dtbs" "DTC_FLAGS=-@"]
@@ -309,15 +318,14 @@ let
         export HOME=${installkernel}
       '';
 
-      # Some image types need special install targets (e.g. uImage is installed with make uinstall on arm)
-      installTargets = [
-        (kernelConf.installTarget or (
-          /**/ if kernelConf.target == "uImage" && stdenv.hostPlatform.linuxArch == "arm" then "uinstall"
-          else if kernelConf.target == "zImage" || kernelConf.target == "Image.gz" || kernelConf.target == "vmlinuz.efi" then "zinstall"
-          else "install"))
-      ];
+      # Some image types need special install targets (e.g. uImage is installed with make uinstall)
+      installTargets = if installTargets == [ ] then [ "install" ] else installTargets;
 
-      postInstall = optionalString isModular ''
+      postInstall = (lib.concatStringsSep "\n" (lib.mapAttrsToList (target: output: ''
+        mkdir -p "''${${output}}"
+        moveToOutput "${target}" "''${${output}}"
+        ln -sf "''${${output}}/${target}" "$out/${target}"
+      '') targetsToOutput)) + (optionalString isModular ''
         mkdir -p $dev
         cp vmlinux $dev/
         if [ -z "''${dontStrip-}" ]; then
@@ -387,7 +395,7 @@ let
 
         # Delete empty directories
         find -empty -type d -delete
-      '';
+      '');
 
       requiredSystemFeatures = [ "big-parallel" ];
 


### PR DESCRIPTION
## Description of changes

Preview of an alternative idea for #244706 and inspired by #287122. Needs #239721.

This adds outputs for all built kernel targets and provides symlinks to all built images in the default output for compatibility. This way we can get rid of `lib.platforms.*.linux-kernel.target` eventually and we don't have to build the kernel multiple times for every target.

Looking for feedback. Is this maybe a way to go?

## TODO

 - [ ] Change NixOS bootloader code to use the outputs
 - [ ] Don't depend on all images in the NixOS system closure
 - [ ] Remove target from `lib.platforms.*.linux-kernel`
 - [ ] Maybe split modules and dtbs in separate outputs
 - [ ] Code cleanups for better readability

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
