### PR TITLE
python312Packages.craft-providers: 1.24.0 -> 1.24.1

### DIFF
--- a/pkgs/development/python-modules/craft-providers/default.nix
+++ b/pkgs/development/python-modules/craft-providers/default.nix
@@ -22,7 +22,7 @@
 
 buildPythonPackage rec {
   pname = "craft-providers";
-  version = "1.24.0";
+  version = "1.24.1";
 
   pyproject = true;
 
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     owner = "canonical";
     repo = "craft-providers";
     rev = "refs/tags/${version}";
-    hash = "sha256-CkaJ8taTsnBpCffe/Eu4/FGpMwKcg3yeLVAahCyEsII=";
+    hash = "sha256-l57Y+sdCD0/3sBK48N/3p3ns3o0LB4h9FQ35ha1AOV4=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/craft-store/default.nix
+++ b/pkgs/development/python-modules/craft-store/default.nix
@@ -51,6 +51,8 @@ buildPythonPackage rec {
     requests-toolbelt
   ];
 
+  pythonRelaxDeps = [ "macaroonbakery" ];
+
   pythonImportsCheck = [ "craft_store" ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/craft-store/default.nix
+++ b/pkgs/development/python-modules/craft-store/default.nix
@@ -10,7 +10,7 @@
   pydantic_1,
   pyyaml,
   pytestCheckHook,
-  keyring,
+  keyring-24,
   macaroonbakery,
   overrides,
   pyxdg,
@@ -42,7 +42,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    keyring
+    keyring-24
     macaroonbakery
     overrides
     pydantic_1

--- a/pkgs/development/python-modules/keyring-24/default.nix
+++ b/pkgs/development/python-modules/keyring-24/default.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  installShellFiles,
+  setuptools-scm,
+  shtab,
+  importlib-metadata,
+  jaraco-classes,
+  jaraco-context,
+  jaraco-functools,
+  jeepney,
+  secretstorage,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "keyring";
+  # nixpkgs-update: no auto update
+  version = "24.3.1";
+  pyproject = true;
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-wzJ7b/r8DovvvbWXys20ko/+XBIS92RfGG5tmVeomNs=";
+  };
+
+  nativeBuildInputs = [
+    installShellFiles
+    setuptools-scm
+    shtab
+  ];
+
+  propagatedBuildInputs =
+    [
+      jaraco-classes
+      jaraco-context
+      jaraco-functools
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      jeepney
+      secretstorage
+    ]
+    ++ lib.optionals (pythonOlder "3.12") [ importlib-metadata ];
+
+  postInstall = ''
+    installShellCompletion --cmd keyring \
+      --bash <($out/bin/keyring --print-completion bash) \
+      --zsh <($out/bin/keyring --print-completion zsh)
+  '';
+
+  pythonImportsCheck = [
+    "keyring"
+    "keyring.backend"
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTestPaths =
+    [ "tests/backends/test_macOS.py" ]
+    # These tests fail when sandboxing is enabled because they are unable to get a password from keychain.
+    ++ lib.optional stdenv.isDarwin "tests/test_multiprocess.py";
+
+  meta = with lib; {
+    description = "Store and access your passwords safely";
+    homepage = "https://github.com/jaraco/keyring";
+    changelog = "https://github.com/jaraco/keyring/blob/v${version}/NEWS.rst";
+    license = licenses.mit;
+    mainProgram = "keyring";
+    maintainers = with maintainers; [ jnsgruk ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6483,6 +6483,8 @@ self: super: with self; {
 
   keyring = callPackage ../development/python-modules/keyring { };
 
+  keyring-24 = callPackage ../development/python-modules/keyring-24 { };
+
   keyring-pass = callPackage ../development/python-modules/keyring-pass { };
 
   keyrings-cryptfile = callPackage ../development/python-modules/keyrings-cryptfile { };


### PR DESCRIPTION
## Description of changes

Supersedes #325601, which broke the build for several packages.

This change introduces `python3Packages.keyring-24`, which is pinned to the last version in the `24` series, because version 25 introduced breaking changes by removing a compatibility API that several packages still rely upon. 

The `keyring-24` package is a direct copy and paste of the existing `keyring` package, with the version and maintainer changed.

Additionally, this PR relaxes dependency versions in craft-store to get the build working again.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
