### PR TITLE
newlisp: init at 10.7.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18078,6 +18078,12 @@
     name = "Roland Conybeare";
     keys = [ { fingerprint = "bw5Cr/4ul1C2UvxopphbZbFI1i5PCSnOmPID7mJ/Ogo"; } ];
   };
+  rc-zb = {
+    name = "Xiao Haifan";
+    email = "rc-zb@outlook.com";
+    github = "rc-zb";
+    githubId = 161540043;
+  };
   rdnetto = {
     email = "rdnetto@gmail.com";
     github = "rdnetto";

--- a/pkgs/by-name/ne/newlisp/package.nix
+++ b/pkgs/by-name/ne/newlisp/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  fetchurl,
+  stdenv,
+  libffi,
+  readline,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "newlisp";
+  version = "10.7.5";
+
+  src = fetchurl {
+    url = "https://www.newlisp.org/downloads/newlisp-${finalAttrs.version}.tgz";
+    hash = "sha256-3C0P9lHCsnW8SvOvi6WYUab7bh6t3CCudftgsekBJuw=";
+  };
+
+  buildInputs = [
+    libffi
+    readline
+  ];
+
+  configureScript = "./configure-alt";
+
+  doCheck = true;
+  checkTarget = "testall";
+
+  meta = {
+    description = "Lisp-like, general-purpose scripting language";
+    longDescription = ''
+      newLISP is a Lisp-like, general-purpose scripting language. It is
+      especially well-suited for applications in AI, simulation, natural
+      language processing, big data, machine learning and statistics. Because
+      of its small resource requirements, newLISP is excellent for embedded
+      systems applications. Most of the functions you will ever need are
+      already built in. This includes networking functions, support for
+      distributed and multicore processing, and Bayesian statistics.
+    '';
+    homepage = "https://www.newlisp.org/";
+    downloadPage = "https://www.newlisp.org/downloads/";
+    changelog = "https://www.newlisp.org/downloads/newlisp-${finalAttrs.version}/doc/CHANGES";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ rc-zb ];
+    mainProgram = "newlisp";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Add the reference implementation of [newLISP](https://www.newlisp.org/), a Lisp-like, general-purpose scripting language.

And add myself to the maintainer lists of Nixpkgs as well as this package.

### Limitations

- The recipe follows the upstream, and should also work in FreeBSD, macOS, Windows, etc. But I haven't tested. So these platforms are not added to `meta.platforms`.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
