### PR TITLE
kdePackages.kommit: init at 1.6.0

### DIFF
--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -66,6 +66,7 @@
       kirigami-addons = self.callPackage ./misc/kirigami-addons {};
       kio-extras-kf5 = self.callPackage ./misc/kio-extras-kf5 {};
       kio-fuse = self.callPackage ./misc/kio-fuse {};
+      kommit = self.callPackage ./misc/kommit {};
       ktextaddons = self.callPackage ./misc/ktextaddons {};
       kunifiedpush = self.callPackage ./misc/kunifiedpush {};
       kweathercore = self.callPackage ./misc/kweathercore {};

--- a/pkgs/kde/misc/kommit/default.nix
+++ b/pkgs/kde/misc/kommit/default.nix
@@ -17,5 +17,23 @@ mkKdeDerivation rec {
   extraNativeBuildInputs = [ pkg-config ];
   extraBuildInputs = [ libgit2 ];
 
+  patchPhase = ''
+    cat > src/data/kommitdiff.sh <<EOF
+#!/bin/sh
+$out/bin/kommit diff "\$@"
+EOF
+    cat > src/data/kommitmerge.sh <<EOF
+#!/bin/sh
+$out/bin/kommit merge "\$@"
+EOF
+  '';
+
+  dontWrapQtApps = true;
+  preFixup = ''
+    wrapQtApp $out/bin/kommit
+    patchShebangs --host $out/bin/kommitdiff
+    patchShebangs --host $out/bin/kommitmerge
+  '';
+
   meta.license = [ lib.licenses.gpl3Only ];
 }

--- a/pkgs/kde/misc/kommit/default.nix
+++ b/pkgs/kde/misc/kommit/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  mkKdeDerivation,
+  fetchurl,
+  pkg-config,
+  libgit2,
+}:
+mkKdeDerivation rec {
+  pname = "kommit";
+  version = "1.6.0";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/${pname}/${pname}-${version}.tar.xz";
+    hash = "sha256-rDDrXxqMQDXGSZ0nMl1JkSGsLeez04HKyw3XQn+0UCU=";
+  };
+
+  extraNativeBuildInputs = [ pkg-config ];
+  extraBuildInputs = [ libgit2 ];
+
+  meta.license = [ lib.licenses.gpl3Only ];
+}


### PR DESCRIPTION
## Description of changes
Git GUI for KDE
-  homepage URL: https://apps.kde.org/kommit
-  source URL: https://invent.kde.org/sdk/kommit
-  license: GNU GPLv3
-  platforms: linux

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
(not applicable) Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
(not applicable) Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
