### PR TITLE
nixos/tiny-dfr: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -150,6 +150,8 @@
 
 - [Glance](https://github.com/glanceapp/glance), a self-hosted dashboard that puts all your feeds in one place. Available as [services.glance](option.html#opt-services.glance).
 
+- [tiny-dfr](https://github.com/WhatAmISupposedToPutHere/tiny-dfr), a tiny Apple touchbar display daemon. Available as [services.tiny-dfr](option.html#opt-services.tiny-dfr)
+
 - [Apache Tika](https://github.com/apache/tika), a toolkit that detects and extracts metadata and text from over a thousand different file types. Available as [services.tika](option.html#opt-services.tika).
 
 - [Misskey](https://misskey-hub.net/en/), an interplanetary microblogging platform. Available as [services.misskey](options.html#opt-services.misskey).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -615,6 +615,7 @@
   ./services/hardware/thermald.nix
   ./services/hardware/thinkfan.nix
   ./services/hardware/throttled.nix
+  ./services/hardware/tiny-dfr.nix
   ./services/hardware/tlp.nix
   ./services/hardware/trezord.nix
   ./services/hardware/triggerhappy.nix

--- a/nixos/modules/services/hardware/tiny-dfr.nix
+++ b/nixos/modules/services/hardware/tiny-dfr.nix
@@ -1,0 +1,127 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  inherit (lib) mkOption types;
+
+  toml = pkgs.formats.toml { };
+  filterConfig = lib.filterAttrsRecursive (_: v: v != null);
+  configFile = toml.generate "tiny-dfr.conf" (filterConfig cfg.settings);
+
+  cfg = config.services.tiny-dfr;
+in
+{
+  options = {
+    services.tiny-dfr = {
+      enable = lib.mkEnableOption "tiny-dfr, a tiny Apple touchbar daemon";
+      package = lib.mkPackageOption pkgs "tiny-dfr" { };
+
+      settings = mkOption {
+        description = ''
+          Freeform settings for tiny-dfr.
+
+          See [the template config](https://github.com/WhatAmISupposedToPutHere/tiny-dfr/blob/master/share/tiny-dfr/config.toml)
+          for a list of available options.
+
+          Passing `null` as a value will cause the key to not be set and the value from the template to be used.
+        '';
+        default = { };
+        type = types.submodule {
+          freeformType = toml.type;
+          options = {
+            MediaLayerDefault = mkOption {
+              description = "Whether the media layer (non-Fn keys) should be displayed by default. Hold the fn key to change layers.";
+              type = types.nullOr types.bool;
+              default = false;
+              example = true;
+            };
+            ShowButtonOutlines = mkOption {
+              description = "Whether to show the outline around icons.";
+              type = types.nullOr types.bool;
+              default = true;
+              example = false;
+            };
+            EnablePixelShift = mkOption {
+              description = "Shift the entire touchbar screen by a small amount periodically.";
+              type = types.nullOr types.bool;
+              default = false;
+              example = true;
+            };
+            FontTemplate = mkOption {
+              description = ''
+                The fontconfig pattern to use.
+
+                See the "Font Names" section in [the fontconfig docs](https://www.freedesktop.org/software/fontconfig/fontconfig-user.html)
+                for more information.
+              '';
+              type = types.nullOr types.str;
+              default = "";
+              example = ":bold";
+            };
+            AdaptiveBrightness = mkOption {
+              description = "Whether the touchbar screen should follow the primary screen's brightness.";
+              type = types.nullOr types.bool;
+              default = null;
+              example = true;
+            };
+            ActiveBrightness = mkOption {
+              description = "The brightness to use when adaptive brightness is disabled.";
+              type = types.nullOr types.ints.u8;
+              default = null;
+              example = 155;
+            };
+          };
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.udev.packages = [ cfg.package ];
+
+    # TODO: migrate to systemd.packages
+    systemd.services.tiny-dfr =
+      let
+        backlightDevices = [
+          "dev-tiny_dfr_display.device"
+          "dev-tiny_dfr_backlight.device"
+          "dev-tiny_dfr_display_backlight.device"
+        ];
+      in
+      {
+        enable = true;
+        description = "Tiny Apple Silicon touch bar daemon";
+        after = [
+          "systemd-user-sessions.service"
+          "getty@tty1.service"
+          "plymouth-quit.service"
+          "systemd-logind.service"
+        ] ++ backlightDevices;
+        bindsTo = backlightDevices;
+        startLimitIntervalSec = 30;
+        startLimitBurst = 2;
+        restartTriggers = [
+          cfg.package
+          configFile
+        ];
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = lib.getExe cfg.package;
+        };
+      };
+
+    systemd.units = {
+      "systemd-backlight@backlight:228200000.display-pipe.0.service" = { };
+      "systemd-backlight@backlight:appletb_backlight.service" = { };
+    };
+
+    environment.etc."tiny-dfr/config.toml" = {
+      source = configFile;
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ soopyc ];
+}


### PR DESCRIPTION
## Description of changes

Initialize the `tiny-dfr` module to facilitate configuration of the daemon.

Homepage: <https://github.com/WhatAmISupposedToPutHere/tiny-dfr>

Tested on the latest version of tiny-dfr as submitted as #326552

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
