### PR TITLE
libeatmydata: patch out LFS64 usage

### DIFF
--- a/pkgs/development/libraries/libeatmydata/LFS64.patch
+++ b/pkgs/development/libraries/libeatmydata/LFS64.patch
@@ -1,0 +1,70 @@
+From 59f04ad8730034a205a1a792662d4b5dc2006b7c Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Mon, 13 May 2024 09:53:23 +0200
+Subject: [PATCH] Fix sync_file_range() with musl 1.2.4
+
+musl 1.2.4 has removed the transitional LFS off64_t type.
+sync_file_range is declared with off_t in musl, which is always 64
+bits.
+
+This assumes that the same is true of any other libc which doesn't
+provide off64_t.  If it's not, gcc will produce an error due to the
+conflicting types of sync_file_range(), so it will be caught and can
+be fixed.
+---
+ configure.ac                |  2 ++
+ libeatmydata/libeatmydata.c | 11 +++++++++--
+ 2 files changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 4d101ba..f3c4a69 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -37,6 +37,8 @@ AC_CHECK_HEADERS_ONCE(pthread.h)
+ AC_CHECK_SIZEOF(mode_t)
+ AC_CHECK_SIZEOF(int)
+ 
++AC_CHECK_TYPES([off64_t])
++
+ AC_CHECK_TYPE(pthread_barrier_t,,,[
+   #ifdef HAVE_PTHREAD_H
+   #include <pthread.h>
+diff --git a/libeatmydata/libeatmydata.c b/libeatmydata/libeatmydata.c
+index 134afcd..0015f1f 100644
+--- a/libeatmydata/libeatmydata.c
++++ b/libeatmydata/libeatmydata.c
+@@ -35,6 +35,12 @@
+ #define CHECK_FILE "/tmp/eatmydata"
+ */
+ 
++#ifdef HAVE_OFF64_T
++typedef off64_t sync_file_range_off;
++#else
++typedef off_t sync_file_range_off;
++#endif
++
+ typedef int (*libc_open_t)(const char*, int, ...);
+ #ifdef HAVE_OPEN64
+ typedef int (*libc_open64_t)(const char*, int, ...);
+@@ -44,7 +50,7 @@ typedef int (*libc_sync_t)(void);
+ typedef int (*libc_fdatasync_t)(int);
+ typedef int (*libc_msync_t)(void*, size_t, int);
+ #ifdef HAVE_SYNC_FILE_RANGE
+-typedef int (*libc_sync_file_range_t)(int, off64_t, off64_t, unsigned int);
++typedef int (*libc_sync_file_range_t)(int, sync_file_range_off, sync_file_range_off, unsigned int);
+ #endif
+ #ifdef HAVE_SYNCFS
+ typedef int (*libc_syncfs_t)(int);
+@@ -259,7 +265,8 @@ int LIBEATMYDATA_API msync(void *addr, size_t length, int flags)
+ }
+ 
+ #ifdef HAVE_SYNC_FILE_RANGE
+-int LIBEATMYDATA_API sync_file_range(int fd, off64_t offset, off64_t nbytes,
++int LIBEATMYDATA_API sync_file_range(int fd, sync_file_range_off offset,
++				     sync_file_range_off nbytes,
+ 				     unsigned int flags)
+ {
+ 	if (eatmydata_is_hungry()) {
+-- 
+2.45.1
+

--- a/pkgs/development/libraries/libeatmydata/default.nix
+++ b/pkgs/development/libraries/libeatmydata/default.nix
@@ -17,6 +17,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-0lrYDW51/KSr809whGwg9FYhzcLRfmoxipIgrK1zFCc=";
   };
 
+  patches = [
+    # https://github.com/stewartsmith/libeatmydata/pull/36
+    ./LFS64.patch
+  ];
+
   postPatch = ''
     patchShebangs .
   '';


### PR DESCRIPTION
## Description of changes

This is a revised version of https://github.com/NixOS/nixpkgs/commit/c7f51f0032641a3fae293336070f42dd91b288d8 ("libeatmydata: patch out LFS64 usage") (reverted in https://github.com/NixOS/nixpkgs/commit/7be23ec058c826715a64d0c28bfb78d56f401542 ("Revert "libeatmydata: patch out LFS64 usage"")) that doesn't break 32-bit Glibc builds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
