### PR TITLE
Fix pynitrokey dependencies on Python 3.12

### DIFF
--- a/pkgs/development/python-modules/pylink-square/default.nix
+++ b/pkgs/development/python-modules/pylink-square/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     hash = "sha256-rcM7gvUUfXN5pL9uIihzmOCXA7NKjiMt2GaQaGJxD9M=";
   };
 
-  propagatedBuildInputs = [
+  dependencies = [
     psutil
     six
   ];
@@ -40,6 +40,10 @@ buildPythonPackage rec {
     "test_cp15_register_write_success"
     "test_jlink_restarted"
     "test_set_log_file_success"
+    # AttributeError: 'TestLibrary' object has no attribute 'assertEquals'
+    "test_linux_glibc_unavailable"
+    "test_linux_dl_oserror"
+    "test_linux_dl_unavailable"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pyocd/default.nix
+++ b/pkgs/development/python-modules/pyocd/default.nix
@@ -17,7 +17,6 @@
   pylink-square,
   pyusb,
   pyyaml,
-  setuptools,
   setuptools-scm,
   typing-extensions,
   stdenv,
@@ -44,17 +43,11 @@ buildPythonPackage rec {
     })
   ];
 
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "libusb-package>=1.0,<2.0" ""
-  '';
+  pythonRemoveDeps = [ "libusb-package" ];
 
-  nativeBuildInputs = [
-    setuptools
-    setuptools-scm
-  ];
+  build-system = [ setuptools-scm ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     capstone_4
     cmsis-pack-manager
     colorama
@@ -73,6 +66,11 @@ buildPythonPackage rec {
   ] ++ lib.optionals (!stdenv.isLinux) [ hidapi ];
 
   pythonImportsCheck = [ "pyocd" ];
+
+  disabledTests = [
+    # AttributeError: 'not_called' is not a valid assertion
+    "test_transfer_err_not_flushed"
+  ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 


### PR DESCRIPTION
## Description of changes
Several dependencies of pynitrokey use testing functions that have been removed on Python 3.12.
* `pyocd`:
    * Disable tests which call removed `not_called` function.
    * Update `buildPythonPackage` args.
* `pylink-square`:
    * Disable tests that call removed `assertEquals` function.
    * Update `buildPythonPackage` args.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
