### PR TITLE
python3Packages.expiringdict: Python 3.12 compatibility

### DIFF
--- a/pkgs/development/python-modules/expiringdict/default.nix
+++ b/pkgs/development/python-modules/expiringdict/default.nix
@@ -2,11 +2,10 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
   dill,
-  coverage,
-  coveralls,
   mock,
-  nose,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -23,19 +22,19 @@ buildPythonPackage rec {
     hash = "sha256-vRhJSHIqc51I+s/wndtfANM44CKW3QS1iajqyoSBf0I=";
   };
 
-  nativeCheckInputs = [
-    dill
-    coverage
-    coveralls
-    mock
-    nose
+  patches = [
+    # apply mailgun/expiringdict#49 to address NixOS/nixpkgs#326513
+    (fetchpatch2 {
+      url = "https://github.com/mailgun/expiringdict/commit/1c0f82232d20f8b3b31c9269a4d0e9510c1721a6.patch";
+      hash = "sha256-IeeJVb2tOwRhEPNGqM30fNZyz3jFcnZNWC3I6K1+hSY=";
+    })
   ];
 
-  checkPhase = ''
-    runHook preCheck
-    nosetests -v --with-coverage --cover-package=expiringdict
-    runHook postCheck
-  '';
+  nativeCheckInputs = [
+    dill
+    mock
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "expiringdict" ];
 

--- a/pkgs/development/python-modules/expiringdict/default.nix
+++ b/pkgs/development/python-modules/expiringdict/default.nix
@@ -6,12 +6,13 @@
   dill,
   mock,
   pytestCheckHook,
+  setuptools
 }:
 
 buildPythonPackage rec {
   pname = "expiringdict";
   version = "1.2.2";
-  format = "setuptools";
+  pyproject = true;
 
   # use fetchFromGitHub instead of fetchPypi because the test suite of
   # the package is not included into the PyPI tarball
@@ -35,6 +36,8 @@ buildPythonPackage rec {
       hash = "sha256-FNdnU6iUMyED5j8oAjhmJTR7zQeEc/Z5s64pdeT4F8w=";
     })
   ];
+
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [
     dill

--- a/pkgs/development/python-modules/expiringdict/default.nix
+++ b/pkgs/development/python-modules/expiringdict/default.nix
@@ -28,6 +28,12 @@ buildPythonPackage rec {
       url = "https://github.com/mailgun/expiringdict/commit/1c0f82232d20f8b3b31c9269a4d0e9510c1721a6.patch";
       hash = "sha256-IeeJVb2tOwRhEPNGqM30fNZyz3jFcnZNWC3I6K1+hSY=";
     })
+
+    # apply mailgun/expiringdict#56 for compatibility with Python 3.12
+    (fetchpatch2 {
+      url = "https://github.com/mailgun/expiringdict/commit/976faf3664d54049e443aca054f5819db834577b.patch";
+      hash = "sha256-FNdnU6iUMyED5j8oAjhmJTR7zQeEc/Z5s64pdeT4F8w=";
+    })
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
## Description of changes

Addresses #326513 and [upstream incompatibility](https://github.com/mailgun/expiringdict/issues/55) with Python 3.12.

Resolves build failures of:

- `python3Packages.checkdmarc`
- `python3Packages.mailsuite`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
