### PR TITLE
ente-web: init at 0.9.5

### DIFF
--- a/pkgs/by-name/en/ente-web/package.nix
+++ b/pkgs/by-name/en/ente-web/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchYarnDeps,
+  nodejs,
+  yarnConfigHook,
+  yarnBuildHook,
+  extraBuildEnv ? { },
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ente-web";
+  version = "0.9.16";
+
+  src = fetchFromGitHub {
+    owner = "ente-io";
+    repo = "ente";
+    sparseCheckout = [ "web" ];
+    rev = "refs/tags/photos-v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-DqfUUXY79CndEqPT8TR4PasLtaSCtqZaV2kp10Vu4PQ=";
+  };
+  sourceRoot = "${finalAttrs.src.name}/web";
+
+  offlineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/web/yarn.lock";
+    hash = "sha256-tgFh8Av1Wl77N4hR2Y5TQp9lEH4ZCQnCIWMPmlZBlV4=";
+  };
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    yarnBuildHook
+    nodejs
+  ];
+
+  # See: https://github.com/ente-io/ente/blob/main/web/apps/photos/.env
+  env = extraBuildEnv;
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r apps/photos/out $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Web client for Ente Photos";
+    homepage = "https://ente.io/";
+    changelog = "https://github.com/ente-io/ente/releases";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [
+      surfaceflinger
+      pinpox
+    ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes

Part of: https://github.com/NixOS/nixpkgs/issues/292641

Added the web frontend for [ente](https://ente.io). I have packaged the backend in a [previous PR](https://github.com/NixOS/nixpkgs/pull/325659)

~The package works as expected, but is dependant on the new yarn hooks in https://github.com/NixOS/nixpkgs/pull/318015 and therefore marked as draft PR.~

~When https://github.com/NixOS/nixpkgs/pull/318015 gets merged, I will rebase my PR against nixpkgs master and remove the draft bit.~

EDIT: rebased against master.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
