### PR TITLE
kicad: pin to python 3.11

### DIFF
--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -25,7 +25,7 @@
 , withNgspice ? !stdenv.isDarwin
 , libngspice
 , withScripting ? true
-, python3
+, python311
 , addons ? [ ]
 , debug ? false
 , sanitizeAddress ? false
@@ -122,10 +122,14 @@ let
     else versionsImport.${baseName}.libVersion.version;
 
   wxGTK = wxGTK32;
-  python = python3;
+  # KiCAD depends on wxWidgets, which uses distutils (removed in Python 3.12)
+  # See also: https://github.com/wxWidgets/Phoenix/issues/2104
+  # Eventually, wxWidgets should support Python 3.12: https://github.com/wxWidgets/Phoenix/issues/2553
+  # Until then, we use Python 3.11 which still includes distutils
+  python = python311;
   wxPython = python.pkgs.wxpython;
   addonPath = "addon.zip";
-  addonsDrvs = map (pkg: pkg.override { inherit addonPath python3; }) addons;
+  addonsDrvs = map (pkg: pkg.override { inherit addonPath python; }) addons;
 
   addonsJoined =
     runCommand "addonsJoined"
@@ -157,7 +161,7 @@ stdenv.mkDerivation rec {
 
   # Common libraries, referenced during runtime, via the wrapper.
   passthru.libraries = callPackages ./libraries.nix { inherit libSrc; };
-  passthru.callPackage = newScope { inherit addonPath python3; };
+  passthru.callPackage = newScope { inherit addonPath python; };
   base = callPackage ./base.nix {
     inherit stable testing baseName;
     inherit kicadSrc kicadVersion;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6504,7 +6504,7 @@ self: super: with self; {
   khanaa = callPackage ../development/python-modules/khanaa {};
 
   kicad = toPythonModule (pkgs.kicad.override {
-    python3 = python;
+    python311 = python;
   }).src;
 
   kinparse = callPackage ../development/python-modules/kinparse { };


### PR DESCRIPTION
## Description of changes

Similar to #325682 , this PR pins the Python version used by `kicad` to Python 3.11.

KiCAD depends on wxWidgets, which still uses `distutils` (removed in Python 3.12), see also https://github.com/wxWidgets/Phoenix/issues/2104 .

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
