### PR TITLE
mypy: 1.10.0 → 1.10.1

### DIFF
--- a/pkgs/applications/science/misc/cwltool/default.nix
+++ b/pkgs/applications/science/misc/cwltool/default.nix
@@ -24,7 +24,8 @@ python3.pkgs.buildPythonApplication rec {
       --replace '"schema-salad >= 8.4.20230426093816, < 9",' "" \
       --replace "PYTEST_RUNNER + " ""
     substituteInPlace pyproject.toml \
-      --replace "ruamel.yaml>=0.16.0,<0.18" "ruamel.yaml"
+      --replace "ruamel.yaml>=0.16.0,<0.18" "ruamel.yaml" \
+      --replace "mypy==1.10.0" "mypy==1.10.*"
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  gitUpdater,
   pythonAtLeast,
   pythonOlder,
 
@@ -41,6 +42,9 @@ buildPythonPackage rec {
     repo = "mypy";
     rev = "refs/tags/v${version}";
     hash = "sha256-NCnc4C/YFKHN/kT7RTFCYs/yC00Kt1E7mWCoQuUjxG8=";
+  };
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -32,7 +32,7 @@
 
 buildPythonPackage rec {
   pname = "mypy";
-  version = "1.10.0";
+  version = "1.10.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     owner = "python";
     repo = "mypy";
     rev = "refs/tags/v${version}";
-    hash = "sha256-NCnc4C/YFKHN/kT7RTFCYs/yC00Kt1E7mWCoQuUjxG8=";
+    hash = "sha256-joV+elRaAICNQHkYuYtTDjvOUkHPsRkG1OLRvdxeIHc=";
   };
   passthru.updateScript = gitUpdater {
     rev-prefix = "v";

--- a/pkgs/development/python-modules/schema-salad/default.nix
+++ b/pkgs/development/python-modules/schema-salad/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   cachecontrol,
   fetchFromGitHub,
+  fetchpatch,
   importlib-resources,
   mistune,
   mypy,
@@ -55,6 +56,11 @@ buildPythonPackage rec {
     ]
     ++ cachecontrol.optional-dependencies.filecache
     ++ lib.optionals (pythonOlder "3.9") [ importlib-resources ];
+
+  patches = [ (fetchpatch {
+    url = "https://patch-diff.githubusercontent.com/raw/common-workflow-language/schema_salad/pull/840.patch";
+    hash = "sha256-fke75FCCn23LAMJ5bDWJpuBR6E9XIpjmzzXSbjqpxn8=";
+  } ) ];
 
   nativeCheckInputs = [ pytestCheckHook ] ++ passthru.optional-dependencies.pycodegen;
 


### PR DESCRIPTION
## Description of changes

In `mypy`:
- add `passthru.updateScript`
  otherwise, automatic update (with `update.nix`) did not work
- update to [v1.10.1](https://github.com/python/mypy/compare/v1.10.0...v1.10.1)
  backports an error-reporting bugfix

In `cwltool` and `python3Packages.schema-salad`, fix the version constraint of the `mypy` dependency.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested `mypy.passthru.tests`, i.e. `nixosTests.nixos-test-driver`
- [x] Tested compilation of all affected packages using `nixpkgs-review`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  ran `mypy` under CPython 3.12, on a Python project I was just working on, it reports the same output
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
