### PR TITLE
hyprlandPlugins.hyprgrass: init at 0.7.0, wf-touch: init at 0-unstable-2021-03-19

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
@@ -28,6 +28,7 @@ let
     { hy3 = import ./hy3.nix; }
     { hypr-dynamic-cursors = import ./hypr-dynamic-cursors.nix; }
     { hyprfocus = import ./hyprfocus.nix; }
+    { hyprgrass = import ./hyprgrass.nix; }
     { hyprscroller = import ./hyprscroller.nix; }
     { hyprspace = import ./hyprspace.nix; }
     (import ./hyprland-plugins.nix)

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprgrass.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprgrass.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  mkHyprlandPlugin,
+  hyprland,
+  fetchFromGitHub,
+  cmake,
+  doctest,
+  meson,
+  ninja,
+  wf-touch,
+  nix-update-script,
+}:
+
+mkHyprlandPlugin hyprland rec {
+  pluginName = "hyprgrass";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "horriblename";
+    repo = "hyprgrass";
+    rev = "v${version}";
+    hash = "sha256-DfM2BqnFW48NlHkBfC7ErHgK7WHlOgiiE+aFetN/yJ4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    doctest
+    meson
+    ninja
+  ];
+
+  buildInputs = [ wf-touch ];
+
+  dontUseCmakeConfigure = true;
+
+  doCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Hyprland plugin for touch gestures";
+    homepage = "https://github.com/horriblename/hyprgrass";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ donovanglover ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/wf/wf-touch/package.nix
+++ b/pkgs/by-name/wf/wf-touch/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  pkg-config,
+  meson,
+  cmake,
+  ninja,
+  glm,
+  doctest,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation {
+  pname = "wf-touch";
+  version = "0-unstable-2021-03-19";
+
+  src = fetchFromGitHub {
+    owner = "WayfireWM";
+    repo = "wf-touch";
+    rev = "8974eb0f6a65464b63dd03b842795cb441fb6403";
+    hash = "sha256-MjsYeKWL16vMKETtKM5xWXszlYUOEk3ghwYI85Lv4SE=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    cmake
+    ninja
+  ];
+
+  buildInputs = [ doctest ];
+
+  propagatedBuildInputs = [ glm ];
+
+  mesonBuildType = "release";
+
+  # Patch wf-touch to generate pkgconfig
+  patches = fetchpatch {
+    url = "https://raw.githubusercontent.com/horriblename/hyprgrass/736119f828eecaed2deaae1d6ff1f50d6dabaaba/nix/wf-touch.patch";
+    hash = "sha256-3YK5YnO0NCwshs1reJFjJ9tIEhTNSS0fPWUDFo3XA3s=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Touchscreen gesture library";
+    homepage = "https://github.com/WayfireWM/wf-touch";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ donovanglover ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds https://github.com/horriblename/hyprgrass and its dependency https://github.com/WayfireWM/wf-touch

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
