### PR TITLE
ghidra: 11.1.1 -> 11.1.2, upgrade to gradle 8, openjdk 21

### DIFF
--- a/pkgs/tools/security/ghidra/0001-Use-protobuf-gradle-plugin.patch
+++ b/pkgs/tools/security/ghidra/0001-Use-protobuf-gradle-plugin.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] Use com.google.protobuf:protobuf-gradle-plugin
  Ghidra/Debug/Debugger-isf/build.gradle       |  8 +-
  Ghidra/Debug/Debugger-rmi-trace/build.gradle | 14 +--
  build.gradle                                 |  6 ++
- gradle/debugger/hasProtobuf.gradle           | 94 --------------------
+ gradle/hasProtobuf.gradle           | 94 --------------------
  5 files changed, 26 insertions(+), 103 deletions(-)
 
 diff --git a/Ghidra/Debug/Debugger-gadp/build.gradle b/Ghidra/Debug/Debugger-gadp/build.gradle
@@ -19,7 +19,7 @@ index 9e1c57faf..3a3242eb5 100644
  apply from: "${rootProject.projectDir}/gradle/jacocoProject.gradle"
  apply from: "${rootProject.projectDir}/gradle/javaTestProject.gradle"
  apply from: "${rootProject.projectDir}/gradle/distributableGhidraModule.gradle"
--apply from: "${rootProject.projectDir}/gradle/debugger/hasProtobuf.gradle"
+-apply from: "${rootProject.projectDir}/gradle/hasProtobuf.gradle"
 +apply plugin: 'com.google.protobuf'
  
  apply plugin: 'eclipse'
@@ -41,7 +41,7 @@ index d135294a0..785681ca2 100644
  apply from: "${rootProject.projectDir}/gradle/jacocoProject.gradle"
  apply from: "${rootProject.projectDir}/gradle/javaTestProject.gradle"
  apply from: "${rootProject.projectDir}/gradle/distributableGhidraModule.gradle"
--apply from: "${rootProject.projectDir}/gradle/debugger/hasProtobuf.gradle"
+-apply from: "${rootProject.projectDir}/gradle/hasProtobuf.gradle"
 -
 +apply plugin: 'com.google.protobuf'
  apply plugin: 'eclipse'
@@ -63,9 +63,9 @@ index 40fbc17ab..7517ffe6e 100644
  apply from: "${rootProject.projectDir}/gradle/jacocoProject.gradle"
  apply from: "${rootProject.projectDir}/gradle/javaTestProject.gradle"
  apply from: "${rootProject.projectDir}/gradle/distributableGhidraModule.gradle"
--apply from: "${rootProject.projectDir}/gradle/debugger/hasProtobuf.gradle"
+-apply from: "${rootProject.projectDir}/gradle/hasProtobuf.gradle"
 +apply plugin: 'com.google.protobuf'
- apply from: "${rootProject.projectDir}/gradle/debugger/hasPythonPackage.gradle"
+ apply from: "${rootProject.projectDir}/gradle/hasPythonPackage.gradle"
  
  apply plugin: 'eclipse'
  eclipse.project.name = 'Debug Debugger-rmi-trace'
@@ -110,10 +110,10 @@ index b0c717fb1..5f56506a5 100644
  	}
  }
  else {	
-diff --git a/gradle/debugger/hasProtobuf.gradle b/gradle/debugger/hasProtobuf.gradle
+diff --git a/gradle/hasProtobuf.gradle b/gradle/hasProtobuf.gradle
 index 23b4ce74b..e69de29bb 100644
---- a/gradle/debugger/hasProtobuf.gradle
-+++ b/gradle/debugger/hasProtobuf.gradle
+--- a/gradle/hasProtobuf.gradle
++++ b/gradle/hasProtobuf.gradle
 @@ -1,94 +0,0 @@
 -/* ###
 - * IP: GHIDRA

--- a/pkgs/tools/security/ghidra/build.nix
+++ b/pkgs/tools/security/ghidra/build.nix
@@ -20,7 +20,7 @@
 let
   pkg_path = "$out/lib/ghidra";
   pname = "ghidra";
-  version = "11.1.1";
+  version = "11.1.2";
 
   releaseName = "NIX";
   distroPrefix = "ghidra_${version}_${releaseName}";
@@ -28,7 +28,7 @@ let
     owner = "NationalSecurityAgency";
     repo = "Ghidra";
     rev = "Ghidra_${version}_build";
-    hash = "sha256-t96FcAK3JwO66dOf4OhpOfU8CQfAczfF61Cg7m+B3fA=";
+    hash = "sha256-FL1nLaq8A9PI+RzqZg5+O+4+ZsH16MG3cf7OIKimDqw=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;

--- a/pkgs/tools/security/ghidra/build.nix
+++ b/pkgs/tools/security/ghidra/build.nix
@@ -3,9 +3,9 @@
   fetchFromGitHub,
   lib,
   callPackage,
-  gradle_7,
+  gradle,
   makeBinaryWrapper,
-  openjdk17,
+  openjdk21,
   unzip,
   makeDesktopItem,
   copyDesktopItems,
@@ -42,8 +42,6 @@ let
       find "$out" -name .git -print0 | xargs -0 rm -rf
     '';
   };
-
-  gradle = gradle_7;
 
   patches = [
     # Use our own protoc binary instead of the prebuilt one
@@ -128,7 +126,7 @@ stdenv.mkDerivation (finalAttrs: {
     data = ./deps.json;
   };
 
-  gradleFlags = [ "-Dorg.gradle.java.home=${openjdk17}" ];
+  gradleFlags = [ "-Dorg.gradle.java.home=${openjdk21}" ];
 
   preBuild = ''
     export JAVA_TOOL_OPTIONS="-Duser.home=$NIX_BUILD_TOP/home"
@@ -164,7 +162,7 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s "${pkg_path}/ghidraRun" "$out/bin/ghidra"
     wrapProgram "${pkg_path}/support/launch.sh" \
       --set-default NIX_GHIDRAHOME "${pkg_path}/Ghidra" \
-      --prefix PATH : ${lib.makeBinPath [ openjdk17 ]}
+      --prefix PATH : ${lib.makeBinPath [ openjdk21 ]}
   '';
 
   passthru = {

--- a/pkgs/tools/security/ghidra/deps.json
+++ b/pkgs/tools/security/ghidra/deps.json
@@ -38,37 +38,37 @@
   }
  },
  "https://github.com": {
-  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.1/FunctionID/vs2012_x64": {
+  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.2/FunctionID/vs2012_x64": {
    "fidb": "sha256-1OmKs/eQuDF5MhhDC7oNiySl+/TaZbDB/6jLDPvrDNw="
   },
-  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.1/FunctionID/vs2012_x86": {
+  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.2/FunctionID/vs2012_x86": {
    "fidb": "sha256-pJDtfi7SHlh0Wf6urOcDa37eTOhOcuEN/YxXQ0ppGLY="
   },
-  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.1/FunctionID/vs2015_x64": {
+  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.2/FunctionID/vs2015_x64": {
    "fidb": "sha256-4E6eQPnstgHIX02E7Zv2a0U2O+HR6CwWLkyZArjLUI8="
   },
-  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.1/FunctionID/vs2015_x86": {
+  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.2/FunctionID/vs2015_x86": {
    "fidb": "sha256-tm7mlmU+LtNlkZ3qrviFEDEgx5LiLnmvcNEgnX4dhkQ="
   },
-  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.1/FunctionID/vs2017_x64": {
+  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.2/FunctionID/vs2017_x64": {
    "fidb": "sha256-1fpfaXKYF0+lPSR9NZnmoSiEYFrRgce5VOI4DsHwvYk="
   },
-  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.1/FunctionID/vs2017_x86": {
+  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.2/FunctionID/vs2017_x86": {
    "fidb": "sha256-04nLjXb/SlnKNfiRuFIccq1fDfluJTlzotIahhSkzIE="
   },
-  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.1/FunctionID/vs2019_x64": {
+  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.2/FunctionID/vs2019_x64": {
    "fidb": "sha256-FQAHeW/DakBpZgrWJEmq2q890Rs4ZKXvIeeYMcnOkRg="
   },
-  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.1/FunctionID/vs2019_x86": {
+  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.2/FunctionID/vs2019_x86": {
    "fidb": "sha256-62MKNvqlhqNx63NNwLvY0TzK72l/PbWHJZY1jz3SQyo="
   },
-  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.1/FunctionID/vsOlder_x64": {
+  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.2/FunctionID/vsOlder_x64": {
    "fidb": "sha256-jDtR9GYM0n4aDWEKnz8tX7yDOmasnuQ5PuLySB6FWGY="
   },
-  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.1/FunctionID/vsOlder_x86": {
+  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.2/FunctionID/vsOlder_x86": {
    "fidb": "sha256-mGBca2uSFKlF2ETkHIWGDVRkmkW8p4c+9pkcDpNyB4c="
   },
-  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.1/lib/java-sarif-2.1-modified": {
+  "NationalSecurityAgency/ghidra-data/raw/Ghidra_11.1.2/lib/java-sarif-2.1-modified": {
    "jar": "sha256-f3NlZklHVtJxql5LGvbIncUNB0qxxjdKR9+CImQiawE="
   },
   "pxb1988/dex2jar/releases/download/v2.1/dex2jar-2.1": {


### PR DESCRIPTION
## Description of changes

Updates Ghidra from 11.1.1 to 11.1.2. Also, upgrades Ghidra to build and run with Gradle 8 and OpenJDK 21 to match the upstream.

Tested basic functionality on x86-64_linux.

Ghidraninja scripts needs binwalk. With #326295 applied it seems to compile and load up fine. Other plugins are working inside just this PR.

Tested basic functionality on aarch64-darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
