### PR TITLE
`doRenames` / plural

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -137,7 +137,7 @@ let
       mkAliasAndWrapDefinitions fixMergeModules mkRemovedOptionModule
       mkRenamedOptionModule mkRenamedOptionModuleWith
       mkMergedOptionModule mkChangedOptionModule
-      mkAliasOptionModule mkDerivedConfig doRename
+      mkAliasOptionModule mkDerivedConfig doRename doRenames
       mkAliasOptionModuleMD;
     evalOptionValue = lib.warn "External use of `lib.evalOptionValue` is deprecated. If your use case isn't covered by non-deprecated functions, we'd like to know more and perhaps support your use case well, instead of providing access to these low level functions. In this case please open an issue in https://github.com/nixos/nixpkgs/issues/." self.modules.evalOptionValue;
     inherit (self.options) isOption mkEnableOption mkSinkUndeclaredOptions

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -72,6 +72,9 @@ checkConfigError() {
     fi
 }
 
+# doRenames works with priorities on nested options
+checkConfigOutput '^1234$' config.new.foo ./doRenames-nested-option-priorities.nix
+
 # Shorthand meta attribute does not duplicate the config
 checkConfigOutput '^"one two"$' config.result ./shorthand-meta.nix
 

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -37,6 +37,7 @@ reportFailure() {
 }
 
 checkConfigOutput() {
+    local callPosition="${callPosition:-${BASH_SOURCE[1]}:${BASH_LINENO[0]}}"
     local outputContains=$1
     shift
     if evalConfig "$@" 2>/dev/null | grep -E --silent "$outputContains" ; then
@@ -44,22 +45,29 @@ checkConfigOutput() {
     else
         echo 2>&1 "error: Expected result matching '$outputContains', while evaluating"
         reportFailure "$@"
+        echo 2>&1 "test case: $callPosition"
+        echo 2>&1
     fi
 }
 
 checkConfigError() {
+    local callPosition="${callPosition:-${BASH_SOURCE[1]}:${BASH_LINENO[0]}}"
     local errorContains=$1
     local err=""
     shift
     if err="$(evalConfig "$@" 2>&1 >/dev/null)"; then
         echo 2>&1 "error: Expected error code, got exit code 0, while evaluating"
         reportFailure "$@"
+        echo 2>&1 "test case: $callPosition"
+        echo 2>&1
     else
         if echo "$err" | grep -zP --silent "$errorContains" ; then
             ((++pass))
         else
             echo 2>&1 "error: Expected error matching '$errorContains', while evaluating"
             reportFailure "$@"
+            echo 2>&1 "test case: $callPosition"
+            echo 2>&1
         fi
     fi
 }

--- a/lib/tests/modules/doRenames-nested-option-priorities.nix
+++ b/lib/tests/modules/doRenames-nested-option-priorities.nix
@@ -1,0 +1,14 @@
+{ lib, ... }: {
+  imports = [
+    (lib.doRenames { from = ["old"]; to = ["new"]; })
+  ];
+  options = {
+    new.foo = lib.mkOption {
+      type = lib.types.int;
+    };
+  };
+  config = {
+    new.foo = lib.mkDefault 42;
+    old.foo = lib.mkForce 1234;
+  };
+}


### PR DESCRIPTION
## Description of changes

A simple or simplistic `doRename` reimplementation that
- Closes https://github.com/NixOS/nixpkgs/pull/324798  by providing a working alternative
- Fixes https://github.com/NixOS/nixpkgs/issues/324802  by providing a working alternative

`doRename` did not support renaming multiple options at once and is burdened by too much configurability - probably for legitimate reasons to be conservative about change.
I don't think it can support the extra requirement of doing option "trees" instead of just options, for two reasons:
- The implementation is already very complex
- It's unclear what the interaction with `use` should be
- `doRenames` might be stricter because it analyzes the tree structure instead of making the assumption that it can grab a leaf. Also the list of old options is determined from the new options instead of coming from always-available hardcoded caller input.

I should note though, that aliasing whole option trees might be an antipattern, because when options are added in the new location, they will also appear in the corresponding "old" location. We might want to avoid that, but I'm really not sure whether this really matters.

TODO
- [ ] more tests
- [ ] add `condition`
- [ ] add `visible`
- [ ] add a _module_ that warns about all definitions in an option tree
- [ ] add `warn`, by `imports = optional warn <the above module>`
- [ ] more tests
- [ ] docs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
