### PR TITLE
Remove test-pkgs, buildPackages, and buildFreebsd from excluded-attrnames-at-any-depth

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/package-set.nix
+++ b/pkgs/os-specific/bsd/freebsd/package-set.nix
@@ -21,7 +21,9 @@ lib.packagesFromDirectoryRecursive {
   patches = ./patches + "/${self.versionData.revision}";
 
   # Keep the crawled portion of Nixpkgs finite.
-  buildFreebsd = lib.dontRecurseIntoAttrs buildFreebsd;
+  buildFreebsd = lib.dontRecurseIntoAttrs buildFreebsd // {
+    __attrsFailEvaluation = true;
+  };
 
   ports = fetchzip {
     url = "https://cgit.freebsd.org/ports/snapshot/ports-dde3b2b456c3a4bdd217d0bf3684231cc3724a0a.tar.gz";

--- a/pkgs/top-level/release-attrpaths-superset.nix
+++ b/pkgs/top-level/release-attrpaths-superset.nix
@@ -75,11 +75,7 @@ let
     newScope = true;
     scope = true;
     pkgs = true;
-    test-pkgs = true;
-
-    buildPackages = true;
     buildFreebsd = true;
-
     callPackage = true;
     mkDerivation = true;
     overrideDerivation = true;

--- a/pkgs/top-level/release-attrpaths-superset.nix
+++ b/pkgs/top-level/release-attrpaths-superset.nix
@@ -75,7 +75,6 @@ let
     newScope = true;
     scope = true;
     pkgs = true;
-    buildFreebsd = true;
     callPackage = true;
     mkDerivation = true;
     overrideDerivation = true;


### PR DESCRIPTION
- #324619

## Description of changes

The test (`nix-build pkgs/test/release/default.nix`) continues to pass.

These lines were added in https://github.com/NixOS/nixpkgs/pull/269356.

There is no difference in the package names generated.

## Things done

- [x] Tested, as applicable:
  - [x] `nix-build pkgs/test/release/default.nix`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).