### PR TITLE
hello-cpp: init

### DIFF
--- a/pkgs/by-name/he/hello-cpp/package.nix
+++ b/pkgs/by-name/he/hello-cpp/package.nix
@@ -1,0 +1,18 @@
+{
+  cmake,
+  lib,
+  ninja,
+  stdenv,
+}:
+
+stdenv.mkDerivation {
+  name = "hello-cpp";
+  src = ./src;
+  nativeBuildInputs = [ cmake ninja ];
+  meta = {
+    description = "Basic sanity check that C++ and cmake infrastructure are working";
+    platforms = lib.platforms.all;
+    maintainers = stdenv.meta.maintainers or [];
+    mainProgram = "hello-cpp";
+  };
+}

--- a/pkgs/by-name/he/hello-cpp/src/CMakeLists.txt
+++ b/pkgs/by-name/he/hello-cpp/src/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.10)
+project(hello-cpp)
+
+add_executable(hello-cpp main.cpp)
+
+install(TARGETS hello-cpp)

--- a/pkgs/by-name/he/hello-cpp/src/main.cpp
+++ b/pkgs/by-name/he/hello-cpp/src/main.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main(int argc, char *argv[]) {
+    std::cout << "Hello, C++\n";
+    return 0;
+}


### PR DESCRIPTION
Proposal: a trivial hello-cpp to complement gnu hello, testing C++ and cmake infrastructure.

This is intended to assist with testing exotic stdenvs such as the one used in pkgsLLVM, requiring no additional dependencies to get a quick test that the compiler, the C++ standard library and cmake are working as intended as a basic level.

There does already exist tests.cc-wrapper, but this does not produce any outputs, and sometimes it is useful to have a quick test that something builds. It's also useful to be able to inspect the outputs to look at references and so forth.

This complements nixpkgs.hello since that one tests autotools/make/c, and this one tests cmake/ninja/c++, so they are orthogonal.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
