### PR TITLE
ocamlPackages.xenstore: drop cstruct dependency

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18477,6 +18477,14 @@
     githubId = 53050011;
     name = "Yohann Boniface";
   };
+  sigmasquadron = {
+    name = "Fernando Rodrigues";
+    email = "alpha@sigmasquadron.net";
+    matrix = "@sigmasquadron:matrix.org";
+    github = "SigmaSquadron";
+    githubId = 174749595;
+    keys = [ { fingerprint = "E3CD E225 47C6 2DB6 6CCD  BC06 CC3A E2EA 0000 0000"; } ];
+  };
   sikmir = {
     email = "sikmir@disroot.org";
     matrix = "@sikmir:matrix.org";

--- a/pkgs/development/ocaml-modules/xenstore/default.nix
+++ b/pkgs/development/ocaml-modules/xenstore/default.nix
@@ -1,21 +1,23 @@
-{ lib, buildDunePackage, fetchurl
-, cstruct, ppx_cstruct, lwt, ounit2
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitHub,
+  lwt,
+  ounit2,
 }:
 
 buildDunePackage rec {
   pname = "xenstore";
   version = "2.3.0";
 
-  minimalOCamlVersion = "4.08";
-  duneVersion = "3";
-
-  src = fetchurl {
-    url = "https://github.com/mirage/ocaml-xenstore/releases/download/v${version}/xenstore-${version}.tbz";
-    hash = "sha256-1jxrvLLTwpd2fYPAoPbdRs7P1OaR8c9cW2VURF7Bs/Q=";
+  src = fetchFromGitHub {
+    owner = "mirage";
+    repo = "ocaml-xenstore";
+    rev = "v${version}";
+    hash = "sha256-LaynsbCE/+2QfbQCOLZi8nw1rqmZtgrwAov9cSxYZw8=";
   };
 
-  buildInputs = [ ppx_cstruct ];
-  propagatedBuildInputs = [ cstruct lwt ];
+  propagatedBuildInputs = [ lwt ];
 
   doCheck = true;
   checkInputs = [ ounit2 ];
@@ -23,7 +25,10 @@ buildDunePackage rec {
   meta = with lib; {
     description = "Xenstore protocol in pure OCaml";
     license = licenses.lgpl21Only;
-    maintainers = [ maintainers.sternenseemann ];
+    maintainers = with maintainers; [
+      sternenseemann
+      sigmasquadron
+    ];
     homepage = "https://github.com/mirage/ocaml-xenstore";
   };
 }


### PR DESCRIPTION
## Description of changes
- Drop an unused dependency from ocamlPackages.xenstore (I was working on an update to 2.3.0, but r-ryantm beat me to it. It did miss that dependency though.)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- Built with sandboxing enabled.
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - No automated tests for `pkgs.ocamlPackages.xenstore` yet.
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
