### PR TITLE
narsil: 1.3.0-49-gc042b573a -> 1.3.0-84-g042c39e9c

### DIFF
--- a/pkgs/by-name/na/narsil/package.nix
+++ b/pkgs/by-name/na/narsil/package.nix
@@ -14,13 +14,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "narsil";
-  version = "1.3.0-49-gc042b573a";
+  version = "1.3.0-84-g042c39e9c";
 
   src = fetchFromGitHub {
     owner = "NickMcConnell";
     repo = "NarSil";
     rev = version;
-    hash = "sha256-lVGG4mppsnDmjMFO8YWsLEJEhI3T+QO3z/pCebe0Ai8=";
+    hash = "sha256-P+J+1KR5ZIUSXq8FXHGcIllGH3iEFlNniHWzlT4WZUM=";
   };
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/na/narsil/package.nix
+++ b/pkgs/by-name/na/narsil/package.nix
@@ -1,16 +1,16 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, autoreconfHook
-, ncurses
-, enableSdl2 ? true
-, SDL2
-, SDL2_image
-, SDL2_sound
-, SDL2_mixer
-, SDL2_ttf
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  ncurses,
+  enableSdl2 ? true,
+  SDL2,
+  SDL2_image,
+  SDL2_sound,
+  SDL2_mixer,
+  SDL2_ttf,
 }:
-
 stdenv.mkDerivation rec {
   pname = "narsil";
   version = "1.3.0-49-gc042b573a";
@@ -23,14 +23,15 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ ncurses ]
+  buildInputs =
+    [ ncurses ]
     ++ lib.optionals enableSdl2 [
-    SDL2
-    SDL2_image
-    SDL2_sound
-    SDL2_mixer
-    SDL2_ttf
-  ];
+      SDL2
+      SDL2_image
+      SDL2_sound
+      SDL2_mixer
+      SDL2_ttf
+    ];
 
   enableParallelBuilding = true;
 
@@ -38,7 +39,7 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "bindir=$(out)/bin" ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/NickMcConnell/NarSil/";
     description = "Unofficial rewrite of Sil, a roguelike influenced by Angband";
     mainProgram = "narsil";
@@ -46,7 +47,7 @@ stdenv.mkDerivation rec {
       NarSil attempts to be an almost-faithful recreation of Sil 1.3.0,
       but based on the codebase of modern Angband.
     '';
-    maintainers = [ maintainers.nanotwerp ];
-    license = licenses.gpl2;
+    maintainers = with lib.maintainers; [ nanotwerp ];
+    license = lib.licenses.gpl2;
   };
 }

--- a/pkgs/by-name/na/narsil/package.nix
+++ b/pkgs/by-name/na/narsil/package.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/NickMcConnell/NarSil/";
     description = "Unofficial rewrite of Sil, a roguelike influenced by Angband";
     mainProgram = "narsil";
+    changelog = "https://github.com/NickMcConnell/NarSil/releases/tag/${version}";
     longDescription = ''
       NarSil attempts to be an almost-faithful recreation of Sil 1.3.0,
       but based on the codebase of modern Angband.

--- a/pkgs/by-name/na/narsil/package.nix
+++ b/pkgs/by-name/na/narsil/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
+  nix-update-script,
   ncurses,
   enableSdl2 ? true,
   SDL2,
@@ -21,6 +22,8 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-lVGG4mppsnDmjMFO8YWsLEJEhI3T+QO3z/pCebe0Ai8=";
   };
+
+  passthru.updateScript = nix-update-script { };
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs =

--- a/pkgs/by-name/na/narsil/package.nix
+++ b/pkgs/by-name/na/narsil/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
       NarSil attempts to be an almost-faithful recreation of Sil 1.3.0,
       but based on the codebase of modern Angband.
     '';
-    maintainers = with lib.maintainers; [ nanotwerp ];
+    maintainers = with lib.maintainers; [ nanotwerp x123 ];
     license = lib.licenses.gpl2;
   };
 }


### PR DESCRIPTION
## Description of changes

The narsil package is quite out of date with Nick's work which fixes crashes and other issues.

- refactor package
- add meta.changelog
- set `passthru.updateScript` to use `nix-update-script`
- update narsil from `1.3.0-49-gc042b573a` -> `1.3.0-84-g042c39e9c`
- add x123 as maintainer

Combined changelog from narsil `1.3.0-49-gc042b573a` -> `1.3.0-84-g042c39e9c`:

```
- 1.3.0-83-g8494d0178 Prevent using the mouse to close the door at the player's location
- 1.3.0-82-g1bf26cba8 Tolerate non-NULL obj argument and full inventory in player_pickup_item()
- 1.3.0-81-gb90014e06 Fix typo in place_monster_by_letter()
- 1.3.0-80-g0ece40296 Allow TUNNEL_WALL monsters to actually tunnel
- 1.3.0-79-g464eed68f Restructure some tests using iscloseddoor, iswall, and isdisarmabletrap
- 1.3.0-78-g20b8123e0 Revised Exchange Places, adding pronoun to slipping past message.
- 1.3.0-77-g55b8986c1 Fix logic and comments for place_object()/make_object()'s drop argument
- 1.3.0-76-g14a3b70ab Better match Sil 1.3's summoning logic for roosts and webs
- 1.3.0-75-g441502e84 Adjust lighting, resolves #426
- 1.3.0-74-g66785262c Use TIMED_INC for potions of poison, resolves #429
- 1.3.0-73-g9e0b47316 Add missing line in monster_spell.txt, fixes #428
- 1.3.0-72-g47a1677f9 Make autopickup of fired/thrown objects free, fixes #409
- 1.3.0-71-gefa8173a1 SCARE: use -10 as the dice for noise side effect
- 1.3.0-70-ga976913ea Smithing: plug memory leak in enchant menu
- 1.3.0-69-g962a3a151 Color entries in smithing's enchant menu by affordability
- 1.3.0-68-gc26fded57 Introduce object kind flag to mark special kinds used for smithed artifacts
- 1.3.0-67-g4fcea0572 Avoid some unused variable warnings when compiled with -DNDEBUG
- 1.3.0-66-g9456ff0cb Smithing artifice: plug memory leaks and improve menu usability
- 1.3.0-65-g18ca4f661 Have artifact count match up after reloading with smithed artifacts
- 1.3.0-64-gd82d4b9d8 Be consistent with the list of modifier names
- 1.3.0-63-g833431b0c Mention the LIGHT flag, if present, when an object is examined
- 1.3.0-62-gc101142de Document object.txt properly, fixes #408
- 1.3.0-60-gff7895485 Archers' monster lore now lists attack bonus; resolves #39.
- 1.3.0-59-g5ca1acaa8 Smithing: fix handling of special bonus
- 1.3.0-58-g6a3652ace Workflows: update versions of used actions for compatibility with Node 20
- 1.3.0-57-g2624dc322 Do not display a pass door message for monster going through an open door
- 1.3.0-56-g4fcb2f815 Avoid further processing of deleted monsters in process_monster_recover(), may affect #401
- 1.3.0-54-g34e7c5c64 On a player's ranged attack, only use monster pain message if out of sight
- 1.3.0-53-g6e4a9a002 Set empty messages in monster_spell.txt for songs
- 1.3.0-52-gf7965d772 Fix crash on using an arrow with no bow
- 1.3.0-50-ge79f54753 Update ui-birth.c
```
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
