### PR TITLE
db4: fix pthread configure detection

### DIFF
--- a/pkgs/development/libraries/db/clang-4.8.patch
+++ b/pkgs/development/libraries/db/clang-4.8.patch
@@ -153,20 +153,40 @@ diff -ur a/dist/aclocal/clock.m4 b/dist/aclocal/clock.m4
 diff -ur a/dist/aclocal/mutex.m4 b/dist/aclocal/mutex.m4
 --- a/dist/aclocal/mutex.m4	1969-12-31 19:00:01.000000000 -0500
 +++ b/dist/aclocal/mutex.m4	2023-06-05 19:14:47.214158196 -0400
-@@ -4,6 +4,7 @@
+@@ -3,7 +3,9 @@
+ # POSIX pthreads tests: inter-process safe and intra-process only.
  AC_DEFUN(AM_PTHREADS_SHARED, [
  AC_TRY_RUN([
++#include <stdlib.h>
  #include <pthread.h>
 +int
  main() {
  	pthread_cond_t cond;
  	pthread_mutex_t mutex;
-@@ -46,6 +47,7 @@
+@@ -24,6 +26,7 @@ main() {
+ 	pthread_mutexattr_destroy(&mutexattr));
+ }], [db_cv_mutex="$1"],,
+ AC_TRY_LINK([
++#include <stdlib.h>
+ #include <pthread.h>],[
+ 	pthread_cond_t cond;
+ 	pthread_mutex_t mutex;
+@@ -45,7 +48,9 @@ AC_TRY_LINK([
+ ], [db_cv_mutex="$1"]))])
  AC_DEFUN(AM_PTHREADS_PRIVATE, [
  AC_TRY_RUN([
++#include <stdlib.h>
  #include <pthread.h>
 +int
  main() {
+ 	pthread_cond_t cond;
+ 	pthread_mutex_t mutex;
+@@ -64,6 +69,7 @@ main() {
+ 	pthread_mutexattr_destroy(&mutexattr));
+ }], [db_cv_mutex="$1"],,
+ AC_TRY_LINK([
++#include <stdlib.h>
+ #include <pthread.h>],[
  	pthread_cond_t cond;
  	pthread_mutex_t mutex;
 diff -ur a/dist/aclocal/sequence.m4 b/dist/aclocal/sequence.m4
@@ -183,7 +203,7 @@ diff -ur a/dist/aclocal/sequence.m4 b/dist/aclocal/sequence.m4
  			$db_cv_seq_type l;
  			unsigned $db_cv_seq_type u;
 @@ -59,7 +62,9 @@
-				return (1);
+ 				return (1);
  			return (0);
  		}],, [db_cv_build_sequence="no"],
 -		AC_TRY_LINK(,[

--- a/pkgs/development/libraries/db/db-4.8.nix
+++ b/pkgs/development/libraries/db/db-4.8.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl, autoreconfHook, targetPlatform, ... } @ args:
+{ lib, stdenv, fetchurl, autoreconfHook, ... } @ args:
 
-import ./generic.nix (builtins.removeAttrs args ["targetPlatform"] // {
+import ./generic.nix (args // {
   version = "4.8.30";
   sha256 = "0ampbl2f0hb1nix195kz1syrqqxpmvnvnfvphambj7xjrl3iljg0";
   extraPatches = [
@@ -8,8 +8,6 @@ import ./generic.nix (builtins.removeAttrs args ["targetPlatform"] // {
     ./CVE-2017-10140-4.8-cwd-db_config.patch
     ./darwin-mutexes-4.8.patch
   ];
-
-  drvArgs.configureFlags = lib.optional (targetPlatform.useLLVM or false) "--with-mutex=POSIX/pthreads";
 
   drvArgs.hardeningDisable = [ "format" ];
   drvArgs.doCheck = false;

--- a/pkgs/development/libraries/db/generic.nix
+++ b/pkgs/development/libraries/db/generic.nix
@@ -67,8 +67,7 @@ stdenv.mkDerivation (rec {
       (if compat185 then "--enable-compat185" else "--disable-compat185")
     ]
     ++ lib.optional dbmSupport "--enable-dbm"
-    ++ lib.optional stdenv.isFreeBSD "--with-pic"
-    ++ (drvArgs.configureFlags or []);
+    ++ lib.optional stdenv.isFreeBSD "--with-pic";
 
   preConfigure = ''
     cd build_unix
@@ -93,4 +92,4 @@ stdenv.mkDerivation (rec {
     license = license;
     platforms = platforms.unix;
   };
-} // builtins.removeAttrs drvArgs [ "configureFlags" ])
+} // drvArgs)


### PR DESCRIPTION
## Description of changes

add header stdlib.h so pthread detection doesn't fail do to a missing function prototype for exit.
    
    configure:21863: clang -o conftest -O3   -D_GNU_SOURCE -D_REENTRANT
    conftest.c  >&5
    conftest.c:52:2: error: call to undeclared library function 'exit' with
    type 'void (int) __attribute__((noreturn))'; ISO C99 and later do not
    support implicit function declarations [-Wimplicit-function-declaration]
       52 |         exit (
          |         ^
    conftest.c:52:2: note: include the header <stdlib.h> or explicitly
    provide a declaration for 'exit'

additionally, add a leading space to line 218 to uncorrupt the patch -- git apply was complaining and failed to apply without fix.

this reverts the previous workaround https://github.com/NixOS/nixpkgs/pull/320187

testing: `nix-build -E 'with import ./.{}; db4.override { stdenv = clangStdenv; }` builds

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
