### PR TITLE
gpu-screen-recorder{,-gtk}: Update to unstable-2024-07-05 (+ systemd unit and capabilities)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20170,6 +20170,12 @@
     githubId = 2845239;
     name = "Tim Put";
   };
+  timschumi = {
+    email = "timschumi@gmx.de";
+    github = "timschumi";
+    githubId = 16820960;
+    name = "Tim Schumacher";
+  };
   timstott = {
     email = "stott.timothy@gmail.com";
     github = "timstott";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -204,6 +204,7 @@
   ./programs/goldwarden.nix
   ./programs/gpaste.nix
   ./programs/gphoto2.nix
+  ./programs/gpu-screen-recorder.nix
   ./programs/haguichi.nix
   ./programs/hamster.nix
   ./programs/htop.nix

--- a/nixos/modules/programs/gpu-screen-recorder.nix
+++ b/nixos/modules/programs/gpu-screen-recorder.nix
@@ -1,0 +1,40 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.gpu-screen-recorder;
+  package = cfg.package.override {
+    inherit (config.security) wrapperDir;
+  };
+in {
+  options = {
+    programs.gpu-screen-recorder = {
+      package = lib.mkPackageOption pkgs "gpu-screen-recorder" {};
+
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to install gpu-screen-recorder and generate setcap
+          wrappers for promptless recording.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    security.wrappers."gsr-kms-server" = {
+      owner = "root";
+      group = "root";
+      capabilities = "cap_sys_admin+ep";
+      source = "${package}/bin/gsr-kms-server";
+    };
+    security.wrappers."gpu-screen-recorder" = {
+      owner = "root";
+      group = "root";
+      capabilities = "cap_sys_nice+ep";
+      source = "${package}/bin/gpu-screen-recorder";
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ timschumi ];
+}

--- a/pkgs/applications/video/gpu-screen-recorder/0001-Don-t-install-systemd-unit-files-using-absolute-path.patch
+++ b/pkgs/applications/video/gpu-screen-recorder/0001-Don-t-install-systemd-unit-files-using-absolute-path.patch
@@ -1,0 +1,25 @@
+From cd8c6561079ee4c53b4bed390edd75a730ac685d Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Thu, 4 Jul 2024 16:26:36 +0200
+Subject: [PATCH] Don't install systemd unit files using absolute paths
+
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index a188f16..7807abe 100644
+--- a/meson.build
++++ b/meson.build
+@@ -54,7 +54,7 @@ executable('gsr-kms-server', 'kms/server/kms_server.c', dependencies : dependenc
+ executable('gpu-screen-recorder', src, dependencies : dep, install : true)
+ 
+ if get_option('systemd') == true
+-    install_data(files('extra/gpu-screen-recorder.service'), install_dir : '/usr/lib/systemd/user')
++    install_data(files('extra/gpu-screen-recorder.service'), install_dir : 'lib/systemd/user')
+ endif
+ 
+ if get_option('capabilities') == true
+-- 
+2.45.1
+

--- a/pkgs/applications/video/gpu-screen-recorder/default.nix
+++ b/pkgs/applications/video/gpu-screen-recorder/default.nix
@@ -16,6 +16,7 @@
 , libXi
 , libXrandr
 , libXfixes
+, wrapperDir ? "/run/wrappers/bin"
 }:
 
 stdenv.mkDerivation {
@@ -57,7 +58,7 @@ stdenv.mkDerivation {
   mesonFlags = [
     "-Dsystemd=true"
 
-    # FIXME: Capabilities can not be set if not running the build with root permissions.
+    # Capabilities are handled by security.wrappers if possible.
     "-Dcapabilities=false"
   ];
 
@@ -66,6 +67,7 @@ stdenv.mkDerivation {
     mv $out/bin/gpu-screen-recorder $out/bin/.wrapped/
     makeWrapper "$out/bin/.wrapped/gpu-screen-recorder" "$out/bin/gpu-screen-recorder" \
     --prefix LD_LIBRARY_PATH : ${libglvnd}/lib \
+    --prefix PATH : ${wrapperDir} \
     --suffix PATH : $out/bin
   '';
 

--- a/pkgs/applications/video/gpu-screen-recorder/default.nix
+++ b/pkgs/applications/video/gpu-screen-recorder/default.nix
@@ -2,6 +2,8 @@
 , lib
 , fetchurl
 , makeWrapper
+, meson
+, ninja
 , pkg-config
 , libXcomposite
 , libpulseaudio
@@ -10,24 +12,29 @@
 , libdrm
 , libva
 , libglvnd
+, libXdamage
+, libXi
 , libXrandr
 , libXfixes
 }:
 
 stdenv.mkDerivation {
   pname = "gpu-screen-recorder";
-  version = "unstable-2024-05-21";
+  version = "unstable-2024-07-05";
 
+  # Snapshot tarballs use the following versioning format:
   # printf "r%s.%s\n" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
   src = fetchurl {
-    url = "https://dec05eba.com/snapshot/gpu-screen-recorder.git.r594.e572073.tar.gz";
-    hash = "sha256-MTBxhvkoyotmRUx1sRN/7ruXBYwIbOFQNdJHhZ3DdDk=";
+    url = "https://dec05eba.com/snapshot/gpu-screen-recorder.git.r641.48cd80f.tar.gz";
+    hash = "sha256-hIEK8EYIxQTTiFePPZf4V0nsxqxkfcDeOG9GK9whn+0=";
   };
   sourceRoot = ".";
 
   nativeBuildInputs = [
     pkg-config
     makeWrapper
+    meson
+    ninja
   ];
 
   buildInputs = [
@@ -37,16 +44,21 @@ stdenv.mkDerivation {
     wayland
     libdrm
     libva
+    libXdamage
+    libXi
     libXrandr
     libXfixes
   ];
 
-  buildPhase = ''
-    ./build.sh
-  '';
+  mesonFlags = [
+    # FIXME: systemd unit file gets installed to absolute path.
+    "-Dsystemd=false"
+
+    # FIXME: Capabilities can not be set if not running the build with root permissions.
+    "-Dcapabilities=false"
+  ];
 
   postInstall = ''
-    install -Dt $out/bin gpu-screen-recorder gsr-kms-server
     mkdir $out/bin/.wrapped
     mv $out/bin/gpu-screen-recorder $out/bin/.wrapped/
     makeWrapper "$out/bin/.wrapped/gpu-screen-recorder" "$out/bin/gpu-screen-recorder" \

--- a/pkgs/applications/video/gpu-screen-recorder/default.nix
+++ b/pkgs/applications/video/gpu-screen-recorder/default.nix
@@ -50,9 +50,12 @@ stdenv.mkDerivation {
     libXfixes
   ];
 
+  patches = [
+    ./0001-Don-t-install-systemd-unit-files-using-absolute-path.patch
+  ];
+
   mesonFlags = [
-    # FIXME: systemd unit file gets installed to absolute path.
-    "-Dsystemd=false"
+    "-Dsystemd=true"
 
     # FIXME: Capabilities can not be set if not running the build with root permissions.
     "-Dcapabilities=false"

--- a/pkgs/applications/video/gpu-screen-recorder/gpu-screen-recorder-gtk.nix
+++ b/pkgs/applications/video/gpu-screen-recorder/gpu-screen-recorder-gtk.nix
@@ -9,6 +9,7 @@
 , gpu-screen-recorder
 , libglvnd
 , wrapGAppsHook3
+, wrapperDir ? "/run/wrappers/bin"
 }:
 
 stdenv.mkDerivation {
@@ -37,11 +38,16 @@ stdenv.mkDerivation {
     ./build.sh
   '';
 
-  installPhase = ''
+  installPhase = let
+    gpu-screen-recorder-wrapped = gpu-screen-recorder.override {
+      inherit wrapperDir;
+    };
+  in ''
     install -Dt $out/bin/ gpu-screen-recorder-gtk
     install -Dt $out/share/applications/ gpu-screen-recorder-gtk.desktop
 
-    gappsWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ gpu-screen-recorder ]})
+    gappsWrapperArgs+=(--prefix PATH : ${wrapperDir})
+    gappsWrapperArgs+=(--suffix PATH : ${lib.makeBinPath [ gpu-screen-recorder-wrapped ]})
     # we also append /run/opengl-driver/lib as it otherwise fails to find libcuda.
     gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libglvnd ]}:/run/opengl-driver/lib)
   '';

--- a/pkgs/applications/video/gpu-screen-recorder/gpu-screen-recorder-gtk.nix
+++ b/pkgs/applications/video/gpu-screen-recorder/gpu-screen-recorder-gtk.nix
@@ -1,51 +1,60 @@
 { stdenv
 , lib
-, fetchgit
+, fetchurl
 , pkg-config
+, desktop-file-utils
 , makeWrapper
+, meson
+, ninja
 , gtk3
+, libayatana-appindicator
 , libpulseaudio
 , libdrm
 , gpu-screen-recorder
 , libglvnd
+, libX11
+, libXrandr
+, wayland
 , wrapGAppsHook3
 , wrapperDir ? "/run/wrappers/bin"
 }:
 
 stdenv.mkDerivation {
   pname = "gpu-screen-recorder-gtk";
-  version = "3.7.6";
+  version = "unstable-2024-07-05";
 
-  src = fetchgit {
-    url = "https://repo.dec05eba.com/gpu-screen-recorder-gtk";
-    rev = "cd777c1506e20514df4b97345e480051cbaf9693";
-    hash = "sha256-ZBYYsW75tq8TaZp0F4v7YIHKHk/DFBIGy3X781ho2oE=";
+  # Snapshot tarballs use the following versioning format:
+  # printf "r%s.%s\n" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+  src = fetchurl {
+    url = "https://dec05eba.com/snapshot/gpu-screen-recorder-gtk.git.r311.c611c51.tar.gz";
+    hash = "sha256-86EdmeZ2dlffSfJOrTVGPtYyL3j6DmCQIALX2rpeS1Y=";
   };
+  sourceRoot = ".";
 
   nativeBuildInputs = [
+    desktop-file-utils
     pkg-config
     makeWrapper
+    meson
+    ninja
     wrapGAppsHook3
   ];
 
   buildInputs = [
     gtk3
+    libayatana-appindicator
     libpulseaudio
     libdrm
+    libX11
+    libXrandr
+    wayland
   ];
 
-  buildPhase = ''
-    ./build.sh
-  '';
-
-  installPhase = let
+  preFixup = let
     gpu-screen-recorder-wrapped = gpu-screen-recorder.override {
       inherit wrapperDir;
     };
   in ''
-    install -Dt $out/bin/ gpu-screen-recorder-gtk
-    install -Dt $out/share/applications/ gpu-screen-recorder-gtk.desktop
-
     gappsWrapperArgs+=(--prefix PATH : ${wrapperDir})
     gappsWrapperArgs+=(--suffix PATH : ${lib.makeBinPath [ gpu-screen-recorder-wrapped ]})
     # we also append /run/opengl-driver/lib as it otherwise fails to find libcuda.


### PR DESCRIPTION
## Description of changes

Non-NixOS related changes can be found [here](https://git.dec05eba.com/gpu-screen-recorder-gtk/tree/com.dec05eba.gpu_screen_recorder.appdata.xml). Relevant changes start from 2024-05-21 for `gpu-screen-recorder` and from 3.7.6 for `gpu-screen-recorder-gtk`.

NixOS-specific changes include the following:
- Switch from the script-based build system to meson
- Install the upstream-provided systemd user service file
- Create `programs.gpu-screen-recorder` to host an option for generating `setcap` wrappers
- Return `gpu-screen-recorder-gtk` to using tarballs instead of Git (as the developer explicitly asked for that in #268443)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
