### PR TITLE
ocis-bin: 5.0.5 -> 6.0.0

### DIFF
--- a/pkgs/by-name/oc/ocis-bin/package.nix
+++ b/pkgs/by-name/oc/ocis-bin/package.nix
@@ -5,28 +5,46 @@
   autoPatchelfHook,
 }:
 
+let
+  arch =
+    {
+      i686-linux = "386";
+      x86_64-linux = "amd64";
+      aarch64-linux = "arm64";
+      armv7l-linux = "arm";
+      x86_64-darwin = "amd64";
+      aarch64-darwin = "arm64";
+    }
+    ."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  os =
+    if stdenv.isLinux then
+      "linux"
+    else if stdenv.isDarwin then
+      "darwin"
+    else
+      throw "Unsupported OS";
+
+  hash =
+    {
+      hash_386-linux = "sha256-wP5ObJVhHnifPhHVWvuKZ1W1sSlEjca/MSydYjb9CTo=";
+      hash_amd64-linux = "sha256-gF5RIEbWrD912kSAXiVgovZN3bGOvQDZDYkar2azpBQ=";
+      hash_arm64-linux = "sha256-51MnjUea64rxgnj6P1Pl3m/VQwnDB6//uPTz8VYI93g=";
+      hash_arm-linux = "sha256-5VqgcGBn9yVqfD14KPtpwBeNexHrulHAROFj5fkt57k=";
+      hash_amd64-darwin = "sha256-8NizERBNlGH13pgtaSOIwYg49VSf9K9DOzngR8ng7N8=";
+      hash_arm64-darwin = "sha256-qcXpUudyTMOExkqIJub6qvC4gpiawg8kOJ68qp+xm9g=";
+    }
+    ."hash_${arch}-${os}";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "ocis-bin";
-  version = "5.0.5";
-  system =
-    if stdenv.isLinux && stdenv.isx86_64 then
-      "linux-amd64"
-    else if stdenv.isLinux && stdenv.isAarch64 then
-      "linux-arm64"
-    else
-      "";
+  version = "6.0.0";
 
   src = fetchurl {
-    url = "https://github.com/owncloud/ocis/releases/download/v${finalAttrs.version}/ocis-${finalAttrs.version}-${finalAttrs.system}";
-
-    hash =
-      if stdenv.isLinux && stdenv.isAarch64 then
-        "sha256-OdtT9NOhh0Fkk+8CDic0NWWbGflk3FcuKB60OycJU5E="
-      else if stdenv.isLinux && stdenv.isx86_64 then
-        "sha256-YAIhtHv/cO4yFpkWoRNMf6t4+ifMtGPTcYu84ZMvfD4="
-      else
-        builtins.throw "Unsupported platform, please contact Nixpkgs maintainers for ocis package";
+    url = "https://github.com/owncloud/ocis/releases/download/v${finalAttrs.version}/ocis-${finalAttrs.version}-${os}-${arch}";
+    inherit hash;
   };
+
   dontUnpack = true;
 
   nativeBuildInputs = [ autoPatchelfHook ];
@@ -36,6 +54,8 @@ stdenv.mkDerivation (finalAttrs: {
     install -D $src $out/bin/ocis
     runHook postInstall
   '';
+
+  passthru.updateScript = ./update.sh;
 
   meta = with lib; {
     description = "ownCloud Infinite Scale Stack ";
@@ -50,6 +70,13 @@ stdenv.mkDerivation (finalAttrs: {
       danth
       ramblurr
     ];
+
+    platforms =
+      (lib.intersectLists platforms.linux (
+        lib.platforms.arm ++ lib.platforms.aarch64 ++ lib.platforms.x86
+      ))
+      ++ (lib.intersectLists platforms.darwin (lib.platforms.aarch64 ++ lib.platforms.x86_64));
+
     sourceProvenance = [ sourceTypes.binaryNativeCode ];
     mainProgram = "ocis";
   };

--- a/pkgs/by-name/oc/ocis-bin/update.sh
+++ b/pkgs/by-name/oc/ocis-bin/update.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env nix-shell
+##!nix-shell -I nixpkgs=./. -i bash -p curl jq common-updater-scripts gnused nix coreutils
+
+set -eu -o pipefail
+
+
+latestVersion=$(curl -s ${GITHUB_TOKEN:+ -H "Authorization: Bearer $GITHUB_TOKEN"} https://api.github.com/repos/owncloud/ocis/releases?per_page=1 \
+    | jq -r ".[0].tag_name" \
+    | sed 's/^v//')
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; ocis-bin.version or (lib.getVersion ocis-bin)" | tr -d '"')
+
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+    echo "ocis-bin is up-to-date: $currentVersion"
+    exit 0
+fi
+
+function get_hash() {
+    local os=$1
+    local arch=$2
+    local version=$3
+
+    local pkg_hash=$(nix-prefetch-url --type sha256 \
+        https://github.com/owncloud/ocis/releases/download/v"${version}"/ocis-"${version}"-"${os}"-"${arch}")
+    nix hash to-sri "sha256:$pkg_hash"
+}
+
+
+update-source-version ocis-bin "$latestVersion" $(get_hash darwin arm64 "$latestVersion") --system="aarch64-darwin" --ignore-same-version
+update-source-version ocis-bin "$latestVersion" $(get_hash darwin amd64 "$latestVersion") --system="x86_64-darwin" --ignore-same-version
+update-source-version ocis-bin "$latestVersion" $(get_hash linux arm64 "$latestVersion") --system="aarch64-linux" --ignore-same-version
+update-source-version ocis-bin "$latestVersion" $(get_hash linux arm "$latestVersion") --system="armv7l-linux" --ignore-same-version
+update-source-version ocis-bin "$latestVersion" $(get_hash linux amd64 "$latestVersion") --system="x86_64-linux" --ignore-same-version
+update-source-version ocis-bin "$latestVersion" $(get_hash linux 386 "$latestVersion") --system="i686-linux" --ignore-same-version


### PR DESCRIPTION
Changelog: https://github.com/owncloud/ocis/releases/tag/v6.0.0

@bhankas @danth please see below for a question for ya'll

I've prepared a commit (https://github.com/Ramblurr/nixpkgs/commit/72d34ee020fd4460dc3fd9e62577a386583f5f7e) that we can PR that will:

* Bump ocis-bin to 6.0.0
* Adds an update script that can be used by the `passthru.updateScript` <sup>[0]</sup>
* Adds the full range of architectures released by owncloud
    * darwin: amd64, aarch64
    * linux: i686, x86_64, arm, aarch64

[0]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#automatic-package-updates

However I haven't opened the PR yet because I want to discuss with you all whether we should target the rolling release or the production/stable release?

Owncloud documents the release types here: https://owncloud.dev/ocis/release_roadmap/#release-types

Currently with 5.0.5 we are on the Production (aka stable) release channel, if we go to 6.0.0 we will be moving to the Rolling release channel.

As you can see in the table on the page I linked, the next Production release won't happen until 11.11.2024

**Any thoughts on this?**

my thoughts:

* I don't mind using a rolling release on my nixos unstable systems, however for my nixos stable systems I would prefer to use a Production release.
* It's not clear to me whether we can get the 11.11.2024 oCIS Production release into the NixOS 24.11.
    *  maybe we can backport it?




## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
