### PR TITLE
dotnet: strip signature files from NuGet

### DIFF
--- a/pkgs/build-support/dotnet/make-nuget-deps/default.nix
+++ b/pkgs/build-support/dotnet/make-nuget-deps/default.nix
@@ -1,15 +1,35 @@
-{ linkFarmFromDrvs, fetchurl }:
+{ linkFarmFromDrvs, fetchurl, runCommand, zip }:
 { name, nugetDeps ? import sourceFile, sourceFile ? null }:
 linkFarmFromDrvs "${name}-nuget-deps" (nugetDeps {
   fetchNuGet = { pname, version, sha256 ? "", hash ? ""
     , url ? "https://www.nuget.org/api/v2/package/${pname}/${version}" }:
-    fetchurl {
-      name = "${pname}.${version}.nupkg";
-      # There is no need to verify whether both sha256 and hash are
-      # valid here, because nuget-to-nix does not generate a deps.nix
-      # containing both.
-      inherit url sha256 hash;
-    };
-}) // {
+    let
+      src = fetchurl {
+        name = "${pname}.${version}.nupkg";
+        # There is no need to verify whether both sha256 and hash are
+        # valid here, because nuget-to-nix does not generate a deps.nix
+        # containing both.
+        inherit url sha256 hash;
+      };
+    in
+    # NuGet.org edits packages by signing them during upload, which makes
+    # those packages nondeterministic depending on which source you
+    # get them from. We fix this by stripping out the signature file.
+    # Signing logic is https://github.com/NuGet/NuGet.Client/blob/128a5066b1438627ac69a2ffe9de564b2c09ee4d/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveIOUtility.cs#L518
+    # Non-NuGet.org sources might not have a signature file; in that case, zip
+    # exits with code 12 ("zip has nothing to do", per `man zip`).
+    runCommand src.name
+      {
+        inherit src;
+        nativeBuildInputs = [ zip ];
+      }
+      ''
+        zip "$src" --temp-path "$TMPDIR" --output-file "$out" --delete .signature.p7s || {
+          (( $? == 12 ))
+          install -Dm644 "$src" "$out"
+        }
+      '';
+})
+// {
   inherit sourceFile;
 }


### PR DESCRIPTION
## Description of changes

Strip signature files from downloaded NuGet packages.

The result of this PR is that `fetchNuget` Nupkgs are source-independent [per my testing](https://github.com/NixOS/nixpkgs/issues/326345#issuecomment-2226977017).

Ref https://github.com/NixOS/nixpkgs/issues/326345

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
