### PR TITLE
input-fonts: Parallelise postFetch

### DIFF
--- a/pkgs/data/fonts/input-fonts/default.nix
+++ b/pkgs/data/fonts/input-fonts/default.nix
@@ -4,6 +4,8 @@
 , python3
 , config
 , acceptLicense ? config.input-fonts.acceptLicense or false
+, parallel
+, writeShellApplication
 }:
 
 let
@@ -44,17 +46,28 @@ stdenv.mkDerivation rec {
       sha256 = "BESZ4Bjgm2hvQ7oPpMvYSlE8EqvQjqHZtXWIovqyIzA=";
       stripRoot = false;
 
-      postFetch = ''
-        # Reset the timestamp to release date for determinism.
-        PATH=${lib.makeBinPath [ python3.pkgs.fonttools ]}:$PATH
-        for ttf_file in $out/Input_Fonts/*/*/*.ttf; do
-          ttx_file=$(dirname "$ttf_file")/$(basename "$ttf_file" .ttf).ttx
-          ttx "$ttf_file"
-          rm "$ttf_file"
-          touch -m -t ${builtins.replaceStrings [ "-" ] [ "" ] releaseDate}0000 "$ttx_file"
-          ttx --recalc-timestamp "$ttx_file"
-          rm "$ttx_file"
-        done
+      # Reset the timestamp to release date for determinism.
+      postFetch = let
+        ttf-fixup = writeShellApplication {
+          name = "ttf-fixup";
+          runtimeInputs = [ python3.pkgs.fonttools ];
+          text = ''
+            if [ $# != 1 ]; then
+              echo "Usage: $0 <file.ttf>: Resets timestamp on <file.ttf> for determinism" >&2
+              exit 1
+            fi
+
+            ttf_file="$1"
+            ttx_file=$(dirname "$ttf_file")/$(basename "$ttf_file" .ttf).ttx
+            ttx "$ttf_file"
+            rm "$ttf_file"
+            touch -m -t ${builtins.replaceStrings [ "-" ] [ "" ] releaseDate}0000 "$ttx_file"
+            ttx --recalc-timestamp "$ttx_file"
+            rm "$ttx_file"
+          '';
+        };
+      in ''
+        find $out/Input_Fonts -type f -name '*.ttf' -print0 | ${lib.getExe parallel} -0 -j $NIX_BUILD_CORES ${lib.getExe ttf-fixup} {}
       '';
     };
 


### PR DESCRIPTION
## Description of changes

`time`s on my systems:

Desktop:
Before: 3 minutes 43 seconds
After (6 threads): 46 seconds
After (40 threads): 18 seconds

Laptop (big.LITTLE, so performance scales not quite as well):
Before: 15 minutes 16 seconds
After (2 threads): 8 minutes 30 seconds
After (4 threads): 6 minutes 30 seconds

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
