### PR TITLE
lomiri.*: Revert GLib workarounds

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -36,7 +36,7 @@ in {
         morph-browser
         qtmir # not having its desktop file for Xwayland available causes any X11 application to crash the session
         suru-icon-theme
-        # telephony-service # currently broken: https://github.com/NixOS/nixpkgs/pull/314043
+        telephony-service
       ]);
       variables = {
         # To override the keyboard layouts in Lomiri
@@ -85,7 +85,7 @@ in {
       ] ++ lib.optionals (config.hardware.pulseaudio.enable || config.services.pipewire.pulse.enable) [
         ayatana-indicator-sound
       ]) ++ (with pkgs.lomiri; [
-        # telephony-service # currently broken: https://github.com/NixOS/nixpkgs/pull/314043
+        telephony-service
       ] ++ lib.optionals config.networking.networkmanager.enable [
         lomiri-indicator-network
       ]);

--- a/nixos/tests/ayatana-indicators.nix
+++ b/nixos/tests/ayatana-indicators.nix
@@ -35,7 +35,7 @@ in {
         ayatana-indicator-sound
       ] ++ (with pkgs.lomiri; [
         lomiri-indicator-network
-        # telephony-service # currently broken: https://github.com/NixOS/nixpkgs/pull/314043
+        telephony-service
       ]);
     };
 

--- a/pkgs/desktops/lomiri/applications/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri/default.nix
@@ -208,7 +208,7 @@ stdenv.mkDerivation (finalAttrs: {
     lomiri-settings-components
     lomiri-thumbnailer
     qtmultimedia
-    # telephony-service # currently broken: https://github.com/NixOS/nixpkgs/pull/314043
+    telephony-service
   ];
 
   nativeCheckInputs = [

--- a/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
@@ -101,8 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_DOC" true) # lacks QML docs, needs qdoc: https://github.com/NixOS/nixpkgs/pull/245379
   ];
 
-  # Currently broken: https://github.com/NixOS/nixpkgs/pull/314043
-  doCheck = false;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   postInstall = ''
     substituteInPlace $out/etc/dbus-1/services/com.lomiri.connectivity1.service \

--- a/pkgs/desktops/lomiri/services/telephony-service/default.nix
+++ b/pkgs/desktops/lomiri/services/telephony-service/default.nix
@@ -195,7 +195,5 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.gpl3Only;
     maintainers = teams.lomiri.members;
     platforms = platforms.linux;
-    # Completely broken until https://github.com/NixOS/nixpkgs/pull/314043 is merged
-    broken = true;
   };
 })

--- a/pkgs/desktops/lomiri/services/telephony-service/default.nix
+++ b/pkgs/desktops/lomiri/services/telephony-service/default.nix
@@ -52,9 +52,16 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # Remove when https://gitlab.com/ubports/development/core/telephony-service/-/merge_requests/90 merged & in release
     (fetchpatch {
-      name = "0001-telephony-service-CMakeLists-Make-tests-optional.patch";
-      url = "https://gitlab.com/ubports/development/core/telephony-service/-/commit/9a8297bcf9b34d77ffdae3dfe4ad2636022976fb.patch";
+      name = "0001-lomiri-telephony-service-CMakeLists-Make-tests-optional.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-telephony-service/-/commit/9a8297bcf9b34d77ffdae3dfe4ad2636022976fb.patch";
       hash = "sha256-Za4ZGKnw9iz2RP1LzLhKrEJ1vLUufWk8J07LmWDW40E=";
+    })
+
+    # Remove when version > 0.5.3
+    (fetchpatch {
+      name = "0002-lomiri-telephony-service-Fix-gettext-funcs-in-wrong-namespace.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-telephony-service/-/commit/18e0ba8e025b097eef1217d97d98ef4a4940fe84.patch";
+      hash = "sha256-vOIy+B/OQeccsVn4pXsnr8LYyEapqbebW1I6dBg5u2c=";
     })
   ];
 


### PR DESCRIPTION
## Description of changes

Reverts #315117, since the patched GLib has landed everywhere. This re-enables the tests on `lomiri.lomiri-indicator-network`, and unbreaks `lomiri.telephony-service`.

The latter has been renamed to `lomiri-telephony-service` upstream, but the latest release still has the old name for everything. Rename needs to be handled on next release.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
