### PR TITLE
[24.05] quickemu: 4.9.4 -> 4.9.5

### DIFF
--- a/pkgs/by-name/qu/quickemu/package.nix
+++ b/pkgs/by-name/qu/quickemu/package.nix
@@ -28,6 +28,7 @@
   quickemu,
   testers,
   installShellFiles,
+  fetchpatch2,
 }:
 let
   runtimePaths = [
@@ -72,6 +73,16 @@ stdenv.mkDerivation (finalAttrs: {
       -e 's/Icon=.*qemu.svg/Icon=qemu/' \
       quickemu
   '';
+
+  patches = [
+    # reduces windows vm ram requirements to 4G, to match microsoft recommendations
+    # TODO: remove on next release
+    (fetchpatch2 {
+      name = "decrease-windows-ram-requirements.patch";
+      url = "https://github.com/quickemu-project/quickemu/commit/f51697593a4650c5486661292e2febe1d16f8c71.patch";
+      hash = "sha256-J5hIvQGtkufOcjk2FZN65iox/W2zkLlg+Veg9TF11Fs=";
+    })
+  ];
 
   nativeBuildInputs = [
     makeWrapper

--- a/pkgs/by-name/qu/quickemu/package.nix
+++ b/pkgs/by-name/qu/quickemu/package.nix
@@ -1,32 +1,33 @@
-{ lib
-, fetchFromGitHub
-, stdenv
-, makeWrapper
-, cdrtools
-, curl
-, gawk
-, gnugrep
-, gnused
-, jq
-, ncurses
-, pciutils
-, procps
-, python3
-, qemu
-, socat
-, spice-gtk
-, swtpm
-, usbutils
-, util-linux
-, unzip
-, xdg-user-dirs
-, xrandr
-, zsync
-, OVMF
-, OVMFFull
-, quickemu
-, testers
-, installShellFiles
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  makeWrapper,
+  cdrtools,
+  curl,
+  gawk,
+  gnugrep,
+  gnused,
+  jq,
+  ncurses,
+  pciutils,
+  procps,
+  python3,
+  qemu,
+  socat,
+  spice-gtk,
+  swtpm,
+  usbutils,
+  util-linux,
+  unzip,
+  xdg-user-dirs,
+  xrandr,
+  zsync,
+  OVMF,
+  OVMFFull,
+  quickemu,
+  testers,
+  installShellFiles,
 }:
 let
   runtimePaths = [
@@ -52,7 +53,7 @@ let
   ];
 in
 
-stdenv.mkDerivation (finalAttrs : {
+stdenv.mkDerivation (finalAttrs: {
   pname = "quickemu";
   version = "4.9.4";
 
@@ -72,7 +73,10 @@ stdenv.mkDerivation (finalAttrs : {
       quickemu
   '';
 
-  nativeBuildInputs = [ makeWrapper installShellFiles ];
+  nativeBuildInputs = [
+    makeWrapper
+    installShellFiles
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -98,6 +102,9 @@ stdenv.mkDerivation (finalAttrs : {
     homepage = "https://github.com/quickemu-project/quickemu";
     mainProgram = "quickemu";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ fedx-sudo flexiondotorg ];
+    maintainers = with lib.maintainers; [
+      fedx-sudo
+      flexiondotorg
+    ];
   };
 })

--- a/pkgs/by-name/qu/quickemu/package.nix
+++ b/pkgs/by-name/qu/quickemu/package.nix
@@ -14,7 +14,7 @@
   pciutils,
   procps,
   python3,
-  qemu,
+  qemu_full,
   socat,
   spice-gtk,
   swtpm,
@@ -42,7 +42,7 @@ let
     pciutils
     procps
     python3
-    qemu
+    qemu_full
     socat
     swtpm
     util-linux
@@ -73,6 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
       -e '/OVMF_CODE_4M.fd/s|ovmfs=(|ovmfs=("${OVMF.firmware}","${OVMF.variables}" |' \
       -e '/cp "''${VARS_IN}" "''${VARS_OUT}"/a chmod +w "''${VARS_OUT}"' \
       -e 's/Icon=.*qemu.svg/Icon=qemu/' \
+      -e 's,\[ -x "\$(command -v smbd)" \],true,' \
       quickemu
   '';
 

--- a/pkgs/by-name/qu/quickemu/package.nix
+++ b/pkgs/by-name/qu/quickemu/package.nix
@@ -56,13 +56,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "quickemu";
-  version = "4.9.4";
+  version = "4.9.4-unstable-2024-05-28";
 
   src = fetchFromGitHub {
     owner = "quickemu-project";
     repo = "quickemu";
-    rev = finalAttrs.version;
-    hash = "sha256-fjbXgze6klvbRgkJtPIUh9kEkP/As7dAj+cazpzelBY=";
+    rev = "d78255b097b599e8ab3713cb61c4085cc45f5a95"; # TODO: return to version on next release
+    hash = "sha256-fF306CdGqKM+779OLm0NNyqPBtm7TuU7UN/NanT12y8=";
   };
 
   postPatch = ''
@@ -73,16 +73,6 @@ stdenv.mkDerivation (finalAttrs: {
       -e 's/Icon=.*qemu.svg/Icon=qemu/' \
       quickemu
   '';
-
-  patches = [
-    # reduces windows vm ram requirements to 4G, to match microsoft recommendations
-    # TODO: remove on next release
-    (fetchpatch2 {
-      name = "decrease-windows-ram-requirements.patch";
-      url = "https://github.com/quickemu-project/quickemu/commit/f51697593a4650c5486661292e2febe1d16f8c71.patch";
-      hash = "sha256-J5hIvQGtkufOcjk2FZN65iox/W2zkLlg+Veg9TF11Fs=";
-    })
-  ];
 
   nativeBuildInputs = [
     makeWrapper
@@ -106,7 +96,10 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.tests = testers.testVersion { package = quickemu; };
+  passthru.tests = testers.testVersion {
+    version = "4.9.5"; # required for passing tests, TODO: remove when release bump
+    package = quickemu;
+  };
 
   meta = {
     description = "Quickly create and run optimised Windows, macOS and Linux virtual machines";

--- a/pkgs/by-name/qu/quickemu/package.nix
+++ b/pkgs/by-name/qu/quickemu/package.nix
@@ -6,6 +6,7 @@
   cdrtools,
   curl,
   gawk,
+  glxinfo,
   gnugrep,
   gnused,
   jq,
@@ -28,7 +29,6 @@
   quickemu,
   testers,
   installShellFiles,
-  fetchpatch2,
 }:
 let
   runtimePaths = [
@@ -45,24 +45,26 @@ let
     qemu
     socat
     swtpm
-    usbutils
     util-linux
     unzip
-    xdg-user-dirs
     xrandr
     zsync
+  ] ++ lib.optionals stdenv.isLinux [
+    glxinfo
+    usbutils
+    xdg-user-dirs
   ];
 in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "quickemu";
-  version = "4.9.4-unstable-2024-05-28";
+  version = "4.9.5";
 
   src = fetchFromGitHub {
     owner = "quickemu-project";
     repo = "quickemu";
-    rev = "d78255b097b599e8ab3713cb61c4085cc45f5a95"; # TODO: return to version on next release
-    hash = "sha256-fF306CdGqKM+779OLm0NNyqPBtm7TuU7UN/NanT12y8=";
+    rev = finalAttrs.version;
+    hash = "sha256-UlpNujF2E8H1zcWTen8D29od60pY8FaGueviT0iwupQ=";
   };
 
   postPatch = ''
@@ -97,13 +99,13 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru.tests = testers.testVersion {
-    version = "4.9.5"; # required for passing tests, TODO: remove when release bump
     package = quickemu;
   };
 
   meta = {
     description = "Quickly create and run optimised Windows, macOS and Linux virtual machines";
     homepage = "https://github.com/quickemu-project/quickemu";
+    changelog = "https://github.com/quickemu-project/quickemu/releases/tag/${finalAttrs.version}";
     mainProgram = "quickemu";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [


### PR DESCRIPTION
## Description of changes

backports #316758 #321653 #322688 #323133

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>quickemu</li>
    <li>quickgui</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc