### PR TITLE
fdroidserver: reformat, refactor, unstable-2023-10-23 -> 2.3a1

### DIFF
--- a/pkgs/development/tools/fdroidserver/default.nix
+++ b/pkgs/development/tools/fdroidserver/default.nix
@@ -44,7 +44,7 @@ buildPythonApplication rec {
 
   postPatch = ''
     substituteInPlace fdroidserver/common.py \
-      --replace "FDROID_PATH = os.path.realpath(os.path.join(os.path.dirname(__file__), '..'))" "FDROID_PATH = '$out/bin'"
+      --replace-fail "FDROID_PATH = os.path.realpath(os.path.join(os.path.dirname(__file__), '..'))" "FDROID_PATH = '$out/bin'"
   '';
 
   preConfigure = ''

--- a/pkgs/development/tools/fdroidserver/default.nix
+++ b/pkgs/development/tools/fdroidserver/default.nix
@@ -1,27 +1,28 @@
-{ lib
-, fetchFromGitLab
-, fetchPypi
-, apksigner
-, buildPythonApplication
-, python3
-, installShellFiles
-, androguard
-, babel
-, clint
-, defusedxml
-, gitpython
-, libcloud
-, mwclient
-, paramiko
-, pillow
-, pyasn1
-, pyasn1-modules
-, python-vagrant
-, pyyaml
-, qrcode
-, requests
-, ruamel-yaml
-, yamllint
+{
+  lib,
+  fetchFromGitLab,
+  fetchPypi,
+  apksigner,
+  buildPythonApplication,
+  python3,
+  installShellFiles,
+  androguard,
+  babel,
+  clint,
+  defusedxml,
+  gitpython,
+  libcloud,
+  mwclient,
+  paramiko,
+  pillow,
+  pyasn1,
+  pyasn1-modules,
+  python-vagrant,
+  pyyaml,
+  qrcode,
+  requests,
+  ruamel-yaml,
+  yamllint,
 }:
 
 buildPythonApplication rec {
@@ -57,13 +58,9 @@ buildPythonApplication rec {
       --bash completion/bash-completion
   '';
 
-  nativeBuildInputs = [
-    installShellFiles
-  ];
+  nativeBuildInputs = [ installShellFiles ];
 
-  buildInputs = [
-    babel
-  ];
+  buildInputs = [ babel ];
 
   propagatedBuildInputs = [
     androguard
@@ -100,16 +97,17 @@ buildPythonApplication rec {
   # no tests
   doCheck = false;
 
-  pythonImportsCheck = [
-    "fdroidserver"
-  ];
+  pythonImportsCheck = [ "fdroidserver" ];
 
   meta = with lib; {
     homepage = "https://gitlab.com/fdroid/fdroidserver";
     changelog = "https://gitlab.com/fdroid/fdroidserver/-/blob/${version}/CHANGELOG.md";
     description = "Server and tools for F-Droid, the Free Software repository system for Android";
     license = licenses.agpl3Plus;
-    maintainers = with maintainers; [ linsui jugendhacker ];
+    maintainers = with maintainers; [
+      linsui
+      jugendhacker
+    ];
     mainProgram = "fdroid";
   };
 }

--- a/pkgs/development/tools/fdroidserver/default.nix
+++ b/pkgs/development/tools/fdroidserver/default.nix
@@ -25,9 +25,13 @@
   yamllint,
 }:
 
-buildPythonApplication rec {
-  pname = "fdroidserver";
+let
   version = "unstable-2023-10-23";
+in
+buildPythonApplication {
+  pname = "fdroidserver";
+  inherit version;
+
   format = "setuptools";
 
   src = fetchFromGitLab {
@@ -99,12 +103,12 @@ buildPythonApplication rec {
 
   pythonImportsCheck = [ "fdroidserver" ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://gitlab.com/fdroid/fdroidserver";
     changelog = "https://gitlab.com/fdroid/fdroidserver/-/blob/${version}/CHANGELOG.md";
     description = "Server and tools for F-Droid, the Free Software repository system for Android";
-    license = licenses.agpl3Plus;
-    maintainers = with maintainers; [
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [
       linsui
       jugendhacker
     ];

--- a/pkgs/development/tools/fdroidserver/default.nix
+++ b/pkgs/development/tools/fdroidserver/default.nix
@@ -3,6 +3,7 @@
   fetchFromGitLab,
   fetchPypi,
   apksigner,
+  appdirs,
   buildPythonApplication,
   python3,
   installShellFiles,
@@ -13,6 +14,7 @@
   gitpython,
   libcloud,
   mwclient,
+  oscrypto,
   paramiko,
   pillow,
   pyasn1,
@@ -22,26 +24,28 @@
   qrcode,
   requests,
   ruamel-yaml,
+  sdkmanager,
   yamllint,
 }:
 
 let
-  version = "unstable-2023-10-23";
+  version = "2.3a1";
 in
 buildPythonApplication {
   pname = "fdroidserver";
   inherit version;
 
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitLab {
     owner = "fdroid";
     repo = "fdroidserver";
-    rev = "f4b10cf83935432d19948dac669964384bef0728";
-    hash = "sha256-GmR6Td5pScwEKK9W6m26xQV4XxBdZ7frN2UvwUGY4Dw=";
+    rev = "2.3a1";
+    hash = "sha256-K6P5yGx2ZXHJZ/VyHTbQAObsvcfnOatrpwiW+ixLTuA=";
   };
 
   pythonRelaxDeps = [
+    "androguard"
     "pyasn1"
     "pyasn1-modules"
   ];
@@ -68,11 +72,13 @@ buildPythonApplication {
 
   propagatedBuildInputs = [
     androguard
+    appdirs
     clint
     defusedxml
     gitpython
     libcloud
     mwclient
+    oscrypto
     paramiko
     pillow
     pyasn1
@@ -88,6 +94,7 @@ buildPythonApplication {
         hash = "sha256-i3zml6LyEnUqNcGsQURx3BbEJMlXO+SSa1b/P10jt68=";
       };
     }))
+    sdkmanager
     yamllint
   ];
 


### PR DESCRIPTION
## Description of changes

Fixes fdroidserver by upgrading it to a new version that removes the distutils dependency (broken in Python 3.12.) Also performs RFC formatting and some other refactors to hopefully improve the quality of the derivation.

(Note: The reason why 2.3a1 is chosen is because the latest stable release does not contain the distutils fix.)

Note: I do not have the knowledge to properly exercise this, it seems to work, I'm not sure exactly what to test. Please let me know if there's anything in particular I should be running through.

Fixes #325076.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
