### PR TITLE
Use pbkdf2 in luksFormat example in manual

### DIFF
--- a/nixos/doc/manual/configuration/luks-file-systems.section.md
+++ b/nixos/doc/manual/configuration/luks-file-systems.section.md
@@ -6,7 +6,7 @@ Ext4 file system on the device
 `/dev/disk/by-uuid/3f6b0024-3a44-4fde-a43a-767b872abe5d`:
 
 ```ShellSession
-# cryptsetup luksFormat /dev/disk/by-uuid/3f6b0024-3a44-4fde-a43a-767b872abe5d
+# cryptsetup luksFormat --pbkdf pbkdf2 /dev/disk/by-uuid/3f6b0024-3a44-4fde-a43a-767b872abe5d
 
 WARNING!
 ========
@@ -21,6 +21,11 @@ Enter passphrase for /dev/disk/by-uuid/3f6b0024-3a44-4fde-a43a-767b872abe5d: ***
 
 # mkfs.ext4 /dev/mapper/crypted
 ```
+
+Note that we use the `pbkdf2` key derivation function. This is required
+if you need to boot from this partition, because grub currently cannot
+handle the default key derivation function Argon2, which would render
+the partition unbootable.
 
 The LUKS volume should be automatically picked up by
 `nixos-generate-config`, but you might want to verify that your


### PR DESCRIPTION
When installing NixOS from a minimal image, the manual is available for reading, but the instructions won't work if you intend to boot from the partition.

See also the discourse topic here: https://discourse.nixos.org/t/grub-fails-to-decrypt-boot-partition-are-my-configs-at-fault/43709

Power-users who want to use Argon2 will know what to do anyway. This is aimed at helping out hapless users who are stuck on the minimal boot image, reading the manual there.