### PR TITLE
unilang: init at 0.13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16845,6 +16845,12 @@
     name = "Roland Conybeare";
     keys = [ { fingerprint = "bw5Cr/4ul1C2UvxopphbZbFI1i5PCSnOmPID7mJ/Ogo"; } ];
   };
+  rc-zb = {
+    name = "rczb";
+    email = "rc-zb@outlook.com";
+    github = "rc-zb";
+    githubId = 161540043;
+  };
   rdnetto = {
     email = "rdnetto@gmail.com";
     github = "rdnetto";

--- a/pkgs/by-name/un/unilang/package.nix
+++ b/pkgs/by-name/un/unilang/package.nix
@@ -1,0 +1,115 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  libffi,
+  qt5,
+  lld,
+  parallel,
+  pkg-config,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "unilang";
+  version = "0.13";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = "unilang";
+    rev = "V" + finalAttrs.version;
+    hash = "sha256-GWY9FtbX3+FrxRSKWPcJKXm43tWF6AHggjaLr3YtN/8=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    lld
+    parallel
+    pkg-config
+    qt5.qtbase
+    qt5.qtdeclarative
+    qt5.wrapQtAppsHook
+  ];
+
+  patchPhase = ''
+    runHook prePatch
+
+    # `std.txt` is a component of Unilang installation, and must be kept in the output.
+    substituteInPlace ./src/Main.cpp \
+        --replace-fail \"std.txt\" \"$out/lib/std.txt\"
+
+    # Trim the shabang.
+    sed --in-place --expression='1{/^#!/d}' ./build.sh
+
+    runHook postPatch
+  '';
+
+  postPatch = ''
+    # Trim the shabang.
+    sed --in-place --expression='1{/^#!/d}' ./test.sh
+
+    # Change the paths of test logs.
+    mkdir -p ./test
+    substituteInPlace ./test.sh \
+        --replace-fail =/tmp/out =$(pwd)/test/out.log \
+        --replace-fail =/tmp/err =$(pwd)/test/err.log
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    export Unilang_Output=$out/bin/unilang
+    export Unilang_BuildDir=$(pwd)/build/
+    export UNILANG_NO_LLVM=0; # LLVM-based JIT is disabled for lack of LLVM 7.
+    export LDFLAGS=-fuse-ld=lld
+    ./build.sh
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    cp ./std.txt $out/lib/
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    export UNILANG=$out/bin/unilang
+    ./test.sh
+
+    runHook postInstallCheck
+  '';
+
+  qtWrapperArgs =
+    let
+      runtimeLibPath = lib.strings.makeLibraryPath [
+        libffi
+        qt5.qtbase
+        qt5.qtdeclarative
+        stdenv.cc.cc.lib
+      ];
+    in
+    [ "--suffix LD_LIBRARY_PATH : ${runtimeLibPath}" ];
+
+  meta = {
+    description = "General purpose programming language";
+    longDescription = ''
+      Unilang is a general purpose programming language project proposed to
+      adapt to more effective and flexible development of desktop environment
+      applications.
+    '';
+    homepage = "https://github.com/linuxdeepin/unilang/";
+    changelog =
+      # Currently zh-CN only.
+      "https://github.com/linuxdeepin/unilang/raw/V${finalAttrs.version}/ReleaseNotes.zh-CN.md";
+    license = lib.licenses.bsd2Patent;
+    maintainers = with lib.maintainers; [ rc-zb ];
+    mainProgram = "unilang";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Add the reference implementation of [Unilang](https://github.com/linuxdeepin/unilang/), a general purpose programming language by [UnionTech Software Technology Co., Ltd. (统信软件技术有限公司)](https://www.uniontech.com/).

And add myself to the maintainer lists of Nixpkgs and this package.

### Limitations

- LLVM-based JIT is disabled for lack of LLVM 7 (the version specified by the upstream; I haven't tested whether some other versions work).
- The upstream [`init.txt`](https://github.com/linuxdeepin/unilang/blob/9c4eb374fcdd7af02f35f4730bb7c0db36fa836e/init.txt) that "implements the new high-level language syntaxes" is not included, for that it seems to be expected to be supplied by the user and [put in the current working directory](https://github.com/linuxdeepin/unilang/blob/9c4eb374fcdd7af02f35f4730bb7c0db36fa836e/doc/Interpreter.zh-CN.md#%E7%94%A8%E6%88%B7%E7%8E%AF%E5%A2%83%E5%88%9D%E5%A7%8B%E5%8C%96).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
