### PR TITLE
hyprlandPlugins.hyprspace: init at 0-unstable-2024-06-17

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
@@ -27,6 +27,7 @@ let
   plugins = lib.mergeAttrsList [
     { hy3 = import ./hy3.nix; }
     { hyprfocus = import ./hyprfocus.nix; }
+    { hyprspace = import ./hyprspace.nix; }
     (import ./hyprland-plugins.nix)
   ];
 in

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprspace.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprspace.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchpatch,
+  hyprland,
+  mkHyprlandPlugin,
+}:
+
+mkHyprlandPlugin hyprland {
+  pluginName = "hyprspace";
+  version = "0-unstable-2024-06-17";
+
+  src = fetchFromGitHub {
+    owner = "KZDKM";
+    repo = "hyprspace";
+    rev = "2f3edb68f47a8f5d99d10b322e9a85a285f53cc7";
+    hash = "sha256-iyj4D6c77uROAH9QdZjPd9SKnS/DuACMESqaEKnBgI8=";
+  };
+
+  # Fix build for Hyprland v0.41.2+
+  patches = fetchpatch {
+    url = "https://github.com/KZDKM/Hyprspace/commit/edad6cf735097b7cb4406d3fc8daddd09dfa458a.patch";
+    hash = "sha256-EVabjPymGAMPtC3Uf6lMJOInvccJhu4t09NXhXhq4RY=";
+  };
+
+  dontUseCmakeConfigure = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    mv Hyprspace.so $out/lib/libhyprspace.so
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/KZDKM/Hyprspace";
+    description = "Workspace overview plugin for Hyprland";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ donovanglover ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds https://github.com/KZDKM/Hyprspace

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
