### PR TITLE
tilt: 0.33.10 -> 0.33.17

### DIFF
--- a/pkgs/applications/networking/cluster/tilt/assets.nix
+++ b/pkgs/applications/networking/cluster/tilt/assets.nix
@@ -1,46 +1,86 @@
 { lib
 , stdenvNoCC
-, version, src
-, fetchYarnDeps
-, fixup-yarn-lock, yarn, nodejs
+, nodejs
+, yarn-berry
+, cacert
+, version
+, src
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation {
   pname = "tilt-assets";
+  src = "${src}/web";
+  inherit version;
 
-  inherit src version;
+  nativeBuildInputs = [ nodejs yarn-berry ];
 
-  nativeBuildInputs = [ fixup-yarn-lock yarn nodejs ];
+  yarnOfflineCache = stdenvNoCC.mkDerivation {
+    name = "tilt-assets-deps";
+    src = "${src}/web";
 
-  yarnOfflineCache = fetchYarnDeps {
-    yarnLock = "${src}/web/yarn.lock";
-    hash = "sha256-0JpoAQKRmU7P1bzYNR/vqtPjOOSw8wSlNjXl2f6uBrw=";
+    nativeBuildInputs = [ yarn-berry ];
+
+    supportedArchitectures = builtins.toJSON {
+      os = [ "darwin" "linux" ];
+      cpu = [ "arm" "arm64" "ia32" "x64" ];
+      libc = [ "glibc" "musl" ];
+    };
+
+    NODE_EXTRA_CA_CERTS = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+    configurePhase = ''
+      runHook preConfigure
+
+      export HOME="$NIX_BUILD_TOP"
+      export YARN_ENABLE_TELEMETRY=0
+
+      yarn config set enableGlobalCache false
+      yarn config set cacheFolder $out
+      yarn config set supportedArchitectures --json "$supportedArchitectures"
+
+      runHook postConfigure
+    '';
+
+    buildPhase = ''
+      runHook preBuild
+
+      mkdir -p $out
+      yarn install --immutable --mode skip-build
+
+      runHook postBuild
+    '';
+
+    dontInstall = true;
+
+    outputHashAlgo = "sha256";
+    outputHash = "sha256-UpKWpwKUouW4BHZAQNvg4PeQ3bd28mrbv547GyN/drI=";
+    outputHashMode = "recursive";
   };
 
   configurePhase = ''
-    export HOME=$(mktemp -d)/yarn_home
+    runHook preConfigure
+
+    export HOME="$NIX_BUILD_TOP"
+    export YARN_ENABLE_TELEMETRY=0
+
+    yarn config set enableGlobalCache false
+    yarn config set cacheFolder $yarnOfflineCache
+
+    runHook postConfigure
   '';
 
   buildPhase = ''
     runHook preBuild
 
-    yarn config --offline set yarn-offline-mirror $yarnOfflineCache
-
-    cd web
-    fixup-yarn-lock yarn.lock
-    yarn install --offline --frozen-lockfile --ignore-engines
-    patchShebangs node_modules
-    export PATH=$PWD/node_modules/.bin:$PATH
-    ./node_modules/.bin/react-scripts build
-
-    mkdir -p $out
-    cd ..
+    yarn install --immutable --immutable-cache
+    yarn build
 
     runHook postBuild
   '';
 
   installPhase = ''
-    cp -r web/build/* $out
+    mkdir -p $out
+    cp -r build/. $out/
   '';
 
   meta = with lib; {

--- a/pkgs/applications/networking/cluster/tilt/assets.nix
+++ b/pkgs/applications/networking/cluster/tilt/assets.nix
@@ -53,7 +53,7 @@ stdenvNoCC.mkDerivation {
     dontInstall = true;
 
     outputHashAlgo = "sha256";
-    outputHash = "sha256-UpKWpwKUouW4BHZAQNvg4PeQ3bd28mrbv547GyN/drI=";
+    outputHash = "sha256-5f9lKRD6vc2FOnUeSxK/zlu/tshS1+RCSB0slGSO/Rc=";
     outputHashMode = "recursive";
   };
 

--- a/pkgs/applications/networking/cluster/tilt/default.nix
+++ b/pkgs/applications/networking/cluster/tilt/default.nix
@@ -5,13 +5,13 @@ let args = rec {
       /* Do not use "dev" as a version. If you do, Tilt will consider itself
         running in development environment and try to serve assets from the
         source tree, which is not there once build completes.  */
-      version = "0.33.10";
+      version = "0.33.13";
 
       src = fetchFromGitHub {
         owner = "tilt-dev";
         repo = "tilt";
         rev = "v${version}";
-        hash = "sha256-LPb2tC3xIGhjiLYkTU+NBIUoqiicO2ORM6Nt1eTnwQs=";
+        hash = "sha256-B1kau6G56Iz6Yso2KpJCPE18yznhKCmq+Pabi2sxSmI=";
       };
     };
 

--- a/pkgs/applications/networking/cluster/tilt/default.nix
+++ b/pkgs/applications/networking/cluster/tilt/default.nix
@@ -5,13 +5,13 @@ let args = rec {
       /* Do not use "dev" as a version. If you do, Tilt will consider itself
         running in development environment and try to serve assets from the
         source tree, which is not there once build completes.  */
-      version = "0.33.13";
+      version = "0.33.17";
 
       src = fetchFromGitHub {
         owner = "tilt-dev";
         repo = "tilt";
         rev = "v${version}";
-        hash = "sha256-B1kau6G56Iz6Yso2KpJCPE18yznhKCmq+Pabi2sxSmI=";
+        hash = "sha256-GzWnTq3X615A/jRjYhBriRYaH4tjv+yg2/zHIJuKXPE=";
       };
     };
 


### PR DESCRIPTION
## Description of changes
* Updates Tilt to [v0.33.17](https://github.com/tilt-dev/tilt/releases/tag/v0.33.17) ([diff](https://github.com/tilt-dev/tilt/compare/v0.33.10...v0.33.17))
* Includes a workaround for yarn-berry which no longer works with fetchYarnDeps (https://github.com/NixOS/nixpkgs/issues/254369)

The PR is based upon and includes the changes from #307432 that wasn't merged by @szlend.

I tested the build on x86_64-linux in a real project and found no issues.

cc @szlend @anton-dessiatov 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
