### PR TITLE
python3Packages.django-timezone-field: 5.1 -> 7.0

### DIFF
--- a/pkgs/development/python-modules/django-timezone-field/default.nix
+++ b/pkgs/development/python-modules/django-timezone-field/default.nix
@@ -6,49 +6,44 @@
   poetry-core,
   django,
   djangorestframework,
-  pytz,
-  pytest,
+  pytestCheckHook,
+  pytest-django,
   pytest-lazy-fixture,
-  python,
 }:
 
 buildPythonPackage rec {
   pname = "django-timezone-field";
-  version = "5.1";
-  disabled = pythonOlder "3.5";
-  format = "pyproject";
+  version = "7.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "mfogel";
     repo = pname;
     rev = version;
-    hash = "sha256-FAYO8OEE/h4rsbC4Oc57ylWV7TqQ6DOd6/2M+mb/AsM=";
+    hash = "sha256-q06TuYkBA4z6tJdT3an6Z8o1i/o85XbYa1JYZBHC8lI=";
   };
 
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [ poetry-core ];
 
-  propagatedBuildInputs = [
-    django
-    djangorestframework
-    pytz
+  dependencies = [ django ];
+
+  pythonImportsCheck = [
+    # Requested setting USE_DEPRECATED_PYTZ, but settings are not configured.
+    #"timezone_field"
   ];
 
-  pythonImportsCheck = [ "timezone_field" ];
-
-  # Uses pytest.lazy_fixture directly which is broken in pytest-lazy-fixture
-  # https://github.com/TvoroG/pytest-lazy-fixture/issues/22
-  doCheck = false;
-
-  DJANGO_SETTINGS_MODULE = "tests.settings";
+  preCheck = ''
+    export DJANGO_SETTINGS_MODULE=tests.settings
+  '';
 
   nativeCheckInputs = [
-    pytest
+    djangorestframework
+    pytestCheckHook
+    pytest-django
     pytest-lazy-fixture
   ];
-
-  checkPhase = ''
-    ${python.interpreter} -m django test
-  '';
 
   meta = with lib; {
     description = "Django app providing database, form and serializer fields for pytz timezone objects";


### PR DESCRIPTION
Changelog: https://github.com/mfogel/django-timezone-field/blob/main/README.md#changelog

Needed for https://github.com/NixOS/nixpkgs/pull/325541

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
