### PR TITLE
Update Hackage index, update `Cabal` package

### DIFF
--- a/pkgs/data/misc/hackage/pin.json
+++ b/pkgs/data/misc/hackage/pin.json
@@ -1,6 +1,6 @@
 {
-  "commit": "f9ce92cad6df36ec3b9dfc6807c4a1c0426c608e",
-  "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/f9ce92cad6df36ec3b9dfc6807c4a1c0426c608e.tar.gz",
-  "sha256": "01fnkg977fi44v0scijgrp3hq3yrqzw5k8i326a9pz8j6r676iim",
-  "msg": "Update from Hackage at 2024-06-23T10:38:31Z"
+  "commit": "7984d2867c5cb9c0dcdf7f36413315a772cd4b32",
+  "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/7984d2867c5cb9c0dcdf7f36413315a772cd4b32.tar.gz",
+  "sha256": "097sh1rfvn1wnkb3gazrkfd9ainrzlhcdlr2dd0bfg86bavndm8y",
+  "msg": "Update from Hackage at 2024-07-03T17:09:52Z"
 }

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -27,8 +27,8 @@ self: super: {
     process = self.process_1_6_20_0;
   }));
 
-  Cabal_3_12_0_0 = doDistribute (super.Cabal_3_12_0_0.override ({
-    Cabal-syntax = self.Cabal-syntax_3_12_0_0;
+  Cabal_3_12_1_0 = doDistribute (super.Cabal_3_12_1_0.override ({
+    Cabal-syntax = self.Cabal-syntax_3_12_1_0;
   } // lib.optionalAttrs (lib.versionOlder self.ghc.version "9.2.5") {
     # Use process core package when possible
     process = self.process_1_6_20_0;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -27,6 +27,13 @@ self: super: {
     process = self.process_1_6_20_0;
   }));
 
+  Cabal_3_12_0_0 = doDistribute (super.Cabal_3_12_0_0.override ({
+    Cabal-syntax = self.Cabal-syntax_3_12_0_0;
+  } // lib.optionalAttrs (lib.versionOlder self.ghc.version "9.2.5") {
+    # Use process core package when possible
+    process = self.process_1_6_20_0;
+  }));
+
   # cabal-install needs most recent versions of Cabal and Cabal-syntax,
   # so we need to put some extra work for non-latest GHCs
   inherit (

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -44,6 +44,7 @@ extra-packages:
   - Cabal == 3.6.*                      # used for packages needing newer Cabal on ghc 8.10 and 9.0
   - Cabal-syntax == 3.8.*               # version required for ormolu and fourmolu on ghc 9.2 and 9.0
   - Cabal-syntax == 3.10.*              # version required for cabal-install and other packages
+  - Cabal-syntax == 3.12.*              # version required for cabal-install and other packages
   - Cabal == 3.10.*                     # version required for cabal-install and other packages
   - directory == 1.3.7.*                # required to build cabal-install 3.10.* with GHC 9.2
   - Diff < 0.4                          # required by liquidhaskell-0.8.10.2: https://github.com/ucsd-progsys/liquidhaskell/issues/1729

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -4041,7 +4041,6 @@ dont-distribute-packages:
  - typed-streams
  - typedflow
  - typelevel
- - typesafe-precure
  - typescript-docs
  - typson-beam
  - typson-esqueleto


### PR DESCRIPTION
## Description of changes
This follows https://github.com/NixOS/nixpkgs/pull/324492; that PR fixes `Cabal_3_12_0_0`.

This updates Cabal to `3_12_1_0`
This update would assist this PR: https://github.com/haskell/hackage-server/pull/1322

Other packages also updated

## Things done
```
./maintainers/scripts/haskell/update-hackage.sh
./maintainers/scripts/haskell/regenerate-hackage-packages.sh
```

`nix build .#haskellPackages.Cabal_3_12_1_0` succeeds


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
