### PR TITLE
maelstrom-clj: init at 0.2.3

### DIFF
--- a/pkgs/by-name/ma/maelstrom-clj/package.nix
+++ b/pkgs/by-name/ma/maelstrom-clj/package.nix
@@ -1,0 +1,57 @@
+{ stdenv
+, lib
+, fetchurl
+, makeWrapper
+, git
+, coreutils
+, jdk
+, gnuplot
+, graphviz
+}:
+stdenv.mkDerivation rec {
+  pname = "maelstrom";
+  version = "0.2.3";
+
+  src = fetchurl {
+    url = "https://github.com/jepsen-io/maelstrom/releases/download/v${version}/maelstrom.tar.bz2";
+    hash = "sha256-ISS2qma139Jz9eDxLJvULkqDZeu1vyx9ot4uO0LIVho=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    cp -R lib $out/lib
+
+    # see https://github.com/jepsen-io/maelstrom/blob/b91beef83ee40add17dfe0baf2df272869e144cf/pkg/maelstrom
+    makeWrapper ${jdk}/bin/java $out/bin/maelstrom \
+      --add-flags -Djava.awt.headless=true \
+      --add-flags "-jar $out/lib/maelstrom.jar" \
+      --set PATH ${lib.makeBinPath runtimeDependencies}
+
+    runHook postInstall
+  '';
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  runtimeDependencies = [
+    git
+    coreutils
+    jdk
+    gnuplot
+    graphviz
+  ];
+
+  meta = with lib; {
+    description = "Workbench for writing toy implementations of distributed systems";
+    homepage = "https://github.com/jepsen-io/maelstrom";
+    changelog = "https://github.com/jepsen-io/maelstrom/releases/tag/${version}";
+    mainProgram = "maelstrom";
+    sourceProvenance = [ sourceTypes.binaryBytecode ];
+    license = licenses.epl10;
+    maintainers = [ maintainers.emilioziniades ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds maelstrom, a workbench for writing toy implementations of distributed systems, by the Jepsen team.

Closes #325640

`maelstrom` was already taken so I suffixed the package name with `-clj` - open to suggestions here.

I tried going down the `buildGraalvmNativeImage` route but it was fruitless. Ended up just using the [script in the maelstrom repo](https://github.com/jepsen-io/maelstrom/blob/b91beef83ee40add17dfe0baf2df272869e144cf/pkg/maelstrom) which basically does `java -jar maelstrom.jar`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
