### PR TITLE
k3s: use team for maintainers

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -496,6 +496,20 @@ with lib.maintainers;
     shortName = "Jupyter";
   };
 
+  k3s = {
+    githubTeams = [ "k3s" ];
+    members = [
+      euank
+      marcusramberg
+      mic92
+      superherointj
+      wrmilling
+      yajo
+    ];
+    scope = "Maintain K3s package, NixOS module, NixOS tests, update script";
+    shortName = "K3s";
+  };
+
   kubernetes = {
     members = [
       johanot

--- a/nixos/modules/services/cluster/k3s/default.nix
+++ b/nixos/modules/services/cluster/k3s/default.nix
@@ -432,4 +432,6 @@ in
       };
     };
   };
+
+  meta.maintainers = lib.teams.k3s.members;
 }

--- a/nixos/tests/k3s/auto-deploy.nix
+++ b/nixos/tests/k3s/auto-deploy.nix
@@ -118,5 +118,7 @@ import ../make-test-python.nix (
 
       machine.shutdown()
     '';
+
+    meta.maintainers = lib.teams.k3s.members;
   }
 )

--- a/nixos/tests/k3s/default.nix
+++ b/nixos/tests/k3s/default.nix
@@ -7,6 +7,8 @@ let
   allK3s = lib.filterAttrs (n: _: lib.strings.hasPrefix "k3s_" n) pkgs;
 in
 {
+  # Test whether container images are imported and auto deploying manifests work
+  auto-deploy = lib.mapAttrs (_: k3s: import ./auto-deploy.nix { inherit system pkgs k3s; }) allK3s;
   # Testing K3s with Etcd backend
   etcd = lib.mapAttrs (
     _: k3s:
@@ -19,6 +21,4 @@ in
   single-node = lib.mapAttrs (_: k3s: import ./single-node.nix { inherit system pkgs k3s; }) allK3s;
   # Run a multi-node k3s cluster and verify pod networking works across nodes
   multi-node = lib.mapAttrs (_: k3s: import ./multi-node.nix { inherit system pkgs k3s; }) allK3s;
-  # Test wether container images are imported and auto deploying manifests work
-  auto-deploy = lib.mapAttrs (_: k3s: import ./auto-deploy.nix { inherit system pkgs k3s; }) allK3s;
 }

--- a/nixos/tests/k3s/etcd.nix
+++ b/nixos/tests/k3s/etcd.nix
@@ -125,6 +125,6 @@ import ../make-test-python.nix (
           etcd.shutdown()
     '';
 
-    meta.maintainers = etcd.meta.maintainers ++ k3s.meta.maintainers;
+    meta.maintainers = etcd.meta.maintainers ++ lib.teams.k3s.members;
   }
 )

--- a/nixos/tests/k3s/multi-node.nix
+++ b/nixos/tests/k3s/multi-node.nix
@@ -189,8 +189,6 @@ import ../make-test-python.nix (
         };
     };
 
-    meta.maintainers = k3s.meta.maintainers;
-
     testScript = ''
       machines = [server, server2, agent]
       for m in machines:
@@ -239,5 +237,7 @@ import ../make-test-python.nix (
       for m in machines:
           m.shutdown()
     '';
+
+    meta.maintainers = lib.teams.k3s.members;
   }
 )

--- a/nixos/tests/k3s/single-node.nix
+++ b/nixos/tests/k3s/single-node.nix
@@ -40,7 +40,6 @@ import ../make-test-python.nix (
   in
   {
     name = "${k3s.name}-single-node";
-    meta.maintainers = k3s.meta.maintainers;
 
     nodes.machine =
       { pkgs, ... }:
@@ -120,5 +119,7 @@ import ../make-test-python.nix (
 
         machine.shutdown()
       '';
+
+    meta.maintainers = lib.teams.k3s.members;
   }
 )

--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -92,14 +92,7 @@ let
     description = "Lightweight Kubernetes distribution";
     license = licenses.asl20;
     homepage = "https://k3s.io";
-    maintainers = with maintainers; [
-      euank
-      mic92
-      marcusramberg
-      superherointj
-      wrmilling
-      yajo
-    ];
+    maintainers = lib.teams.k3s.members;
     platforms = platforms.linux;
 
     # resolves collisions with other installations of kubectl, crictl, ctr

--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -419,6 +419,7 @@ buildGoModule rec {
       k3s_version = "k3s_" + lib.replaceStrings [ "." ] [ "_" ] (lib.versions.majorMinor version);
     in
     {
+      auto-deploy = nixosTests.k3s.auto-deploy.${k3s_version};
       etcd = nixosTests.k3s.etcd.${k3s_version};
       single-node = nixosTests.k3s.single-node.${k3s_version};
       multi-node = nixosTests.k3s.multi-node.${k3s_version};


### PR DESCRIPTION
k3s: use team for maintainers

- eliminates duplication of places to log maintainers.
- adds missing entries of upkeep.

For awareness, all K3s maintainers have maintainer privileges at [teams](https://github.com/orgs/NixOS/teams/k3s). Which enables to manipulate the maintainers list as needed to sync [team-list.nix](https://github.com/NixOS/nixpkgs/blob/master/maintainers/team-list.nix).

CC @marcusramberg @yajo @Mic92 @euank @wrmilling 