### PR TITLE
treewide: skip generating shell completions using $out/bin/… when cross compiling

### DIFF
--- a/pkgs/applications/misc/comodoro/default.nix
+++ b/pkgs/applications/misc/comodoro/default.nix
@@ -3,8 +3,8 @@
 , fetchFromGitHub
 , stdenv
 , installShellFiles
-, installShellCompletions ? stdenv.hostPlatform == stdenv.buildPlatform
-, installManPages ? stdenv.hostPlatform == stdenv.buildPlatform
+, installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform
+, installManPages ? stdenv.buildPlatform.canExecute stdenv.hostPlatform
 , withTcp ? true
 }:
 

--- a/pkgs/applications/misc/flavours/default.nix
+++ b/pkgs/applications/misc/flavours/default.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd flavours \
       --zsh <($out/bin/flavours --completions zsh) \
       --fish <($out/bin/flavours --completions fish) \

--- a/pkgs/applications/misc/genact/default.nix
+++ b/pkgs/applications/misc/genact/default.nix
@@ -1,4 +1,4 @@
-{ lib, rustPlatform, fetchFromGitHub, installShellFiles }:
+{ lib, rustPlatform, fetchFromGitHub, installShellFiles, stdenv }:
 
 rustPlatform.buildRustPackage rec {
   pname = "genact";
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     $out/bin/genact --print-manpage > genact.1
     installManPage genact.1
 

--- a/pkgs/applications/misc/inlyne/default.nix
+++ b/pkgs/applications/misc/inlyne/default.nix
@@ -51,7 +51,7 @@ rustPlatform.buildRustPackage rec {
     "--skip=watcher::tests::the_gauntlet"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd inlyne \
       --bash completions/inlyne.bash \
       --fish completions/inlyne.fish \

--- a/pkgs/applications/misc/inlyne/default.nix
+++ b/pkgs/applications/misc/inlyne/default.nix
@@ -53,9 +53,9 @@ rustPlatform.buildRustPackage rec {
 
   postInstall = ''
     installShellCompletion --cmd inlyne \
-      --bash <($out/bin/inlyne --gen-completions bash) \
-      --fish <($out/bin/inlyne --gen-completions fish) \
-      --zsh <($out/bin/inlyne --gen-completions zsh)
+      --bash completions/inlyne.bash \
+      --fish completions/inlyne.fish \
+      --zsh completions/_inlyne
   '';
 
   postFixup = lib.optionalString stdenv.isLinux ''

--- a/pkgs/applications/misc/leetcode-cli/default.nix
+++ b/pkgs/applications/misc/leetcode-cli/default.nix
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
     sqlite
   ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd leetcode \
       --bash <($out/bin/leetcode completions bash) \
       --fish <($out/bin/leetcode completions fish) \

--- a/pkgs/applications/version-management/git-absorb/default.nix
+++ b/pkgs/applications/version-management/git-absorb/default.nix
@@ -19,6 +19,7 @@ rustPlatform.buildRustPackage rec {
 
   postInstall = ''
     installManPage Documentation/git-absorb.1
+  '' + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd git-absorb \
       --bash <($out/bin/git-absorb --gen-completions bash) \
       --fish <($out/bin/git-absorb --gen-completions fish) \

--- a/pkgs/applications/version-management/jujutsu/default.nix
+++ b/pkgs/applications/version-management/jujutsu/default.nix
@@ -52,7 +52,7 @@ rustPlatform.buildRustPackage rec {
     libiconv
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     $out/bin/jj util mangen > ./jj.1
     installManPage ./jj.1
 

--- a/pkgs/applications/virtualization/youki/default.nix
+++ b/pkgs/applications/virtualization/youki/default.nix
@@ -6,6 +6,7 @@
 , dbus
 , libseccomp
 , systemd
+, stdenv
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -27,7 +28,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ dbus libseccomp systemd ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd youki \
       --bash <($out/bin/youki completion -s bash) \
       --fish <($out/bin/youki completion -s fish) \

--- a/pkgs/by-name/ab/ab-av1/package.nix
+++ b/pkgs/by-name/ab/ab-av1/package.nix
@@ -1,4 +1,4 @@
-{ lib, rustPlatform, fetchFromGitHub, installShellFiles }:
+{ lib, rustPlatform, fetchFromGitHub, installShellFiles, stdenv }:
 
 rustPlatform.buildRustPackage rec {
   pname = "ab-av1";
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd ab-av1 \
       --bash <($out/bin/ab-av1 print-completions bash) \
       --fish <($out/bin/ab-av1 print-completions fish) \

--- a/pkgs/by-name/as/ast-grep/package.nix
+++ b/pkgs/by-name/as/ast-grep/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
     rm .cargo/config.toml
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd sg \
       --bash <($out/bin/sg completions bash) \
       --fish <($out/bin/sg completions fish) \

--- a/pkgs/by-name/at/attic-client/package.nix
+++ b/pkgs/by-name/at/attic-client/package.nix
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage {
   # to nix-daemon to import NARs, which is not possible in the build sandbox.
   doCheck = false;
 
-  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     if [[ -f $out/bin/attic ]]; then
       installShellCompletion --cmd attic \
         --bash <($out/bin/attic gen-completions bash) \

--- a/pkgs/by-name/cl/clipcat/package.nix
+++ b/pkgs/by-name/cl/clipcat/package.nix
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage rec {
     "--skip=test_x11_primary"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     for cmd in clipcatd clipcatctl clipcat-menu clipcat-notify; do
       installShellCompletion --cmd $cmd \
         --bash <($out/bin/$cmd completions bash) \

--- a/pkgs/by-name/co/codeberg-cli/package.nix
+++ b/pkgs/by-name/co/codeberg-cli/package.nix
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage rec {
       ]
     );
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd berg \
       --bash <($out/bin/berg completion bash) \
       --fish <($out/bin/berg completion fish) \

--- a/pkgs/by-name/di/diesel-cli/package.nix
+++ b/pkgs/by-name/di/diesel-cli/package.nix
@@ -79,7 +79,7 @@ rustPlatform.buildRustPackage rec {
   # Tests currently fail due to *many* duplicate definition errors
   doCheck = false;
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd diesel \
       --bash <($out/bin/diesel completions bash) \
       --fish <($out/bin/diesel completions fish) \

--- a/pkgs/by-name/el/elf2nucleus/package.nix
+++ b/pkgs/by-name/el/elf2nucleus/package.nix
@@ -4,6 +4,7 @@
 , lib
 , micronucleus
 , rustPlatform
+, stdenv
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -23,7 +24,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ micronucleus ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd elf2nucleus \
       --bash <($out/bin/elf2nucleus --completions bash) \
       --fish <($out/bin/elf2nucleus --completions fish) \

--- a/pkgs/by-name/en/engage/package.nix
+++ b/pkgs/by-name/en/engage/package.nix
@@ -2,6 +2,7 @@
 , installShellFiles
 , rustPlatform
 , fetchFromGitLab
+, stdenv
 }:
 
 let
@@ -25,7 +26,8 @@ rustPlatform.buildRustPackage {
     installShellFiles
   ];
 
-  postInstall = "installShellCompletion --cmd ${pname} "
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) (
+    "installShellCompletion --cmd ${pname} "
     + builtins.concatStringsSep
       " "
       (builtins.map
@@ -35,7 +37,8 @@ rustPlatform.buildRustPackage {
           "fish"
           "zsh"
         ]
-      );
+      )
+    );
 
   meta = {
     description = "Task runner with DAG-based parallelism";

--- a/pkgs/by-name/hi/himalaya/package.nix
+++ b/pkgs/by-name/hi/himalaya/package.nix
@@ -5,8 +5,8 @@
 , pkg-config
 , darwin
 , installShellFiles
-, installShellCompletions ? stdenv.hostPlatform == stdenv.buildPlatform
-, installManPages ? stdenv.hostPlatform == stdenv.buildPlatform
+, installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform
+, installManPages ? stdenv.buildPlatform.canExecute stdenv.hostPlatform
 , notmuch
 , gpgme
 , buildNoDefaultFeatures ? false

--- a/pkgs/by-name/jo/joshuto/package.nix
+++ b/pkgs/by-name/jo/joshuto/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
     darwin.apple_sdk.frameworks.Foundation
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd joshuto \
       --bash <($out/bin/joshuto completions bash) \
       --zsh <($out/bin/joshuto completions zsh) \

--- a/pkgs/by-name/ma/maa-cli/package.nix
+++ b/pkgs/by-name/ma/maa-cli/package.nix
@@ -65,6 +65,7 @@ rustPlatform.buildRustPackage rec {
         ]
       }"
 
+  '' + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd maa \
       --bash <($out/bin/maa complete bash) \
       --fish <($out/bin/maa complete fish) \

--- a/pkgs/by-name/ma/maa-cli/package.nix
+++ b/pkgs/by-name/ma/maa-cli/package.nix
@@ -51,30 +51,32 @@ rustPlatform.buildRustPackage rec {
 
   # maa-cli would only seach libMaaCore.so and resources in itself's path
   # https://github.com/MaaAssistantArknights/maa-cli/issues/67
-  postInstall = ''
-    mkdir -p $out/share/maa-assistant-arknights/
-    ln -s ${maa-assistant-arknights}/share/maa-assistant-arknights/* $out/share/maa-assistant-arknights/
-    ln -s ${maa-assistant-arknights}/lib/* $out/share/maa-assistant-arknights/
-    mv $out/bin/maa $out/share/maa-assistant-arknights/
+  postInstall =
+    ''
+      mkdir -p $out/share/maa-assistant-arknights/
+      ln -s ${maa-assistant-arknights}/share/maa-assistant-arknights/* $out/share/maa-assistant-arknights/
+      ln -s ${maa-assistant-arknights}/lib/* $out/share/maa-assistant-arknights/
+      mv $out/bin/maa $out/share/maa-assistant-arknights/
 
-    makeWrapper $out/share/maa-assistant-arknights/maa $out/bin/maa \
-      --prefix PATH : "${
-        lib.makeBinPath [
-          android-tools
-          git
-        ]
-      }"
+      makeWrapper $out/share/maa-assistant-arknights/maa $out/bin/maa \
+        --prefix PATH : "${
+          lib.makeBinPath [
+            android-tools
+            git
+          ]
+        }"
 
-  '' + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-    installShellCompletion --cmd maa \
-      --bash <($out/bin/maa complete bash) \
-      --fish <($out/bin/maa complete fish) \
-      --zsh <($out/bin/maa complete zsh)
+    ''
+    + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      installShellCompletion --cmd maa \
+        --bash <($out/bin/maa complete bash) \
+        --fish <($out/bin/maa complete fish) \
+        --zsh <($out/bin/maa complete zsh)
 
-    mkdir -p manpage
-    $out/bin/maa mangen --path manpage
-    installManPage manpage/*
-  '';
+      mkdir -p manpage
+      $out/bin/maa mangen --path manpage
+      installManPage manpage/*
+    '';
 
   meta = with lib; {
     description = "Simple CLI for MAA by Rust";

--- a/pkgs/by-name/ne/neverest/package.nix
+++ b/pkgs/by-name/ne/neverest/package.nix
@@ -5,8 +5,8 @@
 , pkg-config
 , darwin
 , installShellFiles
-, installShellCompletions ? stdenv.hostPlatform == stdenv.buildPlatform
-, installManPages ? stdenv.hostPlatform == stdenv.buildPlatform
+, installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform
+, installManPages ? stdenv.buildPlatform.canExecute stdenv.hostPlatform
 , notmuch
 , buildNoDefaultFeatures ? false
 , buildFeatures ? []

--- a/pkgs/by-name/pa/pace/package.nix
+++ b/pkgs/by-name/pa/pace/package.nix
@@ -3,6 +3,7 @@
   rustPlatform,
   fetchFromGitHub,
   installShellFiles,
+  stdenv,
 }: let
   version = "0.15.2";
 in
@@ -21,7 +22,7 @@ in
 
     nativeBuildInputs = [installShellFiles];
 
-    postInstall = ''
+    postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
       installShellCompletion --cmd pace \
         --bash <($out/bin/pace setup completions bash) \
         --fish <($out/bin/pace setup completions fish) \

--- a/pkgs/by-name/pi/pixi/package.nix
+++ b/pkgs/by-name/pi/pixi/package.nix
@@ -80,7 +80,7 @@ rustPlatform.buildRustPackage rec {
     "--skip=cli::shell_hook::tests::test_environment_json"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd pixi \
       --bash <($out/bin/pixi completion --shell bash) \
       --fish <($out/bin/pixi completion --shell fish) \

--- a/pkgs/by-name/qr/qrtool/package.nix
+++ b/pkgs/by-name/qr/qrtool/package.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , fetchFromGitHub
 , rustPlatform
 , asciidoctor
@@ -24,6 +25,7 @@ rustPlatform.buildRustPackage rec {
     # Built by ./build.rs using `asciidoctor`
     installManPage ./target/*/release/build/qrtool*/out/*.?
 
+  '' + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd qrtool \
       --bash <($out/bin/qrtool --generate-completion bash) \
       --fish <($out/bin/qrtool --generate-completion fish) \

--- a/pkgs/by-name/re/release-plz/package.nix
+++ b/pkgs/by-name/re/release-plz/package.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
   # Tests depend on additional infrastructure to be running locally
   doCheck = false;
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd ${meta.mainProgram} \
       --bash <($out/bin/${meta.mainProgram} generate-completions bash) \
       --fish <($out/bin/${meta.mainProgram} generate-completions fish) \

--- a/pkgs/by-name/sn/sn0int/package.nix
+++ b/pkgs/by-name/sn/sn0int/package.nix
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage rec {
   # in "checkPhase", hence fails in sandbox of "nix".
   doCheck = false;
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform)  ''
     installShellCompletion --cmd sn0int \
       --bash <($out/bin/sn0int completions bash) \
       --fish <($out/bin/sn0int completions fish) \

--- a/pkgs/by-name/so/solana-cli/package.nix
+++ b/pkgs/by-name/so/solana-cli/package.nix
@@ -80,7 +80,7 @@ rustPlatform.buildRustPackage rec {
     Libsystem
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd solana \
       --bash <($out/bin/solana completion --shell bash) \
       --fish <($out/bin/solana completion --shell fish) \

--- a/pkgs/by-name/st/steamguard-cli/package.nix
+++ b/pkgs/by-name/st/steamguard-cli/package.nix
@@ -2,6 +2,7 @@
 , lib
 , rustPlatform
 , fetchFromGitHub
+, stdenv
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -18,7 +19,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-LYrn0MKrOYjYPLdBukXRXGW+XWVcGHNAl0vC/qkmkNs=";
 
   nativeBuildInputs = [ installShellFiles ];
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd steamguard \
       --bash <($out/bin/steamguard completion --shell bash) \
       --fish <($out/bin/steamguard completion --shell fish) \

--- a/pkgs/by-name/zo/zola/package.nix
+++ b/pkgs/by-name/zo/zola/package.nix
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage rec {
 
   RUSTONIG_SYSTEM_LIBONIG = true;
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd zola \
       --bash <($out/bin/zola completion bash) \
       --fish <($out/bin/zola completion fish) \

--- a/pkgs/development/compilers/jrsonnet/default.nix
+++ b/pkgs/development/compilers/jrsonnet/default.nix
@@ -1,4 +1,4 @@
-{ lib, rustPlatform, fetchFromGitHub, installShellFiles }:
+{ lib, rustPlatform, fetchFromGitHub, installShellFiles, stdenv }:
 
 rustPlatform.buildRustPackage rec {
   pname = "jrsonnet";
@@ -28,6 +28,7 @@ rustPlatform.buildRustPackage rec {
   postInstall = ''
     ln -s $out/bin/jrsonnet $out/bin/jsonnet
 
+  '' + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     for shell in bash zsh fish; do
       installShellCompletion --cmd jrsonnet \
         --$shell <($out/bin/jrsonnet --generate $shell /dev/null)

--- a/pkgs/development/tools/cocogitto/default.nix
+++ b/pkgs/development/tools/cocogitto/default.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ libgit2 ] ++ lib.optional stdenv.isDarwin Security;
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd cog \
       --bash <($out/bin/cog generate-completions bash) \
       --fish <($out/bin/cog generate-completions fish) \

--- a/pkgs/development/tools/espup/default.nix
+++ b/pkgs/development/tools/espup/default.nix
@@ -56,7 +56,7 @@ rustPlatform.buildRustPackage rec {
     "--skip=toolchain::rust::tests::test_xtensa_rust_parse_version"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd espup \
       --bash <($out/bin/espup completions bash) \
       --fish <($out/bin/espup completions fish) \

--- a/pkgs/development/tools/fnm/default.nix
+++ b/pkgs/development/tools/fnm/default.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
 
   doCheck = false;
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd fnm \
       --bash <($out/bin/fnm completions --shell bash) \
       --fish <($out/bin/fnm completions --shell fish) \

--- a/pkgs/development/tools/rust/cargo-show-asm/default.nix
+++ b/pkgs/development/tools/rust/cargo-show-asm/default.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
     installShellFiles
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd cargo-asm \
       --bash <($out/bin/cargo-asm --bpaf-complete-style-bash) \
       --fish <($out/bin/cargo-asm --bpaf-complete-style-fish) \

--- a/pkgs/development/tools/rust/cauwugo/default.nix
+++ b/pkgs/development/tools/rust/cauwugo/default.nix
@@ -1,4 +1,4 @@
-{ lib, rustPlatform, fetchCrate, installShellFiles }:
+{ lib, rustPlatform, fetchCrate, installShellFiles, stdenv }:
 
 rustPlatform.buildRustPackage rec {
   pname = "cauwugo";
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd cauwugo \
       --bash <($out/bin/cauwugo --bpaf-complete-style-bash) \
       --fish <($out/bin/cauwugo --bpaf-complete-style-fish) \

--- a/pkgs/development/tools/rust/typeshare/default.nix
+++ b/pkgs/development/tools/rust/typeshare/default.nix
@@ -2,6 +2,7 @@
 , rustPlatform
 , fetchFromGitHub
 , installShellFiles
+, stdenv
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -21,7 +22,7 @@ rustPlatform.buildRustPackage rec {
 
   buildFeatures = [ "go" ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd typeshare \
       --bash <($out/bin/typeshare completions bash) \
       --fish <($out/bin/typeshare completions fish) \

--- a/pkgs/development/tools/sentry-cli/default.nix
+++ b/pkgs/development/tools/sentry-cli/default.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-9L02ox2T+dBRx+mmFpy5Bktsyp3C/havfZoDaNevIMw=";
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd sentry-cli \
         --bash <($out/bin/sentry-cli completions bash) \
         --fish <($out/bin/sentry-cli completions fish) \

--- a/pkgs/development/tools/snazy/default.nix
+++ b/pkgs/development/tools/snazy/default.nix
@@ -2,6 +2,7 @@
 , rustPlatform
 , fetchFromGitHub
 , installShellFiles
+, stdenv
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -19,7 +20,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd snazy \
       --bash <($out/bin/snazy --shell-completion bash) \
       --fish <($out/bin/snazy --shell-completion fish) \

--- a/pkgs/development/tools/tokio-console/default.nix
+++ b/pkgs/development/tools/tokio-console/default.nix
@@ -3,6 +3,7 @@
 , installShellFiles
 , rustPlatform
 , protobuf
+, stdenv
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -35,7 +36,7 @@ rustPlatform.buildRustPackage rec {
     "--skip config::tests::toml_example_changed"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd tokio-console \
       --bash <($out/bin/tokio-console --log-dir $(mktemp -d) gen-completion bash) \
       --fish <($out/bin/tokio-console --log-dir $(mktemp -d) gen-completion fish) \

--- a/pkgs/development/tools/volta/default.nix
+++ b/pkgs/development/tools/volta/default.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
 
   HOME = "$TMPDIR";
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd volta \
       --bash <($out/bin/volta completions bash) \
       --fish <($out/bin/volta completions fish) \

--- a/pkgs/development/web/deno/default.nix
+++ b/pkgs/development/web/deno/default.nix
@@ -68,7 +68,7 @@ rustPlatform.buildRustPackage rec {
     find ./target -name libswc_common${stdenv.hostPlatform.extensions.sharedLibrary} -delete
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd deno \
       --bash <($out/bin/deno completions bash) \
       --fish <($out/bin/deno completions fish) \

--- a/pkgs/servers/http/dufs/default.nix
+++ b/pkgs/servers/http/dufs/default.nix
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage rec {
     "--skip=validate_printed_urls"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd dufs \
       --bash <($out/bin/dufs --completions bash) \
       --fish <($out/bin/dufs --completions fish) \

--- a/pkgs/tools/admin/colmena/default.nix
+++ b/pkgs/tools/admin/colmena/default.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage rec {
 
   NIX_EVAL_JOBS = "${nix-eval-jobs}/bin/nix-eval-jobs";
 
-  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd colmena \
       --bash <($out/bin/colmena gen-completions bash) \
       --zsh <($out/bin/colmena gen-completions zsh) \

--- a/pkgs/tools/misc/charasay/default.nix
+++ b/pkgs/tools/misc/charasay/default.nix
@@ -24,10 +24,10 @@ rustPlatform.buildRustPackage rec {
   '';
 
   postInstall = ''
-    installShellCompletion --cmd himalaya \
-      --bash <($out/bin/chara completion --shell bash) \
-      --fish <($out/bin/chara completion --shell fish) \
-      --zsh <($out/bin/chara completion --shell zsh)
+    installShellCompletion --cmd chara \
+      --bash <($out/bin/chara completions --shell bash) \
+      --fish <($out/bin/chara completions --shell fish) \
+      --zsh <($out/bin/chara completions --shell zsh)
   '';
 
   meta = with lib; {

--- a/pkgs/tools/misc/charasay/default.nix
+++ b/pkgs/tools/misc/charasay/default.nix
@@ -2,6 +2,7 @@
 , rustPlatform
 , fetchFromGitHub
 , installShellFiles
+, stdenv
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -23,7 +24,7 @@ rustPlatform.buildRustPackage rec {
     rm .cargo/config.toml
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd chara \
       --bash <($out/bin/chara completions --shell bash) \
       --fish <($out/bin/chara completions --shell fish) \

--- a/pkgs/tools/misc/dotter/default.nix
+++ b/pkgs/tools/misc/dotter/default.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeCheckInputs = [ which installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd dotter \
       --bash <($out/bin/dotter gen-completions --shell bash) \
       --fish <($out/bin/dotter gen-completions --shell fish) \

--- a/pkgs/tools/misc/intermodal/default.nix
+++ b/pkgs/tools/misc/intermodal/default.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd imdl \
       --bash <($out/bin/imdl completions bash) \
       --fish <($out/bin/imdl completions fish) \

--- a/pkgs/tools/misc/miniserve/default.nix
+++ b/pkgs/tools/misc/miniserve/default.nix
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage rec {
     "--skip=validate_printed_urls"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     $out/bin/miniserve --print-manpage >miniserve.1
     installManPage miniserve.1
 

--- a/pkgs/tools/misc/onefetch/default.nix
+++ b/pkgs/tools/misc/onefetch/default.nix
@@ -47,7 +47,7 @@ rustPlatform.buildRustPackage rec {
     git commit -m test
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd onefetch \
       --bash <($out/bin/onefetch --generate bash) \
       --fish <($out/bin/onefetch --generate fish) \

--- a/pkgs/tools/misc/sheldon/default.nix
+++ b/pkgs/tools/misc/sheldon/default.nix
@@ -50,7 +50,7 @@ rustPlatform.buildRustPackage rec {
     "--skip lock_and_source_profiles"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd sheldon \
       --bash <($out/bin/sheldon completions --shell bash) \
       --zsh <($out/bin/sheldon completions --shell zsh)

--- a/pkgs/tools/misc/starship/default.nix
+++ b/pkgs/tools/misc/starship/default.nix
@@ -34,14 +34,14 @@ rustPlatform.buildRustPackage rec {
   '';
 
   postInstall = ''
+    presetdir=$out/share/starship/presets/
+    mkdir -p $presetdir
+    cp docs/public/presets/toml/*.toml $presetdir
+  '' + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd starship \
       --bash <($out/bin/starship completions bash) \
       --fish <($out/bin/starship completions fish) \
       --zsh <($out/bin/starship completions zsh)
-
-    presetdir=$out/share/starship/presets/
-    mkdir -p $presetdir
-    cp docs/public/presets/toml/*.toml $presetdir
   '';
 
   cargoHash = "sha256-yJ32HFaRpujJ9mQa+07b5cQcl1ATO/56dpm1IeKcbzs=";

--- a/pkgs/tools/misc/topgrade/default.nix
+++ b/pkgs/tools/misc/topgrade/default.nix
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage rec {
     "AppKit"
   ]);
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd topgrade \
       --bash <($out/bin/topgrade --gen-completion bash) \
       --fish <($out/bin/topgrade --gen-completion fish) \

--- a/pkgs/tools/misc/trashy/default.nix
+++ b/pkgs/tools/misc/trashy/default.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  preFixup = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd trash \
       --bash <($out/bin/trash completions bash) \
       --fish <($out/bin/trash completions fish) \

--- a/pkgs/tools/misc/trashy/default.nix
+++ b/pkgs/tools/misc/trashy/default.nix
@@ -1,4 +1,4 @@
-{ lib, rustPlatform, fetchCrate, installShellFiles }:
+{ lib, rustPlatform, fetchCrate, installShellFiles, stdenv }:
 
 rustPlatform.buildRustPackage rec {
   pname = "trashy";
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  preFixup = ''
+  preFixup = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd trash \
       --bash <($out/bin/trash completions bash) \
       --fish <($out/bin/trash completions fish) \

--- a/pkgs/tools/misc/tremor-rs/default.nix
+++ b/pkgs/tools/misc/tremor-rs/default.nix
@@ -50,6 +50,7 @@ rustPlatform.buildRustPackage rec {
     # Copy the standard library to $out/lib
     cp -r ${src}/tremor-script/lib/ $out
 
+  '' + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd tremor \
       --bash <($out/bin/tremor completions bash) \
       --fish <($out/bin/tremor completions fish) \

--- a/pkgs/tools/misc/twm/default.nix
+++ b/pkgs/tools/misc/twm/default.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ pkg-config installShellFiles ];
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd twm \
       --bash <($out/bin/twm --print-bash-completion) \
       --zsh <($out/bin/twm --print-zsh-completion) \

--- a/pkgs/tools/misc/zellij/default.nix
+++ b/pkgs/tools/misc/zellij/default.nix
@@ -50,6 +50,7 @@ rustPlatform.buildRustPackage rec {
     mandown docs/MANPAGE.md > zellij.1
     installManPage zellij.1
 
+  '' + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd $pname \
       --bash <($out/bin/zellij setup --generate-completion bash) \
       --fish <($out/bin/zellij setup --generate-completion fish) \

--- a/pkgs/tools/networking/magic-wormhole-rs/default.nix
+++ b/pkgs/tools/networking/magic-wormhole-rs/default.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
   # all tests involve networking and are bound fail
   doCheck = false;
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd wormhole-rs \
       --bash <($out/bin/wormhole-rs completion bash) \
       --fish <($out/bin/wormhole-rs completion fish) \

--- a/pkgs/tools/nix/fh/default.nix
+++ b/pkgs/tools/nix/fh/default.nix
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
     NIX_CFLAGS_COMPILE = "-I${lib.getDev libcxx}/include/c++/v1";
   };
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd fh \
       --bash <($out/bin/fh completion bash) \
       --fish <($out/bin/fh completion fish) \

--- a/pkgs/tools/package-management/nix-template/default.nix
+++ b/pkgs/tools/package-management/nix-template/default.nix
@@ -35,6 +35,7 @@ rustPlatform.buildRustPackage rec {
     wrapProgram $out/bin/nix-template \
       --prefix PATH : ${lib.makeBinPath [ nix ]}
 
+  '' + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd nix-template \
       --bash <($out/bin/nix-template completions bash) \
       --fish <($out/bin/nix-template completions fish) \

--- a/pkgs/tools/security/bws/default.nix
+++ b/pkgs/tools/security/bws/default.nix
@@ -55,7 +55,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoTestFlags = [ "--package" "bws" ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd bws \
       --bash <($out/bin/bws completions bash) \
       --fish <($out/bin/bws completions fish) \

--- a/pkgs/tools/security/jwt-cli/default.nix
+++ b/pkgs/tools/security/jwt-cli/default.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = lib.optional stdenv.isDarwin Security;
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd jwt \
       --bash <($out/bin/jwt completion bash) \
       --fish <($out/bin/jwt completion fish) \

--- a/pkgs/tools/security/kbs2/default.nix
+++ b/pkgs/tools/security/kbs2/default.nix
@@ -39,6 +39,7 @@ rustPlatform.buildRustPackage rec {
   postInstall = ''
     mkdir -p $out/share/kbs2
     cp -r contrib/ $out/share/kbs2
+  '' + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd kbs2 \
       --bash <($out/bin/kbs2 --completions bash) \
       --fish <($out/bin/kbs2 --completions fish) \

--- a/pkgs/tools/security/prs/default.nix
+++ b/pkgs/tools/security/prs/default.nix
@@ -10,6 +10,7 @@
 , gtk3
 , libxcb
 , libxkbcommon
+, stdenv
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -44,7 +45,7 @@ rustPlatform.buildRustPackage rec {
     libxkbcommon
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     for shell in bash fish zsh; do
       installShellCompletion --cmd prs --$shell <($out/bin/prs internal completions $shell --stdout)
     done

--- a/pkgs/tools/security/rbw/default.nix
+++ b/pkgs/tools/security/rbw/default.nix
@@ -51,6 +51,7 @@ rustPlatform.buildRustPackage rec {
 
   postInstall = ''
     install -Dm755 -t $out/bin bin/git-credential-rbw
+  '' + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd rbw \
       --bash <($out/bin/rbw gen-completions bash) \
       --fish <($out/bin/rbw gen-completions fish) \

--- a/pkgs/tools/security/sheesy-cli/default.nix
+++ b/pkgs/tools/security/sheesy-cli/default.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoBuildFlags = [ "--bin" "sy" ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd sy \
       --bash <($out/bin/sy completions bash) \
       --fish <($out/bin/sy completions fish) \

--- a/pkgs/tools/security/shisho/default.nix
+++ b/pkgs/tools/security/shisho/default.nix
@@ -3,6 +3,7 @@
 , rustPlatform
 , installShellFiles
 , rustfmt
+, stdenv
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -24,7 +25,7 @@ rustPlatform.buildRustPackage rec {
     rustfmt
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd shisho \
       --bash <($out/bin/shisho completion bash) \
       --fish <($out/bin/shisho completion fish) \

--- a/pkgs/tools/text/languagetool-rust/default.nix
+++ b/pkgs/tools/text/languagetool-rust/default.nix
@@ -68,7 +68,7 @@ rustPlatform.buildRustPackage rec {
     "--skip=test_words_delete"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd ltrs \
       --bash <($out/bin/ltrs completions bash) \
       --fish <($out/bin/ltrs completions fish) \

--- a/pkgs/tools/text/termbook/default.nix
+++ b/pkgs/tools/text/termbook/default.nix
@@ -43,7 +43,7 @@ rustPlatform.buildRustPackage rec {
     ln -sf ${./Cargo.lock} Cargo.lock
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd termbook \
       --bash <($out/bin/termbook completions bash) \
       --fish <($out/bin/termbook completions fish) \


### PR DESCRIPTION
## Description of changes

Fixes regressions for cross compiling introduced in #289517 on 61 packages. See #308283 for more discussion.

There are a lot of packages that use the following pattern to generate shell completions:
```nix
  postInstall = ''
     installShellCompletion --cmd foo \
       --bash <($out/bin/foo generate-completions bash) \
       …
  '';
```
The crucial part is that it executes `$out/bin/foo`, which failed silently on cross builds so far (ignoring binfmt_misc here), but is now raised as a build error from `installShellCompletion`.

Most of what this PR does is prefix (that part of) those `postInstall` scripts with:
```nix
lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform)
```

Some additional notes:
* This is limited to 61 packages, there are potentially 327 instances of this.
  * I'm not sure this will get merged and fixing ~300 packages manually is too much considering that.
  * They're all `buildRustPackage`, because I'm familiar with that ecosystem, and the completion generation logic is nearly all the same, so it was easy to investigate problems for me.
* comodoro, attic-client, neverest, himalaya, colmena: Since I already stumbled upon them, it also changes some instances of `buildPlatform == hostPlatform` to `buildPlatform.canExecute hostPlatform`. 
* trashy: Move from preFixup to postInstall for consistency
* charasay: Fix generation command
* inlyne: Use checked-in completion scripts

## Checking
nixpkgs-review isn't super insightful for this, since I took extra care to not introduce any changes, not even whitespace, where unnecessary:

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>charasay</li>
    <li>inlyne</li>
    <li>trashy</li>
  </ul>
</details>

So, I also obtained a list of changed packages
```nu
 git diff-tree --no-commit-id --name-only -r HEAD~2 | each { path dirname | path basename } | str join " "
 ```
 and tested that all build, with:
 ```nu
env NIXPKGS_ALLOW_UNFREE=1 nix shell --keep-going --impure -vL --expr 'let nixpkgs = builtins.getFlake "git+file:."; in with nixpkgs.legacyPackages.x86_64-linux.pkgsCross.aarch64-multiplatform; mkShell { packages = [comodoro flavours genact inlyne leetcode-cli git-absorb jujutsu youki ab-av1 ast-grep attic-client clipcat codeberg-cli engage himalaya joshuto neverest pace pixi qrtool release-plz sn0int steamguard-cli zola jrsonnet cocogitto diesel-cli espup fnm cargo-show-asm cauwugo typeshare sentry-cli snazy tokio-console volta  dufs colmena charasay dotter fd intermodal miniserve onefetch sheldon starship topgrade trashy twm zellij magic-wormhole-rs fh nix-template bws jwt-cli kbs2 prs rbw  shisho languagetool-rust termbook]; }'
 ```
 (skipping maa-cli sheesy-cli deno tremor solana-cli elf2nucleus because they fail to compile or link.)
 


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
