### PR TITLE
rke2: fix the update script

### DIFF
--- a/pkgs/applications/networking/cluster/rke2/update-script.sh
+++ b/pkgs/applications/networking/cluster/rke2/update-script.sh
@@ -5,7 +5,9 @@ set -x -eu -o pipefail
 
 CHANNEL_NAME="${1:?Must provide a release channel, like 'stable', as the only argument}"
 
-mkdir --parents --verbose ./${CHANNEL_NAME}
+WORKDIR=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd -P)
+
+mkdir --parents --verbose "${WORKDIR}/${CHANNEL_NAME}"
 
 LATEST_TAG_NAME=$(curl --silent --fail https://update.rke2.io/v1-release/channels | \
     yq eval ".data[] | select(.id == \"${CHANNEL_NAME}\").latest" - | \
@@ -35,9 +37,9 @@ KUBERNETES_EOL=$(curl --silent --fail \
         https://endoflife.date/api/kubernetes/${KUBERNETES_CYCLES}.json | \
     yq eval ".eol" -)
 
-FAKE_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+FAKE_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 
-cat > ./${CHANNEL_NAME}/versions.nix << EOF
+cat << EOF > "${WORKDIR}/${CHANNEL_NAME}/versions.nix"
 {
   rke2Version = "${RKE2_VERSION}";
   rke2RepoSha256 = "${RKE2_REPO_SHA256}";
@@ -54,15 +56,13 @@ cat > ./${CHANNEL_NAME}/versions.nix << EOF
 }
 EOF
 
-NIXPKGS_ROOT=$(git rev-parse --show-toplevel)
-
 set +e
-RKE2_VENDOR_HASH=$(nix-prefetch -I nixpkgs=${NIXPKGS_ROOT} \
-        "{ sha256 }: (import ${NIXPKGS_ROOT}/. {}).rke2_${CHANNEL_NAME}.goModules.overrideAttrs (_: { vendorHash = sha256; })")
+RKE2_VENDOR_HASH=$(nix-prefetch -I nixpkgs=$(git rev-parse --show-toplevel) \
+        "{ sha256 }: rke2_${CHANNEL_NAME}.goModules.overrideAttrs (_: { vendorHash = sha256; })")
 set -e
 
 if [ -n "${RKE2_VENDOR_HASH:-}" ]; then
-    sed -i "s#${FAKE_HASH}#${RKE2_VENDOR_HASH}#g" ./${CHANNEL_NAME}/versions.nix
+    sed -i "s#${FAKE_HASH}#${RKE2_VENDOR_HASH}#g" ${WORKDIR}/${CHANNEL_NAME}/versions.nix
 else
     echo "Update failed. 'RKE2_VENDOR_HASH' is empty."
     exit 1
@@ -70,17 +70,15 @@ fi
 
 # Implement commit
 # See: https://nixos.org/manual/nixpkgs/stable/#var-passthru-updateScript-commit
-OLD_VERSION=$(nix-instantiate --eval -E \
-        "with import ${NIXPKGS_ROOT}/. {}; rke2.version or (builtins.parseDrvName rke2.name).version" | \
-    tr -d '"')
-
 cat << EOF
-[{
-  "attrPath": "rke2_${CHANNEL_NAME}",
-  "oldVersion": "${OLD_VERSION}",
-  "newVersion": "${RKE2_VERSION}",
-  "files": [
-    "${PWD}/${CHANNEL_NAME}/versions.nix"
-  ]
-}]
+[
+  {
+    "attrPath": "rke2_${CHANNEL_NAME}",
+    "oldVersion": "${UPDATE_NIX_OLD_VERSION}",
+    "newVersion": "${RKE2_VERSION}",
+    "files": [
+      "${WORKDIR}/${CHANNEL_NAME}/versions.nix"
+    ]
+  }
+]
 EOF


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR set the correct working directory for the update script. At the same time, because [each update script will pass the **version** attribute of the updated package as an environment variable](https://nixos.org/manual/nixpkgs/stable/#var-passthru-updateScript-execution) (`PDATE_NIX_OLD_VERSION`). This is unnecessary to use `nix-instantiate` to calculate `OLD_VERSION`.

By the way, the package versions of `rke2`, `rke2_latest` and `rke2_testing` have been updated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
