### PR TITLE
shpool: init at 0.6.2

### DIFF
--- a/pkgs/by-name/sh/shpool/package.nix
+++ b/pkgs/by-name/sh/shpool/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  linux-pam,
+  testers,
+  shpool,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "shpool";
+  version = "0.6.2";
+
+  src = fetchFromGitHub {
+    owner = "shell-pool";
+    repo = "shpool";
+    rev = "v${version}";
+    hash = "sha256-6gfK71uM6IOP571Jzv3QPPKITaRteXyySZAstH0e+/M=";
+  };
+
+
+  postPatch = ''
+    substituteInPlace systemd/shpool.service \
+      --replace-fail '/usr/bin/shpool' "$out/bin/shpool"
+  '';
+
+  cargoHash = "sha256-rJ+Avq/6y68xEcJ+EeFVhFaSWJyC+x0a46cclVsTE4Q=";
+
+  buildInputs = [
+    linux-pam
+  ];
+
+  # The majority of tests rely on impure environment
+  # (such as systemd socket, ssh socket), and some of them
+  # have race conditions. They don't print their full name,
+  # tried skipping them but failed
+  doCheck = false;
+
+  postInstall = ''
+    install -Dm444 systemd/shpool.service -t $out/lib/systemd/user
+    install -Dm444 systemd/shpool.socket -t $out/lib/systemd/user
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    command = "shpool version";
+    package = shpool;
+  };
+
+  meta = {
+    description = "Persistent session management like tmux, but more lightweight";
+    homepage = "https://github.com/shell-pool/shpool";
+    license = lib.licenses.asl20;
+    mainProgram = "shpool";
+    maintainers = with lib.maintainers; [ aleksana ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/325193

Trying to fix tests

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
