### PR TITLE
cc-wrapper: add support for `shadowstack` hardening flag

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1538,6 +1538,16 @@ Adds the `-fPIE` compiler and `-pie` linker options. Position Independent Execut
 Static libraries need to be compiled with `-fPIE` so that executables can link them in with the `-pie` linker option.
 If the libraries lack `-fPIE`, you will get the error `recompile with -fPIE`.
 
+#### `shadowstack` {#shadowstack}
+
+Adds the `-fcf-protection=return` compiler option. This enables the Shadow Stack feature supported by some newer processors, which maintains a user-inaccessible copy of the program's stack containing only return-addresses. When returning from a function, the processor compares the return-address value on the two stacks and throws an error if they do not match, considering it a sign of corruption and possible tampering. This should significantly increase the difficulty of ROP attacks.
+
+For the Shadow Stack to be enabled at runtime, all code linked into a process must be built with Shadow Stack enabled, so this is probably only useful to enable on a wide scale, so that all of a packages dependencies also have the feature enabled.
+
+This is currently only supported on some newer Intel and AMD processors as part of the Intel CET set of features. However, the generated code should continue to work on older processors which will simply omit any of this checking.
+
+This breaks some code that does advanced stack management or exception handling. If enabling this hardening flag it is important to test the result on a system that has known working and enabled CET support, so that any such breakage can be discovered.
+
 #### `trivialautovarinit` {#trivialautovarinit}
 
 Adds the `-ftrivial-auto-var-init=pattern` compiler option. This causes "trivially-initializable" uninitialized stack variables to be forcibly initialized with a nonzero value that is likely to cause a crash (and therefore be noticed). Uninitialized variables generally take on their values based on fragments of previous program state, and attackers can carefully manipulate that state to craft malicious initial values for these variables.

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -242,6 +242,8 @@
   - Nemo is now built with gtk-layer-shell support, note that for now it will be expected to see nemo-desktop
     listed as a regular entry in Cinnamon Wayland session's window list applet.
 
+- The `shadowstack` hardening flag has been added, though disabled by default.
+
 - Support for *runner registration tokens* has been [deprecated](https://gitlab.com/gitlab-org/gitlab/-/issues/380872)
   in `gitlab-runner` 15.6 and is expected to be removed in `gitlab-runner` 18.0. Configuration of existing runners
   should be changed to using *runner authentication tokens* by configuring

--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -32,7 +32,7 @@ if [[ -n "${hardeningEnableMap[fortify3]-}" ]]; then
 fi
 
 if (( "${NIX_DEBUG:-0}" >= 1 )); then
-  declare -a allHardeningFlags=(fortify fortify3 stackprotector stackclashprotection pie pic strictoverflow format trivialautovarinit zerocallusedregs)
+  declare -a allHardeningFlags=(fortify fortify3 shadowstack stackprotector stackclashprotection pie pic strictoverflow format trivialautovarinit zerocallusedregs)
   declare -A hardeningDisableMap=()
 
   # Determine which flags were effectively disabled so we can report below.
@@ -74,6 +74,10 @@ for flag in "${!hardeningEnableMap[@]}"; do
           # Ignore unsupported.
           ;;
       esac
+      ;;
+    shadowstack)
+      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling shadowstack >&2; fi
+      hardeningCFlagsBefore+=('-fcf-protection=return')
       ;;
     stackprotector)
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling stackprotector >&2; fi

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -430,6 +430,12 @@ pipe ((callFile ./common/builder.nix {}) ({
       ) "stackclashprotection"
       ++ optional (!atLeast11) "zerocallusedregs"
       ++ optionals (!atLeast12) [ "fortify3" "trivialautovarinit" ]
+      ++ optional (!(
+        atLeast8
+        && targetPlatform.isLinux
+        && targetPlatform.isx86_64
+        && targetPlatform.libc == "glibc"
+      )) "shadowstack"
       ++ optionals (langFortran) [ "fortify" "format" ];
   };
 

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -139,6 +139,11 @@ let
       hardeningUnsupportedFlagsByTargetPlatform = targetPlatform:
         [ "fortify3" ]
         ++ lib.optional (
+          (lib.versionOlder release_version "7")
+          || !targetPlatform.isLinux
+          || !targetPlatform.isx86_64
+        ) "shadowstack"
+        ++ lib.optional (
           (lib.versionOlder release_version "11")
           || (targetPlatform.isAarch64 && (lib.versionOlder release_version "18.1"))
           || (targetPlatform.isFreeBSD && (lib.versionOlder release_version "15"))

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -104,6 +104,7 @@ stdenv.mkDerivation (rec {
 
   hardeningDisable = [
     "trivialautovarinit"
+    "shadowstack"
   ];
 
   nativeBuildInputs = [ cmake ]

--- a/pkgs/development/libraries/glibc/2.39-revert-cet-default-disable.patch
+++ b/pkgs/development/libraries/glibc/2.39-revert-cet-default-disable.patch
@@ -1,0 +1,49 @@
+Revert 55d63e731253de82e96ed4ddca2e294076cd0bc5
+
+--- b/sysdeps/x86/cpu-features.c
++++ a/sysdeps/x86/cpu-features.c
+@@ -110,7 +110,7 @@
+   if (!CPU_FEATURES_CPU_P (cpu_features, RTM_ALWAYS_ABORT))
+     CPU_FEATURE_SET_ACTIVE (cpu_features, RTM);
+ 
++#if CET_ENABLED
+-#if CET_ENABLED && 0
+   CPU_FEATURE_SET_ACTIVE (cpu_features, IBT);
+   CPU_FEATURE_SET_ACTIVE (cpu_features, SHSTK);
+ #endif
+reverted:
+--- b/sysdeps/x86/cpu-tunables.c
++++ a/sysdeps/x86/cpu-tunables.c
+@@ -35,17 +35,6 @@
+       break;								\
+     }
+ 
+-#define CHECK_GLIBC_IFUNC_CPU_BOTH(f, cpu_features, name, len)		\
+-  _Static_assert (sizeof (#name) - 1 == len, #name " != " #len);	\
+-  if (tunable_str_comma_strcmp_cte (&f, #name))				\
+-    {									\
+-      if (f.disable)							\
+-	CPU_FEATURE_UNSET (cpu_features, name)				\
+-      else								\
+-	CPU_FEATURE_SET_ACTIVE (cpu_features, name)			\
+-      break;								\
+-    }
+-
+ /* Disable a preferred feature NAME.  We don't enable a preferred feature
+    which isn't available.  */
+ #define CHECK_GLIBC_IFUNC_PREFERRED_OFF(f, cpu_features, name, len)	\
+@@ -142,13 +131,11 @@
+ 	    }
+ 	  break;
+ 	case 5:
+-	  {
+-	    CHECK_GLIBC_IFUNC_CPU_BOTH (n, cpu_features, SHSTK, 5);
+-	  }
+ 	  if (n.disable)
+ 	    {
+ 	      CHECK_GLIBC_IFUNC_CPU_OFF (n, cpu_features, LZCNT, 5);
+ 	      CHECK_GLIBC_IFUNC_CPU_OFF (n, cpu_features, MOVBE, 5);
++	      CHECK_GLIBC_IFUNC_CPU_OFF (n, cpu_features, SHSTK, 5);
+ 	      CHECK_GLIBC_IFUNC_CPU_OFF (n, cpu_features, SSSE3, 5);
+ 	      CHECK_GLIBC_IFUNC_CPU_OFF (n, cpu_features, XSAVE, 5);
+ 	    }

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -37,6 +37,7 @@
 , profilingLibraries ? false
 , withGd ? false
 , enableCET ? false
+, enableCETRuntimeDefault ? false
 , extraBuildInputs ? []
 , extraNativeBuildInputs ? []
 , ...
@@ -50,6 +51,7 @@ in
 
 assert withLinuxHeaders -> linuxHeaders != null;
 assert withGd -> gd != null && libpng != null;
+assert enableCET == false -> !enableCETRuntimeDefault;
 
 stdenv.mkDerivation ({
   version = version + patchSuffix;
@@ -114,7 +116,8 @@ stdenv.mkDerivation ({
       lib.optional (isAarch64 && isLinux) ./0001-aarch64-math-vector.h-add-NVCC-include-guard.patch
     )
     ++ lib.optional stdenv.hostPlatform.isMusl ./fix-rpc-types-musl-conflicts.patch
-    ++ lib.optional stdenv.buildPlatform.isDarwin ./darwin-cross-build.patch;
+    ++ lib.optional stdenv.buildPlatform.isDarwin ./darwin-cross-build.patch
+    ++ lib.optional enableCETRuntimeDefault ./2.39-revert-cet-default-disable.patch;
 
   postPatch =
     ''

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -3,6 +3,7 @@
 , profilingLibraries ? false
 , withGd ? false
 , enableCET ? if stdenv.hostPlatform.isx86_64 then "permissive" else false
+, enableCETRuntimeDefault ? false
 , pkgsBuildBuild
 , libgcc
 }:
@@ -16,7 +17,7 @@ let
 in
 
 (callPackage ./common.nix { inherit stdenv; } {
-  inherit withLinuxHeaders withGd profilingLibraries enableCET;
+  inherit withLinuxHeaders withGd profilingLibraries enableCET enableCETRuntimeDefault;
   pname = "glibc" + lib.optionalString withGd "-gd" + lib.optionalString (stdenv.cc.isGNU && libgcc==null) "-nolibgcc";
 }).overrideAttrs(previousAttrs: {
 

--- a/pkgs/development/libraries/pcre/default.nix
+++ b/pkgs/development/libraries/pcre/default.nix
@@ -1,5 +1,7 @@
 { lib, stdenv, fetchurl, fetchpatch
 , pcre, windows ? null
+  # Disable jit on Apple Silicon, https://github.com/zherczeg/sljit/issues/51
+, enableJit ? !(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)
 , variant ? null
 }:
 
@@ -18,11 +20,12 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "dev" "out" "doc" "man" ];
 
-  # Disable jit on Apple Silicon, https://github.com/zherczeg/sljit/issues/51
-  configureFlags = lib.optional (!(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)) "--enable-jit=auto" ++ [
+  hardeningDisable = lib.optional enableJit "shadowstack";
+
+  configureFlags = [
     "--enable-unicode-properties"
     "--disable-cpp"
-  ]
+  ] ++ lib.optional enableJit "--enable-jit=auto"
     ++ lib.optional (variant != null) "--enable-${variant}";
 
   patches = [

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -416,6 +416,7 @@ in
                 isFromBootstrapFiles = true;
                 hardeningUnsupportedFlags = [
                   "fortify3"
+                  "shadowstack"
                   "stackclashprotection"
                   "zerocallusedregs"
                 ];

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -115,6 +115,7 @@ let
     "format"
     "fortify"
     "fortify3"
+    "shadowstack"
     "pic"
     "pie"
     "relro"

--- a/pkgs/stdenv/linux/bootstrap-tools-musl/default.nix
+++ b/pkgs/stdenv/linux/bootstrap-tools-musl/default.nix
@@ -15,5 +15,10 @@ derivation ({
   langC = true;
   langCC = true;
   isGNU = true;
-  hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" "trivialautovarinit" ];
+  hardeningUnsupportedFlags = [
+    "fortify3"
+    "stackclashprotection"
+    "trivialautovarinit"
+    "zerocallusedregs"
+  ];
 } // extraAttrs)

--- a/pkgs/stdenv/linux/bootstrap-tools-musl/default.nix
+++ b/pkgs/stdenv/linux/bootstrap-tools-musl/default.nix
@@ -17,6 +17,7 @@ derivation ({
   isGNU = true;
   hardeningUnsupportedFlags = [
     "fortify3"
+    "shadowstack"
     "stackclashprotection"
     "trivialautovarinit"
     "zerocallusedregs"

--- a/pkgs/stdenv/linux/bootstrap-tools/default.nix
+++ b/pkgs/stdenv/linux/bootstrap-tools/default.nix
@@ -17,6 +17,7 @@ derivation ({
   isGNU = true;
   hardeningUnsupportedFlags = [
     "fortify3"
+    "shadowstack"
     "stackclashprotection"
     "trivialautovarinit"
     "zerocallusedregs"

--- a/pkgs/tools/package-management/lix/common.nix
+++ b/pkgs/tools/package-management/lix/common.nix
@@ -245,8 +245,11 @@ stdenv.mkDerivation {
     meson test --no-rebuild "''${flagsArray[@]}"
     runHook postInstallCheck
   '';
-  # strictoverflow is disabled because we trap on signed overflow instead
-  hardeningDisable = [ "strictoverflow" ] ++ lib.optional stdenv.hostPlatform.isStatic "pie";
+  hardeningDisable = [
+    "shadowstack"
+    # strictoverflow is disabled because we trap on signed overflow instead
+    "strictoverflow"
+  ] ++ lib.optional stdenv.hostPlatform.isStatic "pie";
   # hardeningEnable = lib.optionals (!stdenv.isDarwin) [ "pie" ];
   # hardeningDisable = lib.optional stdenv.hostPlatform.isMusl "fortify";
   separateDebugInfo = stdenv.isLinux && !enableStatic;

--- a/pkgs/tools/package-management/nix/common.nix
+++ b/pkgs/tools/package-management/nix/common.nix
@@ -101,7 +101,9 @@ self = stdenv.mkDerivation {
 
   hardeningEnable = lib.optionals (!stdenv.isDarwin) [ "pie" ];
 
-  hardeningDisable = lib.optional stdenv.hostPlatform.isMusl "fortify";
+  hardeningDisable = [
+    "shadowstack"
+  ] ++ lib.optional stdenv.hostPlatform.isMusl "fortify";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -297,6 +297,10 @@ let
               "trivialautovarinit"
             ]
           ) super'.stdenv;
+          glibc = super'.glibc.override rec {
+            enableCET = if self'.stdenv.hostPlatform.isx86_64 then "permissive" else false;
+            enableCETRuntimeDefault = enableCET != false;
+          };
         })
       ] ++ overlays;
     };

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -292,6 +292,7 @@ let
           pkgsExtraHardening = super';
           stdenv = super'.withDefaultHardeningFlags (
             super'.stdenv.cc.defaultHardeningFlags ++ [
+              "shadowstack"
               "stackclashprotection"
               "trivialautovarinit"
             ]

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -301,6 +301,11 @@ let
             enableCET = if self'.stdenv.hostPlatform.isx86_64 then "permissive" else false;
             enableCETRuntimeDefault = enableCET != false;
           };
+        } // lib.optionalAttrs (with super'.stdenv.hostPlatform; isx86_64 && isLinux) {
+          # causes shadowstack disablement
+          pcre = super'.pcre.override { enableJit = false; };
+          pcre-cpp = super'.pcre-cpp.override { enableJit = false; };
+          pcre16 = super'.pcre16.override { enableJit = false; };
         })
       ] ++ overlays;
     };


### PR DESCRIPTION
## Description of changes
Some background: https://discourse.nixos.org/t/future-design-of-hardening-flags/38826

This, along with #324429, is a replacement for #320597, abandoning the idea of combining multiple technologies into a single `hardbackedgecfi` flag.

This also adds an optional reversion of a glibc commit that default-disabled shadow-stack support at runtime, presumably because of distributions that started building with these flags enabled before they were able to test them properly. We don't have that problem, and for package sets like `pkgsExtraHardening` we probably want that on by default so that these packages get more testing.

Again, I do not have access to a shadowstack-capable machine, so I would greatly appreciate someone who does building as many packages as possible on this branch and telling me which packages need to have `hardeningDisable` set for them.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
