### PR TITLE
opensearch-benchmark: init at 1.7.1

### DIFF
--- a/pkgs/by-name/op/opensearch-benchmark/package.nix
+++ b/pkgs/by-name/op/opensearch-benchmark/package.nix
@@ -1,0 +1,90 @@
+{ lib
+, python3
+, fetchPypi
+}:
+let
+  python = python3.override {
+    packageOverrides = self: super: {
+      opensearch-py = super.opensearch-py.overridePythonAttrs (oldAttrs: {
+        nativeCheckInputs = (oldAttrs.nativeCheckInputs or [ ]) ++ [
+          python.pkgs.events
+        ];
+        dependencies = (oldAttrs.dependencies or [ ]) ++ [
+          python.pkgs.events
+        ];
+      });
+      thespian = super.thespian.overridePythonAttrs (oldAttrs: rec {
+        pname = "thespian";
+        version = "3.10.6";
+        src = fetchPypi {
+          inherit pname version;
+          extension = "zip";
+          hash = "sha256-yYeoBCuiMD4iNx84pnNUWT3YHEwRuh66f2ZXQJKI1e0=";
+        };
+      });
+    };
+  };
+in
+python.pkgs.buildPythonApplication rec {
+  pname = "opensearch-benchmark";
+  version = "1.7.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "opensearch_benchmark";
+    inherit version;
+    hash = "sha256-a5sNlekrLFo4MAxPNHmdFiaQXXx63O9ChhhAlIdoB3U=";
+  };
+
+  nativeBuildInputs = with python.pkgs;[
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = with python.pkgs;[
+    boto3
+    certifi
+    google-auth
+    google-resumable-media
+    h5py
+    ijson
+    jinja2
+    jsonschema
+    markupsafe
+    numpy
+    opensearch-py
+    opensearch-py.optional-dependencies.async
+    psutil
+    py-cpuinfo
+    tabulate
+    thespian
+    setuptools
+    wheel
+    yappi
+    zstandard
+  ];
+
+  passthru.optional-dependencies = with python.pkgs; {
+    develop = [
+      coverage
+      github3-py
+      pylint
+      pylint-quotes
+      pytest
+      pytest-asyncio
+      pytest-benchmark
+      tox
+      twine
+      ujson
+      wheel
+    ];
+  };
+
+  meta = {
+    description = "Macrobenchmarking framework for OpenSearch";
+    homepage = "https://pypi.org/project/opensearch-benchmark/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ByteSudoer ];
+    mainProgram = "opensearch-benchmark";
+  };
+}

--- a/pkgs/development/python-modules/pylint-quotes/default.nix
+++ b/pkgs/development/python-modules/pylint-quotes/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, wheel
+, pylint
+}:
+
+buildPythonPackage rec {
+  pname = "pylint-quotes";
+  version = "0.2.3";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-LWuz+ooaha86+KDKh1pxmsW823NcRXVihGmdgJwQnJU=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    pylint
+  ];
+
+  meta = {
+    description = "Quote consistency checker for PyLint";
+    homepage = "https://pypi.org/project/pylint-quotes/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ByteSudoer ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11473,6 +11473,8 @@ self: super: with self; {
 
   pylint-plugin-utils = callPackage ../development/python-modules/pylint-plugin-utils { };
 
+  pylint-quotes = callPackage ../development/python-modules/pylint-quotes { };
+
   pylint-venv = callPackage ../development/python-modules/pylint-venv { };
 
   pylion = callPackage ../development/python-modules/pylion { };


### PR DESCRIPTION
## Description of changes
Project description

OpenSearch Benchmark is a macrobenchmark utility provided by the OpenSearch Project

Metadata
- homepage URL: https://opensearch.org/docs/latest/benchmark/
- source URL: https://github.com/opensearch-project/opensearch-benchmark
- license: Apache 2.0
- platforms: Docker, Linux (via pip), Windows (via pip)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
