### PR TITLE
azure-cli: add tests for cli with extensions/with mutable config

### DIFF
--- a/pkgs/tools/admin/azure-cli/default.nix
+++ b/pkgs/tools/admin/azure-cli/default.nix
@@ -4,6 +4,7 @@
 , stdenvNoCC
 , fetchurl
 , fetchFromGitHub
+, runCommand
 , installShellFiles
 , python3
 
@@ -347,6 +348,42 @@ py.pkgs.toPythonApplication (py.pkgs.buildAzureCliPackage rec {
   passthru = {
     inherit extensions;
     withExtensions = extensions: azure-cli.override { withExtensions = extensions; };
+    tests = {
+      # Test the package builds with some extensions configured, and the
+      # wanted extensions are recognized by the CLI and listed in the output.
+      azWithExtensions =
+        let
+          extensions = with azure-cli.extensions; [
+            aks-preview
+            azure-devops
+            rdbms-connect
+          ];
+          extensionNames = map (ext: ext.pname) extensions;
+          az = (azure-cli.withExtensions extensions);
+        in
+        runCommand "test-az-with-extensions" { } ''
+          export HOME=$TMPDIR
+          ${lib.getExe az} extension list > $out
+          for ext in ${lib.concatStringsSep " " extensionNames}; do
+            if ! grep -q $ext $out; then
+              echo "Extension $ext not found in list"
+              exit 1
+            fi
+          done
+        '';
+      # Test the package builds with mutable config.
+      # TODO: Maybe we can install an extension from local python wheel to
+      #       check mutable extension install still works.
+      azWithMutableConfig =
+        let
+          az = azure-cli.override { withImmutableConfig = false; };
+        in
+        runCommand "test-az-with-immutable-config" { } ''
+          export HOME=$TMPDIR
+          ${lib.getExe az} --version || exit 1
+          touch $out
+        '';
+    };
   };
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Adding some tests so I don't have to check things manually each time...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
