### PR TITLE
python3Packages.jupysql: init at 0.10.11

### DIFF
--- a/pkgs/development/python-modules/jupysql-plugin/default.nix
+++ b/pkgs/development/python-modules/jupysql-plugin/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  hatchling,
+  hatch-jupyter-builder,
+  hatch-nodejs-version,
+  jupyterlab,
+  ploomber-core,
+}:
+
+buildPythonPackage rec {
+  pname = "jupysql-plugin";
+  version = "0.4.4";
+
+  pyproject = true;
+  disabled = pythonOlder "3.6";
+
+  # using pypi archive which includes pre-built assets
+  src = fetchPypi {
+    pname = "jupysql_plugin";
+    inherit version;
+    hash = "sha256-kuaKknbc00nLGwCUsULgUFT52yoptUH2mnUyGYbYYKk=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-jupyter-builder
+    hatch-nodejs-version
+    jupyterlab
+  ];
+
+  dependencies = [ ploomber-core ];
+
+  # testing requires a circular dependency over jupysql
+  doCheck = false;
+
+  pythonImportsCheck = [ "jupysql_plugin" ];
+
+  meta = with lib; {
+    description = "Better SQL in Jupyter";
+    homepage = "https://github.com/ploomber/jupysql-plugin";
+    changelog = "https://github.com/ploomber/jupysql-plugin/blob/${version}/CHANGELOG.md";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ pacien ];
+  };
+}

--- a/pkgs/development/python-modules/jupysql/default.nix
+++ b/pkgs/development/python-modules/jupysql/default.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  setuptools,
+  prettytable,
+  sqlalchemy,
+  sqlparse,
+  ipython-genutils,
+  jinja2,
+  sqlglot,
+  jupysql-plugin,
+  ploomber-core,
+  ploomber-extension,
+  ipython,
+  duckdb,
+  duckdb-engine,
+  matplotlib,
+  polars,
+  ipywidgets,
+  numpy,
+  pandas,
+  js2py,
+  pyspark,
+  pyarrow,
+  grpcio,
+  pytestCheckHook,
+  psutil,
+}:
+
+buildPythonPackage rec {
+  pname = "jupysql";
+  version = "0.10.11";
+
+  pyproject = true;
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "ploomber";
+    repo = "jupysql";
+    rev = "refs/tags/${version}";
+    hash = "sha256-A9zTjH+9RYKcgy4mI6uOMHOc46om06y1zK3IbxeVcWE=";
+  };
+
+  pythonRelaxDeps = [ "sqlalchemy" ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    prettytable
+    sqlalchemy
+    sqlparse
+    ipython-genutils
+    jinja2
+    sqlglot
+    jupysql-plugin
+    ploomber-core
+    ploomber-extension
+  ];
+
+  optional-dependencies.dev = [
+    ipython
+    duckdb
+    duckdb-engine
+    matplotlib
+    polars
+    ipywidgets
+    numpy
+    pandas
+    js2py
+    pyspark
+    pyarrow
+    grpcio
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    psutil
+  ] ++ optional-dependencies.dev;
+
+  disabledTestPaths = [
+    # require docker
+    "src/tests/integration"
+
+    # require network access
+    "src/tests/test_telemetry.py"
+
+    # want to download test data from the network
+    "src/tests/test_parse.py"
+    "src/tests/test_ggplot.py"
+    "src/tests/test_plot.py"
+    "src/tests/test_magic.py"
+    "src/tests/test_magic_plot.py"
+  ];
+
+  preCheck = ''
+    # tests need to write temp data
+    export HOME=$(mktemp -d)
+  '';
+
+  pythonImportsCheck = [ "sql" ];
+
+  meta = with lib; {
+    description = "Better SQL in Jupyter";
+    homepage = "https://github.com/ploomber/jupysql";
+    changelog = "https://github.com/ploomber/jupysql/blob/${version}/CHANGELOG.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ pacien ];
+  };
+}

--- a/pkgs/development/python-modules/ploomber-core/default.nix
+++ b/pkgs/development/python-modules/ploomber-core/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  setuptools,
+  pyyaml,
+  posthog,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "ploomber-core";
+  version = "0.2.25";
+
+  pyproject = true;
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "ploomber";
+    repo = "core";
+    rev = "refs/tags/${version}";
+    hash = "sha256-QUEnWFhf42ppoXoz3H/2SHtoPZOi6lbopsrbmEAk+1U=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    pyyaml
+    posthog
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTests = [
+    "telemetry" # requires network
+    "exceptions" # requires stderr capture
+  ];
+
+  pythonImportsCheck = [ "ploomber_core" ];
+
+  meta = with lib; {
+    description = "Core module shared across Ploomber projects";
+    homepage = "https://github.com/ploomber/core";
+    changelog = "https://github.com/ploomber/core/blob/${version}/CHANGELOG.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ pacien ];
+  };
+}

--- a/pkgs/development/python-modules/ploomber-extension/default.nix
+++ b/pkgs/development/python-modules/ploomber-extension/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchPypi,
+  hatchling,
+  hatch-jupyter-builder,
+  hatch-nodejs-version,
+  jupyterlab,
+  ploomber-core,
+  pytestCheckHook,
+  pytest-jupyter,
+}:
+
+buildPythonPackage rec {
+  pname = "ploomber-extension";
+  version = "0.1.1";
+
+  pyproject = true;
+  disabled = pythonOlder "3.6";
+
+  # using pypi archive which includes pre-built assets
+  src = fetchPypi {
+    pname = "ploomber_extension";
+    inherit version;
+    hash = "sha256-wsldqLhJfOESH9aMMzz1Y/FXofHyfgrl81O95NePXSA=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-jupyter-builder
+    hatch-nodejs-version
+    jupyterlab
+  ];
+
+  dependencies = [ ploomber-core ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-jupyter
+  ];
+
+  pythonImportsCheck = [ "ploomber_extension" ];
+
+  meta = with lib; {
+    description = "Ploomber extension";
+    homepage = "https://pypi.org/project/ploomber-extension";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ pacien ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6323,6 +6323,8 @@ self: super: with self; {
 
   junos-eznc = callPackage ../development/python-modules/junos-eznc { };
 
+  jupysql-plugin = callPackage ../development/python-modules/jupysql-plugin { };
+
   jupyter = callPackage ../development/python-modules/jupyter { };
 
   jupyter-book = callPackage ../development/python-modules/jupyter-book { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10354,6 +10354,8 @@ self: super: with self; {
 
   ploomber-core = callPackage ../development/python-modules/ploomber-core { };
 
+  ploomber-extension = callPackage ../development/python-modules/ploomber-extension { };
+
   plotext = callPackage ../development/python-modules/plotext { };
 
   plotly = callPackage ../development/python-modules/plotly { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10352,6 +10352,8 @@ self: super: with self; {
 
   plone-testing = callPackage ../development/python-modules/plone-testing { };
 
+  ploomber-core = callPackage ../development/python-modules/ploomber-core { };
+
   plotext = callPackage ../development/python-modules/plotext { };
 
   plotly = callPackage ../development/python-modules/plotly { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6325,6 +6325,8 @@ self: super: with self; {
 
   jupysql-plugin = callPackage ../development/python-modules/jupysql-plugin { };
 
+  jupysql = callPackage ../development/python-modules/jupysql { };
+
   jupyter = callPackage ../development/python-modules/jupyter { };
 
   jupyter-book = callPackage ../development/python-modules/jupyter-book { };


### PR DESCRIPTION
## Description of changes

This adds a package for JupySQL (https://jupysql.ploomber.io/) and its
dependencies.

- **python3Packages.ploomber-core: init at 0.2.25**
- **python3Packages.ploomber-extension: init at 0.1.1**
- **python3Packages.jupysql-plugin: init at 0.4.4**
- **python3Packages.jupysql: init at 0.10.11**


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

---

CC: @edublancas

