### PR TITLE
xwayland-satellite: correctly pass xwayland dependency in PATH

### DIFF
--- a/pkgs/by-name/xw/xwayland-satellite/package.nix
+++ b/pkgs/by-name/xw/xwayland-satellite/package.nix
@@ -6,6 +6,7 @@
 , xcb-util-cursor
 , libxcb
 , nix-update-script
+, makeWrapper
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -24,10 +25,10 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     pkg-config
     rustPlatform.bindgenHook
+    makeWrapper
   ];
 
   buildInputs = [
-    xwayland
     libxcb
     xcb-util-cursor
   ];
@@ -42,6 +43,11 @@ rustPlatform.buildRustPackage rec {
     "--skip=reparent"
     "--skip=toplevel_flow"
   ];
+
+  postInstall = ''
+    wrapProgram $out/bin/xwayland-satellite \
+      --prefix PATH : "${lib.makeBinPath [xwayland]}"
+  '';
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/xw/xwayland-satellite/package.nix
+++ b/pkgs/by-name/xw/xwayland-satellite/package.nix
@@ -55,7 +55,7 @@ rustPlatform.buildRustPackage rec {
     description = "Rootless Xwayland integration to any Wayland compositor implementing xdg_wm_base";
     homepage = "https://github.com/Supreeeme/xwayland-satellite";
     license = licenses.mpl20;
-    maintainers = with maintainers; [ if-loop69420 ];
+    maintainers = with maintainers; [ if-loop69420 sodiboo ];
     mainProgram = "xwayland-satellite";
     platforms = platforms.linux;
   };


### PR DESCRIPTION
## Description of changes

`Xwayland` shouldn't be a build input; it's a runtime dependency that must be in PATH.

I maintain an xwayland-satellite package outside of nixpkgs, and was notified of this issue through https://github.com/sodiboo/niri-flake/issues/343. I resolved it in https://github.com/sodiboo/niri-flake/commit/0fa3ab053903c97f90d122e9175de3e7255772a9, which is what this PR is based on and which was in itself based on @GabTheBab's work in [their flake](https://github.com/GabTheBab/xwayland-satellite/blob/9fb3da91cce9885f5376ab47a17ed8113ed2fb5b/xwayland-satellite.nix#L51-L54)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
