### PR TITLE
Added ory oathkeeper

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3128,6 +3128,12 @@
     githubId = 7435854;
     name = "Victor Calvert";
   };
+  camcalaquian = {
+    email = "camcalaquian@gmail.com";
+    github = "camcalaquian";
+    githubId = 36902555;
+    name = "Carl Calaquian";
+  };
   camelpunch = {
     email = "me@andrewbruce.net";
     github = "camelpunch";

--- a/pkgs/by-name/oa/oathkeeper/package.nix
+++ b/pkgs/by-name/oa/oathkeeper/package.nix
@@ -1,0 +1,46 @@
+{
+  fetchFromGitHub,
+  buildGoModule,
+  lib,
+}:
+let
+  pname = "oathkeeper";
+  version = "0.40.7";
+  commit = "c75695837f170334b526359f28967aa33d61bce6";
+in
+buildGoModule {
+  inherit pname version commit;
+
+  src = fetchFromGitHub {
+    owner = "ory";
+    repo = "oathkeeper";
+    rev = "v${version}";
+    hash = "sha256-Y5bowCFR9S70ko0vNCwZnhOIKKGdqgcDEBEtZisKEig=";
+  };
+
+  vendorHash = "sha256-+hh7MFYGPTaAlU/D0ROv5pw6YvzkAm6URuhP5jdgQtM=";
+
+  tags = [
+    "sqlite"
+    "json1"
+    "hsm"
+  ];
+
+  subPackages = [ "." ];
+
+  # Pass versioning information via ldflags
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/ory/oathkeeper/internal/driver/config.Version=${version}"
+    "-X github.com/ory/oathkeeper/internal/driver/config.Commit=${commit}"
+  ];
+
+  meta = {
+    description = "Open-source identity and access proxy that authorizes HTTP requests based on sets of rules";
+    homepage = "https://www.ory.sh/oathkeeper/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ camcalaquian ];
+    mainProgram = "oathkeeper";
+  };
+}


### PR DESCRIPTION
## Description of changes

Added new package - Ory Oathkeeper

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
