### PR TITLE
python312Packages.fastapi-cli: unbreak cli

### DIFF
--- a/pkgs/development/python-modules/fastapi-cli/default.nix
+++ b/pkgs/development/python-modules/fastapi-cli/default.nix
@@ -2,13 +2,13 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pdm-backend
+, rich
 , typer
 , fastapi
 , uvicorn
 
 # checks
 , pytestCheckHook
-, rich
 }:
 
 let self = buildPythonPackage rec {
@@ -25,7 +25,10 @@ let self = buildPythonPackage rec {
 
   build-system = [ pdm-backend ];
 
-  dependencies = [ typer ];
+  dependencies = [
+    rich
+    typer
+  ];
 
   optional-dependencies = {
     standard = [
@@ -40,7 +43,6 @@ let self = buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    rich
   ] ++ optional-dependencies.standard;
 
   # coverage
@@ -51,6 +53,8 @@ let self = buildPythonPackage rec {
   meta = with lib; {
     description = "Run and manage FastAPI apps from the command line with FastAPI CLI";
     homepage = "https://github.com/tiangolo/fastapi-cli";
+    changelog = "https://github.com/tiangolo/fastapi-cli/releases/tag/${version}";
+    mainProgram = "fastapi";
     license = licenses.mit;
     maintainers = with maintainers; [ ];
   };


### PR DESCRIPTION
## Description of changes

Added missing `rich` runtime dependency, unbreaking the CLI script.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
