### PR TITLE
truvari: 4.1.0 -> 4.2.2; abpoa: init at 1.5.1

### DIFF
--- a/pkgs/applications/science/biology/truvari/default.nix
+++ b/pkgs/applications/science/biology/truvari/default.nix
@@ -15,14 +15,14 @@ let
   };
 in python3Packages.buildPythonApplication rec {
   pname = "truvari";
-  version = "4.1.0";
+  version = "4.2.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ACEnglish";
     repo = "truvari";
     rev = "v${version}";
-    hash = "sha256-HFVAv1TTL/nMjr62tQKhMdwh25P/y4nBGzSbxoJxMmo=";
+    hash = "sha256-SFBVatcVavBfQtFbBcXifBX3YnKsxJS669vCcyjsBA4=";
   };
 
   postPatch = ''
@@ -31,11 +31,11 @@ in python3Packages.buildPythonApplication rec {
     patchShebangs repo_utils/test_files
   '';
 
-  nativeBuildInputs = [
+  build-system = [
     python3Packages.setuptools
   ];
 
-  propagatedBuildInputs = with python3Packages; [
+  dependencies = with python3Packages; [
     pywfa
     rich
     edlib
@@ -46,6 +46,7 @@ in python3Packages.buildPythonApplication rec {
     pytabix
     bwapy
     pandas
+    pyabpoa
   ];
 
   makeWrapperArgs = [

--- a/pkgs/by-name/ab/abpoa/package.nix
+++ b/pkgs/by-name/ab/abpoa/package.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  simde,
+  zlib,
+  enableSse4_1 ? stdenv.hostPlatform.sse4_1Support,
+  enableAvx ? stdenv.hostPlatform.avxSupport,
+  enablePython ? false,
+  python3Packages,
+  runCommand,
+  abpoa,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "${lib.optionalString enablePython "py"}abpoa";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "yangao07";
+    repo = "abPOA";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-nPMzkWkjUI+vZExNEvJa24KrR0pWGk89Mvp7TCyka/w=";
+  };
+
+  patches = [ ./simd-arch.patch ];
+
+  postPatch = ''
+    cp -r ${simde.src}/* include/simde
+    substituteInPlace Makefile \
+      --replace-fail "-march=native" ""
+  '';
+
+  nativeBuildInputs = lib.optionals enablePython (
+    with python3Packages;
+    [
+      cython
+      pypaBuildHook
+      pypaInstallHook
+      pythonImportsCheckHook
+      setuptools
+    ]
+  );
+
+  buildFlags = lib.optionals stdenv.hostPlatform.isx86_64 [
+    (
+      if enableAvx then
+        "avx2=1"
+      else if enableSse4_1 then
+        "sse41=1"
+      else
+        "sse2=1"
+    )
+  ];
+
+  env = lib.optionalAttrs enablePython (
+    if enableAvx then
+      { "AVX2" = 1; }
+    else if enableSse4_1 then
+      { "SSE41" = 1; }
+    else
+      { "SSE2" = 1; }
+  );
+
+  buildInputs = [ zlib ];
+
+  installPhase = lib.optionalString (!enablePython) ''
+    runHook preInstall
+
+    install -Dm755 ./bin/abpoa -t $out/bin
+
+    runHook postInstall
+  '';
+
+  pythonImportsCheck = [ "pyabpoa" ];
+
+  doInstallCheck = enablePython;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    python python/example.py
+
+    runHook postInstallCheck
+  '';
+
+  passthru.tests = {
+    simple = runCommand "${finalAttrs.pname}-test" { } ''
+      ${lib.getExe abpoa} ${abpoa.src}/test_data/seq.fa > $out
+    '';
+  };
+
+  meta = with lib; {
+    description = "SIMD-based C library for fast partial order alignment using adaptive band";
+    homepage = "https://github.com/yangao07/abPOA";
+    changelog = "https://github.com/yangao07/abPOA/releases/tag/${finalAttrs.src.rev}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ natsukium ];
+    mainProgram = "abpoa";
+    platforms = platforms.unix;
+  };
+})

--- a/pkgs/by-name/ab/abpoa/simd-arch.patch
+++ b/pkgs/by-name/ab/abpoa/simd-arch.patch
@@ -1,0 +1,27 @@
+diff --git a/setup.py b/setup.py
+index 52c0e7e..f88ec08 100644
+--- a/setup.py
++++ b/setup.py
+@@ -11,11 +11,12 @@ simde = ['-DUSE_SIMDE', '-DSIMDE_ENABLE_NATIVE_ALIASES']
+ 
+ if platform.system() == "Darwin":
+     # note: see https://github.com/pypa/wheel/issues/406
+-    simd_flag = ['-march=native', '-D__AVX2__', '-mmacosx-version-min=10.9']
+     if platform.machine() in ["aarch64", "arm64"]:
++        simd_flag = ['-march=armv8-a+simd', '-D__AVX2__', '-mmacosx-version-min=10.9']
+         os.environ['_PYTHON_HOST_PLATFORM'] = "macosx-10.9-arm64"
+         os.environ['ARCHFLAGS'] = "-arch arm64"
+     else:
++        simd_flag = ['-msse2', '-mmacosx-version-min=10.9']
+         os.environ['_PYTHON_HOST_PLATFORM'] = "macosx-10.9-x86_64"
+         os.environ['ARCHFLAGS'] = "-arch x86_64"
+ else:
+@@ -24,7 +25,7 @@ else:
+     elif platform.machine() in ["aarch32"]:
+         simd_flag = ['-march=armv8-a+simd', '-mfpu=auto -D__AVX2__']
+     else:
+-        simd_flag=['-march=native']
++        simd_flag=[]
+         if os.getenv('SSE4', False):
+             simd_flag=['-msse4.1']
+         elif os.getenv('SSE2', False):

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10041,6 +10041,11 @@ self: super: with self; {
 
   py65 = callPackage ../development/python-modules/py65 { };
 
+  pyabpoa = toPythonModule (pkgs.abpoa.override {
+    enablePython = true;
+    python3Packages = self;
+  });
+
   pyaehw4a1 = callPackage ../development/python-modules/pyaehw4a1 { };
 
   pyatag = callPackage ../development/python-modules/pyatag { };


### PR DESCRIPTION
## Description of changes

Diff: https://github.com/ACEnglish/truvari/compare/v4.1.0...v4.2.2

Changelog: https://github.com/ACEnglish/truvari/releases/tag/v4.2.2

introduce `abpoa` as a dependency
https://github.com/yangao07/abPOA

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
