### PR TITLE
update-python-libraries: fix updating packages without src.fetcher

### DIFF
--- a/pkgs/development/interpreters/python/update-python-libraries/update-python-libraries.py
+++ b/pkgs/development/interpreters/python/update-python-libraries/update-python-libraries.py
@@ -275,16 +275,17 @@ def _get_latest_version_github(attr_path, package, extension, current_version, t
     release = next(filter(lambda x: strip_prefix(x["tag_name"]) == version, releases))
     prefix = get_prefix(release["tag_name"])
 
-    # some attributes require using the fetchgit
-    git_fetcher_args = []
-    if _get_attr_value(f"{attr_path}.src.fetchSubmodules"):
-        git_fetcher_args.append("--fetch-submodules")
-    if _get_attr_value(f"{attr_path}.src.fetchLFS"):
-        git_fetcher_args.append("--fetch-lfs")
-    if _get_attr_value(f"{attr_path}.src.leaveDotGit"):
-        git_fetcher_args.append("--leave-dotGit")
+    fetcher = _get_attr_value(f"{attr_path}.src.fetcher")
+    if fetcher is not None and fetcher.endswith("nix-prefetch-git"):
+        # some attributes require using the fetchgit
+        git_fetcher_args = []
+        if _get_attr_value(f"{attr_path}.src.fetchSubmodules"):
+            git_fetcher_args.append("--fetch-submodules")
+        if _get_attr_value(f"{attr_path}.src.fetchLFS"):
+            git_fetcher_args.append("--fetch-lfs")
+        if _get_attr_value(f"{attr_path}.src.leaveDotGit"):
+            git_fetcher_args.append("--leave-dotGit")
 
-    if git_fetcher_args or _get_attr_value(f"{attr_path}.src.fetcher").endswith("nix-prefetch-git"):
         algorithm = "sha256"
         cmd = [
             "nix-prefetch-git",


### PR DESCRIPTION
## Description of changes

Fixes updating python packages that don't have `src.fetcher` since #322769

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
