### PR TITLE
glusterfs: detect correct Python version by using local m4 files

### DIFF
--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -79,11 +79,14 @@ in stdenv.mkDerivation rec {
   postPatch = ''
     sed -e '/chmod u+s/d' -i contrib/fuse-util/Makefile.am
     substituteInPlace libglusterfs/src/glusterfs/lvm-defaults.h \
-      --replace '/sbin/' '${lvm2}/bin/'
+      --replace-fail '/sbin/' '${lvm2}/bin/'
     substituteInPlace libglusterfs/src/glusterfs/compat.h \
-      --replace '/bin/umount' '${util-linux}/bin/umount'
+      --replace-fail '/bin/umount' '${util-linux}/bin/umount'
     substituteInPlace contrib/fuse-lib/mount-gluster-compat.h \
-      --replace '/bin/mount' '${util-linux}/bin/mount'
+      --replace-fail '/bin/mount' '${util-linux}/bin/mount'
+    # use local up to date m4 files to ensure the correct python version is detected
+    substituteInPlace autogen.sh \
+      --replace-fail '$ACLOCAL -I ./contrib/aclocal' '$ACLOCAL'
   '';
 
   # Note that the VERSION file is something that is present in release tarballs


### PR DESCRIPTION
## Description of changes

This makes sure the correct Python version is detected by using the local m4 files.
The distributed m4 files were added in
https://github.com/gluster/glusterfs/commit/ff043af12856648daa04d4facdda7911976d0a49
to make sure the Python version is detected correctly,
but now fail to identify versions > 3.9 correctly (https://bugs.gnu.org/44239).

fix #325079

## Result of `nixpkgs-review` run (with #325059) on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>16 packages built:</summary>
  <ul>
    <li>ceph</li>
    <li>ceph-client</li>
    <li>ceph-csi</li>
    <li>ceph.dev</li>
    <li>ceph.doc</li>
    <li>libceph (ceph.lib ,libceph.dev ,libceph.doc ,libceph.lib ,libceph.man)</li>
    <li>ceph.man</li>
    <li>glusterfs</li>
    <li>qemu_full</li>
    <li>qemu_full.debug</li>
    <li>qemu_full.ga</li>
    <li>quickemu</li>
    <li>quickgui</li>
    <li>samba4Full</li>
    <li>samba4Full.dev</li>
    <li>samba4Full.man</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc