### PR TITLE
erlang: 25.3.2.12 -> 25.3.2.13; erlang_27: 27.0 -> 27.0.1

### DIFF
--- a/pkgs/development/interpreters/erlang/25.nix
+++ b/pkgs/development/interpreters/erlang/25.nix
@@ -1,6 +1,6 @@
 { mkDerivation }:
 
 mkDerivation {
-  version = "25.3.2.12";
-  sha256 = "sha256-ZqyJtKr0QdzuuzKnJ/S6Z4cGLWolVMVWcMuAHyOGzkQ=";
+  version = "25.3.2.13";
+  sha256 = "sha256-ZBk6oOT0vFY66ttyn4G2zy7Ur5bDKkxPzlTsZPaiosc=";
 }

--- a/pkgs/development/interpreters/erlang/27.nix
+++ b/pkgs/development/interpreters/erlang/27.nix
@@ -1,6 +1,6 @@
 { mkDerivation }:
 
 mkDerivation {
-  version = "27.0";
-  sha256 = "sha256-YZWBLcpkm8B4sjoQO7I9ywXcmxXL+Dvq/JYsLsr7TO0=";
+  version = "27.0.1";
+  sha256 = "sha256-Lp6J9eq6RXDi0RRjeVO/CIa4h/m7/fwOp/y0u0sTdFQ=";
 }

--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -122,20 +122,10 @@ stdenv.mkDerivation ({
   '';
 
   # For OTP 27+ we need ex_doc to build the documentation
-  # When exdocSupport is enabled, grab the raw ex_doc executable from the exdoc
-  # derivation. Next, patch the first line to use the escript that will be
-  # built during the build phase of this derivation. Finally, building the
-  # documentation requires the erlang-logo.png asset.
   preConfigure = ''
     ./otp_build autoconf
   '' + optionalString exdocSupport ''
-    mkdir -p $out/bin
-    cp ${exdoc}/bin/.ex_doc-wrapped $out/bin/ex_doc
-    sed -i "1 s:^.*$:#!$out/bin/escript:" $out/bin/ex_doc
-    export EX_DOC=$out/bin/ex_doc
-
-    mkdir -p $out/lib/erlang/system/doc/assets
-    cp $src/system/doc/assets/erlang-logo.png $out/lib/erlang/system/doc/assets
+    export EX_DOC=${exdoc}/bin/.ex_doc-wrapped
   '';
 
   configureFlags = [ "--with-ssl=${lib.getOutput "out" opensslPackage}" ]


### PR DESCRIPTION
## Description of changes

- https://erlangforums.com/t/patch-package-otp-25-3-2-13-released/3816
- https://erlangforums.com/t/patch-package-otp-27-0-1-released/3824

The 27.0.1 release also allows us to simplify the ex_doc set thanks to

- https://github.com/erlang/otp/pull/8596

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
