### PR TITLE
fail2ban: 1.0.2 -> 1.1.0

### DIFF
--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -22,6 +22,9 @@ python3.pkgs.buildPythonApplication rec {
     lib.optionals stdenv.isLinux [
       systemd
       pyinotify
+
+      # https://github.com/fail2ban/fail2ban/issues/3787, remove it in the next release
+      setuptools
     ];
 
   preConfigure = ''

--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -5,13 +5,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "fail2ban";
-  version = "1.0.2";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "fail2ban";
     repo = "fail2ban";
     rev = version;
-    hash = "sha256-Zd8zLkFlvXTbeInEkNFyHgcAiOsX4WwF6hf5juSQvbY=";
+    hash = "sha256-0xPNhbu6/p/cbHOr5Y+PXbMbt5q/S13S5100ZZSdylE=";
   };
 
   outputs = [ "out" "man" ];

--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -25,9 +25,6 @@ python3.pkgs.buildPythonApplication rec {
     ];
 
   preConfigure = ''
-    patchShebangs fail2ban-2to3
-    ./fail2ban-2to3
-
     for i in config/action.d/sendmail*.conf; do
       substituteInPlace $i \
         --replace /usr/sbin/sendmail sendmail


### PR DESCRIPTION
## Description of changes

Upgrade fail2ban to 1.1.0 (to compatible with Python 3.12). For 1.1.0, I remove `fail2ban-2to3` since the codebase has been migrated (https://github.com/fail2ban/fail2ban/commit/03d7c92ae860dd29987e2090f4d6a24cc55c5b10), and add the dependency `setuptools` to compatible with Python 3.12 (https://github.com/fail2ban/fail2ban/issues/3787).

**Before:**

```
$ sudo systemctl status fail2ban
× fail2ban.service - Fail2Ban Service
     Loaded: loaded (/etc/systemd/system/fail2ban.service; enabled; preset: enabled)
    Drop-In: /nix/store/mrp75dd0q14blbyxlbbvnpk0dp86xsk6-system-units/fail2ban.service.d
             └─overrides.conf
     Active: failed (Result: exit-code) since Mon 2024-07-08 23:53:53 CST; 5s ago
   Duration: 664ms
       Docs: man:fail2ban(1)
    Process: 99883 ExecStart=/nix/store/7isxvz0z77rcrcjj5h1ahp516s6a7z7d-fail2ban-1.0.2/bin/fail2ban-server -xf start (code=exited, status=255/EXCEPTION)
   Main PID: 99883 (code=exited, status=255/EXCEPTION)
         IP: 0B in, 0B out
        CPU: 632ms

Jul 08 23:53:52 panhost-hometw systemd[1]: Started Fail2Ban Service.
Jul 08 23:53:53 panhost-hometw fail2ban-server[99883]: 2024-07-08 23:53:53,180 fail2ban.configreader   [99883]: WARNING 'allowipv6' not defined in 'Definition'. Using default one: 'auto'
Jul 08 23:53:53 panhost-hometw fail2ban-server[99883]: 2024-07-08 23:53:53,285 fail2ban                [99883]: ERROR   No module named 'asynchat'
Jul 08 23:53:53 panhost-hometw systemd[1]: fail2ban.service: Main process exited, code=exited, status=255/EXCEPTION
Jul 08 23:53:53 panhost-hometw systemd[1]: fail2ban.service: Failed with result 'exit-code'.
```

After:

```
● fail2ban.service - Fail2Ban Service
     Loaded: loaded (/etc/systemd/system/fail2ban.service; enabled; preset: enabled)
    Drop-In: /nix/store/37f1cbxg8vz148ga0rd13yr8nk1vi5n4-system-units/fail2ban.service.d
             └─overrides.conf
     Active: active (running) since Tue 2024-07-09 11:12:20 CST; 7s ago
       Docs: man:fail2ban(1)
   Main PID: 146213 (.fail2ban-serve)
         IP: 0B in, 0B out
         IO: 3.6M read, 0B written
      Tasks: 5 (limit: 9395)
     Memory: 24.7M (peak: 25.0M)
        CPU: 1.084s
     CGroup: /system.slice/fail2ban.service
             └─146213 /nix/store/z7xxy35k7620hs6fn6la5fg2lgklv72l-python3-3.12.4/bin/python3.12 /nix/store/grbhd5qv7ky55qwx7s1mg8jminbh1qj6-fail2ban-1.1.0/bin/.fail2ban-server-wrapped -xf start

Jul 09 11:12:21 panhost-hometw fail2ban.jail[146213]: INFO Initiated 'systemd' backend
Jul 09 11:12:21 panhost-hometw fail2ban.filter[146213]: INFO   maxLines: 1
Jul 09 11:12:21 panhost-hometw fail2ban.filtersystemd[146213]: INFO [sshd] Added journal match for: '_SYSTEMD_UNIT=sshd.service + _COMM=sshd'
Jul 09 11:12:21 panhost-hometw fail2ban.filter[146213]: INFO   maxRetry: 3
Jul 09 11:12:21 panhost-hometw fail2ban.filter[146213]: INFO   findtime: 600
Jul 09 11:12:21 panhost-hometw fail2ban.actions[146213]: INFO   banTime: 600
Jul 09 11:12:21 panhost-hometw fail2ban.filter[146213]: INFO   encoding: UTF-8
Jul 09 11:12:21 panhost-hometw fail2ban.jail[146213]: INFO Jail 'sshd' started
Jul 09 11:12:21 panhost-hometw fail2ban-server[146213]: Server ready
Jul 09 11:12:21 panhost-hometw fail2ban.filtersystemd[146213]: INFO [sshd] Jail is in operation now (process new journal entries)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin (basic)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
