### PR TITLE
gnome-clocks: add missing gstreamer dependency

### DIFF
--- a/pkgs/desktops/gnome/apps/gnome-clocks/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-clocks/default.nix
@@ -1,34 +1,35 @@
-{ stdenv
-, lib
-, fetchurl
-, meson
-, ninja
-, gettext
-, pkg-config
-, wrapGAppsHook4
-, itstool
-, desktop-file-utils
-, vala
-, libxml2
-, gtk4
-, glib
-, sound-theme-freedesktop
-, gsettings-desktop-schemas
-, gnome-desktop
-, geocode-glib_2
-, gnome
-, gdk-pixbuf
-, geoclue2
-, libgweather
-, libadwaita
+{
+  stdenv,
+  lib,
+  fetchurl,
+  meson,
+  ninja,
+  gettext,
+  pkg-config,
+  wrapGAppsHook4,
+  itstool,
+  desktop-file-utils,
+  vala,
+  libxml2,
+  gtk4,
+  glib,
+  sound-theme-freedesktop,
+  gsettings-desktop-schemas,
+  gnome-desktop,
+  geocode-glib_2,
+  gnome,
+  gdk-pixbuf,
+  geoclue2,
+  libgweather,
+  libadwaita,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-clocks";
   version = "46.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gnome-clocks/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/gnome-clocks/${lib.versions.major finalAttrs.version}/gnome-clocks-${finalAttrs.version}.tar.xz";
     hash = "sha256-6qPFeM3O+XVOZotWJnCbc/NSZxAjX0tyB20v9JpPmcc=";
   };
 
@@ -72,12 +73,12 @@ stdenv.mkDerivation rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://apps.gnome.org/Clocks/";
     description = "Clock application designed for GNOME 3";
     mainProgram = "gnome-clocks";
-    maintainers = teams.gnome.members;
-    license = licenses.gpl2Plus;
-    platforms = platforms.unix;
+    maintainers = lib.teams.gnome.members;
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/desktops/gnome/apps/gnome-clocks/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-clocks/default.nix
@@ -20,6 +20,7 @@
   gnome,
   gdk-pixbuf,
   geoclue2,
+  gst_all_1,
   libgweather,
   libadwaita,
 }:
@@ -45,17 +46,24 @@ stdenv.mkDerivation (finalAttrs: {
     libxml2
   ];
 
-  buildInputs = [
-    gtk4
-    glib
-    gsettings-desktop-schemas
-    gdk-pixbuf
-    gnome-desktop
-    geocode-glib_2
-    geoclue2
-    libgweather
-    libadwaita
-  ];
+  buildInputs =
+    [
+      gtk4
+      glib
+      gsettings-desktop-schemas
+      gdk-pixbuf
+      gnome-desktop
+      geocode-glib_2
+      geoclue2
+      libgweather
+      libadwaita
+    ]
+    ++ (with gst_all_1; [
+      # GStreamer plugins needed for Alarms
+      gstreamer
+      gst-plugins-base
+      gst-plugins-good
+    ]);
 
   preFixup = ''
     gappsWrapperArgs+=(

--- a/pkgs/desktops/gnome/apps/gnome-clocks/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-clocks/default.nix
@@ -75,7 +75,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://apps.gnome.org/Clocks/";
-    description = "Clock application designed for GNOME 3";
+    description = "A simple and elegant clock application for GNOME";
+    longDescription = ''
+      A simple and elegant clock application. It includes world clocks, alarms,
+      a stopwatch, and timers.
+
+      - Show the time in different cities around the world
+      - Set alarms to wake you up
+      - Measure elapsed time with an accurate stopwatch
+      - Set timers to properly cook your food
+    '';
     mainProgram = "gnome-clocks";
     maintainers = lib.teams.gnome.members;
     license = lib.licenses.gpl2Plus;

--- a/pkgs/desktops/gnome/apps/gnome-clocks/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-clocks/default.nix
@@ -13,7 +13,6 @@
   libxml2,
   gtk4,
   glib,
-  sound-theme-freedesktop,
   gsettings-desktop-schemas,
   gnome-desktop,
   geocode-glib_2,
@@ -64,13 +63,6 @@ stdenv.mkDerivation (finalAttrs: {
       gst-plugins-base
       gst-plugins-good
     ]);
-
-  preFixup = ''
-    gappsWrapperArgs+=(
-      # Fallback sound theme
-      --prefix XDG_DATA_DIRS : "${sound-theme-freedesktop}/share"
-    )
-  '';
 
   doCheck = true;
 


### PR DESCRIPTION
## Description of changes

Looks like we forgot to add gstreamer as a build dependency in the last bump.
Closes https://github.com/NixOS/nixpkgs/issues/316781

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
