### PR TITLE
icestudio: init at unstable-2024-07-11

### DIFF
--- a/pkgs/by-name/ic/icestudio/package.nix
+++ b/pkgs/by-name/ic/icestudio/package.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildNpmPackage,
+  nwjs,
+  makeWrapper,
+  python3,
+  fetchurl,
+}:
+
+let
+  # Use unstable because it has improvements for finding python
+  version = "0-unstable-2024-07-11";
+
+  src = fetchFromGitHub {
+    owner = "FPGAwars";
+    repo = "icestudio";
+    rev = "5df95bfbcc9540675897256e0a372f8039b534c5";
+    hash = "sha256-0HETAeR8OCsu7caP8SbBVYSLQIxMKjV1flR24MizSnU=";
+  };
+
+  collection = fetchurl {
+    url = "https://github.com/FPGAwars/collection-default/archive/v0.4.1.zip";
+    hash = "sha256-F2cAqkTPC7xfGnPQiS8lTrD4y34EkHFUEDPVaYzVVg8=";
+  };
+
+  app = buildNpmPackage {
+    pname = "icestudio-app";
+    inherit version src;
+    sourceRoot = "${src.name}/app";
+    npmDepsHash = "sha256-gfkLW8OaCpaq5KHBhttqMTQPfhUCs22ii6UvNxqWnsQ=";
+    dontNpmBuild = true;
+    installPhase = ''
+      cp -r . $out
+    '';
+  };
+in
+buildNpmPackage rec {
+  inherit version src;
+  pname = "icestudio";
+  npmDepsHash = "sha256-K90zgKHqNEvjjM20YaXa24J0dGA2MESNvzvsr31AR2Y=";
+  npmFlags = [
+    # Use the legacy dependency resolution, with less strict version
+    # requirements for transative dependencies
+    "--legacy-peer-deps"
+
+    # We want to avoid call the scripts/postInstall.sh until we copy the
+    # collection and app derivation we do that on installPhase
+    "--ignore-scripts"
+  ];
+
+  buildPhase = ''
+    # step 1: Copy the `app` derivation into the folder expected for grunt
+    cp -r ${app}/* app
+
+    # step 2: Copy the cached `collection` derivation into the cache location
+    # so that grunt avoids downloading it
+    install -m444 -D ${collection} cache/collection/collection-default.zip
+
+    ./node_modules/.bin/grunt getcollection
+
+    # step 3: use grunt to distribute package
+    # TODO: support aarch64
+    ./node_modules/.bin/grunt dist \
+        --platform=none    `# skip platform-specific steps` \
+        --dont-build-nwjs  `# use the nwjs package shipped by Nix` \
+        --dont-clean-tmp   `# skip cleaning the tmp folder as we'll use it in $out`
+  '';
+
+  installPhase = ''
+    cp -r dist/tmp $out
+    mkdir -p $out/share/applications
+    cp res/AppImage/icestudio.AppDir/Icestudio.desktop $out/share/applications/
+    substituteInPlace $out/share/applications/Icestudio.desktop \
+      --replace-fail "/usr/bin/icestudio" "$out/bin/icestudio"
+    makeWrapper ${nwjs}/bin/nw $out/bin/${pname} \
+        --add-flags $out \
+        --prefix PATH : "${python3}/bin"
+
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ python3 ];
+
+  meta = {
+    description = "Visual editor for open FPGA boards";
+    homepage = "https://github.com/FPGAwars/icestudio/";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [
+      kiike
+      jleightcap
+      rcoeurjoly
+      amerino
+    ];
+    mainProgram = "icestudio";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

This work was done as part of Summer of Nix 2024.

We also opened a PR (https://github.com/NixOS/nixpkgs/pull/324068) for building the AppImage.
Should both derivations be in nixpkgs?
Or only building from source like in this PR?

Building from source is needed to support anything other than Linux x86_64.
@Aleksanaa this is follow up work from the previous PR you reviewed.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
