### PR TITLE
chirp: 0.4.0-unstable-2024-05-24 -> 0.4.0-unstable-2024-07-05, python311Packages.suds: init at 1.1.2

### DIFF
--- a/pkgs/applications/radio/chirp/default.nix
+++ b/pkgs/applications/radio/chirp/default.nix
@@ -10,13 +10,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "chirp";
-  version = "0.4.0-unstable-2024-05-24";
+  version = "0.4.0-unstable-2024-07-05";
 
   src = fetchFromGitHub {
     owner = "kk7ds";
     repo = "chirp";
-    rev = "e17c021ba4fc39eea8a2a1de37ef04a0d1253090";
-    hash = "sha256-YvIRo7g9fxnlf8og5CM2JLf8DeADVkcHdvb4ppS1veE=";
+    rev = "f28814fff0566dcf6f93ac5b7a79d6d594202757";
+    hash = "sha256-SQ0j9DGJc48TsaUaesixJT/pMBm9NGw22qapSokj9r8=";
   };
   buildInputs = [
     glib
@@ -30,6 +30,7 @@ python3.pkgs.buildPythonApplication rec {
     pyserial
     requests
     six
+    suds
     wxpython
     yattag
   ];

--- a/pkgs/applications/radio/chirp/default.nix
+++ b/pkgs/applications/radio/chirp/default.nix
@@ -48,7 +48,7 @@ python3.pkgs.buildPythonApplication rec {
     description = "Free, open-source tool for programming your amateur radio";
     homepage = "https://chirp.danplanet.com/";
     license = licenses.gpl3Plus;
-    maintainers = [ maintainers.emantor ];
+    maintainers = with maintainers; [ emantor wrmilling ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/suds/default.nix
+++ b/pkgs/development/python-modules/suds/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pytestCheckHook,
+  setuptools,
+  six,
+}:
+
+buildPythonPackage rec {
+  pname = "suds";
+  version = "1.1.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-HVz6dBFxk7JEpCM/JGxIPZ9BGYtEjF8UqLrRHE9knys=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    six
+  ];
+
+  pythonImportsCheck = [ "suds" ];
+
+  meta = {
+    changelog = "https://github.com/suds-community/suds/blob/v${version}/CHANGELOG.md";
+    description = "Lightweight SOAP python client for consuming Web Services";
+    homepage = "https://github.com/suds-community/suds";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ wrmilling ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29746,7 +29746,9 @@ with pkgs;
 
   chatty = callPackage ../applications/networking/instant-messengers/chatty { };
 
-  chirp = callPackage ../applications/radio/chirp { };
+  chirp = callPackage ../applications/radio/chirp {
+    python3 = python311;
+  };
 
   browsh = callPackage ../applications/networking/browsers/browsh { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14870,6 +14870,8 @@ self: super: with self; {
 
   sudachipy = callPackage ../development/python-modules/sudachipy { };
 
+  suds = callPackage ../development/python-modules/suds { };
+
   sumo = callPackage ../development/python-modules/sumo { };
 
   sumtypes = callPackage ../development/python-modules/sumtypes { };


### PR DESCRIPTION
## Description of changes

There are three main things in this PR: 

- new mandatory chirp dependency added, `python311Packages.suds: init at 1.1.2`, as mentioned in #317593.
- chirp package updated to 0.4.0-unstable-2024-07-05 and python 3.11 module issues addressed to allow it to build again.
- added myself as a chirp maintainer if acceptable.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>chirp</li>
    <li>chirp.dist</li>
    <li>python311Packages.suds</li>
    <li>python311Packages.suds.dist</li>
  </ul>
</details>

**Request**: This is my first time packaging for python with nixpkgs, please let me know if there are best practices or anything I missed on the new package.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
