### PR TITLE
dut: init at 0-unstable-2024-07-31

### DIFF
--- a/pkgs/by-name/du/dut/package.nix
+++ b/pkgs/by-name/du/dut/package.nix
@@ -1,0 +1,33 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitea,
+}:
+
+stdenv.mkDerivation {
+  pname = "dut";
+  version = "0-unstable-2024-07-31";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "201984";
+    repo = "dut";
+    rev = "041c6f26162c2286776fac246ddbda312da1563d";
+    hash = "sha256-YrBV5rG9rASI/5pwG3kcHoOvXBHhLJHvFFrvNhmGq2Y=";
+  };
+
+  installFlags = [
+    "DESTDIR=${placeholder "out"}"
+    "PREFIX="
+  ];
+
+  meta = {
+    platforms = lib.platforms.all;
+    broken = stdenv.isDarwin;
+    description = "A disk usage calculator for Linux";
+    homepage = "https://codeberg.org/201984/dut";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ errnoh ];
+    mainProgram = "dut";
+  };
+}


### PR DESCRIPTION
## Description of changes

Adding [dut](https://codeberg.org/201984/dut), a disk usage calculator for Linux

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
