### PR TITLE
binwalk, diffoscope: update after Python 3.12

### DIFF
--- a/pkgs/development/python-modules/binwalk/default.nix
+++ b/pkgs/development/python-modules/binwalk/default.nix
@@ -20,6 +20,7 @@
   pycrypto,
   pyqtgraph,
   pyqt5,
+  pythonOlder,
   visualizationSupport ? false,
 }:
 
@@ -43,6 +44,12 @@ buildPythonPackage rec {
       sha256 = "1707n4nf1d1ay1yn4i8qlrvj2c1120g88hjwyklpsc2s2dcnqj9r";
       includes = [ "testing/tests/test_firmware_zip.py" ];
       revert = true;
+    })
+    # binwalk incompatible with Python 3.12
+    # https://github.com/ReFirmLabs/binwalk/pull/668
+    (fetchpatch {
+      url = "https://github.com/ReFirmLabs/binwalk/commit/3e5c6887e840643fdbe7358de4bb31d726d0ce1b.patch";
+      sha256 = "sha256-QhPIC2BKYeeCn2dNm9NeWpyUcIL1S+C/B3F55/nxrjw=";
     })
   ];
 
@@ -74,6 +81,8 @@ buildPythonPackage rec {
   postPatch = ''
     echo '__version__ = "${version}"' > src/binwalk/core/version.py
   '';
+
+  doCheck = pythonOlder "3.12"; # nose requires imp module
 
   # binwalk wants to access ~/.config/binwalk/magic
   preCheck = ''

--- a/pkgs/tools/misc/diffoscope/binwalk-python3.12.patch
+++ b/pkgs/tools/misc/diffoscope/binwalk-python3.12.patch
@@ -1,0 +1,41 @@
+From e27965ac94a74d908213e37b6d529827cc1ee902 Mon Sep 17 00:00:00 2001
+From: Philip Taron <philip.taron@gmail.com>
+Date: Mon, 8 Jul 2024 11:58:15 -0700
+Subject: [PATCH] tests/comparators/test_binwalk.py: binwalk on Python 3.12
+ produces more output
+
+In particular, here is the difference array:
+
+```
+[
+  <Difference .cpio file embedded at offset 0 -- .cpio file embedded at offset 0 [<Difference file list -- file list []>, <Difference dir/link -- dir/link []>, <Difference dir/text -- dir/text []>]>,
+  <Difference .cpio file embedded at offset 600 -- .cpio file embedded at offset 600 [<Difference file list -- file list []>, <Difference dir/link -- dir/link []>, <Difference dir/text -- dir/text []>]>,
+  <Difference .cpio file embedded at offset 670 -- .cpio file embedded at offset 670 [<Difference file list -- file list []>, <Difference dir/link -- dir/link []>, <Difference dir/text -- dir/text []>]>,
+  <Difference .cpio file embedded at offset 6E4 -- .cpio file embedded at offset 6E4 [<Difference file list -- file list []>, <Difference dir/link -- dir/link []>, <Difference dir/text -- dir/text []>]>,
+  <Difference .cpio file embedded at offset 70 -- .cpio file embedded at offset 70 [<Difference file list -- file list []>, <Difference dir/link -- dir/link []>, <Difference dir/text -- dir/text []>]>,
+  <Difference .cpio file embedded at offset E4 -- .cpio file embedded at offset E4 [<Difference file list -- file list []>, <Difference dir/link -- dir/link []>, <Difference dir/text -- dir/text []>]>,
+  <Difference .cpio file embedded at offset 164 -- .cpio file embedded at offset 16C [<Difference file list -- file list []>, <Difference dir/text -- dir/text []>]>,
+  <Difference .cpio file embedded at offset 39C -- .cpio file embedded at offset 484 []>,
+  <Difference .cpio file embedded at offset 76C -- .cpio file embedded at offset 764 [<Difference file list -- file list []>, <Difference dir/text -- dir/text []>]>
+]
+```
+---
+ tests/comparators/test_binwalk.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/comparators/test_binwalk.py b/tests/comparators/test_binwalk.py
+index ba0b1bd4..c85b5934 100644
+--- a/tests/comparators/test_binwalk.py
++++ b/tests/comparators/test_binwalk.py
+@@ -57,7 +57,7 @@ def comparison(binwalk1, binwalk2):
+ @skip_unless_module_exists("binwalk")
+ def test_listing(comparison):
+     differences = comparison.details
+-    assert comparison.comments == ["comprises of 2 embedded members"]
++    assert comparison.comments == ["comprises of 10 embedded members"]
+     assert differences[0].source1 == ".cpio file embedded at offset 0"
+     assert differences[1].source2 == ".cpio file embedded at offset 600"
+ 
+-- 
+2.45.1
+

--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -111,6 +111,9 @@ python.pkgs.buildPythonApplication rec {
   patches = [
     ./ignore_links.patch
     ./openssh-no-dsa.patch # https://salsa.debian.org/reproducible-builds/diffoscope/-/merge_requests/139
+  ] ++ lib.optionals (python.pythonAtLeast "3.12") [
+    # `binwalk` with Python 3.12 produces more output
+    ./binwalk-python3.12.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

- [x] `binwalk` uses both `imp` and `nose` which are not supported on Python 3.12. See https://github.com/ReFirmLabs/binwalk/pull/668
- [x] `diffoscope` unit test for binwalk now sees more cpio binaries in its test.

related to https://github.com/NixOS/nixpkgs/issues/325657#issuecomment-2215424154
cc @Mag1cByt3s

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>15 packages built:</summary>
  <ul>
    <li>binwalk (python312Packages.binwalk)</li>
    <li>binwalk.dist (python312Packages.binwalk.dist)</li>
    <li>diffoscope</li>
    <li>diffoscope.dist</li>
    <li>diffoscope.man</li>
    <li>diffoscopeMinimal</li>
    <li>diffoscopeMinimal.dist</li>
    <li>diffoscopeMinimal.man</li>
    <li>ghidra-extensions.ghidraninja-ghidra-scripts</li>
    <li>python311Packages.binwalk</li>
    <li>python311Packages.binwalk-full</li>
    <li>python311Packages.binwalk-full.dist</li>
    <li>python311Packages.binwalk.dist</li>
    <li>python312Packages.binwalk-full</li>
    <li>python312Packages.binwalk-full.dist</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).