### PR TITLE
pollymc-unwrapped: init at 8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17690,6 +17690,13 @@
     githubId = 766350;
     name = "Richard Zetterberg";
   };
+  s0me1newithhand7s = {
+    name = "hand7s";
+    email = "litvinovb0@gmail.com";
+    matrix = "@s0me1newithhand7s:matrix.org";
+    github = "s0me1newithhand7s";
+    githubId = 117505144;
+  };
   s1341 = {
     email = "s1341@shmarya.net";
     matrix = "@s1341:matrix.org";

--- a/pkgs/by-name/po/pollymc-unwrapped/package.nix
+++ b/pkgs/by-name/po/pollymc-unwrapped/package.nix
@@ -1,0 +1,113 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  cmark,
+  darwin,
+  extra-cmake-modules,
+  gamemode,
+  ghc_filesystem,
+  jdk17,
+  kdePackages,
+  ninja,
+  nix-update-script,
+  stripJavaArchivesHook,
+  tomlplusplus,
+  zlib,
+
+  msaClientID ? null,
+  gamemodeSupport ? stdenv.isLinux,
+}:
+
+let
+  libnbtplusplus = fetchFromGitHub {
+    owner = "PrismLauncher";
+    repo = "libnbtplusplus";
+    rev = "a5e8fd52b8bf4ab5d5bcc042b2a247867589985f";
+    hash = "sha256-A5kTgICnx+Qdq3Fir/bKTfdTt/T1NQP2SC+nhN1ENug=";
+  };
+in
+
+assert lib.assertMsg (
+  gamemodeSupport -> stdenv.isLinux
+) "gamemodeSupport is only available on Linux.";
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pollymc-unwrapped";
+  version = "8.0";
+
+  src = fetchFromGitHub {
+    owner = "fn2006";
+    repo = "PollyMC";
+    rev = finalAttrs.version;
+    hash = "sha256-DF1lxQHetDKZEpRrRZ0HQWqqMDAGNiTZoCJUARdXFSk=";
+  };
+
+  postUnpack = ''
+    rm -rf source/libraries/libnbtplusplus
+    ln -s ${libnbtplusplus} source/libraries/libnbtplusplus
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    extra-cmake-modules
+    jdk17
+    stripJavaArchivesHook
+  ];
+
+  buildInputs =
+    [
+      cmark
+      ghc_filesystem
+      kdePackages.qtbase
+      kdePackages.quazip
+      tomlplusplus
+      zlib
+    ]
+    ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Cocoa ]
+    ++ lib.optional gamemodeSupport gamemode;
+
+  hardeningEnable = lib.optionals stdenv.isLinux [ "pie" ];
+
+  cmakeFlags =
+    [
+      # downstream branding
+      (lib.cmakeFeature "Launcher_BUILD_PLATFORM" "nixpkgs")
+    ]
+    ++ lib.optionals (msaClientID != null) [
+      (lib.cmakeFeature "Launcher_MSA_CLIENT_ID" (toString msaClientID))
+    ]
+    ++ lib.optionals (lib.versionOlder kdePackages.qtbase.version "6") [
+      (lib.cmakeFeature "Launcher_QT_VERSION_MAJOR" "5")
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      # they wrap our binary manually
+      (lib.cmakeFeature "INSTALL_BUNDLE" "nodeps")
+      # disable built-in updater
+      (lib.cmakeFeature "MACOSX_SPARKLE_UPDATE_FEED_URL" "''")
+      (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" "${placeholder "out"}/Applications/")
+    ];
+
+  dontWrapQtApps = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Free, open source launcher for Minecraft";
+    longDescription = ''
+      Allows you to have multiple, separate instances of Minecraft (each with
+      their own mods, texture packs, saves, etc) and helps you manage them and
+      their associated options with a simple interface.
+    '';
+    homepage = "https://github.com/fn2006/PollyMC";
+    changelog = "https://github.com/fn2006/PollyMC/releases/tag/${finalAttrs.src.rev}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ s0me1newithhand7s ];
+    mainProgram = "pollymc";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description of changes
added `s0me1newithhand7s ` into `maintainers-list.nix`.
added new package `pollymc-unwrapped` into `nixpkgs/pkgs/by-name/po/pollymc-unwrapped`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
