### PR TITLE
python3Packages.ledgerwallet: 0.2.4 -> 0.5.0

### DIFF
--- a/pkgs/development/python-modules/ledgerwallet/default.nix
+++ b/pkgs/development/python-modules/ledgerwallet/default.nix
@@ -7,13 +7,13 @@
   click,
   construct,
   ecdsa,
-  flit-core,
   hidapi,
   intelhex,
   pillow,
-  protobuf3,
+  protobuf,
   requests,
   setuptools,
+  setuptools-scm,
   tabulate,
   toml,
   AppKit,
@@ -21,19 +21,19 @@
 
 buildPythonPackage rec {
   pname = "ledgerwallet";
-  version = "0.2.4";
+  version = "0.5.0";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "LedgerHQ";
     repo = "ledgerctl";
     rev = "v${version}";
-    hash = "sha256-IcStYYkKEdZxwgJKL8l2Y1BtO/Oncd4aKUAZD8umbHs=";
+    hash = "sha256-PBULYvyO3+YaW+a1/enJtKB/DR4ndL/o/WdpETbWyZ0=";
   };
 
   buildInputs = [
-    flit-core
     setuptools
+    setuptools-scm
   ] ++ lib.optionals stdenv.isDarwin [ AppKit ];
   propagatedBuildInputs = [
     cryptography
@@ -43,11 +43,22 @@ buildPythonPackage rec {
     hidapi
     intelhex
     pillow
-    protobuf3
+    protobuf
     requests
     tabulate
     toml
   ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"protobuf >=3.20,<4"' '"protobuf >=3.20"'
+  '';
+
+  # Regenerate protobuf bindings to lift the version upper-bound and enable
+  # compatibility the current default protobuf library.
+  preBuild = ''
+    protoc --python_out=. --pyi_out=. ledgerwallet/proto/*.proto
+  '';
 
   pythonImportsCheck = [ "ledgerwallet" ];
 


### PR DESCRIPTION
## Description of changes

https://github.com/LedgerHQ/ledgerctl/compare/v0.2.4...v0.5.0

Added build-time regeneration of the protobuf bindings so we can drop protobuf3 from nixpkgs in the near future.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
