### PR TITLE
[24.05] treewide: remove jonringer as package maintainer and code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -124,7 +124,7 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @raitobezarius @ma27
 
 # Python-related code and docs
 /doc/languages-frameworks/python.section.md                 @mweinelt
-/pkgs/development/interpreters/python/hooks                 @jonringer
+/pkgs/development/interpreters/python/hooks
 
 # Haskell
 /doc/languages-frameworks/haskell.section.md  @sternenseemann @maralorn @ncfavier
@@ -258,13 +258,13 @@ nixos/modules/services/networking/networkmanager.nix @Janik-Haag
 /pkgs/top-level/emacs-packages.nix              @adisbladis
 
 # Neovim
-/pkgs/applications/editors/neovim      @figsoda @jonringer @teto
+/pkgs/applications/editors/neovim      @figsoda @teto
 
 # VimPlugins
-/pkgs/applications/editors/vim/plugins         @figsoda @jonringer
+/pkgs/applications/editors/vim/plugins         @figsoda
 
 # VsCode Extensions
-/pkgs/applications/editors/vscode/extensions   @jonringer
+/pkgs/applications/editors/vscode/extensions
 
 # PHP interpreter, packages, extensions, tests and documentation
 /doc/languages-frameworks/php.section.md          @aanderse @drupol @globin @ma27 @talyz
@@ -361,4 +361,3 @@ pkgs/by-name/in/incus/                  @adamcstephens
 pkgs/by-name/lx/lxc*                    @adamcstephens
 pkgs/by-name/lx/lxd*                    @adamcstephens
 pkgs/os-specific/linux/lxc/             @adamcstephens
-

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10019,13 +10019,6 @@
     github = "jonochang";
     githubId = 13179;
   };
-  jonringer = {
-    email = "jonringer117@gmail.com";
-    matrix = "@jonringer:matrix.org";
-    github = "jonringer";
-    githubId = 7673602;
-    name = "Jonathan Ringer";
-  };
   jopejoe1 = {
     email = "johannes@joens.email";
     matrix = "@jopejoe1:matrix.org";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -485,7 +485,6 @@ with lib.maintainers; {
     members = [
       cleverca22
       disassembler
-      jonringer
       manveru
       nrdxp
     ];
@@ -859,7 +858,6 @@ with lib.maintainers; {
   python = {
     members = [
       hexa
-      jonringer
       tjni
     ];
     scope = "Maintain the Python interpreter and related packages.";
@@ -983,7 +981,6 @@ with lib.maintainers; {
     members = [
       atemu
       eclairevoyant
-      jonringer
       k900
       mkg20001
     ];
@@ -1021,7 +1018,6 @@ with lib.maintainers; {
   vim = {
     members = [
       figsoda
-      jonringer
       softinio
       teto
     ];

--- a/nixos/modules/services/databases/neo4j.nix
+++ b/nixos/modules/services/databases/neo4j.nix
@@ -620,6 +620,6 @@ in {
     };
 
   meta = {
-    maintainers = with lib.maintainers; [ patternspandemic jonringer ];
+    maintainers = with lib.maintainers; [ patternspandemic ];
   };
 }

--- a/nixos/modules/services/hardware/openrgb.nix
+++ b/nixos/modules/services/hardware/openrgb.nix
@@ -51,5 +51,5 @@ in {
     };
   };
 
-  meta.maintainers = with lib.maintainers; [ jonringer ];
+  meta.maintainers = with lib.maintainers; [ ];
 }

--- a/pkgs/applications/misc/hcl2json/default.nix
+++ b/pkgs/applications/misc/hcl2json/default.nix
@@ -22,7 +22,7 @@ buildGoModule rec {
     description = "Convert hcl2 to json";
     homepage = "https://github.com/tmccombs/hcl2json";
     license = licenses.asl20;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
     mainProgram = "hcl2json";
   };
 }

--- a/pkgs/applications/misc/openrgb/default.nix
+++ b/pkgs/applications/misc/openrgb/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Open source RGB lighting control";
     homepage = "https://gitlab.com/CalcProgrammer1/OpenRGB";
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     mainProgram = "openrgb";

--- a/pkgs/applications/networking/cluster/nomad-autoscaler/default.nix
+++ b/pkgs/applications/networking/cluster/nomad-autoscaler/default.nix
@@ -94,7 +94,7 @@ let
       mainProgram = "nomad-autoscaler";
       homepage = "https://github.com/hashicorp/nomad-autoscaler";
       license = licenses.mpl20;
-      maintainers = with maintainers; [ jonringer ];
+      maintainers = with maintainers; [ ];
     };
   };
 

--- a/pkgs/applications/printing/pappl/default.nix
+++ b/pkgs/applications/printing/pappl/default.nix
@@ -58,6 +58,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/michaelrsweet/pappl";
     license = licenses.asl20;
     platforms = platforms.linux; # should also work for darwin, but requires additional work
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/applications/system/glances/default.nix
+++ b/pkgs/applications/system/glances/default.nix
@@ -51,6 +51,6 @@ buildPythonApplication rec {
     mainProgram = "glances";
     changelog = "https://github.com/nicolargo/glances/blob/v${version}/NEWS.rst";
     license = licenses.lgpl3Only;
-    maintainers = with maintainers; [ jonringer primeos koral ];
+    maintainers = with maintainers; [ primeos koral ];
   };
 }

--- a/pkgs/by-name/sp/spicetify-cli/package.nix
+++ b/pkgs/by-name/sp/spicetify-cli/package.nix
@@ -46,7 +46,6 @@ buildGoModule rec {
     homepage = "https://github.com/spicetify/spicetify-cli/";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [
-      jonringer
       mdarocha
     ];
     mainProgram = "spicetify";

--- a/pkgs/development/libraries/fbjni/default.nix
+++ b/pkgs/development/libraries/fbjni/default.nix
@@ -57,6 +57,6 @@ stdenv.mkDerivation rec {
     description = "A library designed to simplify the usage of the Java Native Interface";
     homepage = "https://github.com/facebookincubator/fbjni";
     license = licenses.asl20;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/libraries/onnxruntime/default.nix
+++ b/pkgs/development/libraries/onnxruntime/default.nix
@@ -249,6 +249,6 @@ effectiveStdenv.mkDerivation rec {
     # https://github.com/microsoft/onnxruntime/blob/master/BUILD.md#architectures
     platforms = platforms.unix;
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer puffnfresh ck3d cbourjau ];
+    maintainers = with maintainers; [ puffnfresh ck3d cbourjau ];
   };
 }

--- a/pkgs/development/libraries/protobuf/generic.nix
+++ b/pkgs/development/libraries/protobuf/generic.nix
@@ -108,7 +108,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.bsd3;
     platforms = lib.platforms.all;
     homepage = "https://protobuf.dev/";
-    maintainers = with lib.maintainers; [ jonringer ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "protoc";
   };
 })

--- a/pkgs/development/python-modules/applicationinsights/default.nix
+++ b/pkgs/development/python-modules/applicationinsights/default.nix
@@ -21,6 +21,6 @@ buildPythonPackage rec {
     description = "This project extends the Application Insights API surface to support Python";
     homepage = "https://github.com/Microsoft/ApplicationInsights-Python";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/argon2-cffi-bindings/default.nix
+++ b/pkgs/development/python-modules/argon2-cffi-bindings/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
     description = "Low-level CFFI bindings for Argon2";
     homepage = "https://github.com/hynek/argon2-cffi-bindings";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-appconfiguration/default.nix
+++ b/pkgs/development/python-modules/azure-appconfiguration/default.nix
@@ -37,6 +37,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/appconfiguration/azure-appconfiguration";
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-appconfiguration_${version}/sdk/appconfiguration/azure-appconfiguration/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-core/default.nix
+++ b/pkgs/development/python-modules/azure-core/default.nix
@@ -99,6 +99,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/core/azure-core";
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-core_${version}/sdk/core/azure-core/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-cosmos/default.nix
+++ b/pkgs/development/python-modules/azure-cosmos/default.nix
@@ -39,6 +39,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/cosmos/azure-cosmos";
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-cosmos_${version}/sdk/cosmos/azure-cosmos/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-data-tables/default.nix
+++ b/pkgs/development/python-modules/azure-data-tables/default.nix
@@ -38,6 +38,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-data-tables_${version}/sdk/tables/azure-data-tables/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-functions-devops-build/default.nix
+++ b/pkgs/development/python-modules/azure-functions-devops-build/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "Integrate Azure Functions with Azure DevOps. Specifically made for the Azure CLI";
     homepage = "https://github.com/Azure/azure-functions-devops-build";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-keyvault-administration/default.nix
+++ b/pkgs/development/python-modules/azure-keyvault-administration/default.nix
@@ -41,6 +41,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-administration";
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-administration_${version}/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-keyvault-certificates/default.nix
+++ b/pkgs/development/python-modules/azure-keyvault-certificates/default.nix
@@ -43,6 +43,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/keyvault/azure-keyvault-certificates";
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-certificates_${version}/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-keyvault-keys/default.nix
+++ b/pkgs/development/python-modules/azure-keyvault-keys/default.nix
@@ -51,6 +51,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/keyvault/azure-keyvault-keys";
     changelog = "https://github.com/Azure/azure-sdk-for-python/tree/azure-keyvault-keys_${version}/sdk/keyvault/azure-keyvault-keys";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-keyvault-secrets/default.nix
+++ b/pkgs/development/python-modules/azure-keyvault-secrets/default.nix
@@ -39,6 +39,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/keyvault/azure-keyvault-secrets";
     changelog = "https://github.com/Azure/azure-sdk-for-python/tree/azure-keyvault-secrets_${version}/sdk/keyvault/azure-keyvault-secrets";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-keyvault/default.nix
+++ b/pkgs/development/python-modules/azure-keyvault/default.nix
@@ -40,6 +40,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Key Vault Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-loganalytics/default.nix
+++ b/pkgs/development/python-modules/azure-loganalytics/default.nix
@@ -33,7 +33,6 @@ buildPythonPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [
       maxwilson
-      jonringer
     ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-apimanagement/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-apimanagement/default.nix
@@ -42,6 +42,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/apimanagement/azure-mgmt-apimanagement";
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-mgmt-apimanagement_${version}/sdk/apimanagement/azure-mgmt-apimanagement/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-appconfiguration/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-appconfiguration/default.nix
@@ -45,6 +45,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/appconfiguration/azure-mgmt-appconfiguration";
     changelog = "https://github.com/Azure/azure-sdk-for-python/tree/azure-mgmt-appconfiguration_${version}/sdk/appconfiguration/azure-mgmt-appconfiguration";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-applicationinsights/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-applicationinsights/default.nix
@@ -38,7 +38,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [
-      jonringer
       maxwilson
     ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-botservice/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-botservice/default.nix
@@ -43,6 +43,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/botservice/azure-mgmt-botservice";
     changelog = "https://github.com/Azure/azure-sdk-for-python/tree/azure-mgmt-botservice_${version}/sdk/botservice/azure-mgmt-botservice";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-commerce/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-commerce/default.nix
@@ -45,7 +45,6 @@ buildPythonPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [
       maxwilson
-      jonringer
     ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-containerregistry/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-containerregistry/default.nix
@@ -39,6 +39,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-mgmt-containerregistry_${version}/sdk/containerregistry/azure-mgmt-containerregistry/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-core/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-core/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
     description = "Microsoft Azure Management Core Library for Python";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-databoxedge/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-databoxedge/default.nix
@@ -40,6 +40,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/databox/azure-mgmt-databox";
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-mgmt-databoxedge_${version}/sdk/databox/azure-mgmt-databox/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-datalake-store/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-datalake-store/default.nix
@@ -36,7 +36,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [
-      jonringer
       maxwilson
     ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-datamigration/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-datamigration/default.nix
@@ -38,7 +38,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [
-      jonringer
       maxwilson
     ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-deploymentmanager/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-deploymentmanager/default.nix
@@ -44,6 +44,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/deploymentmanager/azure-mgmt-deploymentmanager";
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-mgmt-deploymentmanager_${version}/sdk/deploymentmanager/azure-mgmt-deploymentmanager/setup.py";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-devtestlabs/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-devtestlabs/default.nix
@@ -38,7 +38,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [
-      jonringer
       maxwilson
     ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-dns/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-dns/default.nix
@@ -37,7 +37,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [
-      jonringer
       maxwilson
     ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-extendedlocation/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-extendedlocation/default.nix
@@ -37,6 +37,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/extendedlocation/azure-mgmt-extendedlocation";
     changelog = "https://github.com/Azure/azure-sdk-for-python/tree/azure-mgmt-extendedlocation_${version}/sdk/extendedlocation/azure-mgmt-extendedlocation";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-hdinsight/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-hdinsight/default.nix
@@ -45,6 +45,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/hdinsight/azure-mgmt-hdinsight";
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-mgmt-hdinsight_${version}/sdk/hdinsight/azure-mgmt-hdinsight/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-imagebuilder/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-imagebuilder/default.nix
@@ -43,6 +43,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/compute/azure-mgmt-imagebuilder";
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-mgmt-imagebuilder_${version}/sdk/compute/azure-mgmt-imagebuilder/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-iothubprovisioningservices/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-iothubprovisioningservices/default.nix
@@ -38,7 +38,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [
-      jonringer
       maxwilson
     ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-keyvault/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-keyvault/default.nix
@@ -37,7 +37,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-mgmt-keyvault_${version}/sdk/keyvault/azure-mgmt-keyvault/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [
-      jonringer
       maxwilson
     ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-kusto/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-kusto/default.nix
@@ -42,6 +42,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-mgmt-kusto_${version}/sdk/kusto/azure-mgmt-kusto/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-managedservices/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-managedservices/default.nix
@@ -45,6 +45,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/managedservices/azure-mgmt-managedservices";
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-mgmt-managedservices_${version}/sdk/managedservices/azure-mgmt-managedservices/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-netapp/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-netapp/default.nix
@@ -39,6 +39,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-mgmt-netapp_${version}/sdk/netapp/azure-mgmt-netapp/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-network/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-network/default.nix
@@ -44,7 +44,6 @@ buildPythonPackage rec {
     maintainers = with maintainers; [
       olcai
       maxwilson
-      jonringer
     ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-privatedns/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-privatedns/default.nix
@@ -42,6 +42,6 @@ buildPythonPackage rec {
     description = "Microsoft Azure DNS Private Zones Client Library for Python";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-redhatopenshift/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-redhatopenshift/default.nix
@@ -38,6 +38,6 @@ buildPythonPackage rec {
     description = "Microsoft Azure Red Hat Openshift Management Client Library for Python";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-resource/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-resource/default.nix
@@ -41,7 +41,6 @@ buildPythonPackage rec {
     maintainers = with maintainers; [
       olcai
       maxwilson
-      jonringer
     ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-security/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-security/default.nix
@@ -42,6 +42,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/security/azure-mgmt-security";
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-mgmt-security_${version}/sdk/security/azure-mgmt-security/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-servicefabricmanagedclusters/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-servicefabricmanagedclusters/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Service Fabric Cluster Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-servicelinker/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-servicelinker/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "Microsoft Azure Servicelinker Management Client Library for Python";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-sqlvirtualmachine/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-sqlvirtualmachine/default.nix
@@ -45,6 +45,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/sql/azure-mgmt-sqlvirtualmachine";
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-mgmt-sqlvirtualmachine_${version}/sdk/sql/azure-mgmt-sqlvirtualmachine/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-storage/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-storage/default.nix
@@ -36,7 +36,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [
-      jonringer
       olcai
       maxwilson
     ];

--- a/pkgs/development/python-modules/azure-mgmt-synapse/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-synapse/default.nix
@@ -39,6 +39,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/synapse/azure-mgmt-synapse";
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-mgmt-synapse_${version}/sdk/synapse/azure-mgmt-synapse/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-multiapi-storage/default.nix
+++ b/pkgs/development/python-modules/azure-multiapi-storage/default.nix
@@ -50,6 +50,6 @@ buildPythonPackage rec {
     description = "Microsoft Azure Storage Client Library for Python with multi API version support.";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-synapse-accesscontrol/default.nix
+++ b/pkgs/development/python-modules/azure-synapse-accesscontrol/default.nix
@@ -40,6 +40,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/synapse/azure-synapse-accesscontrol";
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-synapse-accesscontrol_${version}/sdk/synapse/azure-synapse-accesscontrol/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-synapse-artifacts/default.nix
+++ b/pkgs/development/python-modules/azure-synapse-artifacts/default.nix
@@ -38,6 +38,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-synapse-artifacts_${version}/sdk/synapse/azure-synapse-artifacts/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-synapse-managedprivateendpoints/default.nix
+++ b/pkgs/development/python-modules/azure-synapse-managedprivateendpoints/default.nix
@@ -39,6 +39,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/synapse/azure-synapse-managedprivateendpoints";
     changelog = "https://github.com/Azure/azure-sdk-for-python/tree/azure-synapse-managedprivateendpoints_${version}/sdk/synapse/azure-synapse-managedprivateendpoints";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-synapse-spark/default.nix
+++ b/pkgs/development/python-modules/azure-synapse-spark/default.nix
@@ -37,6 +37,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/synapse/azure-synapse-spark";
     changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-synapse-spark_${version}/sdk/synapse/azure-synapse-spark/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/backports-zoneinfo/default.nix
+++ b/pkgs/development/python-modules/backports-zoneinfo/default.nix
@@ -75,6 +75,6 @@ buildPythonPackage rec {
     description = "Backport of the standard library module zoneinfo";
     homepage = "https://github.com/pganssle/zoneinfo";
     license = licenses.asl20;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/bids-validator/default.nix
+++ b/pkgs/development/python-modules/bids-validator/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/bids-standard/bids-validator";
     changelog = "https://github.com/bids-standard/bids-validator/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/chart-studio/default.nix
+++ b/pkgs/development/python-modules/chart-studio/default.nix
@@ -50,6 +50,6 @@ buildPythonPackage rec {
     description = "Utilities for interfacing with Plotly's Chart Studio service";
     homepage = "https://github.com/plotly/plotly.py/tree/master/packages/python/chart-studio";
     license = with licenses; [ mit ];
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/delegator-py/default.nix
+++ b/pkgs/development/python-modules/delegator-py/default.nix
@@ -25,6 +25,6 @@ buildPythonPackage rec {
     description = "Subprocesses for Humans 2.0";
     homepage = "https://github.com/amitt001/delegator.py";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/docker/default.nix
+++ b/pkgs/development/python-modules/docker/default.nix
@@ -70,6 +70,6 @@ buildPythonPackage rec {
     description = "An API client for docker written in Python";
     homepage = "https://github.com/docker/docker-py";
     license = licenses.asl20;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/elementpath/default.nix
+++ b/pkgs/development/python-modules/elementpath/default.nix
@@ -32,6 +32,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/sissaschool/elementpath";
     changelog = "https://github.com/sissaschool/elementpath/blob/v${version}/CHANGELOG.rst";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/empty-files/default.nix
+++ b/pkgs/development/python-modules/empty-files/default.nix
@@ -28,6 +28,6 @@ buildPythonPackage rec {
     description = "Null Object pattern for files";
     homepage = "https://github.com/approvals/EmptyFiles.Python";
     license = licenses.asl20;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/hypothesis-auto/default.nix
+++ b/pkgs/development/python-modules/hypothesis-auto/default.nix
@@ -39,6 +39,6 @@ buildPythonPackage rec {
     description = "Enables fully automatic tests for type annotated functions";
     homepage = "https://github.com/timothycrosley/hypothesis-auto/";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/iniconfig/default.nix
+++ b/pkgs/development/python-modules/iniconfig/default.nix
@@ -37,6 +37,6 @@ buildPythonPackage rec {
     description = "brain-dead simple parsing of ini files";
     homepage = "https://github.com/pytest-dev/iniconfig";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/iteration-utilities/default.nix
+++ b/pkgs/development/python-modules/iteration-utilities/default.nix
@@ -29,6 +29,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/MSeifert04/iteration_utilities";
     changelog = "https://github.com/MSeifert04/iteration_utilities/releases/tag/v${version}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/javaproperties/default.nix
+++ b/pkgs/development/python-modules/javaproperties/default.nix
@@ -37,6 +37,6 @@ buildPythonPackage rec {
     description = "Microsoft Azure API Management Client Library for Python";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/jinja2-ansible-filters/default.nix
+++ b/pkgs/development/python-modules/jinja2-ansible-filters/default.nix
@@ -30,6 +30,6 @@ buildPythonPackage rec {
     description = "Jinja2 Ansible Filters";
     homepage = "https://pypi.org/project/jinja2-ansible-filters/";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/jschema-to-python/default.nix
+++ b/pkgs/development/python-modules/jschema-to-python/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "Generate source code for Python classes from a JSON schema";
     homepage = "https://github.com/microsoft/jschema-to-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/jupyter-server-mathjax/default.nix
+++ b/pkgs/development/python-modules/jupyter-server-mathjax/default.nix
@@ -40,6 +40,6 @@ buildPythonPackage rec {
     description = "MathJax resources as a Jupyter Server Extension";
     homepage = "https://github.com/jupyter-server/jupyter_server_mathjax";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/jupyterlab-pygments/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-pygments/default.nix
@@ -45,6 +45,6 @@ buildPythonPackage rec {
     description = "Jupyterlab syntax coloring theme for pygments";
     homepage = "https://github.com/jupyterlab/jupyterlab_pygments";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/jupyterlab-widgets/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-widgets/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "Jupyter Widgets JupyterLab Extension";
     homepage = "https://github.com/jupyter-widgets/ipywidgets";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/knack/default.nix
+++ b/pkgs/development/python-modules/knack/default.nix
@@ -55,6 +55,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/microsoft/knack/blob/v${version}/HISTORY.rst";
     platforms = platforms.all;
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/localstack-client/default.nix
+++ b/pkgs/development/python-modules/localstack-client/default.nix
@@ -46,6 +46,6 @@ buildPythonPackage rec {
     description = "A lightweight Python client for LocalStack";
     homepage = "https://github.com/localstack/localstack-python-client";
     license = licenses.asl20;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/localstack-ext/default.nix
+++ b/pkgs/development/python-modules/localstack-ext/default.nix
@@ -63,6 +63,6 @@ buildPythonPackage rec {
     description = "Extensions for LocalStack";
     homepage = "https://github.com/localstack/localstack";
     license = licenses.asl20;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/localstack/default.nix
+++ b/pkgs/development/python-modules/localstack/default.nix
@@ -69,6 +69,6 @@ buildPythonPackage rec {
     description = "A fully functional local Cloud stack";
     homepage = "https://github.com/localstack/localstack";
     license = licenses.asl20;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/lxml/default.nix
+++ b/pkgs/development/python-modules/lxml/default.nix
@@ -57,6 +57,6 @@ buildPythonPackage rec {
     description = "Pythonic binding for the libxml2 and libxslt libraries";
     homepage = "https://lxml.de";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/matplotlib-inline/default.nix
+++ b/pkgs/development/python-modules/matplotlib-inline/default.nix
@@ -45,6 +45,6 @@ buildPythonPackage rec {
     description = "Matplotlib Inline Back-end for IPython and Jupyter";
     homepage = "https://github.com/ipython/matplotlib-inline";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/mkdocs-mermaid2-plugin/default.nix
+++ b/pkgs/development/python-modules/mkdocs-mermaid2-plugin/default.nix
@@ -46,6 +46,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/fralau/mkdocs-mermaid2-plugin";
     changelog = "https://github.com/fralau/mkdocs-mermaid2-plugin/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/msrest/default.nix
+++ b/pkgs/development/python-modules/msrest/default.nix
@@ -79,7 +79,6 @@ buildPythonPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [
       bendlas
-      jonringer
       maxwilson
     ];
   };

--- a/pkgs/development/python-modules/msrestazure/default.nix
+++ b/pkgs/development/python-modules/msrestazure/default.nix
@@ -48,7 +48,6 @@ buildPythonPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [
       bendlas
-      jonringer
     ];
   };
 }

--- a/pkgs/development/python-modules/num2words/default.nix
+++ b/pkgs/development/python-modules/num2words/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     mainProgram = "num2words";
     homepage = "https://github.com/savoirfairelinux/num2words";
     license = licenses.lgpl21;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
 
     longDescription = "num2words is a library that converts numbers like 42 to words like forty-two. It supports multiple languages (see the list below for full list of languages) and can even generate ordinal numbers like forty-second";
   };

--- a/pkgs/development/python-modules/plux/default.nix
+++ b/pkgs/development/python-modules/plux/default.nix
@@ -37,6 +37,6 @@ buildPythonPackage rec {
     description = "Dynamic code loading framework for building pluggable Python distributions";
     homepage = "https://github.com/localstack/plux";
     license = licenses.asl20;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/poetry-core/default.nix
+++ b/pkgs/development/python-modules/poetry-core/default.nix
@@ -55,6 +55,6 @@ buildPythonPackage rec {
     description = "Core utilities for Poetry";
     homepage = "https://github.com/python-poetry/poetry-core/";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/portalocker/default.nix
+++ b/pkgs/development/python-modules/portalocker/default.nix
@@ -51,6 +51,6 @@ buildPythonPackage rec {
     description = "A library to provide an easy API to file locking";
     homepage = "https://github.com/WoLpH/portalocker";
     license = licenses.psfl;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/psutil/default.nix
+++ b/pkgs/development/python-modules/psutil/default.nix
@@ -72,6 +72,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/giampaolo/psutil";
     changelog = "https://github.com/giampaolo/psutil/blob/release-${version}/HISTORY.rst";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/purl/default.nix
+++ b/pkgs/development/python-modules/purl/default.nix
@@ -28,6 +28,6 @@ buildPythonPackage rec {
     description = "Immutable URL class for easy URL-building and manipulation";
     homepage = "https://github.com/codeinthehole/purl";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pybids/default.nix
+++ b/pkgs/development/python-modules/pybids/default.nix
@@ -71,7 +71,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/bids-standard/pybids";
     changelog = "https://github.com/bids-standard/pybids/blob/${version}/CHANGELOG.rst";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
     mainProgram = "pybids";
   };
 }

--- a/pkgs/development/python-modules/pydocumentdb/default.nix
+++ b/pkgs/development/python-modules/pydocumentdb/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "Azure Cosmos DB API";
     homepage = "https://github.com/Azure/azure-cosmos-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pytest-black/default.nix
+++ b/pkgs/development/python-modules/pytest-black/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     description = "A pytest plugin to enable format checking with black";
     homepage = "https://github.com/shopkeep/pytest-black";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pytest-xprocess/default.nix
+++ b/pkgs/development/python-modules/pytest-xprocess/default.nix
@@ -40,6 +40,6 @@ buildPythonPackage rec {
     description = "Pytest external process plugin";
     homepage = "https://github.com/pytest-dev";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pyyaml-include/default.nix
+++ b/pkgs/development/python-modules/pyyaml-include/default.nix
@@ -37,6 +37,6 @@ buildPythonPackage rec {
     description = "Extending PyYAML with a custom constructor for including YAML files within YAML files";
     homepage = "https://github.com/tanbro/pyyaml-include";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/railroad-diagrams/default.nix
+++ b/pkgs/development/python-modules/railroad-diagrams/default.nix
@@ -26,6 +26,6 @@ buildPythonPackage rec {
     description = "Module to generate SVG railroad syntax diagrams";
     homepage = "https://github.com/tabatkins/railroad-diagrams";
     license = licenses.cc0;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/sarif-om/default.nix
+++ b/pkgs/development/python-modules/sarif-om/default.nix
@@ -30,6 +30,6 @@ buildPythonPackage rec {
     description = "Classes implementing the SARIF 2.1.0 object model";
     homepage = "https://github.com/microsoft/sarif-python-om";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/scramp/default.nix
+++ b/pkgs/development/python-modules/scramp/default.nix
@@ -52,6 +52,6 @@ buildPythonPackage rec {
     description = "Implementation of the SCRAM authentication protocol";
     homepage = "https://github.com/tlocke/scramp";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/secure/default.nix
+++ b/pkgs/development/python-modules/secure/default.nix
@@ -34,6 +34,6 @@ buildPythonPackage rec {
     description = "Adds optional security headers and cookie attributes for Python web frameworks";
     homepage = "https://github.com/TypeError/secure.py";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/sshtunnel/default.nix
+++ b/pkgs/development/python-modules/sshtunnel/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
     mainProgram = "sshtunnel";
     homepage = "https://github.com/pahaz/sshtunnel";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/stone/default.nix
+++ b/pkgs/development/python-modules/stone/default.nix
@@ -67,7 +67,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/dropbox/stone";
     changelog = "https://github.com/dropbox/stone/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
     mainProgram = "stone";
   };
 }

--- a/pkgs/development/python-modules/strictyaml/default.nix
+++ b/pkgs/development/python-modules/strictyaml/default.nix
@@ -40,6 +40,6 @@ buildPythonPackage rec {
     homepage = "https://hitchdev.com/strictyaml/";
     changelog = "https://hitchdev.com/strictyaml/changelog/";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/unittest-data-provider/default.nix
+++ b/pkgs/development/python-modules/unittest-data-provider/default.nix
@@ -18,6 +18,6 @@ buildPythonPackage rec {
     description = "PHPUnit-like @dataprovider decorator for unittest";
     homepage = "https://github.com/yourlabs/unittest-data-provider";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/vsts-cd-manager/default.nix
+++ b/pkgs/development/python-modules/vsts-cd-manager/default.nix
@@ -30,6 +30,6 @@ buildPythonPackage rec {
     description = "Microsoft Azure API Management Client Library for Python";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/vsts/default.nix
+++ b/pkgs/development/python-modules/vsts/default.nix
@@ -31,6 +31,6 @@ buildPythonPackage rec {
     description = "Python APIs for interacting with and managing Azure DevOps";
     homepage = "https://github.com/microsoft/azure-devops-python-api";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/xapian/default.nix
+++ b/pkgs/development/python-modules/xapian/default.nix
@@ -45,6 +45,6 @@ buildPythonPackage rec {
     homepage = "https://xapian.org/";
     changelog = "https://xapian.org/docs/xapian-bindings-${version}/NEWS";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/xdg/default.nix
+++ b/pkgs/development/python-modules/xdg/default.nix
@@ -34,6 +34,6 @@ buildPythonPackage rec {
     description = "XDG Base Directory Specification for Python";
     homepage = "https://github.com/srstevenson/xdg";
     license = licenses.isc;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/xmlschema/default.nix
+++ b/pkgs/development/python-modules/xmlschema/default.nix
@@ -48,6 +48,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/sissaschool/xmlschema";
     changelog = "https://github.com/sissaschool/xmlschema/blob/${src.rev}/CHANGELOG.rst";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/yamllint/default.nix
+++ b/pkgs/development/python-modules/yamllint/default.nix
@@ -54,7 +54,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/adrienverge/yamllint/blob/v${version}/CHANGELOG.rst";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [
-      jonringer
       mikefaille
     ];
   };

--- a/pkgs/games/dwarf-fortress/dwarf-therapist/default.nix
+++ b/pkgs/games/dwarf-fortress/dwarf-therapist/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     mainProgram = "dwarftherapist";
     description = "Tool to manage dwarves in a running game of Dwarf Fortress";
-    maintainers = with maintainers; [ abbradar bendlas numinit jonringer ];
+    maintainers = with maintainers; [ abbradar bendlas numinit ];
     license = licenses.mit;
     platforms = platforms.x86;
     homepage = "https://github.com/Dwarf-Therapist/Dwarf-Therapist";

--- a/pkgs/games/steam/steam.nix
+++ b/pkgs/games/steam/steam.nix
@@ -48,7 +48,7 @@ in stdenv.mkDerivation {
     '';
     homepage = "https://store.steampowered.com/";
     license = licenses.unfreeRedistributable;
-    maintainers = with maintainers; [ jagajaga jonringer ];
+    maintainers = with maintainers; [ jagajaga ];
     mainProgram = "steam";
   };
 }

--- a/pkgs/os-specific/linux/catfs/default.nix
+++ b/pkgs/os-specific/linux/catfs/default.nix
@@ -45,6 +45,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/kahing/catfs";
     license = licenses.asl20;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -239,7 +239,7 @@ let
       platforms = [ "x86_64-linux" ]
         ++ optionals (sha256_32bit != null) [ "i686-linux" ]
         ++ optionals (sha256_aarch64 != null) [ "aarch64-linux" ];
-      maintainers = with maintainers; [ jonringer kiskae edwtjo ];
+      maintainers = with maintainers; [ kiskae edwtjo ];
       priority = 4; # resolves collision with xorg-server's "lib/xorg/modules/extensions/libglx.so"
       inherit broken;
     };

--- a/pkgs/servers/nosql/neo4j/default.nix
+++ b/pkgs/servers/nosql/neo4j/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     description = "A highly scalable, robust (fully ACID) native graph database";
     homepage = "https://neo4j.com/";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ jonringer offline ];
+    maintainers = with maintainers; [ offline ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/admin/azure-cli/default.nix
+++ b/pkgs/tools/admin/azure-cli/default.nix
@@ -375,7 +375,7 @@ py.pkgs.toPythonApplication (py.pkgs.buildAzureCliPackage rec {
     sourceProvenance = [ sourceTypes.fromSource ];
     license = licenses.mit;
     mainProgram = "az";
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ katexochen ];
     platforms = platforms.all;
   };
 })

--- a/pkgs/tools/admin/azure-cli/default.nix
+++ b/pkgs/tools/admin/azure-cli/default.nix
@@ -375,7 +375,7 @@ py.pkgs.toPythonApplication (py.pkgs.buildAzureCliPackage rec {
     sourceProvenance = [ sourceTypes.fromSource ];
     license = licenses.mit;
     mainProgram = "az";
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.all;
   };
 })

--- a/pkgs/tools/misc/copier/default.nix
+++ b/pkgs/tools/misc/copier/default.nix
@@ -52,7 +52,7 @@ python3.pkgs.buildPythonApplication rec {
     description = "Library and command-line utility for rendering projects templates";
     homepage = "https://copier.readthedocs.io";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer greg ];
+    maintainers = with maintainers; [ greg ];
     mainProgram = "copier";
   };
 }

--- a/pkgs/tools/package-management/nix-template/default.nix
+++ b/pkgs/tools/package-management/nix-template/default.nix
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/jonringer/nix-template/";
     changelog = "https://github.com/jonringer/nix-template/releases/tag/v${version}";
     license = licenses.cc0;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
     mainProgram = "nix-template";
   };
 }

--- a/pkgs/tools/security/spire/default.nix
+++ b/pkgs/tools/security/spire/default.nix
@@ -32,6 +32,6 @@ buildGoModule rec {
     homepage = "https://github.com/spiffe/spire";
     changelog = "https://github.com/spiffe/spire/releases/tag/v${version}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ jonringer fkautz ];
+    maintainers = with maintainers; [ fkautz ];
   };
 }

--- a/pkgs/tools/video/gopro/default.nix
+++ b/pkgs/tools/video/gopro/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/KonradIT/gopro-linux";
     platforms = platforms.unix;
     license = licenses.gpl3;
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ ];
     mainProgram = "gopro";
   };
 }


### PR DESCRIPTION

## Description of changes

Backport of #322386.

- **CODEOWNERS: remove jonringer**
- **maintainers: remove jonringer from all teams**
- **treewide: remove jonringer as package maintainer**
- **maintainers: remove jonringer**
- **azure-cli: add katexochen as maintainer**
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
