### PR TITLE
[Backport release-24.05] profiles/qemu_guest: add virtio_gpu to initrd

### DIFF
--- a/nixos/modules/profiles/qemu-guest.nix
+++ b/nixos/modules/profiles/qemu-guest.nix
@@ -5,7 +5,7 @@
 
 {
   boot.initrd.availableKernelModules = [ "virtio_net" "virtio_pci" "virtio_mmio" "virtio_blk" "virtio_scsi" "9p" "9pnet_virtio" ];
-  boot.initrd.kernelModules = [ "virtio_balloon" "virtio_console" "virtio_rng" ];
+  boot.initrd.kernelModules = [ "virtio_balloon" "virtio_console" "virtio_rng" "virtio_gpu" ];
 
   boot.initrd.postDeviceCommands = lib.mkIf (!config.boot.initrd.systemd.enable)
     ''


### PR DESCRIPTION
(cherry picked from commit 66b896630df0a79149aea3fe6fae16cee3dd646f)

Manual backport of #325377.