### PR TITLE
makeFontsConf: accept 'includes'

### DIFF
--- a/pkgs/development/libraries/fontconfig/make-fonts-conf.nix
+++ b/pkgs/development/libraries/fontconfig/make-fonts-conf.nix
@@ -4,7 +4,7 @@ let fontconfig_ = fontconfig; in
 {
   fontconfig ? fontconfig_
   # an array of fonts, e.g. `[ pkgs.dejavu_fonts.minimal ]`
-,  fontDirectories
+  ,  fontDirectories
   , impureFontDirectories ? [
     # nix user profile
     "~/.nix-profile/lib/X11/fonts" "~/.nix-profile/share/fonts"
@@ -18,19 +18,23 @@ let fontconfig_ = fontconfig; in
   ++ lib.optionals stdenv.isDarwin [ "/Library/Fonts" "/System/Library/Fonts" ]
   # nix default profile
   ++ [ "/nix/var/nix/profiles/default/lib/X11/fonts" "/nix/var/nix/profiles/default/share/fonts" ]
+
+  # to include custom config
+  , includes ? ["/etc/fonts/conf.d"]
 }:
 
 runCommand "fonts.conf"
   {
     nativeBuildInputs = [ libxslt ];
     buildInputs = [ fontconfig ];
-    inherit fontDirectories;
+    inherit fontDirectories includes;
     # Add a default font for non-nixos systems, <1MB and in nixos defaults.
     impureFontDirectories = impureFontDirectories ++ [ dejavu_fonts.minimal ];
   }
   ''
     xsltproc --stringparam fontDirectories "$fontDirectories" \
       --stringparam impureFontDirectories "$impureFontDirectories" \
+      --stringparam includes "$includes" \
       --path ${fontconfig.out}/share/xml/fontconfig \
       ${./make-fonts-conf.xsl} ${fontconfig.out}/etc/fonts/fonts.conf \
       > $out

--- a/pkgs/development/libraries/fontconfig/make-fonts-conf.xsl
+++ b/pkgs/development/libraries/fontconfig/make-fonts-conf.xsl
@@ -16,6 +16,7 @@
 
   <xsl:param name="fontDirectories" />
   <xsl:param name="impureFontDirectories" />
+  <xsl:param name="includes" />
 
   <xsl:template match="/fontconfig">
 
@@ -30,8 +31,10 @@
       <xsl:text>&#0010;</xsl:text>
 
       <!-- system-wide config -->
-      <include ignore_missing="yes">/etc/fonts/conf.d</include>
-      <xsl:text>&#0010;</xsl:text>
+      <xsl:for-each select="str:tokenize($includes)">
+        <include ignore_missing="yes"><xsl:value-of select="." /></include>
+        <xsl:text>&#0010;</xsl:text>
+      </xsl:for-each>
 
       <dir prefix="xdg">fonts</dir>
       <xsl:text>&#0010;</xsl:text>


### PR DESCRIPTION
## Description of changes

Lets you add pure font configuration without having to copy/paste the whole generated config.
We use `playwright` for browser end to end testing with pixel-perfect compareason of screenshots.
Right now we wrote the fontconfig by hand (or rather copied the one generated by nix and tweaked it a bit).

This lets us include the "tweak" rather than writing the font config from scratch. 
It also makes it possible to ignore the fontconfig in /etc/ which can be desired for purity reasons ?!

@xworld21 

NB: if you approve, I will target staging since it will trigger quite a few rebuilds ^^''

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
