### PR TITLE
tailscale-nginx-auth: re-use most from tailscale package

### DIFF
--- a/pkgs/by-name/ta/tailscale-nginx-auth/package.nix
+++ b/pkgs/by-name/ta/tailscale-nginx-auth/package.nix
@@ -1,30 +1,12 @@
-{ lib, stdenv, buildGoModule, fetchFromGitHub }:
+{ lib, stdenv, buildGoModule, tailscale }:
 
-let
-  version = "1.68.1";
-in
 buildGoModule {
   pname = "tailscale-nginx-auth";
-  inherit version;
-
-  src = fetchFromGitHub {
-    owner = "tailscale";
-    repo = "tailscale";
-    rev = "v${version}";
-    hash = "sha256-ZAzro69F7ovfdqzRss/U7puh1T37bkEtUXabCYc5LwU=";
-  };
-  vendorHash = "sha256-SUjoeOFYz6zbEgv/vND7kEXbuWlZDrUKF2Dmqsf/KVw=";
+  inherit (tailscale) version src vendorHash ldflags;
 
   CGO_ENABLED = 0;
 
   subPackages = [ "cmd/nginx-auth" ];
-
-  ldflags = [
-    "-w"
-    "-s"
-    "-X tailscale.com/version.longStamp=${version}"
-    "-X tailscale.com/version.shortStamp=${version}"
-  ];
 
   postInstall = lib.optionalString stdenv.isLinux ''
     mv $out/bin/nginx-auth $out/bin/tailscale.nginx-auth

--- a/pkgs/by-name/ta/tailscale-nginx-auth/package.nix
+++ b/pkgs/by-name/ta/tailscale-nginx-auth/package.nix
@@ -2,11 +2,18 @@
 
 buildGoModule {
   pname = "tailscale-nginx-auth";
-  inherit (tailscale) version src vendorHash ldflags;
+  inherit (tailscale) version src vendorHash;
 
   CGO_ENABLED = 0;
 
   subPackages = [ "cmd/nginx-auth" ];
+
+  ldflags = [
+    "-w"
+    "-s"
+    "-X tailscale.com/version.longStamp=${tailscale.version}"
+    "-X tailscale.com/version.shortStamp=${tailscale.version}"
+  ];
 
   postInstall = lib.optionalString stdenv.isLinux ''
     mv $out/bin/nginx-auth $out/bin/tailscale.nginx-auth

--- a/pkgs/servers/tailscale/default.nix
+++ b/pkgs/servers/tailscale/default.nix
@@ -11,6 +11,7 @@
 , procps
 , nixosTests
 , installShellFiles
+, tailscale-nginx-auth
 }:
 
 let
@@ -76,6 +77,7 @@ buildGoModule {
 
   passthru.tests = {
     inherit (nixosTests) headscale;
+    inherit tailscale-nginx-auth;
   };
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Closes #324476

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
