### PR TITLE
add iroh service

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4120,6 +4120,13 @@
     githubId = 1707779;
     name = "Chris Ertel";
   };
+  crimeminister = {
+    email = "robert@crimeminister.org";
+    name = "Robert Medeiros";
+    github = "crimeminister";
+    githubId = 29072;
+    keys = [ { fingerprint = "E3BD A35E 590A 8D29 701A  9723 F448 7FA0 4BC6 44F2"; } ];
+  };
   crinklywrappr = {
     email = "crinklywrappr@pm.me";
     name = "Daniel Fitzpatrick";

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -11,6 +11,8 @@
 
 ## New Services {#sec-release-24.11-new-services}
 
+- [Iroh](https://github.com/n0-computer/iroh), a toolkit for building distributed apps. Available as [services.iroh](options.html#opt-services.iroh) service.
+
 - [Open-WebUI](https://github.com/open-webui/open-webui), a user-friendly WebUI
   for LLMs. Available as [services.open-webui](#opt-services.open-webui.enable)
   service.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -922,6 +922,7 @@
   ./services/network-filesystems/drbd.nix
   ./services/network-filesystems/eris-server.nix
   ./services/network-filesystems/glusterfs.nix
+  ./services/network-filesystems/iroh.nix
   ./services/network-filesystems/kbfs.nix
   ./services/network-filesystems/kubo.nix
   ./services/network-filesystems/litestream/default.nix

--- a/nixos/modules/services/network-filesystems/iroh.nix
+++ b/nixos/modules/services/network-filesystems/iroh.nix
@@ -1,0 +1,275 @@
+{ config, lib, pkgs, utils, ... }:
+with lib;
+let
+  # NB: build the manual with:
+  # $ nix-build nixos/release.nix -A manual.x86_64-linux
+
+  # NB: run the tests with:
+  # $ nix-build -A nixosTests.iroh
+
+  # Docs for writing tests:
+  # https://nixos.org/manual/nixos/stable/index.html#sec-nixos-tests
+
+  # TODO test: configure systemd logs directory:
+  # iroh: Failed to create log directory: Read-only filesystem
+
+  # TODO run systemd-analyze security and apply whatever sandboxing doesn't break the service
+  # TODO add tests
+
+  # cfg is a conventional alias for the configuration of the current module
+  cfg = config.services.iroh;
+
+  # Default listening port.
+  listenPort = 11204;
+  # Default RPC port.
+  rpcPort = 1337;
+  # Default metrics port. With a value of -1 serving metrics is disabled.
+  metricsPort = -1;
+
+  # --add <ADD>: optionally add a file or folder to the node
+  irohFlags = utils.escapeSystemdExecArgs (
+    optional (cfg.metricsPort != -1) "--metrics-port ${cfg.metricsPort}" ++
+    optional cfg.noTicket "--no-ticket" ++
+    optional (cfg.tag != null) "--tag ${cfg.tag}" ++
+    cfg.extraFlags
+  );
+
+  # A submodule to describe where logs may be placed.
+  logOutput = types.submodule {
+    options = {
+      # TODO output should be: rust=$level (a tracing_subscriber::EnvFilter)
+      level = mkOption {
+        type = types.enum [ "error" "warn" "info" "debug" "trace" ];
+        default = "info";
+      };
+      rotation = mkOption {
+        type = types.enum [ "hourly" "daily" "never" ];
+        default = "daily";
+      };
+      maxFiles = mkOption {
+        # TODO make sure unsigned >= 1
+        type = types.int;
+        default = 1;
+      };
+      dir = mkOption {
+        type = types.path;
+      };
+    };
+  };
+
+  # A submodule that describes a relay node used to assist in NAT traversal.
+  relayNode = types.submodule {
+    options = {
+      # TODO use regex to match URL, including https:// prefix!
+      url = mkOption {
+        description = "The URL of the relay node.";
+        type = types.str;
+      };
+
+      stunOnly = mkOption {
+        description = "Only use STUN for traversal of NAT gateways.";
+        type = types.bool;
+      };
+
+      stunPort = mkOption {
+        description = "Port at which STUN service is listening.";
+        type = types.port;
+      };
+    };
+  };
+
+  # The total set of relays is the merge of relayNodes (which are the default nodes provided by
+  # iroh, if not replaced) and any extra nodes defined by the user.
+  relaySettings = cfg.relayNodes // cfg.extraRelayNodes;
+
+  # The config file should be located in the data directory and is NOT created by default. All
+  # values are optional, including the file itself.
+  configFormat = pkgs.formats.toml { };
+  #configFile = configFormat.generate "${cfg.dataDir}/iroh.config.toml" relaySettings;
+  configFile = configFormat.generate "/var/lib/iroh/iroh.config.toml" relaySettings;
+in
+{
+  # A NixOS module is a function that takes an environment and returns an attrset with the imports,
+  # options, and config fields. The provided parameters include:
+  # - config: an attrset with all the values of the configuration options
+  # - pkgs: all the packages defined in nixpkgs
+  # - lib: the utility library that comes with nixpkgs; it's commonly required so it is imported
+  #   using 'with lib'
+  # - other fields not usually needed by user modules
+
+  # A list of other modules to import. Only necessary if the imported module isn't already in
+  # module-list.nix, e.g. when writing several related modules, where only one of them is added to
+  # the global module list. When using "imports' the arguments to the current module (config, lib,
+  # pkgs) will also be passed to the submodules.
+  imports = [
+    #./other-module.nix
+  ];
+
+  # Option declarations for our module.
+  options = {
+    services.iroh = {
+
+      # By convention, modules have an "enable" option that determines whether they are active or
+      # not.
+      enable = mkEnableOption "Iroh is a protocol for syncing bytes. Bytes of any size, across any number of devices. Use iroh to create apps that scale different.";
+
+      package = mkPackageOption pkgs "iroh" { };
+
+      # NB: This is READ ONLY because there's no way to configure the listen port; iroh exposes as
+      # few configuration knobs as possible. The default port can be read from this read-only
+      # option, but if a different port is chosen by the service it has to be retrieved another way (?).
+      listenPort = mkOption {
+        description = "Address iroh listens on for connections from other nodes. If the port is taken iroh will choose a random port to listen on, so it can't be configured. This port is NOT automatically opened in the firewall.";
+        type = types.port;
+        readOnly = true;
+        default = listenPort;
+      };
+
+      rpcPort = mkOption {
+        description = "Port for localhost-only Remote Procedure Calls, used to control an iroh node from another process. If the port is taken iroh will fail to start. This port is NOT automatically opened in the firewall.";
+        type = types.port;
+        readOnly = true;
+        default = rpcPort;
+      };
+
+      metricsPort = mkOption {
+        description = "Port at which metrics data is served. By default it is not enabled. Value must be -1 to disable serving metrics, or a valid port number. This port is NOT automatically opened in the firewall.";
+        type = types.either (types.ints.between (-1) (-1)) types.port;
+        default = metricsPort;
+      };
+
+      noTicket = mkOption {
+        description = "Do not print the all-in-one ticket to get the data from this node.";
+        type = types.bool;
+        default = false;
+      };
+
+      tag = mkOption {
+        description = "An optional tag to apply to hosted data.";
+        type = types.nullOr types.str;
+        default = null;
+      };
+
+      extraFlags = mkOption {
+        type = types.listOf types.str;
+        description = "Extra flags passed to the Iroh daemon";
+        default = [ ];
+      };
+
+      fileLogs = mkOption {
+        description = "Set the output location for logs.";
+        type = logOutput;
+      };
+
+      relayNodes = mkOption {
+        description = "Nodes used to assist in holepunching when NAT traversal fails. If configured, these nodes replace the default set of relay nodes.";
+        type = types.listOf relayNode;
+        default = [
+          {
+            url = "https//use1-1.derp.iroh.network.";
+            stunOnly = false;
+            stunPort = 3478;
+          }
+          {
+            url = "https//euw1-1.derp.iroh.network.";
+            stunOnly = false;
+            stunPort = 3478;
+          }
+        ];
+      };
+
+      extraRelayNodes = mkOption {
+        description = "Nodes used to assist in holepunching. If configured, any nodes are added to the default set of relay nodes.";
+        type = types.listOf relayNode;
+        default = [ ];
+      };
+
+    };
+  };
+
+  # Generate the actual configuration produced by this module.
+  #
+  # NB: The iroh CLI loads configuration from a iroh.config.toml file within the data directory. The
+  # file is in TOML format, and all values are optional, including the file itself. Iroh does not
+  # create iroh.config.toml by default.
+  #
+  # Here's the default configuration for relay nodes:
+  #
+  # [[relay_nodes]]
+  # url = "https://use1-1.derp.iroh.network."
+  # stun_only = false
+  # stun_port = 3478
+  #
+  # [[relay_nodes]]
+  # url = "https://euw1-1.derp.iroh.network."
+  # stun_only = false
+  # stun_port = 3478
+
+  # New config format as of v0.19.0:
+  # [[relay_nodes]]
+  # secret_key: ""
+  # enable_relay: true
+  # http_bind_addr: [::]:80
+  # tls:
+  # enable_stun: true
+  # stun_bind_addr: [::]:80
+  # limits:
+  # enable_metrics: true
+  # metrics_bind_addr
+
+  # [file_logs]
+  # rust_log = "iroh=info"
+  # rotation = "daily"
+  # max_files = 1
+  # dir = "/home/me/my_logs"
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.rpcPort != null;
+        message = "The RPC port must be specified.";
+      }
+    ];
+
+    environment.systemPackages = [ cfg.package ];
+
+    # Run iroh with a systemd "dynamic user":
+    # https://0pointer.net/blog/dynamic-users-with-systemd.html
+
+    # Define the systemd service.
+    systemd.services.iroh = {
+      wants = [ "network-online.target" ];
+      wantedBy = [ "default.target" ];
+
+      path = [ "/run/wrappers" pkgs.iroh ];
+
+      # If the IROH_DATA_DIR environment variable is set, all other values will be ignored in favour
+      # of IROH_DATA_DIR. If the directory path does not exist, iroh will attempt to create all
+      # directories in the path string (similar to mkdir -p on Unix systems), failing if the final
+      # path cannot be written to.
+
+      # When the service state directory is "iroh" a writable directory is created at /var/lib/iroh.
+      environment.IROH_DATA_DIR = "/var/lib/iroh";
+
+      # TODO create configuration that causes logs to be written under /var/log/iroh. This feature
+      # is currently pending release in next version of iroh.
+
+      # NB: we don't start in the background with --start because defining a systemd service.
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/iroh start ${irohFlags}";
+
+        DynamicUser = true;
+        # /var/lib/iroh -> /var/lib/private/iroh
+        StateDirectory = "iroh";
+        # /var/log/iroh -> /var/log/private/iroh
+        LogsDirectory = "iroh";
+      };
+
+    };
+
+    meta = {
+      maintainers = with lib.maintainers; [ crimeminister ];
+    };
+
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -453,6 +453,7 @@ in {
   invoiceplane = handleTest ./invoiceplane.nix {};
   iodine = handleTest ./iodine.nix {};
   ipv6 = handleTest ./ipv6.nix {};
+  iroh = handleTest ./iroh.nix {};
   iscsi-multipath-root = handleTest ./iscsi-multipath-root.nix {};
   iscsi-root = handleTest ./iscsi-root.nix {};
   isso = handleTest ./isso.nix {};

--- a/nixos/tests/iroh.nix
+++ b/nixos/tests/iroh.nix
@@ -1,0 +1,51 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+let
+  listenPort = 11204;
+in
+{
+  name = "iroh";
+
+  nodes = {
+    write = { config, ... }: {
+      users.users.alice = {
+        isNormalUser = true;
+      };
+
+      networking.firewall.allowedTCPPorts = [
+        # TODO read listening port fro configuration
+        #config.listenPort
+        listenPort
+      ];
+
+      services.iroh = {
+        enable = true;
+      };
+    };
+    # read = { config, ... }: {
+    # TODO create multiple nodes, add on one and retrieve on the other.
+    # };
+  };
+
+  testScript = ''
+    start_all()
+
+    # TODO read port from service configuration
+    #write.wait_for_open_port(${toString listenPort})
+    write.wait_for_unit("default.target")
+
+    with subtest("Add and retrieve data"):
+        machine.succeed("echo fnord0 >> test-data")
+        # iroh_hash = machine.succeed(
+        #     "su -- alice -l -c 'iroh blob add test-data' | grep Blob | cut -d ':' -f 2 | tr -d ' '"
+        # )
+        output = machine.succeed("su -- alice -l -c 'iroh blob add test-data'")
+        # Get the output line that looks like: 'Blob: xxxx....yyyy'
+        iroh_blob = [line for line in output.splitlines() if line.startswith('Blob')].pop()
+        # ['Blob:', 'xxxx....yyyy'] => 'xxxx....yyyy'
+        iroh_hash = iroh_blob.split().pop()
+        machine.succeed(f"iroh blob get {iroh_hash} output.txt")
+        machine.succeed("cat output.txt | grep fnord0")
+
+    machine.stop_job("iroh")
+  '';
+})


### PR DESCRIPTION
## Description of changes

This is a service module for [iroh](https://iroh.computer), a content-addressable network filesystem similar to [IPFS](https://ipfs.tech) but aimed at greater scalability and performance. This module enables users to run an iroh node, enabling the distribution of data added locally as well as facilitating the dissemination of data stored in remote nodes participating in the global content distribution network. The service supports the distribution of data blobs and structured "documents", and features a cryptographic author and permission model.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
