### PR TITLE
buildEnv: ignore empty `paths` derivations containing an empty file

### DIFF
--- a/pkgs/build-support/buildenv/builder.pl
+++ b/pkgs/build-support/buildenv/builder.pl
@@ -117,9 +117,16 @@ sub prependDangling {
 sub findFiles {
     my ($relName, $target, $baseName, $ignoreCollisions, $checkCollisionContents, $priority) = @_;
 
-    # The store path must not be a file
-    if (-f $target && isStorePath $target) {
-        die "The store path $target is a file and can't be merged into an environment using pkgs.buildEnv!";
+    if (-f $target) {
+        if (-z $target) {
+            warn "skipping empty file: `$target'\n";
+            return;
+        }
+
+        # The store path must not be a file
+        if (isStorePath $target) {
+            die "The store path $target is a file and can't be merged into an environment using pkgs.buildEnv!";
+        }
     }
 
     # Urgh, hacky...


### PR DESCRIPTION
## Description of changes

`pkgs.buildEnv` fails with `paths` derivations containing an empty file:

```nix
pkgs.buildEnv {
  name = "touch";

  paths = [
    (pkgs.stdenvNoCC.mkDerivation {
      installPhase = ''touch "$out"'';
      name = "touch";
      src = ./.;
    })
  ];
}
```

The lacking `$out` directory causes `pkgs.buildEnv` to fail due to:

https://github.com/NixOS/nixpkgs/blob/b6bcda5de105b202e7ef53af5109d5f256b1181d/pkgs/build-support/buildenv/builder.pl#L120-L123

For convenience, `paths` derivations containing an empty file should be ignored, avoiding workarounds like replacing `touch $out` with `mkdir $out`.

For example, [git-hooks.nix](https://github.com/cachix/git-hooks.nix)' `run` derivation runs pre-commit hooks and fails accordingly, while including `touch $out` merely to satisfy Nix derivation requirements:

https://github.com/cachix/git-hooks.nix/blob/0ff4381bbb8f7a52ca4a851660fc7a437a4c6e07/modules/pre-commit.nix#L55-L82

Essentially, the following happens:

```nix
pkgs.buildEnv {
  name = "touch";

  paths = [
    (pkgs.stdenvNoCC.mkDerivation {
      installPhase = ''
        # Run validations.
        [ 0 -eq 0 ] || exit

        touch "$out"
      '';

      name = "touch";
      src = ./.;
    })
  ];
}
```

The following minimal working example demonstrates the issue before and after this PR:

```bash
#!/usr/bin/env bash

nix_build() {
  printf "[BEFORE]: nix_build '%s' '%s'\n" "$1" "$2"

  nix \
    build \
    --expr "
      let
        pkgs = import <nixpkgs> {};
      in
        pkgs.buildEnv {
          name = ''$2'';

          paths = [
            (pkgs.stdenvNoCC.mkDerivation {
              installPhase = ''$2 \$out'';
              name = ''$2'';
              src = ./.;
            })
          ];
        }
    " \
    --impure \
    -I "nixpkgs=$1"

  printf "[AFTER] [%d]: nix_build '%s' '%s'\n" "$?" "$1" "$2"
}

nix_build_after() {
  nix_build \
    https://github.com/trueNAHO/nixpkgs/archive/9f3e28853defa9275ce724275e9472a468e58bb1.tar.gz \
    "$@"
}

nix_build_before() {
  nix_build \
    https://github.com/NixOS/nixpkgs/archive/ed0fe13cc637546cad8c3ee903a23459b59f5080.tar.gz \
    "$@"
}

nix_build_before touch
nix_build_before mkdir

nix_build_after touch
nix_build_after mkdir
```

The following output should be produced:

```
[BEFORE]: nix_build 'https://github.com/NixOS/nixpkgs/archive/38a95579896675d1db3f6156065297d865337a85.tar.gz' 'touch'
error: builder for '/nix/store/y51b4zr2azk81sq4ccq3q07lqzi6pmqa-touch.drv' failed with exit code 255;
       last 10 log lines:
       > sourcing setup hook '/nix/store/fyaryjvghbkpfnsyw97hb3lyb37s1pd6-move-lib64.sh'
       > sourcing setup hook '/nix/store/kd4xwxjpjxi71jkm6ka0np72if9rm3y0-move-sbin.sh'
       > sourcing setup hook '/nix/store/pag6l61paj1dc9sv15l7bm5c17xn5kyk-move-systemd-user-units.sh'
       > sourcing setup hook '/nix/store/jivxp510zxakaaic7qkrb7v1dd2rdbw9-multiple-outputs.sh'
       > sourcing setup hook '/nix/store/ilaf1w22bxi6jsi45alhmvvdgy4ly3zs-patch-shebangs.sh'
       > sourcing setup hook '/nix/store/cickvswrvann041nqxb0rxilc46svw1n-prune-libtool-files.sh'
       > sourcing setup hook '/nix/store/xyff06pkhki3qy1ls77w10s0v79c9il0-reproducible-builds.sh'
       > sourcing setup hook '/nix/store/ngg1cv31c8c7bcm2n8ww4g06nq7s4zhm-set-source-date-epoch-to-latest.sh'
       > sourcing setup hook '/nix/store/gps9qrh99j7g02840wv5x78ykmz30byp-strip.sh'
       > error: The store path /nix/store/kf4bxck34i3bhcaplq1dzxbcgdcg16z9-touch is a file and can't be merged into an environment using pkgs.buildEnv! at /nix/store/77my1q03gyb36mhs0sij87yr710w9gha-builder.pl line 122.
       For full logs, run 'nix log /nix/store/y51b4zr2azk81sq4ccq3q07lqzi6pmqa-touch.drv'.
[AFTER] [1]: nix_build 'https://github.com/NixOS/nixpkgs/archive/38a95579896675d1db3f6156065297d865337a85.tar.gz' 'touch'
[BEFORE]: nix_build 'https://github.com/NixOS/nixpkgs/archive/38a95579896675d1db3f6156065297d865337a85.tar.gz' 'mkdir'
[AFTER] [0]: nix_build 'https://github.com/NixOS/nixpkgs/archive/38a95579896675d1db3f6156065297d865337a85.tar.gz' 'mkdir'
[BEFORE]: nix_build 'https://github.com/trueNAHO/nixpkgs/archive/c5bcaea1ade2dc77c8a5203cd910d46021336c3c.tar.gz' 'touch'
[AFTER] [0]: nix_build 'https://github.com/trueNAHO/nixpkgs/archive/c5bcaea1ade2dc77c8a5203cd910d46021336c3c.tar.gz' 'touch'
[BEFORE]: nix_build 'https://github.com/trueNAHO/nixpkgs/archive/c5bcaea1ade2dc77c8a5203cd910d46021336c3c.tar.gz' 'mkdir'
[AFTER] [0]: nix_build 'https://github.com/trueNAHO/nixpkgs/archive/c5bcaea1ade2dc77c8a5203cd910d46021336c3c.tar.gz' 'mkdir'
```

For reference, this PR follows up on https://github.com/NixOS/nixpkgs/pull/56085 and https://github.com/NixOS/nixpkgs/pull/134215.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
