### PR TITLE
clash-nyanpasu: 1.4.5 -> 1.5.1

### DIFF
--- a/pkgs/by-name/cl/clash-nyanpasu/package.nix
+++ b/pkgs/by-name/cl/clash-nyanpasu/package.nix
@@ -1,23 +1,36 @@
-{ lib
-, clash-verge
-, mihomo
-, fetchurl
+{
+  lib,
+  appimageTools,
+  fetchurl,
+  nix-update-script,
 }:
-
-(clash-verge.override {
-  clash-meta = mihomo;
-}).overrideAttrs (old: rec {
+appimageTools.wrapType2 rec {
   pname = "clash-nyanpasu";
-  version = "1.4.5";
+  version = "1.5.1";
 
   src = fetchurl {
-    url = "https://github.com/keiko233/clash-nyanpasu/releases/download/v${version}/clash-nyanpasu_${version}_amd64.deb";
-    hash = "sha256-cxaq7Rndf0ytEaqc7CGQix5SOAdsTOoTj1Jlhjr5wEA=";
+    url = "https://github.com/LibNyanpasu/clash-nyanpasu/releases/download/v${version}/clash-nyanpasu_${version}_amd64.AppImage";
+    hash = "sha256-uUWs7yfSrqe/6kTb4iMA9ty6j/Wi9qGYX65VzTG5nkc=";
   };
 
-  meta = old.meta // (with lib; {
+  extraInstallCommands =
+    let
+      appimageContents = appimageTools.extractType2 { inherit pname version src; };
+    in
+    ''
+      install -Dm444 ${appimageContents}/clash-nyanpasu.desktop -t $out/share/applications
+      cp -r ${appimageContents}/usr/share/icons $out/share
+    '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Clash GUI based on tauri";
     homepage = "https://github.com/keiko233/clash-nyanpasu";
-    maintainers = with maintainers; [ Guanran928 ];
+    license = lib.licenses.gpl3Plus;
     mainProgram = "clash-nyanpasu";
-  });
-})
+    maintainers = with lib.maintainers; [ Guanran928 ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/324928

Switched to AppImage because `'result/bin/clash-nyanpasu' terminated by signal SIGSEGV (Address boundary error)` and I had no idea whats happening.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
