### PR TITLE
python3Packages.pynput: 1.7.6 → 1.7.7

### DIFF
--- a/pkgs/development/python-modules/pynput/default.nix
+++ b/pkgs/development/python-modules/pynput/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonPackage rec {
   pname = "pynput";
-  version = "1.7.6";
-  format = "pyproject";
+  version = "1.7.7";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "moses-palmer";
     repo = "pynput";
     rev = "refs/tags/v${version}";
-    hash = "sha256-gRq4LS9NvPL98N0Jk09Z0GfoHS09o3zM284BEWS+NW4=";
+    hash = "sha256-6PwfFU1f/osEamSX9kxpOl2wDnrQk5qq1kHi2BgSHes=";
   };
   passthru.updateScript = gitUpdater {
     rev-prefix = "v";
@@ -37,7 +37,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'sphinx >=1.3.1'" ""
+      --replace-fail "'sphinx >=1.3.1'," "" \
+      --replace-fail "'twine >=4.0']" "]"
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/pynput/default.nix
+++ b/pkgs/development/python-modules/pynput/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  gitUpdater,
 
   # build-system
   setuptools,
@@ -29,6 +30,9 @@ buildPythonPackage rec {
     repo = "pynput";
     rev = "refs/tags/v${version}";
     hash = "sha256-gRq4LS9NvPL98N0Jk09Z0GfoHS09o3zM284BEWS+NW4=";
+  };
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
   };
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

In `python3Packages.pynput`:
- add `passthru.updateScript`,
- update to v1.7.7 using `update.nix`,
- update the `postPatch` phase, as the list of dependencies in `setup.py` changed

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested compilation of all affected packages using `nixpkgs-review`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
