### PR TITLE
libfprint-2-tod1-broadcom: init at 5.12.018

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15887,6 +15887,11 @@
     githubId = 1830959;
     name = "Piper McCorkle";
   };
+  pitkling = {
+    github = "pitkling";
+    githubId = 1018801;
+    name = "Peter Kling";
+  };
   piturnah = {
     email = "peterhebden6@gmail.com";
     github = "Piturnah";

--- a/pkgs/by-name/li/libfprint-2-tod1-broadcom/package.nix
+++ b/pkgs/by-name/li/libfprint-2-tod1-broadcom/package.nix
@@ -22,16 +22,22 @@ let
     inherit version;
   };
 
-  # wraps `fopen()` for finding firmware files
   wrapperLibName = "wrapper-lib.so";
+  wrapperLibSource = "wrapper-lib.c";
+
+  # wraps `fopen()` for finding firmware files
   wrapperLib = stdenv.mkDerivation {
     pname = "${pname}-wrapper-lib";
     inherit version;
 
-    src = ./.;
+    src = builtins.path {
+      name = "${pname}-source";
+      path = ./.;
+      filter = (path: type: baseNameOf path == wrapperLibSource);
+    };
 
     postPatch = ''
-      substitute wrapper-lib.c lib.c \
+      substitute ${wrapperLibSource} lib.c \
         --subst-var-by to "${src}/var/lib/fprint/fw"
       cc -fPIC -shared lib.c -o ${wrapperLibName}
     '';

--- a/pkgs/by-name/li/libfprint-2-tod1-broadcom/package.nix
+++ b/pkgs/by-name/li/libfprint-2-tod1-broadcom/package.nix
@@ -1,0 +1,85 @@
+{
+  autoPatchelfHook,
+  fetchzip,
+  lib,
+  libfprint-tod,
+  openssl,
+  patchelfUnstable, # have to use patchelfUnstable to support --rename-dynamic-symbols
+  stdenv,
+}:
+
+# Based on ideas from (using a wrapper library to redirect fopen() calls to firmware files):
+#   * https://tapesoftware.net/replace-symbol/
+#   * https://github.com/NixOS/nixpkgs/pull/260715
+let
+  pname = "libfprint-2-tod1-broadcom";
+  version = "5.12.018";
+
+  src = fetchzip {
+    url = "http://dell.archive.canonical.com/updates/pool/public/libf/${pname}/${pname}_${version}.orig.tar.gz";
+    hash = "sha256-0C2PpYpEJNrU+8NT95w4QV0J5nHQisMY94Czw3jQOzw=";
+    pname = "${pname}-unpacked";
+    inherit version;
+  };
+
+  # wraps `fopen()` for finding firmware files
+  wrapperLibName = "wrapper-lib.so";
+  wrapperLib = stdenv.mkDerivation {
+    pname = "${pname}-wrapper-lib";
+    inherit version;
+
+    src = ./.;
+
+    postPatch = ''
+      substitute wrapper-lib.c lib.c \
+        --subst-var-by to "${src}/var/lib/fprint/fw"
+      cc -fPIC -shared lib.c -o ${wrapperLibName}
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      install -D -t $out/lib ${wrapperLibName}
+      runHook postInstall
+    '';
+  };
+in
+stdenv.mkDerivation {
+  inherit src pname version;
+
+  buildInputs = [
+    libfprint-tod
+    openssl
+    wrapperLib
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    patchelfUnstable
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D -t "$out/lib/libfprint-2/tod-1/" -m 644 -v usr/lib/x86_64-linux-gnu/libfprint-2/tod-1/libfprint-2-tod-1-broadcom.so
+    install -D -t "$out/lib/udev/rules.d/"      -m 644 -v lib/udev/rules.d/60-libfprint-2-device-broadcom.rules
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    echo fopen64 fopen_wrapper > fopen_name_map
+    patchelf \
+      --rename-dynamic-symbols fopen_name_map \
+      --add-needed ${wrapperLibName} \
+      "$out/lib/libfprint-2/tod-1/libfprint-2-tod-1-broadcom.so"
+  '';
+
+  passthru.driverPath = "/lib/libfprint-2/tod-1";
+
+  meta = with lib; {
+    description = "Broadcom driver module for libfprint-2-tod Touch OEM Driver (from Dell)";
+    homepage = "http://dell.archive.canonical.com/updates/pool/public/libf/libfprint-2-tod1-broadcom/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ pitkling ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/li/libfprint-2-tod1-broadcom/package.nix
+++ b/pkgs/by-name/li/libfprint-2-tod1-broadcom/package.nix
@@ -31,9 +31,9 @@ let
     inherit version;
 
     src = builtins.path {
-      name = "${pname}-source";
+      name = "${pname}-wrapper-lib-source";
       path = ./.;
-      filter = (path: type: baseNameOf path == wrapperLibSource);
+      filter = path: type: baseNameOf path == wrapperLibSource;
     };
 
     postPatch = ''

--- a/pkgs/by-name/li/libfprint-2-tod1-broadcom/wrapper-lib.c
+++ b/pkgs/by-name/li/libfprint-2-tod1-broadcom/wrapper-lib.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char from[] =  "/var/lib/fprint/fw";
+static const char to[]   = "@to@";
+
+FILE* fopen_wrapper(const char* fn, const char* mode) {
+    size_t fn_len = strlen(fn);
+    size_t from_len = strlen(from);
+    if (fn_len > from_len && memcmp(fn, from, from_len) == 0) {
+        size_t to_len = strlen(to);
+        char* rewritten = calloc(fn_len + (to_len - from_len) + 1, 1);
+        memcpy(rewritten, to, to_len);
+        memcpy(rewritten + to_len, fn + from_len, fn_len - from_len);
+
+        printf("fopen_wrapper.c: Replacing path '%s' with '%s'\n", fn, rewritten);
+        FILE* result = fopen(rewritten, mode);
+        free(rewritten);
+        return result;
+    }
+    return fopen(fn, mode);
+}


### PR DESCRIPTION
## Description of changes

Added a linux driver for broadcom fingerprint readers (used, e.g., in DELL Latitude 7440 laptops) to use with libfprint-tod.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
