### PR TITLE
nixos/alsa: kill sound.enable and friends with fire

### DIFF
--- a/nixos/doc/manual/configuration/profiles/headless.section.md
+++ b/nixos/doc/manual/configuration/profiles/headless.section.md
@@ -2,8 +2,7 @@
 
 Common configuration for headless machines (e.g., Amazon EC2 instances).
 
-Disables [sound](#opt-sound.enable),
-[vesa](#opt-boot.vesa), serial consoles,
+Disables [vesa](#opt-boot.vesa), serial consoles,
 [emergency mode](#opt-systemd.enableEmergencyMode),
 [grub splash images](#opt-boot.loader.grub.splashImage)
 and configures the kernel to reboot automatically on panic.

--- a/nixos/doc/manual/configuration/profiles/minimal.section.md
+++ b/nixos/doc/manual/configuration/profiles/minimal.section.md
@@ -5,5 +5,4 @@ graphical stuff. It's a very short file that enables
 [noXlibs](#opt-environment.noXlibs), sets
 [](#opt-i18n.supportedLocales) to
 only support the user-selected locale,
-[disables packages' documentation](#opt-documentation.enable),
-and [disables sound](#opt-sound.enable).
+and [disables packages' documentation](#opt-documentation.enable).

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -197,6 +197,8 @@
 
 - `services.roundcube.maxAttachmentSize` will multiply the value set with `1.37` to offset overhead introduced by the base64 encoding applied to attachments.
 
+- The `sound` options have been removed or renamed, as they had a lot of unintended side effects. See [below](#sec-release-24.11-migration-sound) for details.
+
 - The `services.mxisd` module has been removed as both [mxisd](https://github.com/kamax-matrix/mxisd) and [ma1sd](https://github.com/ma1uta/ma1sd) are not maintained any longer.
   Consequently the package `pkgs.ma1sd` has also been removed.
 
@@ -233,3 +235,46 @@
   should be changed to using *runner authentication tokens* by configuring
   {option}`services.gitlab-runner.services.<name>.authenticationTokenConfigFile` instead of the former
   {option}`services.gitlab-runner.services.<name>.registrationConfigFile` option.
+
+## Detailed migration information {#sec-release-24.11-migration}
+
+### `sound` options removal {#sec-release-24.11-migration-sound}
+
+The `sound` options have been largely removed, as they are unnecessary for most modern setups, and cause issues when enabled.
+
+If you set `sound.enable` in your configuration:
+  - If you are using Pulseaudio or PipeWire, simply remove that option
+  - If you are not using an external sound server, and want volumes to be persisted across shutdowns, set `hardware.alsa.enablePersistence = true` instead
+
+If you set `sound.enableOSSEmulation` in your configuration:
+  - Make sure it is still necessary, as very few applications actually use OSS
+  - If necessary, set `boot.kernelModules = [ "snd_pcm_oss" ]`
+
+If you set `sound.extraConfig` in your configuration:
+  - If you are using another sound server, like Pulseaudio, JACK or PipeWire, migrate your configuration to that
+  - If you are not using an external sound server, set `environment.etc."asound.conf".text = yourExtraConfig` instead
+
+If you set `sound.mediaKeys` in your configuration:
+  - Preferably switch to handling media keys in your desktop environment/compositor
+  - If you want to maintain the exact behavior of the option, use the following snippet
+
+```nix
+services.actkbd = let
+  volumeStep = "1%";
+in {
+  enable = true;
+  bindings = [
+    # "Mute" media key
+    { keys = [ 113 ]; events = [ "key" ];       command = "${alsa-utils}/bin/amixer -q set Master toggle"; }
+
+    # "Lower Volume" media key
+    { keys = [ 114 ]; events = [ "key" "rep" ]; command = "${alsa-utils}/bin/amixer -q set Master ${volumeStep}- unmute"; }
+
+    # "Raise Volume" media key
+    { keys = [ 115 ]; events = [ "key" "rep" ]; command = "${alsa-utils}/bin/amixer -q set Master ${volumeStep}+ unmute"; }
+
+    # "Mic Mute" media key
+    { keys = [ 190 ]; events = [ "key" ];       command = "${alsa-utils}/bin/amixer -q set Capture toggle"; }
+  ];
+};
+```

--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -6,7 +6,6 @@ with lib;
 let
 
   cfg = config.hardware.pulseaudio;
-  alsaCfg = config.sound;
 
   hasZeroconf = let z = cfg.zeroconf; in z.publish.enable || z.discovery.enable;
 
@@ -58,7 +57,7 @@ let
   # Write an /etc/asound.conf that causes all ALSA applications to
   # be re-routed to the PulseAudio server through ALSA's Pulse
   # plugin.
-  alsaConf = writeText "asound.conf" (''
+  alsaConf = ''
     pcm_type.pulse {
       libs.native = ${pkgs.alsa-plugins}/lib/alsa-lib/libasound_module_pcm_pulse.so ;
       ${lib.optionalString enable32BitAlsaPlugins
@@ -76,8 +75,7 @@ let
     ctl.!default {
       type pulse
     }
-    ${alsaCfg.extraConfig}
-  '');
+  '';
 
 in {
 
@@ -221,10 +219,8 @@ in {
 
       environment.systemPackages = [ overriddenPackage ];
 
-      sound.enable = true;
-
       environment.etc = {
-        "asound.conf".source = alsaConf;
+        "alsa/conf.d/99-pulseaudio.conf".text = alsaConf;
 
         "pulse/daemon.conf".source = writeText "daemon.conf"
           (lib.generators.toKeyValue {} cfg.daemon.config);

--- a/nixos/modules/services/audio/alsa.nix
+++ b/nixos/modules/services/audio/alsa.nix
@@ -3,132 +3,38 @@
 
 with lib;
 
-let
-
-  inherit (pkgs) alsa-utils;
-
-  pulseaudioEnabled = config.hardware.pulseaudio.enable;
-
-in
-
 {
   imports = [
-    (mkRenamedOptionModule [ "sound" "enableMediaKeys" ] [ "sound" "mediaKeys" "enable" ])
+    (mkRemovedOptionModule [ "sound" ] "The option was heavily overloaded and can be removed from most configurations.")
   ];
 
-  ###### interface
-
-  options = {
-
-    sound = {
-
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable ALSA sound.
-        '';
-      };
-
-      enableOSSEmulation = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable ALSA OSS emulation (with certain cards sound mixing may not work!).
-        '';
-      };
-
-      extraConfig = mkOption {
-        type = types.lines;
-        default = "";
-        example = ''
-          defaults.pcm.!card 3
-        '';
-        description = ''
-          Set addition configuration for system-wide alsa.
-        '';
-      };
-
-      mediaKeys = {
-
-        enable = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-            Whether to enable volume and capture control with keyboard media keys.
-
-            You want to leave this disabled if you run a desktop environment
-            like KDE, Gnome, Xfce, etc, as those handle such things themselves.
-            You might want to enable this if you run a minimalistic desktop
-            environment or work from bare linux ttys/framebuffers.
-
-            Enabling this will turn on {option}`services.actkbd`.
-          '';
-        };
-
-        volumeStep = mkOption {
-          type = types.str;
-          default = "1";
-          example = "1%";
-          description = ''
-            The value by which to increment/decrement volume on media keys.
-
-            See amixer(1) for allowed values.
-          '';
-        };
-
-      };
-
-    };
-
+  options.hardware.alsa.enablePersistence = mkOption {
+    type = types.bool;
+    default = false;
+    description = ''
+      Whether to enable ALSA sound card state saving on shutdown.
+      This is generally not necessary if you're using an external sound server.
+    '';
   };
 
-
-  ###### implementation
-
-  config = mkIf config.sound.enable {
-
-    environment.systemPackages = [ alsa-utils ];
-
-    environment.etc = mkIf (!pulseaudioEnabled && config.sound.extraConfig != "")
-      { "asound.conf".text = config.sound.extraConfig; };
-
+  config = mkIf config.hardware.alsa.enablePersistence {
     # ALSA provides a udev rule for restoring volume settings.
     services.udev.packages = [ alsa-utils ];
 
-    boot.kernelModules = optional config.sound.enableOSSEmulation "snd_pcm_oss";
-
-    systemd.services.alsa-store =
-      { description = "Store Sound Card State";
-        wantedBy = [ "multi-user.target" ];
-        unitConfig.RequiresMountsFor = "/var/lib/alsa";
-        unitConfig.ConditionVirtualization = "!systemd-nspawn";
-        serviceConfig = {
-          Type = "oneshot";
-          RemainAfterExit = true;
-          ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p /var/lib/alsa";
-          ExecStart = "${alsa-utils}/sbin/alsactl restore --ignore";
-          ExecStop = "${alsa-utils}/sbin/alsactl store --ignore";
-        };
+    systemd.services.alsa-store = {
+      description = "Store Sound Card State";
+      wantedBy = [ "multi-user.target" ];
+      unitConfig = {
+        RequiresMountsFor = "/var/lib/alsa";
+        ConditionVirtualization = "!systemd-nspawn";
       };
-
-    services.actkbd = mkIf config.sound.mediaKeys.enable {
-      enable = true;
-      bindings = [
-        # "Mute" media key
-        { keys = [ 113 ]; events = [ "key" ];       command = "${alsa-utils}/bin/amixer -q set Master toggle"; }
-
-        # "Lower Volume" media key
-        { keys = [ 114 ]; events = [ "key" "rep" ]; command = "${alsa-utils}/bin/amixer -q set Master ${config.sound.mediaKeys.volumeStep}- unmute"; }
-
-        # "Raise Volume" media key
-        { keys = [ 115 ]; events = [ "key" "rep" ]; command = "${alsa-utils}/bin/amixer -q set Master ${config.sound.mediaKeys.volumeStep}+ unmute"; }
-
-        # "Mic Mute" media key
-        { keys = [ 190 ]; events = [ "key" ];       command = "${alsa-utils}/bin/amixer -q set Capture toggle"; }
-      ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p /var/lib/alsa";
+        ExecStart = "${alsa-utils}/sbin/alsactl restore --ignore";
+        ExecStop = "${alsa-utils}/sbin/alsactl store --ignore";
+      };
     };
-
   };
-
 }

--- a/nixos/modules/services/audio/jack.nix
+++ b/nixos/modules/services/audio/jack.nix
@@ -122,7 +122,7 @@ in {
   config = mkMerge [
 
     (mkIf pcmPlugin {
-      sound.extraConfig = ''
+      environment.etc."alsa/conf.d/98-jack.conf".text = ''
         pcm_type.jack {
           libs.native = ${pkgs.alsa-plugins}/lib/alsa-lib/libasound_module_pcm_jack.so ;
           ${lib.optionalString enable32BitAlsaPlugins
@@ -139,7 +139,7 @@ in {
     (mkIf loopback {
       boot.kernelModules = [ "snd-aloop" ];
       boot.kernelParams = [ "snd-aloop.index=${toString cfg.loopback.index}" ];
-      sound.extraConfig = cfg.loopback.config;
+      environment.etc."alsa/conf.d/99-jack-loopback.conf".text = cfg.loopback.config;
     })
 
     (mkIf cfg.jackd.enable {

--- a/nixos/modules/virtualisation/vagrant-virtualbox-image.nix
+++ b/nixos/modules/virtualisation/vagrant-virtualbox-image.nix
@@ -15,7 +15,6 @@
     usb = "off";
     usbehci = "off";
   };
-  sound.enable = false;
   documentation.man.enable = false;
   documentation.nixos.enable = false;
 

--- a/nixos/tests/domination.nix
+++ b/nixos/tests/domination.nix
@@ -10,7 +10,6 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     ];
 
     services.xserver.enable = true;
-    sound.enable = true;
     environment.systemPackages = [ pkgs.domination ];
   };
 

--- a/nixos/tests/firefox.nix
+++ b/nixos/tests/firefox.nix
@@ -21,8 +21,7 @@ import ./make-test-python.nix ({ lib, pkgs, firefoxPackage, ... }:
       # Create a virtual sound device, with mixing
       # and all, for recording audio.
       boot.kernelModules = [ "snd-aloop" ];
-      sound.enable = true;
-      sound.extraConfig = ''
+      environment.etc."asound.conf".text = ''
         pcm.!default {
           type plug
           slave.pcm pcm.dmixer

--- a/nixos/tests/ft2-clone.nix
+++ b/nixos/tests/ft2-clone.nix
@@ -8,8 +8,6 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     imports = [
       ./common/x11.nix
     ];
-
-    sound.enable = true;
     environment.systemPackages = [ pkgs.ft2-clone ];
   };
 

--- a/nixos/tests/login.nix
+++ b/nixos/tests/login.nix
@@ -9,7 +9,6 @@ import ./make-test-python.nix ({ pkgs, latestKernel ? false, ... }:
   nodes.machine =
     { pkgs, lib, ... }:
     { boot.kernelPackages = lib.mkIf latestKernel pkgs.linuxPackages_latest;
-      sound.enable = true; # needed for the factl test, /dev/snd/* exists without them but udev doesn't care then
     };
 
   testScript = ''

--- a/nixos/tests/mpd.nix
+++ b/nixos/tests/mpd.nix
@@ -37,7 +37,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
 
     mkServer = { mpd, musicService, }:
       { boot.kernelModules = [ "snd-dummy" ];
-        sound.enable = true;
         services.mpd = mpd;
         systemd.services.musicService = musicService;
       };

--- a/nixos/tests/pt2-clone.nix
+++ b/nixos/tests/pt2-clone.nix
@@ -10,7 +10,6 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     ];
 
     services.xserver.enable = true;
-    sound.enable = true;
     environment.systemPackages = [ pkgs.pt2-clone ];
   };
 

--- a/nixos/tests/sfxr-qt.nix
+++ b/nixos/tests/sfxr-qt.nix
@@ -10,7 +10,6 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     ];
 
     services.xserver.enable = true;
-    sound.enable = true;
     environment.systemPackages = [ pkgs.sfxr-qt ];
   };
 

--- a/nixos/tests/shattered-pixel-dungeon.nix
+++ b/nixos/tests/shattered-pixel-dungeon.nix
@@ -10,7 +10,6 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     ];
 
     services.xserver.enable = true;
-    sound.enable = true;
     environment.systemPackages = [ pkgs.shattered-pixel-dungeon ];
   };
 

--- a/nixos/tests/slimserver.nix
+++ b/nixos/tests/slimserver.nix
@@ -8,8 +8,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
       enable = true;
       extraArguments = "-s 127.0.0.1 -d slimproto=info";
     };
-    sound.enable = true;
-    boot.initrd.kernelModules = ["snd-dummy"];
+    boot.kernelModules = ["snd-dummy"];
   };
 
   testScript =

--- a/nixos/tests/systemd-analyze.nix
+++ b/nixos/tests/systemd-analyze.nix
@@ -9,7 +9,6 @@ import ./make-test-python.nix ({ pkgs, latestKernel ? false, ... }:
   nodes.machine =
     { pkgs, lib, ... }:
     { boot.kernelPackages = lib.mkIf latestKernel pkgs.linuxPackages_latest;
-      sound.enable = true; # needed for the factl test, /dev/snd/* exists without them but udev doesn't care then
     };
 
   testScript = ''

--- a/pkgs/tools/nix/nixos-option/src/nixos-option.cc
+++ b/pkgs/tools/nix/nixos-option/src/nixos-option.cc
@@ -319,7 +319,7 @@ void mapOptions(const std::function<void(const std::string & path)> & f, Context
 }
 
 // Calls f on all the config values inside one option.
-// Simple options have one config value inside, like sound.enable = true.
+// Simple options have one config value inside, like services.foo.enable = true.
 // Compound options have multiple config values.  For example, the option
 // "users.users" has about 1000 config values inside it:
 //   users.users.avahi.createHome = false;


### PR DESCRIPTION
## Description of changes

This is an alternative take on #319839, which just removes most of `sound.enable` and provides instructions to mitigate the impact for people that actually use it for things.

Testing on JACK and Pulse setups would be very much appreciated. All the affected tests still work ~~, except sfxr-qt which segfaults for seemingly unrelated reasons and pt2-clone which does not actually build (CC @fgaz for both of those).~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
