### PR TITLE
python312Packages.pycountry: 23.12.11 -> 24.6.1

### DIFF
--- a/pkgs/development/python-modules/pycountry/default.nix
+++ b/pkgs/development/python-modules/pycountry/default.nix
@@ -3,14 +3,13 @@
   buildPythonPackage,
   pythonOlder,
   fetchFromGitHub,
-  fetchpatch2,
   poetry-core,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "pycountry";
-  version = "23.12.11";
+  version = "24.6.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -19,27 +18,15 @@ buildPythonPackage rec {
     owner = "pycountry";
     repo = "pycountry";
     rev = "refs/tags/${version}";
-    hash = "sha256-B6kphZZZgK0YuPSmkiQNbEqEfqOQb+WZGnO2UeEqQN4=";
+    hash = "sha256-4YVPh6OGWguqO9Ortv+vAejxx7WLs4u0SVLv8JlKSWM=";
   };
 
-  patches = [
-    (fetchpatch2 {
-      name = "fix-usage-of-importlib_metadata.patch";
-      url = "https://github.com/pycountry/pycountry/commit/824d2535833d061c04a1f1b6b964f42bb53bced2.patch";
-      excludes = [
-        "HISTORY.txt"
-        "poetry.lock"
-        "pyproject.toml"
-      ];
-      hash = "sha256-U4fbZP++d6YfTJkVG3k2rBC8nOF9NflM6+ONlwBNu+g=";
-    })
-  ];
-
   postPatch = ''
-    sed -i "/addopts/d" pytest.ini
+    sed -i "/addopts/d" pyproject.toml
+    sed -i "/pytest-cov/d" pyproject.toml
   '';
 
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [ poetry-core ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/pycountry/pycountry/compare/refs/tags/23.12.11...24.6.1

Changelog: https://github.com/pycountry/pycountry/blob/refs/tags/24.6.1/HISTORY.txt



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
