### PR TITLE
libreoffice, hyphen: Load hyphen dicts in LibreOffice, modularize hyphen dicts, add german hyphen dict

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19913,6 +19913,14 @@
     githubId = 34945377;
     name = "John Smith";
   };
+  theCapypara = {
+    name = "Marco Köpcke";
+    email = "hello@capypara.de";
+    matrix = "@capypara:matrix.org";
+    github = "theCapypara";
+    githubId = 3512122;
+    keys = [ { fingerprint = "5F29 132D EFA8 5DA0 B598  5BF2 5941 754C 1CDE 33BB"; } ];
+  };
   thedavidmeister = {
     email = "thedavidmeister@gmail.com";
     github = "thedavidmeister";

--- a/pkgs/applications/office/libreoffice/wrapper.nix
+++ b/pkgs/applications/office/libreoffice/wrapper.nix
@@ -50,9 +50,13 @@ let
     # Add dictionaries from all NIX_PROFILES
     "--run" (lib.escapeShellArg ''
       for PROFILE in $NIX_PROFILES; do
-          HDIR="$PROFILE/share/hunspell"
-          if [ -d "$HDIR" ]; then
-              export DICPATH=$DICPATH''${DICPATH:+:}$HDIR
+          HU_DIR="$PROFILE/share/hunspell"
+          HY_DIR="$PROFILE/share/hyphen"
+          if [ -d "$HU_DIR" ]; then
+              export DICPATH=$DICPATH''${DICPATH:+:}$HU_DIR
+          fi
+          if [ -d "$HY_DIR" ]; then
+              export DICPATH=$DICPATH''${DICPATH:+:}$HY_DIR
           fi
       done
     '')

--- a/pkgs/development/libraries/hyphen/default.nix
+++ b/pkgs/development/libraries/hyphen/default.nix
@@ -23,7 +23,7 @@ in stdenv.mkDerivation rec {
     make install-libLTLIBRARIES
     make install-binSCRIPTS
     make install-includeHEADERS
-    
+
     # license
     install -D -m644 COPYING "$out/share/licenses/${pname}/LICENSE"
     runHook postInstall

--- a/pkgs/development/libraries/hyphen/default.nix
+++ b/pkgs/development/libraries/hyphen/default.nix
@@ -17,6 +17,18 @@ in stdenv.mkDerivation rec {
     sha256 = "01ap9pr6zzzbp4ky0vy7i1983fwyqy27pl0ld55s30fdxka3ciih";
   };
 
+  # Do not install the en_US dictionary.
+  installPhase = ''
+    runHook preInstall
+    make install-libLTLIBRARIES
+    make install-binSCRIPTS
+    make install-includeHEADERS
+    
+    # license
+    install -D -m644 COPYING "$out/share/licenses/${pname}/LICENSE"
+    runHook postInstall
+  '';
+
   meta = with lib; {
     description = "Text hyphenation library";
     mainProgram = "substrings.pl";

--- a/pkgs/development/libraries/hyphen/dictionaries.nix
+++ b/pkgs/development/libraries/hyphen/dictionaries.nix
@@ -1,0 +1,91 @@
+/* hyphen dictionaries */
+
+{ hyphen, stdenv, lib, fetchgit, fetchurl }:
+
+
+let
+  libreofficeRepository = "https://anongit.freedesktop.org/git/libreoffice/dictionaries.git";
+  libreofficeCommit = "9e27d044d98e65f89af8c86df722a77be827bdc8";
+  libreofficeSubdir = "de";
+
+  mkDictFromLibreofficeGit =
+    { subdir, shortName, shortDescription, dictFileName, readmeFileName }:
+    stdenv.mkDerivation rec {
+      version = "24.8";
+      pname = "hyphen-dict-${shortName}-libreoffice";
+      src = fetchgit {
+        url = "https://anongit.freedesktop.org/git/libreoffice/dictionaries.git";
+        rev = "a2bf59878dd76685803ec260e15d875746ad6e25";
+        sha256 = "sha256-3CvjgNjsrm4obATK6LmtYob8i2ngTbwP6FB4HlJMPCE=";
+      };
+      meta = with lib; {
+        description = "Hyphen dictionary for ${shortDescription} from LibreOffice";
+        homepage = "https://wiki.documentfoundation.org/Development/Dictionaries";
+        license = with licenses; [ mpl20 ];
+        maintainers = with maintainers; [ theCapypara ];
+        platforms = platforms.all;
+      };
+      phases = [ "unpackPhase" "installPhase" ];
+      installPhase = ''
+        runHook preInstall
+        cd $src/${subdir}
+        install -dm755 "$out/share/hyphen"
+        install -m644 "hyph_${dictFileName}.dic" "$out/share/hyphen"
+        # docs
+        install -dm755 "$out/share/doc/"
+        install -m644 "README_hyph_${readmeFileName}.txt" "$out/share/doc/${pname}.txt"
+        runHook postInstall
+      '';
+    };
+
+in
+rec {
+
+  /* ENGLISH */
+
+  en_US = en-us;
+  en-us = stdenv.mkDerivation rec {
+    nativeBuildInputs = hyphen.nativeBuildInputs;
+    version = hyphen.version;
+    pname = "hyphen-dict-en-us";
+    src =  hyphen.src;
+    meta = {
+      inherit (hyphen.meta) homepage platforms license mainatiners;
+      description = "Hyphen dictionary for English (United States)";
+    };
+    installPhase = ''
+      runHook preInstall
+      make install-hyphDATA
+      runHook postInstall
+    '';
+  };
+
+  /* GERMAN */
+
+  de_DE = de-de;
+  de-de = mkDictFromLibreofficeGit {
+    subdir = "de";
+    shortName = "de-de";
+    shortDescription = "German (Germany)";
+    dictFileName = "de_DE";
+    readmeFileName = "de";
+  };
+
+  de_AT = de-at;
+  de-at = mkDictFromLibreofficeGit {
+    subdir = "de";
+    shortName = "de-at";
+    shortDescription = "German (Austria)";
+    dictFileName = "de_AT";
+    readmeFileName = "de";
+  };
+
+  de_CH = de-ch;
+  de-ch = mkDictFromLibreofficeGit {
+    subdir = "de";
+    shortName = "de-ch";
+    shortDescription = "German (Switzerland)";
+    dictFileName = "de_CH";
+    readmeFileName = "de";
+  };
+}

--- a/pkgs/development/libraries/hyphen/dictionaries.nix
+++ b/pkgs/development/libraries/hyphen/dictionaries.nix
@@ -50,7 +50,7 @@ rec {
     pname = "hyphen-dict-en-us";
     src =  hyphen.src;
     meta = {
-      inherit (hyphen.meta) homepage platforms license mainatiners;
+      inherit (hyphen.meta) homepage platforms license maintainers;
       description = "Hyphen dictionary for English (United States)";
     };
     installPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8951,6 +8951,8 @@ with pkgs;
 
   hyphen = callPackage ../development/libraries/hyphen { };
 
+  hyphenDicts = recurseIntoAttrs (callPackages ../development/libraries/hyphen/dictionaries.nix {});
+
   i2c-tools = callPackage ../os-specific/linux/i2c-tools { };
 
   i2pd = callPackage ../tools/networking/i2pd { };


### PR DESCRIPTION
## Description of changes
Fixes parts of #14430

Let me know if I should split this PR! I needed all these things so I added and tested them together.

1. Makes sure that all hyphen dictionaries are loaded for LibreOffice (1st commit)
2. Adds a new package group `hyphenDicts` that follows the same principle as `hunspellDicts` (2nd commit)
3. Removes the `en_US` dict from `hyphen` and moves it to `hyphenDicts.en_US` (2nd commit)
4. Adds the hyphen dictionaries `de_DE`, `de_CH`, `de_AT`

NOTE: This is a breaking change, as `hyphen` now no longer contains the `en_US` dictionary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
