### PR TITLE
python311Packages.robotframework-seleniumlibrary: 6.4.0 -> 6.5.0 

### DIFF
--- a/pkgs/development/python-modules/approvaltests/default.nix
+++ b/pkgs/development/python-modules/approvaltests/default.nix
@@ -21,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "approvaltests";
-  version = "12.2.1";
+  version = "14.0.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     owner = "approvals";
     repo = "ApprovalTests.Python";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Hd0cEAL5RGmAhob1oZwOVC+eXOxc9OTeUnrTTNCpL2E=";
+    hash = "sha256-BTTmmtmFjYBfzbVf/Fi8PwnpVJBcOOBTdFBmGowGez4=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/robotframework-pythonlibcore/default.nix
+++ b/pkgs/development/python-modules/robotframework-pythonlibcore/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   pythonOlder,
   fetchFromGitHub,
-  fetchpatch2,
   setuptools,
   robotframework,
   approvaltests,
@@ -14,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "robotframework-pythonlibcore";
-  version = "4.4.0";
+  version = "4.4.1";
 
   disabled = pythonOlder "3.8";
 
@@ -24,15 +23,8 @@ buildPythonPackage rec {
     owner = "robotframework";
     repo = "PythonLibCore";
     rev = "refs/tags/v${version}";
-    hash = "sha256-282A4EW88z6ODSIEIIeBbN8YO491rwI4M7njI7kL3XQ=";
+    hash = "sha256-5RUi65+DljCqWoB8vZxc0hyIefEFOWuKluplXrD0SkI=";
   };
-
-  patches = [
-    (fetchpatch2 {
-      url = "https://github.com/robotframework/PythonLibCore/commit/8b756a4bd119d660109437023789bfada21bdc78.patch";
-      hash = "sha256-4NtgkGbIj9gH9Det6VNh1MpGSGroESxQ8X2ZTeoX/zU=";
-    })
-  ];
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/robotframework-seleniumlibrary/default.nix
+++ b/pkgs/development/python-modules/robotframework-seleniumlibrary/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
+  click,
   robotframework,
   robotframework-pythonlibcore,
   selenium,
@@ -14,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "robotframework-seleniumlibrary";
-  version = "6.4.0";
+  version = "6.5.0";
   pyproject = true;
 
   # no tests included in PyPI tarball
@@ -22,12 +23,13 @@ buildPythonPackage rec {
     owner = "robotframework";
     repo = "SeleniumLibrary";
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-Rjbdn1WXdXLn//HLtHwVrlLD+3vw9mgre/0wvMb+xbc=";
+    sha256 = "sha256-sB2lWFFpCGgF0XFes84fBBvR8GF+S8aWWJoih+xBmW8=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
+    click
     robotframework
     robotframework-pythonlibcore
     selenium
@@ -44,11 +46,11 @@ buildPythonPackage rec {
     mkdir utest/output_dir
   '';
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/robotframework/SeleniumLibrary/blob/${src.rev}/docs/SeleniumLibrary-${version}.rst";
     description = "Web testing library for Robot Framework";
     homepage = "https://github.com/robotframework/SeleniumLibrary";
-    license = licenses.asl20;
-    maintainers = [ ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ dotlambda ];
   };
 }


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/robotframework/SeleniumLibrary/compare/refs/tags/v6.4.0...v6.5.0

Changelog: https://github.com/robotframework/SeleniumLibrary/blob/refs/tags/v6.5.0/docs/SeleniumLibrary-6.5.0.rst
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
