### PR TITLE
python312Packages.typer: include optional dependencies

### DIFF
--- a/pkgs/applications/misc/dbx/default.nix
+++ b/pkgs/applications/misc/dbx/default.nix
@@ -50,8 +50,7 @@ python.pkgs.buildPythonApplication rec {
       tenacity
       typer
       watchdog
-    ]
-    ++ typer.optional-dependencies.all;
+    ];
 
   passthru.optional-dependencies = with python3.pkgs; {
     aws = [ boto3 ];

--- a/pkgs/applications/misc/shell-genie/default.nix
+++ b/pkgs/applications/misc/shell-genie/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     rich
     shellingham
     typer
-  ] ++ typer.optional-dependencies.all;
+  ];
 
   # No tests available
   doCheck = false;

--- a/pkgs/by-name/au/audiness/package.nix
+++ b/pkgs/by-name/au/audiness/package.nix
@@ -30,8 +30,7 @@ python3.pkgs.buildPythonApplication rec {
       pytenable
       typer
       validators
-    ]
-    ++ typer.optional-dependencies.all;
+    ];
 
   pythonImportsCheck = [ "audiness" ];
 

--- a/pkgs/by-name/cu/cups-printers/package.nix
+++ b/pkgs/by-name/cu/cups-printers/package.nix
@@ -30,8 +30,7 @@ python3.pkgs.buildPythonApplication rec {
       pycups
       typer
       validators
-    ]
-    ++ typer.optional-dependencies.all;
+    ];
 
   # Project has no tests
   doCheck = false;

--- a/pkgs/by-name/kr/krr/package.nix
+++ b/pkgs/by-name/kr/krr/package.nix
@@ -40,7 +40,7 @@ python3.pkgs.buildPythonPackage rec {
     pydantic_1
     slack-sdk
     typer
-  ] ++ typer.optional-dependencies.all;
+  ];
 
   nativeCheckInputs = with python3.pkgs; [
     pytestCheckHook

--- a/pkgs/by-name/ro/route-graph/package.nix
+++ b/pkgs/by-name/ro/route-graph/package.nix
@@ -31,7 +31,7 @@ python3.pkgs.buildPythonApplication rec {
     scapy
     typer
     typing-extensions
-  ] ++ typer.optional-dependencies.all);
+  ]);
 
   # Project has no tests
   doCheck = false;

--- a/pkgs/by-name/tr/trak/package.nix
+++ b/pkgs/by-name/tr/trak/package.nix
@@ -20,7 +20,7 @@ python3Packages.buildPythonApplication rec {
   dependencies = with python3Packages; [
     questionary
     typer
-  ] ++ typer.optional-dependencies.all;
+  ];
 
   build-system = [ python3Packages.poetry-core ];
 

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -123,7 +123,7 @@ buildPythonPackage rec {
     uvicorn
     typer
     tomlkit
-  ] ++ typer.passthru.optional-dependencies.all;
+  ];
 
   passthru.optional-dependencies.oauth = [
     authlib

--- a/pkgs/development/python-modules/manifestoo/default.nix
+++ b/pkgs/development/python-modules/manifestoo/default.nix
@@ -2,15 +2,12 @@
   buildPythonPackage,
   fetchPypi,
   hatch-vcs,
-  importlib-metadata,
   lib,
   manifestoo-core,
   nix-update-script,
   pytestCheckHook,
-  pythonOlder,
   textual,
   typer,
-  typing-extensions,
 }:
 
 buildPythonPackage rec {
@@ -32,9 +29,7 @@ buildPythonPackage rec {
       manifestoo-core
       textual
       typer
-    ]
-    ++ typer.passthru.optional-dependencies.all
-    ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+    ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/development/python-modules/pymodbus/default.nix
+++ b/pkgs/development/python-modules/pymodbus/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
       prompt-toolkit
       pygments
       click
-    ] ++ typer.optional-dependencies.all;
+    ];
     serial = [ pyserial ];
   };
 

--- a/pkgs/development/python-modules/pyunifiprotect/default.nix
+++ b/pkgs/development/python-modules/pyunifiprotect/default.nix
@@ -71,7 +71,7 @@ buildPythonPackage rec {
     pyjwt
     pytz
     typer
-  ] ++ typer.optional-dependencies.all ++ lib.optionals (pythonOlder "3.11") [ async-timeout ];
+  ] ++ lib.optionals (pythonOlder "3.11") [ async-timeout ];
 
   passthru.optional-dependencies = {
     shell = [

--- a/pkgs/development/python-modules/rstcheck/default.nix
+++ b/pkgs/development/python-modules/rstcheck/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     types-docutils
     pydantic
     typer
-  ] ++ typer.optional-dependencies.all;
+  ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/torchio/default.nix
+++ b/pkgs/development/python-modules/torchio/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     torch
     tqdm
     typer
-  ] ++ typer.passthru.optional-dependencies.all;
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/typer/default.nix
+++ b/pkgs/development/python-modules/typer/default.nix
@@ -33,11 +33,12 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     click
     typing-extensions
-  ];
+  # Build includes the standard optional by default
+  # https://github.com/tiangolo/typer/blob/0.12.3/pyproject.toml#L71-L72
+  ] ++ optional-dependencies.standard;
 
-  passthru.optional-dependencies = {
-    all = [
-      colorama
+  optional-dependencies = {
+    standard = [
       shellingham
       rich
     ];
@@ -48,7 +49,7 @@ buildPythonPackage rec {
     pytest-sugar
     pytest-xdist
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.all;
+  ];
 
   preCheck = ''
     export HOME=$(mktemp -d);

--- a/pkgs/tools/misc/markdown-anki-decks/default.nix
+++ b/pkgs/tools/misc/markdown-anki-decks/default.nix
@@ -28,7 +28,7 @@ python3.pkgs.buildPythonApplication rec {
     markdown
     python-frontmatter
     typer
-  ] ++ typer.optional-dependencies.all;
+  ];
 
   # No tests available on Pypi and there is only a failing version assertion test in the repo.
   doCheck = false;


### PR DESCRIPTION
Typer specifies the standard optional-dependencies package list, but then due to internal tooling includes it by default in Require-Dist.

https://github.com/tiangolo/typer/blob/0.12.3/pyproject.toml#L71-L72

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
