### PR TITLE
pre-commit: add setuptools to virtualenv

### DIFF
--- a/pkgs/tools/misc/pre-commit/default.nix
+++ b/pkgs/tools/misc/pre-commit/default.nix
@@ -16,6 +16,11 @@
 }:
 
 with python3Packages;
+let
+  virtualenv-with-setuptools = virtualenv.overrideAttrs (prev: {
+    propagatedBuildInputs = prev.propagatedBuildInputs ++ [setuptools];
+  });
+in
 buildPythonApplication rec {
   pname = "pre-commit";
   version = "3.7.1";
@@ -42,7 +47,7 @@ buildPythonApplication rec {
     nodeenv
     pyyaml
     toml
-    virtualenv
+    virtualenv-with-setuptools
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
I encountered a problem with the pre-commit package that when run with python3.12 some of the tasks, in particular autoflakes would crash with `ModuleNotFoundError: No module named 'distutils'`.


![Screenshot 2024-07-10 at 12 49 51](https://github.com/NixOS/nixpkgs/assets/1183303/17a36de1-3c7c-4c63-8393-07dbf5f778dc)

## Description of changes
Add setuptools to virtualenv dependency of pre-commit. Adding pre-commit as a propagatedBuildInput of pre-commit directly doesn't work since propagation is disabled for pre-commit https://github.com/NixOS/nixpkgs/pull/235123

Python3.12 no longer ships with distutils. Setuptools package continues to provide distutils.
https://docs.python.org/3/whatsnew/3.12.html
Many pre-commit jobs require distutils to function.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
