### PR TITLE
nixos/zfs: add option to load pool credentials into kernel keyring

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -233,7 +233,7 @@ let
                     tries=3
                     success=false
                     while [[ $success != true ]] && [[ $tries -gt 0 ]]; do
-                      ${systemd}/bin/systemd-ask-password --timeout=${toString cfgZfs.passwordTimeout} "Enter key for $ds:" | ${cfgZfs.package}/sbin/zfs load-key "$ds" \
+                      ${systemd}/bin/systemd-ask-password ${lib.optionalString cfgZfs.useKeyringForCredentials ("--keyname=zfs-$ds")} --timeout=${toString cfgZfs.passwordTimeout} "Enter key for $ds:" | ${cfgZfs.package}/sbin/zfs load-key "$ds" \
                         && success=true \
                         || tries=$((tries - 1))
                     done
@@ -402,6 +402,8 @@ in
           an interactive prompt (keylocation=prompt) and from a file (keylocation=file://).
         '';
       };
+
+      useKeyringForCredentials = lib.mkEnableOption "Uses the kernel keyring for encryption credentials with keyname=zfs-<poolname>";
 
       passwordTimeout = lib.mkOption {
         type = lib.types.int;


### PR DESCRIPTION
## Description of changes

With this patch, if one would enable `boot.zfs.storeEncryptionCredentials`  systemd-ask-password would store the inserted key phrase that unlocks the zfs pool as `zfs-<poolname>` in the kernels keyring <sup>[1]</sup>

Said key phrase is stored there for 2.5 min and can be used for other unlock actions. 
A prominent example would be to unlock a password manager like kwallet or gnome keyring.

There is a pam module provided by systemd that will load the password from the keyring afterwards <sup>[2]</sup>.

A working usage example can be found at <sup>[3]</sup>.  It is still hacky as sddm modules pam declaration is text and thus injection of extra content is not possible with the new pam declaration, or maybe ill add it inline text, but i am willing to try to convert the text to the "new" pam thing, as its heavily increasing the possibility to customize pam usage.

The resulting workflow is that on boot i get asked for my pools key phrase, have sddm setup for auto login and kwallet gets unlocked by the kernels keyring, so that i as user have to pass the password only once.

Once i have figured out said pam topic, i am planning a PR to support that declarative in the sddm module (and possibly a gdm interested person could pick that up then later).

Kinda relates to https://github.com/NixOS/nixpkgs/pull/282317 in the long run, tho using `pam_gdm` is less flexible than `pam_systemd_loadkey` as the firsts keyname is hardcoded for `cryptsetup` and latter accepts user defined keynames (having `cryptsetup` as default).

In the naming of the option and the description is likely some room for improvements, i did not find a better expression.
Feedback is very welcome.

If i should first complete the sddm part (and combine it in one pr), please let me know. 

[1] https://www.freedesktop.org/software/systemd/man/latest/systemd-ask-password.html#--keyname=
[2] https://www.freedesktop.org/software/systemd/man/latest/pam_systemd_loadkey.html
[3] https://github.com/Shawn8901/nix-configuration/commit/9a45a50329c3c1ac04a9f6fc96346acbb65a3278

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
