### PR TITLE
vscode-extensions.myriad-dreamin.tinymist: fix hash mismatch

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/myriad-dreamin.tinymist/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/myriad-dreamin.tinymist/default.nix
@@ -11,7 +11,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     name = "tinymist";
     publisher = "myriad-dreamin";
     inherit (tinymist) version;
-    hash = "sha256-e/7HAvaohATDet7ynYc34e5cbOzBL5Rcjvimggs68c4=";
+    hash = "sha256-byylRSPfuMBsZsnV/cUJFKrPWiLZFPKGB20Stpe6b0Y=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
```
❯ nix build .#vscode-extensions.myriad-dreamin.tinymist -L
myriad-dreamin-tinymist.zip> sourcing setup hook '/nix/store/yq6n8b0mnk0qxzbs3ajsjcp8ziwqylrl-patchelf-0.15.0/nix-support/setup-hook'
myriad-dreamin-tinymist.zip> sourcing setup hook '/nix/store/iks1pihvbilsh5sy8qvpd638k422w9i8-update-autotools-gnu-config-scripts-hook/nix-support/setup-hook'
myriad-dreamin-tinymist.zip> sourcing setup hook '/nix/store/h9lc1dpi14z7is86ffhl3ld569138595-audit-tmpdir.sh'
myriad-dreamin-tinymist.zip> sourcing setup hook '/nix/store/m54bmrhj6fqz8nds5zcj97w9s9bckc9v-compress-man-pages.sh'
myriad-dreamin-tinymist.zip> sourcing setup hook '/nix/store/wgrbkkaldkrlrni33ccvm3b6vbxzb656-make-symlinks-relative.sh'
myriad-dreamin-tinymist.zip> sourcing setup hook '/nix/store/5yzw0vhkyszf2d179m0qfkgxmp5wjjx4-move-docs.sh'
myriad-dreamin-tinymist.zip> sourcing setup hook '/nix/store/fyaryjvghbkpfnsyw97hb3lyb37s1pd6-move-lib64.sh'
myriad-dreamin-tinymist.zip> sourcing setup hook '/nix/store/kd4xwxjpjxi71jkm6ka0np72if9rm3y0-move-sbin.sh'
myriad-dreamin-tinymist.zip> sourcing setup hook '/nix/store/pag6l61paj1dc9sv15l7bm5c17xn5kyk-move-systemd-user-units.sh'
myriad-dreamin-tinymist.zip> sourcing setup hook '/nix/store/jivxp510zxakaaic7qkrb7v1dd2rdbw9-multiple-outputs.sh'
myriad-dreamin-tinymist.zip> sourcing setup hook '/nix/store/ilaf1w22bxi6jsi45alhmvvdgy4ly3zs-patch-shebangs.sh'
myriad-dreamin-tinymist.zip> sourcing setup hook '/nix/store/cickvswrvann041nqxb0rxilc46svw1n-prune-libtool-files.sh'
myriad-dreamin-tinymist.zip> sourcing setup hook '/nix/store/xyff06pkhki3qy1ls77w10s0v79c9il0-reproducible-builds.sh'
myriad-dreamin-tinymist.zip> sourcing setup hook '/nix/store/ngg1cv31c8c7bcm2n8ww4g06nq7s4zhm-set-source-date-epoch-to-latest.sh'
myriad-dreamin-tinymist.zip> sourcing setup hook '/nix/store/gps9qrh99j7g02840wv5x78ykmz30byp-strip.sh'
myriad-dreamin-tinymist.zip> trying https://myriad-dreamin.gallery.vsassets.io/_apis/public/gallery/publisher/myriad-dreamin/extension/tinymist/0.11.14/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage
myriad-dreamin-tinymist.zip>   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
myriad-dreamin-tinymist.zip>                                  Dload  Upload   Total   Spent    Left  Speed
myriad-dreamin-tinymist.zip> 100 24.7M  100 24.7M    0     0  5825k      0  0:00:04  0:00:04 --:--:-- 5826k
error: hash mismatch in fixed-output derivation '/nix/store/mjmxklnxz4fbsw512sd05ka94qsz50pc-myriad-dreamin-tinymist.zip.drv':
         specified: sha256-e/7HAvaohATDet7ynYc34e5cbOzBL5Rcjvimggs68c4=
            got:    sha256-byylRSPfuMBsZsnV/cUJFKrPWiLZFPKGB20Stpe6b0Y=
error: 1 dependencies of derivation '/nix/store/n9nxblhj3h90qgangz62cnwfky6il5fp-vscode-extension-myriad-dreamin-tinymist-0.11.14.drv' failed to build
```

That issue appeared after this PR was merged: https://github.com/NixOS/nixpkgs/pull/325275

@myriad-dreamin Did you recreated the 0.11.14 tag?

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
