### PR TITLE
lomiri.lomiri-polkit-agent: init at 0.1

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -23,6 +23,7 @@ in {
         lomiri
         lomiri-download-manager
         lomiri-filemanager-app
+        lomiri-polkit-agent
         lomiri-schemas # exposes some required dbus interfaces
         lomiri-session # wrappers to properly launch the session
         lomiri-sounds
@@ -143,6 +144,18 @@ in {
         serviceConfig = {
           Type = "oneshot";
           ExecStart = "${pkgs.lomiri.lomiri-url-dispatcher}/libexec/lomiri-url-dispatcher/lomiri-update-directory /run/current-system/sw/share/lomiri-url-dispatcher/urls/";
+        };
+      };
+
+      "lomiri-polkit-agent" = rec {
+        description = "Lomiri Polkit agent";
+        wantedBy = [ "lomiri.service" "lomiri-full-greeter.service" "lomiri-full-shell.service" "lomiri-greeter.service" "lomiri-shell.service" ];
+        after = [ "graphical-session.target" ];
+        partOf = wantedBy;
+        serviceConfig = {
+          Type = "simple";
+          Restart = "always";
+          ExecStart = "${pkgs.lomiri.lomiri-polkit-agent}/libexec/lomiri-polkit-agent/policykit-agent";
         };
       };
     };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -51,6 +51,7 @@ let
     history-service = callPackage ./services/history-service { };
     lomiri-download-manager = callPackage ./services/lomiri-download-manager { };
     lomiri-indicator-network = callPackage ./services/lomiri-indicator-network { };
+    lomiri-polkit-agent = callPackage ./services/lomiri-polkit-agent { };
     lomiri-thumbnailer = callPackage ./services/lomiri-thumbnailer { };
     lomiri-url-dispatcher = callPackage ./services/lomiri-url-dispatcher { };
     mediascanner2 = callPackage ./services/mediascanner2 { };

--- a/pkgs/desktops/lomiri/services/lomiri-polkit-agent/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-polkit-agent/default.nix
@@ -1,0 +1,104 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  fetchpatch,
+  gitUpdater,
+  cmake,
+  cmake-extras,
+  dbus,
+  dbus-test-runner,
+  gtest,
+  libnotify,
+  pkg-config,
+  polkit,
+  properties-cpp,
+  python3,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-polkit-agent";
+  version = "0.1";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-polkit-agent";
+    rev = finalAttrs.version;
+    hash = "sha256-nA2jkyNQC1YIMpJkfJt2F97txGUT4UO7+aSgzr7IUU0=";
+  };
+
+  patches = [
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-polkit-agent/-/merge_requests/2 merged & in release
+    (fetchpatch {
+      name = "0001-lomiri-polkit-agent-Fix-authentication-test-with-libnotify-gteq-0.8.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-polkit-agent/-/commit/415d897735b9005426ec29348a882b9080fcd808.patch";
+      hash = "sha256-fAJJ5Bz4P76arhSmiWVa/8S+mb/NqPr65Nm3MkwKtjA=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-polkit-agent/-/merge_requests/9 merged & in release
+    (fetchpatch {
+      name = "0002-lomiri-polkit-agent-Make-tests-optional-and-use-BUILD_TESTING.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-polkit-agent/-/commit/908177fa24b79b06161116c3c274357122984d36.patch";
+      hash = "sha256-duHx4iNqgAlS649BO1s6D5E2SX9MPRCKb+mit+2cybM=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-polkit-agent/-/merge_requests/10 merged & in release
+    (fetchpatch {
+      name = "0003-lomiri-polkit-agent-Explicitly-look-for-properties-cpp.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-polkit-agent/-/commit/08bf36e50025aeefc5ba388d6d0f84d760add9cb.patch";
+      hash = "sha256-OFzj/FFXm1fX6+1GY97CON7Nne9wVPmQAxVFpP9rIpU=";
+    })
+  ];
+
+  postPatch = ''
+    # Partial application of still-under-discussion https://gitlab.com/ubports/development/core/lomiri-polkit-agent/-/merge_requests/8
+    substituteInPlace data/lomiri-polkit-agent.service.in \
+      --replace-fail 'After=lomiri-full-greeter.service lomiri-full-shell.service lomiri-greeter.service lomiri-shell.service' 'After=graphical-session.target' \
+      --replace-fail 'PartOf=' 'PartOf=lomiri.service ' \
+      --replace-fail 'WantedBy=' 'WantedBy=lomiri.service '
+
+    # Workaround to avoid coredump on logout
+    # https://gitlab.com/ubports/development/core/lomiri-polkit-agent/-/issues/1
+    substituteInPlace service/main.cpp \
+      --replace-fail 'retval.set_value(0);' 'try { retval.set_value(0); } catch (const std::future_error& ex) {}'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    cmake-extras
+    libnotify
+    polkit
+    properties-cpp
+  ];
+
+  nativeCheckInputs = [
+    dbus
+    (python3.withPackages (ps: with ps; [ python-dbusmock ]))
+  ];
+
+  checkInputs = [
+    dbus-test-runner
+    gtest
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  # Parallelism breaks dbus during tests
+  enableParallelChecking = false;
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "Policy kit agent for the Lomiri desktop";
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-polkit-agent";
+    license = lib.licenses.gpl3Only;
+    maintainers = lib.teams.lomiri.members;
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[Lomiri Polkit Agent](https://gitlab.com/ubports/development/core/lomiri-polkit-agent) is an agent for graphically handling polkit authentication on the Lomiri desktop.

![polkit_agent](https://github.com/NixOS/nixpkgs/assets/23431373/8092d01d-3156-4649-8ad3-3d12453b369d)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
