### PR TITLE
python3Packages.python-redis-lock: fix tests for django support

### DIFF
--- a/pkgs/development/python-modules/python-redis-lock/default.nix
+++ b/pkgs/development/python-modules/python-redis-lock/default.nix
@@ -12,7 +12,6 @@
   pytestCheckHook,
   pythonOlder,
   redis,
-  withDjango ? false,
   django-redis,
 }:
 
@@ -21,7 +20,6 @@ buildPythonPackage rec {
   version = "4.0.0";
 
   pyproject = true;
-  build-system = [ setuptools ];
 
   disabled = pythonOlder "3.7";
 
@@ -30,16 +28,26 @@ buildPythonPackage rec {
     hash = "sha256-Sr0Lz0kTasrWZye/VIbdJJQHjKVeSe+mk/eUB3MZCRo=";
   };
 
+  # Fix django tests
+  postPatch = ''
+    substituteInPlace tests/test_project/settings.py \
+      --replace "USE_L10N = True" ""
+  '';
+
   patches = [
+    # https://github.com/ionelmc/python-redis-lock/pull/119
     (fetchpatch {
-      url = "https://github.com/ionelmc/python-redis-lock/pull/119.diff";
+      url = "https://github.com/ionelmc/python-redis-lock/commit/ae404b7834990b833c1f0f703ec8fbcfecd201c2.patch";
       hash = "sha256-Fo43+pCtnrEMxMdEEdo0YfJGkBlhhH0GjYNgpZeHF3U=";
     })
-
     ./test_signal_expiration_increase_sleep.patch
   ];
 
-  dependencies = [ redis ] ++ lib.optionals withDjango [ django-redis ];
+  build-system = [ setuptools ];
+
+  dependencies = [ redis ];
+
+  optional-dependencies.django = [ django-redis ];
 
   nativeCheckInputs = [
     eventlet
@@ -47,18 +55,16 @@ buildPythonPackage rec {
     pytestCheckHook
     process-tests
     pkgs.redis
-  ];
+  ] ++ optional-dependencies.django;
 
-  disabledTests =
-    [
-      # https://github.com/ionelmc/python-redis-lock/issues/86
-      "test_no_overlap2"
-    ]
-    ++ lib.optionals stdenv.isDarwin [
-      # fail on Darwin because it defaults to multiprocessing `spawn`
-      "test_reset_signalizes"
-      "test_reset_all_signalizes"
-    ];
+  # For Django tests
+  preCheck = "export DJANGO_SETTINGS_MODULE=test_project.settings";
+
+  disabledTests = lib.optionals stdenv.isDarwin [
+    # fail on Darwin because it defaults to multiprocessing `spawn`
+    "test_reset_signalizes"
+    "test_reset_all_signalizes"
+  ];
 
   pythonImportsCheck = [ "redis_lock" ];
 
@@ -67,6 +73,6 @@ buildPythonPackage rec {
     description = "Lock context manager implemented via redis SETNX/BLPOP";
     homepage = "https://github.com/ionelmc/python-redis-lock";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ vanschelven ];
+    maintainers = with maintainers; [ erictapen ];
   };
 }


### PR DESCRIPTION
Also remove a skipped test that just seems to work

Remove maintainer, as they asked for it here:
https://github.com/NixOS/nixpkgs/pull/212270#issuecomment-1400459355

Needed for https://github.com/NixOS/nixpkgs/pull/325541

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
