### PR TITLE
doc: lib.composeExtensions reference to overlays

### DIFF
--- a/lib/fixed-points.nix
+++ b/lib/fixed-points.nix
@@ -63,7 +63,6 @@ rec {
     See [`extends`](#function-library-lib.fixedPoints.extends) for an example use case.
     There `self` is also often called `final`.
 
-
     # Inputs
 
     `f`
@@ -90,7 +89,12 @@ rec {
 
     :::
   */
-  fix = f: let x = f x; in x;
+  fix =
+    f:
+    let
+      x = f x;
+    in
+    x;
 
   /**
     A variant of `fix` that records the original recursive attribute set in the
@@ -99,14 +103,20 @@ rec {
     This is useful in combination with the `extends` function to
     implement deep overriding.
 
-
     # Inputs
 
     `f`
 
     : 1\. Function argument
   */
-  fix' = f: let x = f x // { __unfix__ = f; }; in x;
+  fix' =
+    f:
+    let
+      x = f x // {
+        __unfix__ = f;
+      };
+    in
+    x;
 
   /**
     Return the fixpoint that `f` converges to when called iteratively, starting
@@ -116,7 +126,6 @@ rec {
     nix-repl> converge (x: x / 2) 16
     0
     ```
-
 
     # Inputs
 
@@ -134,13 +143,12 @@ rec {
     (a -> a) -> a -> a
     ```
   */
-  converge = f: x:
+  converge =
+    f: x:
     let
       x' = f x;
     in
-      if x' == x
-      then x
-      else converge f x';
+    if x' == x then x else converge f x';
 
   /**
     Extend a function using an overlay.
@@ -148,7 +156,6 @@ rec {
     Overlays allow modifying and extending fixed-point functions, specifically ones returning attribute sets.
     A fixed-point function is a function which is intended to be evaluated by passing the result of itself as the argument.
     This is possible due to Nix's lazy evaluation.
-
 
     A fixed-point function returning an attribute set has the form
 
@@ -257,7 +264,6 @@ rec {
     ```
     :::
 
-
     # Inputs
 
     `overlay`
@@ -299,8 +305,7 @@ rec {
     :::
   */
   extends =
-    overlay:
-    f:
+    overlay: f:
     # The result should be thought of as a function, the argument of that function is not an argument to `extends` itself
     (
       final:
@@ -316,9 +321,11 @@ rec {
   */
   composeExtensions =
     f: g: final: prev:
-      let fApplied = f final prev;
-          prev' = prev // fApplied;
-      in fApplied // g final prev';
+    let
+      fApplied = f final prev;
+      prev' = prev // fApplied;
+    in
+    fApplied // g final prev';
 
   /**
     Composes a list of [`overlays`](#chap-overlays) and returns a single overlay function that combines them.
@@ -341,7 +348,6 @@ rec {
     : Each overlay function takes two arguments, by convention `final` and `prev`, and returns an attribute set.
       - `final` is the result of the fixed-point function, with all overlays applied.
       - `prev` is the result of the previous overlay function.
-
 
     # Type
 
@@ -385,8 +391,7 @@ rec {
     ```
     :::
   */
-  composeManyExtensions =
-    lib.foldr (x: y: composeExtensions x y) (final: prev: {});
+  composeManyExtensions = lib.foldr (x: y: composeExtensions x y) (final: prev: { });
 
   /**
     Create an overridable, recursive attribute set. For example:
@@ -414,7 +419,6 @@ rec {
     Same as `makeExtensible` but the name of the extending attribute is
     customized.
 
-
     # Inputs
 
     `extenderName`
@@ -425,8 +429,13 @@ rec {
 
     : 2\. Function argument
   */
-  makeExtensibleWithCustomName = extenderName: rattrs:
-    fix' (self: (rattrs self) // {
-      ${extenderName} = f: makeExtensibleWithCustomName extenderName (extends f rattrs);
-    });
+  makeExtensibleWithCustomName =
+    extenderName: rattrs:
+    fix' (
+      self:
+      (rattrs self)
+      // {
+        ${extenderName} = f: makeExtensibleWithCustomName extenderName (extends f rattrs);
+      }
+    );
 }

--- a/lib/fixed-points.nix
+++ b/lib/fixed-points.nix
@@ -347,7 +347,7 @@ rec {
 
     : Each overlay function takes two arguments, by convention `final` and `prev`, and returns an attribute set.
       - `final` is the result of the fixed-point function, with all overlays applied.
-      - `prev` is the result of the previous overlay function.
+      - `prev` is the result of the previous overlay function(s).
 
     # Type
 
@@ -356,9 +356,9 @@ rec {
     let
       #               final      prev
       #                 ↓          ↓
-      OverlayFn :: ( { ... } -> { ... } -> { ... } );
+      OverlayFn = { ... } -> { ... } -> { ... };
     in
-      composeManyExtensions :: [ OverlayFn ] -> OverlayFn
+      composeManyExtensions :: ListOf OverlayFn -> OverlayFn
     ```
 
     # Examples
@@ -368,7 +368,7 @@ rec {
     ```nix
     let
       # The "original function" that is extended by the overlays.
-      # Note that it doesn't have prev: as argument since it can be thought of as the first function.
+      # Note that it doesn't have prev: as argument since no overlay function precedes it.
       original = final: { a = 1; };
 
       # Each overlay function has 'final' and 'prev' as arguments.

--- a/lib/fixed-points.nix
+++ b/lib/fixed-points.nix
@@ -311,28 +311,8 @@ rec {
     );
 
   /**
-    Compose two extending functions of the type expected by 'extends'
-    into one where changes made in the first are available in the
-    'super' of the second
-
-
-    # Inputs
-
-    `f`
-
-    : 1\. Function argument
-
-    `g`
-
-    : 2\. Function argument
-
-    `final`
-
-    : 3\. Function argument
-
-    `prev`
-
-    : 4\. Function argument
+    Compose two overlay functions and return a single overlay function that combines them.
+    For more details see: [composeManyExtensions](#function-library-lib.fixedPoints.composeManyExtensions).
   */
   composeExtensions =
     f: g: final: prev:
@@ -341,14 +321,69 @@ rec {
       in fApplied // g final prev';
 
   /**
-    Compose several extending functions of the type expected by 'extends' into
-    one where changes made in preceding functions are made available to
-    subsequent ones.
+    Composes a list of [`overlays`](#chap-overlays) and returns a single overlay function that combines them.
+
+    :::{.note}
+    The result is produced by using the update operator `//`.
+    This means nested values of previous overlays are not merged recursively.
+    In other words, previously defined attributes are replaced, ignoring the previous value, unless referenced by the overlay; for example `final: prev: { foo = final.foo + 1; }`.
+    :::
+
+    # Inputs
+
+    `extensions`
+
+    : A list of overlay functions
+      :::{.note}
+      The order of the overlays in the list is important.
+      :::
+
+    : Each overlay function takes two arguments, by convention `final` and `prev`, and returns an attribute set.
+      - `final` is the result of the fixed-point function, with all overlays applied.
+      - `prev` is the result of the previous overlay function.
+
+
+    # Type
 
     ```
-    composeManyExtensions : [packageSet -> packageSet -> packageSet] -> packageSet -> packageSet -> packageSet
-                              ^final        ^prev         ^overrides     ^final        ^prev         ^overrides
+    # Pseudo code
+    let
+      #               final      prev
+      #                 ↓          ↓
+      OverlayFn :: ( { ... } -> { ... } -> { ... } );
+    in
+      composeManyExtensions :: [ OverlayFn ] -> OverlayFn
     ```
+
+    # Examples
+    :::{.example}
+    ## `lib.fixedPoints.composeManyExtensions` usage example
+
+    ```nix
+    let
+      # The "original function" that is extended by the overlays.
+      # Note that it doesn't have prev: as argument since it can be thought of as the first function.
+      original = final: { a = 1; };
+
+      # Each overlay function has 'final' and 'prev' as arguments.
+      overlayA = final: prev: { b = final.c; c = 3; };
+      overlayB = final: prev: { c = 10; x = prev.c or 5; };
+
+      extensions = composeManyExtensions [ overlayA overlayB ];
+
+      # Caluculate the fixed point of all composed overlays.
+      fixedpoint = lib.fix (lib.extends extensions original );
+
+    in fixedpoint
+    =>
+    {
+      a = 1;
+      b = 10;
+      c = 10;
+      x = 3;
+    }
+    ```
+    :::
   */
   composeManyExtensions =
     lib.foldr (x: y: composeExtensions x y) (final: prev: {});
@@ -357,17 +392,17 @@ rec {
     Create an overridable, recursive attribute set. For example:
 
     ```
-    nix-repl> obj = makeExtensible (self: { })
+    nix-repl> obj = makeExtensible (final: { })
 
     nix-repl> obj
     { __unfix__ = «lambda»; extend = «lambda»; }
 
-    nix-repl> obj = obj.extend (self: super: { foo = "foo"; })
+    nix-repl> obj = obj.extend (final: prev: { foo = "foo"; })
 
     nix-repl> obj
     { __unfix__ = «lambda»; extend = «lambda»; foo = "foo"; }
 
-    nix-repl> obj = obj.extend (self: super: { foo = super.foo + " + "; bar = "bar"; foobar = self.foo + self.bar; })
+    nix-repl> obj = obj.extend (final: prev: { foo = prev.foo + " + "; bar = "bar"; foobar = final.foo + final.bar; })
 
     nix-repl> obj
     { __unfix__ = «lambda»; bar = "bar"; extend = «lambda»; foo = "foo + "; foobar = "foo + bar"; }


### PR DESCRIPTION
## Description of changes

- Clarify type signature. `packageSet` is not defined, strictly speaking overlays can be used to extend attribute sets.
- `Overlay` is a common term that is now linked into its concept chapter.
- Adds concrete function inputs and document them.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
