### PR TITLE
octoprint: py12 compatibility

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -38,6 +38,17 @@ let
                 inherit version;
                 hash = "sha256-7e6bCn/yZiG9WowQ/0hK4oc3okENmbC7mmhQx/uXeqA=";
               };
+              doCheck = false;
+            });
+            flask-login = super.flask-login.overridePythonAttrs (oldAttrs: rec {
+              version = "0.6.3";
+              src = fetchPypi {
+                pname = "Flask-Login";
+                inherit version;
+                hash = "sha256-XiPRSmB+8SgGxplZC4nQ8ODWe67sWZ11lHv5wUczAzM=";
+              };
+              build-system = [ self.setuptools ];
+              doCheck = false; # DeprecationWarnings
             });
 
             netaddr = super.netaddr.overridePythonAttrs (oldAttrs: rec {
@@ -243,6 +254,9 @@ let
                 "test_check_setup" # Why should it be able to call pip?
               ] ++ lib.optionals stdenv.isDarwin [
                 "test_set_external_modification"
+              ];
+              disabledTestPaths = [
+                "tests/test_octoprint_setuptools.py" # fails due to distutils and python3.12
               ];
 
               passthru = {

--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -1,287 +1,278 @@
-{ pkgs
-, stdenv
-, callPackage
-, lib
-, fetchFromGitHub
-, fetchPypi
-, python3
-, substituteAll
-, nix-update-script
-, nixosTests
+{
+  pkgs,
+  stdenv,
+  callPackage,
+  lib,
+  fetchFromGitHub,
+  fetchPypi,
+  python3,
+  substituteAll,
+  nix-update-script,
+  nixosTests,
   # To include additional plugins, pass them here as an overlay.
-, packageOverrides ? self: super: { }
+  packageOverrides ? self: super: { },
 }:
 let
 
   py = python3.override {
     self = py;
-    packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) (
-      [
-        (
-          # Due to flask > 2.3 the login will not work
-          self: super: {
-            werkzeug = super.werkzeug.overridePythonAttrs (oldAttrs: rec {
-              version = "2.2.3";
-              format = "setuptools";
-              src = fetchPypi {
-                pname = "Werkzeug";
-                inherit version;
-                hash = "sha256-LhzMlBfU2jWLnebxdOOsCUOR6h1PvvLWZ4ZdgZ39Cv4=";
-              };
-              doCheck = false;
-            });
-            flask = super.flask.overridePythonAttrs (oldAttrs: rec {
-              version = "2.2.5";
-              format = "setuptools";
-              src = fetchPypi {
-                pname = "Flask";
-                inherit version;
-                hash = "sha256-7e6bCn/yZiG9WowQ/0hK4oc3okENmbC7mmhQx/uXeqA=";
-              };
-              doCheck = false;
-            });
-            flask-login = super.flask-login.overridePythonAttrs (oldAttrs: rec {
-              version = "0.6.3";
-              src = fetchPypi {
-                pname = "Flask-Login";
-                inherit version;
-                hash = "sha256-XiPRSmB+8SgGxplZC4nQ8ODWe67sWZ11lHv5wUczAzM=";
-              };
-              build-system = [ self.setuptools ];
-              doCheck = false; # DeprecationWarnings
-            });
-
-            netaddr = super.netaddr.overridePythonAttrs (oldAttrs: rec {
-              version = "0.9.0";
-
-              src = fetchPypi {
-                pname = "netaddr";
-                inherit version;
-                hash = "sha256-e0b6mxotcf1d6eSjeE7zOXAKU6CMgEDwi69fEZTaASg=";
-              };
-            });
-          }
-        )
-
-        # Built-in dependency
-        (
-          self: super: {
-            octoprint-filecheck = self.buildPythonPackage rec {
-              pname = "OctoPrint-FileCheck";
-              version = "2021.2.23";
-
-              src = fetchFromGitHub {
-                owner = "OctoPrint";
-                repo = "OctoPrint-FileCheck";
-                rev = version;
-                sha256 = "sha256-e/QGEBa9+pjOdrZq3Zc6ifbSMClIyeTOi0Tji0YdVmI=";
-              };
-              doCheck = false;
+    packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) ([
+      (
+        # Due to flask > 2.3 the login will not work
+        self: super: {
+          werkzeug = super.werkzeug.overridePythonAttrs (oldAttrs: rec {
+            version = "2.2.3";
+            format = "setuptools";
+            src = fetchPypi {
+              pname = "Werkzeug";
+              inherit version;
+              hash = "sha256-LhzMlBfU2jWLnebxdOOsCUOR6h1PvvLWZ4ZdgZ39Cv4=";
             };
-          }
-        )
-
-        # Built-in dependency
-        (
-          self: super: {
-            octoprint-firmwarecheck = self.buildPythonPackage rec {
-              pname = "OctoPrint-FirmwareCheck";
-              version = "2021.10.11";
-
-              src = fetchFromGitHub {
-                owner = "OctoPrint";
-                repo = "OctoPrint-FirmwareCheck";
-                rev = version;
-                hash = "sha256-wqbD82bhJDrDawJ+X9kZkoA6eqGxqJc1Z5dA0EUwgEI=";
-              };
-              doCheck = false;
+            doCheck = false;
+          });
+          flask = super.flask.overridePythonAttrs (oldAttrs: rec {
+            version = "2.2.5";
+            format = "setuptools";
+            src = fetchPypi {
+              pname = "Flask";
+              inherit version;
+              hash = "sha256-7e6bCn/yZiG9WowQ/0hK4oc3okENmbC7mmhQx/uXeqA=";
             };
-          }
-        )
-
-        (
-          self: super: {
-            octoprint-pisupport = self.buildPythonPackage rec {
-              pname = "OctoPrint-PiSupport";
-              version = "2023.5.24";
-              format = "setuptools";
-
-              src = fetchFromGitHub {
-                owner = "OctoPrint";
-                repo = "OctoPrint-PiSupport";
-                rev = version;
-                hash = "sha256-KfkZXJ2f02G2ee+J1w+YQRKz+LSWwxVIIwmdevDGhew=";
-              };
-
-              # requires octoprint itself during tests
-              doCheck = false;
-              postPatch = ''
-                substituteInPlace octoprint_pi_support/__init__.py \
-                  --replace /usr/bin/vcgencmd ${self.pkgs.libraspberrypi}/bin/vcgencmd
-              '';
+            doCheck = false;
+          });
+          flask-login = super.flask-login.overridePythonAttrs (oldAttrs: rec {
+            version = "0.6.3";
+            src = fetchPypi {
+              pname = "Flask-Login";
+              inherit version;
+              hash = "sha256-XiPRSmB+8SgGxplZC4nQ8ODWe67sWZ11lHv5wUczAzM=";
             };
-          }
-        )
+            build-system = [ self.setuptools ];
+            doCheck = false; # DeprecationWarnings
+          });
 
-        (
-          self: super: {
-            octoprint = self.buildPythonPackage rec {
-              pname = "OctoPrint";
-              version = "1.10.2";
+          netaddr = super.netaddr.overridePythonAttrs (oldAttrs: rec {
+            version = "0.9.0";
 
-              src = fetchFromGitHub {
-                owner = "OctoPrint";
-                repo = "OctoPrint";
-                rev = version;
-                hash = "sha256-vISMps2v18A7MkF24SyIcK5yOQsTxBQLnKybVd8R2FU=";
-              };
-
-              propagatedBuildInputs = with self; [
-                argon2-cffi
-                blinker
-                cachelib
-                click
-                colorlog
-                emoji
-                feedparser
-                filetype
-                flask
-                flask-babel
-                flask-assets
-                flask-login
-                flask-limiter
-                frozendict
-                future
-                itsdangerous
-                immutabledict
-                jinja2
-                markdown
-                markupsafe
-                netaddr
-                netifaces
-                octoprint-filecheck
-                octoprint-firmwarecheck
-                passlib
-                pathvalidate
-                pkginfo
-                pip
-                psutil
-                pylru
-                pyserial
-                pyyaml
-                regex
-                requests
-                rsa
-                sarge
-                semantic-version
-                sentry-sdk
-                setuptools
-                tornado
-                unidecode
-                watchdog
-                websocket-client
-                werkzeug
-                wrapt
-                zeroconf
-                zipstream-ng
-                class-doc
-                pydantic_1
-              ] ++ lib.optionals stdenv.isDarwin [
-                py.pkgs.appdirs
-              ] ++ lib.optionals (!stdenv.isDarwin) [
-                octoprint-pisupport
-              ];
-
-              nativeCheckInputs = with self; [
-                ddt
-                mock
-                pytestCheckHook
-              ];
-
-              patches = [
-                # substitute pip and let it find out, that it can't write anywhere
-                (substituteAll {
-                  src = ./pip-path.patch;
-                  pip = "${self.pip}/bin/pip";
-                })
-
-                # hardcore path to ffmpeg and hide related settings
-                (substituteAll {
-                  src = ./ffmpeg-path.patch;
-                  ffmpeg = "${pkgs.ffmpeg}/bin/ffmpeg";
-                })
-              ];
-
-              postPatch =
-                let
-                  ignoreVersionConstraints = [
-                    "cachelib"
-                    "colorlog"
-                    "emoji"
-                    "immutabledict"
-                    "PyYAML"
-                    "sarge"
-                    "sentry-sdk"
-                    "watchdog"
-                    "wrapt"
-                    "zeroconf"
-                    "Flask-Login"
-                    "werkzeug"
-                    "flask"
-                    "Flask-Limiter"
-                    "blinker"
-                  ];
-                in
-                ''
-                    sed -r -i \
-                      ${lib.concatStringsSep "\n" (
-                    map (
-                      e:
-                        ''-e 's@${e}[<>=]+.*@${e}",@g' \''
-                    ) ignoreVersionConstraints
-                  )}
-                      setup.py
-                '';
-
-              dontUseSetuptoolsCheck = true;
-
-              preCheck = ''
-                export HOME=$(mktemp -d)
-                rm pytest.ini
-              '';
-
-              disabledTests = [
-                "test_check_setup" # Why should it be able to call pip?
-              ] ++ lib.optionals stdenv.isDarwin [
-                "test_set_external_modification"
-              ];
-              disabledTestPaths = [
-                "tests/test_octoprint_setuptools.py" # fails due to distutils and python3.12
-              ];
-
-              passthru = {
-                inherit (self) python;
-                updateScript = nix-update-script { };
-                tests = {
-                  plugins = (callPackage ./plugins.nix { }) super self;
-                  inherit (nixosTests) octoprint;
-                };
-              };
-
-              meta = with lib; {
-                homepage = "https://octoprint.org/";
-                description = "Snappy web interface for your 3D printer";
-                mainProgram = "octoprint";
-                license = licenses.agpl3Only;
-                maintainers = with maintainers; [ abbradar gebner WhittlesJr gador ];
-              };
+            src = fetchPypi {
+              pname = "netaddr";
+              inherit version;
+              hash = "sha256-e0b6mxotcf1d6eSjeE7zOXAKU6CMgEDwi69fEZTaASg=";
             };
-          }
-        )
-        (callPackage ./plugins.nix { })
-        packageOverrides
-      ]
-    );
+          });
+        })
+
+      # Built-in dependency
+      (self: super: {
+        octoprint-filecheck = self.buildPythonPackage rec {
+          pname = "OctoPrint-FileCheck";
+          version = "2021.2.23";
+
+          src = fetchFromGitHub {
+            owner = "OctoPrint";
+            repo = "OctoPrint-FileCheck";
+            rev = version;
+            sha256 = "sha256-e/QGEBa9+pjOdrZq3Zc6ifbSMClIyeTOi0Tji0YdVmI=";
+          };
+          doCheck = false;
+        };
+      })
+
+      # Built-in dependency
+      (self: super: {
+        octoprint-firmwarecheck = self.buildPythonPackage rec {
+          pname = "OctoPrint-FirmwareCheck";
+          version = "2021.10.11";
+
+          src = fetchFromGitHub {
+            owner = "OctoPrint";
+            repo = "OctoPrint-FirmwareCheck";
+            rev = version;
+            hash = "sha256-wqbD82bhJDrDawJ+X9kZkoA6eqGxqJc1Z5dA0EUwgEI=";
+          };
+          doCheck = false;
+        };
+      })
+
+      (self: super: {
+        octoprint-pisupport = self.buildPythonPackage rec {
+          pname = "OctoPrint-PiSupport";
+          version = "2023.5.24";
+          format = "setuptools";
+
+          src = fetchFromGitHub {
+            owner = "OctoPrint";
+            repo = "OctoPrint-PiSupport";
+            rev = version;
+            hash = "sha256-KfkZXJ2f02G2ee+J1w+YQRKz+LSWwxVIIwmdevDGhew=";
+          };
+
+          # requires octoprint itself during tests
+          doCheck = false;
+          postPatch = ''
+            substituteInPlace octoprint_pi_support/__init__.py \
+              --replace /usr/bin/vcgencmd ${self.pkgs.libraspberrypi}/bin/vcgencmd
+          '';
+        };
+      })
+
+      (self: super: {
+        octoprint = self.buildPythonPackage rec {
+          pname = "OctoPrint";
+          version = "1.10.2";
+
+          src = fetchFromGitHub {
+            owner = "OctoPrint";
+            repo = "OctoPrint";
+            rev = version;
+            hash = "sha256-vISMps2v18A7MkF24SyIcK5yOQsTxBQLnKybVd8R2FU=";
+          };
+
+          propagatedBuildInputs =
+            with self;
+            [
+              argon2-cffi
+              blinker
+              cachelib
+              click
+              colorlog
+              emoji
+              feedparser
+              filetype
+              flask
+              flask-babel
+              flask-assets
+              flask-login
+              flask-limiter
+              frozendict
+              future
+              itsdangerous
+              immutabledict
+              jinja2
+              markdown
+              markupsafe
+              netaddr
+              netifaces
+              octoprint-filecheck
+              octoprint-firmwarecheck
+              passlib
+              pathvalidate
+              pkginfo
+              pip
+              psutil
+              pylru
+              pyserial
+              pyyaml
+              regex
+              requests
+              rsa
+              sarge
+              semantic-version
+              sentry-sdk
+              setuptools
+              tornado
+              unidecode
+              watchdog
+              websocket-client
+              werkzeug
+              wrapt
+              zeroconf
+              zipstream-ng
+              class-doc
+              pydantic_1
+            ]
+            ++ lib.optionals stdenv.isDarwin [ py.pkgs.appdirs ]
+            ++ lib.optionals (!stdenv.isDarwin) [ octoprint-pisupport ];
+
+          nativeCheckInputs = with self; [
+            ddt
+            mock
+            pytestCheckHook
+          ];
+
+          patches = [
+            # substitute pip and let it find out, that it can't write anywhere
+            (substituteAll {
+              src = ./pip-path.patch;
+              pip = "${self.pip}/bin/pip";
+            })
+
+            # hardcore path to ffmpeg and hide related settings
+            (substituteAll {
+              src = ./ffmpeg-path.patch;
+              ffmpeg = "${pkgs.ffmpeg}/bin/ffmpeg";
+            })
+          ];
+
+          postPatch =
+            let
+              ignoreVersionConstraints = [
+                "cachelib"
+                "colorlog"
+                "emoji"
+                "immutabledict"
+                "PyYAML"
+                "sarge"
+                "sentry-sdk"
+                "watchdog"
+                "wrapt"
+                "zeroconf"
+                "Flask-Login"
+                "werkzeug"
+                "flask"
+                "Flask-Limiter"
+                "blinker"
+              ];
+            in
+            ''
+              sed -r -i \
+                ${
+                  lib.concatStringsSep "\n" (map (e: ''-e 's@${e}[<>=]+.*@${e}",@g' \'') ignoreVersionConstraints)
+                }
+                setup.py
+            '';
+
+          dontUseSetuptoolsCheck = true;
+
+          preCheck = ''
+            export HOME=$(mktemp -d)
+            rm pytest.ini
+          '';
+
+          disabledTests = [
+            "test_check_setup" # Why should it be able to call pip?
+          ] ++ lib.optionals stdenv.isDarwin [ "test_set_external_modification" ];
+          disabledTestPaths = [
+            "tests/test_octoprint_setuptools.py" # fails due to distutils and python3.12
+          ];
+
+          passthru = {
+            inherit (self) python;
+            updateScript = nix-update-script { };
+            tests = {
+              plugins = (callPackage ./plugins.nix { }) super self;
+              inherit (nixosTests) octoprint;
+            };
+          };
+
+          meta = with lib; {
+            homepage = "https://octoprint.org/";
+            description = "Snappy web interface for your 3D printer";
+            mainProgram = "octoprint";
+            license = licenses.agpl3Only;
+            maintainers = with maintainers; [
+              abbradar
+              gebner
+              WhittlesJr
+              gador
+            ];
+          };
+        };
+      })
+      (callPackage ./plugins.nix { })
+      packageOverrides
+    ]);
   };
 in
-with py.pkgs; toPythonApplication octoprint
+with py.pkgs;
+toPythonApplication octoprint


### PR DESCRIPTION
## Description of changes

Fix octoprint to build with python3.12. Upstream still relies on `flask` <2.3 which causes all those overrides and disabled tests.

When not using those, login will fail. 

Tested in a VM (x86_64-linux) and confirmed basic functionality.

Please note: depends on #325445 to build. So that will have to merged, first.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [x] Tested in a VM

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
