### PR TITLE
Prevent some rebuilds for future Nix reformats

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -542,21 +542,21 @@ checkConfigOutput '^"pear\\npear"$' config.twice.raw ./merge-module-with-key.nix
 
 # Declaration positions
 # Line should be present for direct options
-checkConfigOutput '^10$' options.imported.line10.declarationPositions.0.line ./declaration-positions.nix
-checkConfigOutput '/declaration-positions.nix"$' options.imported.line10.declarationPositions.0.file ./declaration-positions.nix
+checkConfigOutput '^14$' options.imported.line14.declarationPositions.0.line ./declaration-positions.nix
+checkConfigOutput '/declaration-positions.nix"$' options.imported.line14.declarationPositions.0.file ./declaration-positions.nix
 # Generated options may not have line numbers but they will at least get the
 # right file
-checkConfigOutput '/declaration-positions.nix"$' options.generated.line18.declarationPositions.0.file ./declaration-positions.nix
-checkConfigOutput '^null$' options.generated.line18.declarationPositions.0.line ./declaration-positions.nix
+checkConfigOutput '/declaration-positions.nix"$' options.generated.line22.declarationPositions.0.file ./declaration-positions.nix
+checkConfigOutput '^null$' options.generated.line22.declarationPositions.0.line ./declaration-positions.nix
 # Submodules don't break it
-checkConfigOutput '^39$' config.submoduleLine34.submodDeclLine39.0.line ./declaration-positions.nix
-checkConfigOutput '/declaration-positions.nix"$' config.submoduleLine34.submodDeclLine39.0.file ./declaration-positions.nix
+checkConfigOutput '^45$' config.submoduleLine38.submodDeclLine45.0.line ./declaration-positions.nix
+checkConfigOutput '/declaration-positions.nix"$' config.submoduleLine38.submodDeclLine45.0.file ./declaration-positions.nix
 # New options under freeform submodules get collected into the parent submodule
 # (consistent with .declarations behaviour, but weird; notably appears in system.build)
-checkConfigOutput '^34|23$' options.submoduleLine34.declarationPositions.0.line ./declaration-positions.nix
-checkConfigOutput '^34|23$' options.submoduleLine34.declarationPositions.1.line ./declaration-positions.nix
+checkConfigOutput '^38|27$' options.submoduleLine38.declarationPositions.0.line ./declaration-positions.nix
+checkConfigOutput '^38|27$' options.submoduleLine38.declarationPositions.1.line ./declaration-positions.nix
 # nested options work
-checkConfigOutput '^30$' options.nested.nestedLine30.declarationPositions.0.line ./declaration-positions.nix
+checkConfigOutput '^34$' options.nested.nestedLine34.declarationPositions.0.line ./declaration-positions.nix
 
 cat <<EOF
 ====== module tests ======

--- a/lib/tests/modules/declaration-positions.nix
+++ b/lib/tests/modules/declaration-positions.nix
@@ -1,13 +1,17 @@
 { lib, options, ... }:
-let discardPositions = lib.mapAttrs (k: v: v);
+let
+  discardPositions = lib.mapAttrs (k: v: v);
 in
 # unsafeGetAttrPos is unspecified best-effort behavior, so we only want to consider this test on an evaluator that satisfies some basic assumptions about this function.
 assert builtins.unsafeGetAttrPos "a" { a = true; } != null;
-assert builtins.unsafeGetAttrPos "a" (discardPositions { a = true; }) == null;
+assert
+  builtins.unsafeGetAttrPos "a" (discardPositions {
+    a = true;
+  }) == null;
 {
   imports = [
     {
-      options.imported.line10 = lib.mkOption {
+      options.imported.line14 = lib.mkOption {
         type = lib.types.int;
       };
 
@@ -15,35 +19,39 @@ assert builtins.unsafeGetAttrPos "a" (discardPositions { a = true; }) == null;
       # programs.firefox.nativeMessagingHosts.ff2mpv. We don't expect to get
       # line numbers for these, but we can fall back on knowing the file.
       options.generated = discardPositions {
-        line18 = lib.mkOption {
+        line22 = lib.mkOption {
           type = lib.types.int;
         };
       };
 
-      options.submoduleLine34.extraOptLine23 = lib.mkOption {
+      options.submoduleLine38.extraOptLine27 = lib.mkOption {
         default = 1;
         type = lib.types.int;
       };
     }
   ];
 
-  options.nested.nestedLine30 = lib.mkOption {
+  options.nested.nestedLine34 = lib.mkOption {
     type = lib.types.int;
   };
 
-  options.submoduleLine34 = lib.mkOption {
+  options.submoduleLine38 = lib.mkOption {
     default = { };
     type = lib.types.submoduleWith {
       modules = [
-        ({ options, ... }: {
-          options.submodDeclLine39 = lib.mkOption { };
-        })
+        (
+          { options, ... }:
+          {
+            options.submodDeclLine45 = lib.mkOption { };
+          }
+        )
         { freeformType = with lib.types; lazyAttrsOf (uniq unspecified); }
       ];
     };
   };
 
   config = {
-    submoduleLine34.submodDeclLine39 = (options.submoduleLine34.type.getSubOptions [ ]).submodDeclLine39.declarationPositions;
+    submoduleLine38.submodDeclLine45 =
+      (options.submoduleLine38.type.getSubOptions [ ]).submodDeclLine45.declarationPositions;
   };
 }

--- a/pkgs/applications/editors/vim/plugins/get-plugins.nix
+++ b/pkgs/applications/editors/vim/plugins/get-plugins.nix
@@ -1,19 +1,28 @@
-with import <localpkgs> {};
+with import <localpkgs> { };
 let
-  inherit (vimUtils.override {inherit vim;}) buildVimPlugin;
+  inherit (vimUtils.override { inherit vim; }) buildVimPlugin;
   inherit (neovimUtils) buildNeovimPlugin;
 
   generated = callPackage <localpkgs/pkgs/applications/editors/vim/plugins/generated.nix> {
     inherit buildNeovimPlugin buildVimPlugin;
-  } {} {};
-  hasChecksum = value:
-    lib.isAttrs value && lib.hasAttrByPath ["src" "outputHash"] value;
-  getChecksum = name: value:
-    if hasChecksum value then {
-      submodules = value.src.fetchSubmodules or false;
-      sha256 = value.src.outputHash;
-      rev = value.src.rev;
-    } else null;
+  } { } { };
+  hasChecksum =
+    value:
+    lib.isAttrs value
+    && lib.hasAttrByPath [
+      "src"
+      "outputHash"
+    ] value;
+  getChecksum =
+    name: value:
+    if hasChecksum value then
+      {
+        submodules = value.src.fetchSubmodules or false;
+        sha256 = value.src.outputHash;
+        rev = value.src.rev;
+      }
+    else
+      null;
   checksums = lib.mapAttrs getChecksum generated;
 in
-  lib.filterAttrs (n: v: v != null) checksums
+lib.filterAttrs (n: v: v != null) checksums

--- a/pkgs/build-support/trivial-builders/test/references/apath.txt
+++ b/pkgs/build-support/trivial-builders/test/references/apath.txt
@@ -1,0 +1,1 @@
+Just some text

--- a/pkgs/build-support/trivial-builders/test/references/samples.nix
+++ b/pkgs/build-support/trivial-builders/test/references/samples.nix
@@ -18,8 +18,8 @@
   norefsDup = writeText "hi" "hello";
   helloRef = writeText "hi" "hello ${hello}";
   helloRefDup = writeText "hi" "hello ${hello}";
-  path = ./samples.nix;
-  pathLike.outPath = ./samples.nix;
+  path = ./apath.txt;
+  pathLike.outPath = ./apath.txt;
   helloFigletRef = writeText "hi" "hello ${hello} ${figlet}";
   selfRef = runCommand "self-ref-1" { } "echo $out >$out";
   selfRef2 = runCommand "self-ref-2" { } ''echo "${figlet}, $out" >$out'';

--- a/pkgs/tools/nix/info/multiuser.nix
+++ b/pkgs/tools/nix/info/multiuser.nix
@@ -1,12 +1,11 @@
 let
-  pkgs = import <nixpkgs> {};
-in pkgs.runCommand "diagnostics-multiuser"
-  {  }
-  ''
-    set -x
-    # no cache: ${toString builtins.currentTime}
-    # For reproducibility, nix always uses nixbld group:
-    # https://github.com/NixOS/nix/blob/1dd29d7aebae706f3e90a18bbfae727f2ed03c70/src/libstore/build.cc#L1896-L1908
-    test "$(groups)" == "nixbld"
-    touch $out
-  ''
+  pkgs = import <nixpkgs> { };
+in
+pkgs.runCommand "diagnostics-multiuser" { } ''
+  set -x
+  # no cache: ${toString builtins.currentTime}
+  # For reproducibility, nix always uses nixbld group:
+  # https://github.com/NixOS/nix/blob/1dd29d7aebae706f3e90a18bbfae727f2ed03c70/src/libstore/build.cc#L1896-L1908
+  test "$(groups)" == "nixbld"
+  touch $out
+''

--- a/pkgs/tools/nix/info/relaxedsandbox.nix
+++ b/pkgs/tools/nix/info/relaxedsandbox.nix
@@ -1,6 +1,7 @@
 let
-  pkgs = import <nixpkgs> {};
-in pkgs.runCommand "diagnostics-sandbox"
+  pkgs = import <nixpkgs> { };
+in
+pkgs.runCommand "diagnostics-sandbox"
   {
     __noChroot = true;
   }

--- a/pkgs/tools/nix/info/sandbox.nix
+++ b/pkgs/tools/nix/info/sandbox.nix
@@ -1,10 +1,9 @@
 let
-  pkgs = import <nixpkgs> {};
-in pkgs.runCommand "diagnostics-sandbox"
-  { }
-  ''
-    set -x
-    # no cache: ${toString builtins.currentTime}
-    test -d "$(dirname "$out")/../var/nix"
-    touch $out
-  ''
+  pkgs = import <nixpkgs> { };
+in
+pkgs.runCommand "diagnostics-sandbox" { } ''
+  set -x
+  # no cache: ${toString builtins.currentTime}
+  test -d "$(dirname "$out")/../var/nix"
+  touch $out
+''


### PR DESCRIPTION
## Description of changes
This is motivated by https://github.com/NixOS/nixpkgs/pull/322537, which I'd like to get close to 0 rebuilds, although due to the nature of that PR not formatting files modified by other PRs, me making _this_ PR makes the other PR avoid these files entirely, so this PR doesn't have to be merged before the other one.

This PR either avoids Nix files ending up in the build result (so that changing them won't cause rebuilds), or formats Nix files in advance, so that they don't need to be changed in the treewide reformat.

This is effectively part of https://github.com/NixOS/nixpkgs/issues/301014

## Things done
- [x] Built all the changed derivations

---

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
