### PR TITLE
[24.05] maintainer-list: Fix formatting

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6375,9 +6375,7 @@
     matrix = "@nico:felbinger.eu";
     github = "felbinger";
     githubId = 26925347;
-    keys = [{
-      fingerprint = "0797 D238 9769 CA1E 57B7 2ED9 2BA7 8116 87C9 0DE4";
-    }];
+    keys = [ { fingerprint = "0797 D238 9769 CA1E 57B7 2ED9 2BA7 8116 87C9 0DE4"; } ];
   };
   felipeqq2 = {
     name = "Felipe Silva";


### PR DESCRIPTION
## Description of changes

Not sure which nixfmt version was used in https://github.com/NixOS/nixpkgs/pull/325548, but it doesn't look like the right one, because CI fails: https://github.com/NixOS/nixpkgs/actions/runs/9910609620/job/27381383799?pr=326589

That reminds me, https://github.com/NixOS/nixpkgs/pull/322512 should be backported! (Edit: https://github.com/NixOS/nixpkgs/pull/326630)

Ping @superherointj @Ma27 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
