### PR TITLE
python312Packages.unicorn: pull in a patch for missing `distutils` import

### DIFF
--- a/pkgs/development/python-modules/unicorn/avoid-distutils-python312.patch
+++ b/pkgs/development/python-modules/unicorn/avoid-distutils-python312.patch
@@ -1,0 +1,29 @@
+From bcc65c0be18fc6ea6ec39da89d0de77544fa18c7 Mon Sep 17 00:00:00 2001
+From: Mrmaxmeier <Mrmaxmeier@gmail.com>
+Date: Tue, 9 Jul 2024 17:41:08 +0200
+Subject: [PATCH] Drop removed `distutils` import in favor of `sysconfig`
+
+This patch is available online as https://github.com/unicorn-engine/unicorn/pull/1973
+
+diff --git a/unicorn/unicorn.py b/unicorn/unicorn.py
+index 2e6a938f43..7204b8215f 100644
+--- a/unicorn/unicorn.py
++++ b/unicorn/unicorn.py
+@@ -2,7 +2,7 @@
+ from __future__ import annotations
+ import ctypes
+ import ctypes.util
+-import distutils.sysconfig
++import sysconfig
+ from functools import wraps
+ from typing import Any, Callable, List, Tuple, Union
+ import pkg_resources
+@@ -85,7 +85,7 @@ def _load_lib(path, lib_name):
+               pkg_resources.resource_filename(__name__, 'lib'),
+               os.path.join(os.path.split(__file__)[0], 'lib'),
+               '',
+-              distutils.sysconfig.get_python_lib(),
++              sysconfig.get_path('platlib'),
+               "/usr/local/lib/" if sys.platform == 'darwin' else '/usr/lib64',
+               os.getenv('PATH', '')]
+ 

--- a/pkgs/development/python-modules/unicorn/default.nix
+++ b/pkgs/development/python-modules/unicorn/default.nix
@@ -15,6 +15,11 @@ buildPythonPackage rec {
 
   sourceRoot = "${src.name}/bindings/python";
 
+  patches = [
+    # Python 3.12 compatibility: Drop removed `distutils` import in favor of `sysconfig`
+    ./avoid-distutils-python312.patch
+  ];
+
   prePatch = ''
     ln -s ${unicorn-emu}/lib/libunicorn.* prebuilt/
   '';


### PR DESCRIPTION
## Description of changes

This fixes the bindings for `unicorn` on Python 3.12. I'm depending on a fresh PR here (https://github.com/unicorn-engine/unicorn/pull/1973), so this patch has not yet landed upstream.


Xref #325882

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of the python module

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
