### PR TITLE
bruno: fix css issue with patch file

### DIFF
--- a/pkgs/by-name/br/bruno/package.nix
+++ b/pkgs/by-name/br/bruno/package.nix
@@ -73,6 +73,11 @@ buildNpmPackage' rec {
     })
   ];
 
+  patches = [
+    # Workaround to fix css issue in bruno due to electron difference between Nix and mainstream. https://github.com/NixOS/nixpkgs/issues/324176
+    ./scroll-width-fix.patch
+  ];
+
   postPatch = ''
     substituteInPlace scripts/build-electron.sh \
       --replace-fail 'if [ "$1" == "snap" ]; then' 'exit 0; if [ "$1" == "snap" ]; then'

--- a/pkgs/by-name/br/bruno/scroll-width-fix.patch
+++ b/pkgs/by-name/br/bruno/scroll-width-fix.patch
@@ -1,0 +1,37 @@
+diff --git a/packages/bruno-app/src/globalStyles.js b/packages/bruno-app/src/globalStyles.js
+index c2b16781..936449ed 100644
+--- a/packages/bruno-app/src/globalStyles.js
++++ b/packages/bruno-app/src/globalStyles.js
+@@ -163,32 +163,6 @@ const GlobalStyle = createGlobalStyle`
+   }
+ 
+ 
+-  // scrollbar styling
+-  // the below media query target non-macos devices
+-  // (macos scrollbar styling is the ideal style reference)
+-  @media not all and (pointer: coarse) {
+-    * {
+-      scrollbar-width: thin;
+-      scrollbar-color: ${(props) => props.theme.scrollbar.color};
+-    }
+-    
+-    *::-webkit-scrollbar {
+-      width: 5px;
+-    }
+-    
+-    *::-webkit-scrollbar-track {
+-      background: transparent;
+-      border-radius: 5px;
+-    }
+-    
+-    *::-webkit-scrollbar-thumb {
+-      background-color: ${(props) => props.theme.scrollbar.color};
+-      border-radius: 14px;
+-      border: 3px solid ${(props) => props.theme.scrollbar.color};
+-    }
+-  }
+-
+-
+   // codemirror
+   .CodeMirror {
+     .cm-variable-valid {


### PR DESCRIPTION
## Description of changes
Fix a css issue in bruno due to electron version used in Nix as compared to bruno upstream that uses older EOL version.


## Things done
- Created a patch file with the fix
- Reference patch file to patches attribute list in the package definition

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
