### PR TITLE
pyqt5: 5.15.9 -> 5.15.10

### DIFF
--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -28,7 +28,7 @@
 
 buildPythonPackage rec {
   pname = "pyqt5";
-  version = "5.15.9";
+  version = "5.15.10";
   format = "pyproject";
 
   disabled = isPy27;
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "PyQt5";
     inherit version;
-    hash = "sha256-3EHoQBqQ3D4raStBG9VJKrVZrieidCTu1L05FVZOxMA=";
+    hash = "sha256-1Gt4BLGxCk/5F1P4ET5bVYDStEYvMiYoji2ESXM0iYo=";
   };
 
   patches = [


### PR DESCRIPTION
The release announcement mentions that Python 3.12 is now supported:
https://www.riverbankcomputing.com/pipermail/pyqt/2023-October/045542.html

Without this update I'm seeing a segfault when trying to import PyQt5 on Python 3.12.

Resolves #325804, resolves #326048, resolves #325946 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - "3726 packages updated". I'll let OfBorg chew through these...
- [x] Tested basic functionality: tested and built the `git-cola` GUI while submitting this PR

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->
