### PR TITLE
javaPackages.compiler.adoptopenjdk: all attrsets evaluate, so remove __attrsFailEvaluation

### DIFF
--- a/pkgs/top-level/java-packages.nix
+++ b/pkgs/top-level/java-packages.nix
@@ -34,7 +34,6 @@ in {
         else package-darwin;
     in {
       inherit package-linux package-darwin;
-      __attrsFailEvaluation = true;
 
       jdk-hotspot = callPackage package.jdk-hotspot {};
       jre-hotspot = callPackage package.jre-hotspot {};


### PR DESCRIPTION
## Description of changes

- #324619

The test (`nix-build pkgs/test/release/default.nix`) continues to pass.

These lines were added in https://github.com/NixOS/nixpkgs/pull/269356.

New derivations reported:

```diff
--- /dev/fd/63	2024-07-04 14:26:57.697312468 -0700
+++ /dev/fd/62	2024-07-04 14:26:57.697312468 -0700
@@ -31717,8 +31717,34 @@
   "jasper",
   "java-language-server",
   "java-service-wrapper",
   "javaCup",
+  "javaPackages.compiler.adoptopenjdk-11.jdk-hotspot",
+  "javaPackages.compiler.adoptopenjdk-11.jdk-openj9",
+  "javaPackages.compiler.adoptopenjdk-11.jre-hotspot",
+  "javaPackages.compiler.adoptopenjdk-11.jre-openj9",
+  "javaPackages.compiler.adoptopenjdk-13.jdk-hotspot",
+  "javaPackages.compiler.adoptopenjdk-13.jdk-openj9",
+  "javaPackages.compiler.adoptopenjdk-13.jre-hotspot",
+  "javaPackages.compiler.adoptopenjdk-13.jre-openj9",
+  "javaPackages.compiler.adoptopenjdk-14.jdk-hotspot",
+  "javaPackages.compiler.adoptopenjdk-14.jdk-openj9",
+  "javaPackages.compiler.adoptopenjdk-14.jre-hotspot",
+  "javaPackages.compiler.adoptopenjdk-14.jre-openj9",
+  "javaPackages.compiler.adoptopenjdk-15.jdk-hotspot",
+  "javaPackages.compiler.adoptopenjdk-15.jdk-openj9",
+  "javaPackages.compiler.adoptopenjdk-15.jre-hotspot",
+  "javaPackages.compiler.adoptopenjdk-15.jre-openj9",
+  "javaPackages.compiler.adoptopenjdk-16.jdk-hotspot",
+  "javaPackages.compiler.adoptopenjdk-16.jdk-openj9",
+  "javaPackages.compiler.adoptopenjdk-16.jre-hotspot",
+  "javaPackages.compiler.adoptopenjdk-16.jre-openj9",
+  "javaPackages.compiler.adoptopenjdk-17.jdk-hotspot",
+  "javaPackages.compiler.adoptopenjdk-17.jre-hotspot",
+  "javaPackages.compiler.adoptopenjdk-8.jdk-hotspot",
+  "javaPackages.compiler.adoptopenjdk-8.jdk-openj9",
+  "javaPackages.compiler.adoptopenjdk-8.jre-hotspot",
+  "javaPackages.compiler.adoptopenjdk-8.jre-openj9",
   "javaPackages.compiler.corretto11",
   "javaPackages.compiler.corretto17",
   "javaPackages.compiler.corretto19",
   "javaPackages.compiler.corretto21",
```

## Things done

- [x] Tested, as applicable:
  - [x] `nix-build pkgs/test/release/default.nix`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).