### PR TITLE
home-assistant: 2024.7.1 -> 2024.7.2

### DIFF
--- a/pkgs/development/python-modules/jaraco-abode/default.nix
+++ b/pkgs/development/python-modules/jaraco-abode/default.nix
@@ -25,7 +25,7 @@
 
 buildPythonPackage rec {
   pname = "jaraco-abode";
-  version = "5.2.0";
+  version = "5.2.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     owner = "jaraco";
     repo = "jaraco.abode";
     rev = "refs/tags/v${version}";
-    hash = "sha256-O7adVcczkEZ3B7qhZlIWp5A7ujHlEjLQG6OfR59eSO4=";
+    hash = "sha256-1omRBbUNS2/U2laK7E1M0uZfejZVMdGezG5oIGILj70=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/tailscale/default.nix
+++ b/pkgs/development/python-modules/tailscale/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "tailscale";
-  version = "0.6.0";
+  version = "0.6.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.11";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "frenck";
     repo = "python-tailscale";
     rev = "refs/tags/v${version}";
-    hash = "sha256-wO6yMMU5fxk8GQ0e4ZCse2atlR4wrzulZOFXkVKAsmU=";
+    hash = "sha256-47n/BjTHkw0rT8xTHGZOMNwZTy0nDuoHsTJrRyr8qjc=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/xiaomi-ble/default.nix
+++ b/pkgs/development/python-modules/xiaomi-ble/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "xiaomi-ble";
-  version = "0.30.1";
+  version = "0.30.2";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "Bluetooth-Devices";
     repo = "xiaomi-ble";
     rev = "refs/tags/v${version}";
-    hash = "sha256-1YeT525L6SsybiA+k5vPx5D2yvYdcuxfhpUMlZCX2Jo=";
+    hash = "sha256-x+i5zC0WTWO+F1uIliAzyc+48X3njwTNz5ss5KK6xuQ=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/yalexs/default.nix
+++ b/pkgs/development/python-modules/yalexs/default.nix
@@ -20,7 +20,7 @@
 
 buildPythonPackage rec {
   pname = "yalexs";
-  version = "6.4.1";
+  version = "6.4.2";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     owner = "bdraco";
     repo = "yalexs";
     rev = "refs/tags/v${version}";
-    hash = "sha256-lCRil1SeYXZeXT0SJielJg2Ma8voBXPgij+RK/oT1iU=";
+    hash = "sha256-0EvQj+aKzpnehvI5IS3DBaJOp4wYpAWwkkaOLgwtdJs=";
   };
 
   postPatch = ''

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2024.7.1";
+  version = "2024.7.2";
   components = {
     "3_day_blinds" = ps: with ps; [
     ];
@@ -269,7 +269,7 @@
     "arve" = ps: with ps; [
     ]; # missing inputs: asyncarve
     "arwn" = ps: with ps; [
-      paho-mqtt
+      paho-mqtt_1
     ];
     "aseko_pool_live" = ps: with ps; [
       aioaseko
@@ -335,7 +335,7 @@
     ];
     "axis" = ps: with ps; [
       axis
-      paho-mqtt
+      paho-mqtt_1
     ];
     "azure_data_explorer" = ps: with ps; [
     ]; # missing inputs: azure-kusto-data azure-kusto-ingest
@@ -947,13 +947,13 @@
     ];
     "drop_connect" = ps: with ps; [
       dropmqttapi
-      paho-mqtt
+      paho-mqtt_1
     ];
     "dsmr" = ps: with ps; [
       dsmr-parser
     ];
     "dsmr_reader" = ps: with ps; [
-      paho-mqtt
+      paho-mqtt_1
     ];
     "dte_energy_bridge" = ps: with ps; [
     ];
@@ -1431,7 +1431,7 @@
     "fujitsu_anywair" = ps: with ps; [
     ];
     "fully_kiosk" = ps: with ps; [
-      paho-mqtt
+      paho-mqtt_1
       python-fullykiosk
     ];
     "futurenow" = ps: with ps; [
@@ -2595,7 +2595,7 @@
     "manual" = ps: with ps; [
     ];
     "manual_mqtt" = ps: with ps; [
-      paho-mqtt
+      paho-mqtt_1
     ];
     "map" = ps: with ps; [
       fnv-hash-fast
@@ -2906,19 +2906,19 @@
       mpd2
     ];
     "mqtt" = ps: with ps; [
-      paho-mqtt
+      paho-mqtt_1
     ];
     "mqtt_eventstream" = ps: with ps; [
-      paho-mqtt
+      paho-mqtt_1
     ];
     "mqtt_json" = ps: with ps; [
-      paho-mqtt
+      paho-mqtt_1
     ];
     "mqtt_room" = ps: with ps; [
-      paho-mqtt
+      paho-mqtt_1
     ];
     "mqtt_statestream" = ps: with ps; [
-      paho-mqtt
+      paho-mqtt_1
     ];
     "msteams" = ps: with ps; [
       pymsteams
@@ -2942,7 +2942,7 @@
     "myq" = ps: with ps; [
     ];
     "mysensors" = ps: with ps; [
-      paho-mqtt
+      paho-mqtt_1
       pymysensors
     ];
     "mystrom" = ps: with ps; [
@@ -3295,7 +3295,7 @@
       hassil
       home-assistant-intents
       mutagen
-      paho-mqtt
+      paho-mqtt_1
       psutil-home-assistant
       pynacl
       python-matter-server
@@ -4144,7 +4144,7 @@
       snapcast
     ];
     "snips" = ps: with ps; [
-      paho-mqtt
+      paho-mqtt_1
     ];
     "snmp" = ps: with ps; [
       pysnmp-lextudio
@@ -4431,7 +4431,7 @@
     ]; # missing inputs: tapsaff
     "tasmota" = ps: with ps; [
       hatasmota
-      paho-mqtt
+      paho-mqtt_1
     ];
     "tautulli" = ps: with ps; [
       pytautulli

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -231,15 +231,6 @@ let
         };
       });
 
-      psutil = super.psutil.overridePythonAttrs (oldAttrs: rec {
-        version = "5.9.8";
-        src = fetchPypi {
-          inherit (oldAttrs) pname;
-          inherit version;
-          hash = "sha256-a+Em4yJUht/yhqj7mgYkalJT9MfFO0depfWsk05kGUw=";
-        };
-      });
-
       pyasn1 = super.pyasn1.overridePythonAttrs (oldAttrs: rec {
         version = "0.4.8";
         src = fetchPypi {
@@ -485,7 +476,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2024.7.1";
+  hassVersion = "2024.7.2";
 
 in python.pkgs.buildPythonApplication rec {
   pname = "homeassistant";
@@ -503,13 +494,13 @@ in python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = "refs/tags/${version}";
-    hash = "sha256-y3VYxlPit9LuC+9F+fQoJs3WD9LsvrMZMiSCqbzkgmk=";
+    hash = "sha256-FML1JZFj2xebcQvXJmBu02Eczz3ejg4r7PfnpBiDc50=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-pFsv0guypnRPeZOg2WrG2HL27W903iANHkvdQ8dCJHo=";
+    hash = "sha256-okukdAbBXJCaDpnOCDY91dsLQdm5pMJ1SKXV9A68eoQ=";
   };
 
   build-system = with python.pkgs; [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,7 +4,7 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20240705.0";
+  version = "20240710.0";
   format = "wheel";
 
   src = fetchPypi {
@@ -12,7 +12,7 @@ buildPythonPackage rec {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    hash = "sha256-uZs/2/+fmnZzDzEuzEus0LDUNTSQIs/jL4FMBJBpXAE=";
+    hash = "sha256-EP4r59sgrLuK+n3ydq4LMCUS4xsT2XYE2OvK9N+Gd+M=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2024.7.0";
+  version = "2024.7.2";
   pyproject = true;
 
   disabled = python.version != home-assistant.python.version;
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     rev = "refs/tags/${version}";
-    hash = "sha256-p/0OM72XcfGLKWbReMcUCBZTxHFDe0VZk5gmaI0Qx2Q=";
+    hash = "sha256-MMFt8TGWB+7wUKYWL4IJyhI3YOumll8Jq5GWZpaZZ8I=";
   };
 
   build-system = [

--- a/pkgs/servers/home-assistant/update-component-packages.py
+++ b/pkgs/servers/home-assistant/update-component-packages.py
@@ -43,6 +43,7 @@ PKG_PREFERENCES = {
     "HAP-python": "hap-python",
     "numpy": "numpy_1",
     "ollama-hass": "ollama",
+    "paho-mqtt": "paho-mqtt_1",
     "sentry-sdk": "sentry-sdk",
     "slackclient": "slack-sdk",
     "SQLAlchemy": "sqlalchemy",


### PR DESCRIPTION
https://github.com/jaraco/jaraco.abode/blob/5.2.1/CHANGES.rst
https://github.com/Bluetooth-Devices/xiaomi-ble/releases/tag/v0.30.2
https://github.com/frenck/python-tailscale/releases/tag/v0.6.1
https://github.com/jaraco/jaraco.abode/blob/5.2.1/CHANGES.rst
https://github.com/home-assistant/core/releases/tag/2024.7.2
https://github.com/KapJI/homeassistant-stubs/releases/tag/2024.7.2


## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
