### PR TITLE
k3s: use nixosTests.k3s as source reference for tests + minimal refactor

### DIFF
--- a/nixos/tests/k3s/auto-deploy.nix
+++ b/nixos/tests/k3s/auto-deploy.nix
@@ -1,3 +1,4 @@
+# Tests whether container images are imported and auto deploying manifests work
 import ../make-test-python.nix (
   {
     pkgs,

--- a/nixos/tests/k3s/auto-deploy.nix
+++ b/nixos/tests/k3s/auto-deploy.nix
@@ -109,8 +109,8 @@ import ../make-test-python.nix (
       machine.succeed("ls /var/lib/rancher/k3s/server/manifests/hello.yaml")
 
       # check if container images got imported
-      machine.succeed("crictl img | grep 'test\.local/pause'")
-      machine.succeed("crictl img | grep 'test\.local/hello'")
+      machine.wait_until_succeeds("crictl img | grep 'test\.local/pause'")
+      machine.wait_until_succeeds("crictl img | grep 'test\.local/hello'")
 
       # check if resources of manifests got created
       machine.wait_until_succeeds("kubectl get ns foo")

--- a/nixos/tests/k3s/default.nix
+++ b/nixos/tests/k3s/default.nix
@@ -7,9 +7,7 @@ let
   allK3s = lib.filterAttrs (n: _: lib.strings.hasPrefix "k3s_" n) pkgs;
 in
 {
-  # Test whether container images are imported and auto deploying manifests work
   auto-deploy = lib.mapAttrs (_: k3s: import ./auto-deploy.nix { inherit system pkgs k3s; }) allK3s;
-  # Testing K3s with Etcd backend
   etcd = lib.mapAttrs (
     _: k3s:
     import ./etcd.nix {
@@ -17,8 +15,6 @@ in
       inherit (pkgs) etcd;
     }
   ) allK3s;
-  # Run a single node k3s cluster and verify a pod can run
   single-node = lib.mapAttrs (_: k3s: import ./single-node.nix { inherit system pkgs k3s; }) allK3s;
-  # Run a multi-node k3s cluster and verify pod networking works across nodes
   multi-node = lib.mapAttrs (_: k3s: import ./multi-node.nix { inherit system pkgs k3s; }) allK3s;
 }

--- a/nixos/tests/k3s/etcd.nix
+++ b/nixos/tests/k3s/etcd.nix
@@ -1,3 +1,4 @@
+# Tests K3s with Etcd backend
 import ../make-test-python.nix (
   {
     pkgs,

--- a/nixos/tests/k3s/multi-node.nix
+++ b/nixos/tests/k3s/multi-node.nix
@@ -1,3 +1,4 @@
+# A test that runs a multi-node k3s cluster and verify pod networking works across nodes
 import ../make-test-python.nix (
   {
     pkgs,

--- a/nixos/tests/k3s/single-node.nix
+++ b/nixos/tests/k3s/single-node.nix
@@ -1,3 +1,4 @@
+# A test that runs a single node k3s cluster and verify a pod can run
 import ../make-test-python.nix (
   {
     pkgs,

--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -418,12 +418,8 @@ buildGoModule rec {
     let
       k3s_version = "k3s_" + lib.replaceStrings [ "." ] [ "_" ] (lib.versions.majorMinor version);
     in
-    {
-      auto-deploy = nixosTests.k3s.auto-deploy.${k3s_version};
-      etcd = nixosTests.k3s.etcd.${k3s_version};
-      single-node = nixosTests.k3s.single-node.${k3s_version};
-      multi-node = nixosTests.k3s.multi-node.${k3s_version};
-    };
+    lib.mapAttrs (name: value: nixosTests.k3s.${name}.${k3s_version}) nixosTests.k3s;
+
   passthru.tests = passthru.mkTests k3sVersion;
 
   meta = baseMeta;

--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -417,16 +417,21 @@ buildGoModule rec {
     runHook postInstallCheck
   '';
 
-  passthru.updateScript = updateScript;
-
-  passthru.mkTests =
-    version:
-    let
-      k3s_version = "k3s_" + lib.replaceStrings [ "." ] [ "_" ] (lib.versions.majorMinor version);
-    in
-    lib.mapAttrs (name: value: nixosTests.k3s.${name}.${k3s_version}) nixosTests.k3s;
-
-  passthru.tests = passthru.mkTests k3sVersion;
+  passthru = {
+    k3sCNIPlugins = k3sCNIPlugins;
+    k3sContainerd = k3sContainerd;
+    k3sRepo = k3sRepo;
+    k3sRoot = k3sRoot;
+    k3sServer = k3sServer;
+    mkTests =
+      version:
+      let
+        k3s_version = "k3s_" + lib.replaceStrings [ "." ] [ "_" ] (lib.versions.majorMinor version);
+      in
+      lib.mapAttrs (name: value: nixosTests.k3s.${name}.${k3s_version}) nixosTests.k3s;
+    tests = passthru.mkTests k3sVersion;
+    updateScript = updateScript;
+  };
 
   meta = baseMeta;
 }

--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -88,12 +88,12 @@ lib:
 # make sure they're in the path if desired.
 let
 
-  baseMeta = with lib; {
+  baseMeta = {
     description = "Lightweight Kubernetes distribution";
-    license = licenses.asl20;
+    license = lib.licenses.asl20;
     homepage = "https://k3s.io";
     maintainers = lib.teams.k3s.members;
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
 
     # resolves collisions with other installations of kubectl, crictl, ctr
     # prefer non-k3s versions


### PR DESCRIPTION
- k3s: use nixosTests.k3s as source reference for tests

- k3s: minimal refactor
  - refactor passthru and expose k3s dependencies for update script
  - add missing phases hook
  - remove nested with
  - nixos/tests: move comments to test (clean-up)

I ask reviewers to avoid expanding the scope of this PR, because the refactor could go much longer and I don't have the time. Particularly update script, hash, etc.

CC @NixOS/k3s 