### PR TITLE
frigate: pin to python3.11, support mpl 3.9.0

### DIFF
--- a/pkgs/applications/video/frigate/default.nix
+++ b/pkgs/applications/video/frigate/default.nix
@@ -1,6 +1,6 @@
 { lib
 , callPackage
-, python3
+, python311
 , fetchFromGitHub
 , fetchurl
 , fetchpatch2
@@ -23,7 +23,7 @@ let
     inherit version src;
   };
 
-  python = python3.override {
+  python = python311.override {
     packageOverrides = self: super: {
       pydantic = super.pydantic_1;
 
@@ -71,6 +71,14 @@ python.pkgs.buildPythonApplication rec {
       url = "https://github.com/blakeblackshear/frigate/commit/b65656fa8733c1c2f3d944f716d2e9493ae7c99f.patch";
       hash = "sha256-taPWFV4PldBGUKAwFMKag4W/3TLMSGdKLYG8bj1Y5mU=";
     })
+    (fetchpatch2 {
+      # https://github.com/blakeblackshear/frigate/pull/10097
+      name = "frigate-secrets-permissionerror.patch";
+      url = "https://github.com/blakeblackshear/frigate/commit/a1424bad6c0163e790129ade7a9784514d0bf89d.patch";
+      hash = "sha256-/kIy4aW9o5AKHJQfCDVY46si+DKaUb+CsZsCGIbXvUQ=";
+    })
+    # https://github.com/blakeblackshear/frigate/pull/12324
+    ./mpl-3.9.0.patch
   ];
 
   postPatch = ''

--- a/pkgs/applications/video/frigate/mpl-3.9.0.patch
+++ b/pkgs/applications/video/frigate/mpl-3.9.0.patch
@@ -1,0 +1,42 @@
+From fba8cff13186bd80ceaa06806392957598139deb Mon Sep 17 00:00:00 2001
+From: Martin Weinelt <hexa@darmstadt.ccc.de>
+Date: Sun, 7 Jul 2024 14:23:29 +0200
+Subject: [PATCH] Fix colormap usage with matplotlib 3.9.0
+
+The mpl.cm toplevel registration has been removed.
+
+https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.9.0.html#top-level-cmap-registration-and-access-functions-in-mpl-cm
+---
+ frigate/config.py                    | 2 +-
+ frigate/detectors/detector_config.py | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/frigate/config.py b/frigate/config.py
+index 2e8b2570..af4f3263 100644
+--- a/frigate/config.py
++++ b/frigate/config.py
+@@ -807,7 +807,7 @@ class CameraConfig(FrigateBaseModel):
+     def __init__(self, **config):
+         # Set zone colors
+         if "zones" in config:
+-            colors = plt.cm.get_cmap("tab10", len(config["zones"]))
++            colors = plt.colormaps["tab10"].resampled(len(config["zones"]))
+             config["zones"] = {
+                 name: {**z, "color": tuple(round(255 * c) for c in colors(idx)[:3])}
+                 for idx, (name, z) in enumerate(config["zones"].items())
+diff --git a/frigate/detectors/detector_config.py b/frigate/detectors/detector_config.py
+index 7fc958a3..b65631eb 100644
+--- a/frigate/detectors/detector_config.py
++++ b/frigate/detectors/detector_config.py
+@@ -125,7 +125,7 @@ class ModelConfig(BaseModel):
+ 
+     def create_colormap(self, enabled_labels: set[str]) -> None:
+         """Get a list of colors for enabled labels."""
+-        cmap = plt.cm.get_cmap("tab10", len(enabled_labels))
++        cmap = plt.colormaps["tab10"].resampled(len(enabled_labels))
+ 
+         for key, val in enumerate(enabled_labels):
+             self._colormap[val] = tuple(int(round(255 * c)) for c in cmap(key)[:3])
+-- 
+2.45.1
+


### PR DESCRIPTION
and backport a patch that prevents crashes if /run/secrets exists, but is unaccessible to frigate.

Closes: #325228

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
