### PR TITLE
decklink: init at 14.0.1a2

### DIFF
--- a/nixos/modules/hardware/decklink.nix
+++ b/nixos/modules/hardware/decklink.nix
@@ -1,0 +1,18 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.hardware.decklink;
+  kernelPackages = config.boot.kernelPackages;
+in
+{
+  options.hardware.decklink.enable = lib.mkEnableOption "hardware support for the Blackmagic Design Decklink audio/video interfaces";
+
+  config = lib.mkIf cfg.enable {
+    # snd_blackmagic-io can cause issues with pipewire,
+    # so we do not enable it by default
+    boot.kernelModules = [ "blackmagic" "blackmagic-io" ];
+    boot.extraModulePackages = [ kernelPackages.decklink ];
+    systemd.packages = [ pkgs.blackmagic-desktop-video ];
+    systemd.services.DesktopVideoHelper.wantedBy = [ "multi-user.target" ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -59,6 +59,7 @@
   ./hardware/cpu/intel-microcode.nix
   ./hardware/cpu/intel-sgx.nix
   ./hardware/cpu/x86-msr.nix
+  ./hardware/decklink.nix
   ./hardware/device-tree.nix
   ./hardware/digitalbitbox.nix
   ./hardware/flipperzero.nix

--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -48,6 +48,8 @@
 , nlohmann_json
 , websocketpp
 , asio
+, decklinkSupport ? false
+, blackmagic-desktop-video
 , libdatachannel
 , libvpl
 , qrcodegencpp
@@ -165,6 +167,8 @@ stdenv.mkDerivation (finalAttrs: {
       xorg.libX11
       libvlc
       libGL
+    ] ++ optionals decklinkSupport [
+      blackmagic-desktop-video
     ];
   in ''
     # Remove libcef before patchelf, otherwise it will fail

--- a/pkgs/by-name/bl/blackmagic-desktop-video/package.nix
+++ b/pkgs/by-name/bl/blackmagic-desktop-video/package.nix
@@ -1,0 +1,108 @@
+{ stdenv
+, cacert
+, curl
+, runCommandLocal
+, lib
+, autoPatchelfHook
+, libcxx
+, libGL
+, gcc7
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "blackmagic-desktop-video";
+  version = "14.0.1a2";
+
+  buildInputs = [
+    autoPatchelfHook
+    libcxx
+    libGL
+    gcc7.cc.lib
+  ];
+
+  # yes, the below download function is an absolute mess.
+  # blame blackmagicdesign.
+  src =
+    let
+    # from the URL that the POST happens to, see browser console
+      DOWNLOADID = "d73a63095b6a4a189916fb2baa5a0ef3";
+    in
+    runCommandLocal "${finalAttrs.pname}-${lib.versions.majorMinor finalAttrs.version}-src.tar.gz"
+      {
+        outputHashMode = "recursive";
+        outputHashAlgo = "sha256";
+        outputHash = "sha256-jkKzUqfirvsVIefjWLx4NlqznXanWDtvhTsIThWFTo4=";
+
+        impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+
+        nativeBuildInputs = [ curl ];
+
+        # ENV VARS
+        SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+        inherit DOWNLOADID;
+        # from the URL the download page where you click the "only download" button is at
+        REFERID = "76801bc1d84147da9cb1a16e663ac33e";
+        SITEURL = "https://www.blackmagicdesign.com/api/register/us/download/${DOWNLOADID}";
+
+        USERAGENT = builtins.concatStringsSep " " [
+          "User-Agent: Mozilla/5.0 (X11; Linux ${stdenv.hostPlatform.linuxArch})"
+          "AppleWebKit/537.36 (KHTML, like Gecko)"
+          "Chrome/77.0.3865.75"
+          "Safari/537.36"
+        ];
+
+        REQJSON = builtins.toJSON {
+          "country" = "nl";
+          "downloadOnly" = true;
+          "platform" = "Linux";
+          "policy" = true;
+        };
+
+      } ''
+      RESOLVEURL=$(curl \
+        -s \
+        -H "$USERAGENT" \
+        -H 'Content-Type: application/json;charset=UTF-8' \
+        -H "Referer: https://www.blackmagicdesign.com/support/download/$REFERID/Linux" \
+        --data-ascii "$REQJSON" \
+        --compressed \
+        "$SITEURL")
+      curl \
+        --retry 3 --retry-delay 3 \
+        --compressed \
+        "$RESOLVEURL" \
+        > $out
+    '';
+
+  postUnpack =
+    let
+      arch = stdenv.hostPlatform.uname.processor;
+    in
+    ''
+      tar xf Blackmagic_Desktop_Video_Linux_${lib.head (lib.splitString "a" finalAttrs.version)}/other/${arch}/desktopvideo-${finalAttrs.version}-${arch}.tar.gz
+      unpacked=$NIX_BUILD_TOP/desktopvideo-${finalAttrs.version}-${stdenv.hostPlatform.uname.processor}
+    '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,share/doc,lib/systemd/system}
+    cp -r $unpacked/usr/share/doc/desktopvideo $out/share/doc
+    cp $unpacked/usr/lib/*.so $out/lib
+    cp $unpacked/usr/lib/systemd/system/DesktopVideoHelper.service $out/lib/systemd/system
+    cp $unpacked/usr/lib/blackmagic/DesktopVideo/DesktopVideoHelper $out/bin/
+    substituteInPlace $out/lib/systemd/system/DesktopVideoHelper.service \
+      --replace-fail "/usr/lib/blackmagic/DesktopVideo/DesktopVideoHelper" "$out/bin/DesktopVideoHelper"
+    runHook postInstall
+  '';
+
+  # need to tell the DesktopVideoHelper where to find its own library
+  appendRunpaths = [ "${placeholder "out"}/lib" ];
+
+  meta = with lib; {
+    homepage = "https://www.blackmagicdesign.com/support/family/capture-and-playback";
+    maintainers = [ maintainers.naxdy ];
+    license = licenses.unfree;
+    description = "Supporting applications for Blackmagic Decklink. Doesn't include the desktop applications, only the helper required to make the driver work";
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/os-specific/linux/decklink/default.nix
+++ b/pkgs/os-specific/linux/decklink/default.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, lib
+, blackmagic-desktop-video
+, kernel
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "decklink";
+
+  # the download is a horrible curl mess. we reuse it between the kernel module
+  # and desktop service, since the version of the two have to match anyways.
+  # See pkgs/by-name/bl/blackmagic-desktop-video/package.nix for more.
+  inherit (blackmagic-desktop-video) src version;
+
+  KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+  INSTALL_MOD_PATH = placeholder "out";
+
+  nativeBuildInputs =  kernel.moduleBuildDependencies;
+
+  postUnpack = let
+    arch = stdenv.hostPlatform.uname.processor;
+  in ''
+    tar xf Blackmagic_Desktop_Video_Linux_${lib.head (lib.splitString "a" finalAttrs.version)}/other/${arch}/desktopvideo-${finalAttrs.version}-${arch}.tar.gz
+    moduleRoot=$NIX_BUILD_TOP/desktopvideo-${finalAttrs.version}-${stdenv.hostPlatform.uname.processor}/usr/src
+    sourceRoot=$moduleRoot
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    make -C $moduleRoot/blackmagic-${finalAttrs.version} -j$NIX_BUILD_CORES
+    make -C $moduleRoot/blackmagic-io-${finalAttrs.version} -j$NIX_BUILD_CORES
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    make -C $KERNELDIR M=$moduleRoot/blackmagic-${finalAttrs.version} modules_install
+    make -C $KERNELDIR M=$moduleRoot/blackmagic-io-${finalAttrs.version} modules_install
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.blackmagicdesign.com/support/family/capture-and-playback";
+    maintainers = [ maintainers.naxdy ];
+    license = licenses.unfree;
+    description = "Kernel module for the Blackmagic Design Decklink cards";
+    sourceProvenance = with lib.sourceTypes; [ binaryFirmware ];
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -134,7 +134,6 @@ mapAliases ({
   bitwarden = bitwarden-desktop; # Added 2024-02-25
   bitwig-studio1 = throw "bitwig-studio1 has been removed, you can upgrade to 'bitwig-studio'"; # Added 2023-01-03
   bitwig-studio2 = throw "bitwig-studio2 has been removed, you can upgrade to 'bitwig-studio'"; # Added 2023-01-03
-  blackmagic-desktop-video = throw "blackmagic-desktop-video has been due to being unmaintained"; # Added 2024-07-02
   blender-with-packages = args:
     lib.warn "blender-with-packages is deprecated in favor of blender.withPackages, e.g. `blender.withPackages(ps: [ ps.foobar ])`"
       (blender.withPackages (_: args.packages)).overrideAttrs

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -343,7 +343,7 @@ in {
 
     dddvb = callPackage ../os-specific/linux/dddvb { };
 
-    decklink = throw "The decklink kernel module has been removed due to being unmaintained"; # Module removed on 2024-07-02
+    decklink = callPackage ../os-specific/linux/decklink { };
 
     digimend = callPackage ../os-specific/linux/digimend { };
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Taking over as maintainer after hexchen's departure (see https://github.com/NixOS/nixpkgs/pull/324101 for context)

Also updated to latest version. PR still pending local tests on actual hardware on my side, but so far everything builds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
