### PR TITLE
frescobaldi: fix build; cleanup deps

### DIFF
--- a/pkgs/development/python-modules/pyqtwebengine/default.nix
+++ b/pkgs/development/python-modules/pyqtwebengine/default.nix
@@ -94,11 +94,11 @@ buildPythonPackage (
       inherit (libsForQt5) wrapQtAppsHook;
     };
 
-    meta = with lib; {
+    meta = {
       description = "Python bindings for Qt5";
       homepage = "http://www.riverbankcomputing.co.uk";
-      license = licenses.gpl3;
-      hydraPlatforms = lib.lists.intersectLists libsForQt5.qtwebengine.meta.platforms platforms.mesaPlatforms;
+      license = lib.licenses.gpl3;
+      hydraPlatforms = lib.lists.intersectLists libsForQt5.qtwebengine.meta.platforms lib.platforms.mesaPlatforms;
     };
   }
   // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {

--- a/pkgs/development/python-modules/pyqtwebengine/default.nix
+++ b/pkgs/development/python-modules/pyqtwebengine/default.nix
@@ -1,28 +1,20 @@
 {
   lib,
+  setuptools,
   stdenv,
-  pythonPackages,
   fetchPypi,
   pkg-config,
-  qmake,
-  qtbase,
-  qtsvg,
-  qtwebengine,
-  qtwebchannel,
-  qtdeclarative,
-  wrapQtAppsHook,
+  libsForQt5,
   darwin,
+  buildPythonPackage,
+  python,
+  isPy27,
+  pyqt5,
+  sip,
+  pyqt-builder,
 }:
 
 let
-  inherit (pythonPackages)
-    buildPythonPackage
-    python
-    isPy27
-    pyqt5
-    sip
-    pyqt-builder
-    ;
   inherit (darwin) autoSignDarwinBinariesHook;
 in
 buildPythonPackage (
@@ -52,32 +44,33 @@ buildPythonPackage (
     nativeBuildInputs =
       [
         pkg-config
-        qmake
+        libsForQt5.qmake
+        libsForQt5.wrapQtAppsHook
       ]
       ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ sip ]
       ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
         python.pythonOnBuildForHost.pkgs.sip
       ]
       ++ [
-        qtbase
-        qtsvg
-        qtwebengine
+        libsForQt5.qtbase
+        libsForQt5.qtsvg
+        libsForQt5.qtwebengine
         pyqt-builder
-        pythonPackages.setuptools
+        setuptools
       ]
-      ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ qtdeclarative ]
+      ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ libsForQt5.qtdeclarative ]
       ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [ autoSignDarwinBinariesHook ];
 
     buildInputs =
       [
         sip
-        qtbase
-        qtsvg
-        qtwebengine
+        libsForQt5.qtbase
+        libsForQt5.qtsvg
+        libsForQt5.qtwebengine
       ]
       ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-        qtwebchannel
-        qtdeclarative
+        libsForQt5.qtwebchannel
+        libsForQt5.qtdeclarative
       ];
 
     propagatedBuildInputs = [ pyqt5 ];
@@ -98,21 +91,21 @@ buildPythonPackage (
     enableParallelBuilding = true;
 
     passthru = {
-      inherit wrapQtAppsHook;
+      inherit (libsForQt5) wrapQtAppsHook;
     };
 
     meta = with lib; {
       description = "Python bindings for Qt5";
       homepage = "http://www.riverbankcomputing.co.uk";
       license = licenses.gpl3;
-      hydraPlatforms = lib.lists.intersectLists qtwebengine.meta.platforms platforms.mesaPlatforms;
+      hydraPlatforms = lib.lists.intersectLists libsForQt5.qtwebengine.meta.platforms platforms.mesaPlatforms;
     };
   }
   // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
     # TODO: figure out why the env hooks aren't adding these inclusions automatically
     env.NIX_CFLAGS_COMPILE = lib.concatStringsSep " " [
-      "-I${lib.getDev qtbase}/include/QtPrintSupport/"
-      "-I${lib.getDev qtwebchannel}/include/QtWebChannel/"
+      "-I${lib.getDev libsForQt5.qtbase}/include/QtPrintSupport/"
+      "-I${lib.getDev libsForQt5.qtwebchannel}/include/QtWebChannel/"
     ];
   }
 )

--- a/pkgs/development/python-modules/qpageview/default.nix
+++ b/pkgs/development/python-modules/qpageview/default.nix
@@ -2,11 +2,13 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
-  python3Packages,
   pythonOlder,
+  pyqt5,
+  poppler-qt5,
+  pycups,
 }:
 
-python3Packages.buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "qpageview";
   version = "0.6.2";
   format = "setuptools";
@@ -20,7 +22,7 @@ python3Packages.buildPythonPackage rec {
     hash = "sha256-XFMTOD7ums8sbFHUViEI9q6/rCjUmEtXAdd3/OmLsHU=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  propagatedBuildInputs = [
     pyqt5
     poppler-qt5
     pycups

--- a/pkgs/misc/frescobaldi/default.nix
+++ b/pkgs/misc/frescobaldi/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, buildPythonApplication, fetchFromGitHub, python3Packages, pyqtwebengine, lilypond }:
+{ lib, stdenv, fetchFromGitHub, python311Packages, lilypond }:
 
-buildPythonApplication rec {
+python311Packages.buildPythonApplication rec {
   pname = "frescobaldi";
   version = "3.3.0";
 
@@ -11,7 +11,7 @@ buildPythonApplication rec {
     sha256 = "sha256-Q6ruthNcpjLlYydUetkuTECiCIzu055bw40O8BPGq/A=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  propagatedBuildInputs = with python311Packages; [
     qpageview
     lilypond
     pygame
@@ -22,7 +22,7 @@ buildPythonApplication rec {
     pyqtwebengine
   ];
 
-  nativeBuildInputs = [ pyqtwebengine.wrapQtAppsHook ];
+  nativeBuildInputs = [ python311Packages.pyqtwebengine.wrapQtAppsHook ];
 
   # Needed because source is fetched from git
   preBuild = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7974,7 +7974,7 @@ with pkgs;
     wxGTK = wxGTK32;
   };
 
-  frescobaldi = python3Packages.callPackage ../misc/frescobaldi { };
+  frescobaldi = callPackage ../misc/frescobaldi { };
 
   freshfetch = callPackage ../tools/misc/freshfetch {
     inherit (darwin.apple_sdk.frameworks) AppKit CoreFoundation DiskArbitration Foundation IOKit;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12013,9 +12013,7 @@ self: super: with self; {
 
   pyqtgraph = callPackage ../development/python-modules/pyqtgraph { };
 
-  pyqtwebengine = pkgs.libsForQt5.callPackage ../development/python-modules/pyqtwebengine {
-    pythonPackages = self;
-  };
+  pyqtwebengine = callPackage ../development/python-modules/pyqtwebengine { };
 
   pyquery = callPackage ../development/python-modules/pyquery { };
 


### PR DESCRIPTION
## Description of changes

- **python311Packages.qpageview: remove references to python3Packages**
- **python311Packages.pyqtwebengine: use regular callPackage** - tracked by #180841 
- **frescobaldi: pin to python 3.11 to fix build**
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
