### PR TITLE
buildNimPackage: adjust patch to avoid cyclic module dependency when cross-compiling for windows

### DIFF
--- a/pkgs/development/compilers/nim/default.nix
+++ b/pkgs/development/compilers/nim/default.nix
@@ -303,7 +303,7 @@ in {
         meta = nim'.meta // {
           description = nim'.meta.description
             + " (${targetPlatformConfig} wrapper)";
-          platforms = with lib.platforms; unix ++ genode;
+          platforms = with lib.platforms; unix ++ genode ++ windows;
         };
       });
 in {

--- a/pkgs/development/compilers/nim/nixbuild.patch
+++ b/pkgs/development/compilers/nim/nixbuild.patch
@@ -6,7 +6,7 @@ index f31ae94dd..debed9c07 100644
  
  import strutils
  
-+when defined(nixbuild):
++when defined(nixbuild) and not defined(windows):
 +  import os
 +
  type
@@ -16,7 +16,7 @@ index f31ae94dd..debed9c07 100644
        libCandidates(prefix & middle & suffix, dest)
    else:
      add(dest, s)
-+  when defined(nixbuild):
++  when defined(nixbuild) and not defined(windows):
 +    # Nix doesn't have a global library directory so
 +    # load libraries using an absolute path if one
 +    # can be derived from NIX_LDFLAGS.


### PR DESCRIPTION
## Description of changes

The `nixbuild` patch imports the `os` module in `dynlib.nim`. This breaks cross compilation for windows, due to a cyclic module dependecy.

When the `windows` symbol is defined, dynlib.nim is imported from oserrors.nim, which is imported by os, which is imported by dynlib...

I just added an `and not defined(windows)` to avoid this.
The dynamic linking stuff that `nixbuild.patch` introduces also does not make much sense when cross-compiling for windows, so I don't think we lose anything.

Here is a repo that reproduces the issue: https://gitlab.com/AsbjornOlling/reproduce-nim-windows-funk

(notice that `nix build '.#windows'` fails due to a cyclic module dependency when using upstream nixpkgs, but works and builds when using my fork).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
