### PR TITLE
hubstaff: change updateScript url to use new RSS feed

### DIFF
--- a/pkgs/applications/misc/hubstaff/default.nix
+++ b/pkgs/applications/misc/hubstaff/default.nix
@@ -1,12 +1,12 @@
 { lib, stdenv, fetchurl, unzip, makeWrapper, libX11, zlib, libSM, libICE
 , libXext , freetype, libXrender, fontconfig, libXft, libXinerama
 , libXfixes, libXScrnSaver, libnotify, glib , gtk3, libappindicator-gtk3
-, curl, writeShellScript, common-updater-scripts }:
+, curl, writeShellScript, common-updater-scripts, xmlstarlet }:
 
 let
-  url = "https://hubstaff-production.s3.amazonaws.com/downloads/HubstaffClient/Builds/Release/1.6.13-269829b4/Hubstaff-1.6.13-269829b4.sh";
-  version = "1.6.13-269829b4";
-  sha256 = "0i05d8kivm09hqsc1z6vn7w0bbc3l9dawssqpqsm7kqdyaq0l304";
+  url = "https://app.hubstaff.com/download/7473-standard-linux-1-6-24-release";
+  version = "1.6.24-094b0af9";
+  sha256 = "sha256:1jwyl51lljxn6hnkp07bvgw60bqmq3gb0rdgvxmd7r8x3y3xshx1";
 
   rpath = lib.makeLibraryPath
     [ libX11 zlib libSM libICE libXext freetype libXrender fontconfig libXft
@@ -36,9 +36,9 @@ stdenv.mkDerivation {
   dontBuild = true;
 
   installPhase = ''
-    # TODO: handle 32-bit arch?
-    rm -r x86
-    rm -r x86_64/lib64
+    # remove files for 32-bit arch to skip building for this arch
+    # but add -f flag to not fail if files were not found (new versions dont provide 32-bit arch)
+    rm -rf x86 x86_64/lib64
 
     opt=$out/opt/hubstaff
     mkdir -p $out/bin $opt
@@ -55,16 +55,25 @@ stdenv.mkDerivation {
     ln -s $opt/data/resources $opt/x86_64/resources
   '';
 
+  # to test run:
+  # nix-shell maintainers/scripts/update.nix --argstr package hubstaff
+  # nix-build -A pkgs.hubstaff
   passthru.updateScript = writeShellScript "hubstaff-updater" ''
     set -eu -o pipefail
 
-    installation_script_url=$(curl --fail --head --location --silent --output /dev/null --write-out %{url_effective} https://app.hubstaff.com/download/linux)
+    # Create a temporary file
+    temp_file=$(mktemp)
 
-    version=$(echo "$installation_script_url" | sed -r 's/^https:\/\/hubstaff\-production\.s3\.amazonaws\.com\/downloads\/HubstaffClient\/Builds\/Release\/([^\/]+)\/Hubstaff.+$/\1/')
+    # Fetch the appcast.xml and save it to the temporary file
+    curl --silent --output "$temp_file" https://app.hubstaff.com/appcast.xml
+
+    # Extract the latest release URL for Linux using xmlstarlet
+    installation_script_url=$(${xmlstarlet}/bin/xmlstarlet sel -t -v '//enclosure[@sparkle:os="linux"]/@url' "$temp_file")
+    version=$(${xmlstarlet}/bin/xmlstarlet sel -t -v '//enclosure[@sparkle:os="linux"]/@sparkle:version' "$temp_file")
 
     sha256=$(nix-prefetch-url "$installation_script_url")
 
-    ${common-updater-scripts}/bin/update-source-version hubstaff "$version" "$sha256" "$installation_script_url"
+    ${common-updater-scripts}/bin/update-source-version hubstaff "$version" "sha256:$sha256" "$installation_script_url"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

I've got an email 

```
Hello,

I'm the Tech Lead of the Client Desktop team at Hubstaff and saw that you are the maintainers of the hubstaff nixOS package!?

We just got a notification from one of our clients. He patched it for his own use and asked about upstreaming it:

https://github.com/allgreed/nixos-config/commit/7402b23e8285b5094e5b3ca2b3845cb2aaf66063

The thing is we don't support nixOS unfortunately (I'm personally a big fan though!).
Any chance you guys can update that? If you need any more information please just let me know!

We also have a RSS feed with the newest releases (just look for the "enclosure" and sparkle:os="linux"):
https://app.hubstaff.com/appcast.xml

The latest linux release is:
https://app.hubstaff.com/download/7473-standard-linux-1-6-24-release

Thanks,
Artur

```

![Screenshot](https://github.com/NixOS/nixpkgs/assets/7573215/4ffb222a-a54a-4da3-8338-b12390503540)

![Screenshot (1)](https://github.com/NixOS/nixpkgs/assets/7573215/44a7d5dc-2fe9-4d36-98c0-c1786a62ab3c) 

and updated script

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
