### PR TITLE
qbittorrent-enhanced: init at 4.6.5.10

### DIFF
--- a/pkgs/by-name/qb/qbittorrent-enhanced/package.nix
+++ b/pkgs/by-name/qb/qbittorrent-enhanced/package.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, boost
+, libtorrent-rasterbar
+, openssl
+, qt5
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qbittorrent-enhanced";
+  version = "4.6.5.10";
+
+  src = fetchFromGitHub {
+    owner = "c0re100";
+    repo = "qBittorrent-Enhanced-Edition";
+    rev = "release-${version}";
+    hash = "sha256-Yy0DUTz1lWkseh9x1xnHJCI89BKqi/D7zUn/S+qC+kM=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    qt5.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    openssl.dev
+    boost
+    zlib
+    libtorrent-rasterbar
+    qt5.qtbase
+    qt5.qttools
+  ];
+
+  meta = {
+    description = "Unofficial enhanced version of qBittorrent, a BitTorrent client";
+    homepage = "https://github.com/c0re100/qBittorrent-Enhanced-Edition";
+    changelog = "https://github.com/c0re100/qBittorrent-Enhanced-Edition/blob/${src.rev}/Changelog";
+    license = with lib.licenses; [ gpl2Only gpl3Only ];
+    maintainers = with lib.maintainers; [ ByteSudoer ];
+    mainProgram = "qBittorrent-enhanced";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes
Project description
An unofficial version of qBittorrent featuring community enhancements such as: automatic banning of Xunlei, QQ, Baidu, Xfplay, DLBT, and Offline downloader; an option to automatically ban unknown peers from China; automatic updating of public trackers list; an option to automatically ban BitTorrent media player peers; and peer whitelisting/blacklisting.
Metadata
- homepage URL: https://github.com/c0re100/qBittorrent-Enhanced-Edition
- source URL: https://github.com/c0re100/qBittorrent-Enhanced-Edition
- license: gpl2/gpl3, See [copying](https://github.com/c0re100/qBittorrent-Enhanced-Edition/blob/v4_6_x/COPYING)
- platforms: unix, linux, darwin, windows

Closes https://github.com/NixOS/nixpkgs/issues/322158
> This PR builds the package with Qt5 support (Qt6 option is also available).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Closes https://github.com/NixOS/nixpkgs/issues/322158
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
