### PR TITLE
cue2pops: modernize derivation; add missing license & update to `0-unstable-2023-01-15`

### DIFF
--- a/pkgs/tools/cd-dvd/cue2pops/default.nix
+++ b/pkgs/tools/cd-dvd/cue2pops/default.nix
@@ -5,18 +5,16 @@
 
 stdenv.mkDerivation {
   pname = "cue2pops";
-  version = "unstable-2018-01-04";
+  version = "0-unstable-2023-01-15";
 
   src = fetchFromGitHub {
     owner = "makefu";
     repo = "cue2pops-linux";
-    rev = "541863adf23fdecde92eba5899f8d58586ca4551";
-    sha256 = "05w84726g3k33rz0wwb9v77g7xh4cnhy9sxlpilf775nli9bynrk";
+    rev = "3f2be6126bd50dfe6b998bc8926f88ce9139c19a";
+    hash = "sha256-7rgYvqeH8ZDI8Vc5vnjIhe3Ke0TE1q/iFHEqucanhUM=";
   };
 
   dontConfigure = true;
-
-  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/tools/cd-dvd/cue2pops/default.nix
+++ b/pkgs/tools/cd-dvd/cue2pops/default.nix
@@ -19,15 +19,20 @@ stdenv.mkDerivation {
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   installPhase = ''
+    runHook preInstall
     install --directory --mode=755 $out/bin
     install --mode=755 cue2pops $out/bin
+    runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Convert CUE to ISO suitable to POPStarter";
     homepage = "https://github.com/makefu/cue2pops-linux";
-    maintainers = with maintainers; [ AndersonTorres ];
-    platforms = platforms.all;
+    # Upstream license is unclear.
+    # <https://github.com/ErikAndren/cue2pops-mac/issues/2#issuecomment-673983298>
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ AndersonTorres ];
+    platforms = lib.platforms.all;
     mainProgram = "cue2pops";
   };
 }


### PR DESCRIPTION
- **cue2pops: modernize derivation; add missing license**
- **cue2pops: unstable-2018-01-04 -> 0-unstable-2023-01-15**

## Description of changes

Cleans up the cue2pops derivation a little, removing nested `with lib;` and
adding missing hooks for the installPhase.

Also adds the missing license (unfree, as upstream provides none), updates the
program to the latest commit and removes the CC hack as it has been fixed
upstream.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See
  [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)
    (look inside
    [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or
    [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in
    [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or
    [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are
    [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking)
    to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using
      `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all
      changes have to be committed, also see
      [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in
      `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md)
  (or backporting
  [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md)
  and
  [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md)
  Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or
        breaking
  - [ ] (Module updates) Added a release notes entry if the change is
        significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS
        module
- [x] Fits
      [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
