### PR TITLE
dcm2niix: wrap with pigz binary for parallel output compression

### DIFF
--- a/pkgs/by-name/dc/dcm2niix/package.nix
+++ b/pkgs/by-name/dc/dcm2niix/package.nix
@@ -2,13 +2,16 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  makeBinaryWrapper,
   replaceVars,
   cmake,
   openjpeg,
+  pigz,
   yaml-cpp,
   batchVersion ? false,
   withJpegLs ? true,
   withOpenJpeg ? true,
+  withPigz ? true,
   withCloudflareZlib ? true,
 }:
 
@@ -39,7 +42,11 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    makeBinaryWrapper
+  ];
+
   buildInputs =
     lib.optionals batchVersion [ yaml-cpp ]
     ++ lib.optionals withOpenJpeg [
@@ -62,6 +69,10 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals withCloudflareZlib [
       "-DZLIB_IMPLEMENTATION=Cloudflare"
     ];
+
+  postInstall = lib.optionalString withPigz ''
+    wrapProgram $out/bin/dcm2niix --prefix PATH : "${lib.makeBinPath [ pigz ]}"
+  '';
 
   meta = {
     description = "DICOM to NIfTI converter";


### PR DESCRIPTION
## Description of changes

`dcm2niix` can optionally use the `pigz` binary for parallel compression, so give it access to this program via `makeBinaryWrapper`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
