### PR TITLE
python312Packages.wxpython: fix build

### DIFF
--- a/pkgs/development/python-modules/wxpython/4.2.nix
+++ b/pkgs/development/python-modules/wxpython/4.2.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildPythonPackage,
   setuptools,
-  pythonAtLeast,
   fetchPypi,
   substituteAll,
 
@@ -15,6 +14,7 @@
   python,
   sip,
   which,
+  buildPackages,
 
   # runtime
   cairo,
@@ -44,7 +44,6 @@ buildPythonPackage rec {
   pname = "wxpython";
   version = "4.2.1";
   format = "other";
-  disabled = pythonAtLeast "3.12";
 
   src = fetchPypi {
     pname = "wxPython";
@@ -60,6 +59,13 @@ buildPythonPackage rec {
       libcairo = "${cairo}/lib/libcairo.so";
     })
   ];
+
+  # https://github.com/wxWidgets/Phoenix/issues/2575
+  postPatch = ''
+    ln -s ${lib.getExe buildPackages.waf} bin/waf
+    substituteInPlace build.py \
+      --replace-fail "distutils.dep_util" "setuptools.modified"
+  '';
 
   nativeBuildInputs = [
     attrdict
@@ -103,6 +109,7 @@ buildPythonPackage rec {
     export DOXYGEN=${doxygen}/bin/doxygen
     export PATH="${wxGTK}/bin:$PATH"
     export SDL_CONFIG="${SDL.dev}/bin/sdl-config"
+    export WAF=$PWD/bin/waf
 
     ${python.pythonOnBuildForHost.interpreter} build.py -v --use_syswx dox etg sip --nodoc build_py
 


### PR DESCRIPTION
## Description of changes

ngi-nix/ngipkgs#311 and #325726 both pin Python to version 3.11 for certain packages, as `python312Packages.wxpython` is disabled in Nixpkgs, whose reason is probably that wxPython depends on distutils.

What confuses me is that there are wheels for Python 3.12 on PyPI (see https://pypi.org/project/wxPython/#files), and there are no active issues about Python 3.12 support or the use of distutils in the wxPython issue tracker.

So there should be a way to build `python312Packages.wxpython`, right?

<img width="744" alt="Capture d’écran 2024-07-10 à 18 25 39" src="https://github.com/NixOS/nixpkgs/assets/9713184/5aed403e-d9d4-474e-9e0b-64eed5a2e4a6">

Fixes #326764

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
