### PR TITLE
Fix array handling in rust hooks

### DIFF
--- a/pkgs/build-support/rust/hooks/cargo-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-build-hook.sh
@@ -44,7 +44,7 @@ cargoBuildHook() {
         ${cargoBuildNoDefaultFeaturesFlag} \
         ${cargoBuildFeaturesFlag} \
         ${cargoBuildFlags} \
-        ${cargoBuildFlagsArray[@]}
+        ${cargoBuildFlagsArray+"${cargoBuildFlagsArray[@]}"}
     )
 
     if [ ! -z "${buildAndTestSubdir-}" ]; then

--- a/pkgs/build-support/rust/hooks/cargo-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-build-hook.sh
@@ -1,4 +1,4 @@
-declare -a cargoBuildFlags
+declare -a cargoBuildFlagsArray
 
 cargoBuildHook() {
     echo "Executing cargoBuildHook"
@@ -43,7 +43,8 @@ cargoBuildHook() {
         ${cargoBuildProfileFlag} \
         ${cargoBuildNoDefaultFeaturesFlag} \
         ${cargoBuildFeaturesFlag} \
-        ${cargoBuildFlags}
+        ${cargoBuildFlags} \
+        ${cargoTestFlagsArray[@]}
     )
 
     if [ ! -z "${buildAndTestSubdir-}" ]; then

--- a/pkgs/build-support/rust/hooks/cargo-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-build-hook.sh
@@ -44,7 +44,7 @@ cargoBuildHook() {
         ${cargoBuildNoDefaultFeaturesFlag} \
         ${cargoBuildFeaturesFlag} \
         ${cargoBuildFlags} \
-        ${cargoTestFlagsArray[@]}
+        ${cargoBuildFlagsArray[@]}
     )
 
     if [ ! -z "${buildAndTestSubdir-}" ]; then

--- a/pkgs/build-support/rust/hooks/cargo-check-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-check-hook.sh
@@ -1,5 +1,5 @@
-declare -a checkFlags
-declare -a cargoTestFlags
+declare -a checkFlagsArray
+declare -a cargoTestFlagsArray
 
 cargoCheckHook() {
     echo "Executing cargoCheckHook"
@@ -28,14 +28,18 @@ cargoCheckHook() {
         cargoCheckFeaturesFlag="--features=${cargoCheckFeatures// /,}"
     fi
 
-    argstr="${cargoCheckProfileFlag} ${cargoCheckNoDefaultFeaturesFlag} ${cargoCheckFeaturesFlag}
-        --target @rustHostPlatformSpec@ --offline ${cargoTestFlags}"
-
     (
         set -x
         cargo test \
               -j $NIX_BUILD_CORES \
-              ${argstr} -- \
+              ${cargoCheckProfileFlag} \
+              ${cargoCheckNoDefaultFeaturesFlag} \
+              ${cargoCheckFeaturesFlag} \
+              --target @rustHostPlatformSpec@ \
+              --offline \
+              ${cargoTestFlags} \
+              ${cargoTestFlagsArray+"${cargoTestFlagsArray[@]}"} \
+              -- \
               --test-threads=${threads} \
               ${checkFlags} \
               ${checkFlagsArray+"${checkFlagsArray[@]}"}

--- a/pkgs/build-support/rust/hooks/cargo-nextest-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-nextest-hook.sh
@@ -1,5 +1,5 @@
-declare -a checkFlags
-declare -a cargoTestFlags
+declare -a checkFlagsArray
+declare -a cargoTestFlagsArray
 
 cargoNextestHook() {
     echo "Executing cargoNextestHook"
@@ -28,14 +28,18 @@ cargoNextestHook() {
         cargoCheckFeaturesFlag="--features=${cargoCheckFeatures// /,}"
     fi
 
-    argstr="${cargoCheckProfileFlag} ${cargoCheckNoDefaultFeaturesFlag} ${cargoCheckFeaturesFlag}
-        --target @rustHostPlatformSpec@ --offline ${cargoTestFlags}"
-
     (
         set -x
         cargo nextest run \
               -j ${threads} \
-              ${argstr} -- \
+              ${cargoCheckProfileFlag} \
+              ${cargoCheckNoDefaultFeaturesFlag} \
+              ${cargoCheckFeaturesFlag} \
+              --target @rustHostPlatformSpec@ \
+              --offline \
+              ${cargoTestFlags} \
+              ${cargoTestFlagsArray+"${cargoTestFlagsArray[@]}"} \
+              -- \
               ${checkFlags} \
               ${checkFlagsArray+"${checkFlagsArray[@]}"}
     )


### PR DESCRIPTION
## Description of changes

The rust hooks have several variables used for flags which are bash arrays. When expanding these variables in nearly all places we just used `${varName}` which results in _only the first element_ actually being expanded. This PR fixes this to use the correct `${varName[@]}` expansion to ensure all elements of the array get included.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
