### PR TITLE
prettier-plugin-go-template: add package

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10078,6 +10078,12 @@
     githubId = 12773748;
     matrix = "@j.r:chaos.jetzt";
   };
+  jukremer = {
+    email = "nixpkgs@jankremer.eu";
+    github = "jukremer";
+    githubId = 79042825;
+    name = "Jan Kremer";
+  };
   juliendehos = {
     email = "dehos@lisic.univ-littoral.fr";
     github = "juliendehos";

--- a/pkgs/by-name/pr/prettier-plugin-go-template/package.nix
+++ b/pkgs/by-name/pr/prettier-plugin-go-template/package.nix
@@ -20,6 +20,7 @@ buildNpmPackage rec {
 
   meta = {
     description = "Fixes prettier formatting for go templates";
+    mainProgram = "prettier-plugin-go-template";
     homepage = "https://github.com/NiklasPor/prettier-plugin-go-template";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ jukremer ];

--- a/pkgs/by-name/pr/prettier-plugin-go-template/package.nix
+++ b/pkgs/by-name/pr/prettier-plugin-go-template/package.nix
@@ -6,6 +6,7 @@
 
 buildNpmPackage rec {
   pname = "prettier-plugin-go-template";
+  version = "0-unstable-2023-07-26";
 
   src = fetchFromGitHub {
     owner = "NiklasPor";

--- a/pkgs/by-name/pr/prettier-plugin-go-template/package.nix
+++ b/pkgs/by-name/pr/prettier-plugin-go-template/package.nix
@@ -4,23 +4,24 @@
   fetchFromGitHub,
 }:
 
-buildNpmPackage {
+buildNpmPackage rec {
   pname = "prettier-plugin-go-template";
 
   src = fetchFromGitHub {
     owner = "NiklasPor";
-    repo = "prettier-plugin-go-template";
+    repo = pname;
     rev = "d91c82e1377b89592ea3365e7e5569688fbc7954";
     hash = "sha256-3Tvh+OzqDTtzoaTp5dZpgEQiNA2Y2dbyq4SV9Od499A=";
   };
 
   npmDepsHash = "sha256-PpJnVZFRxpUHux2jIBDtyBS4qNo6IJY4kwTAq6stEVQ=";
 
+  dontNpmBuild = true;
+
   meta = {
     description = "Fixes prettier formatting for go templates";
     homepage = "https://github.com/NiklasPor/prettier-plugin-go-template";
     license = lib.licenses.mit;
-    mainProgram = "prettier-plugin-go-template";
     maintainers = with lib.maintainers; [ jukremer ];
   };
 }

--- a/pkgs/by-name/pr/prettier-plugin-go-template/package.nix
+++ b/pkgs/by-name/pr/prettier-plugin-go-template/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage {
+  pname = "prettier-plugin-go-template";
+
+  src = fetchFromGitHub {
+    owner = "NiklasPor";
+    repo = "prettier-plugin-go-template";
+    rev = "d91c82e1377b89592ea3365e7e5569688fbc7954";
+    hash = "sha256-3Tvh+OzqDTtzoaTp5dZpgEQiNA2Y2dbyq4SV9Od499A=";
+  };
+
+  npmDepsHash = "sha256-PpJnVZFRxpUHux2jIBDtyBS4qNo6IJY4kwTAq6stEVQ=";
+
+  meta = {
+    description = "Fixes prettier formatting for go templates";
+    homepage = "https://github.com/NiklasPor/prettier-plugin-go-template";
+    license = lib.licenses.mit;
+    mainProgram = "prettier-plugin-go-template";
+    maintainers = with lib.maintainers; [ jukremer ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-→

Adds [prettier-plugin-go-template](https://github.com/NiklasPor/prettier-plugin-go-template). Useful for formatting Hugo websites.

#324008 and #324782

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
