### PR TITLE
telegram-macos: init at 10.15.2-265540

### DIFF
--- a/pkgs/by-name/te/telegram-macos/package.nix
+++ b/pkgs/by-name/te/telegram-macos/package.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  fetchzip,
+  makeWrapper,
+  gnused,
+  darwin,
+}:
+let
+  version = "10.15.2-265540";
+  versionTokens = lib.split "-" version;
+  versionFirst = lib.head versionTokens;
+  versionSecond = lib.last versionTokens;
+  sigtool = darwin.sigtool.overrideAttrs (old: {
+    # this is a fork of sigtool that supports -v and --remove-signature
+    # As seen in dotnet derivation:
+    # https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/compilers/dotnet/sigtool.nix
+    src = fetchFromGitHub {
+      owner = "corngood";
+      repo = "sigtool";
+      rev = "new-commands";
+      sha256 = "sha256-EVM5ZG3sAHrIXuWrnqA9/4pDkJOpWCeBUl5fh0mkK4k=";
+    };
+
+    nativeBuildInputs = old.nativeBuildInputs or [ ] ++ [ makeWrapper ];
+
+    postInstall =
+      old.postInstall or ""
+      + ''
+        wrapProgram $out/bin/codesign \
+          --set-default CODESIGN_ALLOCATE \
+            "${darwin.cctools}/bin/${darwin.cctools.targetPrefix}codesign_allocate"
+      '';
+  });
+in
+stdenvNoCC.mkDerivation {
+  inherit version;
+
+  pname = "telegram-macos";
+
+  src = fetchzip {
+    url = "https://osx.telegram.org/updates/Telegram-${versionFirst}.${versionSecond}.app.zip";
+    hash = "sha256-9eWx1vTDyWdlJ8mAFqj06T7P6VWbU0AwOFHm4aQfyCw=";
+    stripRoot = false;
+  };
+
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    gnused
+    sigtool
+  ];
+
+  patchPhase = ''
+    runHook prePatch
+
+    # Disable Sparkle auto-update feature
+    # https://sparkle-project.org/documentation/customization/
+
+    plist_file="Telegram.app/Contents/Info.plist"
+
+    sed '$d' $plist_file | sed '$d' > temp.plist
+
+    cat <<EOF >> temp.plist
+            <key>SUAllowsAutomaticUpdates</key>
+            <false/>
+            <key>SUEnableAutomaticChecks</key>
+            <false/>
+    </dict>
+    </plist>
+    EOF
+
+    mv temp.plist $plist_file
+
+    # Remove signature
+
+    codesign --remove-signature Telegram.app/Contents/MacOS/Telegram
+
+    runHook postPatch
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/Applications
+    cp -r Telegram.app $out/Applications
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Telegram client for macOS, written in Swift";
+    homepage = "https://macos.telegram.org/";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ matteopacini ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
## Description of changes

- Added Telegram MacOS, the native Telegram client for Darwin

Pinging @NixOS/darwin-maintainers for testing 🙏🏻 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
