### PR TITLE
python312Packages.pyserial-asyncio-fast: 0.12 -> 0.13

### DIFF
--- a/pkgs/development/python-modules/pyserial-asyncio-fast/default.nix
+++ b/pkgs/development/python-modules/pyserial-asyncio-fast/default.nix
@@ -5,7 +5,6 @@
 
   # build-system
   setuptools,
-  wheel,
 
   # dependencies
   pyserial,
@@ -17,22 +16,19 @@
 
 buildPythonPackage rec {
   pname = "pyserial-asyncio-fast";
-  version = "0.12";
+  version = "0.13";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "bdraco";
     repo = "pyserial-asyncio-fast";
     rev = version;
-    hash = "sha256-37dbJq+9Ex+/uiRR2esgOP15CjySA0MLvxnjiPDTF08=";
+    hash = "sha256-qAJ9jkhY2Gq/+/JBRObdSljTDPe3cKbjUfFon2ZgEps=";
   };
 
-  nativeBuildInputs = [
-    setuptools
-    wheel
-  ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [ pyserial ];
+  dependencies = [ pyserial ];
 
   pythonImportsCheck = [ "serial_asyncio_fast" ];
 
@@ -42,6 +38,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
+    changelog = "https://github.com/home-assistant-libs/pyserial-asyncio-fast/releases/tag/${version}";
     description = "Fast asyncio extension package for pyserial that implements eager writes";
     homepage = "https://github.com/bdraco/pyserial-asyncio-fast";
     license = licenses.bsd3;


### PR DESCRIPTION
## Description of changes
https://github.com/bdraco/pyserial-asyncio-fast/compare/0.12...0.13

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>37 packages built:</summary>
  <ul>
    <li>home-assistant-component-tests.elkm1</li>
    <li>home-assistant-component-tests.homeassistant_green</li>
    <li>home-assistant-component-tests.homeassistant_hardware</li>
    <li>home-assistant-component-tests.homeassistant_sky_connect</li>
    <li>home-assistant-component-tests.homeassistant_yellow</li>
    <li>home-assistant-component-tests.opentherm_gw</li>
    <li>home-assistant-component-tests.otbr</li>
    <li>home-assistant-component-tests.rainforest_raven</li>
    <li>home-assistant-component-tests.upb</li>
    <li>home-assistant-component-tests.velbus</li>
    <li>home-assistant-component-tests.zha</li>
    <li>python311Packages.aioraven</li>
    <li>python311Packages.aioraven.dist</li>
    <li>python311Packages.elkm1-lib</li>
    <li>python311Packages.elkm1-lib.dist</li>
    <li>python311Packages.pyotgw</li>
    <li>python311Packages.pyotgw.dist</li>
    <li>python311Packages.pyserial-asyncio-fast</li>
    <li>python311Packages.pyserial-asyncio-fast.dist</li>
    <li>python311Packages.upb-lib</li>
    <li>python311Packages.upb-lib.dist</li>
    <li>python311Packages.velbus-aio</li>
    <li>python311Packages.velbus-aio.dist</li>
    <li>python312Packages.aioraven</li>
    <li>python312Packages.aioraven.dist</li>
    <li>python312Packages.elkm1-lib</li>
    <li>python312Packages.elkm1-lib.dist</li>
    <li>python312Packages.pyotgw</li>
    <li>python312Packages.pyotgw.dist</li>
    <li>python312Packages.pyserial-asyncio-fast</li>
    <li>python312Packages.pyserial-asyncio-fast.dist</li>
    <li>python312Packages.upb-lib</li>
    <li>python312Packages.upb-lib.dist</li>
    <li>python312Packages.velbus-aio</li>
    <li>python312Packages.velbus-aio.dist</li>
    <li>python312Packages.zha</li>
    <li>python312Packages.zha.dist</li>
  </ul>
</details>

Result of `nixpkgs-review` run on aarch64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>37 packages built:</summary>
  <ul>
    <li>home-assistant-component-tests.elkm1</li>
    <li>home-assistant-component-tests.homeassistant_green</li>
    <li>home-assistant-component-tests.homeassistant_hardware</li>
    <li>home-assistant-component-tests.homeassistant_sky_connect</li>
    <li>home-assistant-component-tests.homeassistant_yellow</li>
    <li>home-assistant-component-tests.opentherm_gw</li>
    <li>home-assistant-component-tests.otbr</li>
    <li>home-assistant-component-tests.rainforest_raven</li>
    <li>home-assistant-component-tests.upb</li>
    <li>home-assistant-component-tests.velbus</li>
    <li>home-assistant-component-tests.zha</li>
    <li>python311Packages.aioraven</li>
    <li>python311Packages.aioraven.dist</li>
    <li>python311Packages.elkm1-lib</li>
    <li>python311Packages.elkm1-lib.dist</li>
    <li>python311Packages.pyotgw</li>
    <li>python311Packages.pyotgw.dist</li>
    <li>python311Packages.pyserial-asyncio-fast</li>
    <li>python311Packages.pyserial-asyncio-fast.dist</li>
    <li>python311Packages.upb-lib</li>
    <li>python311Packages.upb-lib.dist</li>
    <li>python311Packages.velbus-aio</li>
    <li>python311Packages.velbus-aio.dist</li>
    <li>python312Packages.aioraven</li>
    <li>python312Packages.aioraven.dist</li>
    <li>python312Packages.elkm1-lib</li>
    <li>python312Packages.elkm1-lib.dist</li>
    <li>python312Packages.pyotgw</li>
    <li>python312Packages.pyotgw.dist</li>
    <li>python312Packages.pyserial-asyncio-fast</li>
    <li>python312Packages.pyserial-asyncio-fast.dist</li>
    <li>python312Packages.upb-lib</li>
    <li>python312Packages.upb-lib.dist</li>
    <li>python312Packages.velbus-aio</li>
    <li>python312Packages.velbus-aio.dist</li>
    <li>python312Packages.zha</li>
    <li>python312Packages.zha.dist</li>
  </ul>
</details>



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
