### PR TITLE
ocamlPackages.lsp: 1.17.0 → 1.18.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
@@ -1,4 +1,5 @@
 { lib
+, ocaml
 , buildDunePackage
 , lsp
 , xdg
@@ -11,18 +12,30 @@
 , merlin-lib
 , astring
 , camlp-streams
+, base
 }:
+
+# Freeze ocaml-lsp-version at 1.17.0 for OCaml 5.0
+#  for which merlin 4.16 is not available
+let lsp_v =
+  if lib.versions.majorMinor ocaml.version == "5.0"
+  then lsp.override { version = "1.17.0"; }
+  else lsp
+; in
+
+let lsp = lsp_v; in
 
 buildDunePackage rec {
   pname = "ocaml-lsp-server";
   inherit (lsp) version src preBuild;
-  duneVersion = "3";
 
   buildInputs = lsp.buildInputs ++ [ lsp re ]
   ++ lib.optional (lib.versionAtLeast version "1.9") spawn
   ++ lib.optionals (lib.versionAtLeast version "1.10") [ fiber xdg ]
   ++ lib.optional (lib.versionAtLeast version "1.14.2") ocamlc-loc
-  ++ lib.optionals (lib.versionAtLeast version "1.17.0") [ astring camlp-streams merlin-lib ];
+  ++ lib.optionals (lib.versionAtLeast version "1.17.0") [ astring camlp-streams merlin-lib ]
+  ++ lib.optional (lib.versionAtLeast version "1.18.0") base
+  ;
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
@@ -9,7 +9,7 @@
 , ocaml
 , version ?
     if lib.versionAtLeast ocaml.version "4.14" then
-      "1.17.0"
+      "1.18.0"
     else if lib.versionAtLeast ocaml.version "4.13" then
       "1.10.5"
     else if lib.versionAtLeast ocaml.version "4.12" then
@@ -19,6 +19,11 @@
 }:
 
 let params = {
+  "1.18.0" = {
+    name = "lsp";
+    minimalOCamlVersion = "4.14";
+    sha256 = "sha256-tZ2kPM/S/9J3yeX2laDjnHLA144b8svy9iwae32nXwM=";
+  };
   "1.17.0" = {
     name = "lsp";
     minimalOCamlVersion = "4.14";
@@ -54,7 +59,6 @@ buildDunePackage rec {
     inherit (params) sha256;
   };
 
-  duneVersion = "3";
   inherit (params) minimalOCamlVersion;
 
   buildInputs =

--- a/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
@@ -24,7 +24,7 @@
 , ocaml
 , version ?
     if lib.versionAtLeast ocaml.version "4.14" then
-      "1.17.0"
+      "1.18.0"
     else if lib.versionAtLeast ocaml.version "4.13" then
       "1.10.5"
     else if lib.versionAtLeast ocaml.version "4.12" then
@@ -39,7 +39,6 @@ let jsonrpc_v = jsonrpc.override {
 buildDunePackage rec {
   pname = "lsp";
   inherit (jsonrpc_v) version src;
-  duneVersion = "3";
   minimalOCamlVersion =
     if lib.versionAtLeast version "1.7.0" then
       "4.12"


### PR DESCRIPTION
## Description of changes

https://github.com/ocaml/ocaml-lsp/releases/tag/1.18.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
