### PR TITLE
python3Packages.beancount: refactor

### DIFF
--- a/pkgs/development/python-modules/beancount/subprocess_python.patch
+++ b/pkgs/development/python-modules/beancount/subprocess_python.patch
@@ -1,0 +1,13 @@
+diff --git a/beancount/tools/treeify_test.py b/beancount/tools/treeify_test.py
+index 851e7692..65f35916 100644
+--- a/beancount/tools/treeify_test.py
++++ b/beancount/tools/treeify_test.py
+@@ -20,7 +20,7 @@ def treeify(string, options=None):
+     Returns:
+       The treeified string.
+     """
+-    pipe = subprocess.Popen([PROGRAM] + (options or []),
++    pipe = subprocess.Popen(["python", PROGRAM] + (options or []),
+                             shell=False,
+                             stdin=subprocess.PIPE,
+                             stdout=subprocess.PIPE,


### PR DESCRIPTION
## Description of changes
This pull request updates Beancount to version [3.0.0](https://github.com/beancount/beancount/releases/tag/3.0.0). Given the major changes in this update, the Python dependencies have been significantly altered.

One of the tests attempts to run a Python script that formats Beancount files. However, the script files were not marked as executable in the Nix store, causing the tests to fail due to permission errors. To address this issue, this pull request includes a patch that adds Python to the `subprocess.Popen` call.

Additionally, several other tests are currently disabled due to failures.

Supersedes #320696

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
