### PR TITLE
python312Packages.msgraph-core: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/development/python-modules/expiringdict/default.nix
+++ b/pkgs/development/python-modules/expiringdict/default.nix
@@ -6,7 +6,7 @@
   dill,
   mock,
   pytestCheckHook,
-  setuptools
+  setuptools,
 }:
 
 buildPythonPackage rec {
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   # the package is not included into the PyPI tarball
   src = fetchFromGitHub {
     owner = "mailgun";
-    repo = pname;
+    repo = "expiringdict";
     rev = "refs/tags/v${version}";
     hash = "sha256-vRhJSHIqc51I+s/wndtfANM44CKW3QS1iajqyoSBf0I=";
   };
@@ -48,6 +48,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "expiringdict" ];
 
   meta = with lib; {
+    changelog = "https://github.com/mailgun/expiringdict/blob/${src.rev}/CHANGELOG.rst";
     description = "Dictionary with auto-expiring values for caching purposes";
     homepage = "https://github.com/mailgun/expiringdict";
     license = licenses.asl20;

--- a/pkgs/development/python-modules/kafka-python-ng/default.nix
+++ b/pkgs/development/python-modules/kafka-python-ng/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  setuptools-scm,
+  crc32c,
+  lz4,
+  python-snappy,
+  zstandard,
+  botocore,
+  pytest-mock,
+  pytestCheckHook,
+  xxhash,
+}:
+
+buildPythonPackage rec {
+  version = "2.2.2";
+  pname = "kafka-python-ng";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "wbarnha";
+    repo = "kafka-python-ng";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-ELJvcj91MQ2RTjT1dwgnTGSSG5lP6B6/45dFgtNY2Cc=";
+  };
+
+  build-system = [ setuptools-scm ];
+
+  passthru.optional-dependencies = {
+    crc32c =  [ crc32c ];
+    lz4 = [ lz4 ];
+    snappy = [ python-snappy ];
+    zstd = [ zstandard ];
+    boto = [ botocore ];
+  };
+
+  pythonImportsCheck = [ "kafka" ];
+
+  nativeCheckInputs = [
+    pytest-mock
+    pytestCheckHook
+    xxhash
+  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+
+  meta = {
+    changelog = "https://github.com/wbarnha/kafka-python-ng/releases/tag/v${version}";
+    description = "Pure Python client for Apache Kafka";
+    homepage = "https://github.com/wbarnha/kafka-python-ng";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/msgraph-core/default.nix
+++ b/pkgs/development/python-modules/msgraph-core/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "msgraph-core";
-  version = "1.1.0";
+  version = "1.1.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "microsoftgraph";
     repo = "msgraph-sdk-python-core";
     rev = "refs/tags/v${version}";
-    hash = "sha256-bQW1piSypfj3YAfzuEk/AkrB1x0lrHoIDyZv+KeCYgE=";
+    hash = "sha256-MrZGlp0rvKBNrIOYCWJfnRmD983/OjuQv1DoRVNngKU=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/parsedmarc/default.nix
+++ b/pkgs/development/python-modules/parsedmarc/default.nix
@@ -20,7 +20,7 @@
   google-auth-oauthlib,
   hatchling,
   imapclient,
-  kafka-python,
+  kafka-python-ng,
   lxml,
   mailsuite,
   msgraph-core,
@@ -77,7 +77,7 @@ buildPythonPackage rec {
     google-auth-httplib2
     google-auth-oauthlib
     imapclient
-    kafka-python
+    kafka-python-ng
     lxml
     mailsuite
     msgraph-core

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6446,6 +6446,8 @@ self: super: with self; {
 
   kafka-python = callPackage ../development/python-modules/kafka-python { };
 
+  kafka-python-ng = callPackage ../development/python-modules/kafka-python-ng { };
+
   kaggle = callPackage ../development/python-modules/kaggle { };
 
   kaitaistruct = callPackage ../development/python-modules/kaitaistruct { };


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/microsoftgraph/msgraph-sdk-python-core/compare/refs/tags/v1.1.0...v1.1.1

Changelog: https://github.com/microsoftgraph/msgraph-sdk-python-core/releases/tag/v1.1.1
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
