### PR TITLE
indicator-sound-switcher: fix Gtk Namespace error

### DIFF
--- a/pkgs/applications/audio/indicator-sound-switcher/default.nix
+++ b/pkgs/applications/audio/indicator-sound-switcher/default.nix
@@ -1,7 +1,6 @@
 { python3Packages
 , lib
 , fetchFromGitHub
-, perlPackages
 , gettext
 , gtk3
 , gobject-introspection
@@ -35,6 +34,7 @@ python3Packages.buildPythonApplication rec {
     wrapGAppsHook3
     glib
     gdk-pixbuf
+    gobject-introspection
   ];
 
   buildInputs = [
@@ -45,7 +45,6 @@ python3Packages.buildPythonApplication rec {
     python3Packages.setuptools
     python3Packages.pygobject3
     gtk3
-    gobject-introspection
     librsvg
     libayatana-appindicator
     libpulseaudio


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

indicator-sound-switcher on master has been broken for quite some time:
```
nix run nixpkgs#indicator-sound-switcher
Traceback (most recent call last):
  File "/nix/store/0kkmhyrzmj5ym22vgjccb4frx50hlxlg-indicator-sound-switcher-2.3.9/bin/..indicator-sound-switcher-wrapped-wrapped", line 6, in <module>
    from indicator_sound_switcher import main
  File "/nix/store/0kkmhyrzmj5ym22vgjccb4frx50hlxlg-indicator-sound-switcher-2.3.9/lib/python3.11/site-packages/indicator_sound_switcher/__init__.py", line 32, in <module>
    from .indicator import SoundSwitcherIndicator, APP_ID
  File "/nix/store/0kkmhyrzmj5ym22vgjccb4frx50hlxlg-indicator-sound-switcher-2.3.9/lib/python3.11/site-packages/indicator_sound_switcher/indicator.py", line 8, in <module>
    gi.require_version('Gtk', '3.0')
  File "/nix/store/ak80bykk8halwf1klflhvpncq9lw2f8s-python3.11-pygobject-3.48.2/lib/python3.11/site-packages/gi/__init__.py", line 122, in require_version
    raise ValueError('Namespace %s not available' % namespace)
ValueError: Namespace Gtk not available
```

Moved gobject-introspection to nativeBuildInputs as suggested here https://github.com/NixOS/nixpkgs/pull/174422#issuecomment-1344413989

Not sure if removing `gobject-introspection` from progagatedBuildInputs has any unintended effects, but it works on my end.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Pinging maintainer: @Alexnortung

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
