### PR TITLE
Remove key management setting in wpa_cli examples

### DIFF
--- a/nixos/doc/manual/installation/installing.chapter.md
+++ b/nixos/doc/manual/installation/installing.chapter.md
@@ -174,8 +174,6 @@ commands:
 OK
 > set_network 0 psk "mypassword"
 OK
-> set_network 0 key_mgmt WPA-PSK
-OK
 > enable_network 0
 OK
 ```
@@ -190,8 +188,6 @@ OK
 > set_network 0 identity "myname@example.com"
 OK
 > set_network 0 password "mypassword"
-OK
-> set_network 0 key_mgmt WPA-EAP
 OK
 > enable_network 0
 OK


### PR DESCRIPTION
When manually setting the key management, this will actually cause wifi to not connect if a different type is used by the access point.

WPA supplicant typically can detect the key management from the access point's broadcast, and not overriding it has a bigger chance of succeeding.

As a `wpa_cli` newbie, I just followed the instructions in the manual on the minimal install disk and they didn't work. I tried setting `key_mgmt` what was shown in the scan results, but `wpa_cli` barfed at the string (quoted or unquoted). Only when dropping the `set key_mgmt` line entirely, it worked. So I think this would provide a better help for people using the minimal install disk.

**NOTE:** IMO a better approach would be to provide something like `wicd-curses` or `nmtui` in the minimal installation disk instead, as they're a little bit more user-friendly than `wpa_cli`.