### PR TITLE
gpgme: patch out LFS64 usage

### DIFF
--- a/pkgs/development/libraries/gpgme/LFS64.patch
+++ b/pkgs/development/libraries/gpgme/LFS64.patch
@@ -1,0 +1,34 @@
+From 1726e0a0a3b9765a4ddf99c506178d3939a46ccd Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Fri, 3 May 2024 13:39:26 +0200
+Subject: [PATCH] posix: don't use LFS64 types in struct linux_dirent64
+
+The *64_t types are transitional APIs for applications that do not yet
+fully support large files on 32-bit platforms.  They have been removed
+in musl 1.2.5, which caused gpgme to fail to build.  Since this is for
+a raw syscall anyway, it doesn't make sense to use libc-specific types
+here anyway, so I've changed this to match the definition of the
+struct used in the kernel (except there the kernel-specific u64 and
+s64 typedefs are used instead).
+---
+ src/posix-io.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/posix-io.c b/src/posix-io.c
+index a422d8f6..c943f75c 100644
+--- a/src/posix-io.c
++++ b/src/posix-io.c
+@@ -74,8 +74,8 @@
+  * define it ourselves.  */
+ struct linux_dirent64
+ {
+-  ino64_t d_ino;
+-  off64_t d_off;
++  uint64_t d_ino;
++  int64_t d_off;
+   unsigned short d_reclen;
+   unsigned char d_type;
+   char d_name[];
+-- 
+2.44.0
+

--- a/pkgs/development/libraries/gpgme/default.nix
+++ b/pkgs/development/libraries/gpgme/default.nix
@@ -40,6 +40,9 @@ stdenv.mkDerivation rec {
     ./python-310-312-remove-distutils.patch
     # Fix a test after disallowing compressed signatures in gpg (PR #180336)
     ./test_t-verify_double-plaintext.patch
+    # Don't use deprecated LFS64 APIs (removed in musl 1.2.4)
+    # https://dev.gnupg.org/D600
+    ./LFS64.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

Needed for compatibility with musl 1.2.4+.  Was hoping we could get this upstream, but seems like that's a long way off, so we'll have to patch it for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
