### PR TITLE
python312Packages.freud: fix build

### DIFF
--- a/pkgs/development/python-modules/freud/default.nix
+++ b/pkgs/development/python-modules/freud/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , cython
 , oldest-supported-numpy
@@ -30,6 +31,15 @@ buildPythonPackage rec {
     hash = "sha256-jlscEHQ1q4oqxE06NhVWCOlPRcjDcJVrvy4h6iYrkz0=";
     fetchSubmodules = true;
   };
+
+  patches = [
+    # https://github.com/glotzerlab/freud/issues/1269
+    (fetchpatch {
+      url = "https://github.com/glotzerlab/freud/commit/8f636e3815737945e45da5b9996b5f69df07c9a5.patch";
+      hash = "sha256-PLorRrYj16oBWHYzXDq62kECzVTtyr+1Z20DJqTkXxg=";
+    })
+  ];
+
   # Because we prefer to not `leaveDotGit`, we need to fool upstream into
   # thinking we left the .git files in the submodules, so cmake won't think we
   # didn't initialize them. Upstream doesn't support using the system wide

--- a/pkgs/development/python-modules/freud/default.nix
+++ b/pkgs/development/python-modules/freud/default.nix
@@ -1,22 +1,23 @@
-{ lib
-, stdenv
-, buildPythonPackage
-, fetchFromGitHub
-, fetchpatch
-, cmake
-, cython
-, oldest-supported-numpy
-, scikit-build
-, setuptools
-, tbb
-, numpy
-, rowan
-, scipy
-, pytestCheckHook
-, python
-, gsd
-, matplotlib
-, sympy
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  cython,
+  oldest-supported-numpy,
+  scikit-build,
+  setuptools,
+  tbb,
+  numpy,
+  rowan,
+  scipy,
+  pytestCheckHook,
+  python,
+  gsd,
+  matplotlib,
+  sympy,
 }:
 
 buildPythonPackage rec {
@@ -65,9 +66,7 @@ buildPythonPackage rec {
     setuptools
   ];
   dontUseCmakeConfigure = true;
-  buildInputs = [
-    tbb
-  ];
+  buildInputs = [ tbb ];
 
   propagatedBuildInputs = [
     numpy
@@ -81,8 +80,7 @@ buildPythonPackage rec {
     matplotlib
     sympy
   ];
-  disabledTests = [
-  ] ++ lib.optionals stdenv.isAarch64 [
+  disabledTests = lib.optionals stdenv.isAarch64 [
     # https://github.com/glotzerlab/freud/issues/961
     "test_docstring"
   ];
@@ -95,11 +93,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "freud" ];
 
-  meta = with lib; {
+  meta = {
     description = "Powerful, efficient particle trajectory analysis in scientific Python";
     homepage = "https://github.com/glotzerlab/freud";
     changelog = "https://github.com/glotzerlab/freud/blob/${src.rev}/ChangeLog.md";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ doronbehar ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ doronbehar ];
   };
 }

--- a/pkgs/development/python-modules/freud/default.nix
+++ b/pkgs/development/python-modules/freud/default.nix
@@ -39,6 +39,13 @@ buildPythonPackage rec {
     touch extern/{voro++,fsph,Eigen}/.git
   '';
 
+  # Scipy still depends on numpy 1, and so we'd get 'package duplicates in
+  # closure' error if we'd use numpy_2
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'numpy>=2.0.0rc1' 'numpy' \
+  '';
+
   nativeBuildInputs = [
     cmake
     cython


### PR DESCRIPTION
## Description of changes

- **python312Packages.freud: fix numpy version check**
- **python312Packages.freud: use pytestCheckHook**
- **python312Packages.freud: disable a failing test**

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
