### PR TITLE
python312Packages.capstone: enable, add distutils patch

### DIFF
--- a/pkgs/development/python-modules/capstone/default.nix
+++ b/pkgs/development/python-modules/capstone/default.nix
@@ -4,19 +4,24 @@
   capstone,
   stdenv,
   setuptools,
-  pythonAtLeast,
+  fetchpatch,
 }:
 
 buildPythonPackage rec {
   pname = "capstone";
   version = lib.getVersion capstone;
-  format = "setuptools";
-
-  # distutils usage
-  disabled = pythonAtLeast "3.12";
 
   src = capstone.src;
   sourceRoot = "${src.name}/bindings/python";
+  patches = [
+    # Drop distutils in python binding (PR 2271)
+    (fetchpatch {
+      name = "drop-distutils-in-python-binding.patch";
+      url = "https://github.com/capstone-engine/capstone/commit/d63211e3acb64fceb8b1c4a0d804b4b027f4ef71.patch";
+      hash = "sha256-zUGeFmm3xH5dzfPJE8nnHwqwFBrsZ7w8LBJAy20/3RI=";
+      stripLen = 2;
+    })
+  ];
 
   # libcapstone.a is not built with BUILD_SHARED_LIBS. For some reason setup.py
   # checks if it exists but it is not really needed. Most likely a bug in setup.py.


### PR DESCRIPTION
This fixes the python bindings for `capstone` on python 3.12 by pulling in a merged but not yet released patch from upstream (https://github.com/capstone-engine/capstone/pull/2271).

Note: `nixpkgs-review` is not happy because multiple dependants rely on `unicorn` which is broken on python 3.12 for similar reasons. (=> https://github.com/NixOS/nixpkgs/pull/325888)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) <- smoke-tested python312 and python311 module functionality

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->
