### PR TITLE
epson-escpr: 1.7.20 -> 1.8.5

### DIFF
--- a/pkgs/by-name/ep/epson-escpr/package.nix
+++ b/pkgs/by-name/ep/epson-escpr/package.nix
@@ -21,7 +21,7 @@ in stdenv.mkDerivation rec {
 
   patches = [ ./cups-filter-ppd-dirs.patch ];
 
-  buildInputs = [ cups ];
+  buildInputs = [ cups rpm cpio ];
 
   unpackPhase = ''
     runHook preUnpack
@@ -34,7 +34,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "https://download.ebz.epson.net/dsc/du/02/DriverDownloadInfo.do?LG2=EN&CN2=&DSCMI=156882&DSCCHK=031e5c220930be9458438571a1fdeedb7dfcb8a6";
+    homepage = "http://download.ebz.epson.net/dsc/search/01/search";
     description = "ESC/P-R Driver (generic driver)";
     longDescription = ''
       Epson Inkjet Printer Driver (ESC/P-R) for Linux and the

--- a/pkgs/by-name/ep/epson-escpr/package.nix
+++ b/pkgs/by-name/ep/epson-escpr/package.nix
@@ -1,9 +1,10 @@
-{ lib, stdenv, fetchurl, cups }:
+{ lib, stdenv, fetchurl, cups, rpm, cpio }:
 
-let version = "1.7.20";
-in stdenv.mkDerivation {
+let
+  fullname = "epson-inkjet-printer-escpr";
+in stdenv.mkDerivation rec {
   pname = "epson-escpr";
-  inherit version;
+  version = "1.8.5";
 
   src = fetchurl {
     # To find new versions, visit
@@ -12,19 +13,28 @@ in stdenv.mkDerivation {
     # version.
     # NOTE: Don't forget to update the webarchive link too!
     urls = [
-      "https://download3.ebz.epson.net/dsc/f/03/00/13/76/45/5ac2ea8f9cf94a48abd64afd0f967f98c4fc24aa/epson-inkjet-printer-escpr-${version}-1lsb3.2.tar.gz"
-
-      "https://web.archive.org/web/https://download3.ebz.epson.net/dsc/f/03/00/13/76/45/5ac2ea8f9cf94a48abd64afd0f967f98c4fc24aa/epson-inkjet-printer-escpr-${version}-1lsb3.2.tar.gz"
+      "https://download3.ebz.epson.net/dsc/f/03/00/15/68/85/403b320df777490a52c42030397edd10363b2c56/${fullname}-1.8.5-1.src.rpm"
+      "https://web.archive.org/web/20241109053348/https://download3.ebz.epson.net/dsc/f/03/00/15/68/85/403b320df777490a52c42030397edd10363b2c56/${fullname}-1.8.5-1.src.rpm"
     ];
-    sha256 = "sha256:09rscpm557dgaflylr93wcwmyn6fnvr8nc77abwnq97r6hxwrkhk";
+    sha256 = "1m2061mqlsrgq5ykjg6m0s2708g727xckk0kxwh64dk15n8ki1lx";
   };
 
   patches = [ ./cups-filter-ppd-dirs.patch ];
 
   buildInputs = [ cups ];
 
+  unpackPhase = ''
+    runHook preUnpack
+
+    ${lib.getBin rpm}/bin/rpm2cpio $src | ${lib.getBin cpio}/bin/cpio -idmv
+    tar -xvf ${fullname}-${version}-1.tar.gz
+    cd ${fullname}-${version}
+
+    runHook postUnpack
+  '';
+
   meta = with lib; {
-    homepage = "http://download.ebz.epson.net/dsc/search/01/search/";
+    homepage = "https://download.ebz.epson.net/dsc/du/02/DriverDownloadInfo.do?LG2=EN&CN2=&DSCMI=156882&DSCCHK=031e5c220930be9458438571a1fdeedb7dfcb8a6";
     description = "ESC/P-R Driver (generic driver)";
     longDescription = ''
       Epson Inkjet Printer Driver (ESC/P-R) for Linux and the


### PR DESCRIPTION
## Description of changes
Routine update. Couldn't find source tarballs beside the source rpm.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
