### PR TITLE
llvmPackages.bolt: init at 19.0.0-unstable-2024-07-08

### DIFF
--- a/pkgs/development/compilers/llvm/common/bolt/default.nix
+++ b/pkgs/development/compilers/llvm/common/bolt/default.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  llvm_meta,
+  monorepoSrc,
+  runCommand,
+  cmake,
+  libxml2,
+  libllvm,
+  libclang,
+  version,
+  python3,
+  buildLlvmTools,
+  patches ? [ ],
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bolt";
+  inherit version patches;
+
+  # Blank llvm dir just so relative path works
+  src = runCommand "bolt-src-${finalAttrs.version}" { } ''
+    mkdir $out
+    cp -r ${monorepoSrc}/cmake "$out"
+    cp -r ${monorepoSrc}/${finalAttrs.pname} "$out"
+    cp -r ${monorepoSrc}/third-party "$out"
+
+    # tablegen stuff, probably not the best way but it works...
+    cp -r ${monorepoSrc}/llvm/ "$out"
+    chmod -R +w $out/llvm
+  '';
+
+  sourceRoot = "${finalAttrs.src.name}/bolt";
+
+  nativeBuildInputs = [
+    cmake
+    python3
+  ];
+
+  buildInputs = [
+    libllvm
+    libclang
+    libxml2
+  ];
+
+  cmakeFlags = lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    (lib.cmakeFeature "LLVM_TABLEGEN_EXE" "${buildLlvmTools.llvm}/bin/llvm-tblgen")
+  ];
+
+  postUnpack = ''
+    chmod -R u+w -- $sourceRoot/..
+  '';
+
+  prePatch = ''
+    cd ..
+  '';
+
+  postPatch = ''
+    cd bolt
+  '';
+
+  postInstall = ''
+    mkdir -p $dev/lib
+    mv $out/lib/libLLVMBOLT*.a $dev/lib
+  '';
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  meta = llvm_meta // {
+    homepage = "https://github.com/llvm/llvm-project/tree/main/bolt";
+    description = "LLVM post-link optimizer.";
+  };
+})

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -633,6 +633,16 @@ let
       mlir = callPackage ./mlir { };
       libclc = callPackage ./libclc.nix { };
     }
+    // lib.optionalAttrs (lib.versionAtLeast metadata.release_version "19") {
+      bolt = callPackage ./bolt {
+        patches = lib.optionals (lib.versions.major metadata.release_version == "19") [
+          (fetchpatch {
+            url = "https://github.com/llvm/llvm-project/commit/abc2eae68290c453e1899a94eccc4ed5ea3b69c1.patch";
+            hash = "sha256-oxCxOjhi5BhNBEraWalEwa1rS3Mx9CuQgRVZ2hrbd7M=";
+          })
+        ];
+      };
+    }
   );
 
   libraries = lib.makeExtensible (

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15995,6 +15995,7 @@ with pkgs;
     lld_19 = llvmPackages_19.lld;
     lldb_19 = llvmPackages_19.lldb;
     llvm_19 = llvmPackages_19.llvm;
+    bolt_19 = llvmPackages_19.bolt;
 
     llvmPackages_git = llvmPackagesSet.git;
   }) llvmPackages_13
@@ -16012,6 +16013,7 @@ with pkgs;
     lld_19
     lldb_19
     llvm_19
+    bolt_19
     llvmPackages_git;
 
   lorri = callPackage ../tools/misc/lorri {


### PR DESCRIPTION
## Description of changes

Continue from #289587, fixes #176536

Init LLVM's bolt onto the git version because of https://github.com/llvm/llvm-project/pull/97130, we can backport once the upstream PR is merged.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
