### PR TITLE
inter-nerdfont: init at 4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4217,6 +4217,12 @@
     name = "Serg Nesterov";
     keys = [ { fingerprint = "6E7D BA30 DB5D BA60 693C  3BE3 1512 F6EB 84AE CC8C"; } ];
   };
+  cvoges12 = {
+    email = "vogesclayton@gmail.com";
+    github = "cvoges12";
+    githubId = 38054771;
+    name = "Claton Voges";
+  };
   cwoac = {
     email = "oliver@codersoffortune.net";
     github = "cwoac";

--- a/pkgs/data/fonts/inter-nerdfont/default.nix
+++ b/pkgs/data/fonts/inter-nerdfont/default.nix
@@ -1,0 +1,39 @@
+{ lib, pkgs, stdenvNoCC, fetchzip }:
+
+let
+  version = "4.0";
+in stdenvNoCC.mkDerivation {
+  pname = "inter-nerdfont";
+  inherit version;
+
+  src = fetchzip {
+    url = "https://github.com/rsms/inter/releases/download/v${version}/Inter-${version}.zip";
+    stripRoot = false;
+    hash = "sha256-hFK7xFJt69n+98+juWgMvt+zeB9nDkc8nsR8vohrFIc=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/truetype
+    nerd-font-patcher Inter.ttc
+    cp 'Inter Nerd Font.ttc' $out/share/fonts/truetype/InterNerdFont.tcc
+    cp *.ttf $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
+
+  buildInputs = builtins.attrValues {
+    inherit (pkgs)
+      fontforge
+      nerd-font-patcher;
+  };
+
+  meta = {
+    homepage = "https://gitlab.com/mid_os/inter-nerdfont";
+    description = "A NerdFont patch of the Inter font";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.cvoges12 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28928,6 +28928,8 @@ with pkgs;
 
   inter = callPackage ../data/fonts/inter { };
 
+  inter-nerdfont = callPackage ../data/fonts/inter-nerdfont { };
+
   open-fonts = callPackage ../data/fonts/open-fonts { };
 
   scientifica = callPackage ../data/fonts/scientifica { };


### PR DESCRIPTION
## Description of changes

Adding NerdFont patch of Inter to nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
