### PR TITLE
museum: init at photos-v0.9.5

### DIFF
--- a/pkgs/by-name/mu/museum/package.nix
+++ b/pkgs/by-name/mu/museum/package.nix
@@ -1,0 +1,48 @@
+{ lib
+, fetchFromGitHub
+, pkg-config
+, libsodium
+, buildGoModule
+}:
+
+buildGoModule rec {
+
+  version = "photos-v0.9.5";
+  pname = "museum";
+
+  src = fetchFromGitHub {
+    owner = "ente-io";
+    repo = "ente";
+    sparseCheckout = [ "server" ];
+    rev = version;
+    hash = "sha256-U+3k6uIJWDw7QxF1GRF+f6ZXdmCwSkOJ/F60rU1PXRM=";
+  };
+
+  sourceRoot = "${src.name}/server";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libsodium ];
+
+  # fatal: "Not running tests in non-test environment"
+  doCheck = false;
+
+  postInstall = ''
+    mkdir -p $out/share/museum
+    cp -R configurations \
+      migrations \
+      mail-templates \
+      $out/share/museum
+  '';
+
+  meta = with lib; {
+    description = "API server for ente.io";
+    homepage = "https://github.com/ente-io/ente/tree/main/server";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ surfaceflinger pinpox ];
+    mainProgram = "museum";
+    platforms = platforms.linux;
+  };
+  vendorHash = "sha256-Vo3KhWWxO0k/d5qUFRfX44oTZBXtJeUlz6qaUvXLDag=";
+}
+
+


### PR DESCRIPTION
## Description of changes

Superseeding https://github.com/NixOS/nixpkgs/pull/292813 with newer version and cleaned up package.
Part of: https://github.com/NixOS/nixpkgs/issues/292641

I have a working nixos module aswell, but will submit it in a seperate PR since it needs more work and I don't know when it will be ready yet.

The package works as-is when specifying configuration manually, it can be used without the web-client. Desktop and webclients are separate packages.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
