### PR TITLE
binwalk: migrate to fork, 2.4.1

### DIFF
--- a/pkgs/development/python-modules/binwalk/default.nix
+++ b/pkgs/development/python-modules/binwalk/default.nix
@@ -14,6 +14,7 @@
   cramfsprogs,
   cramfsswap,
   sasquatch,
+  setuptools,
   squashfsTools,
   matplotlib,
   nose,
@@ -26,7 +27,7 @@
 buildPythonPackage rec {
   pname = "binwalk${lib.optionalString visualizationSupport "-full"}";
   version = "2.3.4";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ReFirmLabs";
@@ -45,6 +46,8 @@ buildPythonPackage rec {
       revert = true;
     })
   ];
+
+  build-system = [ setuptools ];
 
   propagatedBuildInputs =
     [

--- a/pkgs/development/python-modules/binwalk/default.nix
+++ b/pkgs/development/python-modules/binwalk/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   stdenv,
   zlib,
   xz,
@@ -17,35 +16,24 @@
   setuptools,
   squashfsTools,
   matplotlib,
-  nose,
   pycrypto,
   pyqtgraph,
   pyqt5,
+  pytestCheckHook,
   visualizationSupport ? false,
 }:
 
 buildPythonPackage rec {
   pname = "binwalk${lib.optionalString visualizationSupport "-full"}";
-  version = "2.3.4";
+  version = "2.4.1";
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "ReFirmLabs";
+    owner = "OSPG";
     repo = "binwalk";
     rev = "v${version}";
-    hash = "sha256-hlPbzqGRSXcIqlI+SNKq37CnnHd1IoMBNSjhyeAM1TE=";
+    hash = "sha256-VApqQrVBV7w15Bpwc6Fd/cA1Ikqu7Ds8qu0TH68YVog=";
   };
-
-  patches = [
-    # test_firmware_zip fails with 2.3.3 upgrade
-    # https://github.com/ReFirmLabs/binwalk/issues/566
-    (fetchpatch {
-      url = "https://github.com/ReFirmLabs/binwalk/commit/dd4f2efd275c9dd1001130e82e0f985110cd2754.patch";
-      sha256 = "1707n4nf1d1ay1yn4i8qlrvj2c1120g88hjwyklpsc2s2dcnqj9r";
-      includes = [ "testing/tests/test_firmware_zip.py" ];
-      revert = true;
-    })
-  ];
 
   build-system = [ setuptools ];
 
@@ -83,12 +71,12 @@ buildPythonPackage rec {
     HOME=$(mktemp -d)
   '';
 
-  nativeCheckInputs = [ nose ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "binwalk" ];
 
   meta = with lib; {
-    homepage = "https://github.com/ReFirmLabs/binwalk";
+    homepage = "https://github.com/OSPG/binwalk";
     description = "Tool for searching a given binary image for embedded files";
     mainProgram = "binwalk";
     maintainers = [ maintainers.koral ];


### PR DESCRIPTION
## Description of changes

Binwalk has [gone unmaintained for some time](https://github.com/ReFirmLabs/binwalk/issues/671), unfortunately. Thankfully our friends at Gentoo have been [maintaining a fork](https://github.com/OSPG/binwalk). It is currently used by both [Gentoo](https://gitweb.gentoo.org/repo/gentoo.git/tree/app-misc/binwalk/binwalk-2.4.1.ebuild) and [Alpine](https://git.alpinelinux.org/aports/tree/testing/binwalk/APKBUILD).

This PR moves to the fork and updates the derivation accordingly. It also migrates to the PEP517 builder.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
