### PR TITLE
nixos/modules/services/logging: Remove top-level with lib;

### DIFF
--- a/nixos/modules/services/logging/SystemdJournal2Gelf.nix
+++ b/nixos/modules/services/logging/SystemdJournal2Gelf.nix
@@ -1,8 +1,7 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let cfg = config.services.SystemdJournal2Gelf;
+inherit (lib) mkOption mkPackageOption mkIf types;
 in
 
 { options = {

--- a/nixos/modules/services/logging/awstats.nix
+++ b/nixos/modules/services/logging/awstats.nix
@@ -1,8 +1,21 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib)
+    mkOption
+    types
+    literalExpression
+    mkRemovedOptionModule
+    mkRenamedOptionModule
+    mkEnableOption
+    mkIf
+    optionalString
+    filterAttrs
+    mapAttrs'
+    mapAttrsToList
+    nameValuePair
+    concatStringsSep;
+
   cfg = config.services.awstats;
   package = pkgs.awstats;
   configOpts = {name, config, ...}: {

--- a/nixos/modules/services/logging/fluentd.nix
+++ b/nixos/modules/services/logging/fluentd.nix
@@ -1,8 +1,7 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib) mkEnableOption types mkOption mkPackageOption mkIf concatStringsSep;
   cfg = config.services.fluentd;
 
   pluginArgs = concatStringsSep " " (map (x: "-p ${x}") cfg.plugins);
@@ -37,7 +36,7 @@ in {
   ###### implementation
 
   config = mkIf cfg.enable {
-    systemd.services.fluentd = with pkgs; {
+    systemd.services.fluentd = {
       description = "Fluentd Daemon";
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {

--- a/nixos/modules/services/logging/graylog.nix
+++ b/nixos/modules/services/logging/graylog.nix
@@ -1,8 +1,7 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib) mkEnableOption boolToString mkOption types concatStringsSep literalExpression versionOlder mkIf;
   cfg = config.services.graylog;
 
   confFile = pkgs.writeText "graylog.conf" ''

--- a/nixos/modules/services/logging/heartbeat.nix
+++ b/nixos/modules/services/logging/heartbeat.nix
@@ -1,8 +1,7 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib) mkEnableOption mkPackageOption mkOption types mkIf;
   cfg = config.services.heartbeat;
 
   heartbeatYml = pkgs.writeText "heartbeat.yml" ''
@@ -62,7 +61,7 @@ in
       "d '${cfg.stateDir}' - nobody nogroup - -"
     ];
 
-    systemd.services.heartbeat = with pkgs; {
+    systemd.services.heartbeat = {
       description = "heartbeat log shipper";
       wantedBy = [ "multi-user.target" ];
       preStart = ''

--- a/nixos/modules/services/logging/journalbeat.nix
+++ b/nixos/modules/services/logging/journalbeat.nix
@@ -1,8 +1,7 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib) mkEnableOption mkOption mkPackageOption types mkIf hasPrefix;
   cfg = config.services.journalbeat;
 
   journalbeatYml = pkgs.writeText "journalbeat.yml" ''

--- a/nixos/modules/services/logging/journaldriver.nix
+++ b/nixos/modules/services/logging/journaldriver.nix
@@ -11,7 +11,9 @@
 
 { config, lib, pkgs, ...}:
 
-with lib; let cfg = config.services.journaldriver;
+let
+  inherit (lib) mkOption types mkIf;
+  cfg = config.services.journaldriver;
 in {
   options.services.journaldriver = {
     enable = mkOption {

--- a/nixos/modules/services/logging/journalwatch.nix
+++ b/nixos/modules/services/logging/journalwatch.nix
@@ -1,7 +1,6 @@
 { config, lib, pkgs, ... }:
-with lib;
-
 let
+  inherit (lib) optionalString concatStringsSep mkOption mkPackageOption mkIf types literalExpression;
   cfg = config.services.journalwatch;
   user = "journalwatch";
   # for journal access
@@ -242,7 +241,7 @@ in {
         # requires a relative directory name to create beneath /var/lib
         StateDirectory = user;
         StateDirectoryMode = "0750";
-        ExecStart = "${getExe cfg.package} mail";
+        ExecStart = "${lib.getExe cfg.package} mail";
         # lowest CPU and IO priority, but both still in best-effort class to prevent starvation
         Nice=19;
         IOSchedulingPriority=7;

--- a/nixos/modules/services/logging/logcheck.nix
+++ b/nixos/modules/services/logging/logcheck.nix
@@ -1,8 +1,7 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib) getAttrFromPath types mkOption mapAttrsToList optionalAttrs mkIf;
   cfg = config.services.logcheck;
 
   defaultRules = pkgs.runCommand "logcheck-default-rules" { preferLocalBuild = true; } ''
@@ -43,7 +42,7 @@ let
       };
 
   writeIgnoreCronRule = name: {level, user, regex, cmdline, ...}:
-    let escapeRegex = escape (stringToCharacters "\\[]{}()^$?*+|.");
+    let escapeRegex = lib.escape (lib.stringToCharacters "\\[]{}()^$?*+|.");
         cmdline_ = builtins.unsafeDiscardStringContext cmdline;
         re = if regex != "" then regex else if cmdline_ == "" then ".*" else escapeRegex cmdline_;
     in writeIgnoreRule "cron-${name}" {
@@ -109,7 +108,7 @@ in
 {
   options = {
     services.logcheck = {
-      enable = mkEnableOption "logcheck cron job, to mail anomalies in the system logfiles to the administrator";
+      enable = lib.mkEnableOption "logcheck cron job, to mail anomalies in the system logfiles to the administrator";
 
       user = mkOption {
         default = "logcheck";
@@ -236,7 +235,7 @@ in
             mkCron = name: {user, cmdline, timeArgs, ...}: ''
               ${timeArgs} ${user} ${cmdline}
             '';
-        in mapAttrsToList mkCron (filterAttrs withTime cfg.ignoreCron)
+        in mapAttrsToList mkCron (lib.filterAttrs withTime cfg.ignoreCron)
            ++ [ cronJob ];
   };
 }

--- a/nixos/modules/services/logging/logstash.nix
+++ b/nixos/modules/services/logging/logstash.nix
@@ -1,8 +1,17 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib)
+    concatMapStringsSep
+    concatStringsSep
+    filter
+    mkIf
+    mkOption
+    mkPackageOption
+    mkRemovedOptionModule
+    mkRenamedOptionModule
+    stringLength
+    types;
   cfg = config.services.logstash;
   ops = lib.optionalString;
   verbosityFlag = "--log.level " + cfg.logLevel;
@@ -59,7 +68,7 @@ in
       plugins = mkOption {
         type = types.listOf types.path;
         default = [ ];
-        example = literalExpression "[ pkgs.logstash-contrib ]";
+        example = lib.literalExpression "[ pkgs.logstash-contrib ]";
         description = "The paths to find other logstash plugins in.";
       };
 
@@ -100,7 +109,7 @@ in
         type = types.lines;
         default = "generator { }";
         description = "Logstash input configuration.";
-        example = literalExpression ''
+        example = lib.literalExpression ''
           '''
             # Read from journal
             pipe {

--- a/nixos/modules/services/logging/promtail.nix
+++ b/nixos/modules/services/logging/promtail.nix
@@ -1,5 +1,8 @@
-{ config, lib, pkgs, ... }: with lib;
+{ config, lib, pkgs, ... }:
 let
+
+  inherit (lib) types mkOption mkEnableOption mkIf mkDefault escapeShellArgs optionalAttrs;
+
   cfg = config.services.promtail;
 
   prettyJSON = conf: pkgs.runCommandLocal "promtail-config.json" {} ''
@@ -11,7 +14,7 @@ let
   allowPositionsFile = !lib.hasPrefix "/var/cache/promtail" positionsFile;
   positionsFile = cfg.configuration.positions.filename;
 in {
-  options.services.promtail = with types; {
+  options.services.promtail = {
     enable = mkEnableOption "the Promtail ingresser";
 
 
@@ -23,7 +26,7 @@ in {
     };
 
     extraFlags = mkOption {
-      type = listOf str;
+      type = types.listOf types.str;
       default = [];
       example = [ "--server.http-listen-port=3101" ];
       description = ''

--- a/nixos/modules/services/logging/rsyslogd.nix
+++ b/nixos/modules/services/logging/rsyslogd.nix
@@ -1,8 +1,8 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+
+  inherit (lib) mkOption mkIf types;
 
   cfg = config.services.rsyslogd;
 

--- a/nixos/modules/services/logging/syslog-ng.nix
+++ b/nixos/modules/services/logging/syslog-ng.nix
@@ -1,8 +1,8 @@
 { config, pkgs, lib, ... }:
 
-with lib;
-
 let
+
+  inherit (lib) concatStringsSep mkRemovedOptionModule mkOption types mkPackageOption mkIf;
 
   cfg = config.services.syslog-ng;
 

--- a/nixos/modules/services/logging/syslogd.nix
+++ b/nixos/modules/services/logging/syslogd.nix
@@ -1,8 +1,7 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib) optionalString mkOption types mkIf optional;
 
   cfg = config.services.syslogd;
 

--- a/nixos/modules/services/logging/ulogd.nix
+++ b/nixos/modules/services/logging/ulogd.nix
@@ -1,10 +1,10 @@
 { config, lib, pkgs, ... }:
 
-with lib;
 let
   cfg = config.services.ulogd;
   settingsFormat = pkgs.formats.ini { listsAsDuplicateKeys = true; };
   settingsFile = settingsFormat.generate "ulogd.conf" cfg.settings;
+  inherit (lib) mkEnableOption mkOption mkIf types;
 in {
   options = {
     services.ulogd = {

--- a/nixos/modules/services/logging/vector.nix
+++ b/nixos/modules/services/logging/vector.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }:
 
-with lib;
 let cfg = config.services.vector;
+inherit (lib) mkEnableOption mkPackageOption mkOption types mkIf getExe;
 
 in
 {


### PR DESCRIPTION
## Description of changes
This removes all usage of `with lib;` under nixos/modules/services/logging. This is similar in scope to #306640, and is related to removing `with lib;` since it's an antipattern. See #208242 for more information on that.
I've run all applicable NixOS tests, and there are no behavioral changes, so there should be no incompatibilities.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
