### PR TITLE
treewide: fix packages that use cmake strict deps when cmake strict deps works

### DIFF
--- a/pkgs/applications/graphics/panotools/default.nix
+++ b/pkgs/applications/graphics/panotools/default.nix
@@ -22,13 +22,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
+    perl
   ];
 
   buildInputs = [
     libjpeg
     libpng
     libtiff
-    perl
   ] ++ lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.Carbon
   ];

--- a/pkgs/applications/misc/pwsafe/default.nix
+++ b/pkgs/applications/misc/pwsafe/default.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
     gettext
     perl
     pkg-config
+    wxGTK32
     zip
   ];
 

--- a/pkgs/applications/networking/ids/zeek/broker/default.nix
+++ b/pkgs/applications/networking/ids/zeek/broker/default.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
     substituteInPlace bindings/python/CMakeLists.txt --replace " -u -r" ""
   '';
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake python3 ];
   buildInputs = [ openssl python3.pkgs.pybind11 ];
   propagatedBuildInputs = [ caf' ];
 

--- a/pkgs/applications/networking/ids/zeek/default.nix
+++ b/pkgs/applications/networking/ids/zeek/default.nix
@@ -45,6 +45,7 @@ stdenv.mkDerivation rec {
     file
     flex
     python
+    swig
   ];
 
   buildInputs = [
@@ -55,7 +56,6 @@ stdenv.mkDerivation rec {
     libpcap
     ncurses
     openssl
-    swig
     zlib
     python
   ] ++ lib.optionals stdenv.isLinux [

--- a/pkgs/applications/science/electronics/flopoco/default.nix
+++ b/pkgs/applications/science/electronics/flopoco/default.nix
@@ -54,12 +54,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     bison
     cmake
+    flex
     installShellFiles
   ];
 
   buildInputs = [
     boost
-    flex
     gmp
     libxml2
     mpfi

--- a/pkgs/by-name/ar/arcan/package.nix
+++ b/pkgs/by-name/ar/arcan/package.nix
@@ -41,6 +41,7 @@
   valgrind,
   wayland,
   wayland-protocols,
+  wayland-scanner,
   xcbutil,
   xcbutilwm,
   xz,
@@ -63,6 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     makeWrapper
     pkg-config
+    wayland-scanner
   ] ++ lib.optionals buildManPages [ ruby ];
 
   buildInputs = [

--- a/pkgs/by-name/ay/ayatana-indicator-datetime/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-datetime/package.nix
@@ -85,6 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [
     dbus
+    dbus-test-runner
     (python3.withPackages (ps: with ps; [
       python-dbusmock
     ]))

--- a/pkgs/by-name/ce/cemu/package.nix
+++ b/pkgs/by-name/ce/cemu/package.nix
@@ -73,6 +73,7 @@ in stdenv.mkDerivation (finalAttrs: {
     nasm
     ninja
     pkg-config
+    wxGTK32
   ];
 
   buildInputs = [

--- a/pkgs/by-name/hy/hyprlock/package.nix
+++ b/pkgs/by-name/hy/hyprlock/package.nix
@@ -11,6 +11,7 @@
   pam,
   wayland,
   wayland-protocols,
+  wayland-scanner,
   cairo,
   file,
   libjpeg,
@@ -37,6 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
+    wayland-scanner
   ];
 
   buildInputs = [

--- a/pkgs/by-name/ne/nextpnr/package.nix
+++ b/pkgs/by-name/ne/nextpnr/package.nix
@@ -40,10 +40,10 @@ stdenv.mkDerivation rec {
   sourceRoot = main_src.name;
 
   nativeBuildInputs
-     = [ cmake ]
+     = [ cmake python3 ]
     ++ (lib.optional enableGui wrapQtAppsHook);
   buildInputs
-     = [ boostPython python3 eigen python3Packages.apycula ]
+     = [ boostPython eigen python3Packages.apycula ]
     ++ (lib.optional enableGui qtbase)
     ++ (lib.optional stdenv.cc.isClang llvmPackages.openmp);
 

--- a/pkgs/by-name/ri/ricochet-refresh/package.nix
+++ b/pkgs/by-name/ri/ricochet-refresh/package.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
+    protobuf
     cmake
     qt5.wrapQtAppsHook
   ];

--- a/pkgs/desktops/lomiri/applications/lomiri-system-settings/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-system-settings/default.nix
@@ -127,6 +127,7 @@ stdenv.mkDerivation (finalAttrs: {
     glib # glib-compile-schemas
     intltool
     pkg-config
+    qtdeclarative
     validatePkgConfig
   ];
 

--- a/pkgs/desktops/lomiri/applications/lomiri-system-settings/plugins/lomiri-system-settings-security-privacy.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-system-settings/plugins/lomiri-system-settings-security-privacy.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
     python3
+    qtdeclarative
   ];
 
   buildInputs = [

--- a/pkgs/desktops/lomiri/applications/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri/default.nix
@@ -155,8 +155,6 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs tests/whitespace/check_whitespace.py
   '';
 
-  strictDeps = true;
-
   nativeBuildInputs = [
     cmake
     glib # populates GSETTINGS_SCHEMAS_PATH

--- a/pkgs/desktops/lomiri/data/lomiri-session/default.nix
+++ b/pkgs/desktops/lomiri/data/lomiri-session/default.nix
@@ -150,8 +150,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       --replace-fail '/usr/libexec/Xwayland.lomiri' '${lib.getBin lomiri}/libexec/Xwayland.lomiri'
   '';
 
-  strictDeps = true;
-
   nativeBuildInputs = [
     cmake
     makeWrapper

--- a/pkgs/desktops/lomiri/development/lomiri-api/default.nix
+++ b/pkgs/desktops/lomiri/development/lomiri-api/default.nix
@@ -60,6 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     doxygen
     graphviz
     pkg-config
+    qtdeclarative
   ];
 
   buildInputs = [

--- a/pkgs/desktops/lomiri/development/lomiri-app-launch/default.nix
+++ b/pkgs/desktops/lomiri/development/lomiri-app-launch/default.nix
@@ -76,6 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     dpkg # for setting LOMIRI_APP_LAUNCH_ARCH
     gobject-introspection
+    lttng-ust
     pkg-config
     validatePkgConfig
   ] ++ lib.optionals withDocumentation [

--- a/pkgs/desktops/lomiri/development/qtmir/default.nix
+++ b/pkgs/desktops/lomiri/development/qtmir/default.nix
@@ -96,6 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     glib # glib-compile-schemas
+    lttng-ust
     pkg-config
     validatePkgConfig
     wrapQtAppsHook

--- a/pkgs/desktops/lomiri/qml/lomiri-action-api/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-action-api/default.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
+    qtdeclarative
     validatePkgConfig
   ];
 

--- a/pkgs/desktops/lomiri/qml/lomiri-settings-components/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-settings-components/default.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
+    qtdeclarative
   ];
 
   buildInputs = [

--- a/pkgs/desktops/lomiri/services/hfd-service/default.nix
+++ b/pkgs/desktops/lomiri/services/hfd-service/default.nix
@@ -45,6 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
+    qtdeclarative
   ];
 
   buildInputs = [

--- a/pkgs/development/compilers/p4c/default.nix
+++ b/pkgs/development/compilers/p4c/default.nix
@@ -76,6 +76,8 @@ stdenv.mkDerivation (finalAttrs: {
     bison
     flex
     cmake
+    protobuf
+    python3
   ]
   ++ lib.optionals enableDocumentation [ doxygen graphviz ]
   ++ lib.optionals enableBPF [ libllvm libbpf ];
@@ -86,7 +88,6 @@ stdenv.mkDerivation (finalAttrs: {
     boehmgc
     gmp
     flex
-    python3
   ];
 
   meta = {

--- a/pkgs/development/libraries/cppcms/default.nix
+++ b/pkgs/development/libraries/cppcms/default.nix
@@ -9,8 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-aXAxx9FB/dIVxr5QkLZuIQamO7PlLwnugSDo78bAiiE=";
   };
 
-  nativeBuildInputs = [ cmake ];
-  buildInputs = [ pcre zlib python3 openssl ];
+  nativeBuildInputs = [ cmake python3 ];
+  buildInputs = [ pcre zlib openssl ];
 
   strictDeps = true;
 

--- a/pkgs/development/libraries/crocoddyl/default.nix
+++ b/pkgs/development/libraries/crocoddyl/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
+  ] ++ lib.optionals pythonSupport [
+    python3Packages.python
   ];
 
   propagatedBuildInputs = lib.optionals (!pythonSupport) [

--- a/pkgs/development/libraries/hpp-fcl/default.nix
+++ b/pkgs/development/libraries/hpp-fcl/default.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     doxygen
+  ] ++ lib.optionals pythonSupport [
+    python3Packages.numpy
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/libraries/liblinphone/default.nix
+++ b/pkgs/development/libraries/liblinphone/default.nix
@@ -59,7 +59,6 @@ stdenv.mkDerivation rec {
 
     jsoncpp
     libxml2
-    (python3.withPackages (ps: [ ps.pystache ps.six ]))
     sqlite
     xercesc
     zxing-cpp
@@ -68,6 +67,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     doxygen
+    (python3.withPackages (ps: [ ps.pystache ps.six ]))
   ];
 
   strictDeps = true;

--- a/pkgs/development/libraries/partio/default.nix
+++ b/pkgs/development/libraries/partio/default.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
     unzip
     cmake
     doxygen
+    python3
   ];
 
   buildInputs = [
@@ -38,7 +39,6 @@ stdenv.mkDerivation rec {
     swig
     xorg.libXi
     xorg.libXmu
-    python3
   ] ++ lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.Cocoa
     darwin.apple_sdk.frameworks.GLUT

--- a/pkgs/development/libraries/science/math/clblas/default.nix
+++ b/pkgs/development/libraries/science/math/clblas/default.nix
@@ -42,10 +42,9 @@ stdenv.mkDerivation rec {
      "-DBUILD_TEST=OFF"
   ];
 
-  nativeBuildInputs = [ cmake gfortran ];
+  nativeBuildInputs = [ cmake gfortran python3 ];
   buildInputs = [
     blas
-    python3
     boost
   ] ++ lib.optionals (!stdenv.isDarwin) [
     ocl-icd

--- a/pkgs/development/tools/parsing/spicy/default.nix
+++ b/pkgs/development/tools/parsing/spicy/default.nix
@@ -24,13 +24,14 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    bison
     cmake
+    flex
     makeWrapper
     python3
   ];
 
   buildInputs = [
-    bison
     flex
     zlib
   ];

--- a/pkgs/tools/security/grap/default.nix
+++ b/pkgs/tools/security/grap/default.nix
@@ -16,12 +16,12 @@ stdenv.mkDerivation rec {
     cmake
     flex
     python3
+    swig4
   ];
 
   buildInputs = [
     boost.all
     libseccomp
-    swig4
   ];
 
   strictDeps = true;


### PR DESCRIPTION
## Description of changes

strict deps doesn't quite work for cmake as it (effectively) pulls in `buildInputs` into the `PATH` (precisely, it makes `find_program` discover executables form `buildInputs` via `CMAKE_PREFIX_PATH`). this change uses a fix for cmake https://github.com/NixOS/nixpkgs/pull/318226 so this doesn't happen and then fixes the packages that set strict deps but broke with the fixed cmake.

there were a couple of lomiri packages where i just disabled strict deps due to how cmake would package scripts, it seemed to want to locate them in the PATH and then package them. I could've just added them to nativeBuildInputs but i didn't -- there are only 2 packages and marked by `disable strict deps` in the title.

kdePackages.* are fixed by https://github.com/NixOS/nixpkgs/pull/329977   

packages were found using:
<details><summary>cmake-strict-deps.nix</summary>

```sh
nix-instantiate --show-trace --eval --strict --json -A devs - <<EOF
{
  paths ? (import ./pkgs/top-level/release-attrpaths-superset.nix { }).paths,
  pkgs ? (import ./. { }),
}:

let
  inherit (pkgs) lib;
  inherit (builtins) currentSystem tryEval;

  usesCmake =
    let
      hasCmakeNativeBuildInputs =
        p: p ? nativeBuildInputs && lib.lists.any (x: x == pkgs.cmake) p.nativeBuildInputs;

      usesCmake' =
        p:
        p != null
        && p.strictDeps or false
        && !(p.meta.broken or false)
        && lib.meta.availableOn p currentSystem
        && hasCmakeNativeBuildInputs p;
    in
    path: (tryEval (usesCmake' (lib.attrByPath path null pkgs))).value;
in
{
  devs = map (f: lib.concatStringsSep "." f) (lib.filter usesCmake paths);
}
EOF
```
</details>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
