### PR TITLE
cudaPackages.cuda_gdb: fix libexpat.so.1 on aarch64

### DIFF
--- a/pkgs/development/cuda-modules/cuda/overrides.nix
+++ b/pkgs/development/cuda-modules/cuda/overrides.nix
@@ -156,13 +156,17 @@ filterAndCreateOverrides {
     {
       cudaAtLeast,
       gmp,
+      expat,
+      stdenv,
       lib,
     }:
     prevAttrs: {
       buildInputs =
         prevAttrs.buildInputs
         # x86_64 only needs gmp from 12.0 and on
-        ++ lib.lists.optionals (cudaAtLeast "12.0") [ gmp ];
+        ++ lib.lists.optionals (cudaAtLeast "12.0") [ gmp ]
+        # aarch64,sbsa needs expat
+        ++ lib.lists.optionals (stdenv.hostPlatform.isAarch64) [ expat ];
     };
 
   cuda_nvcc =


### PR DESCRIPTION
## Description of changes

Root cause of the problem - `cuda_gdb` for `aarch64`,`sbsa` requires `libexpat.so.1`, while  `x86_64` does not.

For investigation, manually download and extract `https://developer.download.nvidia.com/compute/cuda/redist/cuda_gdb/linux-{x86_64,aarch64,sbsa}/cuda_gdb-linux-{x86_64,aarch64,sbsa}-12.2.140-archive.tar.xz`

<details>
  <summary>Expand - running ldd for different architectures</summary>

```
$ ldd ./cuda_gdb-linux-x86_64-12.2.140-archive/bin/cuda-gdb
	linux-vdso.so.1 (0x00007fff1bcf7000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x000070c6a3529000)
	libgmp.so.10 => /lib/x86_64-linux-gnu/libgmp.so.10 (0x000070c6a34a7000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x000070c6a327b000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x000070c6a3194000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x000070c6a3174000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x000070c6a316d000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x000070c6a2f44000)
	/lib64/ld-linux-x86-64.so.2 (0x000070c6a3541000)

$ ldd ./cuda_gdb-linux-aarch64-12.2.140-archive/bin/cuda-gdb
	linux-vdso.so.1 (0x0000ffff8deed000)
	libdl.so.2 => /lib/aarch64-linux-gnu/libdl.so.2 (0x0000ffff8de66000)
	libexpat.so.1 => /lib/aarch64-linux-gnu/libexpat.so.1 (0x0000ffff8de2f000)
	libgmp.so.10 => /lib/aarch64-linux-gnu/libgmp.so.10 (0x0000ffff8dda7000)
	libstdc++.so.6 => /lib/aarch64-linux-gnu/libstdc++.so.6 (0x0000ffff8dbc2000)
	libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000ffff8db17000)
	libgcc_s.so.1 => /lib/aarch64-linux-gnu/libgcc_s.so.1 (0x0000ffff8daf3000)
	libpthread.so.0 => /lib/aarch64-linux-gnu/libpthread.so.0 (0x0000ffff8dac2000)
	libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000ffff8d94f000)
	/lib/ld-linux-aarch64.so.1 (0x0000ffff8debd000)

$ ldd ./cuda_gdb-linux-sbsa-12.2.140-archive/bin/cuda-gdb
	linux-vdso.so.1 (0x0000ffffbddd3000)
	libdl.so.2 => /lib/aarch64-linux-gnu/libdl.so.2 (0x0000ffffbdd4c000)
	libexpat.so.1 => /lib/aarch64-linux-gnu/libexpat.so.1 (0x0000ffffbdd15000)
	libgmp.so.10 => /lib/aarch64-linux-gnu/libgmp.so.10 (0x0000ffffbdc8d000)
	libstdc++.so.6 => /lib/aarch64-linux-gnu/libstdc++.so.6 (0x0000ffffbdaa8000)
	libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000ffffbd9fd000)
	libgcc_s.so.1 => /lib/aarch64-linux-gnu/libgcc_s.so.1 (0x0000ffffbd9d9000)
	libpthread.so.0 => /lib/aarch64-linux-gnu/libpthread.so.0 (0x0000ffffbd9a8000)
	libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000ffffbd835000)
	/lib/ld-linux-aarch64.so.1 (0x0000ffffbdda3000)
```

</details>


The problem was reproduceable on master branch. Running `nix-shell --show-trace --packages cudaPackages_*_*.cuda_gdb` (from upstream without applying this PR):

<details>
  <summary>missing libraries over architectures and cudaPackages versions, on aarch64 linux computer</summary>

To use `aarch64`, put `{ cudaCapabilities = [ "7.2" ]; }` into `.config/nixpkgs/config.nix`

| cudaPackages_ | arch | not found     |
| ------------- | ---- | ------------- |
| 12_3          | sbsa | libexpat.so.1 |
| 12_2          | sbsa | libexpat.so.1 |
| 12_1          | sbsa | libexpat.so.1 |
| 12_0          | sbsa | libexpat.so.1 |
| 11_8          | sbsa | libexpat.so.1 |
| 11_7          | sbsa | libexpat.so.1 |
| 11_6          | sbsa | libexpat.so.1 |
| 11_5          | sbsa | libexpat.so.1 |
| 11_4          | sbsa | libexpat.so.1 |
| 12_3          | aarch64 | N/A |
| 12_2          | aarch64 | libexpat.so.1 |
| 12_1          | aarch64 | libexpat.so.1 |
| 12_0          | aarch64 | libexpat.so.1 |
| 11_8          | aarch64 | libexpat.so.1 |
| 11_7          | aarch64 | N/A |
| 11_6          | aarch64 | N/A |
| 11_5          | aarch64 | N/A |
| 11_4          | aarch64 | N/A |

</details>


fixes #327222

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
