### PR TITLE
lorri: use cargoHash instead of cargoSha256

### DIFF
--- a/pkgs/tools/misc/lorri/default.nix
+++ b/pkgs/tools/misc/lorri/default.nix
@@ -16,7 +16,7 @@ let
   # Also don’t forget to run `nix-build -A lorri.tests`
   version = "1.7.0";
   sha256 = "sha256-pGNhhEBHyWhTaW24dHrxAvpb/qr5RPbHXRwDZx6Rf74=";
-  cargoSha256 = "sha256-ENZATiBhoO+N6NpSknOWpvsatkaYb4mS/E63XNRXfMU=";
+  cargoHash = "sha256-ENZATiBhoO+N6NpSknOWpvsatkaYb4mS/E63XNRXfMU=";
 
 in (rustPlatform.buildRustPackage rec {
   pname = "lorri";


### PR DESCRIPTION
Evaluation is broken for `lorri`, because #323983 renamed `cargoSha256` to `cargoHash`, but #322749 updated `cargoSha256` at the same time.

Pinging @JohnRTitor and @SuperSandro2000 as those who merged the two PRs.
