### PR TITLE
Update kubernetes proxy.nix to use fqdn for default hostname

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/proxy.nix
+++ b/nixos/modules/services/cluster/kubernetes/proxy.nix
@@ -38,8 +38,8 @@ in
 
     hostname = mkOption {
       description = "Kubernetes proxy hostname override.";
-      default = config.networking.hostName;
-      defaultText = literalExpression "config.networking.hostName";
+      default = config.networking.fqdn;
+      defaultText = literalExpression "config.networking.fqdn";
       type = str;
     };
 


### PR DESCRIPTION
## Description of changes

- Fix kubernetes proxy default hostname to use fqdn

This fixes the errors:
- `Failed to retrieve node info" err="nodes \\"<hostname>\\" not found`
- `Can't determine this node's IP, assuming loopback`

```console
Jul 07 18:20:46 nixos-box kube-proxy[38777]: I0707 18:20:46.553759   38777 server_linux.go:69] "Using iptables proxy"
Jul 07 18:20:47 nixos-box kube-proxy[38777]: E0707 18:20:47.588569   38777 server.go:1051] "Failed to retrieve node info" err="nodes \"nixos-box\" is forbidden: User \"system:kube-proxy\" cannot get resource \"nodes\" in API group \"\" a>
Jul 07 18:20:48 nixos-box kube-proxy[38777]: E0707 18:20:48.615340   38777 server.go:1051] "Failed to retrieve node info" err="nodes \"nixos-box\" not found"
Jul 07 18:20:50 nixos-box kube-proxy[38777]: E0707 18:20:50.880253   38777 server.go:1051] "Failed to retrieve node info" err="nodes \"nixos-box\" not found"
Jul 07 18:20:55 nixos-box kube-proxy[38777]: E0707 18:20:55.396714   38777 server.go:1051] "Failed to retrieve node info" err="nodes \"nixos-box\" not found"
Jul 07 18:21:03 nixos-box kube-proxy[38777]: E0707 18:21:03.691568   38777 server.go:1051] "Failed to retrieve node info" err="nodes \"nixos-box\" not found"
Jul 07 18:21:21 nixos-box kube-proxy[38777]: E0707 18:21:21.946483   38777 server.go:1051] "Failed to retrieve node info" err="nodes \"nixos-box\" not found"
Jul 07 18:21:21 nixos-box kube-proxy[38777]: I0707 18:21:21.946505   38777 server.go:1032] "Can't determine this node's IP, assuming loopback; if this is incorrect, please set the --bind-address flag"
Jul 07 18:21:21 nixos-box kube-proxy[38777]: I0707 18:21:21.951239   38777 conntrack.go:59] "Setting nf_conntrack_max" nfConntrackMax=524288
Jul 07 18:21:21 nixos-box kube-proxy[38777]: I0707 18:21:21.957357   38777 server.go:659] "kube-proxy running in dual-stack mode" primary ipFamily="IPv4"
```

The correct message is now logged:
- `Successfully retrieved node IP(s)`

```console
Jul 07 19:00:10 nixos-box kube-proxy[66174]: I0707 19:00:10.805207   66174 server_linux.go:69] "Using iptables proxy"
Jul 07 19:00:11 nixos-box kube-proxy[66174]: I0707 19:00:11.137930   66174 server.go:1062] "Successfully retrieved node IP(s)" IPs=["192.168.1.180"]
Jul 07 19:00:11 nixos-box kube-proxy[66174]: I0707 19:00:11.142006   66174 conntrack.go:59] "Setting nf_conntrack_max" nfConntrackMax=524288
```

- Note the startup time improvement between `"Using iptables proxy"` and `"Setting nf_conntrack_max" nfConntrackMax=524288`

BEFORE:

```console
18:20:46.553759 Using iptables proxy 
...
18:21:21.951239 "Setting nf_conntrack_max" nfConntrackMax=524288
```

AFTER:

```console
19:00:10.805207 Using iptables proxy
...
19:00:11.142006 "Setting nf_conntrack_max" nfConntrackMax=524288
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
