### PR TITLE
codeberg-pages: 5.0 -> 5.1

### DIFF
--- a/pkgs/development/tools/continuous-integration/codeberg-pages/default.nix
+++ b/pkgs/development/tools/continuous-integration/codeberg-pages/default.nix
@@ -26,7 +26,7 @@ buildGoModule rec {
   passthru.updateScript = nix-update-script {};
 
   meta = with lib; {
-    mainProgram = "codeberg-pages";
+    mainProgram = "pages";
     maintainers = with maintainers; [ laurent-f1z1 ];
     license = licenses.eupl12;
     homepage = "https://codeberg.org/Codeberg/pages-server";

--- a/pkgs/development/tools/continuous-integration/codeberg-pages/default.nix
+++ b/pkgs/development/tools/continuous-integration/codeberg-pages/default.nix
@@ -2,17 +2,17 @@
 
 buildGoModule rec {
   pname = "codeberg-pages";
-  version = "5.0";
+  version = "5.1";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "Codeberg";
     repo = "pages-server";
-    rev = "ea68a82cd22a8a8c1f265260af22b9406f13e3a9";
-    hash = "sha256-TSXRB0oq1CtHC9ooO+Y3ICS5YE+q+ivZAcYBSd1oWi0=";
+    rev = "v${version}";
+    hash = "sha256-txWRYQnJCGVZ0/6pZdKkRFsdUe2B+A0Fy0/WJCiBVa0=";
   };
 
-  vendorHash = "sha256-vTYB3ka34VooN2Wh/Rcj+2S1qAsA2a/VtXlILn1W7oU=";
+  vendorHash = "sha256-0JPnBf4NA4t+63cNMZYnB56y93nOc8Wn7TstRiHgvhk=";
 
   postPatch = ''
     # disable httptest

--- a/pkgs/development/tools/continuous-integration/codeberg-pages/default.nix
+++ b/pkgs/development/tools/continuous-integration/codeberg-pages/default.nix
@@ -27,7 +27,7 @@ buildGoModule rec {
 
   meta = with lib; {
     mainProgram = "pages";
-    maintainers = with maintainers; [ laurent-f1z1 ];
+    maintainers = with maintainers; [ laurent-f1z1 christoph-heiss ];
     license = licenses.eupl12;
     homepage = "https://codeberg.org/Codeberg/pages-server";
     description = "Static websites hosting from Gitea repositories";

--- a/pkgs/development/tools/continuous-integration/codeberg-pages/default.nix
+++ b/pkgs/development/tools/continuous-integration/codeberg-pages/default.nix
@@ -31,5 +31,6 @@ buildGoModule rec {
     license = licenses.eupl12;
     homepage = "https://codeberg.org/Codeberg/pages-server";
     description = "Static websites hosting from Gitea repositories";
+    changelog = "https://codeberg.org/Codeberg/pages-server/releases/tag/v${version}";
   };
 }

--- a/pkgs/development/tools/continuous-integration/codeberg-pages/default.nix
+++ b/pkgs/development/tools/continuous-integration/codeberg-pages/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitea, buildGoModule }:
+{ lib, fetchFromGitea, buildGoModule, nix-update-script }:
 
 buildGoModule rec {
   pname = "codeberg-pages";
@@ -22,6 +22,8 @@ buildGoModule rec {
   ldflags = [ "-s" "-w" ];
 
   tags = [ "sqlite" "sqlite_unlock_notify" "netgo" ];
+
+  passthru.updateScript = nix-update-script {};
 
   meta = with lib; {
     mainProgram = "codeberg-pages";


### PR DESCRIPTION
## Description of changes

Changelog: https://codeberg.org/Codeberg/pages-server/releases/tag/v5.1

Also adds/fixes a few small improvements along the way:
- `meta.mainProgram` binary name
- add `meta.changelog`
- add nix-update-script for automated updates

@Laurent2916 Are you actually still interested in maintaining this or not?
As v5.1 was released 6(!) months ago.

If not, I'll happily take this over and maintain it actively.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
