### PR TITLE
magic-wormhole: make usable with Python 3.12

### DIFF
--- a/nixos/modules/services/networking/magic-wormhole-mailbox-server.nix
+++ b/nixos/modules/services/networking/magic-wormhole-mailbox-server.nix
@@ -1,11 +1,19 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 with lib;
 
 let
   cfg = config.services.magic-wormhole-mailbox-server;
   dataDir = "/var/lib/magic-wormhole-mailbox-server;";
-  python = pkgs.python3.withPackages (py: [ py.magic-wormhole-mailbox-server py.twisted ]);
+  python = pkgs.python3.withPackages (py: [
+    py.magic-wormhole-mailbox-server
+    py.twisted
+  ]);
 in
 {
   options.services.magic-wormhole-mailbox-server = {
@@ -23,6 +31,5 @@ in
         StateDirectory = baseNameOf dataDir;
       };
     };
-
   };
 }

--- a/nixos/modules/services/networking/magic-wormhole-mailbox-server.nix
+++ b/nixos/modules/services/networking/magic-wormhole-mailbox-server.nix
@@ -5,22 +5,23 @@
   ...
 }:
 
-with lib;
-
 let
   cfg = config.services.magic-wormhole-mailbox-server;
+  # keep semicolon in dataDir for backward compatibility
   dataDir = "/var/lib/magic-wormhole-mailbox-server;";
-  python = pkgs.python3.withPackages (py: [
-    py.magic-wormhole-mailbox-server
-    py.twisted
-  ]);
+  python = pkgs.python311.withPackages (
+    py: with py; [
+      magic-wormhole-mailbox-server
+      twisted
+    ]
+  );
 in
 {
   options.services.magic-wormhole-mailbox-server = {
-    enable = mkEnableOption "Magic Wormhole Mailbox Server";
+    enable = lib.mkEnableOption "Magic Wormhole Mailbox Server";
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     systemd.services.magic-wormhole-mailbox-server = {
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
@@ -32,4 +33,6 @@ in
       };
     };
   };
+
+  meta.maintainers = [ lib.maintainers.mjoerg ];
 }

--- a/pkgs/development/python-modules/magic-wormhole-mailbox-server/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole-mailbox-server/default.nix
@@ -21,9 +21,6 @@ buildPythonPackage rec {
   version = "0.4.1";
   pyproject = true;
 
-  # python 3.12 support: https://github.com/magic-wormhole/magic-wormhole-mailbox-server/issues/41
-  disabled = pythonOlder "3.7" || pythonAtLeast "3.12";
-
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-GvEFkpCcqvUZwA5wbqyELF53+NQ1YhX+nGHHsiWKiPs=";
@@ -38,13 +35,14 @@ buildPythonPackage rec {
     })
   ];
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     attrs
+    autobahn
+    setuptools # pkg_resources is referenced at runtime
     six
     twisted
-    autobahn
   ] ++ autobahn.optional-dependencies.twisted ++ twisted.optional-dependencies.tls;
 
   pythonImportsCheck = [ "wormhole_mailbox_server" ];
@@ -66,5 +64,7 @@ buildPythonPackage rec {
     changelog = "https://github.com/magic-wormhole/magic-wormhole-mailbox-server/blob/${version}/NEWS.md";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.mjoerg ];
+    # Python 3.12 support: https://github.com/magic-wormhole/magic-wormhole-mailbox-server/issues/41
+    broken = pythonOlder "3.7" || pythonAtLeast "3.12";
   };
 }

--- a/pkgs/development/python-modules/magic-wormhole-transit-relay/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole-transit-relay/default.nix
@@ -16,17 +16,16 @@ buildPythonPackage rec {
   version = "0.2.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.7" || pythonAtLeast "3.12";
-
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-y0gBtGiQ6v+XKG4OP+xi0dUv/jF9FACDtjNqH7To+l4=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     autobahn
+    setuptools # pkg_resources is referenced at runtime
     twisted
   ];
 
@@ -38,11 +37,15 @@ buildPythonPackage rec {
     twisted
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = {
     description = "Transit Relay server for Magic-Wormhole";
     homepage = "https://github.com/magic-wormhole/magic-wormhole-transit-relay";
     changelog = "https://github.com/magic-wormhole/magic-wormhole-transit-relay/blob/${version}/NEWS.md";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.mjoerg ];
+    # Python 3.12 support: https://github.com/magic-wormhole/magic-wormhole-transit-relay/issues/35
+    broken = pythonOlder "3.7" || pythonAtLeast "3.12";
   };
 }

--- a/pkgs/development/python-modules/magic-wormhole/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole/default.nix
@@ -44,20 +44,32 @@ buildPythonPackage rec {
     hash = "sha256-AG0jn4i/98N7wu/2CgBOJj+vklj3J5GS0Gugyc7WsIA=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  postPatch =
+    # enable tests by fixing the location of the wormhole binary
+    ''
+      substituteInPlace src/wormhole/test/test_cli.py --replace-fail \
+        'locations = procutils.which("wormhole")' \
+        'return "${placeholder "out"}/bin/wormhole"'
+    ''
+    # fix the location of the ifconfig binary
+    + lib.optionalString stdenv.isLinux ''
+      sed -i -e "s|'ifconfig'|'${nettools}/bin/ifconfig'|" src/wormhole/ipaddrs.py
+    '';
 
-  propagatedBuildInputs = [
-    spake2
-    pynacl
-    six
+  build-system = [ setuptools ];
+
+  dependencies = [
     attrs
-    twisted
     autobahn
     automat
-    tqdm
     click
     humanize
     iterable-io
+    pynacl
+    six
+    spake2
+    tqdm
+    twisted
     txtorcon
     zipstream-ng
   ] ++ autobahn.optional-dependencies.twisted ++ twisted.optional-dependencies.tls;
@@ -66,43 +78,33 @@ buildPythonPackage rec {
     dilation = [ noiseprotocol ];
   };
 
-  nativeCheckInputs = [
-    mock
-    magic-wormhole-transit-relay
-    magic-wormhole-mailbox-server
-    pytestCheckHook
-  ] ++ passthru.optional-dependencies.dilation ++ lib.optionals stdenv.isDarwin [ unixtools.locale ];
+  nativeCheckInputs =
+    # For Python 3.12, remove magic-wormhole-mailbox-server and magic-wormhole-transit-relay from test dependencies,
+    # which are not yet supported with this version.
+    lib.optionals (!magic-wormhole-mailbox-server.meta.broken) [ magic-wormhole-mailbox-server ]
+    ++ lib.optionals (!magic-wormhole-transit-relay.meta.broken) [ magic-wormhole-transit-relay ]
+    ++ [
+      mock
+      pytestCheckHook
+    ]
+    ++ passthru.optional-dependencies.dilation
+    ++ lib.optionals stdenv.isDarwin [ unixtools.locale ];
 
-  disabledTests = lib.optionals stdenv.isDarwin [
-    # These tests doesn't work within Darwin's sandbox
-    "test_version"
-    "test_text"
-    "test_receiver"
-    "test_sender"
-    "test_sender_allocation"
-    "test_text_wrong_password"
-    "test_override"
-    "test_allocate_port"
-    "test_allocate_port_no_reuseaddr"
-    "test_ignore_localhost_hint"
-    "test_ignore_localhost_hint_orig"
-    "test_keep_only_localhost_hint"
-    "test_get_direct_hints"
-    "test_listener"
-    "test_success_direct"
-    "test_direct"
-    "test_relay"
-  ];
+  __darwinAllowLocalNetworking = true;
 
-  disabledTestPaths = lib.optionals stdenv.isDarwin [
-    # These tests doesn't work within Darwin's sandbox
-    "src/wormhole/test/test_xfer_util.py"
-    "src/wormhole/test/test_wormhole.py"
-  ];
-
-  postPatch = lib.optionalString stdenv.isLinux ''
-    sed -i -e "s|'ifconfig'|'${nettools}/bin/ifconfig'|" src/wormhole/ipaddrs.py
-  '';
+  disabledTestPaths =
+    # For Python 3.12, remove the tests depending on magic-wormhole-mailbox-server and magic-wormhole-transit-relay,
+    # which are not yet supported with this version.
+    lib.optionals
+      (magic-wormhole-mailbox-server.meta.broken || magic-wormhole-transit-relay.meta.broken)
+      [
+        "src/wormhole/test/dilate/test_full.py"
+        "src/wormhole/test/test_args.py"
+        "src/wormhole/test/test_cli.py"
+        "src/wormhole/test/test_wormhole.py"
+        "src/wormhole/test/test_xfer_util.py"
+      ]
+    ++ lib.optionals magic-wormhole-transit-relay.meta.broken [ "src/wormhole/test/test_transit.py" ];
 
   postInstall = ''
     install -Dm644 docs/wormhole.1 $out/share/man/man1/wormhole.1


### PR DESCRIPTION
## Description of changes

magic-wormhole-mailbox-server, magic-wormhole-transit-relay
+ add `setuptools` as dependency, as `pkg_resources` is referenced at runtime
+ use `meta.broken` instead of `disabled` in order to make `magic-wormhole` usable with Python 3.12

magic-wormhole:
+ disable tests using `magic-wormhole-mailbox-server` and `magic-wormhole-transit-relay` when these dependencies are not available (Python 3.12)

nixos/magic-wormhole-mailbox-server:
+ use Python 3.11
+ adopt

fixes #325854

build failure in `tahoe-lafs` is caused by a different broken dependency

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>4 packages marked as broken and skipped:</summary>
  <ul>
    <li>python312Packages.magic-wormhole-mailbox-server</li>
    <li>python312Packages.magic-wormhole-mailbox-server.dist</li>
    <li>python312Packages.magic-wormhole-transit-relay</li>
    <li>python312Packages.magic-wormhole-transit-relay.dist</li>
  </ul>
</details>
<details>
  <summary>1 package blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
  </ul>
</details>
<details>
  <summary>4 packages failed to build:</summary>
  <ul>
    <li>tahoe-lafs</li>
    <li>tahoe-lafs.dist</li>
    <li>tahoe-lafs.doc</li>
    <li>tahoe-lafs.info</li>
  </ul>
</details>
<details>
  <summary>10 packages built:</summary>
  <ul>
    <li>gnome-keysign</li>
    <li>gnome-keysign.dist</li>
    <li>magic-wormhole (python312Packages.magic-wormhole)</li>
    <li>magic-wormhole.dist (python312Packages.magic-wormhole.dist)</li>
    <li>python311Packages.magic-wormhole</li>
    <li>python311Packages.magic-wormhole-mailbox-server</li>
    <li>python311Packages.magic-wormhole-mailbox-server.dist</li>
    <li>python311Packages.magic-wormhole-transit-relay</li>
    <li>python311Packages.magic-wormhole-transit-relay.dist</li>
    <li>python311Packages.magic-wormhole.dist</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc