### PR TITLE
python3Packages.vllm: relax deps, add cuda stdenv

### DIFF
--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   which,
@@ -35,6 +36,10 @@
   gpuTargets ? [ ],
 }:
 
+let
+  stdenv_pkg = stdenv;
+in
+
 buildPythonPackage rec {
   pname = "vllm";
   version = "0.3.3";
@@ -52,25 +57,24 @@ buildPythonPackage rec {
     lib.strings.concatStringsSep ";" rocmPackages.clr.gpuTargets
   );
 
-  # xformers 0.0.23.post1 github release specifies its version as 0.0.24
-  #
   # cupy-cuda12x is the same wheel as cupy, but built with cuda dependencies, we already have it set up
   # like that in nixpkgs. Version upgrade is due to upstream shenanigans
   # https://github.com/vllm-project/vllm/pull/2845/commits/34a0ad7f9bb7880c0daa2992d700df3e01e91363
   #
   # hipcc --version works badly on NixOS due to unresolved paths.
+  # Unclear why pythonRelaxDeps doesn't work here, but on last attempt, it didn't.
   postPatch =
     ''
       substituteInPlace requirements.txt \
-        --replace "xformers == 0.0.23.post1" "xformers == 0.0.24"
+        --replace "xformers == 0.0.23.post1" "xformers"
       substituteInPlace requirements.txt \
-        --replace "cupy-cuda12x == 12.1.0" "cupy == 12.3.0"
+        --replace "cupy-cuda12x == 12.1.0" "cupy"
       substituteInPlace requirements-build.txt \
-        --replace "torch==2.1.2" "torch == 2.2.1"
+        --replace "torch==2.1.2" "torch"
       substituteInPlace pyproject.toml \
-        --replace "torch == 2.1.2" "torch == 2.2.1"
+        --replace "torch == 2.1.2" "torch"
       substituteInPlace requirements.txt \
-        --replace "torch == 2.1.2" "torch == 2.2.1"
+        --replace "torch == 2.1.2" "torch"
     ''
     + lib.optionalString rocmSupport ''
       substituteInPlace setup.py \
@@ -140,6 +144,8 @@ buildPythonPackage rec {
       pynvml
       cupy
     ];
+
+  stdenv = if cudaSupport then cudaPackages.backendStdenv else stdenv_pkg;
 
   pythonImportsCheck = [ "vllm" ];
 


### PR DESCRIPTION
## Description of changes

Dependent on PRs: https://github.com/NixOS/nixpkgs/pull/324672, and https://github.com/NixOS/nixpkgs/pull/324674
- The latter adds a new version of cutensor, which is required to build cupy
- The formers fixes cupy which is broken, and a dependency of vllm.

The changes made here:
- remove hardcoded package version setting in requirements.txt (makes vllm not break if someone updates torch or cupy.)
- adds a conditional setting of stdenv for building using the special env required to build cuda code.

Happy to make an overall joint PR to show the fixes work all together if that would make things easier. Have tested locally and they do in fact all build together happily.

@SomeoneSerge @samuela @happysalada (not sure Lach's handle)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
