### PR TITLE
freej2me: init at 0-unstable-2024-02-16

### DIFF
--- a/pkgs/by-name/fr/freej2me/package.nix
+++ b/pkgs/by-name/fr/freej2me/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  ant,
+  jdk19,
+  stripJavaArchivesHook,
+  writeShellScriptBin,
+}:
+
+stdenv.mkDerivation {
+  pname = "freej2me";
+  # Requested release at https://github.com/hex007/freej2me/issues/220
+  version = "0-unstable-2024-02-16";
+
+  src = fetchFromGitHub {
+    owner = "hex007";
+    repo = "freej2me";
+    rev = "8b9bc8a19baf26e3d92f88934a64a32f1cbc2795";
+    hash = "sha256-FaB2qnbtJnSZbrGRYDiz3Q/uNgD4GX//VaID6jHtyeU=";
+  };
+
+  nativeBuildInputs = [
+    ant
+    jdk19
+    stripJavaArchivesHook
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    ant
+    make -C src/libretro
+
+    runHook postBuild
+  '';
+
+  installPhase = let
+    mk-script-bin = front-end: writeShellScriptBin front-end ''
+      if [ "$#" != 3 ]; then
+        echo "usage: ${front-end} [midlet] [width] [height]"
+        exit 2
+      fi
+
+      ${lib.getExe' jdk19 "java"} -jar        \
+        "@out@/share/java/${front-end}.jar" \
+        "file://$(realpath "$1")" $2 $3
+    '';
+
+    mk-script-install = front-end: ''
+      install -D --mode=755 --verbose \
+        ${mk-script-bin front-end}/bin/${front-end} --target-directory=$out/bin
+
+      substituteInPlace $out/bin/${front-end} \
+        --replace-fail "@out@" "${placeholder "out"}"
+    '';
+
+    front-ends = [ "freej2me" "freej2me-lr" ];
+    install-scripts = builtins.map mk-script-install front-ends;
+  in ''
+    runHook preInstall
+
+    install -D --mode=644 --verbose \
+      build/freej2me{,-lr}.jar --target-directory=$out/share/java
+
+    ${builtins.concatStringsSep "\n" install-scripts}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/hex007/freej2me";
+    description = "Free J2ME emulator with libretro, awt and sdl2 frontends";
+    # From LICENSE file: "FreeJ2ME depends on ObjectWeb ASM"
+    # ObjectWeb ASM License is 3-clause BSD
+    license = with lib.licenses; [ gpl3Plus bsd3 ];
+    maintainers = with lib.maintainers; [ sigmanificient ];
+    mainProgram = "freej2me";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

Fix:
- #326214

```
file="~/Download/splinter_cell_double_240x320_147976.jar"
java -jar result/share/java/freej2me-sdl.jar "file://$file" 240 320
```

![image](https://github.com/user-attachments/assets/82462647-1f5f-43b2-97e4-c9035869bf5a)


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
