### PR TITLE
qgis-ltr: fix pyqt patch

### DIFF
--- a/pkgs/applications/gis/qgis/set-pyqt-package-dirs-ltr.patch
+++ b/pkgs/applications/gis/qgis/set-pyqt-package-dirs-ltr.patch
@@ -1,0 +1,59 @@
+diff --git a/cmake/FindPyQt5.cmake b/cmake/FindPyQt5.cmake
+index b51fd0075e..87ee317e05 100644
+--- a/cmake/FindPyQt5.cmake
++++ b/cmake/FindPyQt5.cmake
+@@ -25,7 +25,7 @@ ELSE(EXISTS PYQT5_VERSION_STR)
+   IF(SIP_BUILD_EXECUTABLE)
+     # SIP >= 5.0 path
+ 
+-    FILE(GLOB _pyqt5_metadata "${Python_SITEARCH}/PyQt5-*.dist-info/METADATA")
++    FILE(GLOB _pyqt5_metadata "@pyQt5PackageDir@/PyQt5-*.dist-info/METADATA")
+     IF(_pyqt5_metadata)
+       FILE(READ ${_pyqt5_metadata} _pyqt5_metadata_contents)
+       STRING(REGEX REPLACE ".*\nVersion: ([^\n]+).*$" "\\1" PYQT5_VERSION_STR ${_pyqt5_metadata_contents})
+@@ -34,8 +34,8 @@ ELSE(EXISTS PYQT5_VERSION_STR)
+     ENDIF(_pyqt5_metadata)
+ 
+     IF(PYQT5_VERSION_STR)
+-      SET(PYQT5_MOD_DIR "${Python_SITEARCH}/PyQt5")
+-      SET(PYQT5_SIP_DIR "${Python_SITEARCH}/PyQt5/bindings")
++      SET(PYQT5_MOD_DIR "@pyQt5PackageDir@/PyQt5")
++      SET(PYQT5_SIP_DIR "@pyQt5PackageDir@/PyQt5/bindings")
+       FIND_PROGRAM(__pyuic5 "pyuic5")
+       GET_FILENAME_COMPONENT(PYQT5_BIN_DIR ${__pyuic5} DIRECTORY)
+ 
+diff --git a/cmake/FindQsci.cmake b/cmake/FindQsci.cmake
+index 69e41c1fe9..5456c3d59b 100644
+--- a/cmake/FindQsci.cmake
++++ b/cmake/FindQsci.cmake
+@@ -24,7 +24,7 @@ ELSE(QSCI_MOD_VERSION_STR)
+   IF(SIP_BUILD_EXECUTABLE)
+     # SIP >= 5.0 path
+ 
+-    FILE(GLOB _qsci_metadata "${Python_SITEARCH}/QScintilla*.dist-info/METADATA")
++    FILE(GLOB _qsci_metadata "@qsciPackageDir@/QScintilla*.dist-info/METADATA")
+     IF(_qsci_metadata)
+       FILE(READ ${_qsci_metadata} _qsci_metadata_contents)
+       STRING(REGEX REPLACE ".*\nVersion: ([^\n]+).*$" "\\1" QSCI_MOD_VERSION_STR ${_qsci_metadata_contents})
+@@ -33,7 +33,7 @@ ELSE(QSCI_MOD_VERSION_STR)
+     ENDIF(_qsci_metadata)
+ 
+     IF(QSCI_MOD_VERSION_STR)
+-      SET(QSCI_SIP_DIR "${PYQT_SIP_DIR}")
++      SET(QSCI_SIP_DIR "@qsciPackageDir@/PyQt5/bindings")
+       SET(QSCI_FOUND TRUE)
+     ENDIF(QSCI_MOD_VERSION_STR)
+ 
+diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
+index 4cd19c3af4..668cc6a5e6 100644
+--- a/python/CMakeLists.txt
++++ b/python/CMakeLists.txt
+@@ -212,7 +212,7 @@ if (WITH_GUI)
+     install(FILES ${QGIS_PYTHON_OUTPUT_DIRECTORY}/_gui.pyi DESTINATION ${QGIS_PYTHON_DIR})
+   endif()
+   if(QSCI_SIP_DIR)
+-    set(SIP_EXTRA_OPTIONS ${SIP_EXTRA_OPTIONS} -I ${QSCI_SIP_DIR})
++    set(SIP_BUILD_EXTRA_OPTIONS ${SIP_BUILD_EXTRA_OPTIONS} --include-dir=${QSCI_SIP_DIR})
+   else()
+     message(STATUS "Qsci sip file not found - disabling bindings for derived classes")
+     set(SIP_DISABLE_FEATURES ${SIP_DISABLE_FEATURES} HAVE_QSCI_SIP)

--- a/pkgs/applications/gis/qgis/unwrapped-ltr.nix
+++ b/pkgs/applications/gis/qgis/unwrapped-ltr.nix
@@ -139,7 +139,7 @@ in mkDerivation rec {
 
   patches = [
     (substituteAll {
-      src = ./set-pyqt-package-dirs.patch;
+      src = ./set-pyqt-package-dirs-ltr.patch;
       pyQt5PackageDir = "${py.pkgs.pyqt5}/${py.pkgs.python.sitePackages}";
       qsciPackageDir = "${py.pkgs.qscintilla-qt5}/${py.pkgs.python.sitePackages}";
     })


### PR DESCRIPTION
## Description of changes

Fix pyqt dirs patch which I broke in 09087b56f09595a5a9e650ad027b8836bf94bbe1 .

This PR is adding `set-pyqt-package-dirs-ltr.patch` file which is exactly the same as `set-pyqt-package-dirs.patch` until it was modified for QGIS 3.38.0. In other words, it keeps the original pyqt dirs patch for `qgis-ltr` version.

`qgis-ltr` is failing to build without this PR.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
