### PR TITLE
fprintd: 1.94.2 -> 1.94.3, python312Packages.pypamtest 1.1.3 -> 1.1.5, fix build issues

### DIFF
--- a/pkgs/development/libraries/libpam-wrapper/default.nix
+++ b/pkgs/development/libraries/libpam-wrapper/default.nix
@@ -1,22 +1,33 @@
-{ lib, stdenv
-, fetchgit
-, cmake
-, linux-pam
-, enablePython ? false
-, python ? null
+{
+  lib,
+  stdenv,
+  fetchgit,
+  cmake,
+  linux-pam,
+  substituteAll,
+  enablePython ? false,
+  python ? null,
 }:
 
 assert enablePython -> python != null;
 
 stdenv.mkDerivation rec {
   pname = "libpam-wrapper";
-  version = "1.1.3";
+  version = "1.1.5";
 
   src = fetchgit {
     url = "git://git.samba.org/pam_wrapper.git";
     rev = "pam_wrapper-${version}";
-    sha256 = "00mqhsashx7njrvxz085d0b88nizhdy7m3x17ip5yhvwsl63km6p";
+    hash = "sha256-AtfkiCUvCxUfll6lOlbMyy5AhS5R2BGF1+ecC1VuwzM=";
   };
+
+  patches = [
+    (substituteAll {
+      src = ./python.patch;
+      siteDir = lib.optionalString enablePython python.sitePackages;
+      includeDir = lib.optionalString enablePython "include/${python.libPrefix}";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ] ++ lib.optionals enablePython [ python ];
 

--- a/pkgs/development/libraries/libpam-wrapper/python.patch
+++ b/pkgs/development/libraries/libpam-wrapper/python.patch
@@ -1,0 +1,38 @@
+diff --git a/cmake/Modules/FindPythonSiteLibs.cmake b/cmake/Modules/FindPythonSiteLibs.cmake
+index ab2931e..08e2c98 100644
+--- a/cmake/Modules/FindPythonSiteLibs.cmake
++++ b/cmake/Modules/FindPythonSiteLibs.cmake
+@@ -27,30 +27,9 @@
+ 
+ if (PYTHON_EXECUTABLE)
+     ### PYTHON_SITELIB
+-    execute_process(
+-        COMMAND
+-        ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=True, prefix=''))"
+-        OUTPUT_VARIABLE
+-            PYTHON_SITELIB_OUTPUT_VARIABLE
+-        RESULT_VARIABLE
+-            PYTHON_SITELIB_RESULT_VARIABLE
+-        OUTPUT_STRIP_TRAILING_WHITESPACE
+-    )
+-    if (NOT PYTHON_SITELIB_RESULT_VARIABLE)
+-        file(TO_CMAKE_PATH "${PYTHON_SITELIB_OUTPUT_VARIABLE}" PYTHON_SITELIB)
+-    endif ()
++    file(TO_CMAKE_PATH "@siteDir@" PYTHON_SITELIB)
++
+ 
+     ### PYTHON_SITEINC
+-    execute_process(
+-        COMMAND
+-            ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_inc; print(get_python_inc(plat_specific=True, prefix=''))"
+-        OUTPUT_VARIABLE
+-            PYTHON_SITEINC_OUTPUT_VARIABLE
+-        RESULT_VARIABLE
+-            PYTHON_SITEINC_RESULT_VARIABLE
+-        OUTPUT_STRIP_TRAILING_WHITESPACE
+-    )
+-    if (NOT PYTHON_SITEINC_RESULT_VARIABLE)
+-        file(TO_CMAKE_PATH "${PYTHON_SITEINC_OUTPUT_VARIABLE}" PYTHON_SITEINC)
+-    endif ()
++    file(TO_CMAKE_PATH "@includeDir@" PYTHON_SITEINC)
+ endif (PYTHON_EXECUTABLE)

--- a/pkgs/tools/security/fprintd/default.nix
+++ b/pkgs/tools/security/fprintd/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv
 , fetchFromGitLab
-, fetchpatch
 , pkg-config
 , gobject-introspection
 , meson
@@ -24,7 +23,7 @@
 
 stdenv.mkDerivation rec {
   pname = "fprintd";
-  version = "1.94.2";
+  version = "1.94.3";
   outputs = [ "out" "devdoc" ];
 
   src = fetchFromGitLab {
@@ -32,16 +31,8 @@ stdenv.mkDerivation rec {
     owner = "libfprint";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-ePhcIZyXoGr8XlBuzKjpibU9D/44iCXYBlpVR9gcswQ=";
+    sha256 = "sha256-shH+ctQAx4fpTMWTmo3wB45ZS38Jf8RknryPabfZ6QE=";
   };
-
-  patches = [
-    # backport upstream patch fixing tests
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/libfprint/fprintd/-/commit/ae04fa989720279e5558c3b8ff9ebe1959b1cf36.patch";
-      sha256 = "sha256-jW5vlzrbZQ1gUDLBf7G50GnZfZxhlnL2Eu+9Bghdwdw=";
-    })
-  ];
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
## Description of changes

Update and fix of `python312Packages.pypamtest` to fix build issue in `fprintd` (which coulnd't find the python bindings)

Also updates `fprintd` and `pypamtest` 
[Release notes fprintd](https://gitlab.freedesktop.org/libfprint/fprintd/-/releases)
[Changelog pypamtest](https://git.samba.org/?p=pam_wrapper.git;a=log;h=refs/tags/pam_wrapper-1.1.5)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
