### PR TITLE
bpftune: disable `zerocallusedregs` hardening

### DIFF
--- a/pkgs/os-specific/linux/bpftune/default.nix
+++ b/pkgs/os-specific/linux/bpftune/default.nix
@@ -58,6 +58,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [
     "stackprotector"
+    "zerocallusedregs"
   ];
 
   passthru.tests = {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Disable `zercallusedregs` to fix build of `bpftune`.
Without disabling it, I get 

```
error: builder for '/nix/store/ysv5kr8cxqizxdhr64k4v3khxyqyfr64-bpftune-0-unstable-2024-06-07.drv' failed with exit code 2;
       last 25 log lines:
       > clang: error: clang: error: unsupported option '-fzero-call-used-regs=used-gpr' for target 'bpf'
       > unsupported option '-fzero-call-used-regs=used-gpr' for target 'bpf'
       > clang: error: unsupported option '-fzero-call-used-regs=used-gpr' for target 'bpf'
       > clang: error: unsupported option '-fzero-call-used-regs=used-gpr' for target 'bpf'
       > make[1]: *** [Makefile:173: sysctl_tuner.bpf.o] Error 1
       > make[1]: *** Waiting for unfinished jobs....
       > make[1]: *** [Makefile:173: neigh_table_tuner.bpf.o] Error 1
       > make[1]: *** [Makefile:173: route_table_tuner.bpf.o] Error 1
       > make[1]: *** [Makefile:173: tcp_buffer_tuner.bpf.o] Error 1
       > make[1]: *** [Makefile:173: tcp_conn_tuner.bpf.o] Error 1
       > make[1]: *** [Makefile:173: net_buffer_tuner.bpf.o] Error 1
       > clangclangclangclang: : : error: : unsupported option '-fzero-call-used-regs=used-gpr' for target 'bpf'
       > error: error: error: unsupported option '-fzero-call-used-regs=used-gpr' for target 'bpf'
       > unsupported option '-fzero-call-used-regs=used-gpr' for target 'bpf'
       > unsupported option '-fzero-call-used-regs=used-gpr' for target 'bpf'
       > clang: error: unsupported option '-fzero-call-used-regs=used-gpr' for target 'bpf'
       > make[1]: *** [Makefile:177: tcp_buffer_tuner.bpf.legacy.o] Error 1
       > make[1]: *** [Makefile:173: probe.bpf.o] Error 1
       > make[1]: *** [Makefile:177: route_table_tuner.bpf.legacy.o] Error 1
       > make[1]: *** [Makefile:177: neigh_table_tuner.bpf.legacy.o] Error 1
       > make[1]: *** [Makefile:173: ip_frag_tuner.bpf.o] Error 1
       > clang: error: unsupported option '-fzero-call-used-regs=used-gpr' for target 'bpf'
       > make[1]: *** [Makefile:173: netns_tuner.bpf.o] Error 1
       > make[1]: Leaving directory '/build/source/src'
       > make: *** [Makefile:41: srcdir] Error 2
```

I have little knowledge of the C build system. I skimmed the manual and saw this new hardening option and tried disabling it, which seems to have worked.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>bpftune</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
