### PR TITLE
pythonPackages.doc8: fix build by pinning docutils to 0.20.x

### DIFF
--- a/pkgs/development/python-modules/doc8/default.nix
+++ b/pkgs/development/python-modules/doc8/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   chardet,
-  docutils,
+  docutils_0_20_x,
   fetchpatch,
   fetchPypi,
   pbr,
@@ -44,7 +44,7 @@ buildPythonPackage rec {
   buildInputs = [ pbr ];
 
   propagatedBuildInputs = [
-    docutils
+    docutils_0_20_x
     chardet
     stevedore
     restructuredtext-lint

--- a/pkgs/development/python-modules/docutils/v0_20_x.nix
+++ b/pkgs/development/python-modules/docutils/v0_20_x.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, lib
+, fetchPypi
+, buildPythonPackage
+, python
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "docutils";
+  version = "0.20.1";
+
+  disabled = pythonOlder "3.7";
+
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-8IpOJ2w6FYOobc4+NKuj/gTQK7ot1R7RYQYkToqSPjs=";
+  };
+
+  # Only Darwin needs LANG, but we could set it in general.
+  # It's done here conditionally to prevent mass-rebuilds.
+  checkPhase = lib.optionalString stdenv.isDarwin ''LANG="en_US.UTF-8" LC_ALL="en_US.UTF-8" '' + ''
+    ${python.interpreter} test/alltests.py
+  '';
+
+  # Create symlinks lacking a ".py" suffix, many programs depend on these names
+  postFixup = ''
+    for f in $out/bin/*.py; do
+      ln -s $(basename $f) $out/bin/$(basename $f .py)
+    done
+  '';
+
+  meta = with lib; {
+    description = "Python Documentation Utilities";
+    homepage = "http://docutils.sourceforge.net/";
+    license = with licenses; [ publicDomain bsd2 psfl gpl3Plus ];
+    maintainers = with maintainers; [ AndersonTorres ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3541,6 +3541,8 @@ self: super: with self; {
 
   docutils = callPackage ../development/python-modules/docutils { };
 
+  docutils_0_20_x = callPackage ../development/python-modules/docutils/v0_20_x.nix { };
+
   docx2python = callPackage ../development/python-modules/docx2python { };
 
   docx2txt = callPackage ../development/python-modules/docx2txt { };


### PR DESCRIPTION
## Description of changes

Doc8 has an upper constraint on docutils <0.21.
This MR pin the 0.20.1 version of docutils to use in doc8

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
