### PR TITLE
{audacious, audacious-plugins}: 4.3.1 -> 4.4, port to qt6

### DIFF
--- a/pkgs/applications/audio/audacious/default.nix
+++ b/pkgs/applications/audio/audacious/default.nix
@@ -1,26 +1,28 @@
 { lib
 , stdenv
 , audacious-plugins
-, fetchurl
-, gettext
+, fetchFromGitHub
 , meson
 , ninja
 , pkg-config
 , qtbase
+, qtsvg
+, qtwayland
 , wrapQtAppsHook
 }:
 
 stdenv.mkDerivation rec {
   pname = "audacious";
-  version = "4.3.1";
+  version = "4.4";
 
-  src = fetchurl {
-    url = "http://distfiles.audacious-media-player.org/audacious-${version}.tar.bz2";
-    sha256 = "sha256-heniaEFQW1HjQu5yotBfGb74lPVnoCnrs/Pgwa20IEI=";
+  src = fetchFromGitHub {
+    owner = "audacious-media-player";
+    repo = "audacious";
+    rev = "${pname}-${version}";
+    hash = "sha256-qAJztvNI3uGmQfECJJ7tJ/xLLgMU5OiW0O3ZSJhvt0k=";
   };
 
   nativeBuildInputs = [
-    gettext
     meson
     ninja
     pkg-config
@@ -29,6 +31,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     qtbase
+    qtsvg
+    qtwayland
   ];
 
   mesonFlags = [
@@ -41,12 +45,14 @@ stdenv.mkDerivation rec {
     ln -s ${audacious-plugins}/share/audacious/Skins $out/share/audacious/
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Lightweight and versatile audio player";
-    homepage = "https://audacious-media-player.org/";
-    maintainers = with maintainers; [ eelco ramkromberg ttuegel thiagokokada ];
-    platforms = with platforms; linux;
-    license = with licenses; [
+    homepage = "https://audacious-media-player.org";
+    downloadPage = "https://github.com/audacious-media-player/audacious";
+    mainProgram = "audacious";
+    maintainers = with lib.maintainers; [ eelco ramkromberg ttuegel thiagokokada ];
+    platforms = lib.platforms.linux;
+    license = with lib.licenses; [
       bsd2
       bsd3 #https://github.com/audacious-media-player/audacious/blob/master/COPYING
       gpl2

--- a/pkgs/applications/audio/audacious/plugins.nix
+++ b/pkgs/applications/audio/audacious/plugins.nix
@@ -1,5 +1,5 @@
 { stdenv
-, fetchurl
+, fetchFromGitHub
 , alsa-lib
 , audacious
 , curl
@@ -8,7 +8,6 @@
 , flac
 , fluidsynth
 , gdk-pixbuf
-, gettext
 , lame
 , libbs2b
 , libcddb
@@ -39,7 +38,7 @@
 , pipewire
 , qtbase
 , qtmultimedia
-, qtx11extras
+, qtwayland
 , soxr
 , vgmstream
 , wavpack
@@ -47,17 +46,18 @@
 
 stdenv.mkDerivation rec {
   pname = "audacious-plugins";
-  version = "4.3.1";
+  version = "4.4";
 
-  src = fetchurl {
-    url = "http://distfiles.audacious-media-player.org/audacious-plugins-${version}.tar.bz2";
-    sha256 = "sha256-Leom469YOi1oTfJAsnsrKTK81lPfTbUAqF9P5dX9yKY=";
+  src = fetchFromGitHub {
+    owner = "audacious-media-player";
+    repo = "audacious-plugins";
+    rev = "${pname}-${version}";
+    hash = "sha256-J9jgBl8J4W9Yvrlg1KlzYgGTmdxUZM9L11rCftKFSlE=";
   };
 
   patches = [ ./0001-Set-plugindir-to-PREFIX-lib-audacious.patch ];
 
   nativeBuildInputs = [
-    gettext
     meson
     ninja
     pkg-config
@@ -98,7 +98,7 @@ stdenv.mkDerivation rec {
     pipewire
     qtbase
     qtmultimedia
-    qtx11extras
+    qtwayland
     soxr
     wavpack
     libopenmpt
@@ -116,5 +116,6 @@ stdenv.mkDerivation rec {
 
   meta = audacious.meta // {
     description = "Plugins for Audacious music player";
+    downloadPage = "https://github.com/audacious-media-player/audacious-plugins";
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -108,6 +108,7 @@ mapAliases ({
   atom-beta = throw "'atom-beta' has been removed because discontinued and deprecated. Consider using 'pulsar', a maintained fork"; # Added 2023-10-01
   atomEnv = throw "'atomEnv' has been removed because 'atom' is discontinued and deprecated. Consider using 'pulsar', a maintained fork"; # Added 2023-10-01
   atomPackages = throw "'atomPackages' has been removed because 'atom' is discontinued and deprecated. Consider using 'pulsar', a maintained fork"; # Added 2023-10-01
+  audaciousQt5 = throw "'audaciousQt5' has been removed, since audacious is built with Qt 6 now"; # Added 2024-07-06
   auditBlasHook = throw "'auditBlasHook' has been removed since it never worked"; # Added 2024-04-02
   authy = throw "'authy' has been removed since it reached end of life"; # Added 2024-04-19
   avldrums-lv2 = x42-avldrums; # Added 2020-03-29

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29452,7 +29452,6 @@ with pkgs;
     # Avoid circular dependency
     audacious = audacious.override { audacious-plugins = null; };
   };
-  audaciousQt5 = audacious;
 
   audacity = callPackage ../applications/audio/audacity {
     inherit (darwin.apple_sdk.frameworks) AppKit CoreAudioKit;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29447,8 +29447,8 @@ with pkgs;
 
   aucatctl = callPackage ../applications/audio/aucatctl { };
 
-  audacious = libsForQt5.callPackage ../applications/audio/audacious { };
-  audacious-plugins = libsForQt5.callPackage ../applications/audio/audacious/plugins.nix {
+  audacious = qt6Packages.callPackage ../applications/audio/audacious { };
+  audacious-plugins = qt6Packages.callPackage ../applications/audio/audacious/plugins.nix {
     # Avoid circular dependency
     audacious = audacious.override { audacious-plugins = null; };
   };


### PR DESCRIPTION
## Description of changes

https://audacious-media-player.org/news/59-audacious-4-4-released

https://github.com/audacious-media-player

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
