### PR TITLE
auto-cpufreq: add pyasyncore to propogatedBuildInputs

### DIFF
--- a/pkgs/by-name/au/auto-cpufreq/package.nix
+++ b/pkgs/by-name/au/auto-cpufreq/package.nix
@@ -37,6 +37,7 @@ python3Packages.buildPythonPackage rec {
     poetry-dynamic-versioning
     setuptools
     pyinotify
+    pyasyncore
   ];
 
   doCheck = false;


### PR DESCRIPTION
## Description of changes


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes: https://github.com/NixOS/nixpkgs/issues/325514

`pyasyncore` was missing from propogatedBuildInputs and causing auto-cpufreq to fail a runtime

Confirmation that runtime error is fixed:
```
$ sudo auto-cpufreq --live

Note: You can quit live mode by pressing "ctrl+c"

----------------------------------- Warning -----------------------------------

Detected running GNOME Power Profiles daemon service!
This daemon might interfere with auto-cpufreq and has been disabled.

This daemon is not automatically disabled in "monitor" mode and
will be enabled after auto-cpufreq is removed.


-------------------------------------------------------------------------------

Linux distro: NixOS 24.05 Uakari
Linux kernel: 6.6.32
Processor: Intel(R) Core(TM) i7-5500U CPU @ 2.40GHz
Cores: 4
Architecture: x86_64
Driver: intel_cpufreq

------------------------------ Current CPU stats ------------------------------

CPU max frequency: 3000 MHz
CPU min frequency: 500 MHz

Core    Usage   Temperature     Frequency
CPU0      1.0%        38 °C      2895 MHz
CPU1      0.0%        38 °C      2990 MHz
CPU2      1.0%        38 °C      2546 MHz
CPU3      0.0%        38 °C      2395 MHz

---------------------------- CPU frequency scaling ----------------------------

Battery is: charging

Setting to use: "performance" governor
Not setting EPP (not supported by system)

Total CPU usage: 0.5 %
Total system load: 0.08
Average temp. of all cores: 38.00 °C

Load optimal (load average: 0.08, 0.08, 0.08)
setting turbo boost: off

-------------------------------------------------------------------------------

                "auto-cpufreq" is about to refresh .
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
