### PR TITLE
kdePackages.kde-cli-tools: install a symlink to kdesu in bin

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -219,6 +219,7 @@
   ./programs/kbdlight.nix
   ./programs/kclock.nix
   ./programs/kdeconnect.nix
+  ./programs/kdesu.nix
   ./programs/ladybird.nix
   ./programs/lazygit.nix
   ./programs/kubeswitch.nix

--- a/nixos/modules/programs/kdesu.nix
+++ b/nixos/modules/programs/kdesu.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.kdesu;
+
+in
+{
+  options = {
+    programs.kdesu = {
+      enable = lib.mkEnableOption "kdesu with setuid wrapper";
+      package.kdesu = lib.mkPackageOption pkgs.kdePackages "kdesu" {};
+      package.kde-cli-tools = lib.mkPackageOption pkgs.kdePackages "kde-cli-tools" {};
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package.kde-cli-tools ];
+    security.wrappers.kdesud = {
+      setgid = true;
+      owner = "root";
+      group = "nogroup";
+      source = "${cfg.package.kdesu}/libexec/kf6/kdesud";
+    };
+  };
+}

--- a/pkgs/kde/plasma/kde-cli-tools/default.nix
+++ b/pkgs/kde/plasma/kde-cli-tools/default.nix
@@ -6,4 +6,10 @@ mkKdeDerivation {
   pname = "kde-cli-tools";
 
   extraBuildInputs = [qtsvg];
+
+  postInstall = ''
+    # install a symlink in bin so that kdesu can eventually be found in PATH
+    mkdir -p $out/bin
+    ln -s $out/libexec/kf6/kdesu $out/bin/
+  '';
 }


### PR DESCRIPTION
## Description of changes

Installs a symbolic link to `kdesu` in `$out/bin`, so that `kdesu` can eventually be found in `$PATH`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
