### PR TITLE
rustPackages.buildRustPackages: allow one level of introspection before applying __attrsFailEvaluation

### DIFF
--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -65,7 +65,10 @@ in
       bootRustPlatform = makeRustPlatform bootstrapRustPackages;
     in {
       # Packages suitable for build-time, e.g. `build.rs`-type stuff.
-      buildRustPackages = (selectRustPackage pkgsBuildHost).packages.stable // { __attrsFailEvaluation = true; };
+      buildRustPackages = (selectRustPackage pkgsBuildHost).packages.stable // {
+        # Prevent `pkgs/top-level/release-attrpaths-superset.nix` from recursing more than one level here.
+        buildRustPackages = self.buildRustPackages // { __attrsFailEvaluation = true; };
+      };
       # Analogous to stdenv
       rustPlatform = makeRustPlatform self.buildRustPackages;
       rustc-unwrapped = self.callPackage ./rustc.nix ({


### PR DESCRIPTION
## Description of changes

- #324619

The test (`nix-build pkgs/test/release/default.nix`) continues to pass.

These lines were added in https://github.com/NixOS/nixpkgs/pull/269356.

I learned this trick from this file, where it's used to allow one level of inspection.

https://github.com/NixOS/nixpkgs/blob/1b87ff2df27a431984301a350e9782d2a36efda2/pkgs/top-level/perl-packages.nix#L26

New derivations reported:

```diff
--- /dev/fd/63	2024-07-04 11:37:43.896690011 -0700
+++ /dev/fd/62	2024-07-04 11:37:43.896690011 -0700
@@ -82087,8 +82087,26 @@
   "russ",
   "rust.packages.prebuilt.cargo",
   "rust.packages.prebuilt.rustc",
   "rust.packages.prebuilt.rustc-unwrapped",
+  "rust.packages.stable.buildRustPackages.cargo",
+  "rust.packages.stable.buildRustPackages.cargo-auditable",
+  "rust.packages.stable.buildRustPackages.cargo-auditable-cargo-wrapper",
+  "rust.packages.stable.buildRustPackages.clippy",
+  "rust.packages.stable.buildRustPackages.rustPlatform.bindgenHook",
+  "rust.packages.stable.buildRustPackages.rustPlatform.cargoBuildHook",
+  "rust.packages.stable.buildRustPackages.rustPlatform.cargoCheckHook",
+  "rust.packages.stable.buildRustPackages.rustPlatform.cargoInstallHook",
+  "rust.packages.stable.buildRustPackages.rustPlatform.cargoNextestHook",
+  "rust.packages.stable.buildRustPackages.rustPlatform.cargoSetupHook",
+  "rust.packages.stable.buildRustPackages.rustPlatform.maturinBuildHook",
+  "rust.packages.stable.buildRustPackages.rustPlatform.rust.cargo",
+  "rust.packages.stable.buildRustPackages.rustPlatform.rust.rustc",
+  "rust.packages.stable.buildRustPackages.rustPlatform.rustLibSrc",
+  "rust.packages.stable.buildRustPackages.rustPlatform.rustcSrc",
+  "rust.packages.stable.buildRustPackages.rustc",
+  "rust.packages.stable.buildRustPackages.rustc-unwrapped",
+  "rust.packages.stable.buildRustPackages.rustfmt",
   "rust.packages.stable.cargo",
   "rust.packages.stable.cargo-auditable",
   "rust.packages.stable.cargo-auditable-cargo-wrapper",
   "rust.packages.stable.clippy",
@@ -82119,8 +82137,26 @@
   "rust-motd",
   "rust-petname",
   "rust-script",
   "rust-traverse",
+  "rustPackages.buildRustPackages.cargo",
+  "rustPackages.buildRustPackages.cargo-auditable",
+  "rustPackages.buildRustPackages.cargo-auditable-cargo-wrapper",
+  "rustPackages.buildRustPackages.clippy",
+  "rustPackages.buildRustPackages.rustPlatform.bindgenHook",
+  "rustPackages.buildRustPackages.rustPlatform.cargoBuildHook",
+  "rustPackages.buildRustPackages.rustPlatform.cargoCheckHook",
+  "rustPackages.buildRustPackages.rustPlatform.cargoInstallHook",
+  "rustPackages.buildRustPackages.rustPlatform.cargoNextestHook",
+  "rustPackages.buildRustPackages.rustPlatform.cargoSetupHook",
+  "rustPackages.buildRustPackages.rustPlatform.maturinBuildHook",
+  "rustPackages.buildRustPackages.rustPlatform.rust.cargo",
+  "rustPackages.buildRustPackages.rustPlatform.rust.rustc",
+  "rustPackages.buildRustPackages.rustPlatform.rustLibSrc",
+  "rustPackages.buildRustPackages.rustPlatform.rustcSrc",
+  "rustPackages.buildRustPackages.rustc",
+  "rustPackages.buildRustPackages.rustc-unwrapped",
+  "rustPackages.buildRustPackages.rustfmt",
   "rustPackages.cargo",
   "rustPackages.cargo-auditable",
   "rustPackages.cargo-auditable-cargo-wrapper",
   "rustPackages.clippy",
@@ -82137,8 +82173,26 @@
   "rustPackages.rustPlatform.rustcSrc",
   "rustPackages.rustc",
   "rustPackages.rustc-unwrapped",
   "rustPackages.rustfmt",
+  "rustPackages_1_78.buildRustPackages.cargo",
+  "rustPackages_1_78.buildRustPackages.cargo-auditable",
+  "rustPackages_1_78.buildRustPackages.cargo-auditable-cargo-wrapper",
+  "rustPackages_1_78.buildRustPackages.clippy",
+  "rustPackages_1_78.buildRustPackages.rustPlatform.bindgenHook",
+  "rustPackages_1_78.buildRustPackages.rustPlatform.cargoBuildHook",
+  "rustPackages_1_78.buildRustPackages.rustPlatform.cargoCheckHook",
+  "rustPackages_1_78.buildRustPackages.rustPlatform.cargoInstallHook",
+  "rustPackages_1_78.buildRustPackages.rustPlatform.cargoNextestHook",
+  "rustPackages_1_78.buildRustPackages.rustPlatform.cargoSetupHook",
+  "rustPackages_1_78.buildRustPackages.rustPlatform.maturinBuildHook",
+  "rustPackages_1_78.buildRustPackages.rustPlatform.rust.cargo",
+  "rustPackages_1_78.buildRustPackages.rustPlatform.rust.rustc",
+  "rustPackages_1_78.buildRustPackages.rustPlatform.rustLibSrc",
+  "rustPackages_1_78.buildRustPackages.rustPlatform.rustcSrc",
+  "rustPackages_1_78.buildRustPackages.rustc",
+  "rustPackages_1_78.buildRustPackages.rustc-unwrapped",
+  "rustPackages_1_78.buildRustPackages.rustfmt",
   "rustPackages_1_78.cargo",
   "rustPackages_1_78.cargo-auditable",
   "rustPackages_1_78.cargo-auditable-cargo-wrapper",
   "rustPackages_1_78.clippy",
@@ -82169,8 +82223,26 @@
   "rustPlatform.rustcSrc",
   "rust_1_78.packages.prebuilt.cargo",
   "rust_1_78.packages.prebuilt.rustc",
   "rust_1_78.packages.prebuilt.rustc-unwrapped",
+  "rust_1_78.packages.stable.buildRustPackages.cargo",
+  "rust_1_78.packages.stable.buildRustPackages.cargo-auditable",
+  "rust_1_78.packages.stable.buildRustPackages.cargo-auditable-cargo-wrapper",
+  "rust_1_78.packages.stable.buildRustPackages.clippy",
+  "rust_1_78.packages.stable.buildRustPackages.rustPlatform.bindgenHook",
+  "rust_1_78.packages.stable.buildRustPackages.rustPlatform.cargoBuildHook",
+  "rust_1_78.packages.stable.buildRustPackages.rustPlatform.cargoCheckHook",
+  "rust_1_78.packages.stable.buildRustPackages.rustPlatform.cargoInstallHook",
+  "rust_1_78.packages.stable.buildRustPackages.rustPlatform.cargoNextestHook",
+  "rust_1_78.packages.stable.buildRustPackages.rustPlatform.cargoSetupHook",
+  "rust_1_78.packages.stable.buildRustPackages.rustPlatform.maturinBuildHook",
+  "rust_1_78.packages.stable.buildRustPackages.rustPlatform.rust.cargo",
+  "rust_1_78.packages.stable.buildRustPackages.rustPlatform.rust.rustc",
+  "rust_1_78.packages.stable.buildRustPackages.rustPlatform.rustLibSrc",
+  "rust_1_78.packages.stable.buildRustPackages.rustPlatform.rustcSrc",
+  "rust_1_78.packages.stable.buildRustPackages.rustc",
+  "rust_1_78.packages.stable.buildRustPackages.rustc-unwrapped",
+  "rust_1_78.packages.stable.buildRustPackages.rustfmt",
   "rust_1_78.packages.stable.cargo",
   "rust_1_78.packages.stable.cargo-auditable",
   "rust_1_78.packages.stable.cargo-auditable-cargo-wrapper",
   "rust_1_78.packages.stable.clippy",
```

## Things done

- [x] Tested, as applicable:
  - [x] `nix-build pkgs/test/release/default.nix`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).