### PR TITLE
[24.05] librenms: add patches for CVE-2024-32461, CVE-2024-32479 & CVE-2024-32480

### DIFF
--- a/pkgs/servers/monitoring/librenms/default.nix
+++ b/pkgs/servers/monitoring/librenms/default.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchFromGitHub
+, fetchpatch
 , unixtools
 , php82
 , python3
@@ -32,6 +33,24 @@ in phpPackage.buildComposerProject rec {
     rev = "${version}";
     sha256 = "sha256-glcD9AhxkvMmGo/7/RhQFeOtvHJ4pSiEFxaAjeVrTaI=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2024-32461.patch";
+      url = "https://github.com/librenms/librenms/commit/d29201fce134347f891102699fbde7070debee33.patch";
+      hash = "sha256-uKhMcKUsE0E1OvE4AlfX+mkHyLu7Xqq7oS86hj0H0fo=";
+    })
+    (fetchpatch {
+      name = "CVE-2024-32479.patch";
+      url = "https://github.com/librenms/librenms/commit/19344f0584d4d6d4526fdf331adc60530e3f685b.patch";
+      hash = "sha256-O6w/YIq1jrc3YJ65e4R6fw3PUgbaYZV/8sdAo5yf7Iw=";
+    })
+    (fetchpatch {
+      name = "CVE-2024-32480.patch";
+      url = "https://github.com/librenms/librenms/commit/83fe4b10c440d69a47fe2f8616e290ba2bd3a27c.patch";
+      hash = "sha256-8Fzh4EV35VyJG6aGzDQ/DVgWHnIxigirQ9dX5QIe3lg=";
+    })
+  ];
 
   vendorHash = "sha256-s6vdGfM7Ehy1bbkB44EQaHBBvTkpVw9yxhVsc/O8dHc=";
 


### PR DESCRIPTION
## Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2024-32461
https://nvd.nist.gov/vuln/detail/CVE-2024-32479
https://nvd.nist.gov/vuln/detail/CVE-2024-32480

The patched files/sections of files haven't been touched since 2021, so I'm reasoning this is safe. However I would still greatly value a user of this package giving it a proper testing (the nixos test really just checks it launches fine)

See #312805 for unstable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
