### PR TITLE
brainflow: init at 5.12.1

### DIFF
--- a/pkgs/by-name/br/brainflow/package.nix
+++ b/pkgs/by-name/br/brainflow/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  bluez,
+  cmake,
+  dbus,
+  libftdi1,
+  nix-update-script,
+  pkg-config,
+  useLibFTDI ? true,
+  useOpenMP ? true,
+  buildBluetooth ? true,
+  buildBluetoothLowEnergy ? true,
+  buildONNX ? true,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "brainflow";
+  version = "5.12.1";
+
+  src = fetchFromGitHub {
+    owner = "brainflow-dev";
+    repo = "brainflow";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-haQO03nkvLoXtFVe+C+yi+MwM0CFh6rLcLvU8fQ4k/w=";
+  };
+
+  patches = [
+    # All of these are PRs that were merged into the upstream repository and will be included in the next release
+    # These should be removed once the next version is released
+    (fetchpatch {
+      # Fixes a major issue that prevented the build from working at all (why was this not backported???)
+      url = "https://github.com/brainflow-dev/brainflow/commit/883b0cd08acb99d7b6e241e92fba2e9a363d17b1.patch";
+      hash = "sha256-QQd+BI3I65gfaNS/SKLjCoqbCwPCiTh+nh0tJAZM6hQ=";
+    })
+    (fetchpatch {
+      # Bumps the version of a python dependency that had a backwards-incompatible change
+      url = "https://github.com/brainflow-dev/brainflow/commit/ea23a6f0483ce4d6fdd7a82bace865356ee78d7f.patch";
+      hash = "sha256-dvMpxxRrnJQ9ADGagB1JhuoB9SNwn755wbHzW/3ECeo=";
+    })
+    (fetchpatch {
+      # Fixes an incorrect use of an environment variable during the build
+      url = "https://github.com/brainflow-dev/brainflow/commit/053b8c1253b686cbec49ab4adb47c9ee02d3f99a.patch";
+      hash = "sha256-Pfhe1ZvMagfVAGZqeWn1uHXgwlTtkOm+gyWuvC5/Sro=";
+    })
+  ];
+
+  cmakeFlags = with lib; [
+    (cmakeBool "USE_LIBFTDI" useLibFTDI)
+    (cmakeBool "USE_OPENMP" useOpenMP)
+    (cmakeBool "BUILD_OYMOTION_SDK" false) # Needs a "GFORCE_SDK"
+    (cmakeBool "BUILD_BLUETOOTH" buildBluetooth)
+    (cmakeBool "BUILD_BLE" buildBluetoothLowEnergy)
+    (cmakeBool "BUILD_ONNX" buildONNX)
+  ];
+
+  buildInputs =
+    [ dbus ]
+    ++ lib.optional (buildBluetooth || buildBluetoothLowEnergy) bluez
+    ++ lib.optional useLibFTDI libftdi1;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  postPatch = ''
+    find . -type f -name 'build.cmake' -exec \
+    sed -i 's/DESTINATION inc/DESTINATION include/g' {} \;
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A library to obtain, parse and analyze data (EEG, EMG, ECG) from biosensors";
+    homepage = "https://brainflow.org/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      pandapip1
+      ziguana
+    ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/python-modules/brainflow/default.nix
+++ b/pkgs/development/python-modules/brainflow/default.nix
@@ -1,0 +1,39 @@
+{
+  buildPythonPackage,
+  brainflow,
+  nptyping,
+  numpy,
+  python,
+  setuptools,
+}:
+
+buildPythonPackage {
+  inherit (brainflow)
+    pname
+    version
+    src
+    patches
+    meta
+    ;
+
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  dependencies = [
+    numpy
+    nptyping
+  ];
+
+  buildInputs = [ brainflow ];
+
+  postPatch = ''
+    cd python_package
+  '';
+
+  postInstall = ''
+    mkdir -p "$out/${python.sitePackages}/brainflow/lib/"
+    cp -Tr "${brainflow}/lib" "$out/${python.sitePackages}/brainflow/lib/"
+  '';
+
+  pythonImportsCheck = [ "brainflow" ];
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1767,6 +1767,10 @@ self: super: with self; {
 
   bracex = callPackage ../development/python-modules/bracex { };
 
+  brainflow = callPackage ../development/python-modules/brainflow {
+    inherit (pkgs) brainflow;
+  };
+
   braintree = callPackage ../development/python-modules/braintree { };
 
   branca = callPackage ../development/python-modules/branca { };


### PR DESCRIPTION
## Description of changes

Continuation of https://github.com/NixOS/nixpkgs/pull/303718, since I goofed up my rebase command and pinged like 100 people. Sorry :(

Closes https://github.com/NixOS/nixpkgs/pull/278412 (supersedes)

Closes https://github.com/NixOS/nixpkgs/issues/303517

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
