### PR TITLE
dcm2niix: 1.0.20230411 -> 1.0.20240202

### DIFF
--- a/pkgs/applications/science/biology/dcm2niix/dont-fetch-external-libs.patch
+++ b/pkgs/applications/science/biology/dcm2niix/dont-fetch-external-libs.patch
@@ -12,14 +12,4 @@ index 9f064eb..fe74df5 100644
      SOURCE_DIR cloudflare-zlib
      BINARY_DIR cloudflare-zlib-build
      CMAKE_ARGS
-diff --git a/SuperBuild/SuperBuild.cmake b/SuperBuild/SuperBuild.cmake
-index 2a0a956..81354a7 100644
---- a/SuperBuild/SuperBuild.cmake
-+++ b/SuperBuild/SuperBuild.cmake
-@@ -1,6 +1,1 @@
--# Check if git exists
--find_package(Git)
--if(NOT GIT_FOUND)
--    message(FATAL_ERROR "Cannot find Git. Git is required for Superbuild")
--endif()
  

--- a/pkgs/applications/science/biology/dcm2niix/dont-use-git.patch
+++ b/pkgs/applications/science/biology/dcm2niix/dont-use-git.patch
@@ -1,0 +1,11 @@
+diff --git a/SuperBuild/SuperBuild.cmake b/SuperBuild/SuperBuild.cmake
+index 2a0a956..81354a7 100644
+--- a/SuperBuild/SuperBuild.cmake
++++ b/SuperBuild/SuperBuild.cmake
+@@ -1,6 +1,1 @@
+-# Check if git exists
+-find_package(Git)
+-if(NOT GIT_FOUND)
+-    message(FATAL_ERROR "Cannot find Git. Git is required for Superbuild")
+-endif()
+ 


### PR DESCRIPTION
## Description of changes

 - build using zlib (not the included miniz) instead of cloudflareZlib by default since this should be more secure (cloudflareZlib is a fork and also less likely to be updated in nixpkgs since it's not even its own separate file)
 - update cloudflareZlib commit and URL
 - give `dcm2niix` access to `pigz` binary for parallel compression
 - split patch to remove git from patch to use Nix-fetched cloudflareZlib since the former is always needed
 - add changelog
 - refactor to finalAttrs style

changelog: https://github.com/rordenlab/dcm2niix/releases/tag/v1.0.20240202

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
