### PR TITLE
python312Packages.binwalk: support Python 3.12

### DIFF
--- a/pkgs/development/python-modules/binwalk/default.nix
+++ b/pkgs/development/python-modules/binwalk/default.nix
@@ -44,6 +44,12 @@ buildPythonPackage rec {
       includes = [ "testing/tests/test_firmware_zip.py" ];
       revert = true;
     })
+    # binwalk incompatible with Python 3.12
+    # https://github.com/ReFirmLabs/binwalk/pull/668
+    (fetchpatch {
+      url = "https://github.com/ReFirmLabs/binwalk/commit/3e5c6887e840643fdbe7358de4bb31d726d0ce1b.patch";
+      sha256 = "sha256-QhPIC2BKYeeCn2dNm9NeWpyUcIL1S+C/B3F55/nxrjw=";
+    })
     ./use-pytest.patch
   ];
 

--- a/pkgs/development/python-modules/binwalk/default.nix
+++ b/pkgs/development/python-modules/binwalk/default.nix
@@ -16,10 +16,10 @@
   sasquatch,
   squashfsTools,
   matplotlib,
-  nose,
   pycrypto,
   pyqtgraph,
   pyqt5,
+  pytestCheckHook,
   visualizationSupport ? false,
 }:
 
@@ -44,6 +44,7 @@ buildPythonPackage rec {
       includes = [ "testing/tests/test_firmware_zip.py" ];
       revert = true;
     })
+    ./use-pytest.patch
   ];
 
   propagatedBuildInputs =
@@ -80,7 +81,9 @@ buildPythonPackage rec {
     HOME=$(mktemp -d)
   '';
 
-  nativeCheckInputs = [ nose ];
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTestPaths = [ "testing/test_generator.py" ];
 
   pythonImportsCheck = [ "binwalk" ];
 

--- a/pkgs/development/python-modules/binwalk/use-pytest.patch
+++ b/pkgs/development/python-modules/binwalk/use-pytest.patch
@@ -1,0 +1,248 @@
+diff --git a/testing/test_generator.py b/testing/test_generator.py
+index 972237a..51b7482 100755
+--- a/testing/test_generator.py
++++ b/testing/test_generator.py
+@@ -10,7 +10,6 @@ import binwalk
+ test_script_template = """
+ import os
+ import binwalk
+-from nose.tools import eq_, ok_
+ 
+ def test_%s():
+     '''
+@@ -30,15 +29,15 @@ def test_%s():
+                                quiet=True)
+ 
+     # Test number of modules used
+-    eq_(len(scan_result), 1)
++    assert len(scan_result) == 1
+ 
+     # Test number of results for that module
+-    eq_(len(scan_result[0].results), len(expected_results))
++    assert len(scan_result[0].results) == len(expected_results)
+ 
+     # Test result-description
+     for i in range(0, len(scan_result[0].results)):
+-        eq_(scan_result[0].results[i].offset, expected_results[i][0])
+-        eq_(scan_result[0].results[i].description, expected_results[i][1])
++        assert scan_result[0].results[i].offset == expected_results[i][0]
++        assert scan_result[0].results[i].description == expected_results[i][1]
+ """
+ 
+ try:
+diff --git a/testing/tests/test_dirtraversal.py b/testing/tests/test_dirtraversal.py
+index 66ef003..888353f 100644
+--- a/testing/tests/test_dirtraversal.py
++++ b/testing/tests/test_dirtraversal.py
+@@ -1,6 +1,5 @@
+ import os
+ import binwalk
+-from nose.tools import eq_, ok_, assert_equal, assert_not_equal
+ 
+ def test_dirtraversal():
+     '''
+@@ -27,7 +26,7 @@ def test_dirtraversal():
+     # good symlinks have not been sanitized.
+     for symlink in bad_symlink_file_list:
+         linktarget = os.path.realpath(os.path.join(output_directory, symlink))
+-        assert_equal(linktarget, os.devnull)
++        assert linktarget == os.devnull
+     for symlink in good_symlink_file_list:
+         linktarget = os.path.realpath(os.path.join(output_directory, symlink))
+-        assert_not_equal(linktarget, os.devnull)
++        assert linktarget != os.devnull
+diff --git a/testing/tests/test_firmware_cpio.py b/testing/tests/test_firmware_cpio.py
+index ad8f38a..677ddb7 100644
+--- a/testing/tests/test_firmware_cpio.py
++++ b/testing/tests/test_firmware_cpio.py
+@@ -1,7 +1,6 @@
+ 
+ import os
+ import binwalk
+-from nose.tools import eq_, ok_
+ 
+ def test_firmware_cpio():
+     '''
+@@ -18,14 +17,14 @@ def test_firmware_cpio():
+                                quiet=True)
+ 
+     # Test number of modules used
+-    eq_(len(scan_result), 1)
++    assert len(scan_result) == 1
+ 
+     # Make sure we got some results
+-    ok_(len(scan_result[0].results) > 0)
++    assert len(scan_result[0].results) > 0
+ 
+     # First result should be at offset 0
+-    eq_(scan_result[0].results[0].offset, 0)
++    assert scan_result[0].results[0].offset == 0
+ 
+     # Make sure the only thing found were cpio archive entries
+     for result in scan_result[0].results:
+-        ok_(result.description.startswith("ASCII cpio archive"))
++        assert result.description.startswith("ASCII cpio archive")
+diff --git a/testing/tests/test_firmware_gzip.py b/testing/tests/test_firmware_gzip.py
+index 1d3a826..34cb659 100644
+--- a/testing/tests/test_firmware_gzip.py
++++ b/testing/tests/test_firmware_gzip.py
+@@ -1,7 +1,6 @@
+ 
+ import os
+ import binwalk
+-from nose.tools import eq_, ok_
+ 
+ def test_firmware_gzip():
+     '''
+@@ -17,13 +16,13 @@ def test_firmware_gzip():
+                                quiet=True)
+ 
+     # Test number of modules used
+-    eq_(len(scan_result), 1)
++    assert len(scan_result) == 1
+ 
+     # There should be only one result
+-    eq_(len(scan_result[0].results), 1)
++    assert len(scan_result[0].results) == 1
+ 
+     # That result should be at offset 0
+-    eq_(scan_result[0].results[0].offset, 0)
++    assert scan_result[0].results[0].offset == 0
+ 
+     # That result should be a gzip file
+-    ok_(scan_result[0].results[0].description.startswith("gzip compressed data"))
++    assert scan_result[0].results[0].description.startswith("gzip compressed data")
+diff --git a/testing/tests/test_firmware_jffs2.py b/testing/tests/test_firmware_jffs2.py
+index 09c1de2..d483474 100644
+--- a/testing/tests/test_firmware_jffs2.py
++++ b/testing/tests/test_firmware_jffs2.py
+@@ -1,7 +1,6 @@
+ 
+ import os
+ import binwalk
+-from nose.tools import eq_, ok_
+ 
+ def test_firmware_jffs2():
+     '''
+@@ -18,25 +17,25 @@ def test_firmware_jffs2():
+                                quiet=True)
+ 
+     # Test number of modules used
+-    eq_(len(scan_result), 1)
++    assert len(scan_result) == 1
+ 
+     # Test number of results for that module, should be more than one
+-    ok_(len(scan_result[0].results) > 1)
++    assert len(scan_result[0].results) > 1
+ 
+     first_result = scan_result[0].results[0]
+ 
+     # Check the offset of the first result
+-    eq_(first_result.offset, 0)
++    assert first_result.offset == 0
+ 
+     # Make sure we found the jffs file system
+-    ok_(first_result.description.startswith("JFFS2 filesystem"))
++    assert first_result.description.startswith("JFFS2 filesystem")
+ 
+     # Check to make sure the first result was displayed
+-    ok_(first_result.display == True)
++    assert first_result.display == True
+ 
+     # Make sure we only found jffs2 file system entries
+     # and that nothing but the first entry was displayed
+     for result in scan_result[0].results[1:]:
+-        ok_(result.description.startswith("JFFS2 filesystem"))
+-        ok_(result.display == False)
++        assert result.description.startswith("JFFS2 filesystem")
++        assert result.display == False
+ 
+diff --git a/testing/tests/test_firmware_squashfs.py b/testing/tests/test_firmware_squashfs.py
+index f496103..fd877ac 100644
+--- a/testing/tests/test_firmware_squashfs.py
++++ b/testing/tests/test_firmware_squashfs.py
+@@ -1,7 +1,6 @@
+ 
+ import os
+ import binwalk
+-from nose.tools import eq_, ok_
+ 
+ def test_firmware_squashfs():
+     '''
+@@ -18,13 +17,13 @@ def test_firmware_squashfs():
+                                quiet=True)
+ 
+     # Test number of modules used
+-    eq_(len(scan_result), 1)
++    assert len(scan_result) == 1
+ 
+     # There should be only one result
+-    eq_(len(scan_result[0].results), 1)
++    assert len(scan_result[0].results) == 1
+ 
+     # That result should be at offset zero
+-    eq_(scan_result[0].results[0].offset, 0)
++    assert scan_result[0].results[0].offset == 0
+ 
+     # That result should be a squashfs file system
+-    ok_(scan_result[0].results[0].description.startswith("Squashfs filesystem"))
++    assert scan_result[0].results[0].description.startswith("Squashfs filesystem")
+diff --git a/testing/tests/test_firmware_zip.py b/testing/tests/test_firmware_zip.py
+index 58b486c..ebcd7e4 100644
+--- a/testing/tests/test_firmware_zip.py
++++ b/testing/tests/test_firmware_zip.py
+@@ -1,7 +1,6 @@
+ 
+ import os
+ import binwalk
+-from nose.tools import eq_, ok_
+ 
+ def test_firmware_zip():
+     '''
+@@ -23,12 +22,12 @@ def test_firmware_zip():
+                                quiet=True)
+ 
+     # Test number of modules used
+-    eq_(len(scan_result), 1)
++    assert len(scan_result) == 1
+ 
+     # Test number of results for that module
+-    eq_(len(scan_result[0].results), len(expected_results))
++    assert len(scan_result[0].results) == len(expected_results)
+ 
+     # Test result-description
+     for i in range(0, len(scan_result[0].results)):
+-        eq_(scan_result[0].results[i].offset, expected_results[i][0])
+-        eq_(scan_result[0].results[i].description, expected_results[i][1])
++        assert scan_result[0].results[i].offset == expected_results[i][0]
++        assert scan_result[0].results[i].description == expected_results[i][1]
+diff --git a/testing/tests/test_lzma.py b/testing/tests/test_lzma.py
+index e9f4f1c..a7c34d0 100644
+--- a/testing/tests/test_lzma.py
++++ b/testing/tests/test_lzma.py
+@@ -1,7 +1,6 @@
+ 
+ import os
+ import binwalk
+-from nose.tools import eq_, ok_
+ 
+ def test_lzma():
+     '''
+@@ -19,13 +18,13 @@ def test_lzma():
+                                quiet=True)
+ 
+     # Test number of modules used
+-    eq_(len(scan_result), 1)
++    assert len(scan_result) == 1
+ 
+     # There should be only one result
+-    eq_(len(scan_result[0].results), 1)
++    assert len(scan_result[0].results) == 1
+ 
+     # That result should be at offset 0
+-    eq_(scan_result[0].results[0].offset, 0)
++    assert scan_result[0].results[0].offset == 0
+ 
+     # That result should be an LZMA file
+-    ok_(scan_result[0].results[0].description == expected_result)
++    assert scan_result[0].results[0].description == expected_result


### PR DESCRIPTION
## Description of changes
partially replaces https://github.com/NixOS/nixpkgs/pull/325623

However this PR reveals that binwalk's tests fail under Python 3.12 which makes it sound like we should pin to Python 3.11.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
