### PR TITLE
neo4j: remove default neo4j.conf settings, fix obsolete dbms.threads.worker_count

### DIFF
--- a/nixos/modules/services/databases/neo4j.nix
+++ b/nixos/modules/services/databases/neo4j.nix
@@ -38,7 +38,7 @@ let
     server.default_listen_address=${cfg.defaultListenAddress}
     server.databases.default_to_read_only=${boolToString cfg.readOnly}
     ${optionalString (cfg.workerCount > 0) ''
-      dbms.threads.worker_count=${toString cfg.workerCount}
+      server.threads.worker_count=${toString cfg.workerCount}
     ''}
 
     # Directories (readonly)

--- a/nixos/modules/services/databases/neo4j.nix
+++ b/nixos/modules/services/databases/neo4j.nix
@@ -76,18 +76,18 @@ let
     ${concatStringsSep "\n" sslPolicies}
 
     # Default retention policy from neo4j.conf
-    db.tx_log.rotation.retention_policy=1 days
+    #db.tx_log.rotation.retention_policy=1 days
 
     # Default JVM parameters from neo4j.conf
-    server.jvm.additional=-XX:+UseG1GC
-    server.jvm.additional=-XX:-OmitStackTraceInFastThrow
-    server.jvm.additional=-XX:+AlwaysPreTouch
-    server.jvm.additional=-XX:+UnlockExperimentalVMOptions
-    server.jvm.additional=-XX:+TrustFinalNonStaticFields
-    server.jvm.additional=-XX:+DisableExplicitGC
-    server.jvm.additional=-Djdk.tls.ephemeralDHKeySize=2048
-    server.jvm.additional=-Djdk.tls.rejectClientInitiatedRenegotiation=true
-    server.jvm.additional=-Dunsupported.dbms.udc.source=tarball
+    #server.jvm.additional=-XX:+UseG1GC
+    #server.jvm.additional=-XX:-OmitStackTraceInFastThrow
+    #server.jvm.additional=-XX:+AlwaysPreTouch
+    #server.jvm.additional=-XX:+UnlockExperimentalVMOptions
+    #server.jvm.additional=-XX:+TrustFinalNonStaticFields
+    #server.jvm.additional=-XX:+DisableExplicitGC
+    #server.jvm.additional=-Djdk.tls.ephemeralDHKeySize=2048
+    #server.jvm.additional=-Djdk.tls.rejectClientInitiatedRenegotiation=true
+    #server.jvm.additional=-Dunsupported.dbms.udc.source=tarball
 
     #server.memory.off_heap.transaction_max_size=12000m
     #server.memory.heap.max_size=12000m


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I believe that duplication of default settings from neo4j.conf is unnecessary and complicates module use. I needed to change `db.tx_log.rotation.retention_policy` and found out that I cannot change it because it is already configured in the module. Moreover, this is not the default settings as comment suggest because it was recently many times [changed](https://neo4j.com/docs/operations-manual/current/configuration/configuration-settings/#config_db.tx_log.rotation.retention_policy).

In my point of view, it is best to leave these settings on upstream defaults and let module consumers to override them as they need.

Also, I have fixed  deprecated `dbms.threads.worker_count` to   `server.threads.worker_count` based on warning during the neo4j start log event.

```
Warning: Use of deprecated setting 'dbms.threads.worker_count'. It is replaced by 'server.threads.worker_count'.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
