### PR TITLE
thefuck: fix build, modernise, reformat, move to by-name

### DIFF
--- a/pkgs/by-name/th/thefuck/package.nix
+++ b/pkgs/by-name/th/thefuck/package.nix
@@ -6,12 +6,12 @@ python311Packages.buildPythonApplication rec {
 
   src = fetchFromGitHub {
     owner = "nvbn";
-    repo = pname;
-    rev = version;
-    sha256 = "sha256-bRCy95owBJaxoyCNQF6gEENoxCkmorhyKzZgU1dQN6I=";
+    repo = "thefuck";
+    rev = "refs/tags/${version}";
+    hash = "sha256-bRCy95owBJaxoyCNQF6gEENoxCkmorhyKzZgU1dQN6I=";
   };
 
-  propagatedBuildInputs = with python311Packages; [ colorama decorator psutil pyte six ];
+  dependencies = with python311Packages; [ colorama decorator psutil pyte six ];
 
   nativeCheckInputs = [ go ] ++ (with python311Packages; [ mock pytest7CheckHook pytest-mock ]);
 
@@ -32,10 +32,10 @@ python311Packages.buildPythonApplication rec {
     "test_when_successfully_configured"
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/nvbn/thefuck";
     description = "Magnificent app which corrects your previous console command";
-    license = licenses.mit;
-    maintainers = with maintainers; [ marcusramberg ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ marcusramberg ];
   };
 }

--- a/pkgs/by-name/th/thefuck/package.nix
+++ b/pkgs/by-name/th/thefuck/package.nix
@@ -1,9 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, buildPythonApplication
-, colorama, decorator, psutil, pyte, six
-, go, mock, pytest7CheckHook, pytest-mock
-}:
+{ lib, stdenv, fetchFromGitHub, python3Packages, go }:
 
-buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "thefuck";
   version = "3.32";
 
@@ -14,9 +11,9 @@ buildPythonApplication rec {
     sha256 = "sha256-bRCy95owBJaxoyCNQF6gEENoxCkmorhyKzZgU1dQN6I=";
   };
 
-  propagatedBuildInputs = [ colorama decorator psutil pyte six ];
+  propagatedBuildInputs = with python3Packages; [ colorama decorator psutil pyte six ];
 
-  nativeCheckInputs = [ go mock pytest7CheckHook pytest-mock ];
+  nativeCheckInputs = [ go ] ++ (with python3Packages; [ mock pytest7CheckHook pytest-mock ]);
 
   disabledTests = lib.optionals stdenv.isDarwin [
     "test_settings_defaults"

--- a/pkgs/by-name/th/thefuck/package.nix
+++ b/pkgs/by-name/th/thefuck/package.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, fetchFromGitHub, python311Packages, go }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  python311Packages,
+  go,
+}:
 
 python311Packages.buildPythonApplication rec {
   pname = "thefuck";
@@ -11,9 +17,21 @@ python311Packages.buildPythonApplication rec {
     hash = "sha256-bRCy95owBJaxoyCNQF6gEENoxCkmorhyKzZgU1dQN6I=";
   };
 
-  dependencies = with python311Packages; [ colorama decorator psutil pyte six ];
+  dependencies = with python311Packages; [
+    colorama
+    decorator
+    psutil
+    pyte
+    six
+  ];
 
-  nativeCheckInputs = [ go ] ++ (with python311Packages; [ mock pytest7CheckHook pytest-mock ]);
+  nativeCheckInputs =
+    [ go ]
+    ++ (with python311Packages; [
+      mock
+      pytest7CheckHook
+      pytest-mock
+    ]);
 
   disabledTests = lib.optionals stdenv.isDarwin [
     "test_settings_defaults"

--- a/pkgs/by-name/th/thefuck/package.nix
+++ b/pkgs/by-name/th/thefuck/package.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, python3Packages, go }:
+{ lib, stdenv, fetchFromGitHub, python311Packages, go }:
 
-python3Packages.buildPythonApplication rec {
+python311Packages.buildPythonApplication rec {
   pname = "thefuck";
   version = "3.32";
 
@@ -11,9 +11,9 @@ python3Packages.buildPythonApplication rec {
     sha256 = "sha256-bRCy95owBJaxoyCNQF6gEENoxCkmorhyKzZgU1dQN6I=";
   };
 
-  propagatedBuildInputs = with python3Packages; [ colorama decorator psutil pyte six ];
+  propagatedBuildInputs = with python311Packages; [ colorama decorator psutil pyte six ];
 
-  nativeCheckInputs = [ go ] ++ (with python3Packages; [ mock pytest7CheckHook pytest-mock ]);
+  nativeCheckInputs = [ go ] ++ (with python311Packages; [ mock pytest7CheckHook pytest-mock ]);
 
   disabledTests = lib.optionals stdenv.isDarwin [
     "test_settings_defaults"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13392,8 +13392,6 @@ with pkgs;
     themes = recurseIntoAttrs (getPackagesWithPrefix "theme");
   };
 
-  thefuck = python3Packages.callPackage ../tools/misc/thefuck { };
-
   theme-sh = callPackage ../tools/misc/theme-sh { };
 
   thiefmd = callPackage ../applications/editors/thiefmd { };


### PR DESCRIPTION

## Description of changes

- **thefuck: move to by-name**
- **thefuck: pin to python 3.11 to fix build**
- **thefuck: modernise**
- **thefuck: nixfmt-rfc-style**

Fixes #325799
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
