### PR TITLE
incus: 6.2.0 -> 6.3.0

### DIFF
--- a/nixos/modules/virtualisation/incus.nix
+++ b/nixos/modules/virtualisation/incus.nix
@@ -44,12 +44,14 @@ let
         qemu-utils
         qemu_kvm
         rsync
+        skopeo
         squashfs-tools-ng
         squashfsTools
         sshfs
         swtpm
         systemd
         thin-provisioning-tools
+        umoci
         util-linux
         virtiofsd
         xdelta

--- a/nixos/modules/virtualisation/incus.nix
+++ b/nixos/modules/virtualisation/incus.nix
@@ -111,7 +111,7 @@ let
   environment = lib.mkMerge [
     {
       INCUS_LXC_TEMPLATE_CONFIG = "${pkgs.lxcfs}/share/lxc/config";
-      INCUS_OVMF_PATH = ovmf;
+      INCUS_EDK2_PATH = ovmf;
       INCUS_USBIDS_PATH = "${pkgs.hwdata}/share/hwdata/usb.ids";
       PATH = lib.mkForce serverBinPath;
     }

--- a/pkgs/by-name/in/incus/package.nix
+++ b/pkgs/by-name/in/incus/package.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  hash = "sha256-33qUmET1BYAv6e8ZaFNSa7jrn8WGf3BqY8Nud/ZywSY=";
-  version = "6.2.0";
-  vendorHash = "sha256-dFg3LSG/ao73ODWcPDq5s9xUjuHabCMOB2AtngNCrlA=";
+  hash = "sha256-qRx2l677OAo8or/form1fTgL3vjM/kz3RA/8umkAP80=";
+  version = "6.3.0";
+  vendorHash = "sha256-VlJyq+PzToBicKCF3EMqzDsnIWuPhbk4JS4ASyhfiss=";
   patches = [ ];
 }

--- a/pkgs/by-name/lx/lxcfs/package.nix
+++ b/pkgs/by-name/lx/lxcfs/package.nix
@@ -12,6 +12,7 @@
   pkg-config,
   python3,
   util-linux,
+  coreutils,
 }:
 
 stdenv.mkDerivation rec {
@@ -51,8 +52,8 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    # `mount` hook requires access to the `mount` command from `util-linux`:
-    wrapProgram "$out/share/lxcfs/lxc.mount.hook" --prefix PATH : "${util-linux}/bin"
+    # `mount` hook requires access to the `mount` command from `util-linux` and `readlink` from `coreutils`:
+    wrapProgram "$out/share/lxcfs/lxc.mount.hook" --prefix PATH : ${lib.makeBinPath [ coreutils util-linux ]}
   '';
 
   postFixup = ''


### PR DESCRIPTION
## Description of changes

- `skopeo`, `umoci` and `readlink` are needed to use OCI containers.

```
lxc mydocker 20240715032412.339 DEBUG    utils - ../src/lxc/utils.c:run_buffer:560 - Script exec /nix/store/cfwa9a0aiv9h5mlw8k5zj3jv0ak0cir6-lxcfs-6.0.1/share/lxcfs/lxc.mount.hook produced output: /nix/store/cfwa9a0aiv9h5mlw8k5zj3jv0ak0cir6-lxcfs-6.0.1/share/lxcfs/.lxc.mount.hook-wrapped: line 15: readlink: command not found
```

`incus launch docker:nginx mynginx --console --ephemeral`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
