### PR TITLE
ocamlPackages.gitlab: init at 0.1.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22313,6 +22313,12 @@
     githubId = 250877;
     name = "Elmar Athmer";
   };
+  zazedd = {
+    name = "Leonardo Santos";
+    email = "leomendesantos@gmail.com";
+    github = "zazedd";
+    githubId = 93401987;
+  };
   zbioe = {
     name = "Iury Fukuda";
     email = "zbioe@protonmail.com";

--- a/pkgs/development/ocaml-modules/gitlab/default.nix
+++ b/pkgs/development/ocaml-modules/gitlab/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitHub,
+  uri,
+  cohttp-lwt,
+  atdgen,
+  yojson,
+  iso8601,
+  stringext,
+}:
+
+buildDunePackage rec {
+  pname = "gitlab";
+  version = "0.1.8";
+
+  src = fetchFromGitHub {
+    owner = "tmcgilchrist";
+    repo = "ocaml-gitlab";
+    rev = version;
+    hash = "sha256-7pUpH1SoP4eW8ild5j+Tcy+aTXq0+eSkhKUOXJ6Z30k=";
+  };
+
+  minimalOCamlVersion = "4.08";
+
+  buildInputs = [ stringext ];
+
+  nativeBuildInputs = [ atdgen ];
+
+  propagatedBuildInputs = [
+    uri
+    cohttp-lwt
+    atdgen
+    yojson
+    iso8601
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/tmcgilchrist/ocaml-gitlab";
+    description = "Native OCaml bindings to Gitlab REST API v4";
+    license = licenses.bsd3;
+    changelog = "https://github.com/tmcgilchrist/ocaml-gitlab/releases/tag/${version}";
+    maintainers = with maintainers; [ zazedd ];
+  };
+}

--- a/pkgs/development/ocaml-modules/gitlab/jsoo.nix
+++ b/pkgs/development/ocaml-modules/gitlab/jsoo.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildDunePackage,
+  gitlab,
+  cohttp,
+  cohttp-lwt-jsoo,
+  js_of_ocaml-lwt,
+}:
+
+buildDunePackage {
+  pname = "gitlab-jsoo";
+  inherit (gitlab) version src;
+
+  minimalOCamlVersion = "4.08";
+
+  propagatedBuildInputs = [
+    gitlab
+    cohttp
+    cohttp-lwt-jsoo
+    js_of_ocaml-lwt
+  ];
+
+  doCheck = true;
+
+  meta = gitlab.meta // {
+    description = "Gitlab APIv4 JavaScript library";
+  };
+}

--- a/pkgs/development/ocaml-modules/gitlab/unix.nix
+++ b/pkgs/development/ocaml-modules/gitlab/unix.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildDunePackage,
+  gitlab,
+  cmdliner,
+  cohttp,
+  cohttp-lwt-unix,
+  tls,
+  lwt,
+  stringext,
+  alcotest,
+}:
+
+buildDunePackage {
+  pname = "gitlab-unix";
+  inherit (gitlab) version src;
+
+  minimalOCamlVersion = "4.08";
+
+  postPatch = ''
+    substituteInPlace unix/dune --replace-fail "gitlab bytes" "gitlab"
+  '';
+
+  buildInputs = [
+    cohttp
+    tls
+    stringext
+  ];
+
+  propagatedBuildInputs = [
+    gitlab
+    cmdliner
+    cohttp-lwt-unix
+    lwt
+  ];
+
+  checkInputs = [ alcotest ];
+
+  doCheck = true;
+
+  meta = gitlab.meta // {
+    description = "Gitlab APIv4 Unix library";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -610,6 +610,10 @@ let
     github-jsoo = callPackage ../development/ocaml-modules/github/jsoo.nix {  };
     github-unix = callPackage ../development/ocaml-modules/github/unix.nix {  };
 
+    gitlab = callPackage ../development/ocaml-modules/gitlab {  };
+    gitlab-jsoo = callPackage ../development/ocaml-modules/gitlab/jsoo.nix {  };
+    gitlab-unix = callPackage ../development/ocaml-modules/gitlab/unix.nix {  };
+
     gluon = callPackage ../development/ocaml-modules/gluon { };
 
     gluten = callPackage ../development/ocaml-modules/gluten { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Native OCaml bindings to [Gitlab REST API v4](https://docs.gitlab.com/ee/api/README.html).
[Homepage](https://github.com/tmcgilchrist/ocaml-gitlab).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

`dune runtest` ran for each package.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
