### PR TITLE
nixos/systemd-boot: add efiBootOptionDescription option

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10968,6 +10968,12 @@
     githubId = 2943605;
     name = "Evgeny Kurnevsky";
   };
+  kurtkilpela = {
+    name = "Kurt Kilpela";
+    email = "dev@kurtkilpela.com";
+    github = "kurtkilpela";
+    githubId = 823814;
+  };
   kuwii = {
     name = "kuwii";
     email = "kuwii.someone@gmail.com";

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -158,6 +158,8 @@
   services.portunus.ldap.package = pkgs.openldap.override { libxcrypt = pkgs.libxcrypt-legacy; };
   ```
 
+- Added `boot.loader.systemd-boot.efiBootOptionDescription`. A user can distinguish different bootloaders, on multi-boot systems with distinct ESP, by setting this option.
+
 - The default value of `services.kubernetes.kubelet.hostname` is now lowercased.
   Explicitly set `kubelet.hostname` to `networking.fqdnOrHostName` to get back
   the old default behavior.

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -32,6 +32,8 @@ CAN_TOUCH_EFI_VARIABLES = "@canTouchEfiVariables@"
 GRACEFUL = "@graceful@"
 COPY_EXTRA_FILES = "@copyExtraFiles@"
 CHECK_MOUNTPOINTS = "@checkMountpoints@"
+EFI_BOOT_OPTION_DESCRIPTION = "@efiBootOptionDescription@"
+SET_EFI_BOOT_OPTION_DESCRIPTION = "@setEfiBootOptionDescription@" == "1"
 
 @dataclass
 class BootSpec:
@@ -282,6 +284,9 @@ def install_bootloader(args: argparse.Namespace) -> None:
 
     if GRACEFUL == "1":
         bootctl_flags.append("--graceful")
+
+    if SET_EFI_BOOT_OPTION_DESCRIPTION:
+        bootctl_flags.append(f"--efi-boot-option-description={EFI_BOOT_OPTION_DESCRIPTION}")
 
     if os.getenv("NIXOS_INSTALL_BOOTLOADER") == "1":
         # bootctl uses fopen() with modes "wxe" and fails if the file exists.

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -38,7 +38,9 @@ let
 
     configurationLimit = if cfg.configurationLimit == null then 0 else cfg.configurationLimit;
 
-    inherit (cfg) consoleMode graceful editor;
+    inherit (cfg) consoleMode graceful editor efiBootOptionDescription;
+
+    setEfiBootOptionDescription = cfg.efiBootOptionDescription != null;
 
     inherit (efi) efiSysMountPoint canTouchEfiVariables;
 
@@ -314,6 +316,21 @@ in {
 
         Only enable this option if `systemd-boot` otherwise fails to install, as the
         scope or implication of the `--graceful` option may change in the future.
+      '';
+    };
+
+    efiBootOptionDescription = mkOption {
+      default = null;
+      type = types.nullOr types.str;
+      description = ''
+        Invoke `bootctl` with the `--efi-boot-option-description` option,
+        which specifies the boot entry name.
+
+        This option allows a user to distinguish between separate bootloaders
+        on multi-boot systems.
+
+        The UEFI standard defines the use of UCS-2 strings. Using invalid UCS-2
+        codepoints is a bad idea.
       '';
     };
 


### PR DESCRIPTION
## Description of changes
By default, `bootctl` will use "Linux Boot Manager" as the boot option description. This is not ideal when dual-booting. In systemd 252, the `--efi-boot-option-description` flag was added to permit custom description text.

When `boot.loader.systemd-boot.efiBootOptionDescription` option is not set, the `--efi-boot-option-description` is not used and `bootctl` is left to use its default value.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
