### PR TITLE
lib.network: ipv6 type, mkNetworkingOption and lib documentation

### DIFF
--- a/doc/doc-support/lib-function-docs.nix
+++ b/doc/doc-support/lib-function-docs.nix
@@ -84,6 +84,10 @@
       name = "derivations";
       description = "miscellaneous derivation-specific functions";
     }
+    {
+      name = "network";
+      description = "networking functions";
+    }
   ],
 }:
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -27,6 +27,7 @@ Most files in this directory are definitions of sub-libraries, but there are a f
   - All other files in this directory exist to support the tests
 - [`systems`](systems): The `lib.systems` sub-library, structured into a directory instead of a file due to its complexity
 - [`path`](path): The `lib.path` sub-library, which includes tests as well as a document describing the design goals of `lib.path`
+- [`network`](network): The `lib.network` sub-library, which mostly includes functions to work with IP addresses
 - All other files in this directory are sub-libraries
 
 ### Module system
@@ -136,6 +137,9 @@ path/tests/prop.sh
 
 # Run the lib.fileset tests
 fileset/tests.sh
+
+# Run the lib.network tests
+network/tests.sh
 ```
 
 ## Commit conventions

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -149,7 +149,7 @@ let
       optionAttrSetToDocList optionAttrSetToDocList'
       scrubOptionValue literalExpression literalExample
       showOption showOptionWithDefLocs showFiles
-      unknownModule mkOption mkPackageOption mkPackageOptionMD
+      unknownModule mkOption mkPackageOption mkNetworkingOption mkPackageOptionMD
       mdDoc literalMD;
     inherit (self.types) isType setType defaultTypeMerge defaultFunctor
       isOptionType mkOptionType;

--- a/lib/network/README.md
+++ b/lib/network/README.md
@@ -1,0 +1,80 @@
+# Network library
+
+## General
+
+This document explains why the `lib.network` library is designed the way it is.
+
+This library is intended mainly for working with IP addresses, finding derived
+information. The library is divided into IPv4 and IPv6. There are two types
+that can be used in modules: `ipv4Addr`, `ipv6Addr` that can be used in modules:
+`ipv4Addr`, `ipv6Addr`. Each type represent a string that is a valid ip address.
+
+To use types in a module system, use `mkNetworkingOption` with `type = 4`
+or `type = 6`. Internally, it converts the supplied string version of an IP
+address to a parsed version using the `lib.ipv${version}.fromString` function.
+The returned `ipv4AddrAttrs` or `ipv6AddrAttrs` contains different versions
+of the parsed IP address strings and the internal representation of the parsed
+addresses. So other functions from the network library can easily use the IP
+address without re-parsing.
+
+Structure of `ipv${version}AddrAttr`:
+* `address`: a string representation of an IP address without prefix length. Example: `"2001:0000:130f:0000:0000:09c0:876a:130b"`.
+  See [String representation].
+* `addressCidr`: a string representation of an IP address with prefix length. Example: `"2001:0000:130f:0000:0000:09c0:876a:130b/64"`.
+* `url`: a string representation used in URL's syntax. Example: `"[2001:0000:130f:0000:0000:09c0:876a:130b]"`.
+* `urlWithPort`: a function that consumes port and appends port to the url representation. Example: `"[2001:0000:130f:0000:0000:09c0:876a:130b]:80"`.
+* `prefixLength`: subnet size. Example: 64.
+* `_address`: an internal representation of an IP address, which is used by network functions. Example: `[8193 0 4879 0 0 2496 34666 4875]`
+  See [Internal representation].
+
+## Design
+
+### IP Parser
+[IP Parser]: #ip-parser
+
+IP addresses do not have a single unified representation. There is a "default"
+IP address such as `192.168.0.1` or CIDR notation `192.168.0.1/32`. IPv6
+addresses have even more different variations and compressions. In order not
+to complicate the life of the end user, the network library provides only two
+functions `fromString` (one for ipv4 and one for ipv6) that analyzes the various
+parameters and determines by itself what the current structure is. For example,
+if the IP address contains the prefix length character "/", then the function
+will parse the address in CIDR notation. If the prefix length is missing, the
+default length will be set.
+
+Note: Currently IPv6 parser doesn't support an alternative form that is
+sometimes more convenient when dealing with a mixed environment of IPv4 and IPv6
+nodes is `x:x:x:x:x:x:d.d.d.d` defined in [IP Version 6 Addressing Architecture RFC 4291][RFC 4291].
+
+[RFC 4291]: https://datatracker.ietf.org/doc/html/rfc4291#section-2.2
+
+### Internal representation
+[Internal representation]: #internal-representation
+
+End users want to work with IP addresses as strings most of the time. But
+strings are not easy to work with. Internal functions are much more comfortable
+working with a list of integers that can only be parsed once, then worked with
+and stored hidden. You can easily convert such data backto a string.
+See [String representation]. In the code, every time you see `ipv6IR` - it means
+that it is an internal representation / list of integers.
+
+### String representation
+[String representation]: #string-representation
+
+For IPv4, everything is simple - join all octets with a colon and add prefix
+length for `addressCidr`.
+
+For IPv6, everything is much more complicated. It can be presented in different
+ ways: lowercase or uppercase, with compression or without, etc. Read the
+[A Recommendation for IPv6 Address Text Representation RFC 5952][RFC 5952] to
+ understand the problem.
+
+Since in most cases IP addresses are used in configurations, there is no point
+in doing compression. After all operations, the address that can be written `::`
+will look like `0:0:0:0:0:0:0:0`. This greatly simplifies the library.
+
+[RFC 5952]: https://datatracker.ietf.org/doc/html/rfc5952
+
+## Other implementations and references
+
+- [Rust](https://doc.rust-lang.org/std/net/enum.IpAddr.html)

--- a/lib/network/default.nix
+++ b/lib/network/default.nix
@@ -5,45 +5,92 @@ in
 {
   ipv6 = {
     /**
-      Creates an `IPv6Address` object from an IPv6 address as a string. If
-      the prefix length is omitted, it defaults to 64. The parser is limited
-      to the first two versions of IPv6 addresses addressed in RFC 4291.
-      The form "x:x:x:x:x:x:d.d.d.d" is not yet implemented. Addresses are
-      NOT compressed, so they are not always the same as the canonical text
-      representation of IPv6 addresses defined in RFC 5952.
+      Creates an `ipv6AddrAttrs` object from an `ipv6Addr` (valid ip string). If
+      the prefix length is omitted, it defaults to *128*.
+
+      The parser is limited to the first two versions of IPv6 addresses
+      addressed in RFC 4291. An alternative form that is sometimes
+      more convenient when dealing with a mixed environment of IPv4
+      "x:x:x:x:x:x:d.d.d.d" is not yet implemented.
+
+      Addresses are NOT compressed, so they are not always the same as the
+      canonical text representation of IPv6 addresses defined in RFC 5952.
+
+      The fields of the returned set may contain errors if an invalid ip string
+      was passed. So, to make sure the parsing completes successfully, you need to
+      deeply evaluate all fields using `builtins.deepSeq`.
 
       # Type
 
       ```
-      fromString :: String -> IPv6Address
+      fromString :: ipv6Addr -> ipv6AddrAttrs
       ```
 
       # Examples
 
       ```nix
-      fromString "2001:DB8::ffff/32"
+      fromString "2001:DB8::ffff/64"
       => {
         address = "2001:db8:0:0:0:0:0:ffff";
-        prefixLength = 32;
+        addressCidr = "2001:db8:0:0:0:0:0:ffff/64";
+        url = "[2001:db8:0:0:0:0:0:ffff]";
+        urlWithPort = int -> string;
+        prefixLength = 64;
       }
+      (fromString "2001:DB8::ffff/64").urlWithPort 80
+      => "[2001:db8:0:0:0:0:0:ffff]:80";
       ```
 
       # Arguments
 
-      - [addr] An IPv6 address with optional prefix length.
+      addrStr
+      : A string version of IPv6 address with optional prefix length.
     */
     fromString =
-      addr:
+      addrStr:
       let
-        splittedAddr = _ipv6.split addr;
-
-        addrInternal = splittedAddr.address;
-        prefixLength = splittedAddr.prefixLength;
-
-        address = _ipv6.toStringFromExpandedIp addrInternal;
+        splittedAddr = _ipv6.split addrStr;
       in
-      {
-        inherit address prefixLength;
-      };
+      _ipv6.makeIpv6Type splittedAddr.address splittedAddr.prefixLength;
+
+    /**
+      Checks whether a string is a valid IPv6 address, which can then be
+      safely parsed by other library functions such as `fromString`.
+
+      This is accomplished by calling `fromString` and deeply evaluating the
+      returned set of attributes to ensure that no field contains an error.
+
+      Used as a type checker for `ipv6Addr`. You probably don't want to call
+      it directly.
+
+      # Type
+
+      ```
+      isValidIpStr :: string -> bool
+      ```
+
+      # Examples
+
+      ```nix
+      isValidIpStr "2001:DB8::ffff/64"
+      => true
+      isValidIpStr "::/"
+      => false
+      ```
+
+      # Arguments
+
+      addrStr
+      : A string version of IPv6 address with optional prefix length.
+    */
+    isValidIpStr =
+      addrStr:
+      let
+        parsed = lib.network.ipv6.fromString addrStr;
+        # Several fields may contain error(_address, prefixLength), so we need
+        # to deeply evaluate the returned set to make sure the address is valid.
+        isValid = (builtins.tryEval (builtins.deepSeq parsed parsed)).success;
+      in
+      isValid;
   };
 }

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -220,6 +220,34 @@ rec {
           (if isList example then "${pkgsText}." + concatStringsSep "." example else example);
       });
 
+  /**
+    Creates an Option attribute set for an option that specifies IP address.
+    The difference with `lib.mkOption` is that the `type` field must be an integer version of the IP address used.
+
+    # Examples:
+
+    ```nix
+    mkNetworkingOption {
+      default = "::";
+      type = 6;
+    }
+    => {..., default = "::"; type = lib.types.coercedTo lib.types.ipv6Addr lib.ipv6.fromString lib.ipv6AddAttrs; }
+    ```
+  */
+  mkNetworkingOption =
+    attrSet:
+    let
+      ver = toString attrSet.type;
+    in
+    lib.mkOption (
+      attrSet
+      // {
+        type =
+          lib.types.coercedTo lib.types."ipv${ver}Addr" lib."ipv${ver}".fromString
+            lib.types."ipv${ver}AddrAttrs";
+      }
+    );
+
   /* Deprecated alias of mkPackageOption, to be removed in 25.05.
      Previously used to create options with markdown documentation, which is no longer required.
   */

--- a/lib/tests/network.sh
+++ b/lib/tests/network.sh
@@ -91,7 +91,7 @@ expectSuccess '(internal._ipv6.split "1:1:1:1:1:1:1::").address'                
 expectSuccess '(internal._ipv6.split "1:1:1:1::1:1:1").address'                          '[1,1,1,1,0,1,1,1]'
 expectSuccess '(internal._ipv6.split "1::1").address'                                    '[1,0,0,0,0,0,0,1]'
 
-expectFailure 'internal._ipv6.split "0:0:0:0:0:0:0:-1"' "contains malformed characters for IPv6 address"
+expectFailure 'internal._ipv6.split "0:0:0:0:0:0:0:-1"'  "contains malformed characters for IPv6 address"
 expectFailure 'internal._ipv6.split "::0:"'              "is not a valid IPv6 address"
 expectFailure 'internal._ipv6.split ":0::"'              "is not a valid IPv6 address"
 expectFailure 'internal._ipv6.split "0::0:"'             "is not a valid IPv6 address"
@@ -100,6 +100,7 @@ expectFailure 'internal._ipv6.split "0:0:0:0:0:0:0:0:0"' "is not a valid IPv6 ad
 expectFailure 'internal._ipv6.split "0:0:0:0:0:0:0:0:"'  "is not a valid IPv6 address"
 expectFailure 'internal._ipv6.split "::0:0:0:0:0:0:0:0"' "is not a valid IPv6 address"
 expectFailure 'internal._ipv6.split "0::0:0:0:0:0:0:0"'  "is not a valid IPv6 address"
+expectFailure 'internal._ipv6.split ":::ffff/64"'        "is not a valid IPv6 address"
 expectFailure 'internal._ipv6.split "::10000"'           "0x10000 is not a valid u16 integer"
 
 expectSuccess '(internal._ipv6.split "::").prefixLength'     '128'
@@ -111,7 +112,13 @@ expectFailure '(internal._ipv6.split "::/129").prefixLength' "IPv6 subnet should
 expectFailure '(internal._ipv6.split "/::/").prefixLength'   "is not a valid IPv6 address in CIDR notation"
 
 # Library API
-expectSuccess 'lib.network.ipv6.fromString "2001:DB8::ffff/64"' '{"address":"2001:db8:0:0:0:0:0:ffff","prefixLength":64}'
-expectSuccess 'lib.network.ipv6.fromString "1234:5678:90ab:cdef:fedc:ba09:8765:4321/44"' '{"address":"1234:5678:90ab:cdef:fedc:ba09:8765:4321","prefixLength":44}'
+expectSuccess 'ipv6.isValidIpStr "2001:DB8::ffff/64"' 'true'
+expectSuccess 'ipv6.isValidIpStr ":::ffff/64"'        'false'
+
+expectSuccess '(ipv6.fromString "2001:DB8::ffff/64").address'     '"2001:db8:0:0:0:0:0:ffff"'
+expectSuccess '(ipv6.fromString "2001:DB8::ffff/64").addressCidr' '"2001:db8:0:0:0:0:0:ffff/64"'
+expectSuccess '(ipv6.fromString "2001:DB8::ffff").addressCidr'    '"2001:db8:0:0:0:0:0:ffff/128"'
+expectSuccess '(ipv6.fromString "2001:DB8::ffff").url'    '"[2001:db8:0:0:0:0:0:ffff]"'
+expectSuccess '(ipv6.fromString "2001:DB8::ffff").urlWithPort 80'    '"[2001:db8:0:0:0:0:0:ffff]:80"'
 
 echo >&2 tests ok

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -61,6 +61,8 @@ let
     boolToString
     ;
 
+  inherit (lib.network) ipv6;
+
   inherit (lib.modules)
     mergeDefinitions
     fixupOptionType
@@ -769,6 +771,37 @@ rec {
       functor = (defaultFunctor "functionTo") // { wrapped = elemType; };
       nestedTypes.elemType = elemType;
     };
+
+    # Network types
+    ipv6Addr =
+      elemType:
+      mkOptionType {
+        name = "ipv6Addr";
+        description = "Valid IPv6 address string";
+        descriptionClass = "noun";
+        check = ipv6.isValidIpStr;
+        merge = mergeEqualOption;
+      };
+
+    ipv6AddrAttrs =
+      elemType:
+      mkOptionType {
+        name = "ipv6AddrAttrs";
+        description = "Attribute set of parsed IPv6 address";
+        descriptionClass = "noun";
+        check =
+          v:
+          isAttrs v
+          && all (el: hasAttr el v) [
+            "address"
+            "addressCidr"
+            "url"
+            "urlWithPort"
+            "prefixLength"
+            "_address"
+          ];
+        merge = mergeEqualOption;
+      };
 
     # A submodule (like typed attribute set). See NixOS manual.
     submodule = modules: submoduleWith {

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -213,7 +213,7 @@ merging is handled.
 
 ## Network types {#sec-option-types-network}
 
-Types used in the network library.
+Types provided by the network library.
 
 `types.ipv6AddrStr`
 

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -211,6 +211,24 @@ merging is handled.
     definitions cannot be merged. The regular expression is processed
     using `builtins.match`.
 
+## Network types {#sec-option-types-network}
+
+Types used in the network library.
+
+`types.ipv6AddrStr`
+
+:   A string that is a valid IPv6 address. Used as input to the
+    `lib.network.ipv6.fromString` ipv6 parser.
+
+`types.ipv6AddrAttrs`
+
+:   An attribute set contains the internal representation of an IPv6 address,
+    subnet prefix length and different string representations of the address:
+    default one, cidr notation, url and url with port. Can be created from a
+    string using a parsing function like `lib.network.ipv6.fromString`. Most
+    network library functions accept this type because it already contains a
+    parsed address.
+
 ## Submodule types {#sec-option-types-submodule}
 
 Submodules are detailed in [Submodule](#section-option-types-submodule).


### PR DESCRIPTION
### Description of changes

[lib.network: add ipv6Addr type, mkNetworkingOption option](https://github.com/NixOS/nixpkgs/pull/326765/commits/c7c01a97fe734cb12ca56436f3e4fa8061a3fb3d) 

Add ipv6 ipv6Addr and ipv6AddrAttrs types.
Add ipv6.isValidIpStr function to be used as the ipv6Addr type checker.
Add mkNetworkingOption that uses `coercedTo` function to convert string
IP to parsed attr set ipv6AddrAttrs.

Change the design of `ipv6.fromString` function. It used to be created
to return an attrset of data like `nextAddr`, `firstAddr`, etc. But
now it returns an attrset with a string representation of the address
(default and Cidr) and contains an internal representation. That way,
other future functions like `nextAddr` can easily take such type and
create a new one, because there is no need to reparse the string.

[lib.network: add network library README.md](https://github.com/NixOS/nixpkgs/pull/326765/commits/aff0ea408c79c70e2dd20fcc4ab8351dae731294) 

README.md explains the design and purpose of the network library. At the
time of writing, IPv4 functionality is not yet merged.

Mentor: @Janik-Haag 

### Things done
- [x] Tested, as applicable:
* [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
* and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
* or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [x] Formatted using nixfmt-rfc-style

Add a 👍 [reaction](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to [pull requests you find important](https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
