### PR TITLE
lomiri.teleports: init at 1.20

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -39,6 +39,7 @@ in {
         qtmir # not having its desktop file for Xwayland available causes any X11 application to crash the session
         suru-icon-theme
         telephony-service
+        teleports
       ]);
       variables = {
         # To override the keyboard layouts in Lomiri

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -975,6 +975,7 @@ in {
   teeworlds = handleTest ./teeworlds.nix {};
   telegraf = handleTest ./telegraf.nix {};
   teleport = handleTest ./teleport.nix {};
+  teleports = runTest ./teleports.nix;
   thelounge = handleTest ./thelounge.nix {};
   terminal-emulators = handleTest ./terminal-emulators.nix {};
   thanos = handleTest ./thanos.nix {};

--- a/nixos/tests/teleports.nix
+++ b/nixos/tests/teleports.nix
@@ -1,0 +1,48 @@
+{ pkgs, lib, ... }:
+{
+  name = "teleports-standalone";
+  meta.maintainers = lib.teams.lomiri.members;
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      imports = [ ./common/x11.nix ];
+
+      services.xserver.enable = true;
+
+      environment = {
+        systemPackages = with pkgs.lomiri; [
+          suru-icon-theme
+          teleports
+        ];
+        variables = {
+          UITK_ICON_THEME = "suru";
+        };
+      };
+
+      i18n.supportedLocales = [ "all" ];
+
+      fonts.packages = with pkgs; [
+        # Intended font & helps with OCR
+        ubuntu_font_family
+      ];
+    };
+
+  enableOCR = true;
+
+  testScript = ''
+    machine.wait_for_x()
+
+    with subtest("teleports launches"):
+        machine.execute("teleports >&2 &")
+        machine.wait_for_text(r"(TELEports|Phone Number)")
+        machine.screenshot("teleports_open")
+
+    machine.succeed("pkill -f teleports")
+
+    with subtest("teleports localisation works"):
+        machine.execute("env LANG=de_DE.UTF-8 teleports >&2 &")
+        machine.wait_for_text("Telefonnummer")
+        machine.screenshot("teleports_localised")
+  '';
+}

--- a/pkgs/desktops/lomiri/applications/teleports/default.nix
+++ b/pkgs/desktops/lomiri/applications/teleports/default.nix
@@ -1,0 +1,131 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  fetchFromGitLab,
+  fetchpatch,
+  gitUpdater,
+  cmake,
+  content-hub,
+  intltool,
+  lomiri-indicator-network,
+  lomiri-push-qml,
+  lomiri-thumbnailer,
+  lomiri-ui-toolkit,
+  pkg-config,
+  qqc2-suru-style,
+  qtbase,
+  qtmultimedia,
+  qtpositioning,
+  qtquickcontrols2,
+  quazip,
+  quickflux,
+  rlottie,
+  rlottie-qml,
+  tdlib,
+  wrapQtAppsHook,
+}:
+
+let
+  tdlib-1811 = tdlib.overrideAttrs (
+    oa: fa: {
+      version = "1.8.11";
+      src = fetchFromGitHub {
+        owner = "tdlib";
+        repo = "td";
+        rev = "3179d35694a28267a0b6273fc9b5bdce3b6b1235";
+        hash = "sha256-XvqqDXaFclWK/XpIxOqAXQ9gcc/dTljl841CN0KrlyA=";
+      };
+    }
+  );
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "teleports";
+  version = "1.20";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/apps/teleports";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-hHnQjitBI4RX8DwX1HHicpgAl3pznWN4wC4lkhlh+OI=";
+  };
+
+  patches = [
+    # Remove when https://gitlab.com/ubports/development/apps/teleports/-/merge_requests/551 merged & in release
+    (fetchpatch {
+      name = "0001-teleports-Call-i18n.bindtextdomain.patch";
+      url = "https://gitlab.com/ubports/development/apps/teleports/-/commit/dd537c08453be9bfcdb2ee1eb692514c7e867e41.patch";
+      hash = "sha256-zxxFvoj6jluGPCA9GQsxuYYweaSOVrkD01hZwCtq52U=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'COMMAND git describe --tags --abbrev=0 --exact-match' 'COMMAND echo v${finalAttrs.version}' \
+      --replace-fail 'set(DATA_DIR ''${CMAKE_INSTALL_PREFIX})' 'set(DATA_DIR ''${CMAKE_INSTALL_FULL_DATADIR}/teleports)'
+
+    # Doesn't honour DATA_DIR
+    substituteInPlace app/main.cpp push/pushhelper.cpp libs/qtdlib/client/qtdclient.cpp \
+      --replace-fail 'QGuiApplication::applicationDirPath()' "QString(\"$out/share/teleports\")"
+
+    substituteInPlace teleports.desktop.in \
+      --replace-fail 'assets/icon.svg' 'teleports' \
+      --replace-fail 'assets/splash.svg' 'lomiri-app-launch/splash/teleports.svg'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    intltool
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    content-hub
+    lomiri-indicator-network
+    lomiri-push-qml
+    lomiri-thumbnailer
+    lomiri-ui-toolkit
+    rlottie-qml
+    qqc2-suru-style
+    qtbase
+    qtmultimedia
+    qtpositioning
+    qtquickcontrols2
+    quazip
+    quickflux
+    rlottie
+    tdlib-1811
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share/{applications,content-hub/peers,icons/hicolor/scalable/apps,lomiri-app-launch/splash,lomiri-url-dispatcher/urls}
+
+    ln -s $out/share/teleports/teleports.desktop $out/share/applications/teleports.desktop
+    ln -s $out/share/teleports/teleports.content-hub $out/share/content-hub/peers/teleports
+    ln -s $out/share/teleports/assets/icon.svg $out/share/icons/hicolor/scalable/apps/teleports.svg
+    ln -s $out/share/teleports/assets/splash.svg $out/share/lomiri-app-launch/splash/teleports.svg
+    ln -s $out/share/teleports/teleports.url-dispatcher $out/share/lomiri-url-dispatcher/urls/teleports.url-dispatcher
+  '';
+
+  passthru = {
+    updateScript = gitUpdater { rev-prefix = "v"; };
+  };
+
+  meta = {
+    description = "Ubuntu Touch Telegram client";
+    homepage = "https://gitlab.com/ubports/development/apps/teleports";
+    license = with lib.licenses; [
+      mit # main
+      asl20 # benlau/asyncfuture in qtdlib
+      bsd3 # FastScroll.js from Meego? maybe?
+      gpl3Only # components
+      lgpl3Only # components
+    ];
+    mainProgram = "teleports";
+    maintainers = lib.teams.lomiri.members;
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/desktops/lomiri/applications/teleports/default.nix
+++ b/pkgs/desktops/lomiri/applications/teleports/default.nix
@@ -5,6 +5,7 @@
   fetchFromGitLab,
   fetchpatch,
   gitUpdater,
+  nixosTests,
   cmake,
   content-hub,
   intltool,
@@ -112,6 +113,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = gitUpdater { rev-prefix = "v"; };
+    tests.vm = nixosTests.teleports;
   };
 
   meta = {

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -17,6 +17,7 @@ let
     lomiri-system-settings = callPackage ./applications/lomiri-system-settings/wrapper.nix { };
     lomiri-terminal-app = callPackage ./applications/lomiri-terminal-app { };
     morph-browser = callPackage ./applications/morph-browser { };
+    teleports = callPackage ./applications/teleports { };
 
     #### Data
     lomiri-schemas = callPackage ./data/lomiri-schemas { };


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[TELEports](https://gitlab.com/ubports/development/apps/teleports) is the Telegram client for Ubuntu Touch / Lomiri. The primary communication channel for Ubuntu Touch / Lomiri development are the Telegram channels, and the client makes decent usage of Lomiri stuff.

![Bildschirmfoto_2024-07-04_20-04-31](https://github.com/NixOS/nixpkgs/assets/23431373/a70883b7-61f6-4dc7-bfaa-f425a747bec2)
![image](https://github.com/NixOS/nixpkgs/assets/23431373/2efbf430-9330-4de2-82c0-f7377ba5c55b)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
