### PR TITLE
python312Packages.django-autoslug: init at 1.9.9

### DIFF
--- a/pkgs/development/python-modules/django-autoslug/default.nix
+++ b/pkgs/development/python-modules/django-autoslug/default.nix
@@ -1,0 +1,36 @@
+{
+  pkgs,
+  buildPythonPackage,
+  django,
+  fetchPypi,
+  pythonOlder,
+}:
+
+buildPythonPackage rec {
+  pname = "django-autoslug";
+  version = "1.9.9";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-efiOlDPByI2NPyvsYNZcqYv/r/bAcreKpf2Z0OhKE90=";
+  };
+
+  propagatedBuildInputs = [ django ];
+
+  # django.core.exceptions.ImproperlyConfigured: Requested setting AUTOSLUG_SLUGIFY_FUNCTION, but settings are not configured.
+  doCheck = false;
+
+  # django.core.exceptions.ImproperlyConfigured: Requested setting AUTOSLUG_SLUGIFY_FUNCTION, but settings are not configured.
+  # pythonImportsCheck = [ "autoslug" ];
+
+  meta = with pkgs.lib; {
+    description = "Reusable Django library that provides an improved automatic slug field";
+    homepage = "https://github.com/justinmayer/django-autoslug/";
+    changelog = "https://github.com/justinmayer/django-autoslug/blob/v${version}/CHANGELOG.rst";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3405,6 +3405,8 @@ self: super: with self; {
 
   django-autocomplete-light = callPackage ../development/python-modules/django-autocomplete-light { };
 
+  django-autoslug = callPackage ../development/python-modules/django-autoslug { };
+
   django-axes = callPackage ../development/python-modules/django-axes { };
 
   django-bootstrap3 = callPackage ../development/python-modules/django-bootstrap3 { };


### PR DESCRIPTION
## Description of changes

[https://pypi.org/project/django-autoslug/](https://pypi.org/project/django-autoslug/)
[https://github.com/justinmayer/django-autoslug/](https://github.com/justinmayer/django-autoslug/)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
