### PR TITLE
poptracker: add XDG desktop file and format with nixfmt-rfc-style

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -138,3 +138,6 @@ acd0e3898feb321cb9a71a0fd376f1157d0f4553
 
 # azure-cli: move to by-name, nixfmt #325950
 96cd538b68bd1d0a0a37979356d669abbba32ebc
+
+# poptracker: format with nixfmt-rfc-style (#326697)
+ff5c8f6cc3d1f2e017e86d50965c14b71f00567b

--- a/pkgs/by-name/po/poptracker/package.nix
+++ b/pkgs/by-name/po/poptracker/package.nix
@@ -1,14 +1,15 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, util-linux
-, SDL2
-, SDL2_ttf
-, SDL2_image
-, openssl
-, which
-, libsForQt5
-, makeWrapper
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  util-linux,
+  SDL2,
+  SDL2_ttf,
+  SDL2_image,
+  openssl,
+  which,
+  libsForQt5,
+  makeWrapper,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -26,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [ ./assets-path.diff ];
 
   postPatch = ''
-     substituteInPlace src/poptracker.cpp --replace "@assets@" "$out/share/$pname/"
+    substituteInPlace src/poptracker.cpp --replace "@assets@" "$out/share/$pname/"
   '';
 
   enableParallelBuilding = true;
@@ -53,7 +54,12 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
     install -m555 -Dt $out/bin build/linux-x86_64/poptracker
     install -m444 -Dt $out/share/${finalAttrs.pname} assets/*
-    wrapProgram $out/bin/poptracker --prefix PATH : ${lib.makeBinPath [ which libsForQt5.kdialog ]}
+    wrapProgram $out/bin/poptracker --prefix PATH : ${
+      lib.makeBinPath [
+        which
+        libsForQt5.kdialog
+      ]
+    }
     runHook postInstall
   '';
 
@@ -67,7 +73,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/black-sliver/PopTracker";
     changelog = "https://github.com/black-sliver/PopTracker/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ freyacodes pyrox0 ];
+    maintainers = with lib.maintainers; [
+      freyacodes
+      pyrox0
+    ];
     mainProgram = "poptracker";
     platforms = [ "x86_64-linux" ];
   };

--- a/pkgs/by-name/po/poptracker/package.nix
+++ b/pkgs/by-name/po/poptracker/package.nix
@@ -10,6 +10,8 @@
   which,
   libsForQt5,
   makeWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -27,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [ ./assets-path.diff ];
 
   postPatch = ''
-    substituteInPlace src/poptracker.cpp --replace "@assets@" "$out/share/$pname/"
+    substituteInPlace src/poptracker.cpp --replace "@assets@" "$out/share/poptracker/"
   '';
 
   enableParallelBuilding = true;
@@ -35,6 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     util-linux
     makeWrapper
+    copyDesktopItems
   ];
 
   buildInputs = [
@@ -53,15 +56,32 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
     install -m555 -Dt $out/bin build/linux-x86_64/poptracker
-    install -m444 -Dt $out/share/${finalAttrs.pname} assets/*
+    install -m444 -Dt $out/share/poptracker assets/*
     wrapProgram $out/bin/poptracker --prefix PATH : ${
       lib.makeBinPath [
         which
         libsForQt5.kdialog
       ]
     }
+    mkdir -p $out/share/icons/hicolor/{64x64,512x512}/apps
+    ln -s $out/share/poptracker/icon.png  $out/share/icons/hicolor/64x64/apps/poptracker.png
+    ln -s $out/share/poptracker/icon512.png  $out/share/icons/hicolor/512x512/apps/poptracker.png
     runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "poptracker";
+      desktopName = "PopTracker";
+      exec = "poptracker";
+      comment = "Universal, scriptable randomizer tracking solution";
+      icon = "poptracker";
+      categories = [
+        "Game"
+        "Utility"
+      ];
+    })
+  ];
 
   meta = {
     description = "Scriptable tracker for randomized games";


### PR DESCRIPTION
## Description of changes
Adds a desktop item for poptracker, since it can be launched without any options, and it is useful for people who need to access it frequently. Also formats the package file with nixfmt-rfc-style since there were a few things that it was complaining about.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
