### PR TITLE
sabnzbd: override sabctools version and add updateScript

### DIFF
--- a/pkgs/by-name/sa/sabnzbd/package.nix
+++ b/pkgs/by-name/sa/sabnzbd/package.nix
@@ -1,53 +1,65 @@
-{ lib, stdenv
-, coreutils
-, fetchFromGitHub
-, python3
-, par2cmdline-turbo
-, unzip
-, unrar
-, p7zip
-, util-linux
-, makeWrapper
-, nixosTests
+{
+  lib,
+  stdenv,
+  coreutils,
+  fetchFromGitHub,
+  python3,
+  par2cmdline-turbo,
+  unzip,
+  unrar,
+  p7zip,
+  util-linux,
+  makeWrapper,
+  nixosTests,
 }:
 
 let
-  pythonEnv = python3.withPackages(ps: with ps; [
-    apprise
-    babelfish
-    cffi
-    chardet
-    cheetah3
-    cheroot
-    cherrypy
-    configobj
-    cryptography
-    feedparser
-    guessit
-    jaraco-classes
-    jaraco-collections
-    jaraco-context
-    jaraco-functools
-    jaraco-text
-    more-itertools
-    notify2
-    orjson
-    portend
-    puremagic
-    pycparser
-    pysocks
-    python-dateutil
-    pytz
-    rebulk
-    sabctools
-    sabyenc3
-    sgmllib3k
-    six
-    tempora
-    zc-lockfile
-  ]);
-  path = lib.makeBinPath [ coreutils par2cmdline-turbo unrar unzip p7zip util-linux ];
-in stdenv.mkDerivation rec {
+  pythonEnv = python3.withPackages (
+    ps: with ps; [
+      apprise
+      babelfish
+      cffi
+      chardet
+      cheetah3
+      cheroot
+      cherrypy
+      configobj
+      cryptography
+      feedparser
+      guessit
+      jaraco-classes
+      jaraco-collections
+      jaraco-context
+      jaraco-functools
+      jaraco-text
+      more-itertools
+      notify2
+      orjson
+      portend
+      puremagic
+      pycparser
+      pysocks
+      python-dateutil
+      pytz
+      rebulk
+      sabctools
+      sabyenc3
+      sgmllib3k
+      six
+      tempora
+      zc-lockfile
+    ]
+  );
+  path = lib.makeBinPath [
+    coreutils
+    par2cmdline-turbo
+    unrar
+    unzip
+    p7zip
+    util-linux
+  ];
+in
+stdenv.mkDerivation rec {
   version = "4.3.2";
   pname = "sabnzbd";
 
@@ -83,7 +95,10 @@ in stdenv.mkDerivation rec {
     homepage = "https://sabnzbd.org";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with lib.maintainers; [ jojosch adamcstephens ];
+    maintainers = with lib.maintainers; [
+      jojosch
+      adamcstephens
+    ];
     mainProgram = "sabnzbd";
   };
 }

--- a/pkgs/by-name/sa/sabnzbd/package.nix
+++ b/pkgs/by-name/sa/sabnzbd/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   coreutils,
   fetchFromGitHub,
+  fetchPypi,
   python3,
   par2cmdline-turbo,
   unzip,
@@ -14,6 +15,9 @@
 }:
 
 let
+  sabctoolsVersion = "8.2.0";
+  sabctoolsHash = "sha256-dOMNZoKWQxHJt6yHiNKVtpnYvLJkK8nktOm+djsSTcM=";
+
   pythonEnv = python3.withPackages (
     ps: with ps; [
       apprise
@@ -42,7 +46,15 @@ let
       python-dateutil
       pytz
       rebulk
-      sabctools
+      # sabnzbd requires a specific version of sabctools
+      (sabctools.overridePythonAttrs (old: {
+        version = sabctoolsVersion;
+        src = fetchPypi {
+          pname = "sabctools";
+          version = sabctoolsVersion;
+          hash = sabctoolsHash;
+        };
+      }))
       sabyenc3
       sgmllib3k
       six
@@ -86,8 +98,9 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.tests = {
-    smoke-test = nixosTests.sabnzbd;
+  passthru = {
+    tests.smoke-test = nixosTests.sabnzbd;
+    updateScript = ./update.sh;
   };
 
   meta = with lib; {

--- a/pkgs/by-name/sa/sabnzbd/update.sh
+++ b/pkgs/by-name/sa/sabnzbd/update.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix common-updater-scripts gnugrep gnused nurl
+
+# shellcheck shell=bash
+
+set -euo pipefail
+
+latestVersion=$(list-git-tags --url=https://github.com/sabnzbd/sabnzbd | grep -E '^[0-9.]+$' | sort --reverse --numeric-sort | head -n 1)
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; sabnzbd.version or (lib.getVersion sabnzbd)" | tr -d '"')
+
+if [[ "$latestVersion" == "$currentVersion" ]]; then
+    echo "sabnzbd already latest version $latestVersion"
+    exit 0
+fi
+
+echo "sabnzbd updating $currentVersion -> $latestVersion"
+update-source-version sabnzbd "$latestVersion"
+
+sabctoolsVersion=$(curl -s "https://raw.githubusercontent.com/sabnzbd/sabnzbd/$latestVersion/requirements.txt" | grep sabctools | cut -f 3 -d =)
+sabctoolsHash=$(nurl --hash https://pypi.org/project/sabctools "$sabctoolsVersion")
+
+sed -i -E -e "s#sabctoolsVersion = \".*\"#sabctoolsVersion = \"$sabctoolsVersion\"#" ./pkgs/by-name/sa/sabnzbd/package.nix
+sed -i -E -e "s#sabctoolsHash = \".*\"#sabctoolsHash = \"$sabctoolsHash\"#" ./pkgs/by-name/sa/sabnzbd/package.nix

--- a/pkgs/development/python-modules/sabctools/default.nix
+++ b/pkgs/development/python-modules/sabctools/default.nix
@@ -7,7 +7,7 @@
 }:
 buildPythonPackage rec {
   pname = "sabctools";
-  version = "8.2.3"; # needs to match version sabnzbd expects, e.g. https://github.com/sabnzbd/sabnzbd/blob/4.0.x/requirements.txt#L3
+  version = "8.2.3";
   pyproject = true;
 
   src = fetchPypi {


### PR DESCRIPTION
## Description of changes

sabnzbd requires a specific version of sabctools. Instead of trying to keep back sabctools, which is published independently and could be used externally, let's instead track and override in sabnzbd itself.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
