### PR TITLE
media-downloader: drop extension package support

### DIFF
--- a/pkgs/by-name/me/media-downloader/package.nix
+++ b/pkgs/by-name/me/media-downloader/package.nix
@@ -4,7 +4,6 @@
   # https://github.com/mhogomchungu/media-downloader?tab=readme-ov-file#extensions
   extraPackages ? [
     aria2
-    yt-dlp
     ffmpeg
     python3
   ],
@@ -28,14 +27,6 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-ykPYxRgzKZrA0KwS1FoxZOkSL+7TbLgy0yLfs7Iqpf4=";
   };
 
-  # Disable automatically updating extensions when starting the program because this will
-  # invalidate the dependence on extensions and may cause potential security issues
-  # Can still be enabled in Configure > Actions At Startup
-  postPatch = ''
-    substituteInPlace src/settings.cpp \
-      --replace-fail '"ShowVersionInfoAndAutoDownloadUpdates",true' '"ShowVersionInfoAndAutoDownloadUpdates",false' \
-  '';
-
   nativeBuildInputs = [
     cmake
     libsForQt5.wrapQtAppsHook
@@ -52,8 +43,10 @@ stdenv.mkDerivation (finalAttrs: {
       lux, you-get, svtplay-dl, aria2c, wget and safari books.
 
       Read https://github.com/mhogomchungu/media-downloader/wiki/Extensions
-      for further information. We have packaged most of them, and they can
-      be added by overriding `extraPackages`.
+      for further information. Note that adding these packages to extraPackages
+      doesn't work, because the author doesn't intend to support custom
+      installation of them. These packages will be downloaded from original
+      source when executing the application for the first time.
     '';
     homepage = "https://github.com/mhogomchungu/media-downloader";
     license = lib.licenses.gpl2Plus;


### PR DESCRIPTION
## Description of changes

Looks like my last PR (https://github.com/NixOS/nixpkgs/pull/320357) was incorrect, but because of my local cache I didn't find it.

See https://github.com/mhogomchungu/media-downloader/issues/411

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
