### PR TITLE
nixos/macos-builder.nix: Explain why and how to keep it stateless

### DIFF
--- a/nixos/modules/profiles/macos-builder.nix
+++ b/nixos/modules/profiles/macos-builder.nix
@@ -203,6 +203,23 @@ in
         has a dependency on stateVersion.
 
           nix-instantiate --attr darwin.linux-builder --show-trace
+
+        To solve the problem, if you encounter this error as a NixOS maintainer:
+
+        1. Make sure the stateVersion-dependent behavior can also be controlled
+           directly with one (or perhaps a few) options.
+        2. Add a definition to nixos/modules/profiles/macos-builder.nix with
+           a higher priority than the option default.
+            - `mkDefault` if it's ok for users to override the _option default_.
+            - a normal definition if users should think twice to override it.
+
+        To solve the problem as a user:
+
+        Assuming a change didn't slip through Nixpkgs CI, you've probably enabled
+        an extra module in your configuration that depends on stateVersion. You
+        can either disable the module or set the stateVersion to the latest or
+        upcoming release. If you do so, your configuration may lag behind the
+        latest Nixpkgs changes and best practices.
       '');
     };
 

--- a/nixos/modules/profiles/macos-builder.nix
+++ b/nixos/modules/profiles/macos-builder.nix
@@ -197,8 +197,19 @@ in
       nixos.revision = null;
 
       stateVersion = lib.mkDefault (throw ''
-        The macOS linux builder should not need a stateVersion to be set, but a module
-        has accessed stateVersion nonetheless.
+        The macOS linux builder is designed to have a stateless NixOS
+        configuration internally, i.e. without a stateVersion to be set, but a
+        module has accessed stateVersion nonetheless.
+
+        By avoiding stateVersion, the builder can be updated without needing to
+        update the stateVersion in the configuration. This is important because
+        the linux builder is meant to be very easy to use and update.
+        The error message you're seeing is a safeguard that gives us an
+        opportunity to fix the problem and make the right decision for all its
+        users.
+
+        Troubleshooting & resolution
+
         Please inspect the trace of the following command to figure out which module
         has a dependency on stateVersion.
 


### PR DESCRIPTION
## Description of changes


Improve the error message to make it actionable for maintainers and users.

Context
- https://github.com/NixOS/nixpkgs/issues/325610

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
