### PR TITLE
ceph: fix build

### DIFF
--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -318,6 +318,11 @@ in rec {
     pname = "ceph";
     inherit src version;
 
+    postPatch = ''
+      substituteInPlace cmake/modules/Finduring.cmake \
+        --replace-fail "liburing.a liburing" "uring"
+    '';
+
     nativeBuildInputs = [
       cmake
       fmt


### PR DESCRIPTION
Fix for regression: https://github.com/NixOS/nixpkgs/pull/314945#issuecomment-2211678989

> Could NOT find uring (missing: URING_LIBRARIES)

CC @PedroHLC @vcunat 
