### PR TITLE
treewide: remove uses of `python3` within the python package set

### DIFF
--- a/pkgs/development/python-modules/dbt-core/default.nix
+++ b/pkgs/development/python-modules/dbt-core/default.nix
@@ -17,7 +17,7 @@
   packaging,
   pathspec,
   protobuf,
-  python3,
+  python,
   pythonOlder,
   pytz,
   pyyaml,
@@ -85,7 +85,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   passthru = {
-    withAdapters = python3.pkgs.callPackage ./with-adapters.nix { };
+    withAdapters = python.pkgs.callPackage ./with-adapters.nix { };
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/dbt-core/with-adapters.nix
+++ b/pkgs/development/python-modules/dbt-core/with-adapters.nix
@@ -1,5 +1,5 @@
 {
-  python3,
+  python,
   dbt-bigquery,
   dbt-core,
   dbt-postgres,
@@ -17,7 +17,7 @@ let
   };
 in
 adapterFun:
-(python3.buildEnv.override {
+(python.buildEnv.override {
   extraLibs = [ dbt-core ] ++ (adapterFun adapters);
   ignoreCollisions = true;
 }).overrideAttrs

--- a/pkgs/development/python-modules/django-currentuser/default.nix
+++ b/pkgs/development/python-modules/django-currentuser/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  python3,
+  python,
   pythonOlder,
   django,
   hatchling,
@@ -38,7 +38,7 @@ buildPythonPackage {
 
   checkPhase = ''
     runHook preCheck
-    ${python3.interpreter} manage.py test testapp
+    ${python.interpreter} manage.py test testapp
     runHook postCheck
   '';
 

--- a/pkgs/development/python-modules/kaldi-active-grammar/fork.nix
+++ b/pkgs/development/python-modules/kaldi-active-grammar/fork.nix
@@ -7,7 +7,7 @@
   icu,
   pkg-config,
   fetchFromGitHub,
-  python3,
+  python,
   openblas,
   zlib,
   gfortran,
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkg-config
-    python3
+    python
     gfortran
   ];
 

--- a/pkgs/development/python-modules/laces/default.nix
+++ b/pkgs/development/python-modules/laces/default.nix
@@ -4,7 +4,6 @@
   django,
   fetchFromGitHub,
   flit-core,
-  python3,
 }:
 
 buildPythonPackage rec {

--- a/pkgs/development/python-modules/lcd-i2c/default.nix
+++ b/pkgs/development/python-modules/lcd-i2c/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  python3,
   fetchPypi,
   buildPythonPackage,
   smbus2,

--- a/pkgs/development/python-modules/llm/default.nix
+++ b/pkgs/development/python-modules/llm/default.nix
@@ -5,10 +5,22 @@
   fetchFromGitHub,
   makeWrapper,
   pytestCheckHook,
-  python3,
+  python,
   pythonOlder,
   ruff,
   setuptools,
+  click-default-group,
+  numpy,
+  openai,
+  pip,
+  pluggy,
+  pydantic,
+  python-ulid,
+  pyyaml,
+  sqlite-migrate,
+  cogapp,
+  pytest-httpx,
+  sqlite-utils,
 }:
 let
   llm = buildPythonPackage rec {
@@ -29,7 +41,7 @@ let
 
     nativeBuildInputs = [ setuptools ];
 
-    propagatedBuildInputs = with python3.pkgs; [
+    propagatedBuildInputs = [
       click-default-group
       numpy
       openai
@@ -43,7 +55,7 @@ let
       sqlite-utils
     ];
 
-    nativeCheckInputs = with python3.pkgs; [
+    nativeCheckInputs = [
       cogapp
       numpy
       pytest-httpx
@@ -89,7 +101,7 @@ let
 
       installPhase = ''
         makeWrapper ${llm}/bin/llm $out/bin/llm \
-          --prefix PYTHONPATH : "${llm}/${python3.sitePackages}:$PYTHONPATH"
+          --prefix PYTHONPATH : "${llm}/${python.sitePackages}:$PYTHONPATH"
         ln -sfv ${llm}/lib $out/lib
       '';
 

--- a/pkgs/development/python-modules/nuitka/default.nix
+++ b/pkgs/development/python-modules/nuitka/default.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
   isPyPy,
   ordered-set,
-  python3,
+  python,
   setuptools,
   zstandard,
   wheel,
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   checkPhase = ''
     runHook preCheck
 
-    ${python3.interpreter} tests/basics/run_all.py search
+    ${python.interpreter} tests/basics/run_all.py search
 
     runHook postCheck
   '';

--- a/pkgs/development/python-modules/pybars3/default.nix
+++ b/pkgs/development/python-modules/pybars3/default.nix
@@ -1,5 +1,5 @@
 {
-  python3,
+  python,
   fetchPypi,
   lib,
   pymeta3,
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   checkPhase = ''
     runHook preCheck
-    ${python3.interpreter} tests.py
+    ${python.interpreter} tests.py
     runHook postCheck
   '';
 

--- a/pkgs/development/python-modules/pytest-image-diff/default.nix
+++ b/pkgs/development/python-modules/pytest-image-diff/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  python3,
   buildPythonPackage,
   fetchFromGitHub,
   typing-extensions,

--- a/pkgs/development/python-modules/python-secp256k1-cardano/default.nix
+++ b/pkgs/development/python-modules/python-secp256k1-cardano/default.nix
@@ -1,11 +1,14 @@
 {
   lib,
   fetchFromGitHub,
-  python3,
+  buildPythonPackage,
   pkg-config,
+  cffi,
+  secp256k1,
+  pytestCheckHook,
 }:
 
-python3.pkgs.buildPythonPackage {
+buildPythonPackage {
   pname = "python-secp256k1-cardano";
   version = "0.2.3";
 
@@ -20,20 +23,20 @@ python3.pkgs.buildPythonPackage {
 
   nativeBuildInputs = [ pkg-config ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = [
     cffi
     secp256k1
   ];
 
-  nativeCheckInputs = [ python3.pkgs.pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   # Tests expect .so files and are failing
   doCheck = false;
 
   preConfigure = ''
-    cp -r ${python3.pkgs.secp256k1.src} libsecp256k1
-    export INCLUDE_DIR=${python3.pkgs.secp256k1}/include
-    export LIB_DIR=${python3.pkgs.secp256k1}/lib
+    cp -r ${secp256k1.src} libsecp256k1
+    export INCLUDE_DIR=${secp256k1}/include
+    export LIB_DIR=${secp256k1}/lib
   '';
 
   meta = {

--- a/pkgs/development/python-modules/rtp/default.nix
+++ b/pkgs/development/python-modules/rtp/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  python3,
 
   # nativeCheckInputs
   hypothesis,

--- a/pkgs/development/python-modules/ssg/default.nix
+++ b/pkgs/development/python-modules/ssg/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   fetchpatch,
 
-  python3,
+  python,
   unittestCheckHook,
   setuptools,
 
@@ -45,7 +45,7 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "ssg" ];
 
-  postInstall = "rm -rf $out/${python3.sitePackages}/scripts";
+  postInstall = "rm -rf $out/${python.sitePackages}/scripts";
 
   meta = with lib; {
     description = "TCRF syllable segmenter for Thai";

--- a/pkgs/development/python-modules/tabcmd/default.nix
+++ b/pkgs/development/python-modules/tabcmd/default.nix
@@ -91,6 +91,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "tabcmd" ];
 
   meta = with lib; {
+    broken = true;
     description = "Command line client for working with Tableau Server";
     homepage = "https://github.com/tableau/tabcmd";
     changelog = "https://github.com/tableau/tabcmd/releases/tag/v${version}";

--- a/pkgs/development/python-modules/tabcmd/default.nix
+++ b/pkgs/development/python-modules/tabcmd/default.nix
@@ -10,7 +10,7 @@
   pyinstaller-versionfile,
   pytest-order,
   pytestCheckHook,
-  python3,
+  python,
   pythonOlder,
   requests,
   setuptools,
@@ -79,7 +79,7 @@ buildPythonPackage rec {
     cp -r build/lib/tabcmd/__main__.py $out/bin/
 
     # Create a 'tabcmd' script with python3 shebang
-    echo "#!${python3}/bin/python3" > $out/bin/tabcmd
+    echo "#!${python.interpreter}" > $out/bin/tabcmd
 
     # Append __main__.py contents
     cat $out/bin/__main__.py >> $out/bin/tabcmd


### PR DESCRIPTION
## Description of changes

Fixes #325890

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages marked as broken and skipped:</summary>
  <ul>
    <li>python311Packages.tabcmd</li>
    <li>python311Packages.tabcmd.dist</li>
    <li>python312Packages.tabcmd</li>
    <li>python312Packages.tabcmd.dist</li>
  </ul>
</details>
<details>
  <summary>22 packages built:</summary>
  <ul>
    <li>python311Packages.attacut</li>
    <li>python311Packages.attacut.dist</li>
    <li>python311Packages.django-currentuser</li>
    <li>python311Packages.django-currentuser.dist</li>
    <li>python311Packages.dragonfly</li>
    <li>python311Packages.dragonfly.dist</li>
    <li>python311Packages.kaldi-active-grammar</li>
    <li>python311Packages.kaldi-active-grammar.dist</li>
    <li>python311Packages.llm</li>
    <li>python311Packages.llm.dist</li>
    <li>python311Packages.nuitka</li>
    <li>python311Packages.nuitka.dist</li>
    <li>python311Packages.pluthon</li>
    <li>python311Packages.pluthon.dist</li>
    <li>python311Packages.pybars3</li>
    <li>python311Packages.pybars3.dist</li>
    <li>python311Packages.python-secp256k1-cardano</li>
    <li>python311Packages.python-secp256k1-cardano.dist</li>
    <li>python311Packages.ssg</li>
    <li>python311Packages.ssg.dist</li>
    <li>python311Packages.uplc</li>
    <li>python311Packages.uplc.dist</li>
  </ul>
</details>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
