### PR TITLE
ib-{controller,tws}: mark as broken

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -101,6 +101,7 @@
 
 - Legacy package `ib-tws` can no longer connect to Interactive Brokers, so has
   been marked as broken (ref [#40784](https://github.com/NixOS/nixpkgs/issues/40784)).
+  The accompanying `ib-controller` has also been marked broken.
 
 - `androidndkPkgs` has been updated to `androidndkPkgs_26`.
 

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -99,6 +99,9 @@
   before changing the package to `pkgs.stalwart-mail` in
   [`services.stalwart-mail.package`](#opt-services.stalwart-mail.package).
 
+- Legacy package `ib-tws` can no longer connect to Interactive Brokers, so has
+  been marked as broken (ref [#40784](https://github.com/NixOS/nixpkgs/issues/40784)).
+
 - `androidndkPkgs` has been updated to `androidndkPkgs_26`.
 
 - Android NDK version 26 and SDK version 33 are now the default versions used for cross compilation to android.

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -99,10 +99,6 @@
   before changing the package to `pkgs.stalwart-mail` in
   [`services.stalwart-mail.package`](#opt-services.stalwart-mail.package).
 
-- Legacy package `ib-tws` can no longer connect to Interactive Brokers, so has
-  been marked as broken (ref [#40784](https://github.com/NixOS/nixpkgs/issues/40784)).
-  The accompanying `ib-controller` has also been marked broken.
-
 - `androidndkPkgs` has been updated to `androidndkPkgs_26`.
 
 - Android NDK version 26 and SDK version 33 are now the default versions used for cross compilation to android.

--- a/pkgs/applications/office/ib/controller/default.nix
+++ b/pkgs/applications/office/ib/controller/default.nix
@@ -155,6 +155,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Automation Controller for the Trader Work Station of Interactive Brokers";
+    broken = true;
     homepage = "https://github.com/ib-controller/ib-controller";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3;

--- a/pkgs/applications/office/ib/controller/default.nix
+++ b/pkgs/applications/office/ib/controller/default.nix
@@ -155,7 +155,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Automation Controller for the Trader Work Station of Interactive Brokers";
-    broken = true;
+    broken = true;  # Ref: https://github.com/NixOS/nixpkgs/issues/40784
     homepage = "https://github.com/ib-controller/ib-controller";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3;

--- a/pkgs/applications/office/ib/tws/default.nix
+++ b/pkgs/applications/office/ib/tws/default.nix
@@ -85,6 +85,7 @@ stdenv.mkDerivation rec {
     '';
 
   meta = with lib; {
+    broken = true;
     description = "Trader Work Station of Interactive Brokers";
     homepage = "https://www.interactivebrokers.com";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];

--- a/pkgs/applications/office/ib/tws/default.nix
+++ b/pkgs/applications/office/ib/tws/default.nix
@@ -85,8 +85,8 @@ stdenv.mkDerivation rec {
     '';
 
   meta = with lib; {
-    broken = true;
     description = "Trader Work Station of Interactive Brokers";
+    broken = true;  # Ref: https://github.com/NixOS/nixpkgs/issues/40784
     homepage = "https://www.interactivebrokers.com";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This package hasn't been updated since 2016 (ref [`95db340`](https://github.com/NixOS/nixpkgs/commit/95db340fd0b0d2710285846cc682156f9aa6c8ab#diff-1ab6be1ce1719c73caf15475b9bdb4c777148601249c5d5e37cfe7679c2eb992R4)), and is no long able to connect to Interactive Brokers (ref https://github.com/NixOS/nixpkgs/issues/40784). More recent versions of this utility are packaged differently so it's not a straightforward update.

So, I figure we should mark it broken to avoid users wasting time trying to get the client working until we can devise an update.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
