### PR TITLE
azuki: init at 0-unstable-2021-07-02

### DIFF
--- a/pkgs/by-name/az/azuki/package.nix
+++ b/pkgs/by-name/az/azuki/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+
+let
+  fonts = [
+    {
+      name = "azuki";
+      downloadVersion = "121";
+      hash = "sha256-AMpEJDD8lN0qWJ5C0y4V+/2JE/pKQrUHGfKHcnV+dhA=";
+    }
+    {
+      name = "azuki-b";
+      downloadVersion = "B120";
+      hash = "sha256-GoXnDX9H6D1X0QEgrD2jmQp7ek081PpO+xR3OdIY8Ck=";
+    }
+    {
+      name = "azuki-l";
+      downloadVersion = "L120";
+      hash = "sha256-rvWvSuvLnK3m2+iyKPQyIB1UGjg8dAW5oygjsLCQZ48=";
+    }
+    {
+      name = "azuki-lb";
+      downloadVersion = "LB100";
+      hash = "sha256-zpGomVshCe2W2Z2C5UGtVrJ2k7F//MftndSHPHmG290=";
+    }
+    {
+      name = "azuki-lp";
+      downloadVersion = "LP100";
+      hash = "sha256-Q/ND3dv8q7WTQx4oYVY5pTiGl4Ht89oA+tuCyfPOLUk=";
+    }
+    {
+      name = "azuki-p";
+      downloadVersion = "P100";
+      hash = "sha256-s4uodxyXP5R7jwkzjmg6qJZCllJ/MtgkkVOeELI8hLI=";
+    }
+  ];
+
+in
+stdenvNoCC.mkDerivation {
+  pname = "azuki";
+  version = "0-unstable-2021-07-02";
+
+  sourceRoot = "azuki";
+
+  srcs = map (
+    {
+      name,
+      downloadVersion,
+      hash,
+    }:
+    fetchzip {
+      url = "https://azukifont.com/font/azukifont${downloadVersion}.zip";
+      stripRoot = false;
+      inherit name hash;
+    }
+  ) fonts;
+
+  installPhase = ''
+    runHook preInstall
+
+    for font in $srcs; do
+      install -Dm644 $font/azukifont*/*.ttf -t $out/share/fonts/truetype
+    done
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "http://azukifont.com/font/azuki.html";
+    description = "Azuki Font";
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ nyadiia ];
+  };
+}


### PR DESCRIPTION
## Description of changes

azuki is a monospace handwritten font with a few variants:
- P - proportional ( a normal font )
- L - no emojis
- B - bold monospace
- LP - proportional with no emojis
- LB - bold monospace with no emojis

[azukifont.com/font/azuki.html](http://azukifont.com/font/azuki.html)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
