### PR TITLE
nixos/postgresql: add ensureUsers.*.passwordFile option

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -191,6 +191,7 @@ in
 
             passwordFile = mkOption {
               type = with lib.types; nullOr path;
+              apply = toString;
               example = "/run/keys/db_user_pw";
               default = null;
               description = ''

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -190,14 +190,18 @@ in
             };
 
             passwordFile = mkOption {
-              type = with lib.types; nullOr path;
-              apply = toString;
+              type = with lib.types; nullOr (str // {
+                # We don't want users to be able to pass a path literal here but
+                # it should look like a path.
+                check = it: lib.isString it && lib.types.path.check it;
+              });
               example = "/run/keys/db_user_pw";
               default = null;
               description = ''
                 The path to a file containing a password that is to be set as the user's PASSWORD field.
 
-                A path must be given because Nix strings would be exposed in Nix store through the .drv files.
+                A path must be given because Nix strings would be exposed in Nix store through the .drv files. You must
+                not pass a path literal either for the same reason. The path must therefore be represented as a string.
 
                 Note that the contents of this file are stripped of newlines and that surrounding whitespace is trimmed.
               '';

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -189,6 +189,19 @@ in
               '';
             };
 
+            passwordFile = mkOption {
+              type = with lib.types; nullOr path;
+              example = "/run/keys/db_user_pw";
+              default = null;
+              description = ''
+                The path to a file containing a password that is to be set as the user's PASSWORD field.
+
+                A path must be given because Nix strings would be exposed in Nix store through the .drv files.
+
+                Note that the contents of this file are stripped of newlines and that surrounding whitespace is trimmed.
+              '';
+            };
+
             ensureClauses = mkOption {
               description = ''
                 An attrset of clauses to grant to the user. Under the hood this uses the
@@ -586,6 +599,19 @@ in
                     user.ensureDBOwnership
                     ''$PSQL -tAc 'ALTER DATABASE "${user.name}" OWNER TO "${user.name}";' '';
 
+                  setPW =
+                    pkgs.writeText
+                    "set-pw.sql"
+                    # You can't use prepared statements for ALTER ROLE, we must wrap it in a procedure
+                    ''
+                      DO $$
+                      DECLARE password TEXT;
+                      BEGIN
+                        password := trim(both from replace(pg_read_file('${user.passwordFile}'), E'\n', '''));
+                        EXECUTE 'ALTER ROLE "${user.name}" WITH PASSWORD' || quote_literal(password);
+                      END $$;
+                    '';
+
                   filteredClauses = filterAttrs (name: value: value != null) user.ensureClauses;
 
                   clauseSqlStatements = attrValues (mapAttrs (n: v: if v then n else "no${n}") filteredClauses);
@@ -593,6 +619,7 @@ in
                   userClauses = ''$PSQL -tAc 'ALTER ROLE "${user.name}" ${concatStringsSep " " clauseSqlStatements}' '';
                 in ''
                   $PSQL -tAc "SELECT 1 FROM pg_roles WHERE rolname='${user.name}'" | grep -q 1 || $PSQL -tAc 'CREATE USER "${user.name}"'
+                  ${lib.optionalString (user.passwordFile != null) "$PSQL -tAf ${setPW}"}
                   ${userClauses}
 
                   ${dbOwnershipStmt}


### PR DESCRIPTION
Previously you had to roll your own systemd service that runs some SQL and risk inadvertently exposing your password to the Nix store by doing it wrong.

This provides a standard method to set up user passwords via password files which can safely be deployed via secrets management solutions for those who care about security or alternatively also simply generated for those who don't.

Adapted from https://discourse.nixos.org/t/assign-password-to-postgres-user-declaratively/9726/3

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
