### PR TITLE
docs: $TMP -> $TMPDIR in Darwin build

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -69,8 +69,8 @@ let
       $epubPath
 
     echo "application/epub+zip" > mimetype
-    zip -0Xq -b "$TMP" "$out" mimetype
-    cd scratch && zip -Xr9D -b "$TMP" "$out" *
+    zip -0Xq -b "$TMPDIR" "$out" mimetype
+    cd scratch && zip -Xr9D -b "$TMPDIR" "$out" *
   '';
 
   # NB: This file describes the Nixpkgs manual, which happens to use module


### PR DESCRIPTION
follow-up on #326653 @toonn @emilazy

`TMPDIR` is the canonical form in POSIX and SUS

https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html#tag_08_03


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc