### PR TITLE
ceptre: move to by-name; add license field; cleanup; update to  0-unstable-2024-8-26

### DIFF
--- a/pkgs/by-name/ce/ceptre/package.nix
+++ b/pkgs/by-name/ce/ceptre/package.nix
@@ -1,4 +1,9 @@
-{ lib, stdenv, fetchFromGitHub, mlton }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  mlton,
+}:
 
 stdenv.mkDerivation {
   pname = "ceptre";

--- a/pkgs/by-name/ce/ceptre/package.nix
+++ b/pkgs/by-name/ce/ceptre/package.nix
@@ -20,15 +20,21 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ mlton ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp ceptre $out/bin
+    runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Linear logic programming language for modeling generative interactive systems";
     mainProgram = "ceptre";
     homepage = "https://github.com/chrisamaphone/interactive-lp";
-    maintainers = with maintainers; [ pSub ];
-    platforms = platforms.unix;
+    maintainers = with lib.maintainers; [
+      NotAShelf
+      pSub
+    ];
+    platforms = lib.platforms.unix;
+    license = lib.licenses.unfree;
   };
 }

--- a/pkgs/by-name/ce/ceptre/package.nix
+++ b/pkgs/by-name/ce/ceptre/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation {
   pname = "ceptre";
-  version = "unstable-2016-11-27";
+  version = "0-unstable-2024-8-26";
 
   src = fetchFromGitHub {
     owner = "chrisamaphone";
     repo = "interactive-lp";
-    rev = "e436fda2ccd44e9c9d226feced9d204311deacf5";
-    hash = "sha256-COYrE9O/Y1/ZBNHNakBwrUVklCuk144RF9bjwa3rl5w=";
+    rev = "22df9ff622f3363824f345089a25016e2a897077";
+    hash = "sha256-MKA/289KWIYzHW0RbHC0Q2fMJT45WcABZrNsCWKZr4Y=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
## Description of changes

Cleans up derivation for Ceptre, adds license, formats via nixfmt-rfc-style and
updates to the latest untagged commit: 0-unstable-2023-12-12

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See
  [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)
    (look inside
    [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or
    [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in
    [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or
    [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are
    [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking)
    to the relevant packages
- [x] Tested compilation of all packages that depend on this change using
      `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all
      changes have to be committed, also see
      [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in
      `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md)
  (or backporting
  [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md)
  and
  [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md)
  Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or
        breaking
  - [ ] (Module updates) Added a release notes entry if the change is
        significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS
        module
- [ ] Fits
      [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
