### PR TITLE
swiProlog: 9.1.21 -> 9.2.5

### DIFF
--- a/pkgs/development/compilers/swi-prolog/default.nix
+++ b/pkgs/development/compilers/swi-prolog/default.nix
@@ -34,7 +34,8 @@
 }:
 
 let
-  version = "9.1.21";
+  # minorVersion is even for stable, odd for unstable
+  version = "9.2.5";
   packInstall = swiplPath: pack:
     ''${swiplPath}/bin/swipl -g "pack_install(${pack}, [package_directory(\"${swiplPath}/lib/swipl/pack\"), silent(true), interactive(false)])." -t "halt."
     '';
@@ -43,11 +44,14 @@ stdenv.mkDerivation {
   pname = "swi-prolog";
   inherit version;
 
+  # SWI-Prolog has two repositories: swipl and swipl-devel.
+  # - `swipl`, which tracks stable releases and backports
+  # - `swipl-devel` which tracks continuous development
   src = fetchFromGitHub {
     owner = "SWI-Prolog";
-    repo = "swipl-devel";
+    repo = "swipl";
     rev = "V${version}";
-    hash = "sha256-c4OSntnwIzo6lGhpyNVtNM4el5FGrn8kcz8WkDRfQhU=";
+    hash = "sha256-WbpYu6b0WPfKoAOkBZduWK20vwOYuDUDpJuj19qzPtw=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
## Description of changes
This upgrades SWI-Prolog to the latest stable. See the [changelog](https://www.swi-prolog.org/ChangeLog?branch=stable&from=9.0.4&to=9.2.5) for more details.

Note that it appears to have been established practice in this package to import a development version of the SWI-Prolog source, though I haven't been able to find an indication that this was intentional. I am intentionally upgrading to a stable version instead, with the hope that from now on, this package will track SWI-Prolog stable.

SWI-Prolog stable versions only receive backported fixes after release, whereas in the development versions, anything goes, including backwards-incompatible breaks with previous versions of the same minor number. This means stable is suitable for doing backports to released versions of nixpkgs, while the development version is not.

I left some comments in the package source to point this out, in the hope that future importers will not accidentally pull in a dev version.

## Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
