### PR TITLE
nix-top: init 0.3.0

### DIFF
--- a/pkgs/by-name/ni/nix-top/package.nix
+++ b/pkgs/by-name/ni/nix-top/package.nix
@@ -1,0 +1,62 @@
+{
+  binutils-unwrapped, # strings
+  coreutils,
+  getent, # /etc/passwd
+  fetchFromGitHub,
+  findutils,
+  lib,
+  makeWrapper,
+  ncurses, # tput
+  ruby,
+  stdenv,
+}:
+
+# No gems used, so mkDerivation is fine.
+let
+  additionalPath = lib.makeBinPath [
+    getent
+    ncurses
+    binutils-unwrapped
+    coreutils
+    findutils
+  ];
+in
+stdenv.mkDerivation rec {
+  pname = "nix-top";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "jerith666";
+    repo = "nix-top";
+    rev = "v${version}";
+    hash = "sha256-w/TKzbZmMt4CX2KnLwPvR1ydp5NNlp9nNx78jJvhp54=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ ruby ];
+
+  installPhase =
+    ''
+      runHook preInstall
+      mkdir -p $out/libexec/nix-top
+      install -D -m755 ./nix-top $out/bin/nix-top
+      wrapProgram $out/bin/nix-top \
+        --prefix PATH : "$out/libexec/nix-top:${additionalPath}"
+    ''
+    + lib.optionalString stdenv.isDarwin ''
+      ln -s /bin/stty $out/libexec/nix-top
+    ''
+    + ''
+      runHook postInstall
+    '';
+
+  meta = {
+    description = "Tracks what nix is building";
+    homepage = "https://github.com/jerith666/nix-top";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jerith666 ];
+    platforms = lib.platforms.unix;
+    mainProgram = "nix-top";
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -950,7 +950,6 @@ mapAliases ({
   );
   nix-review = throw "'nix-review' has been renamed to/replaced by 'nixpkgs-review'"; # Converted to throw 2023-09-10
   nix-template-rpm = throw "'nix-template-rpm' has been removed as it is broken and unmaintained"; # Added 2023-11-20
-  nix-top = throw "The nix-top package was dropped since it was unmaintained."; # Added 2024-06-21
   nix-universal-prefetch = throw "The nix-universal-prefetch package was dropped since it was unmaintained."; # Added 2024-06-21
   nixFlakes = nixVersions.stable; # Added 2021-05-21
   nixStable = nixVersions.stable; # Added 2022-01-24


### PR DESCRIPTION
I find this package useful and will make an attempt to maintain it. Fortunately someone had forked the repo before it was deleted.

This reverts commit 329081dc4b72a2b177e034b67fd14484eddf150c.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
