### PR TITLE
ocamlPackages.get-activity: init at 2.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/get-activity/default.nix
+++ b/pkgs/development/ocaml-modules/get-activity/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildDunePackage,
+  get-activity-lib,
+  ppx_expect,
+  cmdliner,
+  dune-build-info,
+  fmt,
+  logs,
+  alcotest
+}:
+
+buildDunePackage rec {
+  pname = "get-activity";
+  inherit (get-activity-lib) version src;
+
+  minimalOCamlVersion = "4.08";
+
+  buildInputs = [
+    get-activity-lib
+    cmdliner
+    dune-build-info
+    fmt
+    logs
+  ];
+
+  checkInputs = [ ppx_expect alcotest ];
+
+  doCheck = true;
+
+  meta = {
+    homepage = "https://github.com/tarides/get-activity";
+    description = "Collect activity and format as markdown for a journal";
+    license = lib.licenses.mit;
+    changelog = "https://github.com/tarides/get-activity/releases/tag/${version}";
+    maintainers = with lib.maintainers; [ zazedd ];
+  };
+}

--- a/pkgs/development/ocaml-modules/get-activity/lib.nix
+++ b/pkgs/development/ocaml-modules/get-activity/lib.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitHub,
+  ppx_expect,
+  astring,
+  curly,
+  fmt,
+  logs,
+  ppx_yojson_conv,
+  ppx_yojson_conv_lib,
+  yojson,
+  alcotest
+}:
+
+buildDunePackage rec {
+  pname = "get-activity-lib";
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "tarides";
+    repo = "get-activity";
+    rev = version;
+    hash = "sha256-QU/LPIxcem5nFvSxcNApOuBu6UHqLHIXVSOJ2UT0eKA=";
+  };
+
+  minimalOCamlVersion = "4.08";
+
+  buildInputs = [ ppx_yojson_conv ];
+
+  propagatedBuildInputs = [
+    astring
+    curly
+    fmt
+    logs
+    ppx_yojson_conv_lib
+    yojson
+  ];
+
+  checkInputs = [ ppx_expect alcotest ];
+
+  doCheck = true;
+
+  meta = {
+    homepage = "https://github.com/tarides/get-activity";
+    description = "Collect activity and format as markdown for a journal (lib)";
+    license = lib.licenses.mit;
+    changelog = "https://github.com/tarides/get-activity/releases/tag/${version}";
+    maintainers = with lib.maintainers; [ zazedd ];
+  };
+}
+

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -585,6 +585,10 @@ let
 
     genspio = callPackage ../development/ocaml-modules/genspio { };
 
+    get-activity = callPackage ../development/ocaml-modules/get-activity { };
+
+    get-activity-lib = callPackage ../development/ocaml-modules/get-activity/lib.nix { };
+
     getopt = callPackage ../development/ocaml-modules/getopt { };
 
     gettext-camomile = callPackage ../development/ocaml-modules/ocaml-gettext/camomile.nix { };


### PR DESCRIPTION
Changelog: https://github.com/tarides/get-activity/releases/tag/2.0.1

## Description of changes

### Fixed
- Filter out null elements that are sometimes in the nodes list (https://github.com/tarides/get-activity/pull/39, @gpetiot)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
