### PR TITLE
llvm: simplify `mkPackage` helper

### DIFF
--- a/pkgs/development/compilers/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/default.nix
@@ -38,17 +38,10 @@ let
       version ? null,
     }@args:
     let
-      args' = {
-        name = null;
-        officialRelease = null;
-        gitRelease = null;
-        monorepoSrc = null;
-        version = null;
-      } // args;
       inherit
         (import ./common/common-let.nix {
           inherit lib;
-          inherit (args') gitRelease officialRelease version;
+          inherit gitRelease officialRelease version;
         })
         releaseInfo
         ;
@@ -68,7 +61,7 @@ let
         else
           stdenv; # does not build with gcc13
       inherit bootBintoolsNoLibc bootBintools;
-      inherit (args')
+      inherit
         officialRelease
         gitRelease
         monorepoSrc


### PR DESCRIPTION
## Description of changes

Minor refactor in the definition of `llvmPackage*`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all affected packages using `nixpkgs-review`
  No difference in the evaluated drvs, no rebuild needed.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
