### PR TITLE
python312Packages.graphrag: init at 0.1.1 and introduce some dependencies

### DIFF
--- a/pkgs/development/python-modules/azure-search-documents/default.nix
+++ b/pkgs/development/python-modules/azure-search-documents/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  azure-common,
+  azure-core,
+  isodate,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "azure-search-documents";
+  version = "11.4.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Azure";
+    repo = "azure-sdk-for-python";
+    rev = "azure-search-documents_${version}";
+    hash = "sha256-0J9AXDH7TOkcKDwFbICiMatLAwiFq3Jtoji8fJSOg8k=";
+  };
+
+  sourceRoot = "${src.name}/sdk/search/azure-search-documents";
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    azure-common
+    azure-core
+    isodate
+  ];
+
+  pythonImportsCheck = [ "azure.search.documents" ];
+
+  # require devtools_testutils which is a internal package for azure-sdk
+  doCheck = false;
+
+  meta = {
+    description = "Microsoft Azure Cognitive Search Client Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/search/azure-search-documents";
+    changelog = "https://github.com/Azure/azure-sdk-for-python/blob/${src.rev}/sdk/search/azure-search-documents/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ natsukium ];
+  };
+}

--- a/pkgs/development/python-modules/datashaper/default.nix
+++ b/pkgs/development/python-modules/datashaper/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  pythonRelaxDepsHook,
+  poetry-core,
+  dacite,
+  diskcache,
+  jsonschema,
+  pandas,
+  pyarrow,
+}:
+
+buildPythonPackage rec {
+  pname = "datashaper";
+  version = "0.0.49";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-Bb+6WWRHSmK91SWew/oBc9AeNlIItqSv9OoOYwlqdTM=";
+  };
+
+  build-system = [ poetry-core ];
+
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
+
+  pythonRelaxDeps = [ "pyarrow" ];
+
+  dependencies = [
+    dacite
+    diskcache
+    jsonschema
+    pandas
+    pyarrow
+  ];
+
+  pythonImportsCheck = [ "datashaper" ];
+
+  # pypi tarball has no tests
+  doCheck = false;
+
+  meta = {
+    description = "Collection of utilities for doing lightweight data wrangling";
+    homepage = "https://github.com/microsoft/datashaper/tree/main/python/datashaper";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ natsukium ];
+  };
+}

--- a/pkgs/development/python-modules/graphrag/default.nix
+++ b/pkgs/development/python-modules/graphrag/default.nix
@@ -1,0 +1,122 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  poetry-dynamic-versioning,
+  aiofiles,
+  aiolimiter,
+  azure-identity,
+  azure-search-documents,
+  azure-storage-blob,
+  datashaper,
+  devtools,
+  environs,
+  fastparquet,
+  graspologic,
+  lancedb,
+  networkx,
+  nltk,
+  numba,
+  numpy,
+  openai,
+  pyaml-env,
+  pydantic,
+  python-dotenv,
+  pyyaml,
+  rich,
+  scipy,
+  swifter,
+  tenacity,
+  textual,
+  tiktoken,
+  typing-extensions,
+  uvloop,
+  nbformat,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "graphrag";
+  version = "0.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "graphrag";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-hIAQOIqm9S9AtssE6UxcXfaIbSt3+506ueMrlathNaQ=";
+  };
+
+  build-system = [
+    poetry-core
+    poetry-dynamic-versioning
+  ];
+
+  pythonRelaxDeps = [
+    "aiofiles"
+    "azure-identity"
+    "scipy"
+    "tiktoken"
+  ];
+
+  dependencies = [
+    aiofiles
+    aiolimiter
+    azure-identity
+    azure-search-documents
+    azure-storage-blob
+    datashaper
+    devtools
+    environs
+    fastparquet
+    graspologic
+    lancedb
+    networkx
+    nltk
+    numba
+    numpy
+    openai
+    pyaml-env
+    pydantic
+    python-dotenv
+    pyyaml
+    rich
+    scipy
+    swifter
+    tenacity
+    textual
+    tiktoken
+    typing-extensions
+    uvloop
+  ];
+
+  env.NUMBA_CACHE_DIR = "$TMPDIR";
+
+  pythonImportsCheck = [ "graphrag" ];
+
+  nativeCheckInputs = [
+    nbformat
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "tests/unit" ];
+
+  disabledTests = [
+    # touch the network
+    "test_child"
+    "test_dotprefix"
+    "test_find"
+    "test_run_extract_entities_multiple_documents"
+    "test_run_extract_entities_single_document"
+  ];
+
+  meta = {
+    description = "Modular graph-based Retrieval-Augmented Generation (RAG) system";
+    homepage = "https://github.com/microsoft/graphrag";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ natsukium ];
+  };
+}

--- a/pkgs/development/python-modules/pyaml-env/default.nix
+++ b/pkgs/development/python-modules/pyaml-env/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pyyaml,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pyaml-env";
+  version = "1.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mkaranasou";
+    repo = "pyaml_env";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-xSu+dksSVugShJwOqedXBrXIKaH0G5JAsynauOuP3OA=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ pyyaml ];
+
+  pythonImportsCheck = [ "pyaml_env" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "Parse YAML configuration with environment variables in Python";
+    homepage = "https://github.com/mkaranasou/pyaml_env";
+    changelog = "https://github.com/mkaranasou/pyaml_env/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ natsukium ];
+  };
+}

--- a/pkgs/development/python-modules/swifter/default.nix
+++ b/pkgs/development/python-modules/swifter/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  dask,
+  pandas,
+  psutil,
+  tqdm,
+  ipywidgets,
+  ray,
+}:
+
+buildPythonPackage rec {
+  pname = "swifter";
+  version = "1.4.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jmcarpenter2";
+    repo = "swifter";
+    rev = "refs/tags/${version}";
+    hash = "sha256-lgdf8E9GGjeLY4ERzxqtjQuYVtdtIZt2HFLSiNBbtX4=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    pandas
+    psutil
+    dask
+    tqdm
+  ] ++ dask.optional-dependencies.dataframe;
+
+  optional-dependencies = {
+    groupby = [ ray ];
+    notebook = [ ipywidgets ];
+  };
+
+  pythonImportsCheck = [ "swifter" ];
+
+  # tests may hang due to ignoring cpu core limit
+  # https://github.com/jmcarpenter2/swifter/issues/221
+  doCheck = false;
+
+  meta = {
+    description = "Package which efficiently applies any function to a pandas dataframe or series in the fastest available manner";
+    homepage = "https://github.com/jmcarpenter2/swifter";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ natsukium ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14961,6 +14961,8 @@ self: super: with self; {
 
   swift = callPackage ../development/python-modules/swift { };
 
+  swifter = callPackage ../development/python-modules/swifter { };
+
   swisshydrodata = callPackage ../development/python-modules/swisshydrodata { };
 
   swspotify = callPackage ../development/python-modules/swspotify { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5218,6 +5218,8 @@ self: super: with self; {
 
   graphql-subscription-manager = callPackage ../development/python-modules/graphql-subscription-manager { };
 
+  graphrag = callPackage ../development/python-modules/graphrag { };
+
   graph-tool = callPackage ../development/python-modules/graph-tool { };
 
   graphtage = callPackage ../development/python-modules/graphtage { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1302,6 +1302,8 @@ self: super: with self; {
 
   azure-nspkg = callPackage ../development/python-modules/azure-nspkg { };
 
+  azure-search-documents = callPackage ../development/python-modules/azure-search-documents { };
+
   azure-servicebus = callPackage ../development/python-modules/azure-servicebus { };
 
   azure-servicefabric = callPackage ../development/python-modules/azure-servicefabric { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2841,6 +2841,8 @@ self: super: with self; {
 
   datashape = callPackage ../development/python-modules/datashape { };
 
+  datashaper = callPackage ../development/python-modules/datashaper { };
+
   datatable = callPackage ../development/python-modules/datatable { };
 
   datauri = callPackage ../development/python-modules/datauri { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10825,6 +10825,8 @@ self: super: with self; {
 
   pyaml = callPackage ../development/python-modules/pyaml { };
 
+  pyaml-env = callPackage ../development/python-modules/pyaml-env { };
+
   pyannotate = callPackage ../development/python-modules/pyannotate { };
 
   pyannote-audio = callPackage ../development/python-modules/pyannote-audio { };


### PR DESCRIPTION
## Description of changes

- graphrag
The GraphRAG project is a data pipeline and transformation suite that is designed to extract meaningful, structured data from unstructured text using the power of LLMs.
https://github.com/microsoft/graphrag

- azure-search-documents
Microsoft Azure Cognitive Search Client Library for Python
https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/search/azure-search-documents

- datashaper
Collection of utilities for doing lightweight data wrangling
https://github.com/microsoft/datashaper/tree/main/python/datashaper

- pyaml-env
Parse YAML configuration with environment variables in Python
https://github.com/mkaranasou/pyaml_env

- swifter
Package which efficiently applies any function to a pandas dataframe or series in the fastest available manner
https://github.com/jmcarpenter2/swifter

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
