### PR TITLE
haskellPackages: remove __attrsFailEvaluation, buildHaskellPackages, and generateOptparseApplicativeCompletions special cases

### DIFF
--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -20,6 +20,8 @@ let
   haskellPackages = pkgs.callPackage makePackageSet {
     package-set = initialPackages;
     inherit stdenv haskellLib ghc extensible-self all-cabal-hashes;
+
+    # Prevent `pkgs/top-level/release-attrpaths-superset.nix` from recursing here.
     buildHaskellPackages = buildHaskellPackages // { __attrsFailEvaluation = true; };
   };
 

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -624,7 +624,7 @@ in package-set { inherit pkgs lib callPackage; } self // {
        Type: [str] -> drv -> drv
     */
     generateOptparseApplicativeCompletions =
-      (self.callPackage (
+      self.callPackage (
         { stdenv }:
 
         commands:
@@ -633,7 +633,7 @@ in package-set { inherit pkgs lib callPackage; } self // {
         if stdenv.buildPlatform.canExecute stdenv.hostPlatform
         then lib.foldr haskellLib.__generateOptparseApplicativeCompletion pkg commands
         else pkg
-      ) { }) // { __attrsFailEvaluation = true; };
+      ) { };
 
     /*
       Modify given Haskell package to force GHC to employ the LLVM

--- a/pkgs/top-level/release-attrpaths-superset.nix
+++ b/pkgs/top-level/release-attrpaths-superset.nix
@@ -77,10 +77,8 @@ let
     pkgs = true;
     test-pkgs = true;
 
-    buildHaskellPackages = true;
     buildPackages = true;
     buildFreebsd = true;
-    generateOptparseApplicativeCompletions = true;
 
     callPackage = true;
     mkDerivation = true;


### PR DESCRIPTION
## Description of changes

- #324619

The test (`nix-build pkgs/test/release/default.nix`) continues to pass.

These lines were added in https://github.com/NixOS/nixpkgs/pull/269356.

There is no change in the set of names which evaluate.

## Things done

- [x] Tested, as applicable:
  - [x] `nix-build pkgs/test/release/default.nix`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).