### PR TITLE
python311Packages.flowmc: init at 0.3.4

### DIFF
--- a/pkgs/development/python-modules/corner/default.nix
+++ b/pkgs/development/python-modules/corner/default.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  matplotlib,
+
+  # optional-dependencies
+  arviz,
+  ipython,
+  myst-nb,
+  pandoc,
+  sphinx,
+  sphinx-book-theme,
+  pytest,
+  scipy,
+
+  # checks
+  pytestCheckHook,
+  corner,
+}:
+
+buildPythonPackage rec {
+  pname = "corner";
+  version = "2.2.2";
+  pyproject = true;
+
+  disable = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "dfm";
+    repo = "corner.py";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-MYos01YCSUwivymSE2hbjV7eKXfaMqG89koD2CWZjcQ=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [ matplotlib ];
+
+  optional-dependencies = {
+    arviz = [ arviz ];
+    docs = [
+      arviz
+      ipython
+      myst-nb
+      pandoc
+      sphinx
+      sphinx-book-theme
+    ];
+    test = [
+      arviz
+      pytest
+      scipy
+    ];
+  };
+
+  pythonImportsCheck = [ "corner" ];
+
+  nativeCheckInputs = [ pytestCheckHook ] ++ corner.passthru.optional-dependencies.test;
+
+  # matplotlib.testing.exceptions.ImageComparisonFailure: images not close
+  disabledTests = [
+    "test_arviz"
+    "test_basic"
+    "test_bins"
+    "test_bins_log"
+    "test_color"
+    "test_color_filled"
+    "test_extended_overplotting"
+    "test_hist_bin_factor"
+    "test_labels"
+    "test_lowNfilled"
+    "test_no_fill_contours"
+    "test_overplot_log"
+    "test_pandas"
+    "test_quantiles"
+    "test_range_fig_arg"
+    "test_reverse_overplotting"
+    "test_tight"
+    "test_title_quantiles"
+    "test_title_quantiles_default"
+    "test_title_quantiles_raises"
+    "test_titles1"
+    "test_titles2"
+    "test_top_ticks"
+    "test_truths"
+  ];
+
+  meta = {
+    description = "Make some beautiful corner plots";
+    homepage = "https://github.com/dfm/corner.py";
+    changelog = "https://github.com/dfm/corner.py/releases/tag/v${version}";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/development/python-modules/evosax/default.nix
+++ b/pkgs/development/python-modules/evosax/default.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  chex,
+  dotmap,
+  flax,
+  jax,
+  jaxlib,
+  matplotlib,
+  numpy,
+  pyyaml,
+
+  # checks
+  # brax, (unpackaged)
+  # gymnax, (unpackaged)
+  pytestCheckHook,
+  torch,
+  torchvision,
+}:
+
+buildPythonPackage rec {
+  pname = "evosax";
+  version = "0.1.6";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "RobertTLange";
+    repo = "evosax";
+    rev = "refs/tags/v.${version}";
+    hash = "sha256-v8wRiWZlJPF9pIXocQ6/caHl1W4QBNjkmuImJ6MAueo=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    chex
+    dotmap
+    flax
+    jax
+    jaxlib
+    matplotlib
+    numpy
+    pyyaml
+  ];
+
+  pythonImportsCheck = [ "evosax" ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  nativeCheckInputs = [
+    # brax
+    # gymnax
+    pytestCheckHook
+    torch
+    torchvision
+  ];
+
+  disabledTests = [
+    # Requires unpackaged gymnax
+    "test_env_ffw_rollout"
+
+    # Tries to download a data set from the internet
+    "test_vision_fitness"
+  ];
+
+  meta = {
+    description = "Evolution Strategies in JAX";
+    homepage = "https://github.com/RobertTLange/evosax";
+    changelog = "https://github.com/RobertTLange/evosax/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/development/python-modules/flowmc/default.nix
+++ b/pkgs/development/python-modules/flowmc/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  corner,
+  equinox,
+  evosax,
+  jax,
+  jaxlib,
+  optax,
+  tqdm,
+
+  # checks
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "flowmc";
+  version = "0.3.4";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "kazewong";
+    repo = "flowMC";
+    rev = "refs/tags/flowMC-${version}";
+    hash = "sha256-unvbNs0AOzW4OI+9y6KxoBC5yEjEz+q0PZblQLXCC/Y=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    corner
+    equinox
+    evosax
+    jax
+    jaxlib
+    optax
+    tqdm
+  ];
+
+  pythonImportsCheck = [ "flowMC" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "Normalizing-flow enhanced sampling package for probabilistic inference in Jax";
+    homepage = "https://github.com/kazewong/flowMC";
+    changelog = "https://github.com/kazewong/flowMC/releases/tag/flowMC-${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4491,6 +4491,8 @@ self: super: with self; {
 
   flowlogs-reader = callPackage ../development/python-modules/flowlogs-reader { };
 
+  flowmc = callPackage ../development/python-modules/flowmc { };
+
   fluent-logger = callPackage ../development/python-modules/fluent-logger { };
 
   flufl-bounce = callPackage ../development/python-modules/flufl/bounce.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4014,6 +4014,8 @@ self: super: with self; {
 
   evohome-async = callPackage ../development/python-modules/evohome-async { };
 
+  evosax = callPackage ../development/python-modules/evosax { };
+
   evtx = callPackage ../development/python-modules/evtx { };
 
   ewmh = callPackage ../development/python-modules/ewmh { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2515,6 +2515,8 @@ self: super: with self; {
 
   coreschema = callPackage ../development/python-modules/coreschema { };
 
+  corner = callPackage ../development/python-modules/corner { };
+
   cornice = callPackage ../development/python-modules/cornice { };
 
   corsair-scan = callPackage ../development/python-modules/corsair-scan { };


### PR DESCRIPTION
## Description of changes

Adds the following python packages:
- [corner](https://github.com/dfm/corner.py): Make some beautiful corner plots
- [evosax](https://github.com/RobertTLange/evosax): Evolution Strategies in JAX
- [flowMC](https://github.com/kazewong/flowMC): Normalizing-flow enhanced sampling package for probabilistic inference in Jax

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
