### PR TITLE
[Backport release-24.05] Development shell with a pinned nixfmt

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@
 
 # CI
 /.github/workflows @NixOS/Security @Mic92 @zowoq
+/.github/workflows/check-nix-format.yml @infinisil
 /ci @infinisil
 
 # Develompent support

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,8 +15,9 @@
 /.github/workflows @NixOS/Security @Mic92 @zowoq
 /ci @infinisil
 
-# EditorConfig
+# Develompent support
 /.editorconfig @Mic92 @zowoq
+/shell.nix @infinisil @NixOS/Security
 
 # Libraries
 /lib                        @infinisil

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,8 +11,9 @@
 # This also holds true for GitHub teams. Since almost none of our teams have write
 # permissions, you need to list all members of the team with commit access individually.
 
-# GitHub actions
+# CI
 /.github/workflows @NixOS/Security @Mic92 @zowoq
+/ci @infinisil
 
 # EditorConfig
 /.editorconfig @Mic92 @zowoq

--- a/.github/workflows/check-nix-format.yml
+++ b/.github/workflows/check-nix-format.yml
@@ -40,14 +40,14 @@ jobs:
           NIX_FMT_PATHS_BSD: pkgs/os-specific/bsd
           NIX_FMT_PATHS_MPVSCRIPTS: pkgs/applications/video/mpv/scripts
           # Format paths related to the Nixpkgs CUDA ecosystem.
-          NIX_FMT_PATHS_CUDA: |
+          NIX_FMT_PATHS_CUDA: |-
             pkgs/development/cuda-modules
             pkgs/test/cuda
             pkgs/top-level/cuda-packages.nix
-          NIX_FMT_PATHS_MAINTAINERS: |
+          NIX_FMT_PATHS_MAINTAINERS: |-
             maintainers/maintainer-list.nix
             maintainers/team-list.nix
-          NIX_FMT_PATHS_K3S: |
+          NIX_FMT_PATHS_K3S: |-
             nixos/modules/services/cluster/k3s
             nixos/tests/k3s
             pkgs/applications/networking/cluster/k3s

--- a/.github/workflows/check-nix-format.yml
+++ b/.github/workflows/check-nix-format.yml
@@ -19,13 +19,18 @@ jobs:
         with:
           # pull_request_target checks out the base branch by default
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - name: Get Nixpkgs revision for nixfmt
+        run: |
+          # pin to a commit from nixpkgs-unstable to avoid e.g. building nixfmt
+          # from staging
+          # This should not be a URL, because it would allow PRs to run arbitrary code in CI!
+          rev=$(jq -r .rev ci/pinned-nixpkgs.json)
+          echo "url=https://github.com/NixOS/nixpkgs/archive/$rev.tar.gz" >> "$GITHUB_ENV"
       - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
         with:
           # explicitly enable sandbox
           extra_nix_config: sandbox = true
-          # fix a commit from nixpkgs-unstable to avoid e.g. building nixfmt
-          # from staging
-          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/4b455dc2048f73a79eb3713f342369ff58f93e0b.tar.gz
+          nix_path: nixpkgs=${{ env.url }}
       - name: Install nixfmt
         run: "nix-env -f '<nixpkgs>' -iAP nixfmt-rfc-style"
       - name: Check that Nix files are formatted according to the RFC style

--- a/.github/workflows/check-nix-format.yml
+++ b/.github/workflows/check-nix-format.yml
@@ -56,6 +56,7 @@ jobs:
           NIX_FMT_PATHS_BUILD_SUPPORT_PHP: pkgs/build-support/php
         # Iterate over all environment variables beginning with NIX_FMT_PATHS_.
         run: |
+          unformattedPaths=()
           for env_var in "${!NIX_FMT_PATHS_@}"; do
             readarray -t paths <<< "${!env_var}"
             if [[ "${paths[*]}" == "" ]]; then
@@ -64,7 +65,12 @@ jobs:
             fi
             echo "Checking paths: ${paths[@]}"
             if ! nixfmt --check "${paths[@]}"; then
-              echo "Error: nixfmt failed."
-              exit 1
+              unformattedPaths+=("${paths[@]}")
             fi
           done
+          if (( "${#unformattedPaths[@]}" > 0 )); then
+            echo "Some required Nix files are not properly formatted"
+            echo "Please run the following in \`nix-shell\`:"
+            echo "nixfmt ${unformattedPaths[*]@Q}"
+            exit 1
+          fi

--- a/.github/workflows/check-shell.yml
+++ b/.github/workflows/check-shell.yml
@@ -1,0 +1,29 @@
+name: "Check shell"
+
+on:
+  pull_request_target:
+
+permissions: {}
+
+jobs:
+  x86_64-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+        with:
+          # pull_request_target checks out the base branch by default
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
+      - name: Build shell
+        run: nix-build shell.nix
+
+  aarch64-darwin:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+        with:
+          # pull_request_target checks out the base branch by default
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
+      - name: Build shell
+        run: nix-build shell.nix

--- a/ci/README.md
+++ b/ci/README.md
@@ -2,3 +2,11 @@
 
 This directory contains files to support CI, such as [GitHub Actions](https://github.com/NixOS/nixpkgs/tree/master/.github/workflows) and [Ofborg](https://github.com/nixos/ofborg).
 This is in contrast with [`maintainers/scripts`](`../maintainers/scripts`) which is for human use instead.
+
+## Pinned Nixpkgs
+
+CI may need certain packages from Nixpkgs.
+In order to ensure that the needed packages are generally available without building,
+[`pinned-nixpkgs.json`](./pinned-nixpkgs.json) contains a pinned Nixpkgs version tested by Hydra.
+
+Run [`update-pinned-nixpkgs.sh`](./update-pinned-nixpkgs.sh) to update it.

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,4 @@
+# CI support files
+
+This directory contains files to support CI, such as [GitHub Actions](https://github.com/NixOS/nixpkgs/tree/master/.github/workflows) and [Ofborg](https://github.com/nixos/ofborg).
+This is in contrast with [`maintainers/scripts`](`../maintainers/scripts`) which is for human use instead.

--- a/ci/pinned-nixpkgs.json
+++ b/ci/pinned-nixpkgs.json
@@ -1,0 +1,4 @@
+{
+  "rev": "cfb89a95f19bea461fc37228dc4d07b22fe617c2",
+  "sha256": "1yhsacvry6j8r02lk70p9dphjpi8lpzgq2qay8hiy4nqlys0mrch"
+}

--- a/ci/update-pinned-nixpkgs.sh
+++ b/ci/update-pinned-nixpkgs.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p jq
+
+set -euo pipefail
+
+# https://stackoverflow.com/a/246128
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+repo=https://github.com/nixos/nixpkgs
+branch=nixpkgs-unstable
+file=$SCRIPT_DIR/pinned-nixpkgs.json
+
+rev=$(git ls-remote "$repo" refs/heads/"$branch" | cut -f1)
+sha256=$(nix-prefetch-url --unpack "$repo/archive/$rev.tar.gz" --name source)
+
+jq -n --arg rev "$rev" --arg sha256 "$sha256" '$ARGS.named' | tee /dev/stderr > $file

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,30 @@
+# A shell to get tooling for Nixpkgs development
+#
+# Note: We intentionally don't use Flakes here,
+# because every time you change any file and do another `nix develop`,
+# it would create another copy of the entire ~500MB tree in the store.
+# See https://github.com/NixOS/nix/pull/6530 for the future
+{
+  system ? builtins.currentSystem,
+}:
+let
+  pinnedNixpkgs = builtins.fromJSON (builtins.readFile ci/pinned-nixpkgs.json);
+
+  nixpkgs = fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/${pinnedNixpkgs.rev}.tar.gz";
+    sha256 = pinnedNixpkgs.sha256;
+  };
+
+  pkgs = import nixpkgs {
+    inherit system;
+    config = {};
+    overlays = [];
+  };
+in
+pkgs.mkShellNoCC {
+  packages = [
+    # The default formatter for Nix code
+    # https://github.com/NixOS/nixfmt
+    pkgs.nixfmt-rfc-style
+  ];
+}


### PR DESCRIPTION
## Description of changes

Manual backport of https://github.com/NixOS/nixpkgs/pull/322512

## Things done

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
