### PR TITLE
s7: init at 11.2-unstable-2024-11-02

### DIFF
--- a/pkgs/by-name/s7/s7/package.nix
+++ b/pkgs/by-name/s7/s7/package.nix
@@ -1,0 +1,159 @@
+{
+  lib,
+  fetchFromGitLab,
+  stdenv,
+  notcurses,
+  gmp,
+  mpfr,
+  libmpc,
+  flint3,
+  unstableGitUpdater,
+  writeScript,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "s7";
+  version = "11.2-unstable-2024-11-02";
+
+  src = fetchFromGitLab {
+    domain = "cm-gitlab.stanford.edu";
+    owner = "bil";
+    repo = "s7";
+    rev = "6b6651de318c3360aa2711a445659f372ffe894e";
+    hash = "sha256-9x1u60jflESAHgP0gwIDVFwhI5XU5gsAiXaic8zdW2U=";
+  };
+
+  buildInputs = [
+    notcurses
+    gmp
+    mpfr
+    libmpc
+    flint3
+  ];
+
+  # The following scripts are modified from [Guix's](https://packages.guix.gnu.org/packages/s7/).
+
+  patchPhase = ''
+    runHook prePatch
+
+    substituteInPlace s7.c \
+        --replace-fail libc_s7.so $out/lib/libc_s7.so
+
+    runHook postPatch
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    # The older REPL
+    cc s7.c -o s7-repl \
+        -O2 -I. \
+        -Wl,-export-dynamic \
+        -lm -ldl \
+        -DWITH_MAIN \
+        -DS7_LOAD_PATH=\"$out/share/s7/scm\"
+
+    # The newer REPL powered by Notcurses
+    cc s7.c -o s7-nrepl \
+        -O2 -I. \
+        -Wl,-export-dynamic \
+        -lm -ldl \
+        -DWITH_MAIN \
+        -DWITH_NOTCURSES -lnotcurses-core \
+        -DS7_LOAD_PATH=\"$out/share/s7/scm\"
+
+    cc libarb_s7.c -o libarb_s7.so \
+        -O2 -I. \
+        -shared \
+        -lflint -lmpc \
+        -fPIC
+
+    cc notcurses_s7.c -o libnotcurses_s7.so \
+        -O2 -I. \
+        -shared \
+        -lnotcurses-core \
+        -fPIC
+
+    cc s7.c -c -o s7.o \
+        -O2 -I. \
+        -ldl -lm
+
+    cc ffitest.c s7.o -o ffitest \
+        -I. \
+        -Wl,-export-dynamic \
+        -ldl -lm
+
+    ./s7-repl libc.scm
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    dst_bin=$out/bin
+    dst_lib=$out/lib
+    dst_inc=$out/include
+    dst_share=$out/share/s7
+    dst_scm=$out/share/s7/scm
+    dst_doc=$out/share/doc/s7
+    mkdir -p $dst_bin $dst_lib $dst_inc $dst_share $dst_scm $dst_doc
+
+    cp -pr -t $dst_bin s7-repl s7-nrepl
+    ln -s s7-nrepl $dst_bin/s7
+    cp -pr -t $dst_lib libarb_s7.so libnotcurses_s7.so libc_s7.so
+    cp -pr -t $dst_share s7.c
+    cp -pr -t $dst_inc s7.h
+    cp -pr -t $dst_scm *.scm
+    cp -pr -t $dst_doc s7.html
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $dst_bin/s7-repl s7test.scm
+
+    runHook postInstallCheck
+  '';
+
+  passthru.updateScript = unstableGitUpdater rec {
+    branch = "master";
+    tagConverter = writeScript "update-s7-version-number" ''
+      #! /usr/bin/env nix-shell
+      #! nix-shell -p curl -i bash
+      set -eu -o pipefail
+      read tag # should be "0" if the upstream sticks to tagging nothing.
+      curl -sS https://cm-gitlab.stanford.edu/bil/s7/-/raw/${branch}/s7.h \
+          | grep '#define S7_VERSION' \
+          | awk -F \" '{print $2}'
+    '';
+  };
+
+  meta = {
+    description = "Scheme interpreter intended as an extension language for other applications";
+    longDescription = ''
+      s7 is a Scheme interpreter intended as an extension language for other
+      applications.
+
+      Although it is a descendant of tinyScheme, s7 is closest as a Scheme
+      dialect to Guile 1.8. It is expected to be compatible with r5rs and r7rs.
+      It has continuations, ratios, complex numbers, macros, keywords,
+      hash-tables, multiprecision arithmetic, generalized `set!`, unicode, and so
+      on. It does not have `syntax-rules` or any of its friends, and it thinks
+      there is no such thing as an inexact integer.
+
+      s7 is an extension language of Snd and sndlib, Rick Taube's Common Music
+      (commonmusic at sourceforge), Kjetil Matheussen's Radium music editor, and
+      Iain Duncan's Scheme for Max (or Pd).
+    '';
+    homepage = "https://ccrma.stanford.edu/software/s7/";
+    license = lib.licenses.bsd0;
+    maintainers = with lib.maintainers; [ rc-zb ];
+    mainProgram = "s7";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Add [s7](https://ccrma.stanford.edu/software/s7/), another Scheme interpreter.

### TODOs

- [x] `passthru.updateScript`. The version number can be extracted from `s7.h`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
