### PR TITLE
Fix pname misuse, part 1

### DIFF
--- a/pkgs/applications/audio/aucatctl/default.nix
+++ b/pkgs/applications/audio/aucatctl/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.1";
 
   src = fetchurl {
-    url = "http://www.sndio.org/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    url = "http://www.sndio.org/aucatctl-${finalAttrs.version}.tar.gz";
     sha256 = "524f2fae47db785234f166551520d9605b9a27551ca438bd807e3509ce246cf0";
   };
 

--- a/pkgs/applications/audio/carla/default.nix
+++ b/pkgs/applications/audio/carla/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "falkTX";
-    repo = finalAttrs.pname;
+    repo = "carla";
     rev = "v${finalAttrs.version}";
     hash = "sha256-H15T/z/IRfgWdqToTzq2eJ7q3n9Kj44IZXsd4uaipuU=";
   };

--- a/pkgs/applications/audio/jack-passthrough/default.nix
+++ b/pkgs/applications/audio/jack-passthrough/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   # https://github.com/guysherman/jack-passthrough
   src = fetchFromGitHub {
     owner = "guysherman";
-    repo = finalAttrs.pname;
+    repo = "jack-passthrough";
     rev = "aad03b7c5ccc4a4dcb8fa38c49aa64cb9d628660";
     hash = "sha256-9IsNaLW5dYAqiwe+vX0+D3oIKFP2TIfy1q1YaqmS6wE=";
   };

--- a/pkgs/applications/audio/jack-passthrough/default.nix
+++ b/pkgs/applications/audio/jack-passthrough/default.nix
@@ -8,7 +8,7 @@
 , fmt_9
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation {
   pname = "jack-passthrough";
   version = "2021-9-25";
 
@@ -37,4 +37,4 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = [ "x86_64-linux" ];
     mainProgram = "jack-passthru";
   };
-})
+}

--- a/pkgs/applications/audio/zrythm/default.nix
+++ b/pkgs/applications/audio/zrythm/default.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0.0-rc.1";
 
   src = fetchzip {
-    url = "https://www.zrythm.org/releases/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
+    url = "https://www.zrythm.org/releases/zrythm-${finalAttrs.version}.tar.xz";
     sha256 = "sha256-Ljbw7bjGI6js4OP9KEXCkhC9AMbInSz0nn+pROm4vXw=";
   };
 

--- a/pkgs/applications/editors/geany/default.nix
+++ b/pkgs/applications/editors/geany/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [ "out" "dev" "doc" "man" ];
 
   src = fetchurl {
-    url = "https://download.geany.org/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
+    url = "https://download.geany.org/geany-${finalAttrs.version}.tar.bz2";
     hash = "sha256-VltM0vAxHB46Fn7HHEoy26ZC4P5VSuW7a4F3t6dMzJI=";
   };
 

--- a/pkgs/applications/graphics/ocrfeeder/default.nix
+++ b/pkgs/applications/graphics/ocrfeeder/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.8.5";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${finalAttrs.pname}/${lib.versions.majorMinor finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
+    url = "mirror://gnome/sources/ocrfeeder/${lib.versions.majorMinor finalAttrs.version}/ocrfeeder-${finalAttrs.version}.tar.xz";
     sha256 = "sha256-sD0qWUndguJzTw0uy0FIqupFf4OX6dTFvcd+Mz+8Su0=";
   };
 

--- a/pkgs/applications/misc/bemenu/default.nix
+++ b/pkgs/applications/misc/bemenu/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "Cloudef";
-    repo = finalAttrs.pname;
+    repo = "bemenu";
     rev = finalAttrs.version;
     hash = "sha256-wdOrVX4AgGXySlwmqFRp9OWoSkEYBIZumBGTrFfyNpg=";
   };

--- a/pkgs/applications/misc/bibletime/default.nix
+++ b/pkgs/applications/misc/bibletime/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "bibletime";
-    repo = finalAttrs.pname;
+    repo = "bibletime";
     rev = "v${finalAttrs.version}";
     hash = "sha256-4O8F5/EyoJFJBEWOAs9lzN3TKuu/CEdKfPaOF8gNqps=";
   };

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "4.1.1";
 
   src = fetchurl {
-    url = "https://download.blender.org/source/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
+    url = "https://download.blender.org/source/blender-${finalAttrs.version}.tar.xz";
     hash = "sha256-T7s69k0/hN9ccQN0hFQibBiFwawu1Tc9DOoegOgsCEg=";
   };
 

--- a/pkgs/applications/misc/citations/default.nix
+++ b/pkgs/applications/misc/citations/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
-    repo = finalAttrs.pname;
+    repo = "citations";
     rev = finalAttrs.version;
     hash = "sha256-RV9oQcXzRsNcvZc/8Xt7qZ/88DvHofC2Av0ftxzeF6Q=";
   };

--- a/pkgs/applications/misc/genesys/default.nix
+++ b/pkgs/applications/misc/genesys/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0.7";
 
   src = fetchurl {
-    url = "https://github.com/mrlem/genesys/releases/download/v${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    url = "https://github.com/mrlem/genesys/releases/download/v${finalAttrs.version}/genesys-${finalAttrs.version}.tar.gz";
     hash = "sha256-I1lEVvwRiGf1f4zUtqKhSb+it/nC8WAmw5S6edquOj8=";
   };
 

--- a/pkgs/applications/misc/rofi-bluetooth/default.nix
+++ b/pkgs/applications/misc/rofi-bluetooth/default.nix
@@ -5,7 +5,7 @@
 , bluez
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation {
   pname = "rofi-bluetooth";
   version = "unstable-2023-02-03";
 
@@ -38,4 +38,4 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "rofi-bluetooth";
     platforms = platforms.linux;
   };
-})
+}

--- a/pkgs/applications/misc/rofi-bluetooth/default.nix
+++ b/pkgs/applications/misc/rofi-bluetooth/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "nickclyde";
-    repo = finalAttrs.pname;
+    repo = "rofi-bluetooth";
     # https://github.com/nickclyde/rofi-bluetooth/issues/19
     rev = "9d91c048ff129819f4c6e9e48a17bd54343bbffb";
     sha256 = "sha256-1Xe3QFThIvJDCUznDP5ZBzwZEMuqmxpDIV+BcVvQDG8=";

--- a/pkgs/applications/networking/gnome-network-displays/default.nix
+++ b/pkgs/applications/networking/gnome-network-displays/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.92.2";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${finalAttrs.pname}/${lib.versions.majorMinor finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
+    url = "mirror://gnome/sources/gnome-network-displays/${lib.versions.majorMinor finalAttrs.version}/gnome-network-displays-${finalAttrs.version}.tar.xz";
     sha256 = "sha256-df35UJnRolVSiYcArpnrglxNKbTKA3LAGsNwlDF7cj4=";
   };
 

--- a/pkgs/applications/networking/instant-messengers/element/element-web.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-web.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: builtins.removeAttrs pinData [ "hashes" ] // {
 
   src = fetchFromGitHub {
     owner = "vector-im";
-    repo = finalAttrs.pname;
+    repo = "element-web";
     rev = "v${finalAttrs.version}";
     hash = webSrcHash;
   };

--- a/pkgs/applications/networking/instant-messengers/hydrogen-web/unwrapped.nix
+++ b/pkgs/applications/networking/instant-messengers/hydrogen-web/unwrapped.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "vector-im";
-    repo = finalAttrs.pname;
+    repo = "hydrogen-web";
     rev = "v${finalAttrs.version}";
     hash = "sha256-u8Yex3r7EZH+JztQHJbfncYeyyl6hgb1ZNFIg//wcb0=";
   };

--- a/pkgs/applications/office/ticktick/default.nix
+++ b/pkgs/applications/office/ticktick/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.0.30";
 
   src = fetchurl {
-    url = "https://d2atcrkye2ik4e.cloudfront.net/download/linux/linux_deb_x64/${finalAttrs.pname}-${finalAttrs.version}-amd64.deb";
+    url = "https://d2atcrkye2ik4e.cloudfront.net/download/linux/linux_deb_x64/ticktick-${finalAttrs.version}-amd64.deb";
     hash = "sha256-oo1ssIU6nYMBoEc888xAiTS7PHuEkoaC7KsPRTwL0ZA=";
   };
 

--- a/pkgs/applications/science/biology/migrate/default.nix
+++ b/pkgs/applications/science/biology/migrate/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "migrate";
 
   src = fetchurl {
-    url = "https://peterbeerli.com/migrate-html5/download_version4/${finalAttrs.pname}-${finalAttrs.version}.src.tar.gz";
+    url = "https://peterbeerli.com/migrate-html5/download_version4/migrate-${finalAttrs.version}.src.tar.gz";
     hash = "sha256-twkoR9L6VPUye12OC0B5w0PxcxyKain6RkhCswLEdwg=";
   };
 

--- a/pkgs/applications/science/logic/surelog/default.nix
+++ b/pkgs/applications/science/logic/surelog/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
-    repo = finalAttrs.pname;
+    repo = "surelog";
     rev = "v${finalAttrs.version}";
     hash = "sha256-V4LmW4ca6KfugOu0XnGwutRqWR/9K6ESokHOB2yAVag=";
     fetchSubmodules = false;  # we use all dependencies from nix

--- a/pkgs/applications/science/logic/uhdm/default.nix
+++ b/pkgs/applications/science/logic/uhdm/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
-    repo = finalAttrs.pname;
+    repo = "UHDM";
     rev = "v${finalAttrs.version}";
     hash = "sha256-va8qAzsg589C6rLmG1uIMDr4X30qpBgRO1ZVKdEs5ok=";
     fetchSubmodules = false;  # we use all dependencies from nix

--- a/pkgs/applications/science/math/maxima/default.nix
+++ b/pkgs/applications/science/math/maxima/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "5.46.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/${finalAttrs.pname}/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    url = "mirror://sourceforge/maxima/maxima-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-c5Dwa0jaZckDPosvYpuXi5AFZFSlQCLbfecOIiWqiwc=";
   };
 

--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "obsproject";
-    repo = finalAttrs.pname;
+    repo = "obs-studio";
     rev = finalAttrs.version;
     sha256 = "sha256-M4IINBoYrgkM37ykb4boHyWP8AxwMX0b7IAeeNIw9Qo=";
     fetchSubmodules = true;

--- a/pkgs/applications/video/obs-studio/plugins/obs-vkcapture.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-vkcapture.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "nowrep";
-    repo = finalAttrs.pname;
+    repo = "obs-vkcapture";
     rev = "v${finalAttrs.version}";
     hash = "sha256-hYPQ1N4k4eb+bvGWZqaQJ/C8C5Lh8ooZ03raGF5ORgE=";
   };

--- a/pkgs/applications/window-managers/hyprwm/hyprland-protocols/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-protocols/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "hyprwm";
-    repo = finalAttrs.pname;
+    repo = "hyprland-protocols";
     rev = "v${finalAttrs.version}";
     hash = "sha256-HUklK5u86w2Yh9dOkk4FdsL8eehcOZ95jPhLixGDRQY=";
   };

--- a/pkgs/applications/window-managers/hyprwm/hyprpaper/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprpaper/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "hyprwm";
-    repo = finalAttrs.pname;
+    repo = "hyprpaper";
     rev = "v${finalAttrs.version}";
     hash = "sha256-l13c8ALA7ZKDgluYA1C1OfkDGYD6e1/GR6LJnxCLRhA=";
   };

--- a/pkgs/applications/window-managers/hyprwm/hyprpicker/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprpicker/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "hyprwm";
-    repo = finalAttrs.pname;
+    repo = "hyprpicker";
     rev = "v${finalAttrs.version}";
     hash = "sha256-BYQF1zM6bJ44ag9FJ0aTSkhOTY9U7uRdp3SmRCs5fJM=";
   };

--- a/pkgs/by-name/al/alsa-lib/package.nix
+++ b/pkgs/by-name/al/alsa-lib/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.2.11";
 
   src = fetchurl {
-    url = "mirror://alsa/lib/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
+    url = "mirror://alsa/lib/alsa-lib-${finalAttrs.version}.tar.bz2";
     hash = "sha256-nz8vabmV+a03NZBy+8aaOoi/uggfyD6b4w4UZieVu00=";
   };
 

--- a/pkgs/by-name/ba/babeltrace/package.nix
+++ b/pkgs/by-name/ba/babeltrace/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.5.11";
 
   src = fetchurl {
-    url = "https://www.efficios.com/files/babeltrace/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
+    url = "https://www.efficios.com/files/babeltrace/babeltrace-${finalAttrs.version}.tar.bz2";
     sha256 = "Z7Q6qu9clR+nrxpVfPcgGhH+iYdrfCK6CgPLwxbbWpw=";
   };
 

--- a/pkgs/by-name/ba/base45/package.nix
+++ b/pkgs/by-name/ba/base45/package.nix
@@ -5,7 +5,7 @@ buildNimPackage (finalAttrs: {
   version = "20230124";
   src = fetchFromSourcehut {
     owner = "~ehmry";
-    repo = finalAttrs.pname;
+    repo = "base45";
     rev = finalAttrs.version;
     hash = "sha256-9he+14yYVGt2s1IuRLPRsv23xnJzERkWRvIHr3PxFYk=";
   };

--- a/pkgs/by-name/c2/c2nim/package.nix
+++ b/pkgs/by-name/c2/c2nim/package.nix
@@ -5,7 +5,7 @@ buildNimPackage (finalAttrs: {
   version = "0.9.19";
   src = fetchFromGitHub {
     owner = "nim-lang";
-    repo = finalAttrs.pname;
+    repo = "c2nim";
     rev = finalAttrs.version;
     hash = "sha256-E8sAhTFIWAnlfWyuvqK8h8g7Puf5ejLEqgLNb5N17os=";
   };

--- a/pkgs/by-name/hy/hyprland/package.nix
+++ b/pkgs/by-name/hy/hyprland/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "hyprwm";
-    repo = finalAttrs.pname;
+    repo = "hyprland";
     fetchSubmodules = true;
     rev = "refs/tags/v${finalAttrs.version}";
     hash = "sha256-JmfnYz+9a4TjNl3mAus1VpoWtTI9d1xkW9MHbkcV0Po=";

--- a/pkgs/by-name/id/ideamaker/package.nix
+++ b/pkgs/by-name/id/ideamaker/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
       );
     in
     fetchurl {
-      url = "https://download.raise3d.com/${finalAttrs.pname}/release/${semver}/ideaMaker_${finalAttrs.version}-ubuntu_amd64.deb";
+      url = "https://download.raise3d.com/ideamaker/release/${semver}/ideaMaker_${finalAttrs.version}-ubuntu_amd64.deb";
       sha256 = "sha256-aTVWCTgnVKD16uhJUVz0vR7KPGJqCVj0xoL53Qi3IKM=";
     };
 

--- a/pkgs/by-name/li/libvpl/package.nix
+++ b/pkgs/by-name/li/libvpl/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "intel";
-    repo = finalAttrs.pname;
+    repo = "libvpl";
     rev = "v${finalAttrs.version}";
     hash = "sha256-2yfJo4iwI/h0CJ+mJJ3cAyG5S7KksUibwJHebF3MR+E=";
   };

--- a/pkgs/by-name/mf/mfoc-hardnested/package.nix
+++ b/pkgs/by-name/mf/mfoc-hardnested/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "nfc-tools";
-    repo = finalAttrs.pname;
+    repo = "mfoc-hardnested";
     rev = "a6007437405a0f18642a4bbca2eeba67c623d736";
     hash = "sha256-YcUMS4wx5ML4yYiARyfm7T7nLomgG9YCSFj+ZUg5XZk=";
   };

--- a/pkgs/by-name/mf/mfoc-hardnested/package.nix
+++ b/pkgs/by-name/mf/mfoc-hardnested/package.nix
@@ -7,7 +7,7 @@
 , xz
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation {
   pname = "mfoc-hardnested";
   version = "unstable-2023-03-27";
 
@@ -37,4 +37,4 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [ azuwis ];
     platforms = platforms.unix;
   };
-})
+}

--- a/pkgs/by-name/ne/neural-amp-modeler-lv2/package.nix
+++ b/pkgs/by-name/ne/neural-amp-modeler-lv2/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "mikeoliphant";
-    repo = finalAttrs.pname;
+    repo = "neural-amp-modeler-lv2";
     rev = finalAttrs.version;
     fetchSubmodules = true;
     hash = "sha256-sRZngmivNvSWcjkIqcqjjaIgXFH8aMq+/caNroXmzIk=";

--- a/pkgs/by-name/ni/nimdow/package.nix
+++ b/pkgs/by-name/ni/nimdow/package.nix
@@ -7,7 +7,7 @@ buildNimPackage (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "avahe-kellenberger";
-    repo = finalAttrs.pname;
+    repo = "nimdow";
     rev = "v${finalAttrs.version}";
     hash = "sha256-GPu3Z63rFBgCCV7bdBg9cJh5thv2xrv/nSMa5Q/zp48=";
   };

--- a/pkgs/by-name/se/serious-sans/package.nix
+++ b/pkgs/by-name/se/serious-sans/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "kaBeech";
-    repo = finalAttrs.pname;
+    repo = "serious-sans";
     rev = "a23f2b303fa3b1ec8788c5abba67b44ca5a3cc0a";
     hash = "sha256-sPb9ZVDTBaZHT0Q/I9OfP7BMYJXPBiKkebzKgUHNuZM=";
   };

--- a/pkgs/by-name/se/serious-sans/package.nix
+++ b/pkgs/by-name/se/serious-sans/package.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "serious-sans";
   version = "unstable-2023-09-04";
 
@@ -30,4 +30,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [ CobaltCause ];
     platforms = lib.platforms.all;
   };
-})
+}

--- a/pkgs/by-name/st/steam-play-none/package.nix
+++ b/pkgs/by-name/st/steam-play-none/package.nix
@@ -7,8 +7,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "steam-play-none";
   version = "0-unstable-2022-12-15";
   src = fetchFromGitHub {
-    repo = finalAttrs.pname;
     owner = "Scrumplex";
+    repo = "steam-play-none";
     rev = "42e38706eb37fdaaedbe9951d59ef44148fcacbf";
     hash = "sha256-sSHLrB5TlGMKpztTnbh5oIOhcrRd+ke2OUUbiQUqoh0=";
   };

--- a/pkgs/by-name/sw/swaycwd/package.nix
+++ b/pkgs/by-name/sw/swaycwd/package.nix
@@ -10,7 +10,7 @@ buildNimPackage (finalAttrs: {
 
   src = fetchFromGitLab {
     owner = "cab404";
-    repo = finalAttrs.pname;
+    repo = "swaycwd";
     rev = "v${finalAttrs.version}";
     hash = "sha256-R/LnojbA0vBQVivGLaoM0+M4qVJ7vjf4kggB59i896w=";
   };

--- a/pkgs/by-name/wb/wb32-dfu-updater/package.nix
+++ b/pkgs/by-name/wb/wb32-dfu-updater/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "WestberryTech";
-    repo = finalAttrs.pname;
+    repo = "wb32-dfu-updater";
     rev = finalAttrs.version;
     hash = "sha256-DKsDVO00JFhR9hIZksFVJLRwC6PF9LCRpf++QywFO2w=";
   };

--- a/pkgs/by-name/xl/xld/package.nix
+++ b/pkgs/by-name/xl/xld/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "20240511";
 
   src = fetchurl {
-    url = "mirror://sourceforge/${finalAttrs.pname}/${finalAttrs.pname}-${finalAttrs.version}.dmg";
+    url = "mirror://sourceforge/xld/xld-${finalAttrs.version}.dmg";
     hash = "sha256-8xfjAWgtSdbD8gGlkGzT8QRz7egIf4PE/rFsFEDX0+c=";
   };
 

--- a/pkgs/data/fonts/aileron/default.nix
+++ b/pkgs/data/fonts/aileron/default.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/${finalAttrs.pname}_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/download/fonts/aileron_${majorVersion}${minorVersion}.zip";
     hash = "sha256-Ht48gwJZrn0djo1yl6jHZ4+0b710FVwStiC1Zk5YXME=";
     stripRoot = false;
   };

--- a/pkgs/data/fonts/aileron/default.nix
+++ b/pkgs/data/fonts/aileron/default.nix
@@ -23,7 +23,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${finalAttrs.pname}/";
+    homepage = "http://dotcolon.net/font/aileron/";
     description = "Helvetica font in nine weights";
     platforms = platforms.all;
     maintainers = with maintainers; [ leenaars minijackson ];

--- a/pkgs/data/fonts/aileron/default.nix
+++ b/pkgs/data/fonts/aileron/default.nix
@@ -4,7 +4,7 @@ let
   majorVersion = "0";
   minorVersion = "102";
 in
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "aileron";
   version = "${majorVersion}.${minorVersion}";
 
@@ -29,4 +29,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [ leenaars minijackson ];
     license = licenses.cc0;
   };
-})
+}

--- a/pkgs/data/fonts/blackout/default.nix
+++ b/pkgs/data/fonts/blackout/default.nix
@@ -6,7 +6,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "theleagueof";
-    repo = finalAttrs.pname;
+    repo = "blackout";
     rev = "4864cfc1749590e9f78549c6e57116fe98480c0f";
     hash = "sha256-UmJVmtuPQYW/w+mdnJw9Ql4R1xf/07l+/Ky1wX9WKqw=";
   };

--- a/pkgs/data/fonts/blackout/default.nix
+++ b/pkgs/data/fonts/blackout/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitHub, stdenvNoCC }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "blackout";
   version = "2014-07-29";
 
@@ -33,4 +33,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.ofl;
     maintainers = with lib.maintainers; [ minijackson ];
   };
-})
+}

--- a/pkgs/data/fonts/chunk/default.nix
+++ b/pkgs/data/fonts/chunk/default.nix
@@ -6,7 +6,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "theleagueof";
-    repo = finalAttrs.pname;
+    repo = "chunk";
     rev = "12a243f3fb7c7a68844901023f7d95d6eaf14104";
     hash = "sha256-NMkRvrUgy9yzOT3a1rN6Ch/p8Cr902CwL4G0w7jVm1E=";
   };

--- a/pkgs/data/fonts/chunk/default.nix
+++ b/pkgs/data/fonts/chunk/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitHub, stdenvNoCC }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "chunk";
   version = "2021-03-03";
 
@@ -35,4 +35,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.ofl;
     maintainers = with lib.maintainers; [ minijackson ];
   };
-})
+}

--- a/pkgs/data/fonts/eunomia/default.nix
+++ b/pkgs/data/fonts/eunomia/default.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/${finalAttrs.pname}_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/download/fonts/eunomia_${majorVersion}${minorVersion}.zip";
     hash = "sha256-Rd2EakaTWjzoEV00tHTgg/bXgJUFfPjCyQUWi7QhFG4=";
     stripRoot = false;
   };

--- a/pkgs/data/fonts/eunomia/default.nix
+++ b/pkgs/data/fonts/eunomia/default.nix
@@ -4,7 +4,7 @@ let
   majorVersion = "0";
   minorVersion = "200";
 in
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "eunomia";
   version = "${majorVersion}.${minorVersion}";
 
@@ -29,4 +29,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [ leenaars minijackson ];
     license = licenses.ofl;
   };
-})
+}

--- a/pkgs/data/fonts/f1_8/default.nix
+++ b/pkgs/data/fonts/f1_8/default.nix
@@ -24,7 +24,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${finalAttrs.pname}/";
+    homepage = "http://dotcolon.net/font/f1_8/";
     description = "Weighted decorative font";
     platforms = platforms.all;
     maintainers = with maintainers; [ minijackson ];

--- a/pkgs/data/fonts/f1_8/default.nix
+++ b/pkgs/data/fonts/f1_8/default.nix
@@ -4,7 +4,7 @@ let
   majorVersion = "1";
   minorVersion = "101";
 in
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "f1_8";
   version = "${majorVersion}.${minorVersion}";
 
@@ -30,4 +30,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [ minijackson ];
     license = licenses.ofl;
   };
-})
+}

--- a/pkgs/data/fonts/f5_6/default.nix
+++ b/pkgs/data/fonts/f5_6/default.nix
@@ -4,7 +4,7 @@ let
   majorVersion = "0";
   minorVersion = "110";
 in
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "f5_6";
   version = "${majorVersion}.${minorVersion}";
 
@@ -29,4 +29,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [ leenaars minijackson ];
     license = licenses.ofl;
   };
-})
+}

--- a/pkgs/data/fonts/f5_6/default.nix
+++ b/pkgs/data/fonts/f5_6/default.nix
@@ -23,7 +23,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${finalAttrs.pname}/";
+    homepage = "http://dotcolon.net/font/f5_6/";
     description = "Weighted decorative font";
     platforms = platforms.all;
     maintainers = with maintainers; [ leenaars minijackson ];

--- a/pkgs/data/fonts/f5_6/default.nix
+++ b/pkgs/data/fonts/f5_6/default.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/${finalAttrs.pname}_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/download/fonts/f5_6_${majorVersion}${minorVersion}.zip";
     hash = "sha256-FeCU+mzR0iO5tixI72XUnhvpGj+WRfKyT3mhBtud3uE=";
     stripRoot = false;
   };

--- a/pkgs/data/fonts/fa_1/default.nix
+++ b/pkgs/data/fonts/fa_1/default.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/${finalAttrs.pname}_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/download/fonts/fa_1_${majorVersion}${minorVersion}.zip";
     hash = "sha256-BPJ+wZMYXY/yg5oEgBc5YnswA6A7w6V0gdv+cac0qdc=";
     stripRoot = false;
   };

--- a/pkgs/data/fonts/fa_1/default.nix
+++ b/pkgs/data/fonts/fa_1/default.nix
@@ -23,7 +23,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${finalAttrs.pname}/";
+    homepage = "http://dotcolon.net/font/fa_1/";
     description = "Weighted decorative font";
     platforms = platforms.all;
     maintainers = with maintainers; [ minijackson ];

--- a/pkgs/data/fonts/fa_1/default.nix
+++ b/pkgs/data/fonts/fa_1/default.nix
@@ -4,7 +4,7 @@ let
   majorVersion = "0";
   minorVersion = "100";
 in
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "fa_1";
   version = "${majorVersion}.${minorVersion}";
 
@@ -29,4 +29,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [ minijackson ];
     license = licenses.ofl;
   };
-})
+}

--- a/pkgs/data/fonts/fanwood/default.nix
+++ b/pkgs/data/fonts/fanwood/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitHub, stdenvNoCC }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "fanwood";
   version = "2011-05-11";
 
@@ -29,4 +29,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.ofl;
     maintainers = with lib.maintainers; [ minijackson ];
   };
-})
+}

--- a/pkgs/data/fonts/fanwood/default.nix
+++ b/pkgs/data/fonts/fanwood/default.nix
@@ -6,7 +6,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "theleagueof";
-    repo = finalAttrs.pname;
+    repo = "fanwood";
     rev = "cbaaed9704e7d37d3dcdbdf0b472e9efd0e39432";
     hash = "sha256-OroFhhb4RxPHkx+/8PtFnxs1GQVXMPiYTd+2vnRbIjg=";
   };

--- a/pkgs/data/fonts/ferrum/default.nix
+++ b/pkgs/data/fonts/ferrum/default.nix
@@ -4,7 +4,7 @@ let
   majorVersion = "0";
   minorVersion = "200";
 in
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "ferrum";
   version = "${majorVersion}.${minorVersion}";
 
@@ -29,4 +29,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [ leenaars minijackson ];
     license = licenses.cc0;
   };
-})
+}

--- a/pkgs/data/fonts/ferrum/default.nix
+++ b/pkgs/data/fonts/ferrum/default.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/${finalAttrs.pname}_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/download/fonts/ferrum_${majorVersion}${minorVersion}.zip";
     hash = "sha256-NDJwgFWZgyhMkGRWlY55l2omEw6ju3e3dHCEsWNzQIc=";
     stripRoot = false;
   };

--- a/pkgs/data/fonts/ferrum/default.nix
+++ b/pkgs/data/fonts/ferrum/default.nix
@@ -23,7 +23,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${finalAttrs.pname}/";
+    homepage = "http://dotcolon.net/font/ferrum/";
     description = "Decorative font";
     platforms = platforms.all;
     maintainers = with maintainers; [ leenaars minijackson ];

--- a/pkgs/data/fonts/goudy-bookletter-1911/default.nix
+++ b/pkgs/data/fonts/goudy-bookletter-1911/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitHub, stdenvNoCC }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "goudy-bookletter-1911";
   version = "2011-05-11";
 
@@ -25,4 +25,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.ofl;
     maintainers = with lib.maintainers; [ minijackson ];
   };
-})
+}

--- a/pkgs/data/fonts/goudy-bookletter-1911/default.nix
+++ b/pkgs/data/fonts/goudy-bookletter-1911/default.nix
@@ -6,7 +6,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "theleagueof";
-    repo = finalAttrs.pname;
+    repo = "goudy-bookletter-1911";
     rev = "85ff5b834b4f63feb36fd2053949c19660580e48";
     hash = "sha256-11axs1+SRQj+1lYTq2LYf1I65WrrvB/UnAgZkHPP1N8=";
   };

--- a/pkgs/data/fonts/junction/default.nix
+++ b/pkgs/data/fonts/junction/default.nix
@@ -6,7 +6,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "theleagueof";
-    repo = finalAttrs.pname;
+    repo = "junction";
     rev = "fb73260e86dd301b383cf6cc9ca8e726ef806535";
     hash = "sha256-Zqh23HPWGed+JkADYjYdsVNRxqJDvC9xhnqAqWZ3Eu8=";
   };

--- a/pkgs/data/fonts/junction/default.nix
+++ b/pkgs/data/fonts/junction/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitHub, stdenvNoCC }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "junction";
   version = "2014-05-29";
 
@@ -31,4 +31,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.ofl;
     maintainers = with lib.maintainers; [ minijackson ];
   };
-})
+}

--- a/pkgs/data/fonts/knewave/default.nix
+++ b/pkgs/data/fonts/knewave/default.nix
@@ -6,7 +6,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "theleagueof";
-    repo = finalAttrs.pname;
+    repo = "knewave";
     rev = "f335d5ff1f12e4acf97d4208e1c37b4d386e57fb";
     hash = "sha256-SaJU2GlxU7V3iJNQzFKg1YugaPsiJuSZpC8NCqtWyz0=";
   };

--- a/pkgs/data/fonts/knewave/default.nix
+++ b/pkgs/data/fonts/knewave/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitHub, stdenvNoCC }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "knewave";
   version = "2012-07-30";
 
@@ -29,4 +29,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.ofl;
     maintainers = with lib.maintainers; [ minijackson ];
   };
-})
+}

--- a/pkgs/data/fonts/league-script-number-one/default.nix
+++ b/pkgs/data/fonts/league-script-number-one/default.nix
@@ -6,7 +6,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "theleagueof";
-    repo = finalAttrs.pname;
+    repo = "league-script-number-one";
     rev = "225add0b37cf8268759ba4572e02630d9fb54ecf";
     hash = "sha256-Z3Zrp0Os3On0tESVical1Qh6wY1H2Hc0OPTlkbtsrCI=";
   };

--- a/pkgs/data/fonts/league-script-number-one/default.nix
+++ b/pkgs/data/fonts/league-script-number-one/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitHub, stdenvNoCC }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "league-script-number-one";
   version = "2011-05-25";
 
@@ -32,4 +32,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.ofl;
     maintainers = with lib.maintainers; [ minijackson ];
   };
-})
+}

--- a/pkgs/data/fonts/linden-hill/default.nix
+++ b/pkgs/data/fonts/linden-hill/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitHub, stdenvNoCC }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "linden-hill";
   version = "2011-05-25";
 
@@ -29,4 +29,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.ofl;
     maintainers = with lib.maintainers; [ minijackson ];
   };
-})
+}

--- a/pkgs/data/fonts/linden-hill/default.nix
+++ b/pkgs/data/fonts/linden-hill/default.nix
@@ -6,7 +6,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "theleagueof";
-    repo = finalAttrs.pname;
+    repo = "linden-hill";
     rev = "a3f7ae6c4cac1b7e5ce5269e1fcc6a2fbb9e31ee";
     hash = "sha256-EjXcLjzVQeOJgLxGua8t0oMc+APOsONGGpG6VJVCgFw=";
   };

--- a/pkgs/data/fonts/medio/default.nix
+++ b/pkgs/data/fonts/medio/default.nix
@@ -4,7 +4,7 @@ let
   majorVersion = "0";
   minorVersion = "200";
 in
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "medio";
   version = "${majorVersion}.${minorVersion}";
 
@@ -34,4 +34,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [ leenaars minijackson ];
     license = licenses.cc0;
   };
-})
+}

--- a/pkgs/data/fonts/medio/default.nix
+++ b/pkgs/data/fonts/medio/default.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/${finalAttrs.pname}_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/download/fonts/medio_${majorVersion}${minorVersion}.zip";
     hash = "sha256-S+CcwD4zGVk7cIFD6K4NnpE/0mrJq4RnDJC576rhcLQ=";
     stripRoot = false;
   };

--- a/pkgs/data/fonts/medio/default.nix
+++ b/pkgs/data/fonts/medio/default.nix
@@ -23,7 +23,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${finalAttrs.pname}/";
+    homepage = "http://dotcolon.net/font/medio/";
     description = "Serif font designed by Sora Sagano";
     longDescription = ''
       Medio is a serif font designed by Sora Sagano, based roughly

--- a/pkgs/data/fonts/melete/default.nix
+++ b/pkgs/data/fonts/melete/default.nix
@@ -23,7 +23,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${finalAttrs.pname}/";
+    homepage = "http://dotcolon.net/font/melete/";
     description = "Headline typeface that could be used as a movie title";
     platforms = platforms.all;
     maintainers = with maintainers; [ minijackson ];

--- a/pkgs/data/fonts/melete/default.nix
+++ b/pkgs/data/fonts/melete/default.nix
@@ -4,7 +4,7 @@ let
   majorVersion = "0";
   minorVersion = "200";
 in
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "melete";
   version = "${majorVersion}.${minorVersion}";
 
@@ -29,4 +29,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [ minijackson ];
     license = licenses.ofl;
   };
-})
+}

--- a/pkgs/data/fonts/melete/default.nix
+++ b/pkgs/data/fonts/melete/default.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/${finalAttrs.pname}_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/download/fonts/melete_${majorVersion}${minorVersion}.zip";
     hash = "sha256-y1xtNM1Oy92gOvbr9J71XNxb1JeTzOgxKms3G2YHK00=";
     stripRoot = false;
   };

--- a/pkgs/data/fonts/nacelle/default.nix
+++ b/pkgs/data/fonts/nacelle/default.nix
@@ -23,7 +23,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${finalAttrs.pname}/";
+    homepage = "http://dotcolon.net/font/nacelle/";
     description = "Improved version of the Aileron font";
     platforms = platforms.all;
     maintainers = with maintainers; [ minijackson ];

--- a/pkgs/data/fonts/nacelle/default.nix
+++ b/pkgs/data/fonts/nacelle/default.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/${finalAttrs.pname}_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/download/fonts/nacelle_${majorVersion}${minorVersion}.zip";
     hash = "sha256-e4QsPiyfWEAYHWdwR3CkGc2UzuA3hZPYYlWtIubY0Oo=";
     stripRoot = false;
   };

--- a/pkgs/data/fonts/nacelle/default.nix
+++ b/pkgs/data/fonts/nacelle/default.nix
@@ -4,7 +4,7 @@ let
   majorVersion = "1";
   minorVersion = "00";
 in
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "nacelle";
   version = "${majorVersion}.${minorVersion}";
 
@@ -29,4 +29,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [ minijackson ];
     license = licenses.ofl;
   };
-})
+}

--- a/pkgs/data/fonts/orbitron/default.nix
+++ b/pkgs/data/fonts/orbitron/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenvNoCC, fetchFromGitHub }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "orbitron";
   version = "2011-05-25";
 
@@ -45,4 +45,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     platforms = platforms.all;
     maintainers = with lib.maintainers; [ leenaars minijackson ];
   };
-})
+}

--- a/pkgs/data/fonts/orbitron/default.nix
+++ b/pkgs/data/fonts/orbitron/default.nix
@@ -6,7 +6,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "theleagueof";
-    repo = finalAttrs.pname;
+    repo = "orbitron";
     rev = "13e6a5222aa6818d81c9acd27edd701a2d744152";
     hash = "sha256-zjNPVrDUxcQbrsg1/8fFa6Wenu1yuG/XDfKA7NVZ0rA=";
   };

--- a/pkgs/data/fonts/ostrich-sans/default.nix
+++ b/pkgs/data/fonts/ostrich-sans/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitHub, stdenvNoCC }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "ostrich-sans";
   version = "2014-04-18";
 
@@ -29,4 +29,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.ofl;
     maintainers = with lib.maintainers; [ minijackson ];
   };
-})
+}

--- a/pkgs/data/fonts/ostrich-sans/default.nix
+++ b/pkgs/data/fonts/ostrich-sans/default.nix
@@ -6,7 +6,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "theleagueof";
-    repo = finalAttrs.pname;
+    repo = "ostrich-sans";
     rev = "a949d40d0576d12ba26e2a45e19c91fd0228c964";
     hash = "sha256-vvTNtl+fO2zWooH1EvCmO/dPYYgCkj8Ckg5xfg1gtnw=";
   };

--- a/pkgs/data/fonts/penna/default.nix
+++ b/pkgs/data/fonts/penna/default.nix
@@ -23,7 +23,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${finalAttrs.pname}/";
+    homepage = "http://dotcolon.net/font/penna/";
     description = "Geometric sans serif designed by Sora Sagano";
     longDescription = ''
      Penna is a geometric sans serif designed by Sora Sagano,

--- a/pkgs/data/fonts/penna/default.nix
+++ b/pkgs/data/fonts/penna/default.nix
@@ -4,7 +4,7 @@ let
   majorVersion = "0";
   minorVersion = "100";
 in
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "penna";
   version = "${majorVersion}.${minorVersion}";
 
@@ -34,4 +34,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [ leenaars minijackson ];
     license = licenses.cc0;
   };
-})
+}

--- a/pkgs/data/fonts/penna/default.nix
+++ b/pkgs/data/fonts/penna/default.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/${finalAttrs.pname}_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/download/fonts/penna_${majorVersion}${minorVersion}.zip";
     hash = "sha256-fmCJnEaoUGdW9JK3J7JSm5D4qOMRW7qVKPgVE7uCH5w=";
     stripRoot = false;
   };

--- a/pkgs/data/fonts/prociono/default.nix
+++ b/pkgs/data/fonts/prociono/default.nix
@@ -6,7 +6,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "theleagueof";
-    repo = finalAttrs.pname;
+    repo = "prociono";
     rev = "f9d9680de6d6f0c13939f23c9dd14cd7853cf844";
     hash = "sha256-gC5E0Z0O2cnthoBEu+UOQLsr3/a/3/JPIx3WCPsXXtk=";
   };

--- a/pkgs/data/fonts/prociono/default.nix
+++ b/pkgs/data/fonts/prociono/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitHub, stdenvNoCC }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "prociono";
   version = "2011-05-25";
 
@@ -31,4 +31,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.ofl;
     maintainers = with lib.maintainers; [ minijackson ];
   };
-})
+}

--- a/pkgs/data/fonts/route159/default.nix
+++ b/pkgs/data/fonts/route159/default.nix
@@ -23,7 +23,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${finalAttrs.pname}/";
+    homepage = "http://dotcolon.net/font/route159/";
     description = "Weighted sans serif font";
     platforms = platforms.all;
     maintainers = with maintainers; [ leenaars minijackson ];

--- a/pkgs/data/fonts/route159/default.nix
+++ b/pkgs/data/fonts/route159/default.nix
@@ -4,7 +4,7 @@ let
   majorVersion = "1";
   minorVersion = "10";
 in
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "route159";
   version = "${majorVersion}.${minorVersion}";
 
@@ -29,4 +29,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [ leenaars minijackson ];
     license = licenses.ofl;
   };
-})
+}

--- a/pkgs/data/fonts/route159/default.nix
+++ b/pkgs/data/fonts/route159/default.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/${finalAttrs.pname}_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/download/fonts/route159_${majorVersion}${minorVersion}.zip";
     hash = "sha256-1InyBW1LGbp/IU/ql9mvT14W3MTxJdWThFwRH6VHpTU=";
     stripRoot = false;
   };

--- a/pkgs/data/fonts/seshat/default.nix
+++ b/pkgs/data/fonts/seshat/default.nix
@@ -4,7 +4,7 @@ let
   majorVersion = "0";
   minorVersion = "100";
 in
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "seshat";
   version = "${majorVersion}.${minorVersion}";
 
@@ -39,4 +39,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [ leenaars minijackson ];
     license = licenses.cc0;
   };
-})
+}

--- a/pkgs/data/fonts/seshat/default.nix
+++ b/pkgs/data/fonts/seshat/default.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/${finalAttrs.pname}_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/download/fonts/seshat_${majorVersion}${minorVersion}.zip";
     hash = "sha256-XgprDhzAbcTzZw2QOwpCnzusYheYmSlM+ApU+Y0wO2Q=";
     stripRoot = false;
   };

--- a/pkgs/data/fonts/seshat/default.nix
+++ b/pkgs/data/fonts/seshat/default.nix
@@ -23,7 +23,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${finalAttrs.pname}/";
+    homepage = "http://dotcolon.net/font/seshat/";
     description = "Roman body font designed for main text by Sora Sagano";
     longDescription = ''
       Seshat is a Roman body font designed for the main text. By

--- a/pkgs/data/fonts/sniglet/default.nix
+++ b/pkgs/data/fonts/sniglet/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitHub, stdenvNoCC }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "sniglet";
   version = "2011-05-25";
 
@@ -30,4 +30,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.ofl;
     maintainers = with lib.maintainers; [ minijackson ];
   };
-})
+}

--- a/pkgs/data/fonts/sniglet/default.nix
+++ b/pkgs/data/fonts/sniglet/default.nix
@@ -6,7 +6,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "theleagueof";
-    repo = finalAttrs.pname;
+    repo = "sniglet";
     rev = "5c6b0860bdd0d8c4f16222e4de3918c384db17c4";
     hash = "sha256-fLT2hZT9o1Ka30EB/6oWwmalhVJ+swXLRFG99yRWd2c=";
   };

--- a/pkgs/data/fonts/sorts-mill-goudy/default.nix
+++ b/pkgs/data/fonts/sorts-mill-goudy/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitHub, stdenvNoCC }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "sorts-mill-goudy";
   version = "2011-05-25";
 
@@ -33,4 +33,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.ofl;
     maintainers = with lib.maintainers; [ minijackson ];
   };
-})
+}

--- a/pkgs/data/fonts/sorts-mill-goudy/default.nix
+++ b/pkgs/data/fonts/sorts-mill-goudy/default.nix
@@ -6,7 +6,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "theleagueof";
-    repo = finalAttrs.pname;
+    repo = "sorts-mill-goudy";
     rev = "06072890c7b05f274215a24f17449655ccb2c8af";
     hash = "sha256-NEfLBJatUmdUL5gJEimJHZfOd1OtI7pxTN97eWMODyM=";
   };

--- a/pkgs/data/fonts/tenderness/default.nix
+++ b/pkgs/data/fonts/tenderness/default.nix
@@ -4,7 +4,7 @@ let
   majorVersion = "0";
   minorVersion = "601";
 in
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "tenderness";
   version = "${majorVersion}.${minorVersion}";
 
@@ -29,4 +29,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [ leenaars minijackson ];
     license = licenses.ofl;
   };
-})
+}

--- a/pkgs/data/fonts/tenderness/default.nix
+++ b/pkgs/data/fonts/tenderness/default.nix
@@ -23,7 +23,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${finalAttrs.pname}/";
+    homepage = "http://dotcolon.net/font/tenderness/";
     description = "Serif font designed by Sora Sagano with old-style figures";
     platforms = platforms.all;
     maintainers = with maintainers; [ leenaars minijackson ];

--- a/pkgs/data/fonts/tenderness/default.nix
+++ b/pkgs/data/fonts/tenderness/default.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/${finalAttrs.pname}_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/download/fonts/tenderness_${majorVersion}${minorVersion}.zip";
     hash = "sha256-bwJKW+rY7/r2pBCSA6HYlaRMsI/U8UdW2vV4tmYuJww=";
     stripRoot = false;
   };

--- a/pkgs/data/fonts/vegur/default.nix
+++ b/pkgs/data/fonts/vegur/default.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/${finalAttrs.pname}_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/download/fonts/vegur_${majorVersion}${minorVersion}.zip";
     hash = "sha256-sGb3mEb3g15ZiVCxEfAanly8zMUopLOOjw8W4qbXLPA=";
     stripRoot = false;
   };

--- a/pkgs/data/fonts/vegur/default.nix
+++ b/pkgs/data/fonts/vegur/default.nix
@@ -4,7 +4,7 @@ let
   majorVersion = "0";
   minorVersion = "701";
 in
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "vegur";
   version = "${majorVersion}.${minorVersion}";
 
@@ -29,4 +29,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [ minijackson ];
     license = licenses.cc0;
   };
-})
+}

--- a/pkgs/data/icons/gruppled-cursors/default.nix
+++ b/pkgs/data/icons/gruppled-cursors/default.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "nim65s";
-    repo = finalAttrs.pname;
+    repo = "gruppled-cursors";
     rev = "v${finalAttrs.version}";
     hash = "sha256-ejlgdogjIYevZvB23si6bEeU6qY7rWXflaUyVk5MzqU=";
   };

--- a/pkgs/data/icons/gruppled-lite-cursors/default.nix
+++ b/pkgs/data/icons/gruppled-lite-cursors/default.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "nim65s";
-    repo = finalAttrs.pname;
+    repo = "gruppled-lite-cursors";
     rev = "v${finalAttrs.version}";
     hash = "sha256-adCXYu8v6mFKXubVQb/RCZXS87//YgixQp20kMt7KT8=";
   };

--- a/pkgs/data/themes/whitesur-kde/default.nix
+++ b/pkgs/data/themes/whitesur-kde/default.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "vinceliuice";
-    repo = finalAttrs.pname;
+    repo = "whitesur-kde";
     rev = "2b4bcc76168bd8a4a7601188e177fa0ab485cdc8";
     hash = "sha256-+Iooj8a7zfLhEWnjLEVoe/ebD9Vew5HZdz0wpWVZxA8=";
   };

--- a/pkgs/data/themes/whitesur-kde/default.nix
+++ b/pkgs/data/themes/whitesur-kde/default.nix
@@ -7,7 +7,7 @@
 , gitUpdater
 }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "whitesur-kde";
   version = "unstable-2023-10-06";
 
@@ -60,4 +60,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     platforms = platforms.all;
     maintainers = [ maintainers.romildo ];
   };
-})
+}

--- a/pkgs/desktops/gnome/core/gdm/default.nix
+++ b/pkgs/desktops/gnome/core/gdm/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gdm/${lib.versions.major finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
+    url = "mirror://gnome/sources/gdm/${lib.versions.major finalAttrs.version}/gdm-${finalAttrs.version}.tar.xz";
     hash = "sha256-TuNFQioWU3FQzYQkUM2lKyyoaYS8Ue4gzcAl3PS9Jos=";
   };
 

--- a/pkgs/development/cuda-modules/cuda-samples/generic.nix
+++ b/pkgs/development/cuda-modules/cuda-samples/generic.nix
@@ -24,7 +24,7 @@ backendStdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
-    repo = finalAttrs.pname;
+    repo = "cuda-samples";
     rev = "v${finalAttrs.version}";
     inherit hash;
   };

--- a/pkgs/development/cuda-modules/nccl-tests/default.nix
+++ b/pkgs/development/cuda-modules/nccl-tests/default.nix
@@ -29,7 +29,7 @@ backendStdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
-    repo = finalAttrs.pname;
+    repo = "nccl-tests";
     rev = "v${finalAttrs.version}";
     hash = "sha256-QYuMBPhvHHVo2ku14jD1CVINLPW0cyiXJkXxb77IxbE=";
   };

--- a/pkgs/development/cuda-modules/nccl/default.nix
+++ b/pkgs/development/cuda-modules/nccl/default.nix
@@ -29,7 +29,7 @@ backendStdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
-    repo = finalAttrs.pname;
+    repo = "nccl";
     rev = "v${finalAttrs.version}";
     hash = "sha256-IF2tILwW8XnzSmfn7N1CO7jXL95gUp02guIW5n1eaig=";
   };

--- a/pkgs/development/libraries/aws-c-cal/default.nix
+++ b/pkgs/development/libraries/aws-c-cal/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "awslabs";
-    repo = finalAttrs.pname;
+    repo = "aws-c-cal";
     rev = "v${finalAttrs.version}";
     hash = "sha256-RrUJz3IqwbBJ8NuJTIWqK33FlJHolcaid55PT2EhO24=";
   };

--- a/pkgs/development/libraries/blaze/default.nix
+++ b/pkgs/development/libraries/blaze/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromBitbucket {
     owner = "blaze-lib";
-    repo = finalAttrs.pname;
+    repo = "blaze";
     rev = "v${finalAttrs.version}";
     hash = "sha256-Jl9ZWFqBvLgQwCoMNX3g7z02yc7oYx+d6mbyLBzBJOs=";
   };

--- a/pkgs/development/libraries/cppcodec/default.nix
+++ b/pkgs/development/libraries/cppcodec/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "tplgy";
-    repo = finalAttrs.pname;
+    repo = "cppcodec";
     rev = "v${finalAttrs.version}";
     hash = "sha256-k4EACtDOSkTXezTeFtVdM1EVJjvGga/IQSrvDzhyaXw=";
   };

--- a/pkgs/development/libraries/crocoddyl/default.nix
+++ b/pkgs/development/libraries/crocoddyl/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "loco-3d";
-    repo = finalAttrs.pname;
+    repo = "crocoddyl";
     rev = "v${finalAttrs.version}";
     hash = "sha256-SVV9sleDXLm2QJmNgL25XLHC3y5bfKab4GSlE8jbT8w=";
   };

--- a/pkgs/development/libraries/freetts/default.nix
+++ b/pkgs/development/libraries/freetts/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.2.2";
 
   src = fetchzip {
-    url = "mirror://sourceforge/freetts/${finalAttrs.pname}-${finalAttrs.version}-src.zip";
+    url = "mirror://sourceforge/freetts/freetts-${finalAttrs.version}-src.zip";
     hash = "sha256-+bhM0ErEZVnmcz5CBqn/AeGaOhKnCjZzGeqgO/89wms=";
     stripRoot = false;
   };

--- a/pkgs/development/libraries/geos/3.11.nix
+++ b/pkgs/development/libraries/geos/3.11.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.11.4";
 
   src = fetchurl {
-    url = "https://download.osgeo.org/geos/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
+    url = "https://download.osgeo.org/geos/geos-${finalAttrs.version}.tar.bz2";
     hash = "sha256-NkyIzPw4qlDPZccA57KuRwbtEDMmEoST2/dQx40TbSw=";
   };
 

--- a/pkgs/development/libraries/geos/3.9.nix
+++ b/pkgs/development/libraries/geos/3.9.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.9.5";
 
   src = fetchurl {
-    url = "https://download.osgeo.org/geos/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
+    url = "https://download.osgeo.org/geos/geos-${finalAttrs.version}.tar.bz2";
     hash = "sha256-xsmu36iGT7RLp4kRQIRCOCv9BpDPLUCRrjgFyGN4kDY=";
   };
 

--- a/pkgs/development/libraries/geos/default.nix
+++ b/pkgs/development/libraries/geos/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.12.2";
 
   src = fetchurl {
-    url = "https://download.osgeo.org/geos/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
+    url = "https://download.osgeo.org/geos/geos-${finalAttrs.version}.tar.bz2";
     hash = "sha256-NMd3C/AJDuiEiK+Ydn0I53nxJPozQ34Kq+yKvUYJ/sY=";
   };
 

--- a/pkgs/development/libraries/glew/1.10.nix
+++ b/pkgs/development/libraries/glew/1.10.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.10.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/glew/${finalAttrs.pname}-${finalAttrs.version}.tgz";
+    url = "mirror://sourceforge/glew/glew-${finalAttrs.version}.tgz";
     sha256 = "01zki46dr5khzlyywr3cg615bcal32dazfazkf360s1znqh17i4r";
   };
 

--- a/pkgs/development/libraries/glew/default.nix
+++ b/pkgs/development/libraries/glew/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.2.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/glew/${finalAttrs.pname}-${finalAttrs.version}.tgz";
+    url = "mirror://sourceforge/glew/glew-${finalAttrs.version}.tgz";
     sha256 = "1qak8f7g1iswgswrgkzc7idk7jmqgwrs58fhg2ai007v7j4q5z6l";
   };
 

--- a/pkgs/development/libraries/graphene/default.nix
+++ b/pkgs/development/libraries/graphene/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "ebassi";
-    repo = finalAttrs.pname;
+    repo = "graphene";
     rev = finalAttrs.version;
     sha256 = "P6JQhSktzvyMHatP/iojNGXPmcsxsFxdYerXzS23ojI=";
   };

--- a/pkgs/development/libraries/gsasl/default.nix
+++ b/pkgs/development/libraries/gsasl/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.2.1";
 
   src = fetchurl {
-    url = "mirror://gnu/gsasl/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    url = "mirror://gnu/gsasl/gsasl-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-1FtWLhO9E7n8ILNy9LUyaXQM9iefg28JzhG50yvO4HU=";
   };
 

--- a/pkgs/development/libraries/hpp-fcl/default.nix
+++ b/pkgs/development/libraries/hpp-fcl/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "humanoid-path-planner";
-    repo = finalAttrs.pname;
+    repo = "hpp-fcl";
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-BwS9RSirdlD6Cqwp7KD59dkh2WsJVwdlH9LzM2AFjI4=";

--- a/pkgs/development/libraries/igraph/default.nix
+++ b/pkgs/development/libraries/igraph/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "igraph";
-    repo = finalAttrs.pname;
+    repo = "igraph";
     rev = finalAttrs.version;
     hash = "sha256-c5yZI5AfaO/NFyy88efu1COb+T2r1LpHhUTfilw2H1U=";
   };

--- a/pkgs/development/libraries/imlib2/default.nix
+++ b/pkgs/development/libraries/imlib2/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.12.2";
 
   src = fetchurl {
-    url = "mirror://sourceforge/enlightenment/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
+    url = "mirror://sourceforge/enlightenment/imlib2-${finalAttrs.version}.tar.xz";
     hash = "sha256-zEmTGiBWCWioZIycoHkIWXYIXqltWaAbHhfLVa8P/kI=";
   };
 

--- a/pkgs/development/libraries/ldb/default.nix
+++ b/pkgs/development/libraries/ldb/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.9.0";
 
   src = fetchurl {
-    url = "mirror://samba/ldb/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    url = "mirror://samba/ldb/ldb-${finalAttrs.version}.tar.gz";
     hash = "sha256-EFqv9xrYgaf661gv1BauKCIbb94zj/+CgoBlBiwlB6U=";
   };
 

--- a/pkgs/development/libraries/libidn/default.nix
+++ b/pkgs/development/libraries/libidn/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.42";
 
   src = fetchurl {
-    url = "mirror://gnu/libidn/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    url = "mirror://gnu/libidn/libidn-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-1sGZ3NgG5P4nk2DLSwg0mg05Vg7VSP/RzK3ajN7LRyM=";
   };
 

--- a/pkgs/development/libraries/libpst/default.nix
+++ b/pkgs/development/libraries/libpst/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.6.76";
 
   src = fetchurl {
-    url = "http://www.five-ten-sg.com/libpst/packages/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    url = "http://www.five-ten-sg.com/libpst/packages/libpst-${finalAttrs.version}.tar.gz";
     hash = "sha256-PSkb7rvbSNK5NGCLwGGVtkHaY9Ko9eDThvLp1tBaC0I=";
   };
 

--- a/pkgs/development/libraries/libsass/default.nix
+++ b/pkgs/development/libraries/libsass/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "sass";
-    repo = finalAttrs.pname;
+    repo = "libsass";
     rev = finalAttrs.version;
     hash = "sha256-FkLL3OAJXDptRQY6ZkYbss2pcc40f/wasIvEIyHRQFo=";
     # Remove unicode file names which leads to different checksums on HFS+

--- a/pkgs/development/libraries/libsodium/default.nix
+++ b/pkgs/development/libraries/libsodium/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0.20";
 
   src = fetchurl {
-    url = "https://download.libsodium.org/libsodium/releases/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    url = "https://download.libsodium.org/libsodium/releases/libsodium-${finalAttrs.version}.tar.gz";
     hash = "sha256-67Ze9spDkzPCu0GgwZkFhyiNoH9sf9B8s6GMwY0wzhk=";
   };
 

--- a/pkgs/development/libraries/libvarlink/default.nix
+++ b/pkgs/development/libraries/libvarlink/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "varlink";
-    repo = finalAttrs.pname;
+    repo = "libvarlink";
     rev = finalAttrs.version;
     sha256 = "sha256-oUy9HhybNMjRBWoqqal1Mw8cC5RddgN4izxAl0cgnKE=";
   };

--- a/pkgs/development/libraries/libzip/default.nix
+++ b/pkgs/development/libraries/libzip/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.10.1";
 
   src = fetchurl {
-    url = "https://libzip.org/download/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    url = "https://libzip.org/download/libzip-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-lmmuXf46xbOJdTbchGaodMjPLA47H90I11snOIQpk2M=";
   };
 

--- a/pkgs/development/libraries/minizip-ng/default.nix
+++ b/pkgs/development/libraries/minizip-ng/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "zlib-ng";
-    repo = finalAttrs.pname;
+    repo = "minizip-ng";
     rev = finalAttrs.version;
     hash = "sha256-rP3WficGQZ2sSYnU9Tj0lVl36ShwV76fn/1lv+TrK2c=";
   };

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -24,7 +24,7 @@ let
     inherit version;
 
     src = fetchurl {
-      url = "https://www.openssl.org/source/${finalAttrs.pname}-${version}.tar.gz";
+      url = "https://www.openssl.org/source/openssl-${version}.tar.gz";
       inherit hash;
     };
 

--- a/pkgs/development/libraries/pcaudiolib/default.nix
+++ b/pkgs/development/libraries/pcaudiolib/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "espeak-ng";
-    repo = finalAttrs.pname;
+    repo = "pcaudiolib";
     rev = finalAttrs.version;
     hash = "sha256-ZG/HBk5DHaZP/H3M01vDr3M2nP9awwsPuKpwtalz3EE=";
   };

--- a/pkgs/development/libraries/pinocchio/default.nix
+++ b/pkgs/development/libraries/pinocchio/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "stack-of-tasks";
-    repo = finalAttrs.pname;
+    repo = "pinocchio";
     rev = "v${finalAttrs.version}";
     hash = "sha256-h4NzfS27+jWyHbegxF+pgN6JzJdVAoM16J6G/9uNJc4=";
   };

--- a/pkgs/development/libraries/pulseaudio-qt/default.nix
+++ b/pkgs/development/libraries/pulseaudio-qt/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3.0";
 
   src = fetchurl {
-    url = "mirror://kde/stable/${finalAttrs.pname}/${finalAttrs.pname}-${lib.versions.majorMinor finalAttrs.version}.tar.xz";
+    url = "mirror://kde/stable/pulseaudio-qt/pulseaudio-qt-${lib.versions.majorMinor finalAttrs.version}.tar.xz";
     sha256 = "1i4yb0v1mmhih8c2i61hybg6q60qys3pc5wbjb7a0vwl1mihgsxw";
   };
 

--- a/pkgs/development/libraries/rocksdb/default.nix
+++ b/pkgs/development/libraries/rocksdb/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "facebook";
-    repo = finalAttrs.pname;
+    repo = "rocksdb";
     rev = "v${finalAttrs.version}";
     hash = "sha256-bTUzh7ch14TDcm6GkfhA5I/qUVmUm+RE5d2HMZ3zaNc=";
   };

--- a/pkgs/development/libraries/science/math/tiny-cuda-nn/default.nix
+++ b/pkgs/development/libraries/science/math/tiny-cuda-nn/default.nix
@@ -46,7 +46,7 @@ in
 
     src = fetchFromGitHub {
       owner = "NVlabs";
-      repo = finalAttrs.pname;
+      repo = "tiny-cuda-nn";
       rev = "v${finalAttrs.version}";
       fetchSubmodules = true;
       hash = "sha256-qW6Fk2GB71fvZSsfu+mykabSxEKvaikZ/pQQZUycOy0=";

--- a/pkgs/development/tools/kdoctor/default.nix
+++ b/pkgs/development/tools/kdoctor/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.1.0";
 
   src = fetchurl {
-    url = "https://github.com/Kotlin/${finalAttrs.pname}/releases/download/v${finalAttrs.version}/kdoctor_${finalAttrs.version}+97.zip";
+    url = "https://github.com/Kotlin/kdoctor/releases/download/v${finalAttrs.version}/kdoctor_${finalAttrs.version}+97.zip";
     hash = "sha256-H4lpdMf1AIU8BC+6DlvcwM1wLuEl+Hd9xBli/TGFMV4=";
   };
 

--- a/pkgs/development/tools/spring-boot-cli/default.nix
+++ b/pkgs/development/tools/spring-boot-cli/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.3.1";
 
   src = fetchzip {
-    url = "mirror://maven/org/springframework/boot/${finalAttrs.pname}/${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}-bin.zip";
+    url = "mirror://maven/org/springframework/boot/spring-boot-cli/${finalAttrs.version}/spring-boot-cli-${finalAttrs.version}-bin.zip";
     hash = "sha256-3Mlid+hvHVjAw5pE6vyieSHWH8Zkoty3GuwE1gB5yQM=";
   };
 

--- a/pkgs/development/tools/xcodes/default.nix
+++ b/pkgs/development/tools/xcodes/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "XcodesOrg";
-    repo = finalAttrs.pname;
+    repo = "xcodes";
     rev = finalAttrs.version;
     hash = "sha256-ARrSQ9ozM90Yg7y4WdU7jjNQ64sXHuhxZh/iNJcFfY0=";
   };

--- a/pkgs/servers/elasticmq-server-bin/default.nix
+++ b/pkgs/servers/elasticmq-server-bin/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.6.5";
 
   src = fetchurl {
-    url = "https://s3-eu-west-1.amazonaws.com/softwaremill-public/${finalAttrs.pname}-${finalAttrs.version}.jar";
+    url = "https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-${finalAttrs.version}.jar";
     sha256 = "sha256-7VpalDKa2Qr3HaIO5LcORvm5rAhgYQzStQkp7rs3pMQ=";
   };
 

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "4.20.1";
 
   src = fetchurl {
-    url = "mirror://samba/pub/samba/stable/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    url = "mirror://samba/pub/samba/stable/samba-${finalAttrs.version}.tar.gz";
     hash = "sha256-+Tw69SlTQNCBBsfA3PuF5PhQV9/RRYeqiBe+sxr/iPc=";
   };
 

--- a/pkgs/servers/squid/default.nix
+++ b/pkgs/servers/squid/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "6.8";
 
   src = fetchurl {
-    url = "http://www.squid-cache.org/Versions/v6/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
+    url = "http://www.squid-cache.org/Versions/v6/squid-${finalAttrs.version}.tar.xz";
     hash = "sha256-EcxWULUYCdmUg8z64kdEouUc0WGZ9f8MkX6E/OaVhw8=";
   };
 

--- a/pkgs/servers/web-apps/pixelfed/default.nix
+++ b/pkgs/servers/web-apps/pixelfed/default.nix
@@ -14,7 +14,7 @@ php.buildComposerProject (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "pixelfed";
-    repo = finalAttrs.pname;
+    repo = "pixelfed";
     rev = "v${finalAttrs.version}";
     hash = "sha256-pNo10vvUD7q0HLM7+GgT+6PyocF4kDZ3Zee4ZCPDJNQ=";
   };

--- a/pkgs/tools/misc/lottieconverter/default.nix
+++ b/pkgs/tools/misc/lottieconverter/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "sot-tech";
-    repo = finalAttrs.pname;
+    repo = "lottieconverter";
     rev = "r${finalAttrs.version}";
     hash = "sha256-oCFQsOQbWzmzClaTOeuEtGo7uXoKYtaJuSLLgqAQP1M=";
   };

--- a/pkgs/tools/misc/qt6gtk2/default.nix
+++ b/pkgs/tools/misc/qt6gtk2/default.nix
@@ -1,6 +1,6 @@
 { fetchFromGitHub, lib, stdenv, gtk2, pkg-config, qmake, qtbase, unstableGitUpdater }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation {
   pname = "qt6gtk2";
   version = "0.2-unstable-2024-06-22";
 
@@ -29,4 +29,4 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ lib.maintainers.misterio77 ];
     platforms = lib.platforms.linux;
   };
-})
+}

--- a/pkgs/tools/misc/qt6gtk2/default.nix
+++ b/pkgs/tools/misc/qt6gtk2/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "trialuser02";
-    repo = finalAttrs.pname;
+    repo = "qt6gtk2";
     rev = "2e8729481649d0a2fd4cc07051daf6134809d2c5";
     hash = "sha256-j1PFJEGCd2snQ6bAcsmFNrupoZg+ib/08Xs1oJyWyN0=";
   };

--- a/pkgs/tools/networking/openapi-generator-cli/default.nix
+++ b/pkgs/tools/networking/openapi-generator-cli/default.nix
@@ -4,14 +4,14 @@ let this = stdenv.mkDerivation (finalAttrs: {
   version = "7.7.0";
   pname = "openapi-generator-cli";
 
-  jarfilename = "${finalAttrs.pname}-${finalAttrs.version}.jar";
+  jarfilename = "openapi-generator-cli-${finalAttrs.version}.jar";
 
   nativeBuildInputs = [
     makeWrapper
   ];
 
   src = fetchurl {
-    url = "mirror://maven/org/openapitools/${finalAttrs.pname}/${finalAttrs.version}/${finalAttrs.jarfilename}";
+    url = "mirror://maven/org/openapitools/openapi-generator-cli/${finalAttrs.version}/${finalAttrs.jarfilename}";
     sha256 = "sha256-OnVydsMdJJpPBqFGUbH/Hxpc9G4RCnCtzEpqKDT4VWE=";
   };
 

--- a/pkgs/tools/networking/passh/default.nix
+++ b/pkgs/tools/networking/passh/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "clarkwang";
-    repo = finalAttrs.pname;
+    repo = "passh";
     rev = "7112e667fc9e65f41c384f89ff6938d23e86826c";
     sha256 = "1g0rx94vqg36kp46f8v4x6jcmvdk85ds6bkrpayq772hbdm1b5z5";
   };


### PR DESCRIPTION
## Description of changes

`finalAttrs.pname` in a url is objectively wrong, so replace its use with a string literal.

- **treewide: fix uses of `repo = finalAttrs.pname`**
- **treewide: fix uses of `finalAttrs.pname` in source urls**
- **treewide: fix uses of `finalAttrs.pname` in `meta.homepage`**

Also, remove the `finalAttrs` arg entirely if the changes above resulted in it being unused:

```sh
sed -i 's/(finalAttrs: {/{/;s/^})$/}/' $(rg -c finalAttrs $(git diff @{^^^,} --name-only) | rg ':1$' | sed 's/:1$//')
```

I didn't touch the whole tree since the regex would need tweaking for edge cases.

Related: #310373, #277994

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
