### PR TITLE
yosys: 0.42 -> 0.43

### DIFF
--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -1,6 +1,5 @@
 { stdenv
 , lib
-, bash
 , bison
 , boost
 , fetchFromGitHub
@@ -76,13 +75,13 @@ let
 
 in stdenv.mkDerivation (finalAttrs: {
   pname   = "yosys";
-  version = "0.42";
+  version = "0.43";
 
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo  = "yosys";
     rev   = "refs/tags/${finalAttrs.pname}-${finalAttrs.version}";
-    hash  = "sha256-P0peg81wxCG0Bw2EJEX5WuDYU7GmRqgRw2SyWK/CGNI=";
+    hash  = "sha256-MJTtQvHsHvuo4aNNYSPxSMbeXCty66q83/sbp1Yiiv4=";
     fetchSubmodules = true;
     leaveDotGit = true;
     postFetch = ''
@@ -122,7 +121,6 @@ in stdenv.mkDerivation (finalAttrs: {
     substituteInPlace ./Makefile \
       --replace-fail 'echo UNKNOWN' 'echo ${builtins.substring 0 10 finalAttrs.src.rev}'
 
-    chmod +x ./misc/yosys-config.in
     patchShebangs tests ./misc/yosys-config.in
   '';
 

--- a/pkgs/development/compilers/yosys/fix-clang-build.patch
+++ b/pkgs/development/compilers/yosys/fix-clang-build.patch
@@ -9,6 +9,14 @@
      ./cxxrtl-test-${subtest}
  }
  
+@@ -14,4 +14,4 @@ run_subtest value_fuzz
+ 
+ # Compile-only test.
+ ../../yosys -p "read_verilog test_unconnected_output.v; proc; clean; write_cxxrtl cxxrtl-test-unconnected_output.cc"
+-${CC:-gcc} -std=c++11 -c -o cxxrtl-test-unconnected_output -I../../backends/cxxrtl/runtime cxxrtl-test-unconnected_output.cc
++${CXX:-gcc} -std=c++11 -c -o cxxrtl-test-unconnected_output -I../../backends/cxxrtl/runtime cxxrtl-test-unconnected_output.cc
+diff --git a/tests/fmt/run-test.sh b/tests/fmt/run-test.sh
+index 998047f83..2a4a59f01 100644
 --- a/tests/fmt/run-test.sh
 +++ b/tests/fmt/run-test.sh
 @@ -51,7 +51,7 @@ test_cxxrtl () {


### PR DESCRIPTION
## Description of changes
https://github.com/YosysHQ/yosys/releases/tag/yosys-0.43

Also:
- Update patch to fix error on macOS
- Remove an unused argument
- Remove a call to `chmod` since the file now has the executable bit already

`openroad` fails to build but this also happens without this commit.

Closes #326018.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
