### PR TITLE
nixos/fcgiwrap: add option migration instruction errors

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -64,7 +64,7 @@
   The option `services.fgciwrap` now takes an attribute set of the
   configuration of each individual instance.
   This requires migrating any previous configuration keys from
-  `services.fcgiwrap.*` to `services.fcgiwrap.some-instance.*`.
+  `services.fcgiwrap.*` to `services.fcgiwrap.instances.some-instance.*`.
   The ownership and mode of the UNIX sockets created by this service are now
   configurable and private by default.
   Processes also now run as a dynamically allocated user by default instead of

--- a/nixos/modules/services/misc/zoneminder.nix
+++ b/nixos/modules/services/misc/zoneminder.nix
@@ -202,7 +202,7 @@ in {
     ];
 
     services = {
-      fcgiwrap.zoneminder = lib.mkIf useNginx {
+      fcgiwrap.instances.zoneminder = lib.mkIf useNginx {
         process.prefork = cfg.cameras;
         process.user = user;
         process.group = group;
@@ -255,7 +255,7 @@ in {
                   fastcgi_param HTTP_PROXY "";
                   fastcgi_intercept_errors on;
 
-                  fastcgi_pass unix:${config.services.fcgiwrap.zoneminder.socket.address};
+                  fastcgi_pass unix:${config.services.fcgiwrap.instances.zoneminder.socket.address};
                 }
 
                 location /cache/ {

--- a/nixos/modules/services/networking/cgit.nix
+++ b/nixos/modules/services/networking/cgit.nix
@@ -32,7 +32,7 @@ let
       fastcgi_split_path_info ^(${regexLocation cfg})(/.+)$;
       fastcgi_param PATH_INFO $fastcgi_path_info;
     ''
-    }fastcgi_pass unix:${config.services.fcgiwrap."cgit-${name}".socket.address};
+    }fastcgi_pass unix:${config.services.fcgiwrap.instances."cgit-${name}".socket.address};
   '';
 
   cgitrcLine = name: value: "${name}=${
@@ -171,7 +171,7 @@ in
       groups.${cfg.group} = { };
     }));
 
-    services.fcgiwrap = flip mapAttrs' cfgs (name: cfg:
+    services.fcgiwrap.instances = flip mapAttrs' cfgs (name: cfg:
       nameValuePair "cgit-${name}" {
         process = { inherit (cfg) user group; };
         socket = { inherit (config.services.nginx) user group; };

--- a/nixos/modules/services/networking/smokeping.nix
+++ b/nixos/modules/services/networking/smokeping.nix
@@ -337,7 +337,7 @@ in
     };
 
     # use nginx to serve the smokeping web service
-    services.fcgiwrap.smokeping = mkIf cfg.webService {
+    services.fcgiwrap.instances.smokeping = mkIf cfg.webService {
       process.user = cfg.user;
       process.group = cfg.user;
       socket = { inherit (config.services.nginx) user group; };
@@ -353,7 +353,7 @@ in
         locations."/smokeping.fcgi" = {
           extraConfig = ''
             include ${config.services.nginx.package}/conf/fastcgi_params;
-            fastcgi_pass unix:${config.services.fcgiwrap.smokeping.socket.address};
+            fastcgi_pass unix:${config.services.fcgiwrap.instances.smokeping.socket.address};
             fastcgi_param SCRIPT_FILENAME ${smokepingHome}/smokeping.fcgi;
             fastcgi_param DOCUMENT_ROOT ${smokepingHome};
           '';

--- a/nixos/modules/services/web-servers/fcgiwrap.nix
+++ b/nixos/modules/services/web-servers/fcgiwrap.nix
@@ -3,12 +3,26 @@
 with lib;
 
 let
-  forEachInstance = f: flip mapAttrs' config.services.fcgiwrap (name: cfg:
-    nameValuePair "fcgiwrap-${name}" (f cfg)
+  forEachInstance = f: flip mapAttrs' config.services.fcgiwrap.instances (
+    name: cfg: nameValuePair "fcgiwrap-${name}" (f cfg)
   );
 
 in {
-  options.services.fcgiwrap = mkOption {
+  imports = forEach [
+    "enable"
+    "user"
+    "group"
+    "socketType"
+    "socketAddress"
+    "preforkProcesses"
+  ] (attr: mkRemovedOptionModule [ "services" "fcgiwrap" attr ] ''
+      The global shared fcgiwrap instance is no longer supported due to
+      security issues.
+      Isolated instances should instead be configured through
+      `services.fcgiwrap.instances.*'.
+  '');
+
+  options.services.fcgiwrap.instances = mkOption {
     description = "Configuration for fcgiwrap instances.";
     default = { };
     type = types.attrsOf (types.submodule ({ config, ... }: { options = {
@@ -95,7 +109,7 @@ in {
         assertion = cfg.socket.mode != null -> cfg.socket.type == "unix";
         message = "Socket mode can only be set for the UNIX socket type.";
       }
-    ]) config.services.fcgiwrap);
+    ]) config.services.fcgiwrap.instances);
 
     systemd.services = forEachInstance (cfg: {
       after = [ "nss-user-lookup.target" ];

--- a/nixos/tests/gitolite-fcgiwrap.nix
+++ b/nixos/tests/gitolite-fcgiwrap.nix
@@ -24,7 +24,7 @@ import ./make-test-python.nix (
               {
                 networking.firewall.allowedTCPPorts = [ 80 ];
 
-                services.fcgiwrap.gitolite = {
+                services.fcgiwrap.instances.gitolite = {
                   process.user = "gitolite";
                   process.group = "gitolite";
                   socket = { inherit (config.services.nginx) user group; };
@@ -64,7 +64,7 @@ import ./make-test-python.nix (
                     fastcgi_param SCRIPT_FILENAME ${pkgs.gitolite}/bin/gitolite-shell;
 
                     # use Unix domain socket or inet socket
-                    fastcgi_pass unix:${config.services.fcgiwrap.gitolite.socket.address};
+                    fastcgi_pass unix:${config.services.fcgiwrap.instances.gitolite.socket.address};
                   '';
                 };
 


### PR DESCRIPTION
## Description of changes

This adds migration instructions for the removed global shared instance
configuration of fcgiwrap.

Adding those explicit messages to the previous options requires moving
the newly defined options from `services.fcgiwrap.*` to
`services.fcgiwrap.instances.*` due to an option namespace clash.

`mkRenamedOptionModule` was not used because the previous options do
not directly map to the new ones. In particular, `user` and `group`
were described as setting the socket's permission, but were actually
setting the process' running user.


## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
