### PR TITLE
cpeditor: file desktop exec path

### DIFF
--- a/pkgs/applications/editors/cpeditor/default.nix
+++ b/pkgs/applications/editors/cpeditor/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace src/Core/Runner.cpp --replace-fail "/bin/bash" "${runtimeShell}"
+    substituteInPlace dist/linux/cpeditor.desktop --replace-fail 'Exec=/usr/bin/cpeditor' "Exec=cpeditor"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

The original path `/usr/bin/cpeditor` is not exists under nix, it was placed in `$out/bin/` folder. The change remove absolute path according to #308324



