### PR TITLE
nixos/nginx-sso: allow using file-based secrets

### DIFF
--- a/nixos/modules/services/security/nginx-sso.nix
+++ b/nixos/modules/services/security/nginx-sso.nix
@@ -1,11 +1,11 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, utils, ... }:
 
 with lib;
 
 let
   cfg = config.services.nginx.sso;
   format = pkgs.formats.yaml { };
-  configYml = format.generate "nginx-sso.yml" cfg.configuration;
+  configPath = "/var/lib/nginx-sso/config.yaml";
 in {
   options.services.nginx.sso = {
     enable = mkEnableOption "nginx-sso service";
@@ -20,7 +20,9 @@ in {
           listen = { addr = "127.0.0.1"; port = 8080; };
 
           providers.token.tokens = {
-            myuser = "MyToken";
+            myuser = {
+              _secret = "/path/to/secret/token.txt"; # File content should be the secret token
+            };
           };
 
           acl = {
@@ -37,6 +39,11 @@ in {
         nginx-sso configuration
         ([documentation](https://github.com/Luzifer/nginx-sso/wiki/Main-Configuration))
         as a Nix attribute set.
+
+        Options containing secret data should be set to an attribute set
+        with the singleton attribute `_secret` - a string value set to the path
+        to the file containing the secret value which should be used in the
+        configuration. This file must be readable by `nginx-sso`.
       '';
     };
   };
@@ -47,14 +54,29 @@ in {
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
+        StateDirectory = "nginx-sso";
+        WorkingDirectory = "/var/lib/nginx-sso";
+        ExecStartPre = pkgs.writeShellScript "merge-nginx-sso-config" ''
+          rm -f '${configPath}'
+          # Relies on YAML being a superset of JSON
+          ${utils.genJqSecretsReplacementSnippet cfg.configuration configPath}
+        '';
         ExecStart = ''
           ${lib.getExe cfg.package} \
-            --config ${configYml} \
+            --config ${configPath} \
             --frontend-dir ${lib.getBin cfg.package}/share/frontend
         '';
         Restart = "always";
-        DynamicUser = true;
+        User = "nginx-sso";
+        Group = "nginx-sso";
       };
     };
+
+    users.users.nginx-sso = {
+      isSystemUser = true;
+      group = "nginx-sso";
+    };
+
+    users.groups.nginx-sso = { };
   };
 }

--- a/nixos/modules/services/security/nginx-sso.nix
+++ b/nixos/modules/services/security/nginx-sso.nix
@@ -5,7 +5,8 @@ with lib;
 let
   cfg = config.services.nginx.sso;
   pkg = getBin cfg.package;
-  configYml = pkgs.writeText "nginx-sso.yml" (builtins.toJSON cfg.configuration);
+  format = pkgs.formats.yaml { };
+  configYml = format.generate "nginx-sso.yml" cfg.configuration;
 in {
   options.services.nginx.sso = {
     enable = mkEnableOption "nginx-sso service";
@@ -13,7 +14,7 @@ in {
     package = mkPackageOption pkgs "nginx-sso" { };
 
     configuration = mkOption {
-      type = types.attrsOf types.unspecified;
+      type = format.type;
       default = {};
       example = literalExpression ''
         {

--- a/nixos/modules/services/security/nginx-sso.nix
+++ b/nixos/modules/services/security/nginx-sso.nix
@@ -4,7 +4,6 @@ with lib;
 
 let
   cfg = config.services.nginx.sso;
-  pkg = getBin cfg.package;
   format = pkgs.formats.yaml { };
   configYml = format.generate "nginx-sso.yml" cfg.configuration;
 in {
@@ -49,9 +48,9 @@ in {
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         ExecStart = ''
-          ${pkg}/bin/nginx-sso \
+          ${lib.getExe cfg.package} \
             --config ${configYml} \
-            --frontend-dir ${pkg}/share/frontend
+            --frontend-dir ${lib.getBin cfg.package}/share/frontend
         '';
         Restart = "always";
         DynamicUser = true;

--- a/nixos/tests/nginx-sso.nix
+++ b/nixos/tests/nginx-sso.nix
@@ -11,7 +11,9 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         listen = { addr = "127.0.0.1"; port = 8080; };
 
         providers.token.tokens = {
-          myuser = "MyToken";
+          myuser = {
+            _secret = pkgs.writeText "secret-token" "MyToken";
+          };
         };
 
         acl = {


### PR DESCRIPTION
## Description of changes

> This was living for a *long* time in my config, I finally decided to upstream it.

Also some very simple cleanups to the module, as it is somewhat showing its age.

I'd love to know if there is a better way to do this nowadays, I literally wrote this when I'd just started using NixOS three years ago.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
