### PR TITLE
python3Packages.j2cli: disable on python 3.12

### DIFF
--- a/pkgs/development/python-modules/j2cli/default.nix
+++ b/pkgs/development/python-modules/j2cli/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchPypi,
   jinja2,
+  pythonAtLeast,
   pyyaml,
   setuptools,
 }:
@@ -11,6 +12,7 @@ buildPythonPackage rec {
   pname = "j2cli";
   version = "0.3.10";
   format = "setuptools";
+  disabled = pythonAtLeast "3.12";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39030,7 +39030,7 @@ with pkgs;
 
   jacktrip = callPackage ../applications/audio/jacktrip { };
 
-  j2cli = with python3Packages; toPythonApplication j2cli;
+  j2cli = with python311Packages; toPythonApplication j2cli;
 
   jq-lsp = callPackage ../development/tools/language-servers/jq-lsp { };
 


### PR DESCRIPTION
## Description of changes
```sh
$ nix run nixpkgs#j2cli -- -h
Traceback (most recent call last):
  File "/nix/store/mgizgbmlrz996i9rvpniga9mqbnkc6xz-python3.12-j2cli-0.3.10/bin/.j2-wrapped", line 6, in <module>
    from j2cli import main
  File "/nix/store/mgizgbmlrz996i9rvpniga9mqbnkc6xz-python3.12-j2cli-0.3.10/lib/python3.12/site-packages/j2cli/__init__.py", line 10, in <module>
    from j2cli.cli import main
  File "/nix/store/mgizgbmlrz996i9rvpniga9mqbnkc6xz-python3.12-j2cli-0.3.10/lib/python3.12/site-packages/j2cli/cli.py", line 8, in <module>
    import imp, inspect
ModuleNotFoundError: No module named 'imp'
```

https://github.com/kolypto/j2cli/issues/80

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
