### PR TITLE
nodejs: disable JS test suite on Darwin

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -133,13 +133,15 @@ let
     # Some dependencies required for tools/doc/node_modules (and therefore
     # test-addons, jstest and others) target are not included in the tarball.
     # Run test targets that do not require network access.
-    checkTarget = lib.concatStringsSep " " [
+    checkTarget = lib.concatStringsSep " " ([
       "build-js-native-api-tests"
       "build-node-api-tests"
       "tooltest"
       "cctest"
+    ] ++ lib.optionals (!stdenv.isDarwin) [
+      # TODO: JS test suite is too flaky on Darwin; revisit at a later date.
       "test-ci-js"
-    ];
+    ]);
 
     checkFlags = [
       # Do not create __pycache__ when running tests.


### PR DESCRIPTION
## Description of changes

This was recently enabled in #313982. It seems to be much too flaky on Darwin currently, especially x86; see:

* <https://hydra.nixos.org/build/264860513/nixlog/8>
* <https://hydra.nixos.org/build/264956149/nixlog/3>
* <https://hydra.nixos.org/build/265094929/nixlog/3>
* <https://hydra.nixos.org/build/264901296/nixlog/3>

Disable these tests on macOS for now as the broken Node.js package is holding up a lot of builds.

Fixes: b26563aae2a1fce011ac52e28ff23a460866e82f

@aduh95 Unfortunately, I lack the expertise to figure out how to get these tests working more reliably on macOS, but if you have any idea what’s going on I’d be happy to work with you to try and get them functioning properly once this is no longer blocking a bunch of builds. There’s a [community builder box](https://nix-community.org/community-builder/) if you don’t have any Mac hardware available, but I understand if you don’t want to spend time trying to fix this on an OS you don’t use, too.

@vcunat I’ve targeted `master` on your prior suggestion, but let me know if you think this is too heavy; it would be unfortunate to have a broken Node.js for another entire staging cycle since a lot of things pull it in, but I don’t want to overload the builders. It could potentially be conditionalized further to `x86_64-darwin` for now as we lucked out with only `nodejs_18` failing on `aarch64-darwin`. I’m also wondering if it might make sense to roll https://github.com/NixOS/nixpkgs/pull/325620, https://github.com/NixOS/nixpkgs/pull/325616, and https://github.com/NixOS/nixpkgs/pull/325621 into this, as they’re ~~high‐severity~~ (only on Windows actually) Node.js security updates that would cause the same number of builds on Darwin anyway (but it’d cause Linux rebuilds too, which this shouldn’t).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
