### PR TITLE
argc: 1.14.0 -> 1.19.0

### DIFF
--- a/pkgs/by-name/ar/argc/package.nix
+++ b/pkgs/by-name/ar/argc/package.nix
@@ -4,6 +4,7 @@
   pkgsCross,
   rustPlatform,
   stdenv,
+  glibcLocales,
   fetchFromGitHub,
   installShellFiles,
 }:
@@ -13,16 +14,16 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "argc";
-  version = "1.14.0";
+  version = "1.19.0";
 
   src = fetchFromGitHub {
     owner = "sigoden";
     repo = "argc";
     rev = "v${version}";
-    hash = "sha256-Li/K5/SLG6JuoRJDz2DQoj1Oi9LQgZWHNvtZ1HVbj88=";
+    hash = "sha256-I5dx0/aHCGmzgAEBL9gZcG7DFWCkSpndGvv2enQIZGU=";
   };
 
-  cargoHash = "sha256-D1T9FWTvwKtAYoqFlR2OmLRLGWhPJ9D8J7lq/QKcBoM=";
+  cargoHash = "sha256-30BY6ceJj0UeZE30O/LovR+YXSd7jIxFo6ojKFuecFM=";
 
   nativeBuildInputs = [ installShellFiles ] ++ lib.optional (!canExecuteHost) buildPackages.argc;
 
@@ -36,6 +37,14 @@ rustPlatform.buildRustPackage rec {
   '';
 
   disallowedReferences = lib.optional (!canExecuteHost) buildPackages.argc;
+
+  env =
+    {
+      LANG = "C.UTF-8";
+    }
+    // lib.optionalAttrs (glibcLocales != null) {
+      LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
+    };
 
   passthru = {
     tests = {


### PR DESCRIPTION
## Description of changes
There were quite a few releases in between, so its best to check the [source repo releases](https://github.com/sigoden/argc/releases).

## Things tried :sweat_smile: 

When I tried building the package the tests of the package failed though, and I was not able to figure out why.

EDIT: The issue was resolved, see my comment below.

<details>
<summary>Here is the failed test result:</summary>

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Snapshot Summary ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Snapshot file: tests/snapshots/integration__misc__escape.snap
Snapshot: escape
Source: tests/misc.rs:5
────────────────────────────────────────────────────────────────────────────────
Expression: data
────────────────────────────────────────────────────────────────────────────────
-old snapshot
+new results
────────────┬───────────────────────────────────────────────────────────────────
   10    10 │ cmd '$foo' '`pwd`' '$(pwd)' ''\''' '\1' '' '
   11    11 │ ' 世界 ' '
   12    12 │ 
   13    13 │ # BUILD_OUTPUT
   14       │-argc__args=([0]="prog" [1]="cmd" [2]="\$foo" [3]="\`pwd\`" [4]="\$(pwd)" [5]="'" [6]="\\1" [7]="" [8]=$'\n' [9]="世界" [10]=" ")
         14 │+argc__args=([0]="prog" [1]="cmd" [2]="\$foo" [3]="\`pwd\`" [4]="\$(pwd)" [5]="'" [6]="\\1" [7]="" [8]=$'\n' [9]=$'\344\270\226\347\225\214' [10]=" ")
   15    15 │ argc__fn=cmd
   16       │-argc__positionals=([0]="\$foo" [1]="\`pwd\`" [2]="\$(pwd)" [3]="'" [4]="\\1" [5]="" [6]=$'\n' [7]="世界" [8]=" ")
         16 │+argc__positionals=([0]="\$foo" [1]="\`pwd\`" [2]="\$(pwd)" [3]="'" [4]="\\1" [5]="" [6]=$'\n' [7]=$'\344\270\226\347\225\214' [8]=" ")
   17    17 │ cmd $foo `pwd` $(pwd) ' \1  
   18    18 │  世界
────────────┴───────────────────────────────────────────────────────────────────
```

</details>

Hopefully the tests will pass on the CI [as they do in the source repo](https://github.com/sigoden/argc/actions/runs/9563590037/job/26362403842) :crossed_fingers: 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
