### PR TITLE
lib.doRename: add test for nested option priorities

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -492,6 +492,8 @@ checkConfigOutput '^"The option `a\.b. defined in `.*/doRename-warnings\.nix. ha
 checkConfigOutput "^true$" config.result ./doRename-condition.nix ./doRename-condition-enable.nix
 checkConfigOutput "^true$" config.result ./doRename-condition.nix ./doRename-condition-no-enable.nix
 checkConfigOutput "^true$" config.result ./doRename-condition.nix ./doRename-condition-migrated.nix
+# doRename works with priorities on nested options
+checkConfigOutput '^1234$' config.new.foo ./doRename-nested-option-priorities.nix
 
 # Anonymous modules get deduplicated by key
 checkConfigOutput '^"pear"$' config.once.raw ./merge-module-with-key.nix

--- a/lib/tests/modules/doRename-nested-option-priorities.nix
+++ b/lib/tests/modules/doRename-nested-option-priorities.nix
@@ -1,0 +1,13 @@
+{ lib, ... }: {
+  imports = [
+    (lib.doRename { from = ["old"]; to = ["new"]; warn = true; use = x: x; visible = true; })
+  ];
+  options = {
+    new.foo = lib.mkOption {
+      type = lib.types.int;
+    };
+  };
+  config = {
+    old.foo = lib.mkDefault 1234;
+  };
+}


### PR DESCRIPTION
issue: https://github.com/NixOS/nixpkgs/issues/324802
This test demonstrates a bug where lib.doRename leads to a crash when a nested old option is defined with priority

If `old.foo` is defined with priority (mkDefault in this example) and then `old` is renamed to `new`, evaluation crashes with a misleading type error:
```
 error: A definition for option `new.foo' is not of type `signed integer'. Definition values:
       - In [...]:
           {
             _type = "override";
             content = 1234;
             priority = 1000;
           }
```

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
