### PR TITLE
segger-jlink: 796k -> 796s

### DIFF
--- a/pkgs/by-name/se/segger-jlink/source.nix
+++ b/pkgs/by-name/se/segger-jlink/source.nix
@@ -1,19 +1,19 @@
 {
-  version = "796k";
+  version = "796s";
   x86_64-linux = {
     name = "x86_64";
-    hash = "sha256-GDmdKjMD9nJLPl4Qaxgrb5+b9CsUdyNqNak1JG4ERjo=";
+    hash = "sha256-fAuBeKrkz/b7rT4939/489nTAhS7XfK0nU6cjQmAom8=";
   };
   i686-linux = {
     name = "i386";
-    hash = "sha256-8j2UkPtDyIA+mfXl4jIVp89CpGA+T4eU5IQ0GwROgwU=";
+    hash = "sha256-OhNYEeaRl1kp16TmsPXrXwx+CZoqcA/qbMwUKZeONfI=";
   };
   aarch64-linux = {
     name = "arm64";
-    hash = "sha256-FIzg7vAPlhnjuKEm5uGa7a37srp1U0e4eqlG9C6q26s=";
+    hash = "sha256-1OnvTNUF590xgUg/j1dPzMO15XEZuT5vl+uE6o4s5mE=";
   };
   armv7l-linux = {
     name = "arm";
-    hash = "sha256-NceqkV54QVXEJr4pJ3nvY3zxSYb9Er0uQWQ4vaojkv8=";
+    hash = "sha256-ynXD7ykuKBLsoiJc+mBTnkXsreeclDvxR5M9ZsrQDxw=";
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR updates `segger-jlink` to version `796s`. Interestingly, the hashes for the previous version were wrong, maybe the upstream changed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
