### PR TITLE
unar: 1.10.7 -> 1.10.8

### DIFF
--- a/pkgs/tools/archivers/unar/default.nix
+++ b/pkgs/tools/archivers/unar/default.nix
@@ -15,18 +15,29 @@
 
 stdenv.mkDerivation rec {
   pname = "unar";
-  version = "1.10.7";
+  version = "1.10.8";
 
-  src = fetchFromGitHub {
-    owner = "MacPaw";
-    # the unar repo contains a shallow clone of both XADMaster and universal-detector
-    repo = "unar";
-    rev = "v${version}";
-    sha256 = "0p846q1l66k3rnd512sncp26zpv411b8ahi145sghfcsz9w8abc4";
-  };
+  srcs = [
+    (fetchFromGitHub rec {
+      owner = "MacPaw";
+      repo = "XADMaster";
+      name = repo;
+      rev = "v${version}";
+      hash = "sha256-dmIyxpa3pq4ls4Grp0gy/6ZjcaA7rmobMn4h1inVgns=";
+    })
+    (fetchFromGitHub {
+      owner = "MacPaw";
+      repo = "universal-detector";
+      name = "UniversalDetector";
+      rev = "1.1";
+      hash = "sha256-6X1HtXhRuRwBOq5TAtL1I/vBBZokZOXIQ+oaRFigtv8=";
+    })
+  ];
 
-  postPatch =
-    if stdenv.hostPlatform.isDarwin then ''
+  postPatch = ''
+      substituteInPlace unar.m lsar.m \
+        --replace-fail "v1.10.7" "v${version}"
+    '' + (if stdenv.hostPlatform.isDarwin then ''
       substituteInPlace "./XADMaster.xcodeproj/project.pbxproj" \
         --replace "libstdc++.6.dylib" "libc++.1.dylib"
     '' else ''
@@ -40,7 +51,7 @@ stdenv.mkDerivation rec {
 
       # we need to build inside this directory as well, so we have to make it writeable
       chmod +w ../UniversalDetector -R
-    '';
+    '');
 
   buildInputs = [ bzip2 icu openssl wavpack zlib ] ++
     lib.optionals stdenv.hostPlatform.isLinux [ gnustep.base ] ++
@@ -63,7 +74,7 @@ stdenv.mkDerivation rec {
 
   dontConfigure = true;
 
-  sourceRoot = "${src.name}/XADMaster";
+  sourceRoot = "XADMaster";
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
## Description of changes

https://github.com/MacPaw/XADMaster/releases/tag/v1.10.8

The XADMaster repo saw a new release in late 2023, while the unar monorepo was left un-updated. This switches the build recipe to fetch the source repos directly.

The unar and lsar commands still report themselves as 1.10.7 due to a hardcoded version number in the makefile, this is easily patched if needed.

Tested on nixos only, need confirmation that it works on darwin (the universal-detector repo in particular has a few changes newer than the latest tag which only affect the xcode project file, and could be necessary).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
