### PR TITLE
vscode-langservers-extracted: avoid vscodium runtime dependencies by …

### DIFF
--- a/pkgs/development/tools/language-servers/vscode-langservers-extracted/default.nix
+++ b/pkgs/development/tools/language-servers/vscode-langservers-extracted/default.nix
@@ -1,24 +1,31 @@
-{ lib, stdenv, buildNpmPackage, fetchFromGitHub, vscodium, vscode-extensions }:
+{ lib, stdenv, buildNpmPackage, fetchFromGitHub, unzip, vscodium, vscode-extensions }:
 
 buildNpmPackage rec {
   pname = "vscode-langservers-extracted";
   version = "4.10.0";
 
-  src = fetchFromGitHub {
-    owner = "hrsh7th";
-    repo = pname;
-    rev = "v${version}";
-    hash = "sha256-3m9+HZY24xdlLcFKY/5DfvftqprwLJk0vve2ZO1aEWk=";
-  };
+  srcs =  [
+    (fetchFromGitHub {
+      owner = "hrsh7th";
+      repo = "vscode-langservers-extracted";
+      rev = "v${version}";
+      hash = "sha256-3m9+HZY24xdlLcFKY/5DfvftqprwLJk0vve2ZO1aEWk=";
+    })
+    vscodium.src
+  ];
+
+  sourceRoot = "source";
 
   npmDepsHash = "sha256-XGlFtmikUrnnWXsAYzTqw2K7Y2O0bUtYug0xXFIASBQ=";
+
+  nativeBuildInputs = [ unzip ];
 
   buildPhase =
     let
       extensions =
         if stdenv.isDarwin
-        then "${vscodium}/Applications/VSCodium.app/Contents/Resources/app/extensions"
-        else "${vscodium}/lib/vscode/resources/app/extensions";
+        then "../VSCodium.app/Contents/Resources/app/extensions"
+        else "../resources/app/extensions";
     in
     ''
       npx babel ${extensions}/css-language-features/server/dist/node \


### PR DESCRIPTION
…using its src

## Description of changes

```
 ➜ diffoscope result-*
--- result-after
+++ result-before
├── stat {}
│ @@ -1,7 +1,7 @@
│
│    Size: 79           Blocks: 8          IO Block: 4096   symbolic link
│  Device: 8,3  Access: (0777/lrwxrwxrwx)  Uid: ( 1000/  sandro)   Gid: (  100/   users)
│
│ -Modify: 2024-07-12 14:30:31.973660833 +0000
│ +Modify: 2024-07-12 14:30:53.818716131 +0000
│   --- result-after/bin
├── +++ result-before/bin
│ │   --- result-after/bin/vscode-css-language-server
│ ├── +++ result-before/bin/vscode-css-language-server
│ │ @@ -1,2 +1,2 @@
│ │  #! /nix/store/m101dg80ngyjdb02g6jwy80sr7kzj26g-bash-5.2p26/bin/bash -e
│ │ +exec "/nix/store/ilkfhnqz4xczrliqjva8770x2svbfznd-nodejs-20.14.0/bin/node"  /nix/store/jd0lrssiwfkgphbzi051php02lzwy72m-vscode-langservers-extracted-4.10.0/lib/node_modules/vscode-langservers-extracted/bin/vscode-css-language-server "$@"
│ │ -exec "/nix/store/ilkfhnqz4xczrliqjva8770x2svbfznd-nodejs-20.14.0/bin/node"  /nix/store/4m8sg5hjg7wlmflq8q6gj0i49qp8ladb-vscode-langservers-extracted-4.10.0/lib/node_modules/vscode-langservers-extracted/bin/vscode-css-language-server "$@"
│ │   --- result-after/bin/vscode-eslint-language-server
│ ├── +++ result-before/bin/vscode-eslint-language-server
│ │ @@ -1,2 +1,2 @@
│ │  #! /nix/store/m101dg80ngyjdb02g6jwy80sr7kzj26g-bash-5.2p26/bin/bash -e
│ │ +exec "/nix/store/ilkfhnqz4xczrliqjva8770x2svbfznd-nodejs-20.14.0/bin/node"  /nix/store/jd0lrssiwfkgphbzi051php02lzwy72m-vscode-langservers-extracted-4.10.0/lib/node_modules/vscode-langservers-extracted/bin/vscode-eslint-language-server "$@"
│ │ -exec "/nix/store/ilkfhnqz4xczrliqjva8770x2svbfznd-nodejs-20.14.0/bin/node"  /nix/store/4m8sg5hjg7wlmflq8q6gj0i49qp8ladb-vscode-langservers-extracted-4.10.0/lib/node_modules/vscode-langservers-extracted/bin/vscode-eslint-language-server "$@"
│ │   --- result-after/bin/vscode-html-language-server
│ ├── +++ result-before/bin/vscode-html-language-server
│ │ @@ -1,2 +1,2 @@
│ │  #! /nix/store/m101dg80ngyjdb02g6jwy80sr7kzj26g-bash-5.2p26/bin/bash -e
│ │ +exec "/nix/store/ilkfhnqz4xczrliqjva8770x2svbfznd-nodejs-20.14.0/bin/node"  /nix/store/jd0lrssiwfkgphbzi051php02lzwy72m-vscode-langservers-extracted-4.10.0/lib/node_modules/vscode-langservers-extracted/bin/vscode-html-language-server "$@"
│ │ -exec "/nix/store/ilkfhnqz4xczrliqjva8770x2svbfznd-nodejs-20.14.0/bin/node"  /nix/store/4m8sg5hjg7wlmflq8q6gj0i49qp8ladb-vscode-langservers-extracted-4.10.0/lib/node_modules/vscode-langservers-extracted/bin/vscode-html-language-server "$@"
│ │   --- result-after/bin/vscode-json-language-server
│ ├── +++ result-before/bin/vscode-json-language-server
│ │ @@ -1,2 +1,2 @@
│ │  #! /nix/store/m101dg80ngyjdb02g6jwy80sr7kzj26g-bash-5.2p26/bin/bash -e
│ │ +exec "/nix/store/ilkfhnqz4xczrliqjva8770x2svbfznd-nodejs-20.14.0/bin/node"  /nix/store/jd0lrssiwfkgphbzi051php02lzwy72m-vscode-langservers-extracted-4.10.0/lib/node_modules/vscode-langservers-extracted/bin/vscode-json-language-server "$@"
│ │ -exec "/nix/store/ilkfhnqz4xczrliqjva8770x2svbfznd-nodejs-20.14.0/bin/node"  /nix/store/4m8sg5hjg7wlmflq8q6gj0i49qp8ladb-vscode-langservers-extracted-4.10.0/lib/node_modules/vscode-langservers-extracted/bin/vscode-json-language-server "$@"
│ │   --- result-after/bin/vscode-markdown-language-server
│ ├── +++ result-before/bin/vscode-markdown-language-server
│ │ @@ -1,2 +1,2 @@
│ │  #! /nix/store/m101dg80ngyjdb02g6jwy80sr7kzj26g-bash-5.2p26/bin/bash -e
│ │ +exec "/nix/store/ilkfhnqz4xczrliqjva8770x2svbfznd-nodejs-20.14.0/bin/node"  /nix/store/jd0lrssiwfkgphbzi051php02lzwy72m-vscode-langservers-extracted-4.10.0/lib/node_modules/vscode-langservers-extracted/bin/vscode-markdown-language-server "$@"
│ │ -exec "/nix/store/ilkfhnqz4xczrliqjva8770x2svbfznd-nodejs-20.14.0/bin/node"  /nix/store/4m8sg5hjg7wlmflq8q6gj0i49qp8ladb-vscode-langservers-extracted-4.10.0/lib/node_modules/vscode-langservers-extracted/bin/vscode-markdown-language-server "$@"
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
