### PR TITLE
epson-escpr2: 1.2.11 -> 1.2.12

### DIFF
--- a/pkgs/misc/drivers/epson-escpr2/default.nix
+++ b/pkgs/misc/drivers/epson-escpr2/default.nix
@@ -1,4 +1,11 @@
-{ lib, stdenv, fetchurl, cups, rpm, cpio }:
+{
+  lib,
+  stdenv,
+  fetchurl,
+  cups,
+  rpm,
+  cpio,
+}:
 
 stdenv.mkDerivation rec {
   pname = "epson-inkjet-printer-escpr2";
@@ -26,7 +33,10 @@ stdenv.mkDerivation rec {
   patches = [ ./cups-filter-ppd-dirs.patch ];
 
   buildInputs = [ cups ];
-  nativeBuildInputs = [ rpm cpio ];
+  nativeBuildInputs = [
+    rpm
+    cpio
+  ];
 
   meta = with lib; {
     homepage = "http://download.ebz.epson.net/dsc/search/01/search/";
@@ -38,7 +48,11 @@ stdenv.mkDerivation rec {
       Refer to the description of epson-escpr for usage.
     '';
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ ma9e ma27 shawn8901 ];
+    maintainers = with maintainers; [
+      ma9e
+      ma27
+      shawn8901
+    ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/misc/drivers/epson-escpr2/default.nix
+++ b/pkgs/misc/drivers/epson-escpr2/default.nix
@@ -9,15 +9,14 @@
 
 stdenv.mkDerivation rec {
   pname = "epson-inkjet-printer-escpr2";
-  version = "1.2.11";
+  version = "1.2.12";
 
   src = fetchurl {
-    # To find new versions, visit
-    # http://download.ebz.epson.net/dsc/search/01/search/?OSC=LX and search for
-    # some printer like for instance "WF-7210" to get to the most recent
-    # version.
-    url = "https://download3.ebz.epson.net/dsc/f/03/00/15/93/07/6926ce2857b2e0f563eecfd6a877b7b71898ad46/epson-inkjet-printer-escpr2-1.2.11-1.src.rpm";
-    sha256 = "sha256-WMjtYYuMGMPf6222rvrP5Ep6fMRwebPTUXeQ6CbwEt4=";
+    # To find the most recent version go to
+    # https://support.epson.net/linux/Printer/LSB_distribution_pages/en/escpr2.php
+    # and retreive the download link for source package for x86 CPU
+    url = "https://download3.ebz.epson.net/dsc/f/03/00/15/98/70/f6a682eeeba1fd8bdf2ac112d5e1111d951c64a6/epson-inkjet-printer-escpr2-1.2.12-1.src.rpm";
+    sha256 = "sha256-7OkDlYhfQ/S3OD5QeN7DgNK0+LHabIm8zErtUDYcqwo=";
   };
 
   unpackPhase = ''


### PR DESCRIPTION
## Description of changes

News from inside the package

```
----------------------------------------------------------------------
epson-inkjet-printer-escpr2-1.2.12                        (2024-07-04)
----------------------------------------------------------------------
 * Fixed a bug in the 32-bit library in the source code.

```


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
