### PR TITLE
skypeforlinux, spotify: remove snap.yaml file

### DIFF
--- a/pkgs/applications/audio/spotify/linux.nix
+++ b/pkgs/applications/audio/spotify/linux.nix
@@ -133,8 +133,6 @@ stdenv.mkDerivation {
       mkdir -p $libdir
       mv ./usr/* $out/
 
-      cp meta/snap.yaml $out
-
       # Work around Spotify referring to a specific minor version of
       # OpenSSL.
 

--- a/pkgs/by-name/sk/skypeforlinux/package.nix
+++ b/pkgs/by-name/sk/skypeforlinux/package.nix
@@ -127,7 +127,7 @@ stdenv.mkDerivation {
   unpackPhase = ''
     runHook preUnpack
 
-    unsquashfs "$src" /meta/{'gui/*.desktop',snap.yaml} \
+    unsquashfs "$src" '/meta/gui/*.desktop' \
         /usr/share/{doc/skypeforlinux,'icons/hicolor/*/apps/skypeforlinux.png',kservices5,pixmaps,skypeforlinux}
     sourceRoot=squashfs-root
 
@@ -139,7 +139,7 @@ stdenv.mkDerivation {
 
     mkdir -p "$out/bin"
     mv meta/gui usr/share/applications
-    mv meta/snap.yaml usr/share "$out"
+    mv usr/share "$out"
     ln -s "$out/share/skypeforlinux/skypeforlinux" "$out/bin"
 
     runHook postInstall


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Using home-manager it's impossible to install these two packages because there is a conflict when setting up the path since both packages will provide a `snap.yaml` file at the same location.

```
home-manager-path> error: collision between `/nix/store/x42s25yqd19z1qlx3b95znszi7ldr0w4-spotify-1.2.37.701.ge66eb7bc/snap.yaml' and `/nix/store/g49q40sbd00y1hpbrz29hqqdgzy13kdd-skypeforlinux-8.119.0.201/snap.yaml'
```

For a nixos user this file is useless as far as I can tell, and other snap-based packages that I have checked don't seem to include it either.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
