### PR TITLE
musikcube: 3.0.2 -> 3.0.3, move to pkgs/by-name, format using nixfmt, modernize

### DIFF
--- a/pkgs/applications/audio/musikcube/default.nix
+++ b/pkgs/applications/audio/musikcube/default.nix
@@ -2,7 +2,7 @@
 , cmake
 , curl
 , fetchFromGitHub
-, ffmpeg
+, ffmpeg_7-headless
 , gnutls
 , lame
 , lib
@@ -29,15 +29,18 @@
 , coreaudioSupport ? stdenv.hostPlatform.isDarwin, CoreAudio
 }:
 
+let
+  ffmpeg = ffmpeg_7-headless;
+in
 stdenv.mkDerivation rec {
   pname = "musikcube";
-  version = "3.0.2";
+  version = "3.0.3";
 
   src = fetchFromGitHub {
     owner = "clangen";
     repo = pname;
     rev = version;
-    hash = "sha512-IakZy6XsAE39awjzQI+R11JCPeQSaibx6+uX8Iea5WdlCundeovnPwSAi6RzzZl9dr2UftzzEiF4Aun8VMtqVA==";
+    hash = "sha512-Yqh35hyGzGZlh4UoHK0MGYBa+zugYJg3F+8F223saTdDChiX4cSncroSTexRyJVGm7EE8INNJoXg3HU6bZ08lA==";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/by-name/mu/musikcube/package.nix
+++ b/pkgs/by-name/mu/musikcube/package.nix
@@ -1,31 +1,34 @@
-{ asio
-, cmake
-, curl
-, fetchFromGitHub
-, ffmpeg_7-headless
-, gnutls
-, lame
-, lib
-, libev
-, game-music-emu
-, libmicrohttpd
-, libopenmpt
-, mpg123
-, ncurses
-, pkg-config
-, portaudio
-, stdenv
-, taglib
-# Linux Dependencies
-, alsa-lib
-, pipewireSupport ? !stdenv.hostPlatform.isDarwin, pipewire
-, pulseaudio
-, sndioSupport ? true, sndio
-, systemd
-, systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd
-# Darwin Dependencies
-, darwin
-, coreaudioSupport ? stdenv.hostPlatform.isDarwin
+{
+  asio,
+  cmake,
+  curl,
+  fetchFromGitHub,
+  ffmpeg_7-headless,
+  gnutls,
+  lame,
+  lib,
+  libev,
+  game-music-emu,
+  libmicrohttpd,
+  libopenmpt,
+  mpg123,
+  ncurses,
+  pkg-config,
+  portaudio,
+  stdenv,
+  taglib,
+  # Linux Dependencies
+  alsa-lib,
+  pipewireSupport ? !stdenv.hostPlatform.isDarwin,
+  pipewire,
+  pulseaudio,
+  sndioSupport ? true,
+  sndio,
+  systemd,
+  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  # Darwin Dependencies
+  darwin,
+  coreaudioSupport ? stdenv.hostPlatform.isDarwin,
 }:
 
 let
@@ -42,44 +45,49 @@ stdenv.mkDerivation rec {
     hash = "sha512-Yqh35hyGzGZlh4UoHK0MGYBa+zugYJg3F+8F223saTdDChiX4cSncroSTexRyJVGm7EE8INNJoXg3HU6bZ08lA==";
   };
 
-  outputs = [ "out" "dev" ];
+  outputs = [
+    "out"
+    "dev"
+  ];
 
   nativeBuildInputs = [
     cmake
     pkg-config
   ];
 
-  buildInputs = [
-    asio
-    curl
-    ffmpeg
-    gnutls
-    lame
-    libev
-    game-music-emu
-    libmicrohttpd
-    libopenmpt
-    mpg123
-    ncurses
-    portaudio
-    taglib
-  ] ++ lib.optionals systemdSupport [
-    systemd
-  ] ++ lib.optionals stdenv.isLinux [
-    alsa-lib pulseaudio
-  ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
-    Cocoa SystemConfiguration
-  ]) ++ lib.optionals coreaudioSupport (with darwin.apple_sdk.frameworks; [
-    CoreAudio
-  ]) ++ lib.optionals sndioSupport [
-    sndio
-  ] ++ lib.optionals pipewireSupport [
-    pipewire
-  ];
+  buildInputs =
+    [
+      asio
+      curl
+      ffmpeg
+      gnutls
+      lame
+      libev
+      game-music-emu
+      libmicrohttpd
+      libopenmpt
+      mpg123
+      ncurses
+      portaudio
+      taglib
+    ]
+    ++ lib.optionals systemdSupport [ systemd ]
+    ++ lib.optionals stdenv.isLinux [
+      alsa-lib
+      pulseaudio
+    ]
+    ++ lib.optionals stdenv.isDarwin (
+      with darwin.apple_sdk.frameworks;
+      [
+        Cocoa
+        SystemConfiguration
+      ]
+    )
+    ++ lib.optionals coreaudioSupport (with darwin.apple_sdk.frameworks; [ CoreAudio ])
+    ++ lib.optionals sndioSupport [ sndio ]
+    ++ lib.optionals pipewireSupport [ pipewire ];
 
-  cmakeFlags = [
-    "-DDISABLE_STRIP=true"
-  ];
+  cmakeFlags = [ "-DDISABLE_STRIP=true" ];
 
   postFixup = lib.optionalString stdenv.isDarwin ''
     install_name_tool -add_rpath $out/share/${pname} $out/share/${pname}/${pname}
@@ -89,7 +97,10 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Terminal-based music player, library, and streaming audio server";
     homepage = "https://musikcube.com/";
-    maintainers = with lib.maintainers; [ aanderse afh ];
+    maintainers = with lib.maintainers; [
+      aanderse
+      afh
+    ];
     license = lib.licenses.bsd3;
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/mu/musikcube/package.nix
+++ b/pkgs/by-name/mu/musikcube/package.nix
@@ -24,9 +24,8 @@
 , systemd
 , systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd
 # Darwin Dependencies
-, Cocoa
-, SystemConfiguration
-, coreaudioSupport ? stdenv.hostPlatform.isDarwin, CoreAudio
+, darwin
+, coreaudioSupport ? stdenv.hostPlatform.isDarwin
 }:
 
 let
@@ -68,11 +67,11 @@ stdenv.mkDerivation rec {
     systemd
   ] ++ lib.optionals stdenv.isLinux [
     alsa-lib pulseaudio
-  ] ++ lib.optionals stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
     Cocoa SystemConfiguration
-  ] ++ lib.optionals coreaudioSupport [
+  ]) ++ lib.optionals coreaudioSupport (with darwin.apple_sdk.frameworks; [
     CoreAudio
-  ] ++ lib.optionals sndioSupport [
+  ]) ++ lib.optionals sndioSupport [
     sndio
   ] ++ lib.optionals pipewireSupport [
     pipewire

--- a/pkgs/by-name/mu/musikcube/package.nix
+++ b/pkgs/by-name/mu/musikcube/package.nix
@@ -34,14 +34,14 @@
 let
   ffmpeg = ffmpeg_7-headless;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "musikcube";
   version = "3.0.3";
 
   src = fetchFromGitHub {
     owner = "clangen";
-    repo = pname;
-    rev = version;
+    repo = "musikcube";
+    rev = finalAttrs.version;
     hash = "sha512-Yqh35hyGzGZlh4UoHK0MGYBa+zugYJg3F+8F223saTdDChiX4cSncroSTexRyJVGm7EE8INNJoXg3HU6bZ08lA==";
   };
 
@@ -90,8 +90,8 @@ stdenv.mkDerivation rec {
   cmakeFlags = [ "-DDISABLE_STRIP=true" ];
 
   postFixup = lib.optionalString stdenv.isDarwin ''
-    install_name_tool -add_rpath $out/share/${pname} $out/share/${pname}/${pname}
-    install_name_tool -add_rpath $out/share/${pname} $out/share/${pname}/${pname}d
+    install_name_tool -add_rpath $out/share/musikcube $out/share/musikcube/musikcube
+    install_name_tool -add_rpath $out/share/musikcube $out/share/musikcube/musikcubed
   '';
 
   meta = {
@@ -101,7 +101,8 @@ stdenv.mkDerivation rec {
       aanderse
       afh
     ];
+    mainProgram = "musikcube";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31365,10 +31365,6 @@ with pkgs;
 
   meerk40t-camera = callPackage ../applications/misc/meerk40t/camera.nix { };
 
-  musikcube = callPackage ../applications/audio/musikcube {
-    inherit (darwin.apple_sdk.frameworks) Cocoa CoreAudio SystemConfiguration;
-  };
-
   libmt32emu = callPackage ../applications/audio/munt/libmt32emu.nix { };
 
   mt32emu-qt = libsForQt5.callPackage ../applications/audio/munt/mt32emu-qt.nix { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* Update to [3.0.3](https://github.com/clangen/musikcube/releases/tag/3.0.3) including update of ffmpeg dependency to 7.x
* Move to `pkgs/by-name/mu/musikcube/package.nix`
* Format package.nix using [`nixfmt`](http://github.com/NixOS/nixfmt)
* Modernize package by:
  * using `finalAttrs` over `rec`
  * adding `meta.mainProgram`
  * Avoiding [superfluous use of `pname`](https://github.com/NixOS/nixpkgs/issues/277994)
  
ℹ️ Happy to squash some (or all) of the commits if preferred, yet I thought it'd be easier to review and possibly split the commits into multiple PRs if desired.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
