### PR TITLE
[24.05] inotify-info 0.0.1 -> 0.0.3

### DIFF
--- a/pkgs/by-name/in/inotify-info/package.nix
+++ b/pkgs/by-name/in/inotify-info/package.nix
@@ -5,23 +5,21 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "inotify-info";
-  version = "0.0.1";
+  version = "0.0.3";
 
   src = fetchFromGitHub {
     owner = "mikesart";
     repo = "inotify-info";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-fsUvIXWnP6Iy9Db0wDG+ntSw6mUt0MQOTJA5vFxhH+U=";
+    hash = "sha256-mxZpJMmSCgm5uV5/wknVb1PdxRIF/b2k+6rdOh4b8zA=";
   };
 
-  installPhase = ''
-    runHook preInstall
-    install -Dm755 _release/inotify-info $out/bin/inotify-info
-    runHook postInstall
-  '';
+  buildFlags = ["INOTIFYINFO_VERSION=v${finalAttrs.version}"];
+
+  installFlags = ["PREFIX=$$out"];
 
   meta = with lib; {
-    description = "Easily track down the number of inotify watches, instances, and which files are being watched.";
+    description = "Easily track down the number of inotify watches, instances, and which files are being watched";
     homepage = "https://github.com/mikesart/inotify-info";
     license = licenses.mit;
     mainProgram = "inotify-info";


### PR DESCRIPTION
## Description of changes

bump in 24.05; the upstream changes are backwards-compatible.

Notably, removes `-march=native` and equivalent.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

