### PR TITLE
[revert] edk2: 202405 -> 202402

### DIFF
--- a/pkgs/by-name/ed/edk2/package.nix
+++ b/pkgs/by-name/ed/edk2/package.nix
@@ -5,7 +5,9 @@
 , bc
 , lib
 , buildPackages
-, nix-update-script
+, nixosTests
+, runCommand
+, writeScript
 }:
 
 let
@@ -29,9 +31,9 @@ buildType = if stdenv.isDarwin then
   else
     "GCC5";
 
-edk2 = stdenv.mkDerivation {
+edk2 = stdenv.mkDerivation rec {
   pname = "edk2";
-  version = "202405";
+  version = "202402";
 
   patches = [
     # pass targetPrefix as an env var
@@ -46,26 +48,27 @@ edk2 = stdenv.mkDerivation {
     })
   ];
 
-  src = fetchFromGitHub {
+  srcWithVendoring = fetchFromGitHub {
     owner = "tianocore";
     repo = "edk2";
     rev = "edk2-stable${edk2.version}";
     fetchSubmodules = true;
-    hash = "sha256-7vNodHocwqQiO0ZXtqo8lEOFyt8JkFHcAathEhrKWE0=";
-
-    # We don't want EDK2 to keep track of OpenSSL,
-    # they're frankly bad at it.
-    postFetch = ''
-      rm -rf $out/CryptoPkg/Library/OpensslLib/openssl
-      mkdir -p $out/CryptoPkg/Library/OpensslLib/openssl
-      tar --strip-components=1 -xf ${buildPackages.openssl.src} -C $out/CryptoPkg/Library/OpensslLib/openssl
-
-      # Fix missing INT64_MAX include that edk2 explicitly does not provide
-      # via it's own <stdint.h>. Let's pull in openssl's definition instead:
-      sed -i $out/CryptoPkg/Library/OpensslLib/openssl/crypto/property/property_parse.c \
-          -e '1i #include "internal/numbers.h"'
-    '';
+    hash = "sha256-Nurm6QNKCyV6wvbj0ELdYAL7mbZ0yg/tTwnEJ+N18ng=";
   };
+
+  # We don't want EDK2 to keep track of OpenSSL,
+  # they're frankly bad at it.
+  src = runCommand "edk2-unvendored-src" { } ''
+    cp --no-preserve=mode -r ${srcWithVendoring} $out
+    rm -rf $out/CryptoPkg/Library/OpensslLib/openssl
+    mkdir -p $out/CryptoPkg/Library/OpensslLib/openssl
+    tar --strip-components=1 -xf ${buildPackages.openssl.src} -C $out/CryptoPkg/Library/OpensslLib/openssl
+    chmod -R +w $out/
+    # Fix missing INT64_MAX include that edk2 explicitly does not provide
+    # via it's own <stdint.h>. Let's pull in openssl's definition instead:
+    sed -i $out/CryptoPkg/Library/OpensslLib/openssl/crypto/property/property_parse.c \
+        -e '1i #include "internal/numbers.h"'
+  '';
 
   nativeBuildInputs = [ pythonEnv ];
   depsBuildBuild = [ buildPackages.stdenv.cc buildPackages.bash ];
@@ -105,7 +108,22 @@ edk2 = stdenv.mkDerivation {
   };
 
   passthru = {
-    updateScript = nix-update-script { };
+    # exercise a channel blocker
+    tests.uefiUsb = nixosTests.boot.uefiCdrom;
+
+    updateScript = writeScript "update-edk2" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts coreutils gnused
+      set -eu -o pipefail
+      version="$(list-git-tags --url="${edk2.srcWithVendoring.url}" |
+                 sed -E --quiet 's/^edk2-stable([0-9]{6})$/\1/p' |
+                 sort --reverse --numeric-sort |
+                 head -n 1)"
+      if [[ "x$UPDATE_NIX_OLD_VERSION" != "x$version" ]]; then
+          update-source-version --source-key=srcWithVendoring \
+              "$UPDATE_NIX_ATTR_PATH" "$version"
+      fi
+    '';
 
     mkDerivation = projectDscPath: attrsOrFun: stdenv.mkDerivation (finalAttrs:
     let


### PR DESCRIPTION
## Description of changes

Revert #321143 as nixos boot tests are hanging and timing out.

Moving unvendor to postFetch added a dependency on openssl in the source fetching, meaning an openssl change causes a hash mismatch.

Added test to catch channel blocking, and verified update script from @mjoerg 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
