### PR TITLE
Init deno language support

### DIFF
--- a/pkgs/build-support/deno/buildDenoApplication.nix
+++ b/pkgs/build-support/deno/buildDenoApplication.nix
@@ -23,7 +23,7 @@
         postPatch
         ;
       name = denoDepsName;
-      hash = denoDepsHash;
+      outputHash = denoDepsHash;
     }
   ),
   # Hash of the vendored dependencies. Leave empty if you dont know it yet

--- a/pkgs/build-support/deno/buildDenoApplication.nix
+++ b/pkgs/build-support/deno/buildDenoApplication.nix
@@ -1,0 +1,214 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchDenoDeps,
+}@topLevelArgs:
+{
+  # Name of the package
+  name ? "${args.pname}-${args.version}",
+  # Use this deno binary
+  deno ? topLevelArgs.deno,
+
+  # Name for the vendored dependencies tarball
+  denoDepsName ? "${name}-deno-deps",
+  # The vendored dependencies. The output structure of that derivation is still tbd
+  denoDeps ? (
+    fetchDenoDeps {
+      inherit
+        src
+        srcs
+        sourceRoot
+        prePatch
+        patches
+        postPatch
+        ;
+      name = denoDepsName;
+      hash = denoDepsHash;
+    }
+  ),
+  # Hash of the vendored dependencies. Leave empty if you dont know it yet
+  denoDepsHash ? "",
+
+  # Configuration for finding the main script and the config file 
+  # The main script you would run with `deno run`
+  script,
+  # The deno.json config file. 
+  # TODO: Add support for deno.jsonc and allow for projects without deno.json
+  denoJson ? "deno.json",
+  # Customize the deno lockfile location
+  denoLock ? null,
+  # TODO: Allow projects with custom vendored dependencies
+
+  # Configuration for how the application should be run
+  # Create a temporary directory, where deno can cache some things. Stops deno from whining about not being able to write to the deno directory.
+  # Not used if compile is true.
+  writableDenoDirectory ? true,
+  # Just produce a single binary, instead of a whole directory.
+  compile ? false,
+  # Add some flags by default, when executing your application. Like `--allow-net` or `-A`
+  runtimeFlags ? [ ],
+
+  # Idk if I actually need to specify these explitly
+  # Both npm and rust explicity specify src, srcs, and sourceRoot
+  src ? null,
+  srcs ? null,
+  sourceRoot ? null,
+  nativeBuildInputs ? [ ],
+  passthru ? { },
+  patches ? [ ],
+  meta ? { },
+  prePatch ? "",
+  postPatch ? "",
+  buildInputs ? [ ],
+  preUnpack ? null,
+  unpackPhase ? null,
+  postUnpack ? null,
+  # We want parallel builds by default
+  # TODO: idk if deno even supports something like parallel building
+  enableParallelBuilding ? false,
+
+  # References used:
+  # pkgs/build-support/rust/build-rust-package/default.nix
+  # pkgs/build-support/node/build-npm-package/default.nix
+  # pkgs/build-support/go/module.nix
+  # 
+  # Looked at and didnt understand:
+  # pkgs/development/compilers/nim/build-nim-package.nix
+
+  # # Go specific things
+  # # TODO: Find out if there are any clever ideas here
+  # # A function to override the goModules derivation
+  # overrideModAttrs ? (_oldAttrs: { }),
+  # # path to go.mod and go.sum directory
+  # modRoot ? "./",
+  # # vendorHash is the SRI hash of the vendored dependencies
+  # #
+  # # if vendorHash is null, then we won't fetch any dependencies and
+  # # rely on the vendor folder within the source.
+  # # TODO: We need something like this
+  # vendorHash ? throw (
+  #   if args' ? vendorSha256 then
+  #     "buildGoModule: Expect vendorHash instead of vendorSha256"
+  #   else
+  #     "buildGoModule: vendorHash is missing"
+  # ),
+  # # Whether to delete the vendor folder supplied with the source.
+  # # TODO: We could do that too, to allow vendored dependencies
+  # deleteVendor ? false,
+  # # Whether to fetch (go mod download) and proxy the vendor directory.
+  # # This is useful if your code depends on c code and go mod tidy does not
+  # # include the needed sources to build or if any dependency has case-insensitive
+  # # conflicts which will produce platform dependant `vendorHash` checksums.
+  # # TODO: Figure out what this does
+  # proxyVendor ? false,
+  # # We want parallel builds by default
+  # # TODO: idk if deno even supports something like parallel building
+  # enableParallelBuilding ? true,
+  # # Do not enable this without good reason
+  # # IE: programs coupled with the compiler
+  # allowGoReference ? false,
+  # CGO_ENABLED ? go.CGO_ENABLED,
+  # # Not needed with buildGoModule
+  # # TODO: Figure out what this does
+  # goPackagePath ? "",
+  # # TODO: I dont think these apply to us. But maybe something similar for deno flags
+  # ldflags ? [ ],
+  # GOFLAGS ? [ ],
+  # # needed for buildFlags{,Array} warning
+  # buildFlags ? "",
+  # buildFlagsArray ? "",
+
+  # # Node specific things
+  # # TODO: Find out if there are any clever ideas here
+
+  # # The output hash of the dependencies for this project.
+  # # Can be calculated in advance with prefetch-npm-deps.
+  # # TODO: We need something like this
+  # npmDepsHash ? "",
+  # # Whether to force the usage of Git dependencies that have install scripts, but not a lockfile.
+  # # Use with care.
+  # # TODO: Is this reproducible
+  # forceGitDeps ? false,
+  # # Whether to force allow an empty dependency cache.
+  # # This can be enabled if there are truly no remote dependencies, but generally an empty cache indicates something is wrong.
+  # # TODO: Figure out if what this does
+  # forceEmptyCache ? false,
+  # # Whether to make the cache writable prior to installing dependencies.
+  # # Don't set this unless npm tries to write to the cache directory, as it can slow down the build.
+  # # TODO: Probably not the same thing as our build deno dir thing
+  # makeCacheWritable ? false,
+  # # The script to run to build the project.
+  # # TODO: Maybe add support for deno scripts. But I think that is a bad idea
+  # npmBuildScript ? "build",
+  # # Flags to pass to all npm commands.
+  # # TODO: We also need something like this to customize the deno build
+  # npmFlags ? [ ],
+  # # Flags to pass to `npm ci`.
+  # npmInstallFlags ? [ ],
+  # # Flags to pass to `npm rebuild`.
+  # npmRebuildFlags ? [ ],
+  # # Flags to pass to `npm run ${npmBuildScript}`.
+  # npmBuildFlags ? [ ],
+  # # Flags to pass to `npm pack`.
+  # npmPackFlags ? [ ],
+  # # Flags to pass to `npm prune`.
+  # npmPruneFlags ? npmInstallFlags,
+  # # Value for npm `--workspace` flag and directory in which the files to be installed are found.
+  # # TODO: Does deno even have workspaces?
+  # npmWorkspace ? null,
+  # # TODO: Figure out what these hooks do
+  # # Custom npmConfigHook
+  # npmConfigHook ? null,
+  # # Custom npmBuildHook
+  # npmBuildHook ? null,
+  # # Custom npmInstallHook
+  # npmInstallHook ? null,
+
+  # # Rust specific things
+  # # TODO: Find out if there are any clever ideas here
+
+  # # TODO: I dont think deno has a way of patching deps. We could however overwrite paths
+  # cargoPatches ? [ ],
+  # # TODO: Figure out what loglevel is set here
+  # logLevel ? "",
+  # # TODO: Figure out where these hook
+  # cargoUpdateHook ? "",
+  # cargoDepsHook ? "",
+  # # TODO: Does deno have different build types?
+  # buildType ? "release",
+  # # TODO: Locking in cargo is done here
+  # cargoLock ? null,
+  # # TODO: Figure out what the vendor dir does
+  # cargoVendorDir ? null,
+  # # TODO: ???
+  # checkType ? buildType,
+  # buildNoDefaultFeatures ? false,
+  # checkNoDefaultFeatures ? buildNoDefaultFeatures,
+  # # TODO: Does deno provide a way of configuring features?
+  # buildFeatures ? [ ],
+  # checkFeatures ? buildFeatures,
+  # # TODO: Does deno have a way of running tests? Are rust tests enabled by default?
+  # useNextest ? false,
+  # # TODO: What does auditable mean in this context? Is it reproducibility?
+  # # Enable except on aarch64 pkgsStatic, where we use lld for reasons
+  # # auditable ?
+  # #   !cargo-auditable.meta.broken
+  # #   && !(
+  # #     stdenv.hostPlatform.isStatic && stdenv.hostPlatform.isAarch64 && !stdenv.hostPlatform.isDarwin
+  # #   ),
+  # # TODO: Figure out what this does
+  # depsExtraArgs ? { },
+
+  # # Toggles whether a custom sysroot is created when the target is a .json file.
+  # # TODO: Figure out what this does
+  # __internal_dontAddSysroot ? false,
+
+  # # Needed to `pushd`/`popd` into a subdir of a tarball if this subdir
+  # # contains a Cargo.toml, but isn't part of a workspace (which is e.g. the
+  # # case for `rustfmt`/etc from the `rust-sources).
+  # # Otherwise, everything from the tarball would've been built/tested.
+  # # Figure out what this does
+  # buildAndTestSubdir ? null,
+  ...
+}@args:
+stdenvNoCC.mkDerivation { }

--- a/pkgs/build-support/deno/buildDenoApplication.nix
+++ b/pkgs/build-support/deno/buildDenoApplication.nix
@@ -8,6 +8,7 @@
   glibc,
   stdenv,
   fetchurl,
+  deno,
 }@topLevelArgs:
 {
   # Name of the package
@@ -37,12 +38,12 @@
 
   # Configuration for finding the main script and the config file 
   # The main script you would run with `deno run`
-  script,
+  mainScript,
   # The deno.json config file. 
   # TODO: Add support for deno.jsonc and allow for projects without deno.json
-  denoJson ? null,
+  denoJson ? "",
   # Customize the deno lockfile location
-  denoLock ? null,
+  denoLock ? "",
   # TODO: Allow projects with custom vendored dependencies
 
   # Configuration for how the application should be run
@@ -235,7 +236,7 @@ let
     args
     // {
       src = src;
-      script = script;
+      mainScript = mainScript;
       outputHash = denoDepsHash;
     }
   );
@@ -270,113 +271,195 @@ let
 in
 # deps;
 stdenvNoCC.mkDerivation (
-  args
-  // {
-    nativeBuildInputs =
-      [ deno ]
-      ++ (
-        if compile then
-          [
-            unzip
-            xxd
-            util-linux
-            glibc
-          ]
-        else
-          [ ]
-      )
-      ++ (if args ? nativeBuildInputs then args.nativeBuildInputs else [ ]);
+  finalAttrs:
+  (
+    args
+    // {
+      nativeBuildInputs =
+        [ deno ]
+        ++ (
+          if compile then
+            [
+              unzip
+              xxd
+              util-linux
+              glibc
+            ]
+          else
+            [ ]
+        )
+        ++ (if args ? nativeBuildInputs then args.nativeBuildInputs else [ ]);
 
-    buildPhase = ''
-      if test -z '${script}' ; then
-        echo "error: You need to specify a script. It is probably something like 'main.ts'"
-        echo "fix: Adjust you nix code to pass a main file."
-        exit 1
-      fi
+      denoJson = denoJson;
+      denoLock = denoLock;
+      mainScript = mainScript;
+      denoDeps = deps;
+      denoRuntime = denoRuntime;
+      executableName = executableName;
 
-      if ! test -f '${script}' ; then
-        echo "error: The script '${script}' for your application does not exist."
-        echo "fix: Run 'echo \"console.log(\\\"Hello world!\\\")\" > ${script}' to create it."
-        exit 1
-      fi
-
-      if ! test -f "${denoJson}" ; then
-        if test "${denoJson}" = "deno.json" ; then
-          echo "error: There is no deno config file in your project. For now we need every project to have a config file."
-          echo "fix: Run 'deno init' to create it."
-        else
-          echo "error: The deno config file at '${denoJson}' you specified does not exist."
-          echo "fix: Create '${denoJson}'."
+      buildPhase = ''
+        if test -z "$mainScript" ; then
+          echo "error: You need to specify a deno main script. It is probably something like 'main.ts'" >&2
+          echo "fix: Adjust you nix code to pass a main script as script." >&2
+          exit 1
         fi
-        exit 1
-      fi
+        if ! test -f "$mainScript" ; then
+          echo "error: The script '$mainScript' for your application does not exist." >&2
+          echo "fix: Run 'echo \"console.log(\\\"Hello world!\\\")\" > $mainScript' to create it." >&2
+          exit 1
+        fi
 
-      if test -e "./vendor" || test -e "./node_modules" ; then
-        ls -a
-        echo "error: It looks like your project already contains some vendored dependencies. Good job, nice reproducibility. However buildDenoApplication doesnt support it for now." >&2
-        echo "fix: Add support for vendored dependencies to buildDenoApplication and submit a patch" >&2
-        echo "fix: Or just remove ./vendor and ./node_modules" >&2
-        exit 1
-      fi
+        SCRIPT_DIR="$(dirname "$mainScript")"
 
-      BUILD_DIR=$(mktemp -d)
-      ln -s ${deps}/node_modules $BUILD_DIR/node_modules
-      ln -s ${deps}/vendor $BUILD_DIR/vendor
-      for file in $(find $src -maxdepth 1 -mindepth 1 -printf "%P\n") ; do
-        ln -s $src/$file $BUILD_DIR/$file
-      done
-    '';
-
-    installPhase =
-      if compile then
-        ''
-          cd $BUILD_DIR
-          export DENO_DIR="$(mktemp -d)"
-          ln -s ${deps}/deno/npm "$DENO_DIR"
-          mkdir -p $DENO_DIR/dl/release/v${deno.version}
-          ln -s ${denoRuntime} $DENO_DIR/dl/release/v${deno.version}/denort-x86_64-unknown-linux-gnu.zip
-
-          export DENO_NO_UPDATE_CHECK=true
-          export DENO_NO_PACKAGE_JSON=true
-          export DENO_JOBS=1
-          deno compile --cached-only --vendor=true --node-modules-dir=true -c ${denoJson} -o $out/bin/${executableName} -A ${script}
-        ''
-      else
-        ''
-          mkdir -p $out
-          mv $BUILD_DIR $out/module
-
-          mkdir -p $out/bin
-          cat << EOF > $out/bin/${executableName}
-          #!/usr/bin/env bash
-          ${
-            if writableDenoDirectory then
-              ''
-                export DENO_DIR="\$(mktemp -td ${executableName}-XXXXXX)"
-                ln -s ${deps}/deno/npm "\$DENO_DIR"
-              ''
+        # Resolve the deno json file. We need it to resolve the lockfile
+        if test -n "$denoJson" ; then
+          if ! test -f "$denoJson" ; then
+            if test "$denoJson" = "deno.json" ; then
+              echo "error: There is no deno config file in your project, but you explicitly specified '$denoJson'." >&2
+              echo "fix: Run 'deno init' to create it." >&2
+              echo "fix: Or remove the denoJson attribute from your nix code to use the default or none." >&2
             else
-              ''
-                export DENO_DIR="${deps}/deno"
-              ''
-          }
-          export DENO_NO_UPDATE_CHECK=true
-          export DENO_NO_PACKAGE_JSON=true
-          export DENO_JOBS=1
-          exec ${lib.getExe deno} run --cached-only --vendor=true --node-modules-dir=true -c $out/module/${denoJson} -A $out/module/${script} "\$@"
-          EOF
-          chmod a+x $out/bin/${executableName}
-        '';
+              echo "error: The deno config file at '$denoJson' you specified does not exist." >&2
+              echo "fix: Create '$denoJson'." >&2
+              echo "fix: Or remove the denoJson attribute from your nix code to use the default or none." >&2
+            fi
+            exit 1
+          fi
+        fi
+        # If the deno json file is not set, we try the default locations
+        implicitDenoJson="$denoJson"
+        if test -z "$implicitDenoJson" ; then
+          if test -f "$SCRIPT_DIR/$deno.json" ; then
+            implicitDenoJson="$(realpath -s --relative-to . "$SCRIPT_DIR/deno.json")"
+          elif test -f "$SCRIPT_DIR/deno.jsonc" ; then
+            implicitDenoJson="$(realpath -s --relative-to . "$SCRIPT_DIR/deno.jsonc")"
+          fi
+        fi
 
-    fixupPhase =
-      if compile then
-        ''
-          # The last 40 bytes of the file have to be the d3n0l4nd trailer
-          TRAILER=$(tail -c 40 $out/bin/${executableName} | hexdump -v -e '1/1 "%02x "')
-          patchelf --set-interpreter "$(cat ${stdenv.cc}/nix-support/dynamic-linker)" $out/bin/${executableName}
-          echo "$TRAILER" | xxd -r -p >>"$out/bin/${executableName}"
-        ''
-      else
-        null;
-  }
+        # If a deno json is to be used, implicitDenoJson is set at this point
+        # If it is set, the file is guaranteed to exist
+
+
+        if test -n "$denoLock" ; then
+          if ! test -f "$denoLock" ; then
+            echo "error: The deno lock file at '$denoLock' you explicitly requested does not exist." >&2
+            echo "fix: Create '$denoLock'." >&2
+            echo "fix: Or remove the denoLock attribute from your nix code to use the default one." >&2
+            exit 1
+          fi
+        fi
+        implicitDenoLock="$denoLock"
+        # If the lockfile is not set, try to read its path from the deno json file
+        if test -z "$implicitDenoLock" ; then
+          if test -n "$implicitDenoJson" ; then
+            implicitDenoLock="$(jq -r '.lock' "$implicitDenoJson" | sed 's/^null//')"
+            if ! test -f "$implicitDenoLock" ; then
+              echo "error: The deno lock file at '$implicitDenoLock' that was specified in '$implicitDenoJson' does not exist." >&2
+              echo "fix: Run 'deno cache -c \"$implicitDenoJson\" $mainScript' to create it." >&2
+              exit 1
+            fi
+          fi
+        fi
+        # If the lockfile is still not set, try the default location
+        if test -z "$implicitDenoLock" ; then
+          if test -f "$SCRIPT_DIR/deno.lock" ; then
+            implicitDenoLock="$(realpath -s --relative-to . "$SCRIPT_DIR/deno.lock")"
+          fi
+        fi
+        if test -z "$implicitDenoLock" ; then
+          echo "error: There is no deno lock file in your project." >&2
+          echo "fix: Run 'deno cache $mainScript' to create it." >&2
+          exit 1
+        fi
+
+        # implicitDenoJson is always set to an existing file at this point, or to an empty string if it is not used
+        # implicitDenoLock is always set to an existing file at this point
+
+        export DENO_FLAGS=""
+        if test -n "$implicitDenoJson" ; then
+          DENO_FLAGS+="-c $implicitDenoJson "
+        fi
+        DENO_FLAGS+="--lock $implicitDenoLock "
+
+        if test -e "$src/vendor" || test -e "$src/node_modules" ; then
+          ls -a
+          echo "error: It looks like your project already contains some vendored dependencies. Good job, nice reproducibility. However buildDenoApplication doesnt support it for now." >&2
+          echo "fix: Add support for vendored dependencies to buildDenoApplication and submit a patch" >&2
+          echo "fix: Or just remove ./vendor and ./node_modules" >&2
+          exit 1
+        fi
+
+        BUILD_DIR=$(mktemp -d)
+        for file in $(find $src -maxdepth 1 -mindepth 1 -printf "%P\n") ; do
+          ln -s $src/$file $BUILD_DIR/$file
+        done
+        ln -s $denoDeps/node_modules $BUILD_DIR/node_modules
+        ln -s $denoDeps/vendor $BUILD_DIR/vendor
+      '';
+
+      installPhase =
+        if compile then
+          ''
+            cd $BUILD_DIR
+            export DENO_DIR="$(mktemp -d)"
+            ln -s $denoDeps/deno_dir/npm "$DENO_DIR"
+            mkdir -p $DENO_DIR/dl/release/v${deno.version}
+            ln -s $denoRuntime $DENO_DIR/dl/release/v${deno.version}/denort-x86_64-unknown-linux-gnu.zip
+
+            export DENO_NO_UPDATE_CHECK=true
+            export DENO_NO_PACKAGE_JSON=true
+            export DENO_JOBS=1
+            pwd
+            ls -a $denoDeps
+
+            echo $denoDeps
+            cat deno.lock
+            deno compile --cached-only --vendor=true --node-modules-dir=true $DENO_FLAGS -o "$out/bin/$executableName" "$mainScript"
+          ''
+        else
+          ''
+            mkdir -p $out
+            mv $BUILD_DIR $out/module
+
+            mkdir -p $out/bin
+            DENO_FLAGS=""
+            if test -n "$implicitDenoJson" ; then
+              DENO_FLAGS+="-c $out/module/$implicitDenoJson "
+            fi
+            DENO_FLAGS+="--lock $out/module/$implicitDenoLock "
+
+            cat << EOF > $out/bin/$executableName
+            #!/usr/bin/env bash
+            ${
+              if writableDenoDirectory then
+                ''
+                  export DENO_DIR="\$(mktemp -td "$executableName-XXXXXX")"
+                  ln -s $denoDeps/deno_dir/* "\$DENO_DIR"
+                ''
+              else
+                ''
+                  export DENO_DIR="$denoDeps/deno_dir"
+                ''
+            }
+            export DENO_NO_UPDATE_CHECK=true
+            export DENO_NO_PACKAGE_JSON=true
+            export DENO_JOBS=1
+
+            exec ${lib.getExe deno} run --cached-only --vendor=true --node-modules-dir=true $DENO_FLAGS $out/module/$mainScript "\$@"
+            EOF
+            chmod a+x $out/bin/$executableName
+          '';
+
+      fixupPhase =
+        if compile then
+          ''
+            # The last 40 bytes of the file have to be the d3n0l4nd trailer
+            TRAILER=$(tail -c 40 $out/bin/$executableName | hexdump -v -e '1/1 "%02x "')
+            patchelf --set-interpreter "$(cat ${stdenv.cc}/nix-support/dynamic-linker)" $out/bin/$executableName
+            echo "$TRAILER" | xxd -r -p >>"$out/bin/$executableName"
+          ''
+        else
+          null;
+    }
+  )
 )

--- a/pkgs/build-support/deno/buildDenoApplication.nix
+++ b/pkgs/build-support/deno/buildDenoApplication.nix
@@ -2,6 +2,12 @@
   lib,
   stdenvNoCC,
   fetchDenoDeps,
+  unzip,
+  xxd,
+  util-linux,
+  glibc,
+  stdenv,
+  fetchurl,
 }@topLevelArgs:
 {
   # Name of the package
@@ -34,7 +40,7 @@
   script,
   # The deno.json config file. 
   # TODO: Add support for deno.jsonc and allow for projects without deno.json
-  denoJson ? "deno.json",
+  denoJson ? null,
   # Customize the deno lockfile location
   denoLock ? null,
   # TODO: Allow projects with custom vendored dependencies
@@ -66,6 +72,18 @@
   # We want parallel builds by default
   # TODO: idk if deno even supports something like parallel building
   enableParallelBuilding ? false,
+
+  #   src,
+  #   script,
+  #   depsHash ? "",
+  #   denoJson ? "deno.json",
+  #   # Create a temporary directory, where deno can cache some things. Stops deno from whining about not being able to write to the deno directory.
+  #   # Not used if compile is true.
+  #   writableDenoDirectory ? true,
+  #   # Just produce a single binary, instead of a whole directory.
+  #   compile ? false,
+  #   ...
+  # }@args:
 
   # References used:
   # pkgs/build-support/rust/build-rust-package/default.nix
@@ -211,4 +229,154 @@
   # buildAndTestSubdir ? null,
   ...
 }@args:
-stdenvNoCC.mkDerivation { }
+let
+  # TODO: Add missing arguments
+  deps = fetchDenoDeps (
+    args
+    // {
+      src = src;
+      script = script;
+      outputHash = denoDepsHash;
+    }
+  );
+  executableName = if args ? meta.mainProgram then args.meta.mainProgram else args.pname;
+  denoRuntimeTable = {
+    "1.44.4" = {
+      x86_64-linux = {
+        url = "https://dl.deno.land/release/v1.44.4/denort-x86_64-unknown-linux-gnu.zip";
+        hash = "sha256-KdTDshZ5G2f07IaOerSpv6/rNhLTOejADgLW9LOXtYU=";
+      };
+      aarch64-linux = {
+        url = "https://dl.deno.land/release/v1.44.4/denort-aarch64-unknown-linux-gnu.zip";
+        hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+      };
+    };
+  };
+  architectureToDenoRuntimeZip = {
+    x86_64-linux = "denort-x86_64-unknown-linux-gnu.zip";
+    aarch64-linux = "denort-aarch64-unknown-linux-gnu.zip";
+  };
+  denoRuntimeUrl =
+    if denoRuntimeTable ? ${deno.version}.${stdenvNoCC.targetPlatform.system} then
+      denoRuntimeTable.${deno.version}.${stdenvNoCC.targetPlatform.system}
+    else
+      {
+        url = "https://dl.deno.land/release/v${deno.version}/${
+          architectureToDenoRuntimeZip.${stdenvNoCC.targetPlatform.system}
+        }";
+        hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+      };
+  denoRuntime = fetchurl denoRuntimeUrl;
+in
+# deps;
+stdenvNoCC.mkDerivation (
+  args
+  // {
+    nativeBuildInputs =
+      [ deno ]
+      ++ (
+        if compile then
+          [
+            unzip
+            xxd
+            util-linux
+            glibc
+          ]
+        else
+          [ ]
+      )
+      ++ (if args ? nativeBuildInputs then args.nativeBuildInputs else [ ]);
+
+    buildPhase = ''
+      if test -z '${script}' ; then
+        echo "error: You need to specify a script. It is probably something like 'main.ts'"
+        echo "fix: Adjust you nix code to pass a main file."
+        exit 1
+      fi
+
+      if ! test -f '${script}' ; then
+        echo "error: The script '${script}' for your application does not exist."
+        echo "fix: Run 'echo \"console.log(\\\"Hello world!\\\")\" > ${script}' to create it."
+        exit 1
+      fi
+
+      if ! test -f "${denoJson}" ; then
+        if test "${denoJson}" = "deno.json" ; then
+          echo "error: There is no deno config file in your project. For now we need every project to have a config file."
+          echo "fix: Run 'deno init' to create it."
+        else
+          echo "error: The deno config file at '${denoJson}' you specified does not exist."
+          echo "fix: Create '${denoJson}'."
+        fi
+        exit 1
+      fi
+
+      if test -e "./vendor" || test -e "./node_modules" ; then
+        ls -a
+        echo "error: It looks like your project already contains some vendored dependencies. Good job, nice reproducibility. However buildDenoApplication doesnt support it for now." >&2
+        echo "fix: Add support for vendored dependencies to buildDenoApplication and submit a patch" >&2
+        echo "fix: Or just remove ./vendor and ./node_modules" >&2
+        exit 1
+      fi
+
+      BUILD_DIR=$(mktemp -d)
+      ln -s ${deps}/node_modules $BUILD_DIR/node_modules
+      ln -s ${deps}/vendor $BUILD_DIR/vendor
+      for file in $(find $src -maxdepth 1 -mindepth 1 -printf "%P\n") ; do
+        ln -s $src/$file $BUILD_DIR/$file
+      done
+    '';
+
+    installPhase =
+      if compile then
+        ''
+          cd $BUILD_DIR
+          export DENO_DIR="$(mktemp -d)"
+          ln -s ${deps}/deno/npm "$DENO_DIR"
+          mkdir -p $DENO_DIR/dl/release/v${deno.version}
+          ln -s ${denoRuntime} $DENO_DIR/dl/release/v${deno.version}/denort-x86_64-unknown-linux-gnu.zip
+
+          export DENO_NO_UPDATE_CHECK=true
+          export DENO_NO_PACKAGE_JSON=true
+          export DENO_JOBS=1
+          deno compile --cached-only --vendor=true --node-modules-dir=true -c ${denoJson} -o $out/bin/${executableName} -A ${script}
+        ''
+      else
+        ''
+          mkdir -p $out
+          mv $BUILD_DIR $out/module
+
+          mkdir -p $out/bin
+          cat << EOF > $out/bin/${executableName}
+          #!/usr/bin/env bash
+          ${
+            if writableDenoDirectory then
+              ''
+                export DENO_DIR="\$(mktemp -td ${executableName}-XXXXXX)"
+                ln -s ${deps}/deno/npm "\$DENO_DIR"
+              ''
+            else
+              ''
+                export DENO_DIR="${deps}/deno"
+              ''
+          }
+          export DENO_NO_UPDATE_CHECK=true
+          export DENO_NO_PACKAGE_JSON=true
+          export DENO_JOBS=1
+          exec ${lib.getExe deno} run --cached-only --vendor=true --node-modules-dir=true -c $out/module/${denoJson} -A $out/module/${script} "\$@"
+          EOF
+          chmod a+x $out/bin/${executableName}
+        '';
+
+    fixupPhase =
+      if compile then
+        ''
+          # The last 40 bytes of the file have to be the d3n0l4nd trailer
+          TRAILER=$(tail -c 40 $out/bin/${executableName} | hexdump -v -e '1/1 "%02x "')
+          patchelf --set-interpreter "$(cat ${stdenv.cc}/nix-support/dynamic-linker)" $out/bin/${executableName}
+          echo "$TRAILER" | xxd -r -p >>"$out/bin/${executableName}"
+        ''
+      else
+        null;
+  }
+)

--- a/pkgs/build-support/deno/buildDenoApplication.nix
+++ b/pkgs/build-support/deno/buildDenoApplication.nix
@@ -9,6 +9,7 @@
   stdenv,
   fetchurl,
   deno,
+  jq,
 }@topLevelArgs:
 {
   # Name of the package
@@ -278,7 +279,10 @@ stdenvNoCC.mkDerivation (
     args
     // {
       nativeBuildInputs =
-        [ deno ]
+        [
+          deno
+          jq
+        ]
         ++ (
           if compile then
             [

--- a/pkgs/build-support/deno/fetchDenoDeps.nix
+++ b/pkgs/build-support/deno/fetchDenoDeps.nix
@@ -1,0 +1,181 @@
+{
+  stdenvNoCC,
+  deno,
+  jq,
+  gnused,
+  coreutils,
+}@topLevelArgs:
+{
+  # Use this deno binary
+  deno ? topLevelArgs.deno,
+
+  # Hash of the vendored dependencies. Leave empty if you dont know it yet
+  outputHash,
+
+  # Configuration for finding the main script and the config file 
+  # The main script. Used with `deno cache` to fetch dependencies.
+  script,
+  # The deno.json config file. Leave unset to use denos default behavior (search for deno.json and deno.jsonc next to the script)
+  denoJson ? null,
+  # Customize the deno lockfile location.  Leave unset to use denos default behavior (search for deno.lock next to the script)
+  denoLock ? null,
+  ...
+}@args:
+stdenvNoCC.mkDerivation (
+  finalAttrs:
+  (
+    args
+    // {
+      denoJsonFlag = if denoJson then "-c ${denoJson}" else "";
+      denoLockFlag = if denoLock then "-c ${denoLock}" else "";
+      nativeBuildInputs = [
+        deno
+        jq
+        gnused
+        coreutils
+      ];
+
+      # run the same build as our main derivation to ensure we capture the correct set of dependencies
+      buildPhase = ''
+        ERROR_OCCURRED=false
+
+        export DENO_DIR="$(mktemp -d)"
+        export DENO_NO_UPDATE_CHECK=true
+        export DENO_NO_PACKAGE_JSON=true
+        export DENO_JOBS=1
+
+        if test -z '${script}' ; then
+          echo "error: You need to specify a script. It is probably something like 'main.ts'"
+          echo "fix: Adjust you nix code to pass a main file."
+          exit 1
+        fi
+
+        if ! test -f '${script}' ; then
+          echo "error: The script '${script}' for your application does not exist."
+          echo "fix: Run 'echo \"console.log(\\\"Hello world!\\\")\" > ${script}' to create it."
+          ERROR_OCCURRED=true
+        fi
+
+        if ! test -f "${denoJson}" ; then
+          if test "${denoJson}" = "deno.json" ; then
+            echo "error: There is no deno config file in your project. For now we need every project to have a config file."
+            echo "fix: Run 'deno init' to create it."
+          else
+            echo "error: The deno config file at '${denoJson}' you specified does not exist."
+            echo "fix: Create '${denoJson}'."
+          fi
+          ERROR_OCCURRED=true
+        fi
+
+        LOCKFILE="$((jq -r '.lock' '${denoJson}' || true) | sed -E 's/^(null)?$/deno.lock/')"
+        if test -z "$LOCKFILE" ; then
+          LOCKFILE="deno.lock"
+        fi
+        mkdir node_modules
+        mkdir vendor
+        mkdir deno
+
+        if ! test -f "$LOCKFILE" ; then
+          echo "error: Your lockfile '$LOCKFILE' does not seem to exist."
+          echo "fix: Run 'deno run --reload ${script}' to create it."
+          ERROR_OCCURRED=true
+        fi
+
+        if test "$ERROR_OCCURRED" = "true" ; then
+          exit 1
+        fi
+
+        export LOCKFILE_HASH=$(sha256sum "$LOCKFILE" | cut -d' ' -f1)
+
+        # This fun dance, makes the cache command run twice, because the DENO_DIR is not reproducible otherwise
+        deno cache ${finalAttrs.denoJsonFlag} --lock deno.lock --vendor=true --node-modules-dir=true ${script}
+        rm -rf deno
+        mkdir deno
+        deno cache -c ${denoJson} --lock deno.lock --vendor=true --node-modules-dir=true ${script}
+
+        # These two files are not always reproducible and also not required
+        rm node_modules/.deno/.deno.lock.poll
+        rm node_modules/.deno/.deno.lock
+
+        # This one is different on every build. There is a open PR to fix this
+        # https://github.com/denoland/deno/issues/24479
+        # rm node_modules/.deno/.setup-cache.bin
+
+        # Make the symlinks in node_modules relative
+        for link in $(find node_modules -type l | sort) ; do
+          ln --force --symbolic --no-dereference --relative "$(readlink --canonicalize "$link")" "$link"
+        done
+
+        # Filter the files in DENO_DIR that we actually need
+        OLD_DENO_DIR="$DENO_DIR"
+        export DENO_DIR="$(mktemp -d)"
+        # We do this weird dance with jq to make sure the content of the files is sorted, because by default they are not. 
+        for file in $(find $OLD_DENO_DIR/npm -type f -name 'registry.json' | sed "s|^$OLD_DENO_DIR||g" | sort) ; do
+          target_file="$DENO_DIR/$file"
+          mkdir -p "$(dirname "$target_file")"
+          # There should only be registry.json files here
+          # echo '###############################################################################'
+          echo $file
+          # cat $file
+
+          jq -Sc '.' "$OLD_DENO_DIR/$file" > "$target_file"
+          # jq -S '.versions = ( .versions | with_entries( select(.key == ("5.1.0", "other")) ) )'
+        done
+
+
+        LOCKFILE_HASH_AFTER=$(sha256sum "$LOCKFILE" | cut -d' ' -f1)
+
+        if test "$LOCKFILE_HASH" != "$LOCKFILE_HASH_AFTER" ; then
+          echo "error: Your lockfile changed while running 'deno cache ${script}'. We cant do reproducible builds this way. You probably have unlocked imports somewhere in your code. To fix this run 'deno cache ${script}' and commit the changed lockfile." >&2
+          echo "fix: Run 'deno cache ${script}' and commit the changed lockfile." >&2
+          ERROR_OCCURRED=true
+        fi
+
+        if test -f vendor/manifest.json ; then
+          for import in $(cat vendor/manifest.json | jq -r '.modules | keys[]') ; do
+            warning="$(cat vendor/manifest.json | jq -r '.modules["'"$import"'"].headers["x-deno-warning"]' || true)"
+            echo "error: Import of '$import' produced a warning. This usually means, that your import is not locked. While this does not always affect reproducibility, it significantly increases the chance of weird errors if we allowed this. You don't like weird bugs, do you? For this reason I am now aborting your build and forcing you to fix it." >&2
+            echo "reference: $warning" >&2
+            echo "fix: Add the import to your '"'${denoJson}'"' file and lock it by running 'deno add \"$import\"'" >&2
+            ERROR_OCCURRED=true
+          done
+        fi
+
+        if test "$ERROR_OCCURRED" = "true" ; then
+          exit 1
+        fi
+      '';
+
+      installPhase = ''
+        mkdir -p $out
+
+        # Place vendored https modules in out
+        mv vendor $out
+
+        # Place node_modules in out
+        mv node_modules $out/node_modules
+
+        # Place lockfile hash in out
+        echo "$LOCKFILE_HASH" | cut -d' ' -f1 > $out/lockfile.hash
+
+        # Place the deno version in out
+        echo "${deno.version}" > $out/deno.version
+
+        # Place the denodir in out 
+        mv $DENO_DIR $out/deno_dir
+      '';
+
+      # specify the content hash of this derivations output
+      outputHashMode = "nar";
+    }
+    // (
+      if outputHash != "" then
+        { outputHash = outputHash; }
+      else
+        {
+          outputHash = "";
+          outputHashAlgo = "sha256";
+        }
+    )
+  )
+)

--- a/pkgs/build-support/deno/fetchDenoDeps.nix
+++ b/pkgs/build-support/deno/fetchDenoDeps.nix
@@ -145,11 +145,12 @@ stdenvNoCC.mkDerivation (
 
         export LOCKFILE_HASH=$(sha256sum "$implicitDenoLock" | cut -d' ' -f1)
 
-        # This fun dance, makes the cache command run twice, because the DENO_DIR is not reproducible otherwise
         deno cache $DENO_FLAGS --vendor --node-modules-dir "$mainScript"
-        rm -rf deno
-        mkdir deno
-        deno cache $DENO_FLAGS --vendor --node-modules-dir "$mainScript"
+        # # This fun dance, makes the cache command run a second time, because the DENO_DIR is not reproducible otherwise.
+        # # We dont need it for now, because we only take the relevant files from the DENO_DIR
+        # rm -rf deno
+        # mkdir deno
+        # deno cache $DENO_FLAGS --vendor --node-modules-dir "$mainScript"
 
         LOCKFILE_HASH_AFTER=$(sha256sum "$implicitDenoLock" | cut -d' ' -f1)
 

--- a/pkgs/by-name/de/department-of-misinformation/package.nix
+++ b/pkgs/by-name/de/department-of-misinformation/package.nix
@@ -1,0 +1,32 @@
+{
+  buildDenoApplication,
+  lib,
+  fetchFromGitHub,
+}:
+buildDenoApplication {
+  pname = "department-of-misinformation";
+  version = "0unstable";
+
+  src = fetchFromGitHub {
+    owner = "zebreus";
+    repo = "department-of-misinformation";
+    rev = "a6f2c780d9b2cd0f6dae01ee769d151a1417ee03";
+    hash = "sha256-UBKSMchw6uE3fEuduiilC3nY0xPQqU/jfnOH1jiWO7E=";
+  };
+  mainScript = "server.ts";
+  denoDepsHash = "sha256-KaZWHX7MNVaGwMt/ubr+YObeXkUq8C7rxA5KA/YKW3Y=";
+  compile = true;
+  runtimeFlags = [
+    "--allow-read"
+    "--allow-env"
+    "--allow-net"
+    "--allow-write"
+  ];
+
+  meta = with lib; {
+    description = "Experimental activitypub server where infra can post status updates";
+    homepage = "https://github.com/zebreus/department-of-misinformation";
+    license = licenses.mit;
+    maintainers = [ maintainers.zebreus ];
+  };
+}

--- a/pkgs/by-name/le/lesskey/package.nix
+++ b/pkgs/by-name/le/lesskey/package.nix
@@ -1,0 +1,28 @@
+{
+  buildDenoApplication,
+  lib,
+  fetchFromGitHub,
+  ...
+}:
+buildDenoApplication rec {
+  pname = "lesskey";
+  version = "0.1.0-prealpha";
+
+  src = fetchFromGitHub {
+    owner = "AsPulse";
+    repo = "lesskey";
+    rev = "v${version}";
+    hash = "sha256-SM6d8Bo6icz7i5CMzkZQwUh4zMu13RPJeI1Uq9bk8jY=";
+  };
+  mainScript = "src/index.ts";
+  denoDepsHash = "sha256-ChBa2kJMqZFrelj7tJebEkmm40TZDX18h8NI3Rh1r9g=";
+  denoJson = "deno.jsonc";
+  denoLock = "deno.lock";
+
+  meta = with lib; {
+    description = "CLI client for misskey";
+    homepage = "https://github.com/AsPulse/lesskey";
+    license = licenses.mit;
+    maintainers = [ maintainers.zebreus ];
+  };
+}

--- a/pkgs/development/web/deno/default.nix
+++ b/pkgs/development/web/deno/default.nix
@@ -15,11 +15,12 @@ rustPlatform.buildRustPackage rec {
   pname = "deno";
   version = "1.44.4";
 
+  # That patch has already been accepted into deno and will be included in 1.45 🎉
   src = fetchFromGitHub {
-    owner = "denoland";
-    repo = pname;
-    rev = "v${version}";
-    hash = "sha256-DQrN5x+UiY6lLY1h96sTWBhD0jrvNyCdTwHsyFo95VE=";
+    owner = "zebreus";
+    repo = "deno";
+    rev = "f67761055b6e3e4346629d06a7ac6028f9d90410";
+    sha256 = "sha256-mlLq6gyoyz+6mnrF86YZ0iBLWXFZ19Qh84MveXG2rfs=";
   };
 
   cargoHash = "sha256-QGBFDFZpOqPj/U1PhMaTZ3mI+d2jG6vYAkW6aNG4wyQ=";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7139,6 +7139,9 @@ with pkgs;
 
   deno = callPackage ../development/web/deno { };
 
+  buildDenoApplication = callPackage ../build-support/deno/buildDenoApplication.nix { };
+  fetchDenoDeps = callPackage ../build-support/deno/fetchDenoDeps.nix { };
+
   deqp-runner = callPackage ../tools/graphics/deqp-runner { };
 
   detox = callPackage ../tools/misc/detox { };


### PR DESCRIPTION
## Description of changes

This PR adds a proof of concept for a `buildDenoApplication` function similar to the `buildRustCrate` function. This is still work in progress.

-----------

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I went through the Deno manual, issues, and code and tried to collect all the information relevant to importing things and fetching dependencies based on the lockfile:

## Imports

In ECMAScript modules, files are imported via [import specifiers](https://nodejs.org/api/esm.html#terminology). They can be either relative (`./file.ts`), bare (`idk/file.ts`), or absolute (`prot:/absolute/path/file.ts`). Deno supports importing via relative and absolute specifiers. Relative specifiers are evaluated relative to the current file. Deno supports the `file`, `data`, `blob`, `node`, `http`, `https`, `npm`, and `jsr` protocols for absolute specifiers.

Deno also supports [import maps](https://html.spec.whatwg.org/multipage/webappapis.html#import-maps), which enable us to define bare specifiers. Import maps are specified when running a script, usually via `deno.json`, which means that libraries cannot use import maps.

Deno can use lockfiles to lock the versions and verify the integrity of all external imports. Similarly to import maps, the lockfile is specified when running a script, so libraries cannot bring their own lockfiles.



### Relative imports and imports from `file:` specifiers

Local imports are unproblematic because they are not dependencies but our project's source. Local imports outside our src repo are out of scope for now.

### Import from `node:` specifiers

Deno can import Node.js built-in modules. I am unsure how Deno does this, but it doesn't produce any files in the `$DENO_DIR` or the vendored directories. The Node.js built-in modules are also built into Deno.

### Imports from `data:` specifiers

Do not need to be locked or included in dependencies.

### Imports from `blob:` specifiers

Blob imports do not need to be locked or included in dependencies.

### Imports from `https:` (and `http:`) specifiers
Imports from URLs. The `deno.lock` version 3 solves the issue with redirects and directly lists all URLs we need to fetch. The more significant issue is caching only the fetched file contents but not the received HTTP headers. This can be a problem because Deno seems to change its behavior based on the headers, as documented in denoland/deno#19512. We can mitigate these issues by just ignoring all headers. I am not even sure if this is an issue anymore because I could not find any trace of the headers in the output of `deno cache --vendor --node-modules-dir`, so when we do `deno --cached-only run`  afterward, the behavior should be unaffected by the headers. Not sure if this leads to failing applications because the behavior changes when using `--cached-only`, but that would be a general deno problem, not a nix problem.

### Imports from `npm:` specifiers

Deno can import packages from npm registries. npm imports consist of a package name, a version requirement, and an optional path in the package.

If the version requirement of a package is a specific version, we can assume that this package is deterministic. I think this is an even stronger assumption than deterministic content behind URLs, as all relevant public registries have the policy that the content of a specific version is immutable ( ([npm.js](https://docs.npmjs.com/policies/unpublish), [deno.land/x](https://deno.land/x#Q%26A), [jsr.io](https://jsr.io/docs/immutability)). However, the dependencies of a version are usually based on relatively broad version requirements, which means that they need to be locked.

The Deno lockfile v3 sufficiently locks the packages. However, it seems like Deno only supports one npm registry at a time. The lockfile tracks the hash for every required package/version combination and the exact package/version combination of every resolved dependency. This is different from npm `package-lock.json` files, which track incomplete versions for dependencies if multiple packages request different versions of the package. Deno does all the heavy lifting for us here; we don't need to determine which version a package uses.

Deno supports using a vendored `node_modules` directory in the project directory. We need to create that directory with Nix as a part of the dependencies. All npm package sources live in directories like `node_modules/.deno/PACKAGE_NAME@VERSION/node_modules/MAYBE_PACKAGE_SCOPE/PACKAGE_NAME`. There is no `node_modules` folder in that folder. I am surprised that this works, but it does. See the list below for more details on the exact structure. There also are relative symlinks at `node_modules/MAYBE_PACKAGE_SCOPE/PACKAGE_NAME` for every direct dependency of our packages that point to the correct version of the package in `node_modules/.deno`. I think the structure is relatively sane, as we have a clean directory without dependencies for every package. Everything else is just symlinks.

`MANGLED_PACKAGE_NAME` refers to a package name in which all slashes have been replaced with `+`. For example, `@webview/webview` becomes `@webview+webview`. As `+` is not allowed in normal package names, this can not produce collisions.

`PACKAGE_NAME` refers to a package's name. If it is a scoped name, it does not include the scope; for `@scope/name`, this is just `name`.

`MAYBE_PACKAGE_SCOPE` refers to the scope of a package. If it is not a scoped package, this is just empty. For example, for `@scope/name`, this is `@scope`. For an unscoped package like `tsx`, this is nothing ``.

The dependencies are stored and symlinked in the node_modules folder as follows:

- `node_modules/.deno/MANGLED_PACKAGE_NAME@VERSION/node_modules/MAYBE_PACKAGE_SCOPE/PACKAGE_NAME` is the directory that contains the actual npm package. It only includes the files fetched from npm and no `node_modules` folder.
- `node_modules/.deno/MANGLED_PACKAGE_NAME@VERSION/node_modules/MAYBE_DEPENDENCY_SCOPE/DEPENDENCY_NAME`   is a symlink to `node_modules/.deno/MANGLED_DEPENDENCY_NAME@RESOLVED_VERSION/node_modules/MAYBE_DEPENDENCY_SCOPE/DEPENDENCY_NAME`. These links exist for all direct dependency of the package in `node_modules/.deno/MANGLED_PACKAGE_NAME@VERSION/node_modules/MAYBE_PACKAGE_SCOPE/PACKAGE_NAME`. I am surprised that this structure works with Node.js imports, but it does.
- `node_modules/MAYBE_DEPENDENCY_SCOPE/DEPENDENCY_NAME` is a symlink to `node_modules/.deno/MANGLED_DEPENDENCY_NAME@RESOLVED_VERSION/node_modules/MAYBE_DEPENDENCY_SCOPE/DEPENDENCY_NAME`. It exists for every direct dependency of our Deno project.

However, there are more files in `node_modules`.

- `node_modules/.deno/.setup-cache.bin` is a binary file that keeps track of the symlink structure in `node_modules`. Having this file isn't strictly necessary, as Deno will recreate it at runtime. However, Deno will fail if it cannot create that file at runtime, which it will if we load node_modules from the Nix store. In Deno 1.44, the file is also not deterministic because the entries are ordered randomly. I submitted a patch; this will be fixed in Deno 1.45.
- `node_modules/.deno/.deno.lock` and `node_modules/.deno/.deno.lock.poll` are probably used as a mutex. They are deterministic. Deno does not mind if they are missing. Deno also does not mind if it can not write these. We don't need to include them in our `node_modules` folder.
- `node_modules/.bin/EXECUTABLE_NAME` are symlinks to all entries in the [`bin`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#bin) sections of all direct and indirect dependencies. I am still determining how Deno handles conflicts if multiple packages export executables with the same name, but it seems deterministic.
- `node_modules/.deno/PACKAGE_NAME@VERSION/.initialized` is an empty file for every npm package. I assume Deno uses these to track whether a package folder is ready to be used. These files do not strictly need to exist, as Deno will create them at runtime. However, Deno will fail if it can not create them because the directory is in the Nix store.

I think these two lists are exhaustive, but I have not checked Deno's source code to verify that.

A bit tricky with using vendored node_modules is the `.setup-cache.bin` in the vendored folder, which maps module names to module names with versions, to keep track of the symlink structure in node_modules. It currently is a binary file without a clearly defined structure. I submitted a patch to deno to make it at least deterministic.

### Imports from `jsr:` specifiers

Deno can resolve `jsr:` specifiers to import packages from [jsr.io](https://jsr.io). Similar to `npm:` imports, `jsr:` imports consist of a package name, a version requirement, and an optional path in the package.

Deno will then decide the actual version for each jsr module and store them in the lockfile. Unlike npm packages, the concept of packages is only used to resolve the versions of dependencies. Afterward, Deno maps JSR imports to https URLs. If we know the resolved version, we can essentially replace a jsr import with the correct https import. So, for example, `jsr:@std/path/join` is equivalent to `https://jsr.io/@std/path/0.225.2/join.ts`. Note that it also added the `.ts` extension to the URL. [JSR package version metadate](https://jsr.io/docs/api#package-version-metadata) can contain an export map that maps paths in the specifier to files in the package. In this case, the export map contains an entry like `"./join": "./join.ts"`.

JSR imports are basically a layer of syntactical sugar on top of `https:` imports, with added support for version requirements. It also brings a few QoL improvements like the ability to use import maps to library authors, at the cost of only being able to publish at JSR because you need a build step ([for various](https://jsr.io/docs/publishing-packages#dependency-manifest) [reasons](https://jsr.io/docs/troubleshooting#invalidexternalimport)).

When vendoring `jsr:` imports, the downloaded files are stored in the `vendor` directory like `https:` imports. In fact, every file is placed in the correct location, corresponding to its URL. However, in addition to the TypeScript files, the vendor directory also contains [`vendor/jsr.io/SCOPE/PACKAGE/meta.json`](https://jsr.io/docs/api#package-metadata) for metadata about the available versions and [`vendor/jsr.io/SCOPE/PACKAGE/VERSION_meta.json`](https://jsr.io/docs/api#package-version-metadata) for every version of the package that we use. The version metadata file also includes an import map for the package. 

Annoyingly, files imported via `jsr:` specifiers are not represented like https imports in the lockfile but in a data structure similar to npm modules. `packages.specifiers` tracks the specifiers for all directly imported jsr and npm packages and their resolved versions. Each specifier's versions and resolved dependencies are tracked in `packages.npm` and `packages.jsr`, respectively. Both are objects with `packagename@resolvedversion` as keys. The values are objects with two fields; `integrity` contains a checksum for the package, and `dependencies` contains an array of specifiers of its dependencies. I have not yet found documentation on calculating the integrity checksum of JSR packages. Unlike `npm` modules, the specifiers in dependencies are not necessarily ~absolute~, so something like `jsr:@std/assert@^0.226.0` instead of `jsr:@std/assert@0.226.0` is possible. We can resolve these via the `packages.specifiers` map, but that is an extra step.

I found the following reproducibility issues with the current vendoring strategy for JSR modules:

1. The `vendor/meta.json` contains all published versions of the package and is constantly changing because of this. Which is not deterministic at all. A file like this should not exist in the vendor directory because the information is not relevant for vendoring; it is only for caching when using vendored dependencies and only when updating them. This file must exist when running with `--cached-only` deno. For npm imports, this type of information is always stored in `$DENO_DIR` in `registry.json` files. jsr imports should handle this in a similar fashion. 
2. The vendor directory only contains the files actually used by the script, but the lockfile does not include information about which files they are. That is a problem because the output does not depend on the lockfile. We could, however, always just fetch all files from the package.
3. The lockfile only contains the integrity checksum for the whole package but not the individual files. This makes integrity checks impossible if we are not fetching the complete package.

My preferred solution for problems 2 and 3 is to include all files in vendor with their checksums in `deno.lock`. This way, we also don't have to bother with the `packages.jsr` structure, as that is only needed for version resolution, which Deno already did for us.

<!--
I think one of the reasons why someone would use jsr is that we can centrally select appropriate semver versions and version ranges for all of our dependencies.

Until now, Deno's module and import system seemed like a sane take on Javascript modules. By only using relative URL imports, ECMAScript modules are predictable and pleasant to use, and they are also really nice for reproducibility. Import maps then solve the usability issue by allowing you to define shorthands for URLs. The only cursed part is the backward compatibility for node modules, but even that is solved in a sane and predictable way.

Something that is not immediately obvious is that libraries don't lock their files beyond what's in the URL. Also, import maps can only be used from the main application. They allow the library's consumer complete control of dependencies. The consumer can also use an import map to modify dependencies imports.

JSR == pain
-->

With this behavior, Deno reintroduces a few of the problems Node.js imports have.

## Ways of triggering imports

I tested various ways of triggering imports to see if they make a difference for the lockfile.

### JSX import with comment
Deno offers a few weird ways of importing jsx runtimes

```
/** @jsxImportSource https://esm.sh/preact */

export const Thing = <span>hi</span>
```
In the above, `/jsx-runtime` is appended to the path and is treated like a normal import from `https://esm.sh/preact/jsx-runtime`. We can also use imports with an npm specifier, in which case nothing is appended.

The jsx source can also be defined in `deno.json`; in that case, it is implicitly imported from all jsx and tsx files. This means that it is only imported if we import at least the tsx file.

```json
{
  "compilerOptions": {
    "jsx": "react-jsx",
    "jsxImportSource": "https://esm.sh/preact"
  }
}
```

If we don't define a jsx import in `deno.json` or via @jsxImportSource comment, deno will import nothing and fail with a `React not defined` error when using tsx files.

### Dynamic imports

Deno supports dynamic imports via the import function. When doing dynamic imports with string literals as URLs, deno will cache and lock the dependencies. When an expression is used as the URL, deno is (obviously) unable to lock and cache that dependency.

However, when we are running deno with `--cached-only` (which we are)

Caches dependency, does not require networking permissions at runtime, works at runtime
```typescript
const dynamicLiteral = (await import('https://deno.land/std@0.224.0/version.ts'));
```

Caches dependency; does not require networking permissions at runtime; works at runtime
```typescript
if (false) {
  const dynamicLiteral = (await import('https://deno.land/std@0.224.0/version.ts'));
}
```

Does not cache dependency; requires networking permissions at runtime; fails at runtime because the module is not in cache.
```typescript
const url = 'https://deno.land/std@0.224.0/version.ts'
const dynamicExpression = (await import(url));
```

Caches dependency; works at runtime
```typescript
import staticLiteral from 'https://deno.land/std@0.224.0/version.ts';
const url = 'https://deno.land/std@0.224.0/version.ts'
const dynamicExpression = (await import(url));
```

Caches dependency; works at runtime
```typescript
const dynamicLiteral = (await import('https://deno.land/std@0.224.0/version.ts'));
const url = 'https://deno.land/std@0.224.0/version.ts'
const dynamicExpression = (await import(url));
```
 I am not sure about the behavior of dynamic imports. The table below shows some results of different combinations in different environments.
<details>
  <summary>Testing the behavior of different dynamic imports</summary>

| cached-only | Already cached | literal import | expression import | literal before expression | Crashes | Asks for network | Cached after deno cache |
| ----------- | -------------- | -------------- | ----------- | ------- | ------- | ---------------- | ----------------------- |
| no          | no             | no             | no          | no      | no      | no               | no                      |
| no          | no             | no             | yes         | no      | no      | yes              | no                      |
| no          | no             | no             | unreachable | no      | no      | no               | no                      |
| no          | no             | yes            | no          | no      | no      | no               | yes                     |
| no          | no             | yes            | yes         | no      | no      | no               | yes                     |
| no          | no             | yes            | yes         | yes     | no      | no               | yes                     |
| no          | no             | yes            | unreachable | no      | no      | no               | yes                     |
| no          | no             | yes            | unreachable | yes     | no      | no               | yes                     |
| no          | no             | unreachable    | no          | no      | no      | no               | yes                     |
| no          | no             | unreachable    | yes         | no      | no      | no               | yes                     |
| no          | no             | unreachable    | yes         | yes     | no      | no               | yes                     |
| no          | no             | unreachable    | unreachable | no      | no      | no               | yes                     |
| no          | no             | unreachable    | unreachable | yes     | no      | no               | yes                     |
| no          | yes            | no             | no          | no      | no      | no               | yes                     |
| no          | yes            | no             | yes         | no      | no      | yes              | yes                     |
| no          | yes            | no             | unreachable | no      | no      | no               | yes                     |
| no          | yes            | yes            | no          | no      | no      | no               | yes                     |
| no          | yes            | yes            | yes         | no      | no      | no               | yes                     |
| no          | yes            | yes            | yes         | yes     | no      | no               | yes                     |
| no          | yes            | yes            | unreachable | no      | no      | no               | yes                     |
| no          | yes            | yes            | unreachable | yes     | no      | no               | yes                     |
| no          | yes            | unreachable    | no          | no      | no      | no               | yes                     |
| no          | yes            | unreachable    | yes         | no      | no      | no               | yes                     |
| no          | yes            | unreachable    | yes         | yes     | no      | no               | yes                     |
| no          | yes            | unreachable    | unreachable | no      | no      | no               | yes                     |
| no          | yes            | unreachable    | unreachable | yes     | no      | no               | yes                     |
| yes         | no             | no             | no          | no      | no      | no               | no                      |
| yes         | no             | no             | yes         | no      | yes     | yes              | no                      |
| yes         | no             | no             | unreachable | no      | no      | no               | no                      |
| yes         | no             | yes            | no          | no      | yes     | unknown          | yes                     |
| yes         | no             | yes            | yes         | no      | yes     | unknown          | yes                     |
| yes         | no             | yes            | yes         | yes     | yes     | unknown          | yes                     |
| yes         | no             | yes            | unreachable | no      | yes     | unknown          | yes                     |
| yes         | no             | yes            | unreachable | yes     | yes     | unknown          | yes                     |
| yes         | no             | unreachable    | no          | no      | no      | no               | yes                     |
| yes         | no             | unreachable    | yes         | no      | yes     | unknown          | yes                     |
| yes         | no             | unreachable    | yes         | yes     | yes     | unknown          | yes                     |
| yes         | no             | unreachable    | unreachable | no      | no      | no               | yes                     |
| yes         | no             | unreachable    | unreachable | yes     | no      | no               | yes                     |
| yes         | yes            | no             | no          | no      | no      | no               | yes                     |
| yes         | yes            | no             | yes         | no      | no      | yes              | yes                     |
| yes         | yes            | no             | unreachable | no      | no      | no               | yes                     |
| yes         | yes            | yes            | no          | no      | no      | no               | yes                     |
| yes         | yes            | yes            | yes         | no      | no      | no               | yes                     |
| yes         | yes            | yes            | yes         | yes     | no      | no               | yes                     |
| yes         | yes            | yes            | unreachable | no      | no      | no               | yes                     |
| yes         | yes            | yes            | unreachable | yes     | no      | no               | yes                     |
| yes         | yes            | unreachable    | no          | no      | no      | no               | yes                     |
| yes         | yes            | unreachable    | yes         | no      | no      | no               | yes                     |
| yes         | yes            | unreachable    | yes         | yes     | no      | no               | yes                     |
| yes         | yes            | unreachable    | unreachable | no      | no      | no               | yes                     |
| yes         | yes            | unreachable    | unreachable | yes     | no      | no               | yes                     |

</details>

## Various other things

### HTTP headers

We have previously seen that Deno sometimes treats files differently depending on the received http headers. However, some package registries also treat us differently depending on the headers we send. 

```console
$ curl https://esm.sh/preact@10.22.1/jsx-runtime
/* esm.sh - preact@10.22.1/jsx-runtime */
import "/stable/preact@10.22.1/esnext/preact.mjs";
export * from "/stable/preact@10.22.1/esnext/jsx-runtime.js";
```

If we set our user agent to `Deno/1.44.4`, we get a different result:

```console
$ curl -H 'User-Agent: Deno/1.44.4' https://esm.sh/preact@10.22.1/jsx-runtime
/* esm.sh - preact@10.22.1/jsx-runtime */
import "/stable/preact@10.22.1/denonext/preact.mjs";
export * from "/stable/preact@10.22.1/denonext/jsx-runtime.js";
```

If we set our user agent to `Deno/1.13.0`, we again get a different result with `deno` instead of `denonext`:

```console
$ curl -H 'User-Agent: Deno/1.13.0' https://esm.sh/preact@10.22.1/jsx-runtime
/* esm.sh - preact@10.22.1/jsx-runtime */
import "/stable/preact@10.22.1/deno/preact.mjs";
export * from "/stable/preact@10.22.1/deno/jsx-runtime.js";

```

This shouldn't be a problem if we send the same headers as Deno. But which version? It's probably best if we either decide on one and keep it or use the same version as Deno.

This should not be a big problem as there are not many sites that do this and even on esm.sh we get responses with `denonext` for all recent versions and that is unlikely to change. I think we should just pin it to `1.45.0` and add a switch in the future. If we would use the correct Deno version, we would also have to write the version number into the output, which would mean that the outputHash would change on every Deno update.

### package.json support

I will just ignore that for now and abort if a project contains a package.json and no deno config. Although it should be possible and not that hard.

### Private npm registries

We will need to add support for these, but not now.

https://docs.deno.com/runtime/manual/node/private_registries/

### Proxies, private repos, and auth tokens

Deno supports HTTP and HTTPS proxies. I don't know how Nix handles proxies; further investigation is needed.

https://docs.deno.com/runtime/manual/basics/modules/proxies/

Deno provides a way to specify an auth token for specific domains. Further investigation is needed.

https://docs.deno.com/runtime/manual/advanced/private_repositories/

### FFI / native code

Deno allows calling into native code using `Deno.dlopen` but does not provide a way of importing or packaging binaries. So, that is not part of the lockfile.

Deno once had a plugin system, but that was removed in 1.13. Good, this way, we do not have to worry about that

### WebAssembly 

WebAssembly is usually fetched at runtime, so we don't need to worry about it. However, Deno may add it to the lockfile in the future, so we might need to keep an eye out for that.

## TODO

### Tasks in Deno

None of the these are strictly required and we should be able to work around all of them. However having those features in Deno would make things a lot cleaner and less hacky.

- Lockfile format changes
  - [ ] Add the hashes of individual files fetched from JSR packages to the lockfile
  - [ ] Adjust the dependencies of JSR imports in the lockfile to always use the same specifier that is also used as the key in `packages.jsr`
- Changes to files in vendored directories
  - [ ] Tread the `meta.json` file like the `registry.json` files and always store them $DENO_DIR
  - [ ] Make sure all non-downloaded files in the `node_modules` directory are deterministic
  - [ ] Convert `node_modules/deno/.setup-cache.bin` to a JSON file
  - [x] Sort the keys in `vendor/manifest.json` (denoland/deno_cache_dir#53)
- Make Deno work with an empty $DENO_DIR and read-only vendor directories
  - [ ] Don't require `meta.json` files with `--cached-only --lock`
  - [ ] Don't require `registry.json` files with `--cached-only --lock`
- [ ] Add a way to check if a script is completely locked by the lockfile without internet access
- [ ] Add a way to verify vendored dependencies against the lockfile

### Tasks in nixpkgs

- [ ] Figure out a good interface for the buildDeno... functions
  - [ ] Look into the available deno environment variables and configuration options and if they are relevant for us 
  - [ ] Maybe use finalAttrs to make overriding the dependencies hash easier than in `buildRustCrate`
  - [ ] Learn from the whole dependency story in `buildRustCrate`
- [ ] Figure out whether we are able to do Typescript type-checking at all, or if we are missing Deno features. 
- [ ] Fetch with the correct user-agent

### Classic nixpkgs checklist

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
