### PR TITLE
filius: init at 2.6.1

### DIFF
--- a/pkgs/by-name/fi/filius/package.nix
+++ b/pkgs/by-name/fi/filius/package.nix
@@ -1,0 +1,125 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchzip,
+  fetchurl,
+  makeWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
+  jre,
+}:
+let
+  # we cache potentially unstable upstream inputs (icon and .zip file) via https://web.archive.org - this is a standard procedure in Nixpkgs
+  icon128 = fetchurl {
+    url = "https://web.archive.org/web/20240623123147/https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/de.lernsoftware_filius.Filius.png";
+    hash = "sha256-xES6RWf2KiNsukD6GwTuPyiDI6SseADGLb1AkBSTgd8=";
+  };
+  icon32 = fetchurl {
+    url = "https://gitlab.com/filius1/filius/-/raw/09fa7d5bdc60d5b4a2ab0e24311d54516a400913/src/deb/filius32.png";
+    hash = "sha256-sVsViRALhiVJFSxfVb9K6Q4M7Y2UEvZh6oOB9BQumh8=";
+  };
+  mimetype_xml = fetchurl {
+    url = "https://gitlab.com/filius1/filius/-/raw/09fa7d5bdc60d5b4a2ab0e24311d54516a400913/src/deb/application-filius-project.xml";
+    hash = "sha256-tChNuWlMuQtGeavQm12FDXCacfPTzFY8p/646WZnHDI=";
+  };
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "filius";
+
+  # UPDATE instructions
+  #
+  # - Open https://www.lernsoftware-filius.de/Herunterladen and copy download link to clipboard.
+  #   (e.g. https://www.lernsoftware-filius.de/downloads/Setup/filius-2.5.1.zip)
+  # - identify the new version string.
+  version = "2.6.1";
+
+  # - Open http://web.archive.org and paste download link from clipboard into "Save Page Now" field and hit the "Save Page" button.
+  # - Unselect "Save Error Pages" and hit "Save Page" again.
+  # - Wait for the archive link to be generated and copy it to the url field - adjust hash accordingly.
+  src = fetchzip {
+    url = "https://web.archive.org/web/20240829130608/https://www.lernsoftware-filius.de/downloads/Setup/filius-2.6.1.zip";
+    hash = "sha256-vrzImMorA1BPA7LRjyZ2pXqLT9ry8qx7Jps5uyTZDp8=";
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      type = "Application";
+      name = "Filius";
+      desktopName = "Filius";
+      genericName = "Computer network simulator";
+      comment = "A Computer network simulator for secondary schools";
+      icon = "filius";
+      exec = "filius";
+      terminal = false;
+      mimeTypes = [ "application/filius-project" ];
+      categories = [ "Education" ];
+      startupNotify = false;
+      extraConfig = {
+        "GenericName[en]" = "Computer network simulator";
+        "GenericName[de]" = "Computer-Netzwerksimulator";
+        "Comment[en]" = "A computer network simulator for secondary schools";
+        "Comment[de]" = "Ein Computer-Netzwerksimulator für Bildungszwecke";
+      };
+    })
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    export CUSTOM_LIBS=$out/share/java
+    export JAR=$CUSTOM_LIBS/filius.jar
+
+    # "install -D" creates missing folders
+    install -D filius.jar $JAR
+    cp -r . $CUSTOM_LIBS/
+
+    makeWrapper ${jre}/bin/java $out/bin/filius \
+      --add-flags "-Duser.dir=$CUSTOM_LIBS/" \
+      --add-flags "-jar $JAR" \
+      --add-flags '-n -wd $HOME' \
+      --set _JAVA_OPTIONS '-Dawt.useSystemAAFontSettings=lcd'
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    mimetypeDir=$out/share/
+    install -D ${mimetype_xml} $out/share/mime/packages/application-filius-project.xml
+    install -D ${icon32} $out/share/icons/hicolor/32x32/mimetypes/filius32.png
+
+    install -Dm444 ${icon128} $out/share/icons/hicolor/128x128/apps/filius.png
+    install -Dm444 ${icon32} $out/share/icons/hicolor/32x32/apps/filius.png
+  '';
+
+  meta = {
+    homepage = "https://www.lernsoftware-filius.de";
+    downloadPage = "https://www.lernsoftware-filius.de/Herunterladen";
+    description = "A Computer Network Simulator for Secondary Schools";
+    longDescription = ''
+      With the software tool Filius, you can design computer networks yourself,
+      simulate the exchange of messages in them and thus explore their structure
+      and functionality experimentally. The target group are learners at secondary
+      level in general education schools. Filius enables learning activities that
+      are designed to support discovery-based learning in particular.";
+    '';
+    license = with lib.licenses; [
+      gpl2Only
+      gpl3Only
+    ];
+    maintainers = with lib.maintainers; [
+      annaaurora
+      rcmlz
+    ];
+    platforms = lib.platforms.all;
+    mainProgram = "filius";
+  };
+})


### PR DESCRIPTION
## Description of changes

Description of changes

Adding new package Filius https://www.lernsoftware-filius.de/

Filius is a Computer Network Simulator written in Java and [distributed](https://www.lernsoftware-filius.de/downloads/Setup/filius-2.5.1.zip) as .jar file.

With the software tool Filius, you can design computer networks yourself, simulate the exchange of messages in them and thus explore their structure and functionality experimentally. The target group are learners at secondary level in general education schools. Filius enables learning activities that are designed to support discovery-based learning in particular.

@auroraanna Unfortunately I got the other pull request messed up.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
