### PR TITLE
python311Packages.mayavi: unbreak, set mainProgram

### DIFF
--- a/pkgs/development/python-modules/mayavi/default.nix
+++ b/pkgs/development/python-modules/mayavi/default.nix
@@ -4,7 +4,6 @@
   buildPythonPackage,
   envisage,
   fetchPypi,
-  fetchpatch,
   numpy,
   packaging,
   pyface,
@@ -19,7 +18,6 @@
 
 buildPythonPackage rec {
   pname = "mayavi";
-  # TODO: Remove meta.broken on next release.
   version = "4.8.2";
   format = "setuptools";
 
@@ -29,30 +27,6 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-sQ/pFF8hxI5JAvDnRrNgOzy2lNEUVlFaRoIPIaCnQik=";
   };
-
-  patches = [
-    # Adds compatibility with Python 3.11.
-    # https://github.com/enthought/mayavi/pull/1199
-    (fetchpatch {
-      name = "python311-compat.patch";
-      url = "https://github.com/enthought/mayavi/commit/50c0cbfcf97560be69c84b7c924635a558ebf92f.patch";
-      hash = "sha256-zZOT6on/f5cEjnDBrNGog/wPQh7rBkaFqrxkBYDUQu0=";
-      includes = [ "tvtk/src/*" ];
-    })
-    # Fixes an incompatible function pointer conversion error
-    # https://github.com/enthought/mayavi/pull/1266
-    (fetchpatch {
-      name = "incompatible-pointer-conversion.patch";
-      url = "https://github.com/enthought/mayavi/commit/887adc8fe2b076a368070f5b1d564745b03b1964.patch";
-      hash = "sha256-88H1NNotd4pO0Zw1oLrYk5WNuuVrmTU01HJgsTRfKlo=";
-    })
-  ];
-
-  postPatch = ''
-    # building the docs fails with the usual Qt xcb error, so skip:
-    substituteInPlace setup.py \
-      --replace "build.build.run(self)" "build.build.run(self); return"
-  '';
 
   nativeBuildInputs = [ wrapQtAppsHook ];
 
@@ -84,8 +58,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/enthought/mayavi";
     license = licenses.bsdOriginal;
     maintainers = with maintainers; [ knedlsepp ];
-    # Should be fixed in a version from after March 26, see:
-    # https://github.com/enthought/mayavi/issues/1284#issuecomment-2020631244
-    broken = pythonAtLeast "3.12";
+    mainProgram = "mayavi2";
   };
 }


### PR DESCRIPTION
All removed patches have been merged and tagged in this release. Docs are no longer built by default as of 4.8.0

fixes https://hydra.nixos.org/build/265230400

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
