### PR TITLE
pyinotify: patch for python 3.12 support

### DIFF
--- a/pkgs/development/python-modules/pyinotify/default.nix
+++ b/pkgs/development/python-modules/pyinotify/default.nix
@@ -17,6 +17,8 @@ buildPythonPackage rec {
   # No tests distributed
   doCheck = false;
 
+  pythonImportsCheck = [ "pyinotify" ];
+
   meta = with lib; {
     homepage = "https://github.com/seb-m/pyinotify/wiki";
     description = "Monitor filesystems events on Linux platforms with inotify";

--- a/pkgs/development/python-modules/pyinotify/default.nix
+++ b/pkgs/development/python-modules/pyinotify/default.nix
@@ -14,6 +14,8 @@ buildPythonPackage rec {
     sha256 = "1x3i9wmzw33fpkis203alygfnrkcmq9w1aydcm887jh6frfqm6cw";
   };
 
+  patches = [ ./skip-asyncore-python-3.12.patch ];
+
   # No tests distributed
   doCheck = false;
 

--- a/pkgs/development/python-modules/pyinotify/skip-asyncore-python-3.12.patch
+++ b/pkgs/development/python-modules/pyinotify/skip-asyncore-python-3.12.patch
@@ -1,0 +1,84 @@
+From 478d595a7d086423733e9f5da5edfe9f1df48682 Mon Sep 17 00:00:00 2001
+From: Troy Curtis Jr <troy@troycurtisjr.com>
+Date: Thu, 10 Aug 2023 21:51:15 -0400
+Subject: [PATCH] Make asyncore support optional for Python 3.
+
+Fixes #204.
+---
+ python3/pyinotify.py | 50 +++++++++++++++++++++++++-------------------
+ 1 file changed, 28 insertions(+), 22 deletions(-)
+
+diff --git a/python3/pyinotify.py b/python3/pyinotify.py
+index bc24313..f4a5a90 100755
+--- a/python3/pyinotify.py
++++ b/python3/pyinotify.py
+@@ -68,7 +68,6 @@ def __init__(self, version):
+ from datetime import datetime, timedelta
+ import time
+ import re
+-import asyncore
+ import glob
+ import locale
+ import subprocess
+@@ -1494,33 +1493,40 @@ def run(self):
+         self.loop()
+ 
+ 
+-class AsyncNotifier(asyncore.file_dispatcher, Notifier):
+-    """
+-    This notifier inherits from asyncore.file_dispatcher in order to be able to
+-    use pyinotify along with the asyncore framework.
++try:
++    import asyncore
+ 
+-    """
+-    def __init__(self, watch_manager, default_proc_fun=None, read_freq=0,
+-                 threshold=0, timeout=None, channel_map=None):
++    class AsyncNotifier(asyncore.file_dispatcher, Notifier):
+         """
+-        Initializes the async notifier. The only additional parameter is
+-        'channel_map' which is the optional asyncore private map. See
+-        Notifier class for the meaning of the others parameters.
++        This notifier inherits from asyncore.file_dispatcher in order to be able to
++        use pyinotify along with the asyncore framework.
+ 
+         """
+-        Notifier.__init__(self, watch_manager, default_proc_fun, read_freq,
+-                          threshold, timeout)
+-        asyncore.file_dispatcher.__init__(self, self._fd, channel_map)
++        def __init__(self, watch_manager, default_proc_fun=None, read_freq=0,
++                     threshold=0, timeout=None, channel_map=None):
++            """
++            Initializes the async notifier. The only additional parameter is
++            'channel_map' which is the optional asyncore private map. See
++            Notifier class for the meaning of the others parameters.
+ 
+-    def handle_read(self):
+-        """
+-        When asyncore tells us we can read from the fd, we proceed processing
+-        events. This method can be overridden for handling a notification
+-        differently.
++            """
++            Notifier.__init__(self, watch_manager, default_proc_fun, read_freq,
++                              threshold, timeout)
++            asyncore.file_dispatcher.__init__(self, self._fd, channel_map)
+ 
+-        """
+-        self.read_events()
+-        self.process_events()
++        def handle_read(self):
++            """
++            When asyncore tells us we can read from the fd, we proceed processing
++            events. This method can be overridden for handling a notification
++            differently.
++
++            """
++            self.read_events()
++            self.process_events()
++except ImportError:
++    # asyncore was removed in Python 3.12, but try the import instead of a
++    # version check in case the compatibility package is installed.
++    pass
+ 
+ 
+ class TornadoAsyncNotifier(Notifier):


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes: https://github.com/NixOS/nixpkgs/issues/325514

`asyncore` was removed from the python-3.12 standard library: https://peps.python.org/pep-0594/ 

Adding backport to 24.05 since its broken there as well (see output below).

This patch was original sourced from: https://github.com/seb-m/pyinotify/pull/205 Its seems like `ipynotify` is no longer maintained so I'm opting to include the patch here. This is similar to what Arch (https://gitlab.archlinux.org/archlinux/packaging/packages/python-pyinotify/-/commit/df875e727a19fb9e83d2af55cc5f368b94eec705) and Fedora (https://src.fedoraproject.org/rpms/python-inotify/pull-request/4) have done:

Testing `pythonImportsCheck = [ pyinotify ]` failing prior to patch on `master`:

```
$ nix build .#python3Packages.pyinotify
warning: Git tree '/home/rherna/workspace/nixpkgs' is dirty
error: builder for '/nix/store/c0ss5a6ypkaq8njck0ybjln7bfmpxih1-python3.12-pyinotify-0.9.6.drv' failed with exit code 1;
       last 10 log lines:
       >            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       >   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
       >   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
       >   File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
       >   File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
       >   File "<frozen importlib._bootstrap_external>", line 995, in exec_module
       >   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
       >   File "/nix/store/wyynknrgd148f0g14faa4xxq9q3rbykn-python3.12-pyinotify-0.9.6/lib/python3.12/site-packages/pyinotify.py", line 71, in <module>
       >     import asyncore
       > ModuleNotFoundError: No module named 'asyncore'
       For full logs, run 'nix log /nix/store/c0ss5a6ypkaq8njck0ybjln7bfmpxih1-python3.12-pyinotify-0.9.6.drv'.
```

Testing the `pythonImportsCheck = [ pyinotify ]` against `release-24.05` (acbecbb607c70bddfc5938b61cedbff3cfb1fc39):
```
$ nix build .#python312Packages.pyinotify
error: builder for '/nix/store/q5m1hdazg071hhbqp8w6cj5s24m1582z-python3.12-pyinotify-0.9.6.drv' failed with exit code 1;
       last 10 log lines:
       >            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       >   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
       >   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
       >   File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
       >   File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
       >   File "<frozen importlib._bootstrap_external>", line 995, in exec_module
       >   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
       >   File "/nix/store/4zrypdc8pz1dp4d9qjqfb19rn9qspb3j-python3.12-pyinotify-0.9.6/lib/python3.12/site-packages/pyinotify.py", line 71, in <module>
       >     import asyncore
       > ModuleNotFoundError: No module named 'asyncore'
       For full logs, run 'nix log /nix/store/q5m1hdazg071hhbqp8w6cj5s24m1582z-python3.12-pyinotify-0.9.6.drv'.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
