### PR TITLE
python312Packages.webrtc-noise-gain: 1.2.3 -> 1.2.4

### DIFF
--- a/pkgs/development/python-modules/webrtc-noise-gain/default.nix
+++ b/pkgs/development/python-modules/webrtc-noise-gain/default.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "webrtc-noise-gain";
-  version = "1.2.3";
+  version = "1.2.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rhasspy";
     repo = "webrtc-noise-gain";
     rev = "v${version}";
-    hash = "sha256-DFEtuO49zXNixLwBjQ/WOiARDhMAXVH+5hfc3eSdPIo=";
+    hash = "sha256-ALRdj9zBcx05DcSKjAI0oEPruTD/p+pQ0kcqqyHl37A=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

https://github.com/rhasspy/webrtc-noise-gain/blob/v1.2.4/CHANGELOG.md (not updated since 1.2.2)
https://github.com/rhasspy/webrtc-noise-gain/compare/v1.2.3...v1.2.4

Result of `nixpkgs-review` run on aarch64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages failed to build:</summary>
  <ul>
    <li>home-assistant-component-tests.azure_devops</li>
    <li>home-assistant-component-tests.songpal</li>
    <li>home-assistant-component-tests.system_log</li>
  </ul>
</details>
<details>
  <summary>838 packages built:</summary>
  <ul>
    <li>home-assistant</li>
    <li>home-assistant-component-tests.abode</li>
    <li>home-assistant-component-tests.accuweather</li>
    <li>home-assistant-component-tests.acmeda</li>
    <li>home-assistant-component-tests.adax</li>
    <li>home-assistant-component-tests.adguard</li>
    <li>home-assistant-component-tests.advantage_air</li>
    <li>home-assistant-component-tests.aemet</li>
    <li>home-assistant-component-tests.aftership</li>
    <li>home-assistant-component-tests.agent_dvr</li>
    <li>home-assistant-component-tests.air_quality</li>
    <li>home-assistant-component-tests.airly</li>
    <li>home-assistant-component-tests.airnow</li>
    <li>home-assistant-component-tests.airq</li>
    <li>home-assistant-component-tests.airthings</li>
    <li>home-assistant-component-tests.airthings_ble</li>
    <li>home-assistant-component-tests.airtouch4</li>
    <li>home-assistant-component-tests.airtouch5</li>
    <li>home-assistant-component-tests.airvisual</li>
    <li>home-assistant-component-tests.airvisual_pro</li>
    <li>home-assistant-component-tests.airzone</li>
    <li>home-assistant-component-tests.airzone_cloud</li>
    <li>home-assistant-component-tests.aladdin_connect</li>
    <li>home-assistant-component-tests.alarm_control_panel</li>
    <li>home-assistant-component-tests.alarmdecoder</li>
    <li>home-assistant-component-tests.alert</li>
    <li>home-assistant-component-tests.alexa</li>
    <li>home-assistant-component-tests.amberelectric</li>
    <li>home-assistant-component-tests.ambient_network</li>
    <li>home-assistant-component-tests.ambient_station</li>
    <li>home-assistant-component-tests.analytics</li>
    <li>home-assistant-component-tests.analytics_insights</li>
    <li>home-assistant-component-tests.android_ip_webcam</li>
    <li>home-assistant-component-tests.androidtv</li>
    <li>home-assistant-component-tests.androidtv_remote</li>
    <li>home-assistant-component-tests.anova</li>
    <li>home-assistant-component-tests.anthemav</li>
    <li>home-assistant-component-tests.aosmith</li>
    <li>home-assistant-component-tests.apache_kafka</li>
    <li>home-assistant-component-tests.apcupsd</li>
    <li>home-assistant-component-tests.api</li>
    <li>home-assistant-component-tests.apple_tv</li>
    <li>home-assistant-component-tests.application_credentials</li>
    <li>home-assistant-component-tests.apprise</li>
    <li>home-assistant-component-tests.aprs</li>
    <li>home-assistant-component-tests.aranet</li>
    <li>home-assistant-component-tests.arcam_fmj</li>
    <li>home-assistant-component-tests.aseko_pool_live</li>
    <li>home-assistant-component-tests.assist_pipeline</li>
    <li>home-assistant-component-tests.asterisk_mbox</li>
    <li>home-assistant-component-tests.asuswrt</li>
    <li>home-assistant-component-tests.atag</li>
    <li>home-assistant-component-tests.august</li>
    <li>home-assistant-component-tests.aurora</li>
    <li>home-assistant-component-tests.aurora_abb_powerone</li>
    <li>home-assistant-component-tests.aussie_broadband</li>
    <li>home-assistant-component-tests.auth</li>
    <li>home-assistant-component-tests.automation</li>
    <li>home-assistant-component-tests.awair</li>
    <li>home-assistant-component-tests.aws</li>
    <li>home-assistant-component-tests.axis</li>
    <li>home-assistant-component-tests.azure_event_hub</li>
    <li>home-assistant-component-tests.backup</li>
    <li>home-assistant-component-tests.baf</li>
    <li>home-assistant-component-tests.balboa</li>
    <li>home-assistant-component-tests.bayesian</li>
    <li>home-assistant-component-tests.binary_sensor</li>
    <li>home-assistant-component-tests.blackbird</li>
    <li>home-assistant-component-tests.blebox</li>
    <li>home-assistant-component-tests.blink</li>
    <li>home-assistant-component-tests.blue_current</li>
    <li>home-assistant-component-tests.bluemaestro</li>
    <li>home-assistant-component-tests.blueprint</li>
    <li>home-assistant-component-tests.bluetooth</li>
    <li>home-assistant-component-tests.bluetooth_adapters</li>
    <li>home-assistant-component-tests.bluetooth_le_tracker</li>
    <li>home-assistant-component-tests.bmw_connected_drive</li>
    <li>home-assistant-component-tests.bond</li>
    <li>home-assistant-component-tests.bosch_shc</li>
    <li>home-assistant-component-tests.braviatv</li>
    <li>home-assistant-component-tests.bring</li>
    <li>home-assistant-component-tests.broadlink</li>
    <li>home-assistant-component-tests.brother</li>
    <li>home-assistant-component-tests.brottsplatskartan</li>
    <li>home-assistant-component-tests.brunt</li>
    <li>home-assistant-component-tests.bsblan</li>
    <li>home-assistant-component-tests.bthome</li>
    <li>home-assistant-component-tests.buienradar</li>
    <li>home-assistant-component-tests.button</li>
    <li>home-assistant-component-tests.caldav</li>
    <li>home-assistant-component-tests.calendar</li>
    <li>home-assistant-component-tests.camera</li>
    <li>home-assistant-component-tests.canary</li>
    <li>home-assistant-component-tests.cast</li>
    <li>home-assistant-component-tests.cert_expiry</li>
    <li>home-assistant-component-tests.clicksend_tts</li>
    <li>home-assistant-component-tests.climate</li>
    <li>home-assistant-component-tests.cloud</li>
    <li>home-assistant-component-tests.cloudflare</li>
    <li>home-assistant-component-tests.co2signal</li>
    <li>home-assistant-component-tests.color_extractor</li>
    <li>home-assistant-component-tests.comelit</li>
    <li>home-assistant-component-tests.comfoconnect</li>
    <li>home-assistant-component-tests.command_line</li>
    <li>home-assistant-component-tests.compensation</li>
    <li>home-assistant-component-tests.config</li>
    <li>home-assistant-component-tests.configurator</li>
    <li>home-assistant-component-tests.control4</li>
    <li>home-assistant-component-tests.conversation</li>
    <li>home-assistant-component-tests.coolmaster</li>
    <li>home-assistant-component-tests.counter</li>
    <li>home-assistant-component-tests.cover</li>
    <li>home-assistant-component-tests.cpuspeed</li>
    <li>home-assistant-component-tests.crownstone</li>
    <li>home-assistant-component-tests.daikin</li>
    <li>home-assistant-component-tests.datadog</li>
    <li>home-assistant-component-tests.date</li>
    <li>home-assistant-component-tests.datetime</li>
    <li>home-assistant-component-tests.debugpy</li>
    <li>home-assistant-component-tests.deconz</li>
    <li>home-assistant-component-tests.default_config</li>
    <li>home-assistant-component-tests.deluge</li>
    <li>home-assistant-component-tests.demo</li>
    <li>home-assistant-component-tests.denonavr</li>
    <li>home-assistant-component-tests.derivative</li>
    <li>home-assistant-component-tests.devialet</li>
    <li>home-assistant-component-tests.device_automation</li>
    <li>home-assistant-component-tests.device_sun_light_trigger</li>
    <li>home-assistant-component-tests.device_tracker</li>
    <li>home-assistant-component-tests.devolo_home_control</li>
    <li>home-assistant-component-tests.devolo_home_network</li>
    <li>home-assistant-component-tests.dexcom</li>
    <li>home-assistant-component-tests.dhcp</li>
    <li>home-assistant-component-tests.diagnostics</li>
    <li>home-assistant-component-tests.dialogflow</li>
    <li>home-assistant-component-tests.directv</li>
    <li>home-assistant-component-tests.discord</li>
    <li>home-assistant-component-tests.discovergy</li>
    <li>home-assistant-component-tests.dlna_dmr</li>
    <li>home-assistant-component-tests.dlna_dms</li>
    <li>home-assistant-component-tests.dnsip</li>
    <li>home-assistant-component-tests.doorbird</li>
    <li>home-assistant-component-tests.dormakaba_dkey</li>
    <li>home-assistant-component-tests.downloader</li>
    <li>home-assistant-component-tests.dremel_3d_printer</li>
    <li>home-assistant-component-tests.drop_connect</li>
    <li>home-assistant-component-tests.dsmr</li>
    <li>home-assistant-component-tests.dsmr_reader</li>
    <li>home-assistant-component-tests.dte_energy_bridge</li>
    <li>home-assistant-component-tests.duckdns</li>
    <li>home-assistant-component-tests.dunehd</li>
    <li>home-assistant-component-tests.duotecno</li>
    <li>home-assistant-component-tests.dwd_weather_warnings</li>
    <li>home-assistant-component-tests.dynalite</li>
    <li>home-assistant-component-tests.eafm</li>
    <li>home-assistant-component-tests.easyenergy</li>
    <li>home-assistant-component-tests.ecobee</li>
    <li>home-assistant-component-tests.ecoforest</li>
    <li>home-assistant-component-tests.econet</li>
    <li>home-assistant-component-tests.ecowitt</li>
    <li>home-assistant-component-tests.edl21</li>
    <li>home-assistant-component-tests.efergy</li>
    <li>home-assistant-component-tests.eight_sleep</li>
    <li>home-assistant-component-tests.elgato</li>
    <li>home-assistant-component-tests.elkm1</li>
    <li>home-assistant-component-tests.elmax</li>
    <li>home-assistant-component-tests.emonitor</li>
    <li>home-assistant-component-tests.emulated_hue</li>
    <li>home-assistant-component-tests.emulated_kasa</li>
    <li>home-assistant-component-tests.emulated_roku</li>
    <li>home-assistant-component-tests.energy</li>
    <li>home-assistant-component-tests.energyzero</li>
    <li>home-assistant-component-tests.enigma2</li>
    <li>home-assistant-component-tests.enocean</li>
    <li>home-assistant-component-tests.enphase_envoy</li>
    <li>home-assistant-component-tests.environment_canada</li>
    <li>home-assistant-component-tests.epion</li>
    <li>home-assistant-component-tests.epson</li>
    <li>home-assistant-component-tests.escea</li>
    <li>home-assistant-component-tests.esphome</li>
    <li>home-assistant-component-tests.eufylife_ble</li>
    <li>home-assistant-component-tests.event</li>
    <li>home-assistant-component-tests.everlights</li>
    <li>home-assistant-component-tests.evil_genius_labs</li>
    <li>home-assistant-component-tests.ezviz</li>
    <li>home-assistant-component-tests.faa_delays</li>
    <li>home-assistant-component-tests.facebook</li>
    <li>home-assistant-component-tests.fail2ban</li>
    <li>home-assistant-component-tests.fan</li>
    <li>home-assistant-component-tests.feedreader</li>
    <li>home-assistant-component-tests.ffmpeg</li>
    <li>home-assistant-component-tests.fibaro</li>
    <li>home-assistant-component-tests.fido</li>
    <li>home-assistant-component-tests.file</li>
    <li>home-assistant-component-tests.file_upload</li>
    <li>home-assistant-component-tests.filesize</li>
    <li>home-assistant-component-tests.filter</li>
    <li>home-assistant-component-tests.fints</li>
    <li>home-assistant-component-tests.fireservicerota</li>
    <li>home-assistant-component-tests.firmata</li>
    <li>home-assistant-component-tests.fitbit</li>
    <li>home-assistant-component-tests.fivem</li>
    <li>home-assistant-component-tests.fjaraskupan</li>
    <li>home-assistant-component-tests.flic</li>
    <li>home-assistant-component-tests.flick_electric</li>
    <li>home-assistant-component-tests.flipr</li>
    <li>home-assistant-component-tests.flo</li>
    <li>home-assistant-component-tests.flume</li>
    <li>home-assistant-component-tests.flux</li>
    <li>home-assistant-component-tests.flux_led</li>
    <li>home-assistant-component-tests.folder</li>
    <li>home-assistant-component-tests.folder_watcher</li>
    <li>home-assistant-component-tests.foobot</li>
    <li>home-assistant-component-tests.forecast_solar</li>
    <li>home-assistant-component-tests.foscam</li>
    <li>home-assistant-component-tests.freebox</li>
    <li>home-assistant-component-tests.freedns</li>
    <li>home-assistant-component-tests.freedompro</li>
    <li>home-assistant-component-tests.fritz</li>
    <li>home-assistant-component-tests.fritzbox</li>
    <li>home-assistant-component-tests.fritzbox_callmonitor</li>
    <li>home-assistant-component-tests.fronius</li>
    <li>home-assistant-component-tests.frontend</li>
    <li>home-assistant-component-tests.frontier_silicon</li>
    <li>home-assistant-component-tests.fully_kiosk</li>
    <li>home-assistant-component-tests.fyta</li>
    <li>home-assistant-component-tests.garages_amsterdam</li>
    <li>home-assistant-component-tests.gardena_bluetooth</li>
    <li>home-assistant-component-tests.gdacs</li>
    <li>home-assistant-component-tests.generic</li>
    <li>home-assistant-component-tests.generic_hygrostat</li>
    <li>home-assistant-component-tests.generic_thermostat</li>
    <li>home-assistant-component-tests.geo_json_events</li>
    <li>home-assistant-component-tests.geo_location</li>
    <li>home-assistant-component-tests.geo_rss_events</li>
    <li>home-assistant-component-tests.geocaching</li>
    <li>home-assistant-component-tests.geofency</li>
    <li>home-assistant-component-tests.geonetnz_quakes</li>
    <li>home-assistant-component-tests.geonetnz_volcano</li>
    <li>home-assistant-component-tests.gios</li>
    <li>home-assistant-component-tests.github</li>
    <li>home-assistant-component-tests.glances</li>
    <li>home-assistant-component-tests.goalzero</li>
    <li>home-assistant-component-tests.gogogate2</li>
    <li>home-assistant-component-tests.goodwe</li>
    <li>home-assistant-component-tests.google</li>
    <li>home-assistant-component-tests.google_assistant</li>
    <li>home-assistant-component-tests.google_assistant_sdk</li>
    <li>home-assistant-component-tests.google_domains</li>
    <li>home-assistant-component-tests.google_generative_ai_conversation</li>
    <li>home-assistant-component-tests.google_mail</li>
    <li>home-assistant-component-tests.google_pubsub</li>
    <li>home-assistant-component-tests.google_sheets</li>
    <li>home-assistant-component-tests.google_tasks</li>
    <li>home-assistant-component-tests.google_translate</li>
    <li>home-assistant-component-tests.google_travel_time</li>
    <li>home-assistant-component-tests.google_wifi</li>
    <li>home-assistant-component-tests.govee_ble</li>
    <li>home-assistant-component-tests.govee_light_local</li>
    <li>home-assistant-component-tests.gpsd</li>
    <li>home-assistant-component-tests.gpslogger</li>
    <li>home-assistant-component-tests.graphite</li>
    <li>home-assistant-component-tests.gree</li>
    <li>home-assistant-component-tests.greeneye_monitor</li>
    <li>home-assistant-component-tests.group</li>
    <li>home-assistant-component-tests.growatt_server</li>
    <li>home-assistant-component-tests.guardian</li>
    <li>home-assistant-component-tests.habitica</li>
    <li>home-assistant-component-tests.hardkernel</li>
    <li>home-assistant-component-tests.hardware</li>
    <li>home-assistant-component-tests.harmony</li>
    <li>home-assistant-component-tests.hassio</li>
    <li>home-assistant-component-tests.hddtemp</li>
    <li>home-assistant-component-tests.hdmi_cec</li>
    <li>home-assistant-component-tests.heos</li>
    <li>home-assistant-component-tests.here_travel_time</li>
    <li>home-assistant-component-tests.hisense_aehw4a1</li>
    <li>home-assistant-component-tests.history</li>
    <li>home-assistant-component-tests.history_stats</li>
    <li>home-assistant-component-tests.hive</li>
    <li>home-assistant-component-tests.hlk_sw16</li>
    <li>home-assistant-component-tests.holiday</li>
    <li>home-assistant-component-tests.home_connect</li>
    <li>home-assistant-component-tests.homeassistant</li>
    <li>home-assistant-component-tests.homeassistant_alerts</li>
    <li>home-assistant-component-tests.homeassistant_green</li>
    <li>home-assistant-component-tests.homeassistant_hardware</li>
    <li>home-assistant-component-tests.homeassistant_sky_connect</li>
    <li>home-assistant-component-tests.homeassistant_yellow</li>
    <li>home-assistant-component-tests.homekit</li>
    <li>home-assistant-component-tests.homekit_controller</li>
    <li>home-assistant-component-tests.homematic</li>
    <li>home-assistant-component-tests.homematicip_cloud</li>
    <li>home-assistant-component-tests.homewizard</li>
    <li>home-assistant-component-tests.homeworks</li>
    <li>home-assistant-component-tests.honeywell</li>
    <li>home-assistant-component-tests.html5</li>
    <li>home-assistant-component-tests.http</li>
    <li>home-assistant-component-tests.huawei_lte</li>
    <li>home-assistant-component-tests.hue</li>
    <li>home-assistant-component-tests.huisbaasje</li>
    <li>home-assistant-component-tests.humidifier</li>
    <li>home-assistant-component-tests.hunterdouglas_powerview</li>
    <li>home-assistant-component-tests.husqvarna_automower</li>
    <li>home-assistant-component-tests.huum</li>
    <li>home-assistant-component-tests.hvv_departures</li>
    <li>home-assistant-component-tests.hydrawise</li>
    <li>home-assistant-component-tests.hyperion</li>
    <li>home-assistant-component-tests.ialarm</li>
    <li>home-assistant-component-tests.iaqualink</li>
    <li>home-assistant-component-tests.ibeacon</li>
    <li>home-assistant-component-tests.icloud</li>
    <li>home-assistant-component-tests.ifttt</li>
    <li>home-assistant-component-tests.ign_sismologia</li>
    <li>home-assistant-component-tests.image</li>
    <li>home-assistant-component-tests.image_processing</li>
    <li>home-assistant-component-tests.image_upload</li>
    <li>home-assistant-component-tests.imap</li>
    <li>home-assistant-component-tests.incomfort</li>
    <li>home-assistant-component-tests.influxdb</li>
    <li>home-assistant-component-tests.inkbird</li>
    <li>home-assistant-component-tests.input_boolean</li>
    <li>home-assistant-component-tests.input_button</li>
    <li>home-assistant-component-tests.input_datetime</li>
    <li>home-assistant-component-tests.input_number</li>
    <li>home-assistant-component-tests.input_select</li>
    <li>home-assistant-component-tests.input_text</li>
    <li>home-assistant-component-tests.insteon</li>
    <li>home-assistant-component-tests.integration</li>
    <li>home-assistant-component-tests.intellifire</li>
    <li>home-assistant-component-tests.intent</li>
    <li>home-assistant-component-tests.intent_script</li>
    <li>home-assistant-component-tests.ios</li>
    <li>home-assistant-component-tests.ipma</li>
    <li>home-assistant-component-tests.ipp</li>
    <li>home-assistant-component-tests.iqvia</li>
    <li>home-assistant-component-tests.isal</li>
    <li>home-assistant-component-tests.isy994</li>
    <li>home-assistant-component-tests.izone</li>
    <li>home-assistant-component-tests.jellyfin</li>
    <li>home-assistant-component-tests.jewish_calendar</li>
    <li>home-assistant-component-tests.juicenet</li>
    <li>home-assistant-component-tests.justnimbus</li>
    <li>home-assistant-component-tests.kaleidescape</li>
    <li>home-assistant-component-tests.keenetic_ndms2</li>
    <li>home-assistant-component-tests.kegtron</li>
    <li>home-assistant-component-tests.keymitt_ble</li>
    <li>home-assistant-component-tests.kira</li>
    <li>home-assistant-component-tests.kitchen_sink</li>
    <li>home-assistant-component-tests.kmtronic</li>
    <li>home-assistant-component-tests.knx</li>
    <li>home-assistant-component-tests.kodi</li>
    <li>home-assistant-component-tests.konnected</li>
    <li>home-assistant-component-tests.kostal_plenticore</li>
    <li>home-assistant-component-tests.kraken</li>
    <li>home-assistant-component-tests.kulersky</li>
    <li>home-assistant-component-tests.lamarzocco</li>
    <li>home-assistant-component-tests.lametric</li>
    <li>home-assistant-component-tests.landisgyr_heat_meter</li>
    <li>home-assistant-component-tests.lastfm</li>
    <li>home-assistant-component-tests.launch_library</li>
    <li>home-assistant-component-tests.laundrify</li>
    <li>home-assistant-component-tests.lawn_mower</li>
    <li>home-assistant-component-tests.lcn</li>
    <li>home-assistant-component-tests.ld2410_ble</li>
    <li>home-assistant-component-tests.led_ble</li>
    <li>home-assistant-component-tests.lg_netcast</li>
    <li>home-assistant-component-tests.lg_soundbar</li>
    <li>home-assistant-component-tests.lidarr</li>
    <li>home-assistant-component-tests.life360</li>
    <li>home-assistant-component-tests.lifx</li>
    <li>home-assistant-component-tests.light</li>
    <li>home-assistant-component-tests.linear_garage_door</li>
    <li>home-assistant-component-tests.litterrobot</li>
    <li>home-assistant-component-tests.livisi</li>
    <li>home-assistant-component-tests.local_calendar</li>
    <li>home-assistant-component-tests.local_file</li>
    <li>home-assistant-component-tests.local_ip</li>
    <li>home-assistant-component-tests.local_todo</li>
    <li>home-assistant-component-tests.locative</li>
    <li>home-assistant-component-tests.lock</li>
    <li>home-assistant-component-tests.logbook</li>
    <li>home-assistant-component-tests.logentries</li>
    <li>home-assistant-component-tests.logger</li>
    <li>home-assistant-component-tests.logi_circle</li>
    <li>home-assistant-component-tests.london_air</li>
    <li>home-assistant-component-tests.lookin</li>
    <li>home-assistant-component-tests.loqed</li>
    <li>home-assistant-component-tests.lovelace</li>
    <li>home-assistant-component-tests.luftdaten</li>
    <li>home-assistant-component-tests.lupusec</li>
    <li>home-assistant-component-tests.lutron</li>
    <li>home-assistant-component-tests.lutron_caseta</li>
    <li>home-assistant-component-tests.lyric</li>
    <li>home-assistant-component-tests.mailbox</li>
    <li>home-assistant-component-tests.mailgun</li>
    <li>home-assistant-component-tests.manual</li>
    <li>home-assistant-component-tests.manual_mqtt</li>
    <li>home-assistant-component-tests.map</li>
    <li>home-assistant-component-tests.matrix</li>
    <li>home-assistant-component-tests.matter</li>
    <li>home-assistant-component-tests.maxcube</li>
    <li>home-assistant-component-tests.mazda</li>
    <li>home-assistant-component-tests.mealie</li>
    <li>home-assistant-component-tests.meater</li>
    <li>home-assistant-component-tests.media_extractor</li>
    <li>home-assistant-component-tests.media_player</li>
    <li>home-assistant-component-tests.media_source</li>
    <li>home-assistant-component-tests.melcloud</li>
    <li>home-assistant-component-tests.meraki</li>
    <li>home-assistant-component-tests.met</li>
    <li>home-assistant-component-tests.met_eireann</li>
    <li>home-assistant-component-tests.meteo_france</li>
    <li>home-assistant-component-tests.meteoclimatic</li>
    <li>home-assistant-component-tests.metoffice</li>
    <li>home-assistant-component-tests.microsoft_face</li>
    <li>home-assistant-component-tests.microsoft_face_detect</li>
    <li>home-assistant-component-tests.microsoft_face_identify</li>
    <li>home-assistant-component-tests.mikrotik</li>
    <li>home-assistant-component-tests.mill</li>
    <li>home-assistant-component-tests.min_max</li>
    <li>home-assistant-component-tests.minecraft_server</li>
    <li>home-assistant-component-tests.minio</li>
    <li>home-assistant-component-tests.mjpeg</li>
    <li>home-assistant-component-tests.moat</li>
    <li>home-assistant-component-tests.mobile_app</li>
    <li>home-assistant-component-tests.modbus</li>
    <li>home-assistant-component-tests.modem_callerid</li>
    <li>home-assistant-component-tests.modern_forms</li>
    <li>home-assistant-component-tests.mold_indicator</li>
    <li>home-assistant-component-tests.monzo</li>
    <li>home-assistant-component-tests.moon</li>
    <li>home-assistant-component-tests.mopeka</li>
    <li>home-assistant-component-tests.motion_blinds</li>
    <li>home-assistant-component-tests.motionblinds_ble</li>
    <li>home-assistant-component-tests.motioneye</li>
    <li>home-assistant-component-tests.motionmount</li>
    <li>home-assistant-component-tests.mpd</li>
    <li>home-assistant-component-tests.mqtt</li>
    <li>home-assistant-component-tests.mqtt_eventstream</li>
    <li>home-assistant-component-tests.mqtt_json</li>
    <li>home-assistant-component-tests.mqtt_room</li>
    <li>home-assistant-component-tests.mqtt_statestream</li>
    <li>home-assistant-component-tests.mullvad</li>
    <li>home-assistant-component-tests.mutesync</li>
    <li>home-assistant-component-tests.my</li>
    <li>home-assistant-component-tests.myq</li>
    <li>home-assistant-component-tests.mysensors</li>
    <li>home-assistant-component-tests.mystrom</li>
    <li>home-assistant-component-tests.mythicbeastsdns</li>
    <li>home-assistant-component-tests.myuplink</li>
    <li>home-assistant-component-tests.nam</li>
    <li>home-assistant-component-tests.namecheapdns</li>
    <li>home-assistant-component-tests.nanoleaf</li>
    <li>home-assistant-component-tests.neato</li>
    <li>home-assistant-component-tests.ness_alarm</li>
    <li>home-assistant-component-tests.nest</li>
    <li>home-assistant-component-tests.netatmo</li>
    <li>home-assistant-component-tests.netgear</li>
    <li>home-assistant-component-tests.netgear_lte</li>
    <li>home-assistant-component-tests.network</li>
    <li>home-assistant-component-tests.nexia</li>
    <li>home-assistant-component-tests.nextbus</li>
    <li>home-assistant-component-tests.nextcloud</li>
    <li>home-assistant-component-tests.nextdns</li>
    <li>home-assistant-component-tests.nfandroidtv</li>
    <li>home-assistant-component-tests.nibe_heatpump</li>
    <li>home-assistant-component-tests.nightscout</li>
    <li>home-assistant-component-tests.nina</li>
    <li>home-assistant-component-tests.nmap_tracker</li>
    <li>home-assistant-component-tests.no_ip</li>
    <li>home-assistant-component-tests.nobo_hub</li>
    <li>home-assistant-component-tests.notify</li>
    <li>home-assistant-component-tests.notify_events</li>
    <li>home-assistant-component-tests.notion</li>
    <li>home-assistant-component-tests.nsw_rural_fire_service_feed</li>
    <li>home-assistant-component-tests.nuheat</li>
    <li>home-assistant-component-tests.nuki</li>
    <li>home-assistant-component-tests.number</li>
    <li>home-assistant-component-tests.nut</li>
    <li>home-assistant-component-tests.nws</li>
    <li>home-assistant-component-tests.nx584</li>
    <li>home-assistant-component-tests.obihai</li>
    <li>home-assistant-component-tests.octoprint</li>
    <li>home-assistant-component-tests.ollama</li>
    <li>home-assistant-component-tests.omnilogic</li>
    <li>home-assistant-component-tests.onboarding</li>
    <li>home-assistant-component-tests.oncue</li>
    <li>home-assistant-component-tests.ondilo_ico</li>
    <li>home-assistant-component-tests.onewire</li>
    <li>home-assistant-component-tests.onvif</li>
    <li>home-assistant-component-tests.open_meteo</li>
    <li>home-assistant-component-tests.openai_conversation</li>
    <li>home-assistant-component-tests.openalpr_cloud</li>
    <li>home-assistant-component-tests.openerz</li>
    <li>home-assistant-component-tests.openexchangerates</li>
    <li>home-assistant-component-tests.opengarage</li>
    <li>home-assistant-component-tests.openhardwaremonitor</li>
    <li>home-assistant-component-tests.openhome</li>
    <li>home-assistant-component-tests.opensky</li>
    <li>home-assistant-component-tests.opentherm_gw</li>
    <li>home-assistant-component-tests.openuv</li>
    <li>home-assistant-component-tests.openweathermap</li>
    <li>home-assistant-component-tests.opnsense</li>
    <li>home-assistant-component-tests.opower</li>
    <li>home-assistant-component-tests.oralb</li>
    <li>home-assistant-component-tests.otbr</li>
    <li>home-assistant-component-tests.otp</li>
    <li>home-assistant-component-tests.overkiz</li>
    <li>home-assistant-component-tests.ovo_energy</li>
    <li>home-assistant-component-tests.owntracks</li>
    <li>home-assistant-component-tests.p1_monitor</li>
    <li>home-assistant-component-tests.panasonic_viera</li>
    <li>home-assistant-component-tests.panel_custom</li>
    <li>home-assistant-component-tests.panel_iframe</li>
    <li>home-assistant-component-tests.peco</li>
    <li>home-assistant-component-tests.pegel_online</li>
    <li>home-assistant-component-tests.persistent_notification</li>
    <li>home-assistant-component-tests.person</li>
    <li>home-assistant-component-tests.philips_js</li>
    <li>home-assistant-component-tests.pi_hole</li>
    <li>home-assistant-component-tests.picnic</li>
    <li>home-assistant-component-tests.ping</li>
    <li>home-assistant-component-tests.plaato</li>
    <li>home-assistant-component-tests.plant</li>
    <li>home-assistant-component-tests.plex</li>
    <li>home-assistant-component-tests.plugwise</li>
    <li>home-assistant-component-tests.point</li>
    <li>home-assistant-component-tests.poolsense</li>
    <li>home-assistant-component-tests.powerwall</li>
    <li>home-assistant-component-tests.private_ble_device</li>
    <li>home-assistant-component-tests.profiler</li>
    <li>home-assistant-component-tests.prometheus</li>
    <li>home-assistant-component-tests.prosegur</li>
    <li>home-assistant-component-tests.proximity</li>
    <li>home-assistant-component-tests.prusalink</li>
    <li>home-assistant-component-tests.pure_energie</li>
    <li>home-assistant-component-tests.purpleair</li>
    <li>home-assistant-component-tests.push</li>
    <li>home-assistant-component-tests.pushbullet</li>
    <li>home-assistant-component-tests.pushover</li>
    <li>home-assistant-component-tests.pvoutput</li>
    <li>home-assistant-component-tests.pvpc_hourly_pricing</li>
    <li>home-assistant-component-tests.pyload</li>
    <li>home-assistant-component-tests.python_script</li>
    <li>home-assistant-component-tests.qbittorrent</li>
    <li>home-assistant-component-tests.qingping</li>
    <li>home-assistant-component-tests.qld_bushfire</li>
    <li>home-assistant-component-tests.qnap</li>
    <li>home-assistant-component-tests.qnap_qsw</li>
    <li>home-assistant-component-tests.qwikswitch</li>
    <li>home-assistant-component-tests.rabbitair</li>
    <li>home-assistant-component-tests.rachio</li>
    <li>home-assistant-component-tests.radarr</li>
    <li>home-assistant-component-tests.radio_browser</li>
    <li>home-assistant-component-tests.radiotherm</li>
    <li>home-assistant-component-tests.rainbird</li>
    <li>home-assistant-component-tests.rainforest_eagle</li>
    <li>home-assistant-component-tests.rainforest_raven</li>
    <li>home-assistant-component-tests.rainmachine</li>
    <li>home-assistant-component-tests.random</li>
    <li>home-assistant-component-tests.rapt_ble</li>
    <li>home-assistant-component-tests.raspberry_pi</li>
    <li>home-assistant-component-tests.rdw</li>
    <li>home-assistant-component-tests.recollect_waste</li>
    <li>home-assistant-component-tests.recorder</li>
    <li>home-assistant-component-tests.recovery_mode</li>
    <li>home-assistant-component-tests.reddit</li>
    <li>home-assistant-component-tests.remote</li>
    <li>home-assistant-component-tests.renault</li>
    <li>home-assistant-component-tests.renson</li>
    <li>home-assistant-component-tests.reolink</li>
    <li>home-assistant-component-tests.repairs</li>
    <li>home-assistant-component-tests.rest</li>
    <li>home-assistant-component-tests.rest_command</li>
    <li>home-assistant-component-tests.rflink</li>
    <li>home-assistant-component-tests.rfxtrx</li>
    <li>home-assistant-component-tests.rhasspy</li>
    <li>home-assistant-component-tests.ridwell</li>
    <li>home-assistant-component-tests.ring</li>
    <li>home-assistant-component-tests.risco</li>
    <li>home-assistant-component-tests.rituals_perfume_genie</li>
    <li>home-assistant-component-tests.rmvtransport</li>
    <li>home-assistant-component-tests.roborock</li>
    <li>home-assistant-component-tests.roku</li>
    <li>home-assistant-component-tests.romy</li>
    <li>home-assistant-component-tests.roomba</li>
    <li>home-assistant-component-tests.roon</li>
    <li>home-assistant-component-tests.rova</li>
    <li>home-assistant-component-tests.rpi_power</li>
    <li>home-assistant-component-tests.rss_feed_template</li>
    <li>home-assistant-component-tests.rtsp_to_webrtc</li>
    <li>home-assistant-component-tests.ruckus_unleashed</li>
    <li>home-assistant-component-tests.ruuvi_gateway</li>
    <li>home-assistant-component-tests.ruuvitag_ble</li>
    <li>home-assistant-component-tests.rympro</li>
    <li>home-assistant-component-tests.sabnzbd</li>
    <li>home-assistant-component-tests.samsungtv</li>
    <li>home-assistant-component-tests.sanix</li>
    <li>home-assistant-component-tests.scene</li>
    <li>home-assistant-component-tests.schedule</li>
    <li>home-assistant-component-tests.schlage</li>
    <li>home-assistant-component-tests.scrape</li>
    <li>home-assistant-component-tests.screenlogic</li>
    <li>home-assistant-component-tests.script</li>
    <li>home-assistant-component-tests.search</li>
    <li>home-assistant-component-tests.season</li>
    <li>home-assistant-component-tests.select</li>
    <li>home-assistant-component-tests.sense</li>
    <li>home-assistant-component-tests.sensibo</li>
    <li>home-assistant-component-tests.sensirion_ble</li>
    <li>home-assistant-component-tests.sensor</li>
    <li>home-assistant-component-tests.sensorpro</li>
    <li>home-assistant-component-tests.sensorpush</li>
    <li>home-assistant-component-tests.sentry</li>
    <li>home-assistant-component-tests.senz</li>
    <li>home-assistant-component-tests.seventeentrack</li>
    <li>home-assistant-component-tests.sfr_box</li>
    <li>home-assistant-component-tests.sharkiq</li>
    <li>home-assistant-component-tests.shell_command</li>
    <li>home-assistant-component-tests.shelly</li>
    <li>home-assistant-component-tests.shopping_list</li>
    <li>home-assistant-component-tests.sia</li>
    <li>home-assistant-component-tests.sigfox</li>
    <li>home-assistant-component-tests.sighthound</li>
    <li>home-assistant-component-tests.signal_messenger</li>
    <li>home-assistant-component-tests.simplepush</li>
    <li>home-assistant-component-tests.simplisafe</li>
    <li>home-assistant-component-tests.simulated</li>
    <li>home-assistant-component-tests.siren</li>
    <li>home-assistant-component-tests.skybell</li>
    <li>home-assistant-component-tests.slack</li>
    <li>home-assistant-component-tests.sleepiq</li>
    <li>home-assistant-component-tests.slimproto</li>
    <li>home-assistant-component-tests.sma</li>
    <li>home-assistant-component-tests.smappee</li>
    <li>home-assistant-component-tests.smart_meter_texas</li>
    <li>home-assistant-component-tests.smartthings</li>
    <li>home-assistant-component-tests.smarttub</li>
    <li>home-assistant-component-tests.smhi</li>
    <li>home-assistant-component-tests.sms</li>
    <li>home-assistant-component-tests.smtp</li>
    <li>home-assistant-component-tests.snapcast</li>
    <li>home-assistant-component-tests.snips</li>
    <li>home-assistant-component-tests.snmp</li>
    <li>home-assistant-component-tests.snooz</li>
    <li>home-assistant-component-tests.solax</li>
    <li>home-assistant-component-tests.soma</li>
    <li>home-assistant-component-tests.somfy_mylink</li>
    <li>home-assistant-component-tests.sonarr</li>
    <li>home-assistant-component-tests.sonos</li>
    <li>home-assistant-component-tests.soundtouch</li>
    <li>home-assistant-component-tests.spaceapi</li>
    <li>home-assistant-component-tests.spc</li>
    <li>home-assistant-component-tests.speedtestdotnet</li>
    <li>home-assistant-component-tests.spider</li>
    <li>home-assistant-component-tests.spotify</li>
    <li>home-assistant-component-tests.sql</li>
    <li>home-assistant-component-tests.squeezebox</li>
    <li>home-assistant-component-tests.srp_energy</li>
    <li>home-assistant-component-tests.ssdp</li>
    <li>home-assistant-component-tests.starline</li>
    <li>home-assistant-component-tests.startca</li>
    <li>home-assistant-component-tests.statistics</li>
    <li>home-assistant-component-tests.statsd</li>
    <li>home-assistant-component-tests.steam_online</li>
    <li>home-assistant-component-tests.steamist</li>
    <li>home-assistant-component-tests.stookalert</li>
    <li>home-assistant-component-tests.stream</li>
    <li>home-assistant-component-tests.streamlabswater</li>
    <li>home-assistant-component-tests.stt</li>
    <li>home-assistant-component-tests.subaru</li>
    <li>home-assistant-component-tests.suez_water</li>
    <li>home-assistant-component-tests.sun</li>
    <li>home-assistant-component-tests.sunweg</li>
    <li>home-assistant-component-tests.surepetcare</li>
    <li>home-assistant-component-tests.swiss_public_transport</li>
    <li>home-assistant-component-tests.switch</li>
    <li>home-assistant-component-tests.switch_as_x</li>
    <li>home-assistant-component-tests.switchbee</li>
    <li>home-assistant-component-tests.switchbot</li>
    <li>home-assistant-component-tests.switchbot_cloud</li>
    <li>home-assistant-component-tests.switcher_kis</li>
    <li>home-assistant-component-tests.syncthing</li>
    <li>home-assistant-component-tests.syncthru</li>
    <li>home-assistant-component-tests.synology_dsm</li>
    <li>home-assistant-component-tests.system_bridge</li>
    <li>home-assistant-component-tests.system_health</li>
    <li>home-assistant-component-tests.systemmonitor</li>
    <li>home-assistant-component-tests.tado</li>
    <li>home-assistant-component-tests.tag</li>
    <li>home-assistant-component-tests.tailscale</li>
    <li>home-assistant-component-tests.tailwind</li>
    <li>home-assistant-component-tests.tankerkoenig</li>
    <li>home-assistant-component-tests.tasmota</li>
    <li>home-assistant-component-tests.tautulli</li>
    <li>home-assistant-component-tests.tcp</li>
    <li>home-assistant-component-tests.technove</li>
    <li>home-assistant-component-tests.tedee</li>
    <li>home-assistant-component-tests.tellduslive</li>
    <li>home-assistant-component-tests.temper</li>
    <li>home-assistant-component-tests.template</li>
    <li>home-assistant-component-tests.tesla_wall_connector</li>
    <li>home-assistant-component-tests.teslemetry</li>
    <li>home-assistant-component-tests.text</li>
    <li>home-assistant-component-tests.thermobeacon</li>
    <li>home-assistant-component-tests.thermopro</li>
    <li>home-assistant-component-tests.thethingsnetwork</li>
    <li>home-assistant-component-tests.thread</li>
    <li>home-assistant-component-tests.threshold</li>
    <li>home-assistant-component-tests.tibber</li>
    <li>home-assistant-component-tests.tile</li>
    <li>home-assistant-component-tests.tilt_ble</li>
    <li>home-assistant-component-tests.time</li>
    <li>home-assistant-component-tests.time_date</li>
    <li>home-assistant-component-tests.timer</li>
    <li>home-assistant-component-tests.tod</li>
    <li>home-assistant-component-tests.todo</li>
    <li>home-assistant-component-tests.todoist</li>
    <li>home-assistant-component-tests.tolo</li>
    <li>home-assistant-component-tests.tomato</li>
    <li>home-assistant-component-tests.tomorrowio</li>
    <li>home-assistant-component-tests.toon</li>
    <li>home-assistant-component-tests.totalconnect</li>
    <li>home-assistant-component-tests.tplink</li>
    <li>home-assistant-component-tests.tplink_omada</li>
    <li>home-assistant-component-tests.traccar</li>
    <li>home-assistant-component-tests.traccar_server</li>
    <li>home-assistant-component-tests.trace</li>
    <li>home-assistant-component-tests.tractive</li>
    <li>home-assistant-component-tests.tradfri</li>
    <li>home-assistant-component-tests.trafikverket_camera</li>
    <li>home-assistant-component-tests.trafikverket_ferry</li>
    <li>home-assistant-component-tests.trafikverket_train</li>
    <li>home-assistant-component-tests.trafikverket_weatherstation</li>
    <li>home-assistant-component-tests.transmission</li>
    <li>home-assistant-component-tests.transport_nsw</li>
    <li>home-assistant-component-tests.trend</li>
    <li>home-assistant-component-tests.tts</li>
    <li>home-assistant-component-tests.tuya</li>
    <li>home-assistant-component-tests.twentemilieu</li>
    <li>home-assistant-component-tests.twilio</li>
    <li>home-assistant-component-tests.twinkly</li>
    <li>home-assistant-component-tests.twitch</li>
    <li>home-assistant-component-tests.uk_transport</li>
    <li>home-assistant-component-tests.ukraine_alarm</li>
    <li>home-assistant-component-tests.unifi</li>
    <li>home-assistant-component-tests.unifiprotect</li>
    <li>home-assistant-component-tests.universal</li>
    <li>home-assistant-component-tests.upb</li>
    <li>home-assistant-component-tests.upcloud</li>
    <li>home-assistant-component-tests.update</li>
    <li>home-assistant-component-tests.upnp</li>
    <li>home-assistant-component-tests.uptime</li>
    <li>home-assistant-component-tests.uptimerobot</li>
    <li>home-assistant-component-tests.usb</li>
    <li>home-assistant-component-tests.usgs_earthquakes_feed</li>
    <li>home-assistant-component-tests.utility_meter</li>
    <li>home-assistant-component-tests.uvc</li>
    <li>home-assistant-component-tests.v2c</li>
    <li>home-assistant-component-tests.vacuum</li>
    <li>home-assistant-component-tests.vallox</li>
    <li>home-assistant-component-tests.valve</li>
    <li>home-assistant-component-tests.velbus</li>
    <li>home-assistant-component-tests.velux</li>
    <li>home-assistant-component-tests.venstar</li>
    <li>home-assistant-component-tests.vera</li>
    <li>home-assistant-component-tests.verisure</li>
    <li>home-assistant-component-tests.version</li>
    <li>home-assistant-component-tests.vesync</li>
    <li>home-assistant-component-tests.vicare</li>
    <li>home-assistant-component-tests.vilfo</li>
    <li>home-assistant-component-tests.vizio</li>
    <li>home-assistant-component-tests.vlc_telnet</li>
    <li>home-assistant-component-tests.vodafone_station</li>
    <li>home-assistant-component-tests.voicerss</li>
    <li>home-assistant-component-tests.volumio</li>
    <li>home-assistant-component-tests.volvooncall</li>
    <li>home-assistant-component-tests.vulcan</li>
    <li>home-assistant-component-tests.vultr</li>
    <li>home-assistant-component-tests.wake_on_lan</li>
    <li>home-assistant-component-tests.wake_word</li>
    <li>home-assistant-component-tests.wallbox</li>
    <li>home-assistant-component-tests.waqi</li>
    <li>home-assistant-component-tests.water_heater</li>
    <li>home-assistant-component-tests.watttime</li>
    <li>home-assistant-component-tests.waze_travel_time</li>
    <li>home-assistant-component-tests.weather</li>
    <li>home-assistant-component-tests.weatherflow</li>
    <li>home-assistant-component-tests.weatherflow_cloud</li>
    <li>home-assistant-component-tests.weatherkit</li>
    <li>home-assistant-component-tests.webhook</li>
    <li>home-assistant-component-tests.webostv</li>
    <li>home-assistant-component-tests.websocket_api</li>
    <li>home-assistant-component-tests.wemo</li>
    <li>home-assistant-component-tests.whirlpool</li>
    <li>home-assistant-component-tests.whois</li>
    <li>home-assistant-component-tests.wiffi</li>
    <li>home-assistant-component-tests.wilight</li>
    <li>home-assistant-component-tests.withings</li>
    <li>home-assistant-component-tests.wiz</li>
    <li>home-assistant-component-tests.wled</li>
    <li>home-assistant-component-tests.workday</li>
    <li>home-assistant-component-tests.worldclock</li>
    <li>home-assistant-component-tests.ws66i</li>
    <li>home-assistant-component-tests.wsdot</li>
    <li>home-assistant-component-tests.wyoming</li>
    <li>home-assistant-component-tests.xbox</li>
    <li>home-assistant-component-tests.xiaomi</li>
    <li>home-assistant-component-tests.xiaomi_aqara</li>
    <li>home-assistant-component-tests.xiaomi_ble</li>
    <li>home-assistant-component-tests.xiaomi_miio</li>
    <li>home-assistant-component-tests.yale_smart_alarm</li>
    <li>home-assistant-component-tests.yalexs_ble</li>
    <li>home-assistant-component-tests.yamaha</li>
    <li>home-assistant-component-tests.yamaha_musiccast</li>
    <li>home-assistant-component-tests.yandex_transport</li>
    <li>home-assistant-component-tests.yandextts</li>
    <li>home-assistant-component-tests.yardian</li>
    <li>home-assistant-component-tests.yeelight</li>
    <li>home-assistant-component-tests.yolink</li>
    <li>home-assistant-component-tests.youless</li>
    <li>home-assistant-component-tests.youtube</li>
    <li>home-assistant-component-tests.zamg</li>
    <li>home-assistant-component-tests.zeroconf</li>
    <li>home-assistant-component-tests.zerproc</li>
    <li>home-assistant-component-tests.zha</li>
    <li>home-assistant-component-tests.zodiac</li>
    <li>home-assistant-component-tests.zone</li>
    <li>home-assistant-component-tests.zwave_js</li>
    <li>home-assistant-component-tests.zwave_me</li>
    <li>home-assistant.dist</li>
    <li>python311Packages.webrtc-noise-gain</li>
    <li>python311Packages.webrtc-noise-gain.dist</li>
    <li>python312Packages.homeassistant-stubs</li>
    <li>python312Packages.homeassistant-stubs.dist</li>
    <li>python312Packages.webrtc-noise-gain</li>
    <li>python312Packages.webrtc-noise-gain.dist</li>
  </ul>
</details>

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages failed to build:</summary>
  <ul>
    <li>home-assistant-component-tests.azure_devops</li>
    <li>home-assistant-component-tests.songpal</li>
    <li>home-assistant-component-tests.system_log</li>
  </ul>
</details>
<details>
  <summary>838 packages built:</summary>
  <ul>
    <li>home-assistant</li>
    <li>home-assistant-component-tests.abode</li>
    <li>home-assistant-component-tests.accuweather</li>
    <li>home-assistant-component-tests.acmeda</li>
    <li>home-assistant-component-tests.adax</li>
    <li>home-assistant-component-tests.adguard</li>
    <li>home-assistant-component-tests.advantage_air</li>
    <li>home-assistant-component-tests.aemet</li>
    <li>home-assistant-component-tests.aftership</li>
    <li>home-assistant-component-tests.agent_dvr</li>
    <li>home-assistant-component-tests.air_quality</li>
    <li>home-assistant-component-tests.airly</li>
    <li>home-assistant-component-tests.airnow</li>
    <li>home-assistant-component-tests.airq</li>
    <li>home-assistant-component-tests.airthings</li>
    <li>home-assistant-component-tests.airthings_ble</li>
    <li>home-assistant-component-tests.airtouch4</li>
    <li>home-assistant-component-tests.airtouch5</li>
    <li>home-assistant-component-tests.airvisual</li>
    <li>home-assistant-component-tests.airvisual_pro</li>
    <li>home-assistant-component-tests.airzone</li>
    <li>home-assistant-component-tests.airzone_cloud</li>
    <li>home-assistant-component-tests.aladdin_connect</li>
    <li>home-assistant-component-tests.alarm_control_panel</li>
    <li>home-assistant-component-tests.alarmdecoder</li>
    <li>home-assistant-component-tests.alert</li>
    <li>home-assistant-component-tests.alexa</li>
    <li>home-assistant-component-tests.amberelectric</li>
    <li>home-assistant-component-tests.ambient_network</li>
    <li>home-assistant-component-tests.ambient_station</li>
    <li>home-assistant-component-tests.analytics</li>
    <li>home-assistant-component-tests.analytics_insights</li>
    <li>home-assistant-component-tests.android_ip_webcam</li>
    <li>home-assistant-component-tests.androidtv</li>
    <li>home-assistant-component-tests.androidtv_remote</li>
    <li>home-assistant-component-tests.anova</li>
    <li>home-assistant-component-tests.anthemav</li>
    <li>home-assistant-component-tests.aosmith</li>
    <li>home-assistant-component-tests.apache_kafka</li>
    <li>home-assistant-component-tests.apcupsd</li>
    <li>home-assistant-component-tests.api</li>
    <li>home-assistant-component-tests.apple_tv</li>
    <li>home-assistant-component-tests.application_credentials</li>
    <li>home-assistant-component-tests.apprise</li>
    <li>home-assistant-component-tests.aprs</li>
    <li>home-assistant-component-tests.aranet</li>
    <li>home-assistant-component-tests.arcam_fmj</li>
    <li>home-assistant-component-tests.aseko_pool_live</li>
    <li>home-assistant-component-tests.assist_pipeline</li>
    <li>home-assistant-component-tests.asterisk_mbox</li>
    <li>home-assistant-component-tests.asuswrt</li>
    <li>home-assistant-component-tests.atag</li>
    <li>home-assistant-component-tests.august</li>
    <li>home-assistant-component-tests.aurora</li>
    <li>home-assistant-component-tests.aurora_abb_powerone</li>
    <li>home-assistant-component-tests.aussie_broadband</li>
    <li>home-assistant-component-tests.auth</li>
    <li>home-assistant-component-tests.automation</li>
    <li>home-assistant-component-tests.awair</li>
    <li>home-assistant-component-tests.aws</li>
    <li>home-assistant-component-tests.axis</li>
    <li>home-assistant-component-tests.azure_event_hub</li>
    <li>home-assistant-component-tests.backup</li>
    <li>home-assistant-component-tests.baf</li>
    <li>home-assistant-component-tests.balboa</li>
    <li>home-assistant-component-tests.bayesian</li>
    <li>home-assistant-component-tests.binary_sensor</li>
    <li>home-assistant-component-tests.blackbird</li>
    <li>home-assistant-component-tests.blebox</li>
    <li>home-assistant-component-tests.blink</li>
    <li>home-assistant-component-tests.blue_current</li>
    <li>home-assistant-component-tests.bluemaestro</li>
    <li>home-assistant-component-tests.blueprint</li>
    <li>home-assistant-component-tests.bluetooth</li>
    <li>home-assistant-component-tests.bluetooth_adapters</li>
    <li>home-assistant-component-tests.bluetooth_le_tracker</li>
    <li>home-assistant-component-tests.bmw_connected_drive</li>
    <li>home-assistant-component-tests.bond</li>
    <li>home-assistant-component-tests.bosch_shc</li>
    <li>home-assistant-component-tests.braviatv</li>
    <li>home-assistant-component-tests.bring</li>
    <li>home-assistant-component-tests.broadlink</li>
    <li>home-assistant-component-tests.brother</li>
    <li>home-assistant-component-tests.brottsplatskartan</li>
    <li>home-assistant-component-tests.brunt</li>
    <li>home-assistant-component-tests.bsblan</li>
    <li>home-assistant-component-tests.bthome</li>
    <li>home-assistant-component-tests.buienradar</li>
    <li>home-assistant-component-tests.button</li>
    <li>home-assistant-component-tests.caldav</li>
    <li>home-assistant-component-tests.calendar</li>
    <li>home-assistant-component-tests.camera</li>
    <li>home-assistant-component-tests.canary</li>
    <li>home-assistant-component-tests.cast</li>
    <li>home-assistant-component-tests.cert_expiry</li>
    <li>home-assistant-component-tests.clicksend_tts</li>
    <li>home-assistant-component-tests.climate</li>
    <li>home-assistant-component-tests.cloud</li>
    <li>home-assistant-component-tests.cloudflare</li>
    <li>home-assistant-component-tests.co2signal</li>
    <li>home-assistant-component-tests.color_extractor</li>
    <li>home-assistant-component-tests.comelit</li>
    <li>home-assistant-component-tests.comfoconnect</li>
    <li>home-assistant-component-tests.command_line</li>
    <li>home-assistant-component-tests.compensation</li>
    <li>home-assistant-component-tests.config</li>
    <li>home-assistant-component-tests.configurator</li>
    <li>home-assistant-component-tests.control4</li>
    <li>home-assistant-component-tests.conversation</li>
    <li>home-assistant-component-tests.coolmaster</li>
    <li>home-assistant-component-tests.counter</li>
    <li>home-assistant-component-tests.cover</li>
    <li>home-assistant-component-tests.cpuspeed</li>
    <li>home-assistant-component-tests.crownstone</li>
    <li>home-assistant-component-tests.daikin</li>
    <li>home-assistant-component-tests.datadog</li>
    <li>home-assistant-component-tests.date</li>
    <li>home-assistant-component-tests.datetime</li>
    <li>home-assistant-component-tests.debugpy</li>
    <li>home-assistant-component-tests.deconz</li>
    <li>home-assistant-component-tests.default_config</li>
    <li>home-assistant-component-tests.deluge</li>
    <li>home-assistant-component-tests.demo</li>
    <li>home-assistant-component-tests.denonavr</li>
    <li>home-assistant-component-tests.derivative</li>
    <li>home-assistant-component-tests.devialet</li>
    <li>home-assistant-component-tests.device_automation</li>
    <li>home-assistant-component-tests.device_sun_light_trigger</li>
    <li>home-assistant-component-tests.device_tracker</li>
    <li>home-assistant-component-tests.devolo_home_control</li>
    <li>home-assistant-component-tests.devolo_home_network</li>
    <li>home-assistant-component-tests.dexcom</li>
    <li>home-assistant-component-tests.dhcp</li>
    <li>home-assistant-component-tests.diagnostics</li>
    <li>home-assistant-component-tests.dialogflow</li>
    <li>home-assistant-component-tests.directv</li>
    <li>home-assistant-component-tests.discord</li>
    <li>home-assistant-component-tests.discovergy</li>
    <li>home-assistant-component-tests.dlna_dmr</li>
    <li>home-assistant-component-tests.dlna_dms</li>
    <li>home-assistant-component-tests.dnsip</li>
    <li>home-assistant-component-tests.doorbird</li>
    <li>home-assistant-component-tests.dormakaba_dkey</li>
    <li>home-assistant-component-tests.downloader</li>
    <li>home-assistant-component-tests.dremel_3d_printer</li>
    <li>home-assistant-component-tests.drop_connect</li>
    <li>home-assistant-component-tests.dsmr</li>
    <li>home-assistant-component-tests.dsmr_reader</li>
    <li>home-assistant-component-tests.dte_energy_bridge</li>
    <li>home-assistant-component-tests.duckdns</li>
    <li>home-assistant-component-tests.dunehd</li>
    <li>home-assistant-component-tests.duotecno</li>
    <li>home-assistant-component-tests.dwd_weather_warnings</li>
    <li>home-assistant-component-tests.dynalite</li>
    <li>home-assistant-component-tests.eafm</li>
    <li>home-assistant-component-tests.easyenergy</li>
    <li>home-assistant-component-tests.ecobee</li>
    <li>home-assistant-component-tests.ecoforest</li>
    <li>home-assistant-component-tests.econet</li>
    <li>home-assistant-component-tests.ecowitt</li>
    <li>home-assistant-component-tests.edl21</li>
    <li>home-assistant-component-tests.efergy</li>
    <li>home-assistant-component-tests.eight_sleep</li>
    <li>home-assistant-component-tests.elgato</li>
    <li>home-assistant-component-tests.elkm1</li>
    <li>home-assistant-component-tests.elmax</li>
    <li>home-assistant-component-tests.emonitor</li>
    <li>home-assistant-component-tests.emulated_hue</li>
    <li>home-assistant-component-tests.emulated_kasa</li>
    <li>home-assistant-component-tests.emulated_roku</li>
    <li>home-assistant-component-tests.energy</li>
    <li>home-assistant-component-tests.energyzero</li>
    <li>home-assistant-component-tests.enigma2</li>
    <li>home-assistant-component-tests.enocean</li>
    <li>home-assistant-component-tests.enphase_envoy</li>
    <li>home-assistant-component-tests.environment_canada</li>
    <li>home-assistant-component-tests.epion</li>
    <li>home-assistant-component-tests.epson</li>
    <li>home-assistant-component-tests.escea</li>
    <li>home-assistant-component-tests.esphome</li>
    <li>home-assistant-component-tests.eufylife_ble</li>
    <li>home-assistant-component-tests.event</li>
    <li>home-assistant-component-tests.everlights</li>
    <li>home-assistant-component-tests.evil_genius_labs</li>
    <li>home-assistant-component-tests.ezviz</li>
    <li>home-assistant-component-tests.faa_delays</li>
    <li>home-assistant-component-tests.facebook</li>
    <li>home-assistant-component-tests.fail2ban</li>
    <li>home-assistant-component-tests.fan</li>
    <li>home-assistant-component-tests.feedreader</li>
    <li>home-assistant-component-tests.ffmpeg</li>
    <li>home-assistant-component-tests.fibaro</li>
    <li>home-assistant-component-tests.fido</li>
    <li>home-assistant-component-tests.file</li>
    <li>home-assistant-component-tests.file_upload</li>
    <li>home-assistant-component-tests.filesize</li>
    <li>home-assistant-component-tests.filter</li>
    <li>home-assistant-component-tests.fints</li>
    <li>home-assistant-component-tests.fireservicerota</li>
    <li>home-assistant-component-tests.firmata</li>
    <li>home-assistant-component-tests.fitbit</li>
    <li>home-assistant-component-tests.fivem</li>
    <li>home-assistant-component-tests.fjaraskupan</li>
    <li>home-assistant-component-tests.flic</li>
    <li>home-assistant-component-tests.flick_electric</li>
    <li>home-assistant-component-tests.flipr</li>
    <li>home-assistant-component-tests.flo</li>
    <li>home-assistant-component-tests.flume</li>
    <li>home-assistant-component-tests.flux</li>
    <li>home-assistant-component-tests.flux_led</li>
    <li>home-assistant-component-tests.folder</li>
    <li>home-assistant-component-tests.folder_watcher</li>
    <li>home-assistant-component-tests.foobot</li>
    <li>home-assistant-component-tests.forecast_solar</li>
    <li>home-assistant-component-tests.foscam</li>
    <li>home-assistant-component-tests.freebox</li>
    <li>home-assistant-component-tests.freedns</li>
    <li>home-assistant-component-tests.freedompro</li>
    <li>home-assistant-component-tests.fritz</li>
    <li>home-assistant-component-tests.fritzbox</li>
    <li>home-assistant-component-tests.fritzbox_callmonitor</li>
    <li>home-assistant-component-tests.fronius</li>
    <li>home-assistant-component-tests.frontend</li>
    <li>home-assistant-component-tests.frontier_silicon</li>
    <li>home-assistant-component-tests.fully_kiosk</li>
    <li>home-assistant-component-tests.fyta</li>
    <li>home-assistant-component-tests.garages_amsterdam</li>
    <li>home-assistant-component-tests.gardena_bluetooth</li>
    <li>home-assistant-component-tests.gdacs</li>
    <li>home-assistant-component-tests.generic</li>
    <li>home-assistant-component-tests.generic_hygrostat</li>
    <li>home-assistant-component-tests.generic_thermostat</li>
    <li>home-assistant-component-tests.geo_json_events</li>
    <li>home-assistant-component-tests.geo_location</li>
    <li>home-assistant-component-tests.geo_rss_events</li>
    <li>home-assistant-component-tests.geocaching</li>
    <li>home-assistant-component-tests.geofency</li>
    <li>home-assistant-component-tests.geonetnz_quakes</li>
    <li>home-assistant-component-tests.geonetnz_volcano</li>
    <li>home-assistant-component-tests.gios</li>
    <li>home-assistant-component-tests.github</li>
    <li>home-assistant-component-tests.glances</li>
    <li>home-assistant-component-tests.goalzero</li>
    <li>home-assistant-component-tests.gogogate2</li>
    <li>home-assistant-component-tests.goodwe</li>
    <li>home-assistant-component-tests.google</li>
    <li>home-assistant-component-tests.google_assistant</li>
    <li>home-assistant-component-tests.google_assistant_sdk</li>
    <li>home-assistant-component-tests.google_domains</li>
    <li>home-assistant-component-tests.google_generative_ai_conversation</li>
    <li>home-assistant-component-tests.google_mail</li>
    <li>home-assistant-component-tests.google_pubsub</li>
    <li>home-assistant-component-tests.google_sheets</li>
    <li>home-assistant-component-tests.google_tasks</li>
    <li>home-assistant-component-tests.google_translate</li>
    <li>home-assistant-component-tests.google_travel_time</li>
    <li>home-assistant-component-tests.google_wifi</li>
    <li>home-assistant-component-tests.govee_ble</li>
    <li>home-assistant-component-tests.govee_light_local</li>
    <li>home-assistant-component-tests.gpsd</li>
    <li>home-assistant-component-tests.gpslogger</li>
    <li>home-assistant-component-tests.graphite</li>
    <li>home-assistant-component-tests.gree</li>
    <li>home-assistant-component-tests.greeneye_monitor</li>
    <li>home-assistant-component-tests.group</li>
    <li>home-assistant-component-tests.growatt_server</li>
    <li>home-assistant-component-tests.guardian</li>
    <li>home-assistant-component-tests.habitica</li>
    <li>home-assistant-component-tests.hardkernel</li>
    <li>home-assistant-component-tests.hardware</li>
    <li>home-assistant-component-tests.harmony</li>
    <li>home-assistant-component-tests.hassio</li>
    <li>home-assistant-component-tests.hddtemp</li>
    <li>home-assistant-component-tests.hdmi_cec</li>
    <li>home-assistant-component-tests.heos</li>
    <li>home-assistant-component-tests.here_travel_time</li>
    <li>home-assistant-component-tests.hisense_aehw4a1</li>
    <li>home-assistant-component-tests.history</li>
    <li>home-assistant-component-tests.history_stats</li>
    <li>home-assistant-component-tests.hive</li>
    <li>home-assistant-component-tests.hlk_sw16</li>
    <li>home-assistant-component-tests.holiday</li>
    <li>home-assistant-component-tests.home_connect</li>
    <li>home-assistant-component-tests.homeassistant</li>
    <li>home-assistant-component-tests.homeassistant_alerts</li>
    <li>home-assistant-component-tests.homeassistant_green</li>
    <li>home-assistant-component-tests.homeassistant_hardware</li>
    <li>home-assistant-component-tests.homeassistant_sky_connect</li>
    <li>home-assistant-component-tests.homeassistant_yellow</li>
    <li>home-assistant-component-tests.homekit</li>
    <li>home-assistant-component-tests.homekit_controller</li>
    <li>home-assistant-component-tests.homematic</li>
    <li>home-assistant-component-tests.homematicip_cloud</li>
    <li>home-assistant-component-tests.homewizard</li>
    <li>home-assistant-component-tests.homeworks</li>
    <li>home-assistant-component-tests.honeywell</li>
    <li>home-assistant-component-tests.html5</li>
    <li>home-assistant-component-tests.http</li>
    <li>home-assistant-component-tests.huawei_lte</li>
    <li>home-assistant-component-tests.hue</li>
    <li>home-assistant-component-tests.huisbaasje</li>
    <li>home-assistant-component-tests.humidifier</li>
    <li>home-assistant-component-tests.hunterdouglas_powerview</li>
    <li>home-assistant-component-tests.husqvarna_automower</li>
    <li>home-assistant-component-tests.huum</li>
    <li>home-assistant-component-tests.hvv_departures</li>
    <li>home-assistant-component-tests.hydrawise</li>
    <li>home-assistant-component-tests.hyperion</li>
    <li>home-assistant-component-tests.ialarm</li>
    <li>home-assistant-component-tests.iaqualink</li>
    <li>home-assistant-component-tests.ibeacon</li>
    <li>home-assistant-component-tests.icloud</li>
    <li>home-assistant-component-tests.ifttt</li>
    <li>home-assistant-component-tests.ign_sismologia</li>
    <li>home-assistant-component-tests.image</li>
    <li>home-assistant-component-tests.image_processing</li>
    <li>home-assistant-component-tests.image_upload</li>
    <li>home-assistant-component-tests.imap</li>
    <li>home-assistant-component-tests.incomfort</li>
    <li>home-assistant-component-tests.influxdb</li>
    <li>home-assistant-component-tests.inkbird</li>
    <li>home-assistant-component-tests.input_boolean</li>
    <li>home-assistant-component-tests.input_button</li>
    <li>home-assistant-component-tests.input_datetime</li>
    <li>home-assistant-component-tests.input_number</li>
    <li>home-assistant-component-tests.input_select</li>
    <li>home-assistant-component-tests.input_text</li>
    <li>home-assistant-component-tests.insteon</li>
    <li>home-assistant-component-tests.integration</li>
    <li>home-assistant-component-tests.intellifire</li>
    <li>home-assistant-component-tests.intent</li>
    <li>home-assistant-component-tests.intent_script</li>
    <li>home-assistant-component-tests.ios</li>
    <li>home-assistant-component-tests.ipma</li>
    <li>home-assistant-component-tests.ipp</li>
    <li>home-assistant-component-tests.iqvia</li>
    <li>home-assistant-component-tests.isal</li>
    <li>home-assistant-component-tests.isy994</li>
    <li>home-assistant-component-tests.izone</li>
    <li>home-assistant-component-tests.jellyfin</li>
    <li>home-assistant-component-tests.jewish_calendar</li>
    <li>home-assistant-component-tests.juicenet</li>
    <li>home-assistant-component-tests.justnimbus</li>
    <li>home-assistant-component-tests.kaleidescape</li>
    <li>home-assistant-component-tests.keenetic_ndms2</li>
    <li>home-assistant-component-tests.kegtron</li>
    <li>home-assistant-component-tests.keymitt_ble</li>
    <li>home-assistant-component-tests.kira</li>
    <li>home-assistant-component-tests.kitchen_sink</li>
    <li>home-assistant-component-tests.kmtronic</li>
    <li>home-assistant-component-tests.knx</li>
    <li>home-assistant-component-tests.kodi</li>
    <li>home-assistant-component-tests.konnected</li>
    <li>home-assistant-component-tests.kostal_plenticore</li>
    <li>home-assistant-component-tests.kraken</li>
    <li>home-assistant-component-tests.kulersky</li>
    <li>home-assistant-component-tests.lamarzocco</li>
    <li>home-assistant-component-tests.lametric</li>
    <li>home-assistant-component-tests.landisgyr_heat_meter</li>
    <li>home-assistant-component-tests.lastfm</li>
    <li>home-assistant-component-tests.launch_library</li>
    <li>home-assistant-component-tests.laundrify</li>
    <li>home-assistant-component-tests.lawn_mower</li>
    <li>home-assistant-component-tests.lcn</li>
    <li>home-assistant-component-tests.ld2410_ble</li>
    <li>home-assistant-component-tests.led_ble</li>
    <li>home-assistant-component-tests.lg_netcast</li>
    <li>home-assistant-component-tests.lg_soundbar</li>
    <li>home-assistant-component-tests.lidarr</li>
    <li>home-assistant-component-tests.life360</li>
    <li>home-assistant-component-tests.lifx</li>
    <li>home-assistant-component-tests.light</li>
    <li>home-assistant-component-tests.linear_garage_door</li>
    <li>home-assistant-component-tests.litterrobot</li>
    <li>home-assistant-component-tests.livisi</li>
    <li>home-assistant-component-tests.local_calendar</li>
    <li>home-assistant-component-tests.local_file</li>
    <li>home-assistant-component-tests.local_ip</li>
    <li>home-assistant-component-tests.local_todo</li>
    <li>home-assistant-component-tests.locative</li>
    <li>home-assistant-component-tests.lock</li>
    <li>home-assistant-component-tests.logbook</li>
    <li>home-assistant-component-tests.logentries</li>
    <li>home-assistant-component-tests.logger</li>
    <li>home-assistant-component-tests.logi_circle</li>
    <li>home-assistant-component-tests.london_air</li>
    <li>home-assistant-component-tests.lookin</li>
    <li>home-assistant-component-tests.loqed</li>
    <li>home-assistant-component-tests.lovelace</li>
    <li>home-assistant-component-tests.luftdaten</li>
    <li>home-assistant-component-tests.lupusec</li>
    <li>home-assistant-component-tests.lutron</li>
    <li>home-assistant-component-tests.lutron_caseta</li>
    <li>home-assistant-component-tests.lyric</li>
    <li>home-assistant-component-tests.mailbox</li>
    <li>home-assistant-component-tests.mailgun</li>
    <li>home-assistant-component-tests.manual</li>
    <li>home-assistant-component-tests.manual_mqtt</li>
    <li>home-assistant-component-tests.map</li>
    <li>home-assistant-component-tests.matrix</li>
    <li>home-assistant-component-tests.matter</li>
    <li>home-assistant-component-tests.maxcube</li>
    <li>home-assistant-component-tests.mazda</li>
    <li>home-assistant-component-tests.mealie</li>
    <li>home-assistant-component-tests.meater</li>
    <li>home-assistant-component-tests.media_extractor</li>
    <li>home-assistant-component-tests.media_player</li>
    <li>home-assistant-component-tests.media_source</li>
    <li>home-assistant-component-tests.melcloud</li>
    <li>home-assistant-component-tests.meraki</li>
    <li>home-assistant-component-tests.met</li>
    <li>home-assistant-component-tests.met_eireann</li>
    <li>home-assistant-component-tests.meteo_france</li>
    <li>home-assistant-component-tests.meteoclimatic</li>
    <li>home-assistant-component-tests.metoffice</li>
    <li>home-assistant-component-tests.microsoft_face</li>
    <li>home-assistant-component-tests.microsoft_face_detect</li>
    <li>home-assistant-component-tests.microsoft_face_identify</li>
    <li>home-assistant-component-tests.mikrotik</li>
    <li>home-assistant-component-tests.mill</li>
    <li>home-assistant-component-tests.min_max</li>
    <li>home-assistant-component-tests.minecraft_server</li>
    <li>home-assistant-component-tests.minio</li>
    <li>home-assistant-component-tests.mjpeg</li>
    <li>home-assistant-component-tests.moat</li>
    <li>home-assistant-component-tests.mobile_app</li>
    <li>home-assistant-component-tests.modbus</li>
    <li>home-assistant-component-tests.modem_callerid</li>
    <li>home-assistant-component-tests.modern_forms</li>
    <li>home-assistant-component-tests.mold_indicator</li>
    <li>home-assistant-component-tests.monzo</li>
    <li>home-assistant-component-tests.moon</li>
    <li>home-assistant-component-tests.mopeka</li>
    <li>home-assistant-component-tests.motion_blinds</li>
    <li>home-assistant-component-tests.motionblinds_ble</li>
    <li>home-assistant-component-tests.motioneye</li>
    <li>home-assistant-component-tests.motionmount</li>
    <li>home-assistant-component-tests.mpd</li>
    <li>home-assistant-component-tests.mqtt</li>
    <li>home-assistant-component-tests.mqtt_eventstream</li>
    <li>home-assistant-component-tests.mqtt_json</li>
    <li>home-assistant-component-tests.mqtt_room</li>
    <li>home-assistant-component-tests.mqtt_statestream</li>
    <li>home-assistant-component-tests.mullvad</li>
    <li>home-assistant-component-tests.mutesync</li>
    <li>home-assistant-component-tests.my</li>
    <li>home-assistant-component-tests.myq</li>
    <li>home-assistant-component-tests.mysensors</li>
    <li>home-assistant-component-tests.mystrom</li>
    <li>home-assistant-component-tests.mythicbeastsdns</li>
    <li>home-assistant-component-tests.myuplink</li>
    <li>home-assistant-component-tests.nam</li>
    <li>home-assistant-component-tests.namecheapdns</li>
    <li>home-assistant-component-tests.nanoleaf</li>
    <li>home-assistant-component-tests.neato</li>
    <li>home-assistant-component-tests.ness_alarm</li>
    <li>home-assistant-component-tests.nest</li>
    <li>home-assistant-component-tests.netatmo</li>
    <li>home-assistant-component-tests.netgear</li>
    <li>home-assistant-component-tests.netgear_lte</li>
    <li>home-assistant-component-tests.network</li>
    <li>home-assistant-component-tests.nexia</li>
    <li>home-assistant-component-tests.nextbus</li>
    <li>home-assistant-component-tests.nextcloud</li>
    <li>home-assistant-component-tests.nextdns</li>
    <li>home-assistant-component-tests.nfandroidtv</li>
    <li>home-assistant-component-tests.nibe_heatpump</li>
    <li>home-assistant-component-tests.nightscout</li>
    <li>home-assistant-component-tests.nina</li>
    <li>home-assistant-component-tests.nmap_tracker</li>
    <li>home-assistant-component-tests.no_ip</li>
    <li>home-assistant-component-tests.nobo_hub</li>
    <li>home-assistant-component-tests.notify</li>
    <li>home-assistant-component-tests.notify_events</li>
    <li>home-assistant-component-tests.notion</li>
    <li>home-assistant-component-tests.nsw_rural_fire_service_feed</li>
    <li>home-assistant-component-tests.nuheat</li>
    <li>home-assistant-component-tests.nuki</li>
    <li>home-assistant-component-tests.number</li>
    <li>home-assistant-component-tests.nut</li>
    <li>home-assistant-component-tests.nws</li>
    <li>home-assistant-component-tests.nx584</li>
    <li>home-assistant-component-tests.obihai</li>
    <li>home-assistant-component-tests.octoprint</li>
    <li>home-assistant-component-tests.ollama</li>
    <li>home-assistant-component-tests.omnilogic</li>
    <li>home-assistant-component-tests.onboarding</li>
    <li>home-assistant-component-tests.oncue</li>
    <li>home-assistant-component-tests.ondilo_ico</li>
    <li>home-assistant-component-tests.onewire</li>
    <li>home-assistant-component-tests.onvif</li>
    <li>home-assistant-component-tests.open_meteo</li>
    <li>home-assistant-component-tests.openai_conversation</li>
    <li>home-assistant-component-tests.openalpr_cloud</li>
    <li>home-assistant-component-tests.openerz</li>
    <li>home-assistant-component-tests.openexchangerates</li>
    <li>home-assistant-component-tests.opengarage</li>
    <li>home-assistant-component-tests.openhardwaremonitor</li>
    <li>home-assistant-component-tests.openhome</li>
    <li>home-assistant-component-tests.opensky</li>
    <li>home-assistant-component-tests.opentherm_gw</li>
    <li>home-assistant-component-tests.openuv</li>
    <li>home-assistant-component-tests.openweathermap</li>
    <li>home-assistant-component-tests.opnsense</li>
    <li>home-assistant-component-tests.opower</li>
    <li>home-assistant-component-tests.oralb</li>
    <li>home-assistant-component-tests.otbr</li>
    <li>home-assistant-component-tests.otp</li>
    <li>home-assistant-component-tests.overkiz</li>
    <li>home-assistant-component-tests.ovo_energy</li>
    <li>home-assistant-component-tests.owntracks</li>
    <li>home-assistant-component-tests.p1_monitor</li>
    <li>home-assistant-component-tests.panasonic_viera</li>
    <li>home-assistant-component-tests.panel_custom</li>
    <li>home-assistant-component-tests.panel_iframe</li>
    <li>home-assistant-component-tests.peco</li>
    <li>home-assistant-component-tests.pegel_online</li>
    <li>home-assistant-component-tests.persistent_notification</li>
    <li>home-assistant-component-tests.person</li>
    <li>home-assistant-component-tests.philips_js</li>
    <li>home-assistant-component-tests.pi_hole</li>
    <li>home-assistant-component-tests.picnic</li>
    <li>home-assistant-component-tests.ping</li>
    <li>home-assistant-component-tests.plaato</li>
    <li>home-assistant-component-tests.plant</li>
    <li>home-assistant-component-tests.plex</li>
    <li>home-assistant-component-tests.plugwise</li>
    <li>home-assistant-component-tests.point</li>
    <li>home-assistant-component-tests.poolsense</li>
    <li>home-assistant-component-tests.powerwall</li>
    <li>home-assistant-component-tests.private_ble_device</li>
    <li>home-assistant-component-tests.profiler</li>
    <li>home-assistant-component-tests.prometheus</li>
    <li>home-assistant-component-tests.prosegur</li>
    <li>home-assistant-component-tests.proximity</li>
    <li>home-assistant-component-tests.prusalink</li>
    <li>home-assistant-component-tests.pure_energie</li>
    <li>home-assistant-component-tests.purpleair</li>
    <li>home-assistant-component-tests.push</li>
    <li>home-assistant-component-tests.pushbullet</li>
    <li>home-assistant-component-tests.pushover</li>
    <li>home-assistant-component-tests.pvoutput</li>
    <li>home-assistant-component-tests.pvpc_hourly_pricing</li>
    <li>home-assistant-component-tests.pyload</li>
    <li>home-assistant-component-tests.python_script</li>
    <li>home-assistant-component-tests.qbittorrent</li>
    <li>home-assistant-component-tests.qingping</li>
    <li>home-assistant-component-tests.qld_bushfire</li>
    <li>home-assistant-component-tests.qnap</li>
    <li>home-assistant-component-tests.qnap_qsw</li>
    <li>home-assistant-component-tests.qwikswitch</li>
    <li>home-assistant-component-tests.rabbitair</li>
    <li>home-assistant-component-tests.rachio</li>
    <li>home-assistant-component-tests.radarr</li>
    <li>home-assistant-component-tests.radio_browser</li>
    <li>home-assistant-component-tests.radiotherm</li>
    <li>home-assistant-component-tests.rainbird</li>
    <li>home-assistant-component-tests.rainforest_eagle</li>
    <li>home-assistant-component-tests.rainforest_raven</li>
    <li>home-assistant-component-tests.rainmachine</li>
    <li>home-assistant-component-tests.random</li>
    <li>home-assistant-component-tests.rapt_ble</li>
    <li>home-assistant-component-tests.raspberry_pi</li>
    <li>home-assistant-component-tests.rdw</li>
    <li>home-assistant-component-tests.recollect_waste</li>
    <li>home-assistant-component-tests.recorder</li>
    <li>home-assistant-component-tests.recovery_mode</li>
    <li>home-assistant-component-tests.reddit</li>
    <li>home-assistant-component-tests.remote</li>
    <li>home-assistant-component-tests.renault</li>
    <li>home-assistant-component-tests.renson</li>
    <li>home-assistant-component-tests.reolink</li>
    <li>home-assistant-component-tests.repairs</li>
    <li>home-assistant-component-tests.rest</li>
    <li>home-assistant-component-tests.rest_command</li>
    <li>home-assistant-component-tests.rflink</li>
    <li>home-assistant-component-tests.rfxtrx</li>
    <li>home-assistant-component-tests.rhasspy</li>
    <li>home-assistant-component-tests.ridwell</li>
    <li>home-assistant-component-tests.ring</li>
    <li>home-assistant-component-tests.risco</li>
    <li>home-assistant-component-tests.rituals_perfume_genie</li>
    <li>home-assistant-component-tests.rmvtransport</li>
    <li>home-assistant-component-tests.roborock</li>
    <li>home-assistant-component-tests.roku</li>
    <li>home-assistant-component-tests.romy</li>
    <li>home-assistant-component-tests.roomba</li>
    <li>home-assistant-component-tests.roon</li>
    <li>home-assistant-component-tests.rova</li>
    <li>home-assistant-component-tests.rpi_power</li>
    <li>home-assistant-component-tests.rss_feed_template</li>
    <li>home-assistant-component-tests.rtsp_to_webrtc</li>
    <li>home-assistant-component-tests.ruckus_unleashed</li>
    <li>home-assistant-component-tests.ruuvi_gateway</li>
    <li>home-assistant-component-tests.ruuvitag_ble</li>
    <li>home-assistant-component-tests.rympro</li>
    <li>home-assistant-component-tests.sabnzbd</li>
    <li>home-assistant-component-tests.samsungtv</li>
    <li>home-assistant-component-tests.sanix</li>
    <li>home-assistant-component-tests.scene</li>
    <li>home-assistant-component-tests.schedule</li>
    <li>home-assistant-component-tests.schlage</li>
    <li>home-assistant-component-tests.scrape</li>
    <li>home-assistant-component-tests.screenlogic</li>
    <li>home-assistant-component-tests.script</li>
    <li>home-assistant-component-tests.search</li>
    <li>home-assistant-component-tests.season</li>
    <li>home-assistant-component-tests.select</li>
    <li>home-assistant-component-tests.sense</li>
    <li>home-assistant-component-tests.sensibo</li>
    <li>home-assistant-component-tests.sensirion_ble</li>
    <li>home-assistant-component-tests.sensor</li>
    <li>home-assistant-component-tests.sensorpro</li>
    <li>home-assistant-component-tests.sensorpush</li>
    <li>home-assistant-component-tests.sentry</li>
    <li>home-assistant-component-tests.senz</li>
    <li>home-assistant-component-tests.seventeentrack</li>
    <li>home-assistant-component-tests.sfr_box</li>
    <li>home-assistant-component-tests.sharkiq</li>
    <li>home-assistant-component-tests.shell_command</li>
    <li>home-assistant-component-tests.shelly</li>
    <li>home-assistant-component-tests.shopping_list</li>
    <li>home-assistant-component-tests.sia</li>
    <li>home-assistant-component-tests.sigfox</li>
    <li>home-assistant-component-tests.sighthound</li>
    <li>home-assistant-component-tests.signal_messenger</li>
    <li>home-assistant-component-tests.simplepush</li>
    <li>home-assistant-component-tests.simplisafe</li>
    <li>home-assistant-component-tests.simulated</li>
    <li>home-assistant-component-tests.siren</li>
    <li>home-assistant-component-tests.skybell</li>
    <li>home-assistant-component-tests.slack</li>
    <li>home-assistant-component-tests.sleepiq</li>
    <li>home-assistant-component-tests.slimproto</li>
    <li>home-assistant-component-tests.sma</li>
    <li>home-assistant-component-tests.smappee</li>
    <li>home-assistant-component-tests.smart_meter_texas</li>
    <li>home-assistant-component-tests.smartthings</li>
    <li>home-assistant-component-tests.smarttub</li>
    <li>home-assistant-component-tests.smhi</li>
    <li>home-assistant-component-tests.sms</li>
    <li>home-assistant-component-tests.smtp</li>
    <li>home-assistant-component-tests.snapcast</li>
    <li>home-assistant-component-tests.snips</li>
    <li>home-assistant-component-tests.snmp</li>
    <li>home-assistant-component-tests.snooz</li>
    <li>home-assistant-component-tests.solax</li>
    <li>home-assistant-component-tests.soma</li>
    <li>home-assistant-component-tests.somfy_mylink</li>
    <li>home-assistant-component-tests.sonarr</li>
    <li>home-assistant-component-tests.sonos</li>
    <li>home-assistant-component-tests.soundtouch</li>
    <li>home-assistant-component-tests.spaceapi</li>
    <li>home-assistant-component-tests.spc</li>
    <li>home-assistant-component-tests.speedtestdotnet</li>
    <li>home-assistant-component-tests.spider</li>
    <li>home-assistant-component-tests.spotify</li>
    <li>home-assistant-component-tests.sql</li>
    <li>home-assistant-component-tests.squeezebox</li>
    <li>home-assistant-component-tests.srp_energy</li>
    <li>home-assistant-component-tests.ssdp</li>
    <li>home-assistant-component-tests.starline</li>
    <li>home-assistant-component-tests.startca</li>
    <li>home-assistant-component-tests.statistics</li>
    <li>home-assistant-component-tests.statsd</li>
    <li>home-assistant-component-tests.steam_online</li>
    <li>home-assistant-component-tests.steamist</li>
    <li>home-assistant-component-tests.stookalert</li>
    <li>home-assistant-component-tests.stream</li>
    <li>home-assistant-component-tests.streamlabswater</li>
    <li>home-assistant-component-tests.stt</li>
    <li>home-assistant-component-tests.subaru</li>
    <li>home-assistant-component-tests.suez_water</li>
    <li>home-assistant-component-tests.sun</li>
    <li>home-assistant-component-tests.sunweg</li>
    <li>home-assistant-component-tests.surepetcare</li>
    <li>home-assistant-component-tests.swiss_public_transport</li>
    <li>home-assistant-component-tests.switch</li>
    <li>home-assistant-component-tests.switch_as_x</li>
    <li>home-assistant-component-tests.switchbee</li>
    <li>home-assistant-component-tests.switchbot</li>
    <li>home-assistant-component-tests.switchbot_cloud</li>
    <li>home-assistant-component-tests.switcher_kis</li>
    <li>home-assistant-component-tests.syncthing</li>
    <li>home-assistant-component-tests.syncthru</li>
    <li>home-assistant-component-tests.synology_dsm</li>
    <li>home-assistant-component-tests.system_bridge</li>
    <li>home-assistant-component-tests.system_health</li>
    <li>home-assistant-component-tests.systemmonitor</li>
    <li>home-assistant-component-tests.tado</li>
    <li>home-assistant-component-tests.tag</li>
    <li>home-assistant-component-tests.tailscale</li>
    <li>home-assistant-component-tests.tailwind</li>
    <li>home-assistant-component-tests.tankerkoenig</li>
    <li>home-assistant-component-tests.tasmota</li>
    <li>home-assistant-component-tests.tautulli</li>
    <li>home-assistant-component-tests.tcp</li>
    <li>home-assistant-component-tests.technove</li>
    <li>home-assistant-component-tests.tedee</li>
    <li>home-assistant-component-tests.tellduslive</li>
    <li>home-assistant-component-tests.temper</li>
    <li>home-assistant-component-tests.template</li>
    <li>home-assistant-component-tests.tesla_wall_connector</li>
    <li>home-assistant-component-tests.teslemetry</li>
    <li>home-assistant-component-tests.text</li>
    <li>home-assistant-component-tests.thermobeacon</li>
    <li>home-assistant-component-tests.thermopro</li>
    <li>home-assistant-component-tests.thethingsnetwork</li>
    <li>home-assistant-component-tests.thread</li>
    <li>home-assistant-component-tests.threshold</li>
    <li>home-assistant-component-tests.tibber</li>
    <li>home-assistant-component-tests.tile</li>
    <li>home-assistant-component-tests.tilt_ble</li>
    <li>home-assistant-component-tests.time</li>
    <li>home-assistant-component-tests.time_date</li>
    <li>home-assistant-component-tests.timer</li>
    <li>home-assistant-component-tests.tod</li>
    <li>home-assistant-component-tests.todo</li>
    <li>home-assistant-component-tests.todoist</li>
    <li>home-assistant-component-tests.tolo</li>
    <li>home-assistant-component-tests.tomato</li>
    <li>home-assistant-component-tests.tomorrowio</li>
    <li>home-assistant-component-tests.toon</li>
    <li>home-assistant-component-tests.totalconnect</li>
    <li>home-assistant-component-tests.tplink</li>
    <li>home-assistant-component-tests.tplink_omada</li>
    <li>home-assistant-component-tests.traccar</li>
    <li>home-assistant-component-tests.traccar_server</li>
    <li>home-assistant-component-tests.trace</li>
    <li>home-assistant-component-tests.tractive</li>
    <li>home-assistant-component-tests.tradfri</li>
    <li>home-assistant-component-tests.trafikverket_camera</li>
    <li>home-assistant-component-tests.trafikverket_ferry</li>
    <li>home-assistant-component-tests.trafikverket_train</li>
    <li>home-assistant-component-tests.trafikverket_weatherstation</li>
    <li>home-assistant-component-tests.transmission</li>
    <li>home-assistant-component-tests.transport_nsw</li>
    <li>home-assistant-component-tests.trend</li>
    <li>home-assistant-component-tests.tts</li>
    <li>home-assistant-component-tests.tuya</li>
    <li>home-assistant-component-tests.twentemilieu</li>
    <li>home-assistant-component-tests.twilio</li>
    <li>home-assistant-component-tests.twinkly</li>
    <li>home-assistant-component-tests.twitch</li>
    <li>home-assistant-component-tests.uk_transport</li>
    <li>home-assistant-component-tests.ukraine_alarm</li>
    <li>home-assistant-component-tests.unifi</li>
    <li>home-assistant-component-tests.unifiprotect</li>
    <li>home-assistant-component-tests.universal</li>
    <li>home-assistant-component-tests.upb</li>
    <li>home-assistant-component-tests.upcloud</li>
    <li>home-assistant-component-tests.update</li>
    <li>home-assistant-component-tests.upnp</li>
    <li>home-assistant-component-tests.uptime</li>
    <li>home-assistant-component-tests.uptimerobot</li>
    <li>home-assistant-component-tests.usb</li>
    <li>home-assistant-component-tests.usgs_earthquakes_feed</li>
    <li>home-assistant-component-tests.utility_meter</li>
    <li>home-assistant-component-tests.uvc</li>
    <li>home-assistant-component-tests.v2c</li>
    <li>home-assistant-component-tests.vacuum</li>
    <li>home-assistant-component-tests.vallox</li>
    <li>home-assistant-component-tests.valve</li>
    <li>home-assistant-component-tests.velbus</li>
    <li>home-assistant-component-tests.velux</li>
    <li>home-assistant-component-tests.venstar</li>
    <li>home-assistant-component-tests.vera</li>
    <li>home-assistant-component-tests.verisure</li>
    <li>home-assistant-component-tests.version</li>
    <li>home-assistant-component-tests.vesync</li>
    <li>home-assistant-component-tests.vicare</li>
    <li>home-assistant-component-tests.vilfo</li>
    <li>home-assistant-component-tests.vizio</li>
    <li>home-assistant-component-tests.vlc_telnet</li>
    <li>home-assistant-component-tests.vodafone_station</li>
    <li>home-assistant-component-tests.voicerss</li>
    <li>home-assistant-component-tests.volumio</li>
    <li>home-assistant-component-tests.volvooncall</li>
    <li>home-assistant-component-tests.vulcan</li>
    <li>home-assistant-component-tests.vultr</li>
    <li>home-assistant-component-tests.wake_on_lan</li>
    <li>home-assistant-component-tests.wake_word</li>
    <li>home-assistant-component-tests.wallbox</li>
    <li>home-assistant-component-tests.waqi</li>
    <li>home-assistant-component-tests.water_heater</li>
    <li>home-assistant-component-tests.watttime</li>
    <li>home-assistant-component-tests.waze_travel_time</li>
    <li>home-assistant-component-tests.weather</li>
    <li>home-assistant-component-tests.weatherflow</li>
    <li>home-assistant-component-tests.weatherflow_cloud</li>
    <li>home-assistant-component-tests.weatherkit</li>
    <li>home-assistant-component-tests.webhook</li>
    <li>home-assistant-component-tests.webostv</li>
    <li>home-assistant-component-tests.websocket_api</li>
    <li>home-assistant-component-tests.wemo</li>
    <li>home-assistant-component-tests.whirlpool</li>
    <li>home-assistant-component-tests.whois</li>
    <li>home-assistant-component-tests.wiffi</li>
    <li>home-assistant-component-tests.wilight</li>
    <li>home-assistant-component-tests.withings</li>
    <li>home-assistant-component-tests.wiz</li>
    <li>home-assistant-component-tests.wled</li>
    <li>home-assistant-component-tests.workday</li>
    <li>home-assistant-component-tests.worldclock</li>
    <li>home-assistant-component-tests.ws66i</li>
    <li>home-assistant-component-tests.wsdot</li>
    <li>home-assistant-component-tests.wyoming</li>
    <li>home-assistant-component-tests.xbox</li>
    <li>home-assistant-component-tests.xiaomi</li>
    <li>home-assistant-component-tests.xiaomi_aqara</li>
    <li>home-assistant-component-tests.xiaomi_ble</li>
    <li>home-assistant-component-tests.xiaomi_miio</li>
    <li>home-assistant-component-tests.yale_smart_alarm</li>
    <li>home-assistant-component-tests.yalexs_ble</li>
    <li>home-assistant-component-tests.yamaha</li>
    <li>home-assistant-component-tests.yamaha_musiccast</li>
    <li>home-assistant-component-tests.yandex_transport</li>
    <li>home-assistant-component-tests.yandextts</li>
    <li>home-assistant-component-tests.yardian</li>
    <li>home-assistant-component-tests.yeelight</li>
    <li>home-assistant-component-tests.yolink</li>
    <li>home-assistant-component-tests.youless</li>
    <li>home-assistant-component-tests.youtube</li>
    <li>home-assistant-component-tests.zamg</li>
    <li>home-assistant-component-tests.zeroconf</li>
    <li>home-assistant-component-tests.zerproc</li>
    <li>home-assistant-component-tests.zha</li>
    <li>home-assistant-component-tests.zodiac</li>
    <li>home-assistant-component-tests.zone</li>
    <li>home-assistant-component-tests.zwave_js</li>
    <li>home-assistant-component-tests.zwave_me</li>
    <li>home-assistant.dist</li>
    <li>python311Packages.webrtc-noise-gain</li>
    <li>python311Packages.webrtc-noise-gain.dist</li>
    <li>python312Packages.homeassistant-stubs</li>
    <li>python312Packages.homeassistant-stubs.dist</li>
    <li>python312Packages.webrtc-noise-gain</li>
    <li>python312Packages.webrtc-noise-gain.dist</li>
  </ul>
</details>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [xx] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
