### PR TITLE
mopidy-youtube: replace youtube-dl with yt-dlp

### DIFF
--- a/pkgs/applications/audio/mopidy/youtube.nix
+++ b/pkgs/applications/audio/mopidy/youtube.nix
@@ -1,8 +1,10 @@
-{ lib
-, fetchFromGitHub
-, python3
-, mopidy
-, extraPkgs ? pkgs: []
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+  mopidy,
+  yt-dlp,
+  extraPkgs ? pkgs: [ ],
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -17,21 +19,35 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-iFt7r8Ljymc+grNJiOClTHkZOeo7AcYpcNc8tLMPROk=";
   };
 
-  propagatedBuildInputs = with python3.pkgs; [
-    beautifulsoup4
-    cachetools
-    pykka
-    requests
-    youtube-dl
-    ytmusicapi
-  ] ++ [
-    mopidy
-  ] ++ extraPkgs pkgs;
+  propagatedBuildInputs =
+    with python3.pkgs;
+    [
+      beautifulsoup4
+      cachetools
+      pykka
+      requests
+      ytmusicapi
+    ]
+    ++ [
+      mopidy
+      yt-dlp
+    ]
+    ++ extraPkgs pkgs;
 
   nativeCheckInputs = with python3.pkgs; [
     vcrpy
     pytestCheckHook
   ];
+
+  postPatch = ''
+    substituteInPlace mopidy_youtube/youtube.py \
+      --replace-fail 'youtube_dl_package = "youtube_dl"' 'youtube_dl_package = "yt_dlp"'
+    substituteInPlace tests/conftest.py \
+      --replace-fail 'import youtube_dl' 'import yt_dlp' \
+      --replace-fail 'patcher = mock.patch.object(youtube, "youtube_dl", spec=youtube_dl)' \
+      'patcher = mock.patch.object(youtube, "youtube_dl", spec=yt_dlp)' \
+      --replace-fail '"youtube_dl_package": "youtube_dl",' '"youtube_dl_package": "yt_dlp",'
+  '';
 
   disabledTests = [
     # Test requires a YouTube API key
@@ -45,9 +61,7 @@ python3.pkgs.buildPythonApplication rec {
     "tests/test_youtube.py"
   ];
 
-  pythonImportsCheck = [
-    "mopidy_youtube"
-  ];
+  pythonImportsCheck = [ "mopidy_youtube" ];
 
   meta = with lib; {
     description = "Mopidy extension for playing music from YouTube";


### PR DESCRIPTION
## Description of changes

#325371

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
