### PR TITLE
onlykey-agent: Add missing cython dependency

### DIFF
--- a/pkgs/tools/security/onlykey-agent/default.nix
+++ b/pkgs/tools/security/onlykey-agent/default.nix
@@ -26,6 +26,7 @@ let
     propagatedBuildInputs = oa.propagatedBuildInputs or [ ] ++ [
       bech32
       cryptography
+      cython
       docutils
       pycryptodome
       pynacl
@@ -52,7 +53,7 @@ python3Packages.buildPythonApplication rec {
     sha256 = "sha256-SbGb7CjcD7cFPvASZtip56B4uxRiFKZBvbsf6sb8fds=";
   };
 
-  propagatedBuildInputs = with python3Packages; [ lib-agent onlykey-cli setuptools cython ];
+  propagatedBuildInputs = with python3Packages; [ lib-agent onlykey-cli setuptools ];
 
   # move the python library into the sitePackages.
   postInstall = ''

--- a/pkgs/tools/security/onlykey-agent/default.nix
+++ b/pkgs/tools/security/onlykey-agent/default.nix
@@ -52,7 +52,7 @@ python3Packages.buildPythonApplication rec {
     sha256 = "sha256-SbGb7CjcD7cFPvASZtip56B4uxRiFKZBvbsf6sb8fds=";
   };
 
-  propagatedBuildInputs = with python3Packages; [ lib-agent onlykey-cli setuptools ];
+  propagatedBuildInputs = with python3Packages; [ lib-agent onlykey-cli setuptools cython ];
 
   # move the python library into the sitePackages.
   postInstall = ''


### PR DESCRIPTION
## Description of changes

`onlykey-agent` was failing to run with `cython` not found. This fixes it for me.
<details>
<summary>Without Cython</summary>

```c#
$ onlykey-agent --version
Traceback (most recent call last):
  File "/nix/store/y6kn44lgahfk6mkh5g4il125g5wawb6c-onlykey-agent-1.1.15/bin/.onlykey-agent-wrapped", line 9, in <module>
    sys.exit(ssh_agent())
             ^^^^^^^^^^^
  File "/nix/store/y6kn44lgahfk6mkh5g4il125g5wawb6c-onlykey-agent-1.1.15/lib/python3.11/site-packages/onlykey_agent/__init__.py", line 5, in <lambda>
    ssh_agent = lambda: libagent.ssh.main(DeviceType)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/5iqxfj0hqb00vdz0vdx4dbxr0gv1ycyv-python3.11-libagent-1.0.6/lib/python3.11/site-packages/libagent/ssh/__init__.py", line 185, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/5iqxfj0hqb00vdz0vdx4dbxr0gv1ycyv-python3.11-libagent-1.0.6/lib/python3.11/site-packages/libagent/ssh/__init__.py", line 268, in main
    args = create_agent_parser(device_type=device_type).parse_args()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/5iqxfj0hqb00vdz0vdx4dbxr0gv1ycyv-python3.11-libagent-1.0.6/lib/python3.11/site-packages/libagent/ssh/__init__.py", line 75, in create_agent_parser
    resources_map = {r.key: r for r in pkg_resources.require(agent_package)}
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/8cx1caij3ghhbgxk0f57xhqm3xfadl88-python3.11-setuptools-69.5.1/lib/python3.11/site-packages/pkg_resources/__init__.py", line 937, in require
    needed = self.resolve(parse_requirements(requirements))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/8cx1caij3ghhbgxk0f57xhqm3xfadl88-python3.11-setuptools-69.5.1/lib/python3.11/site-packages/pkg_resources/__init__.py", line 798, in resolve
    dist = self._resolve_dist(
           ^^^^^^^^^^^^^^^^^^^
  File "/nix/store/8cx1caij3ghhbgxk0f57xhqm3xfadl88-python3.11-setuptools-69.5.1/lib/python3.11/site-packages/pkg_resources/__init__.py", line 839, in _resolve_dist
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'Cython>=0.23.4' distribution was not found and is required by onlykey
```

</details>
<details>
<summary>With Cython</summary>
	
```c#
$ onlykey-agent --version
onlykey-agent=1.1.15 lib-agent=1.0.6
```

</details>



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
