### PR TITLE
python312Packages.nose: fix, use pep517 builder

### DIFF
--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -6,7 +6,6 @@
 , enableSwftools ? false
 , swftools
 , python3Packages
-, pythonOlder
 , qtbase
 , qtcharts
 , makeDesktopItem
@@ -81,9 +80,6 @@ python3Packages.buildPythonPackage rec {
     service-identity
     twisted
   ];
-
-  # tests rely on nose
-  doCheck = pythonOlder "3.12";
 
   nativeCheckInputs = with python3Packages; [
     nose

--- a/pkgs/development/python-modules/actdiag/default.nix
+++ b/pkgs/development/python-modules/actdiag/default.nix
@@ -27,9 +27,6 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ blockdiag ];
 
-  # tests rely on nose
-  doCheck = pythonOlder "3.12";
-
   nativeCheckInputs = [
     nose
     pytestCheckHook

--- a/pkgs/development/python-modules/biopandas/default.nix
+++ b/pkgs/development/python-modules/biopandas/default.nix
@@ -35,10 +35,6 @@ buildPythonPackage rec {
     looseversion
   ];
 
-  # tests rely on nose
-  # resolved in 0.5.1: https://github.com/BioPandas/biopandas/commit/67aa2f237c70c826cd9ab59d6ae114582da2112f
-  doCheck = pythonOlder "3.12";
-
   nativeCheckInputs = [
     nose
     pytestCheckHook

--- a/pkgs/development/python-modules/blockdiag/default.nix
+++ b/pkgs/development/python-modules/blockdiag/default.nix
@@ -48,9 +48,6 @@ buildPythonPackage rec {
     webcolors
   ];
 
-  # tests rely on nose
-  doCheck = pythonOlder "3.12";
-
   nativeCheckInputs = [
     ephem
     nose

--- a/pkgs/development/python-modules/hkdf/default.nix
+++ b/pkgs/development/python-modules/hkdf/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
   nose,
   setuptools,
 }:
@@ -22,9 +21,6 @@ buildPythonPackage {
   build-system = [ setuptools ];
 
   pythonImportsCheck = [ "hkdf" ];
-
-  # tests rely on nose
-  doCheck = pythonOlder "3.12";
 
   nativeCheckInputs = [ nose ];
 

--- a/pkgs/development/python-modules/lockfile/default.nix
+++ b/pkgs/development/python-modules/lockfile/default.nix
@@ -5,7 +5,6 @@
   setuptools,
   pbr,
   nose,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
@@ -22,9 +21,6 @@ buildPythonPackage rec {
     pbr
     setuptools
   ];
-
-  # tests rely on nose
-  doCheck = pythonOlder "3.12";
 
   nativeCheckInputs = [ nose ];
 

--- a/pkgs/development/python-modules/nose/default.nix
+++ b/pkgs/development/python-modules/nose/default.nix
@@ -5,22 +5,33 @@
   isPy3k,
   isPyPy,
   python,
-  pythonAtLeast,
   coverage,
+  setuptools,
+  fetchpatch2,
 }:
 
 buildPythonPackage rec {
   version = "1.3.7";
-  format = "setuptools";
   pname = "nose";
-
-  # unmaintained, relies on the imp module
-  disabled = pythonAtLeast "3.12";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98";
   };
+
+  build-system = [ setuptools ];
+
+  patches = [
+    (fetchpatch2 {
+      url = "https://gitlab.alpinelinux.org/alpine/aports/-/raw/71a773b0618ce60d276a3df74ed69e6bd6d13237/community/py3-nose/python-nose-py311.patch";
+      hash = "sha256-CwY1pxzFFD0AYgmbERQyb6dD3bSInTqteUM85nfYkq8=";
+    })
+    (fetchpatch2 {
+      url = "https://gitlab.alpinelinux.org/alpine/aports/-/raw/71a773b0618ce60d276a3df74ed69e6bd6d13237/community/py3-nose/python-nose-py312.patch";
+      hash = "sha256-/mJHbal8XXOWvLtebrYmoK23rCNp+VWIFYDPUckEEGg=";
+    })
+  ];
 
   # 2to3 was removed in setuptools 58
   postPatch = ''

--- a/pkgs/development/python-modules/nose/default.nix
+++ b/pkgs/development/python-modules/nose/default.nix
@@ -5,6 +5,7 @@
   isPy3k,
   isPyPy,
   python,
+  python312,
   coverage,
   setuptools,
   fetchpatch2,
@@ -42,8 +43,9 @@ buildPythonPackage rec {
       --replace "from setuptools.command.build_py import Mixin2to3" "from distutils.util import Mixin2to3"
   '';
 
-  preBuild = lib.optionalString (isPy3k) ''
-    ${python.pythonOnBuildForHost}/bin/2to3 -wn nose functional_tests unit_tests
+  # Python 3.12 is the last version to ship 2to3.
+  preBuild = lib.optionalString isPy3k ''
+    ${python312.pythonOnBuildForHost}/bin/2to3 -wn nose functional_tests unit_tests
   '';
 
   propagatedBuildInputs = [ coverage ];

--- a/pkgs/development/python-modules/nwdiag/default.nix
+++ b/pkgs/development/python-modules/nwdiag/default.nix
@@ -27,9 +27,6 @@ buildPythonPackage rec {
 
   dependencies = [ blockdiag ];
 
-  # tests rely on nose
-  doCheck = pythonOlder "3.12";
-
   nativeCheckInputs = [
     nose
     pytestCheckHook

--- a/pkgs/development/python-modules/pprintpp/default.nix
+++ b/pkgs/development/python-modules/pprintpp/default.nix
@@ -38,9 +38,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  # tests rely on nose
-  doCheck = pythonOlder "3.12";
-
   nativeCheckInputs = [
     nose
     parameterized

--- a/pkgs/development/python-modules/pydy/default.nix
+++ b/pkgs/development/python-modules/pydy/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonOlder,
   numpy,
   scipy,
   sympy,
@@ -28,9 +27,6 @@ buildPythonPackage rec {
     scipy
     sympy
   ];
-
-  # tests rely on nose
-  doCheck = pythonOlder "3.12";
 
   nativeCheckInputs = [
     nose

--- a/pkgs/development/python-modules/pypass/default.nix
+++ b/pkgs/development/python-modules/pypass/default.nix
@@ -55,8 +55,6 @@ buildPythonPackage rec {
     pexpect
   ];
 
-  doCheck = pythonOlder "3.12";
-
   nativeCheckInputs = [ nose ];
 
   # Configuration so that the tests work

--- a/pkgs/development/python-modules/pytimeparse/default.nix
+++ b/pkgs/development/python-modules/pytimeparse/default.nix
@@ -21,9 +21,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  # tests rely on nose
-  doCheck = pythonOlder "3.12";
-
   nativeCheckInputs = [ nose ];
 
   pythonImportsCheck = [ "pytimeparse" ];

--- a/pkgs/development/python-modules/seqdiag/default.nix
+++ b/pkgs/development/python-modules/seqdiag/default.nix
@@ -27,9 +27,6 @@ buildPythonPackage rec {
 
   dependencies = [ blockdiag ];
 
-  # tests rely on nose
-  doCheck = pythonOlder "3.12";
-
   nativeCheckInputs = [
     nose
     pytestCheckHook

--- a/pkgs/development/python-modules/sphinx-rtd-dark-mode/default.nix
+++ b/pkgs/development/python-modules/sphinx-rtd-dark-mode/default.nix
@@ -25,9 +25,6 @@ buildPythonPackage rec {
 
   dependencies = [ sphinx-rtd-theme ];
 
-  # tests rely on nose
-  doCheck = pythonOlder "3.12";
-
   nativeCheckInputs = [
     nose
     sphinx

--- a/pkgs/development/python-modules/uvcclient/default.nix
+++ b/pkgs/development/python-modules/uvcclient/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
   nose,
   mock,
 }:
@@ -23,9 +22,6 @@ buildPythonPackage rec {
     substituteInPlace tests/test_camera.py \
       --replace-fail "assertEquals" "assertEqual"
   '';
-
-  # tests rely on nose
-  doCheck = pythonOlder "3.12";
 
   nativeCheckInputs = [
     nose

--- a/pkgs/development/python-modules/xlwt/default.nix
+++ b/pkgs/development/python-modules/xlwt/default.nix
@@ -21,9 +21,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  # tests rely on nose, archived in 2020
-  doCheck = pythonOlder "3.12";
-
   nativeCheckInputs = [ nose ];
 
   checkPhase = ''


### PR DESCRIPTION
## Description of changes

(Closed in favor of #325968 for now.)

This ports the Alpine Linux patches for Nose in Python 3.12 to Nixpkgs.

I don't know if I can get consensus on this as the "right" way to go, but with pynose having licensing issues, a ton of packages are broken right now. I don't personally think it makes sense for us to have a bunch of downstream ports of test suites to other test runners. It may be relatively easy, but these patches for Nose are also pretty easy, except they fix Nose for _everything simultaneously_ and only need to be touched when Python updates rather than potentially when any Nose-dependent downstream package updates.

Some packages are still broken in 3.12 for other reasons, so I didn't bother to go around and change other derivations. I think it would make sense to stop the bleeding first, if we can.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
