### PR TITLE
generateLuarocksConfig: dont generate rocks_subdir by default

### DIFF
--- a/pkgs/development/interpreters/lua-5/build-luarocks-package.nix
+++ b/pkgs/development/interpreters/lua-5/build-luarocks-package.nix
@@ -134,12 +134,15 @@ let
       externalDeps = lib.unique (self.externalDeps ++ externalDepsGenerated);
       local_cache = "";
 
+      # To prevent collisions when creating environments, we install the rock
+      # files into per-package subdirectories
+      rocks_subdir = self.rocksSubdir;
+
       # Filter out the lua derivation itself from the Lua module dependency
       # closure, as it doesn't have a rock tree :)
       # luaLib.hasLuaModule
       requiredLuaRocks = lib.filter luaLib.hasLuaModule
         (lua.pkgs.requiredLuaModules (self.nativeBuildInputs ++ self.propagatedBuildInputs));
-      inherit (self) rocksSubdir;
     };
 
     luarocksConfig' = lib.recursiveUpdate luarocksConfig

--- a/pkgs/development/lua-modules/lib.nix
+++ b/pkgs/development/lua-modules/lib.nix
@@ -93,7 +93,6 @@ rec {
       externalDeps ? []
     # a list of lua derivations
     , requiredLuaRocks ? []
-    , rocksSubdir ? "rocks-subdir"
     , ...
     }@args: let
       rocksTrees = lib.imap0
@@ -125,9 +124,6 @@ rec {
 
       generatedConfig = ({
 
-        # To prevent collisions when creating environments, we install the rock
-        # files into per-package subdirectories
-        rocks_subdir = rocksSubdir;
 
         # first tree is the default target where new rocks are installed,
         # any other trees in the list are treated as additional sources of installed rocks for matching dependencies.


### PR DESCRIPTION
## Description of changes

Follow up of https://github.com/NixOS/nixpkgs/pull/324513

Goal is to make generateLuarocksConfig appropriate in more scenarios, in my case, to generate rocks.nvim luarocks config

In nixpkgs, we override the luarocks default for `rocks_subdir` to avoid conflicts when creating lua environments but it is not appropriate for other scenarios.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
