### PR TITLE
miru: added passthru.updateScript

### DIFF
--- a/pkgs/by-name/mi/miru/darwin.nix
+++ b/pkgs/by-name/mi/miru/darwin.nix
@@ -7,9 +7,15 @@
   pname,
   version,
   meta,
+  passthru,
 }:
 stdenvNoCC.mkDerivation rec {
-  inherit pname version meta;
+  inherit
+    pname
+    version
+    meta
+    passthru
+    ;
 
   src = fetchurl {
     url = "https://github.com/ThaUnknown/miru/releases/download/v${version}/mac-Miru-${version}-mac.zip";

--- a/pkgs/by-name/mi/miru/linux.nix
+++ b/pkgs/by-name/mi/miru/linux.nix
@@ -5,15 +5,21 @@
   pname,
   version,
   meta,
+  passthru,
 }:
 
 appimageTools.wrapType2 rec {
-  inherit pname version meta;
+  inherit
+    pname
+    version
+    meta
+    passthru
+    ;
 
   src = fetchurl {
     url = "https://github.com/ThaUnknown/miru/releases/download/v${version}/linux-Miru-${version}.AppImage";
     name = "${pname}-${version}.AppImage";
-    sha256 = "sha256-wnqCKnZKt0Fj8TasdRVzI558W7aIB5FLkcDEiZfz3ZQ=";
+    hash = "sha256-wnqCKnZKt0Fj8TasdRVzI558W7aIB5FLkcDEiZfz3ZQ=";
   };
 
   extraInstallCommands =

--- a/pkgs/by-name/mi/miru/package.nix
+++ b/pkgs/by-name/mi/miru/package.nix
@@ -32,8 +32,25 @@ let
       instead of flat out closing MPV.
     '';
   };
+  passthru = {
+    updateScript = ./update.sh;
+  };
 in
 if stdenv.isDarwin then
-  callPackage ./darwin.nix { inherit pname version meta; }
+  callPackage ./darwin.nix {
+    inherit
+      pname
+      version
+      meta
+      passthru
+      ;
+  }
 else
-  callPackage ./linux.nix { inherit pname version meta; }
+  callPackage ./linux.nix {
+    inherit
+      pname
+      version
+      meta
+      passthru
+      ;
+  }

--- a/pkgs/by-name/mi/miru/update.sh
+++ b/pkgs/by-name/mi/miru/update.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq gnused
+
+set -euo pipefail
+
+ROOT="$(dirname "$(readlink -f "$0")")"
+if [[ ! "$(basename $ROOT)" == "miru" || ! -f "$ROOT/package.nix" ]]; then
+    echo "error: Not in the miru folder" >&2
+    exit 1
+fi
+
+PACKAGE_NIX="$ROOT/package.nix"
+LINUX_NIX="$ROOT/linux.nix"
+DARWIN_NIX="$ROOT/darwin.nix"
+
+MIRU_LATEST_VER="$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/ThaUnknown/miru/releases/latest" | jq -r .tag_name | sed 's/^v//')"
+MIRU_CURRENT_VER="$(grep -oP 'version = "\K[^"]+' "$PACKAGE_NIX")"
+
+if [[ "$MIRU_LATEST_VER" == "null" ]]; then
+    echo "error: could not fetch miru latest version from GitHub API" >&2
+    exit 1
+fi
+
+if [[ "$MIRU_LATEST_VER" == "$MIRU_CURRENT_VER" ]]; then
+    echo "miru is up-to-date"
+    exit 0
+fi
+
+get_hash() {
+    # $1: URL
+    nix-hash --to-sri --type sha256 "$(nix-prefetch-url --type sha256 "$1")"
+}
+
+replace_hash_in_file() {
+    # $1: file
+    # $2: new hash
+    sed -i "s#hash = \".*\"#hash = \"$2\"#g" "$1"
+}
+
+replace_version_in_file() {
+    # $1: file
+    # $2: new version
+    sed -i "s#version = \".*\";#version = \"$2\";#g" "$1"
+}
+
+MIRU_LINUX_HASH="$(get_hash "https://github.com/ThaUnknown/miru/releases/download/v${MIRU_LATEST_VER}/linux-Miru-${MIRU_LATEST_VER}.AppImage")"
+MIRU_DARWIN_HASH="$(get_hash "https://github.com/ThaUnknown/miru/releases/download/v${MIRU_LATEST_VER}/mac-Miru-${MIRU_LATEST_VER}-mac.zip")"
+
+replace_hash_in_file "$LINUX_NIX" "$MIRU_LINUX_HASH"
+replace_hash_in_file "$DARWIN_NIX" "$MIRU_DARWIN_HASH"
+
+replace_version_in_file "$PACKAGE_NIX" "$MIRU_LATEST_VER"


### PR DESCRIPTION
## Description of changes

Added an update script for Miru.

To test it (in my branch):

`nix-shell maintainers/scripts/update.nix --argstr package miru`

Then build miru again - `nix-build -A miru` - and run it.

 It should be the latest available version: 5.1.10 at the time of this port.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
