### PR TITLE
open-webui: 0.3.7 -> 0.3.8

### DIFF
--- a/pkgs/by-name/op/open-webui/package.nix
+++ b/pkgs/by-name/op/open-webui/package.nix
@@ -7,19 +7,19 @@
 }:
 let
   pname = "open-webui";
-  version = "0.3.7";
+  version = "0.3.8";
 
   src = fetchFromGitHub {
     owner = "open-webui";
     repo = "open-webui";
     rev = "v${version}";
-    hash = "sha256-tsJILQ+CuVy8LYSixYNJAwSIZtRegrXXvGzvyf7Knd0=";
+    hash = "sha256-kUdy8zSt8RvGlMKa0gxp0tnZbo7/igDeFV2zsel5LXA=";
   };
 
   frontend = buildNpmPackage {
     inherit pname version src;
 
-    npmDepsHash = "sha256-fB5gvC2sLfH2dJJi+CYyF7PRg+GhZDavhKgeRStaR7I=";
+    npmDepsHash = "sha256-sjQJn94GmSdOY1B2bmFTsxjLrc7LSBgDpWNrXIHunsg=";
 
     # Disabling `pyodide:fetch` as it downloads packages during `buildPhase`
     # Until this is solved, running python packages from the browser will not work.
@@ -63,6 +63,7 @@ python3.pkgs.buildPythonApplication rec {
 
   dependencies = with python3.pkgs; [
     aiohttp
+    alembic
     anthropic
     apscheduler
     argon2-cffi

--- a/pkgs/development/python-modules/ctranslate2/default.nix
+++ b/pkgs/development/python-modules/ctranslate2/default.nix
@@ -13,7 +13,6 @@
 
   # tests
   pytestCheckHook,
-  tensorflow-bin,
   torch,
   transformers,
   wurlitzer,
@@ -48,7 +47,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    tensorflow-bin
     torch
     transformers
     wurlitzer
@@ -64,6 +62,16 @@ buildPythonPackage rec {
   disabledTests = [
     # AssertionError: assert 'int8' in {'float32'}
     "test_get_supported_compute_types"
+    # Tensorflow (tf) not available in Python 3.12 yet
+    # To remove when https://github.com/NixOS/nixpkgs/pull/325224 is fixed
+    "test_opennmt_tf_model_conversion"
+    "test_opennmt_tf_model_quantization"
+    "test_opennmt_tf_model_conversion_invalid_vocab"
+    "test_opennmt_tf_model_conversion_invalid_dir"
+    "test_opennmt_tf_shared_embeddings_conversion"
+    "test_opennmt_tf_postnorm_transformer_conversion"
+    "test_opennmt_tf_gpt_conversion"
+    "test_opennmt_tf_multi_features"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/langchain-community/default.nix
+++ b/pkgs/development/python-modules/langchain-community/default.nix
@@ -6,7 +6,6 @@
   pythonOlder,
   aiohttp,
   dataclasses-json,
-  duckdb-engine,
   langchain,
   langchain-core,
   langsmith,
@@ -65,7 +64,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "langchain_community" ];
 
   nativeCheckInputs = [
-    duckdb-engine
     lark
     pandas
     pytest-asyncio
@@ -88,6 +86,10 @@ buildPythonPackage rec {
   disabledTests = [
     # Test require network access
     "test_ovhcloud_embed_documents"
+    # duckdb-engine needs python-wasmer which is not yet available in Python 3.12
+    # See https://github.com/NixOS/nixpkgs/pull/326337 and https://github.com/wasmerio/wasmer-python/issues/778
+    "test_table_info"
+    "test_sql_database_run"
   ];
 
   meta = {


### PR DESCRIPTION
diff: https://github.com/open-webui/open-webui/compare/v0.3.7..v0.3.8
changelog: https://github.com/open-webui/open-webui/releases/tag/v0.3.8

- Fix `python3Packages.ctranslate2`, remove Tensorflow related tests momentarily.
- Fix `python3Packages.langchain-community`, remove `duckdb-engine` related tests momentarily 

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
