### PR TITLE
treewide: sha256 -> hash attribute for gitlab.com,codeberg.org fetchers

### DIFF
--- a/pkgs/applications/audio/callaudiod/default.nix
+++ b/pkgs/applications/audio/callaudiod/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     owner = "mobian1";
     repo = pname;
     rev = version;
-    sha256 = "sha256-gc66XrrFyhF1TvrDECBfGQc+MiDtqZPxdCn0S/43XQU=";
+    hash = "sha256-gc66XrrFyhF1TvrDECBfGQc+MiDtqZPxdCn0S/43XQU=";
   };
 
   strictDeps = true;

--- a/pkgs/applications/audio/geonkick/default.nix
+++ b/pkgs/applications/audio/geonkick/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     owner = "Geonkick-Synthesizer";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-zoEC85QYcQMF92KvLBikYw1nDoSHaedpTDDqvoAtte0=";
+    hash = "sha256-zoEC85QYcQMF92KvLBikYw1nDoSHaedpTDDqvoAtte0=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];

--- a/pkgs/applications/audio/mellowplayer/default.nix
+++ b/pkgs/applications/audio/mellowplayer/default.nix
@@ -21,7 +21,7 @@ mkDerivation rec {
     owner = "ColinDuquesnoy";
     repo = "MellowPlayer";
     rev = version;
-    sha256 = "sha256-rsF2xQet7U8d4oGU/HgghvE3vvmkxjlGXPBlLD9mWTk=";
+    hash = "sha256-rsF2xQet7U8d4oGU/HgghvE3vvmkxjlGXPBlLD9mWTk=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];

--- a/pkgs/applications/audio/sayonara/default.nix
+++ b/pkgs/applications/audio/sayonara/default.nix
@@ -28,7 +28,7 @@ mkDerivation rec {
     owner = "luciocarreras";
     repo = "sayonara-player";
     rev = version;
-    sha256 = "sha256-tJ/8tGNkmTwWRCpPy/h85SP/6QDAgcaKWJdM5MSAXJw=";
+    hash = "sha256-tJ/8tGNkmTwWRCpPy/h85SP/6QDAgcaKWJdM5MSAXJw=";
   };
 
   nativeBuildInputs = [ cmake ninja pkg-config qttools ];

--- a/pkgs/applications/audio/uade/default.nix
+++ b/pkgs/applications/audio/uade/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     owner = "uade-music-player";
     repo = "uade";
     rev = "uade-${version}";
-    sha256 = "sha256-skPEXBQwyr326zCmZ2jwGxcBoTt3Y/h2hagDeeqbMpw=";
+    hash = "sha256-skPEXBQwyr326zCmZ2jwGxcBoTt3Y/h2hagDeeqbMpw=";
   };
 
   postPatch = ''

--- a/pkgs/applications/blockchains/bitcoin-unlimited/default.nix
+++ b/pkgs/applications/blockchains/bitcoin-unlimited/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "bitcoinunlimited";
     repo = "BCHUnlimited";
     rev = "BCHunlimited${version}";
-    sha256 = "sha256-d+giTXq/6HpysRAPT7yOl/B1x4zie9irs4O7cJsBqHg=";
+    hash = "sha256-d+giTXq/6HpysRAPT7yOl/B1x4zie9irs4O7cJsBqHg=";
   };
 
   nativeBuildInputs = [ pkg-config autoreconfHook python3 ]

--- a/pkgs/applications/emulators/goldberg-emu/default.nix
+++ b/pkgs/applications/emulators/goldberg-emu/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     owner = "mr_goldberg";
     repo = "goldberg_emulator";
     rev = version;
-    sha256 = "sha256-goOgMNjtDmIKOAv9sZwnPOY0WqTN90LFJ5iEp3Vkzog=";
+    hash = "sha256-goOgMNjtDmIKOAv9sZwnPOY0WqTN90LFJ5iEp3Vkzog=";
   };
 
   # It attempts to install windows-only libraries which we never build

--- a/pkgs/applications/gis/zombietrackergps/default.nix
+++ b/pkgs/applications/gis/zombietrackergps/default.nix
@@ -18,7 +18,7 @@ mkDerivation rec {
     # latest revision is not tagged upstream, use commit sha in the meantime
     #rev = "v_${version}";
     rev = "cc75d5744965cc6973323f5bb77f00b0b0153dce";
-    sha256 = "sha256-z/LFNRFdQQFxEWyAjcuGezRbTsv8z6Q6fK8NLjP4HNM=";
+    hash = "sha256-z/LFNRFdQQFxEWyAjcuGezRbTsv8z6Q6fK8NLjP4HNM=";
   };
 
   buildInputs =

--- a/pkgs/applications/graphics/ovito/default.nix
+++ b/pkgs/applications/graphics/ovito/default.nix
@@ -27,7 +27,7 @@ mkDerivation rec {
     owner = "stuko";
     repo = "ovito";
     rev = "v${version}";
-    sha256 = "sha256-Z3uwjOYJ7di/LLllbzdKjzUE7m119i03bA8dJPqhxWA=";
+    hash = "sha256-Z3uwjOYJ7di/LLllbzdKjzUE7m119i03bA8dJPqhxWA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/pizarra/default.nix
+++ b/pkgs/applications/graphics/pizarra/default.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     repo = "pizarra-gtk";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-vnjhveX3EVIfJLiHWhlvhoPcRx1a8Nnjj7hIaPgU3Zw=";
+    hash = "sha256-vnjhveX3EVIfJLiHWhlvhoPcRx1a8Nnjj7hIaPgU3Zw=";
   };
 
   cargoHash = "sha256-btvMUKADGHlXLmeKF1K9Js44SljZ0MejGId8aDwPhVU=";

--- a/pkgs/applications/misc/OSCAR/default.nix
+++ b/pkgs/applications/misc/OSCAR/default.nix
@@ -7,7 +7,7 @@ mkDerivation rec {
     owner = "pholy";
     repo = "OSCAR-code";
     rev = "v${version}";
-    sha256 = "sha256-FBHbPtMZeIgcR1pQflfEWK2FS8bquctXaeY/yaZofHg=";
+    hash = "sha256-FBHbPtMZeIgcR1pQflfEWK2FS8bquctXaeY/yaZofHg=";
   };
 
   buildInputs = [ qtbase qttools qtserialport libGLU ];

--- a/pkgs/applications/misc/corectrl/default.nix
+++ b/pkgs/applications/misc/corectrl/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec{
     owner = "corectrl";
     repo = "corectrl";
     rev = "v${version}";
-    sha256 = "sha256-E2Dqe1IYXjFb/nShQX+ARZW/AWpNonRimb3yQ6/2CFw=";
+    hash = "sha256-E2Dqe1IYXjFb/nShQX+ARZW/AWpNonRimb3yQ6/2CFw=";
   };
   patches = [
     ./polkit-dir.patch

--- a/pkgs/applications/misc/darkman/default.nix
+++ b/pkgs/applications/misc/darkman/default.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
     owner = "WhyNotHugo";
     repo = "darkman";
     rev = "v${version}";
-    sha256 = "sha256-FaEpVy/0PqY5Bmw00hMyFZb9wcwYwEuCKMatYN8Xk3o=";
+    hash = "sha256-FaEpVy/0PqY5Bmw00hMyFZb9wcwYwEuCKMatYN8Xk3o=";
   };
 
   patches = [

--- a/pkgs/applications/misc/fetchmail/v7.nix
+++ b/pkgs/applications/misc/fetchmail/v7.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     owner = "fetchmail";
     repo = "fetchmail";
     rev = "30b368fb8660d8fec08be1cdf2606c160b4bcb80";
-    sha256 = "sha256-83D2YlFCODK2YD+oLICdim2NtNkkJU67S3YLi8Q6ga8=";
+    hash = "sha256-83D2YlFCODK2YD+oLICdim2NtNkkJU67S3YLi8Q6ga8=";
   };
 
   buildInputs = with pkgs; [ openssl python3 ];

--- a/pkgs/applications/misc/gcstar/default.nix
+++ b/pkgs/applications/misc/gcstar/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     owner = "Kerenoc";
     repo = "GCstar";
     rev = "v${version}";
-    sha256 = "sha256-37yjKI4l/nUzDnra1AGxDQxNafMsLi1bSifG6pz33zg=";
+    hash = "sha256-37yjKI4l/nUzDnra1AGxDQxNafMsLi1bSifG6pz33zg=";
   };
 
   nativeBuildInputs = [ wrapGAppsHook3 ];

--- a/pkgs/applications/misc/kile-wl/default.nix
+++ b/pkgs/applications/misc/kile-wl/default.nix
@@ -8,7 +8,7 @@ rustPlatform.buildRustPackage rec {
     owner = "snakedye";
     repo = "kile";
     rev = "c24208761d04e0a74d203fc1dcd2f7fed68da388";
-    sha256 = "sha256-4iclNVd7nm6LkgvsHwWaWyi1bZL/A+bbT5OSXn70bLs=";
+    hash = "sha256-4iclNVd7nm6LkgvsHwWaWyi1bZL/A+bbT5OSXn70bLs=";
   };
 
   passthru.updateScript = unstableGitUpdater {

--- a/pkgs/applications/misc/openrgb/default.nix
+++ b/pkgs/applications/misc/openrgb/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "CalcProgrammer1";
     repo = "OpenRGB";
     rev = "release_${version}";
-    sha256 = "sha256-XBLj4EfupyeVHRc0pVI7hrXFoCNJ7ak2yO0QSfhBsGU=";
+    hash = "sha256-XBLj4EfupyeVHRc0pVI7hrXFoCNJ7ak2yO0QSfhBsGU=";
   };
 
   nativeBuildInputs = [ qmake pkg-config wrapQtAppsHook ];

--- a/pkgs/applications/misc/redshift/default.nix
+++ b/pkgs/applications/misc/redshift/default.nix
@@ -132,7 +132,7 @@ rec {
       owner = "chinstrap";
       repo = pname;
       rev = "v${version}";
-      sha256 = "sha256-EdVLBBIEjMu+yy9rmcxQf4zdW47spUz5SbBDbhmLjOU=";
+      hash = "sha256-EdVLBBIEjMu+yy9rmcxQf4zdW47spUz5SbBDbhmLjOU=";
     };
 
     meta = redshift.meta // {

--- a/pkgs/applications/misc/tipp10/default.nix
+++ b/pkgs/applications/misc/tipp10/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     owner = "tipp10";
     repo = "tipp10";
     rev = "v${version}";
-    sha256 = "sha256-e0sWH4pT7ej9XGK/Sg9XMX2bMqcXqtSaYI7KBZTXvp4=";
+    hash = "sha256-e0sWH4pT7ej9XGK/Sg9XMX2bMqcXqtSaYI7KBZTXvp4=";
   };
 
   nativeBuildInputs = [ cmake qttools wrapQtAppsHook ];

--- a/pkgs/applications/networking/headlines/default.nix
+++ b/pkgs/applications/networking/headlines/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     owner = "caveman250";
     repo = "Headlines";
     rev = version;
-    sha256 = "sha256-wamow0UozX5ecKbXWOgsWCerInL4J0gK0+Muf+eoO9k=";
+    hash = "sha256-wamow0UozX5ecKbXWOgsWCerInL4J0gK0+Muf+eoO9k=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/instant-messengers/signald/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signald/default.nix
@@ -13,7 +13,7 @@ let
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "sha256-EofgwZSDp2ZFhlKL2tHfzMr3EsidzuY4pkRZrV2+1bA=";
+    hash = "sha256-EofgwZSDp2ZFhlKL2tHfzMr3EsidzuY4pkRZrV2+1bA=";
   };
 
   gradleWithJdk = gradle.override { java = jdk17_headless; };

--- a/pkgs/applications/networking/weather/meteo/default.nix
+++ b/pkgs/applications/networking/weather/meteo/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     owner = "bitseater";
     repo = pname;
     rev = version;
-    sha256 = "sha256-hubKusrs0Hh8RryoEI29pnhTSNsIbtGMltlH4qoM6gE=";
+    hash = "sha256-hubKusrs0Hh8RryoEI29pnhTSNsIbtGMltlH4qoM6gE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/radio/gridtracker/default.nix
+++ b/pkgs/applications/radio/gridtracker/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "gridtracker.org";
     repo = "gridtracker";
     rev = "v${version}";
-    sha256 = "sha256-p3PdYOk0yvG3QkM17grzZmf9upK1n0zo4aOrlhGTvTU=";
+    hash = "sha256-p3PdYOk0yvG3QkM17grzZmf9upK1n0zo4aOrlhGTvTU=";
   };
 
   nativeBuildInputs = [ wrapGAppsHook3 ];

--- a/pkgs/applications/science/chemistry/octopus/default.nix
+++ b/pkgs/applications/science/chemistry/octopus/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     owner = "octopus-code";
     repo = "octopus";
     rev = version;
-    sha256 = "sha256-8wZR+bYdxJFsUPMWbIGYxRdNzjLgHm+KFLjY7fSN7io=";
+    hash = "sha256-8wZR+bYdxJFsUPMWbIGYxRdNzjLgHm+KFLjY7fSN7io=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/science/electronics/flopoco/default.nix
+++ b/pkgs/applications/science/electronics/flopoco/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     repo = pname;
     # flopoco-4.1.3 is not tagged on GitLab
     rev = "67598298207c9f3261c35679c8a5966480c4343c";
-    sha256 = "sha256-0jRjg4/qciqBcjsi6BTbKO4VJkcoEzpC98wFkUOIGbI=";
+    hash = "sha256-0jRjg4/qciqBcjsi6BTbKO4VJkcoEzpC98wFkUOIGbI=";
   };
 
   patches = [

--- a/pkgs/applications/version-management/gitlab/gitlab-elasticsearch-indexer/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-elasticsearch-indexer/default.nix
@@ -9,7 +9,7 @@ buildGoModule rec {
     owner = "gitlab-org";
     repo = "gitlab-elasticsearch-indexer";
     rev = "v${version}";
-    sha256 = "sha256-856lRCW4+FIiXjOzMkfoYws6SMIKXWVtvr+867QEjCk=";
+    hash = "sha256-856lRCW4+FIiXjOzMkfoYws6SMIKXWVtvr+867QEjCk=";
   };
 
   vendorHash = "sha256-2XdbTqNGt97jQUJmE06D6M/VxF9+vJAwMM/fF8MP2oo=";

--- a/pkgs/applications/version-management/gitlab/gitlab-shell/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-shell/default.nix
@@ -9,7 +9,7 @@ buildGoModule rec {
     owner = "gitlab-org";
     repo = "gitlab-shell";
     rev = "v${version}";
-    sha256 = "sha256-SclRIIUZm1D5fYDrTH1L8opQpxxIoi+SrG2GO7wtScU=";
+    hash = "sha256-SclRIIUZm1D5fYDrTH1L8opQpxxIoi+SrG2GO7wtScU=";
   };
 
   buildInputs = [ ruby libkrb5 ];

--- a/pkgs/applications/video/devede/default.nix
+++ b/pkgs/applications/video/devede/default.nix
@@ -12,7 +12,7 @@ in buildPythonApplication rec {
     owner = "rastersoft";
     repo = "devedeng";
     rev = version;
-    sha256 = "sha256-CdntdD5DRA/eXTBRBRszkbYFeFxj+0odb8XHkAFdobU=";
+    hash = "sha256-CdntdD5DRA/eXTBRBRszkbYFeFxj+0odb8XHkAFdobU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/video/glaxnimate/default.nix
+++ b/pkgs/applications/video/glaxnimate/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     owner = "mattbas";
     repo = "${pname}";
     rev = version;
-    sha256 = "sha256-8oHJCQdP2xxSSDM0MDkSrG89WgCtMKm1AKlddnq3gig=";
+    hash = "sha256-8oHJCQdP2xxSSDM0MDkSrG89WgCtMKm1AKlddnq3gig=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/video/obs-studio/plugins/obs-nvfbc.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-nvfbc.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "fzwoch";
     repo = "obs-nvfbc";
     rev = "v${version}";
-    sha256 = "sha256-AJ3K0O1vrixskn+/Tpg7LsgRO8N4sgDo1Y6gg3CwGVo=";
+    hash = "sha256-AJ3K0O1vrixskn+/Tpg7LsgRO8N4sgDo1Y6gg3CwGVo=";
   };
 
   nativeBuildInputs = [ meson pkg-config ninja ];

--- a/pkgs/by-name/an/ananicy-cpp/package.nix
+++ b/pkgs/by-name/an/ananicy-cpp/package.nix
@@ -23,7 +23,7 @@ clangStdenv.mkDerivation rec {
     repo = "ananicy-cpp";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-oPinSc00+Z6SxjfTh7DttcXSjsLv1X0NI+O37C8M8GY=";
+    hash = "sha256-oPinSc00+Z6SxjfTh7DttcXSjsLv1X0NI+O37C8M8GY=";
   };
 
   patches = [

--- a/pkgs/by-name/cl/clickable/package.nix
+++ b/pkgs/by-name/cl/clickable/package.nix
@@ -14,7 +14,7 @@ python3Packages.buildPythonApplication rec {
     owner = "clickable";
     repo = "clickable";
     rev = "v${version}";
-    sha256 = "sha256-MFzpeiWeqJ0MG8ouwRkYXD1e6Nsxshmz1NSzCIBRjZ0=";
+    hash = "sha256-MFzpeiWeqJ0MG8ouwRkYXD1e6Nsxshmz1NSzCIBRjZ0=";
   };
 
   propagatedBuildInputs = with python3Packages; [

--- a/pkgs/by-name/ec/eclint/package.nix
+++ b/pkgs/by-name/ec/eclint/package.nix
@@ -12,7 +12,7 @@ rec {
     owner = "greut";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-x0dBiRHaDxKrTCR2RfP2/bpBo6xewu8FX7Bv4ugaUAY=";
+    hash = "sha256-x0dBiRHaDxKrTCR2RfP2/bpBo6xewu8FX7Bv4ugaUAY=";
   };
 
   vendorHash = "sha256-aNQuALDe37lsmTGpClIBOQJlL0NFSAZCgcmTjx0kP+U=";

--- a/pkgs/by-name/sn/snekim/package.nix
+++ b/pkgs/by-name/sn/snekim/package.nix
@@ -9,7 +9,7 @@ buildNimPackage (finalAttrs: {
     owner = "annaaurora";
     repo = "snekim";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-Qgvq4CkGvNppYFpITCCifOHtVQYRQJPEK3rTJXQkTvI=";
+    hash = "sha256-Qgvq4CkGvNppYFpITCCifOHtVQYRQJPEK3rTJXQkTvI=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/sw/swayws/package.nix
+++ b/pkgs/by-name/sw/swayws/package.nix
@@ -8,7 +8,7 @@ rustPlatform.buildRustPackage rec {
     owner = "w0lff";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-f0kXy7/31imgHHqKPmW9K+QrLqroaPaXwlJkzOoezRU=";
+    hash = "sha256-f0kXy7/31imgHHqKPmW9K+QrLqroaPaXwlJkzOoezRU=";
   };
 
   cargoSha256 = "sha256-VYT6wV59fraAoJgR/i6GlO8s7LUoehGtxPAggEL1eLo=";

--- a/pkgs/by-name/wb/wbg/package.nix
+++ b/pkgs/by-name/wb/wbg/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     owner = "dnkl";
     repo = "wbg";
     rev = version;
-    sha256 = "sha256-zd5OWC0r/75IaeKy5xjV+pQefRy48IcFTxx93iy0a0Q=";
+    hash = "sha256-zd5OWC0r/75IaeKy5xjV+pQefRy48IcFTxx93iy0a0Q=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/wo/woodpecker-pipeline-transform/package.nix
+++ b/pkgs/by-name/wo/woodpecker-pipeline-transform/package.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
     owner = "lafriks";
     repo = "woodpecker-pipeline-transform";
     rev = "v${version}";
-    sha256 = "sha256-ngtpWjbL/ccmKTNQdL3osduELYSxcOu5z5UtqclNNSY=";
+    hash = "sha256-ngtpWjbL/ccmKTNQdL3osduELYSxcOu5z5UtqclNNSY=";
   };
 
   vendorHash = "sha256-SZxFsn187UWZqaxwMDdzAmfpRLZSCIpbsAI1mAu7Z6w=";

--- a/pkgs/data/icons/simp1e-cursors/default.nix
+++ b/pkgs/data/icons/simp1e-cursors/default.nix
@@ -8,7 +8,7 @@ stdenvNoCC.mkDerivation rec {
     owner = "cursors";
     repo = "simp1e";
     rev = version;
-    sha256 = "sha256-3DCF6TwxWwYK5pF2Ykr3OwF76H7J03vLNZch/XoZZZk=";
+    hash = "sha256-3DCF6TwxWwYK5pF2Ykr3OwF76H7J03vLNZch/XoZZZk=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/desktops/gnome/extensions/arcmenu/default.nix
+++ b/pkgs/desktops/gnome/extensions/arcmenu/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "arcmenu";
     repo = "ArcMenu";
     rev = "v${version}";
-    sha256 = "sha256-xLKvcrZkqcj7aHiv9JumLWSP5LbajITAyopCIwGqpkE=";
+    hash = "sha256-xLKvcrZkqcj7aHiv9JumLWSP5LbajITAyopCIwGqpkE=";
   };
 
   patches = [

--- a/pkgs/desktops/plasma-5/3rdparty/addons/krunner-ssh.nix
+++ b/pkgs/desktops/plasma-5/3rdparty/addons/krunner-ssh.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "Programie";
     repo = "krunner-ssh";
     rev = version;
-    sha256 = "sha256-rFTTvmetDeN6t0axVc+8t1TRiuyPBpwqhvsq2IFxa/A=";
+    hash = "sha256-rFTTvmetDeN6t0axVc+8t1TRiuyPBpwqhvsq2IFxa/A=";
   };
 
   postPatch = ''

--- a/pkgs/development/compilers/owl-lisp/default.nix
+++ b/pkgs/development/compilers/owl-lisp/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner  = "owl-lisp";
     repo   = "owl";
     rev    = "v${version}";
-    sha256 = "sha256-GfvOkYLo8fgAvGuUa59hDy+sWJSwyntwqMO8TAK/lUo=";
+    hash = "sha256-GfvOkYLo8fgAvGuUa59hDy+sWJSwyntwqMO8TAK/lUo=";
   };
 
   nativeBuildInputs = [ which ];

--- a/pkgs/development/guile-modules/guile-git/default.nix
+++ b/pkgs/development/guile-modules/guile-git/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     owner = "guile-git";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-7xKs5Biq9HHOJbNILLU1oX8oPuEbti0uLMiobKz//bU=";
+    hash = "sha256-7xKs5Biq9HHOJbNILLU1oX8oPuEbti0uLMiobKz//bU=";
   };
 
   strictDeps = true;

--- a/pkgs/development/libraries/arpa2common/default.nix
+++ b/pkgs/development/libraries/arpa2common/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     owner = "arpa2";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-UpAVyDXCe07ZwjD307t6G9f/Nny4QYXxGxft1KsiYYg=";
+    hash = "sha256-UpAVyDXCe07ZwjD307t6G9f/Nny4QYXxGxft1KsiYYg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/eigen/default.nix
+++ b/pkgs/development/libraries/eigen/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     owner = "libeigen";
     repo = pname;
     rev = version;
-    sha256 = "sha256-1/4xMetKMDOgZgzz3WMxfHUEpmdAm52RqZvz6i0mLEw=";
+    hash = "sha256-1/4xMetKMDOgZgzz3WMxfHUEpmdAm52RqZvz6i0mLEw=";
   };
 
   patches = [

--- a/pkgs/development/libraries/fcft/default.nix
+++ b/pkgs/development/libraries/fcft/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     owner = "dnkl";
     repo = "fcft";
     rev = version;
-    sha256 = "sha256-Wgm2QdW4rg573soF/8HhDmlyN4S2cA0VWOejow464gU=";
+    hash = "sha256-Wgm2QdW4rg573soF/8HhDmlyN4S2cA0VWOejow464gU=";
   };
 
   depsBuildBuild = [ pkg-config ];

--- a/pkgs/development/libraries/ldutils/default.nix
+++ b/pkgs/development/libraries/ldutils/default.nix
@@ -14,7 +14,7 @@ mkDerivation rec {
     repo = pname;
     rev = "4fc416f694ce888c5bd4c4432a7730bb6260475c";
     #rev = "v_${version}";
-    sha256 = "sha256-UMDayvz9RlcR4HVJNn7tN4FKbiKAFRSPaK0osA6OGTI=";
+    hash = "sha256-UMDayvz9RlcR4HVJNn7tN4FKbiKAFRSPaK0osA6OGTI=";
   };
 
   buildInputs = with libsForQt5.qt5; [

--- a/pkgs/development/libraries/libaccounts-glib/default.nix
+++ b/pkgs/development/libraries/libaccounts-glib/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "accounts-sso";
     repo = "libaccounts-glib";
     rev = "VERSION_${version}";
-    sha256 = "sha256-mLhcwp8rhCGSB1K6rTWT0tuiINzgwULwXINfCbgPKEg=";
+    hash = "sha256-mLhcwp8rhCGSB1K6rTWT0tuiINzgwULwXINfCbgPKEg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/libarchive-qt/default.nix
+++ b/pkgs/development/libraries/libarchive-qt/default.nix
@@ -8,7 +8,7 @@ mkDerivation rec {
     owner = "marcusbritanicus";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-31a6DsxObSJWyLfT6mVtyjloT26IwFHpH53iuyC2mco=";
+    hash = "sha256-31a6DsxObSJWyLfT6mVtyjloT26IwFHpH53iuyC2mco=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/quickder/default.nix
+++ b/pkgs/development/libraries/quickder/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     owner = "arpa2";
     repo = "quick-der";
     rev = "v${version}";
-    sha256 = "sha256-f+ph5PL+uWRkswpOLDwZFWjh938wxoJ6xocJZ2WZLEk=";
+    hash = "sha256-f+ph5PL+uWRkswpOLDwZFWjh938wxoJ6xocJZ2WZLEk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/quickmem/default.nix
+++ b/pkgs/development/libraries/quickmem/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     owner = "arpa2";
     repo = "Quick-MEM";
     rev = "v${version}";
-    sha256 = "sha256-cqg8QN4/I+zql7lVDDAgFA05Dmg4ylBTvPSPP7WATdc=";
+    hash = "sha256-cqg8QN4/I+zql7lVDDAgFA05Dmg4ylBTvPSPP7WATdc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/science/math/lcalc/default.nix
+++ b/pkgs/development/libraries/science/math/lcalc/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     owner = "sagemath";
     repo = pname;
     rev = version;
-    sha256 = "sha256-RxWZ7T0I9zV7jUVnL6jV/PxEoU32KY7Q1UsOL5Lonuc=";
+    hash = "sha256-RxWZ7T0I9zV7jUVnL6jV/PxEoU32KY7Q1UsOL5Lonuc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/science/networking/ns-3/default.nix
+++ b/pkgs/development/libraries/science/networking/ns-3/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     owner = "nsnam";
     repo = "ns-3-dev";
     rev = "ns-3.${version}";
-    sha256 = "sha256-2d8xCCfxRpcCZgt7ne17F7cUo/wIxLyvjQs3izNUnmY=";
+    hash = "sha256-2d8xCCfxRpcCZgt7ne17F7cUo/wIxLyvjQs3izNUnmY=";
   };
 
   nativeBuildInputs = [ cmake pkg-config pythonEnv ];

--- a/pkgs/development/libraries/soundtouch/default.nix
+++ b/pkgs/development/libraries/soundtouch/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     owner = "soundtouch";
     repo = "soundtouch";
     rev = version;
-    sha256 = "sha256-imeeTj+3gXxoGTuC/13+BAplwcnQ0wRJdSVt7MPlBxc=";
+    hash = "sha256-imeeTj+3gXxoGTuC/13+BAplwcnQ0wRJdSVt7MPlBxc=";
   };
 
   nativeBuildInputs = [ autoconf automake libtool ];

--- a/pkgs/development/libraries/tezos-rust-libs/default.nix
+++ b/pkgs/development/libraries/tezos-rust-libs/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     owner = "tezos";
     repo = "tezos-rust-libs";
     rev = "v${version}";
-    sha256 = "sha256-SuCqDZDXmWdGI/GN+3nYcUk66jnW5FQQaeTB76/rvaw=";
+    hash = "sha256-SuCqDZDXmWdGI/GN+3nYcUk66jnW5FQQaeTB76/rvaw=";
   };
 
   nativeBuildInputs = [ llvmPackages_12.llvm cargo ];

--- a/pkgs/development/ocaml-modules/bls12-381/default.nix
+++ b/pkgs/development/ocaml-modules/bls12-381/default.nix
@@ -16,7 +16,7 @@ buildDunePackage rec {
     owner = "nomadic-labs";
     repo = "cryptography/ocaml-bls12-381";
     rev = version;
-    sha256 = "sha256-z2ZSOrXgm+XjdrY91vqxXSKhA0DyJz6JkkNljDZznX8=";
+    hash = "sha256-z2ZSOrXgm+XjdrY91vqxXSKhA0DyJz6JkkNljDZznX8=";
   };
 
   minimalOCamlVersion = "4.08";

--- a/pkgs/development/ocaml-modules/class_group_vdf/default.nix
+++ b/pkgs/development/ocaml-modules/class_group_vdf/default.nix
@@ -13,7 +13,7 @@ buildDunePackage (rec {
     owner = "nomadic-labs/cryptography";
     repo = "ocaml-chia-vdf";
     rev = "v${version}";
-    sha256 = "sha256-KvpnX2DTUyfKARNWHC2lLBGH2Ou2GfRKjw05lu4jbBs=";
+    hash = "sha256-KvpnX2DTUyfKARNWHC2lLBGH2Ou2GfRKjw05lu4jbBs=";
   };
 
   minimalOCamlVersion = "4.08";

--- a/pkgs/development/ocaml-modules/ctypes_stubs_js/default.nix
+++ b/pkgs/development/ocaml-modules/ctypes_stubs_js/default.nix
@@ -16,7 +16,7 @@ buildDunePackage rec {
     owner = "nomadic-labs";
     repo = pname;
     rev = version;
-    sha256 = "sha256-OJIzg2hnwkXkQHd4bRR051eLf4HNWa/XExxbj46SyUs=";
+    hash = "sha256-OJIzg2hnwkXkQHd4bRR051eLf4HNWa/XExxbj46SyUs=";
   };
 
   propagatedBuildInputs = [ integers_stubs_js ];

--- a/pkgs/development/ocaml-modules/dose3/default.nix
+++ b/pkgs/development/ocaml-modules/dose3/default.nix
@@ -12,7 +12,7 @@ buildDunePackage rec {
     owner = "irill";
     repo = "dose3";
     rev = version;
-    sha256 = "sha256-K0fYSAWV48Rers/foDrEIqieyJ0PvpXkuYrFrZGBkkE=";
+    hash = "sha256-K0fYSAWV48Rers/foDrEIqieyJ0PvpXkuYrFrZGBkkE=";
   };
 
   minimalOCamlVersion = "4.07";

--- a/pkgs/development/ocaml-modules/ff/sig.nix
+++ b/pkgs/development/ocaml-modules/ff/sig.nix
@@ -7,7 +7,7 @@ buildDunePackage rec {
     owner = "nomadic-labs";
     repo = "cryptography/ocaml-ff";
     rev = version;
-    sha256 = "sha256-IoUH4awMOa1pm/t8E5io87R0TZsAxJjGWaXhXjn/w+Y=";
+    hash = "sha256-IoUH4awMOa1pm/t8E5io87R0TZsAxJjGWaXhXjn/w+Y=";
   };
 
   duneVersion = "3";

--- a/pkgs/development/ocaml-modules/lwt-watcher/default.nix
+++ b/pkgs/development/ocaml-modules/lwt-watcher/default.nix
@@ -11,7 +11,7 @@ buildDunePackage rec {
     owner = "nomadic-labs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-35Z73bSzEEgTabNH2cD9lRdDczsyIMZR2ktyKx4aN9k=";
+    hash = "sha256-35Z73bSzEEgTabNH2cD9lRdDczsyIMZR2ktyKx4aN9k=";
   };
 
   useDune2 = true;

--- a/pkgs/development/ocaml-modules/polynomial/default.nix
+++ b/pkgs/development/ocaml-modules/polynomial/default.nix
@@ -14,7 +14,7 @@ buildDunePackage rec {
     owner = "nomadic-labs";
     repo = "cryptography/ocaml-polynomial";
     rev = version;
-    sha256 = "sha256-is/PrYLCwStHiQsNq5OVRCwHdXjO2K2Z7FrXgytRfAU=";
+    hash = "sha256-is/PrYLCwStHiQsNq5OVRCwHdXjO2K2Z7FrXgytRfAU=";
   };
 
   propagatedBuildInputs = [ zarith ff-sig ];

--- a/pkgs/development/ocaml-modules/resto/default.nix
+++ b/pkgs/development/ocaml-modules/resto/default.nix
@@ -8,7 +8,7 @@ buildDunePackage rec {
     owner = "nomadic-labs";
     repo = "resto";
     rev = "v${version}";
-    sha256 = "sha256-DIm7fmISsCgRDi4p3NsUk7Cvs/dHpIKMdAOVdYLX2mc=";
+    hash = "sha256-DIm7fmISsCgRDi4p3NsUk7Cvs/dHpIKMdAOVdYLX2mc=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/ringo/default.nix
+++ b/pkgs/development/ocaml-modules/ringo/default.nix
@@ -7,7 +7,7 @@ buildDunePackage rec {
     owner = "nomadic-labs";
     repo = "ringo";
     rev = "v${version}";
-    sha256 = "sha256-9HW3M27BxrEPbF8cMHwzP8FmJduUInpQQAE2672LOuU=";
+    hash = "sha256-9HW3M27BxrEPbF8cMHwzP8FmJduUInpQQAE2672LOuU=";
   };
 
   minimalOCamlVersion = "4.08";

--- a/pkgs/development/tools/asn2quickder/default.nix
+++ b/pkgs/development/tools/asn2quickder/default.nix
@@ -17,7 +17,7 @@ buildPythonApplication rec {
     owner = "arpa2";
     repo = "quick-der";
     rev = "v${version}";
-    sha256 = "sha256-f+ph5PL+uWRkswpOLDwZFWjh938wxoJ6xocJZ2WZLEk=";
+    hash = "sha256-f+ph5PL+uWRkswpOLDwZFWjh938wxoJ6xocJZ2WZLEk=";
   };
 
   postPatch = ''

--- a/pkgs/development/tools/build-managers/arpa2cm/default.nix
+++ b/pkgs/development/tools/build-managers/arpa2cm/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "arpa2";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-2vb/7UL+uWGrQNh8yOZ3gih5G1/eOp064hF78SDsPGk=";
+    hash = "sha256-2vb/7UL+uWGrQNh8yOZ3gih5G1/eOp064hF78SDsPGk=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/tools/check/default.nix
+++ b/pkgs/development/tools/check/default.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
     owner = "opennota";
     repo = "check";
     inherit rev;
-    sha256 = "sha256-u8U/62LZEn1ffwdGsUCGam4HAk7b2LetomCLZzHuuas=";
+    hash = "sha256-u8U/62LZEn1ffwdGsUCGam4HAk7b2LetomCLZzHuuas=";
   };
 
   vendorHash = "sha256-DyysiVYFpncmyCzlHIOEtWlCMpm90AC3gdItI9WinSo=";

--- a/pkgs/development/tools/click/default.nix
+++ b/pkgs/development/tools/click/default.nix
@@ -25,7 +25,7 @@ buildPythonApplication {
     owner = "ubports";
     repo = "development/core/click";
     rev = "aaf2735e8e6cbeaf2e429c70136733513a81718a";
-    sha256 = "sha256-pNu995/w3tbz15QQVdVYBnWnAoZmqWj1DN/5PZZ0iZw=";
+    hash = "sha256-pNu995/w3tbz15QQVdVYBnWnAoZmqWj1DN/5PZZ0iZw=";
   };
 
   postPatch = ''

--- a/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
@@ -23,7 +23,7 @@ buildGoModule rec {
     owner = "gitlab-org";
     repo = "gitlab-runner";
     rev = "v${version}";
-    sha256 = "sha256-mRL62PIAkPK0aLA7uYpGlUvaJfbD354RDOD4P8MLzx8=";
+    hash = "sha256-mRL62PIAkPK0aLA7uYpGlUvaJfbD354RDOD4P8MLzx8=";
   };
 
   patches = [

--- a/pkgs/development/tools/misc/deheader/default.nix
+++ b/pkgs/development/tools/misc/deheader/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     owner = "esr";
     repo = "deheader";
     rev = version;
-    sha256 = "sha256-dYTHvFWlt3aM/fdZFge7GBdd9bfCrEcp7ULJuBl71Xs=";
+    hash = "sha256-dYTHvFWlt3aM/fdZFge7GBdd9bfCrEcp7ULJuBl71Xs=";
   };
 
   buildInputs = [ python3 ];

--- a/pkgs/development/tools/misc/yodl/default.nix
+++ b/pkgs/development/tools/misc/yodl/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ perl ];
 
   src = fetchFromGitLab {
-    sha256 = "sha256-MeD/jjhwoiWTb/G8pHrnEEX22h+entPr9MhJ6WHO3DM=";
+    hash = "sha256-MeD/jjhwoiWTb/G8pHrnEEX22h+entPr9MhJ6WHO3DM=";
     rev = version;
     repo = "yodl";
     owner = "fbb-git";

--- a/pkgs/development/tools/parsing/bisonc++/default.nix
+++ b/pkgs/development/tools/parsing/bisonc++/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "fbb-git";
     repo = "bisoncpp";
     rev = "6.04.00";
-    sha256 = "sha256:0aa9bij4g08ilsk6cgrbgi03vyhqr9fn6j2164sjin93m63212wl";
+    hash = "sha256:0aa9bij4g08ilsk6cgrbgi03vyhqr9fn6j2164sjin93m63212wl";
   };
 
   buildInputs = [ bobcat ];

--- a/pkgs/development/tools/profiling/EZTrace/default.nix
+++ b/pkgs/development/tools/profiling/EZTrace/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     owner = "eztrace";
     repo = "eztrace";
     rev = "eztrace-${version}";
-    sha256 = "sha256-A6HMr4ib5Ka1lTbbTQOdq3kIdCoN/CwAKRdXdv9wpfU=";
+    hash = "sha256-A6HMr4ib5Ka1lTbbTQOdq3kIdCoN/CwAKRdXdv9wpfU=";
   };
 
   nativeBuildInputs = [ gfortran autoreconfHook ];

--- a/pkgs/development/tools/rust/gitlab-clippy/default.nix
+++ b/pkgs/development/tools/rust/gitlab-clippy/default.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
     owner = "dlalic";
     repo = pname;
     rev = version;
-    sha256 = "sha256-d7SmlAWIV4SngJhIvlud90ZUSF55FWIrzFpkfSXIy2Y=";
+    hash = "sha256-d7SmlAWIV4SngJhIvlud90ZUSF55FWIrzFpkfSXIy2Y=";
   };
   cargoSha256 = "sha256-ztPbI+ncMNMKnIxUksxgz8GHQpLZ7SVWdC4QJWh18Wk=";
 

--- a/pkgs/development/tools/rust/ograc/default.nix
+++ b/pkgs/development/tools/rust/ograc/default.nix
@@ -7,7 +7,7 @@ rustPlatform.buildRustPackage {
     owner = "lirnril";
     repo = "ograc";
     rev = "d09b3102ff7a364bf2593589327a16a473bd4f25";
-    sha256 = "sha256-vdHPFY6zZ/OBNlJO3N/6YXcvlddw2wYHgFWI0yfSgVo=";
+    hash = "sha256-vdHPFY6zZ/OBNlJO3N/6YXcvlddw2wYHgFWI0yfSgVo=";
   };
   cargoSha256 = "sha256-HAeEd7HY+hbTUOkIt6aTfvPYLRPtdAcUGvkuBUMjohA=";
 

--- a/pkgs/development/tools/tapview/default.nix
+++ b/pkgs/development/tools/tapview/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     owner = "esr";
     repo = pname;
     rev = version;
-    sha256 = "sha256-inrxICNglZU/tup+YnHaDiVss32K2OXht/7f8lOZI4g=";
+    hash = "sha256-inrxICNglZU/tup+YnHaDiVss32K2OXht/7f8lOZI4g=";
   };
 
   # Remove unnecessary `echo` checks: `/bin/echo` fails, and `echo -n` works as expected.

--- a/pkgs/games/airshipper/default.nix
+++ b/pkgs/games/airshipper/default.nix
@@ -59,7 +59,7 @@ rustPlatform.buildRustPackage {
     owner = "Veloren";
     repo = "airshipper";
     rev = "v${version}";
-    sha256 = "sha256-5zP1Ye1fJNQp8eWKwdxLqBr4qzBfWEEBsJ9s7+8idL4=";
+    hash = "sha256-5zP1Ye1fJNQp8eWKwdxLqBr4qzBfWEEBsJ9s7+8idL4=";
   };
 
   cargoLock = {

--- a/pkgs/games/cbonsai/default.nix
+++ b/pkgs/games/cbonsai/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "jallbrit";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-XFK6DiIb8CzVubTnEMkqRW8xZkX/SWjUsrfS+I7LOs8=";
+    hash = "sha256-XFK6DiIb8CzVubTnEMkqRW8xZkX/SWjUsrfS+I7LOs8=";
   };
 
   nativeBuildInputs = [ pkg-config scdoc ];

--- a/pkgs/games/doom-ports/enyo-launcher/default.nix
+++ b/pkgs/games/doom-ports/enyo-launcher/default.nix
@@ -8,7 +8,7 @@ mkDerivation rec {
     owner = "sdcofer70";
     repo = "enyo-launcher";
     rev = version;
-    sha256 = "sha256-k6Stc1tQOcdS//j+bFUNfnOUlwuhIPKxf9DHU+ng164=";
+    hash = "sha256-k6Stc1tQOcdS//j+bFUNfnOUlwuhIPKxf9DHU+ng164=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/games/infra-arcana/default.nix
+++ b/pkgs/games/infra-arcana/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     owner = "martin-tornqvist";
     repo = "ia";
     rev = "v${version}";
-    sha256 = "sha256-MI+wH0+1f41JYXT2hzDs3RrrR3eTfOzgtCa5T6m8oQc=";
+    hash = "sha256-MI+wH0+1f41JYXT2hzDs3RrrR3eTfOzgtCa5T6m8oQc=";
   };
 
   nativeBuildInputs = [ cmake makeWrapper ];

--- a/pkgs/games/kabeljau/default.nix
+++ b/pkgs/games/kabeljau/default.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation rec {
     owner = "annaaurora";
     repo = "kabeljau";
     rev = "v${version}";
-    sha256 = "sha256-RedVItgfr6vgqXHA3bOiHXDpfGuHI+sX4jCHL9G5jYk=";
+    hash = "sha256-RedVItgfr6vgqXHA3bOiHXDpfGuHI+sX4jCHL9G5jYk=";
   };
 
   # Inkscape is needed in a just recipe where it is used to export the SVG icon to several different sized PNGs.

--- a/pkgs/games/sfrotz/default.nix
+++ b/pkgs/games/sfrotz/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     owner = "DavidGriffith";
     repo = "frotz";
     rev = version;
-    sha256 = "sha256-GvGxojD8d5GVy/d8h3q6K7KJroz2lsKbfE0F0acjBl8=";
+    hash = "sha256-GvGxojD8d5GVy/d8h3q6K7KJroz2lsKbfE0F0acjBl8=";
   };
 
   buildInputs = [

--- a/pkgs/games/toppler/default.nix
+++ b/pkgs/games/toppler/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "roever";
     repo = "toppler";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-ecEaELu52Nmov/BD9VzcUw6wyWeHJcsKQkEzTnaW330=";
+    hash = "sha256-ecEaELu52Nmov/BD9VzcUw6wyWeHJcsKQkEzTnaW330=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/misc/drivers/argononed/default.nix
+++ b/pkgs/misc/drivers/argononed/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "DarkElvenAngel";
     repo = pname;
     rev = "97c4fa07fc2c09ffc3bd86e0f6319d50fa639578";
-    sha256 = "sha256-5/xUYbprRiwD+FN8V2cUpHxnTbBkEsFG2wfsEXrCrgQ=";
+    hash = "sha256-5/xUYbprRiwD+FN8V2cUpHxnTbBkEsFG2wfsEXrCrgQ=";
   };
 
   patches = [ ./fix-hardcoded-reboot-poweroff-paths.patch ];

--- a/pkgs/misc/drivers/utsushi/default.nix
+++ b/pkgs/misc/drivers/utsushi/default.nix
@@ -21,7 +21,7 @@ in stdenv.mkDerivation rec {
     owner = "utsushi";
     repo = pname;
     rev = version;
-    sha256 = "sha256-CrN9F/WJKmlDN7eozEHtKgGUQBWVwTqwjnrfiATk7lI=";
+    hash = "sha256-CrN9F/WJKmlDN7eozEHtKgGUQBWVwTqwjnrfiATk7lI=";
   };
 
   patches = [

--- a/pkgs/os-specific/linux/brillo/default.nix
+++ b/pkgs/os-specific/linux/brillo/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner= "cameronnemo";
     repo= "brillo";
     rev= "v${version}";
-    sha256 = "sha256-dKGNioWGVAFuB4kySO+QGTnstyAD0bt4/6FBVwuRxJo=";
+    hash = "sha256-dKGNioWGVAFuB4kySO+QGTnstyAD0bt4/6FBVwuRxJo=";
   };
 
   patches = [

--- a/pkgs/os-specific/linux/fanctl/default.nix
+++ b/pkgs/os-specific/linux/fanctl/default.nix
@@ -8,7 +8,7 @@ rustPlatform.buildRustPackage rec {
     owner = "mcoffin";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-XmawybmqRJ9Lj6ii8TZBFwqdQZVp0pOLN4xiSLkU/bw=";
+    hash = "sha256-XmawybmqRJ9Lj6ii8TZBFwqdQZVp0pOLN4xiSLkU/bw=";
   };
 
   cargoSha256 = "sha256-tj00DXQEqC/8+3uzTMWcph+1fNTTVZLSJbV/5lLFkFs=";

--- a/pkgs/os-specific/linux/pscircle/default.nix
+++ b/pkgs/os-specific/linux/pscircle/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "mildlyparallel";
     repo = "pscircle";
     rev = "v${version}";
-    sha256 = "sha256-bqbQBNscNfoqXprhoFUnUQO88YQs9xDhD4d3KHamtG0=";
+    hash = "sha256-bqbQBNscNfoqXprhoFUnUQO88YQs9xDhD4d3KHamtG0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/servers/misc/virtiofsd/default.nix
+++ b/pkgs/servers/misc/virtiofsd/default.nix
@@ -8,7 +8,7 @@ rustPlatform.buildRustPackage rec {
     owner = "virtio-fs";
     repo = "virtiofsd";
     rev = "v${version}";
-    sha256 = "sha256-dgGdSnMsz/6dggZXh5crwHEoVVIlcUIHMH5MSOO29TE=";
+    hash = "sha256-dgGdSnMsz/6dggZXh5crwHEoVVIlcUIHMH5MSOO29TE=";
   };
 
   separateDebugInfo = true;

--- a/pkgs/tools/X11/caffeine-ng/default.nix
+++ b/pkgs/tools/X11/caffeine-ng/default.nix
@@ -26,7 +26,7 @@ python3Packages.buildPythonApplication rec {
     owner = "WhyNotHugo";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-uYzLRZ+6ZgIwhSuJWRBpLYHgonX7sFXgUZid0V26V0Q=";
+    hash = "sha256-uYzLRZ+6ZgIwhSuJWRBpLYHgonX7sFXgUZid0V26V0Q=";
   };
 
   nativeBuildInputs = [ gobject-introspection meson ninja pkg-config wrapGAppsHook3 ];

--- a/pkgs/tools/X11/libstrangle/default.nix
+++ b/pkgs/tools/X11/libstrangle/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "torkel104";
     repo = pname;
     rev = "0273e318e3b0cc759155db8729ad74266b74cb9b";
-    sha256 = "sha256-h10QA7m7hIQHq1g/vCYuZsFR2NVbtWBB46V6OWP5wgM=";
+    hash = "sha256-h10QA7m7hIQHq1g/vCYuZsFR2NVbtWBB46V6OWP5wgM=";
   };
 
   makeFlags = [ "prefix=" "DESTDIR=$(out)" ];

--- a/pkgs/tools/audio/mpd-sima/default.nix
+++ b/pkgs/tools/audio/mpd-sima/default.nix
@@ -12,7 +12,7 @@ buildPythonApplication rec {
     owner = "kaliko";
     repo = "sima";
      rev = version;
-    sha256 = "sha256-lMvM1EqS1govhv4B2hJzIg5DFQYgEr4yJJtgOQxnVlY=";
+    hash = "sha256-lMvM1EqS1govhv4B2hJzIg5DFQYgEr4yJJtgOQxnVlY=";
   };
 
   format = "setuptools";

--- a/pkgs/tools/compression/bzip2/1_1.nix
+++ b/pkgs/tools/compression/bzip2/1_1.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "federicomenaquintero";
     repo = "bzip2";
     rev = "15255b553e7c095fb7a26d4dc5819a11352ebba1";
-    sha256 = "sha256-BAyz35D62LWi47B/gNcCSKpdaECHBGSpt21vtnk3fKs=";
+    hash = "sha256-BAyz35D62LWi47B/gNcCSKpdaECHBGSpt21vtnk3fKs=";
   };
 
   postPatch = ''

--- a/pkgs/tools/graphics/vkbasalt-cli/default.nix
+++ b/pkgs/tools/graphics/vkbasalt-cli/default.nix
@@ -12,7 +12,7 @@ python3Packages.buildPythonApplication rec {
     owner = "TheEvilSkeleton";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-4MFqndnvwAsqyer9kMNuCZFP/Xdl7W//AyCe7n83328=";
+    hash = "sha256-4MFqndnvwAsqyer9kMNuCZFP/Xdl7W//AyCe7n83328=";
   };
 
   postPatch = ''

--- a/pkgs/tools/inputmethods/interception-tools/caps2esc.nix
+++ b/pkgs/tools/inputmethods/interception-tools/caps2esc.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     owner = "linux/plugins";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-gPFElAixiDTTwcl2XKM7MbTkpRrg8ToO5K7H8kz3DHk=";
+    hash = "sha256-gPFElAixiDTTwcl2XKM7MbTkpRrg8ToO5K7H8kz3DHk=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/tools/inputmethods/interception-tools/default.nix
+++ b/pkgs/tools/inputmethods/interception-tools/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "interception/linux";
     repo = "tools";
     rev = "v${version}";
-    sha256 = "sha256-jhdgfCWbkF+jD/iXsJ+fYKOtPymxcC46Q4w0aqpvcek=";
+    hash = "sha256-jhdgfCWbkF+jD/iXsJ+fYKOtPymxcC46Q4w0aqpvcek=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];

--- a/pkgs/tools/misc/ffsend/default.nix
+++ b/pkgs/tools/misc/ffsend/default.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     owner = "timvisee";
     repo = "ffsend";
     rev = "v${version}";
-    sha256 = "sha256-L1j1lXPxy9nWMeED9uzQHV5y7XTE6+DB57rDnXa4kMo=";
+    hash = "sha256-L1j1lXPxy9nWMeED9uzQHV5y7XTE6+DB57rDnXa4kMo=";
   };
 
   cargoHash = "sha256-r1yIPV2sW/EpHJpdaJyi6pzE+rtNkBIxSUJF+XA8kbA=";

--- a/pkgs/tools/misc/gwe/default.nix
+++ b/pkgs/tools/misc/gwe/default.nix
@@ -38,7 +38,7 @@ in stdenv.mkDerivation rec {
     owner = "leinardi";
     repo = pname;
     rev = version;
-    sha256 = "sha256-agq967QN1nsAOn+1Ce64+id7UlSS/K3XGsUUihWOztk=";
+    hash = "sha256-agq967QN1nsAOn+1Ce64+id7UlSS/K3XGsUUihWOztk=";
   };
 
   prePatch = ''

--- a/pkgs/tools/misc/kcollectd/default.nix
+++ b/pkgs/tools/misc/kcollectd/default.nix
@@ -23,7 +23,7 @@ mkDerivation rec {
     owner = "aerusso";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-bUVL5eRQ5UkSZo562pnyEcj0fVoSC5WHRq4BfN67jEM=";
+    hash = "sha256-bUVL5eRQ5UkSZo562pnyEcj0fVoSC5WHRq4BfN67jEM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/misc/ristate/default.nix
+++ b/pkgs/tools/misc/ristate/default.nix
@@ -8,7 +8,7 @@ rustPlatform.buildRustPackage rec {
     owner = "snakedye";
     repo = pname;
     rev = "34dfd0a0bab5b36df118d8da3956fd938c625b15";
-    sha256 = "sha256-CH9DZ/7Bhbe6qKg1Nbj1rA9SzIsqVlBJg51XxAh0XnY=";
+    hash = "sha256-CH9DZ/7Bhbe6qKg1Nbj1rA9SzIsqVlBJg51XxAh0XnY=";
   };
 
   cargoSha256 = "sha256-HTfRWvE3m7XZhZDj5bEkrQI3pD6GNiKd2gJtMjRQ8Rw=";

--- a/pkgs/tools/misc/sanctity/default.nix
+++ b/pkgs/tools/misc/sanctity/default.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage rec {
     owner = "annaaurora";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-y6xj4A5SHcW747aFE9TfuurNnuUxjTUeKJmzxeiWqVc=";
+    hash = "sha256-y6xj4A5SHcW747aFE9TfuurNnuUxjTUeKJmzxeiWqVc=";
   };
 
   cargoSha256 = "sha256-co58YBeFjP9DKzxDegQI7txuJ1smqJxdlRLae+Ppwh0=";

--- a/pkgs/tools/misc/timelimit/default.nix
+++ b/pkgs/tools/misc/timelimit/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "timelimit";
     repo = pname;
     rev = "release/${version}";
-    sha256 = "sha256-5IEAF8zCKaCVH6BAxjoa/2rrue9pRGBBkFzN57d+g+g=";
+    hash = "sha256-5IEAF8zCKaCVH6BAxjoa/2rrue9pRGBBkFzN57d+g+g=";
   };
 
   nativeCheckInputs = [ perl ];

--- a/pkgs/tools/misc/usbimager/default.nix
+++ b/pkgs/tools/misc/usbimager/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "bztsrc";
     repo = pname;
     rev = version;
-    sha256 = "sha256-HTFopc2xrhp0XYubQtOwMKWTQ+3JSKAyL4mMyQ82kAs=";
+    hash = "sha256-HTFopc2xrhp0XYubQtOwMKWTQ+3JSKAyL4mMyQ82kAs=";
   };
 
   sourceRoot = "${src.name}/src";

--- a/pkgs/tools/misc/watchlog/default.nix
+++ b/pkgs/tools/misc/watchlog/default.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
     owner = "kevincox";
     repo = "watchlog";
     rev = "v${version}";
-    sha256 = "sha256-8uNBjkxETQXZOfRtxDg+aS8sIbYTD3g9ttBA4m2wavY=";
+    hash = "sha256-8uNBjkxETQXZOfRtxDg+aS8sIbYTD3g9ttBA4m2wavY=";
   };
 
   cargoHash = "sha256-YFQGqkvUgoJJE2B/SQFksWS42YTF/O2tn3CNL54LRUY=";

--- a/pkgs/tools/networking/goimapnotify/default.nix
+++ b/pkgs/tools/networking/goimapnotify/default.nix
@@ -8,7 +8,7 @@ buildGoModule rec {
     owner = "shackra";
     repo = "goimapnotify";
     rev = version;
-    sha256 = "sha256-da2Q+glDVWSf574pks6UzvQyzKAU+81ypy5H968Y7HE=";
+    hash = "sha256-da2Q+glDVWSf574pks6UzvQyzKAU+81ypy5H968Y7HE=";
   };
 
   vendorHash = "sha256-DphGe9jbKo1aIfpF5kRYNSn/uIYHaRMrygda5t46svw=";

--- a/pkgs/tools/networking/mmsd-tng/default.nix
+++ b/pkgs/tools/networking/mmsd-tng/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     owner = "kop316";
     repo = "mmsd";
     rev = version;
-    sha256 = "sha256-fhbiTJWmQwJpuMaVX2qWyWwJ/2Y/Vczo//+0T0b6jhA=";
+    hash = "sha256-fhbiTJWmQwJpuMaVX2qWyWwJ/2Y/Vczo//+0T0b6jhA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/networking/networkd-notify/default.nix
+++ b/pkgs/tools/networking/networkd-notify/default.nix
@@ -17,7 +17,7 @@ buildPythonApplication rec {
     owner = "wavexx";
     repo = pname;
     rev = "c2f3e71076a0f51c097064b1eb2505a361c7cc0e";
-    sha256 = "sha256-fanP1EWERT2Jy4OnMo8OMdR9flginYUgMw+XgmDve3o=";
+    hash = "sha256-fanP1EWERT2Jy4OnMo8OMdR9flginYUgMw+XgmDve3o=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/tools/networking/ocserv/default.nix
+++ b/pkgs/tools/networking/ocserv/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "openconnect";
     repo = "ocserv";
     rev = version;
-    sha256 = "sha256-IYiYC9oAw35YjpptUEnhuZQqoDevku25r7qi6SG8xtk=";
+    hash = "sha256-IYiYC9oAw35YjpptUEnhuZQqoDevku25r7qi6SG8xtk=";
   };
 
   nativeBuildInputs = [ autoreconfHook gperf pkg-config ronn ];

--- a/pkgs/tools/networking/redfang/default.nix
+++ b/pkgs/tools/networking/redfang/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     owner = "packages";
     repo = pname;
     rev = "upstream/${version}";
-    sha256 = "sha256-dF9QmBckyHAZ+JbLr0jTmp0eMu947unJqjrTMsJAfIE=";
+    hash = "sha256-dF9QmBckyHAZ+JbLr0jTmp0eMu947unJqjrTMsJAfIE=";
   };
 
   patches = [

--- a/pkgs/tools/networking/veilid/default.nix
+++ b/pkgs/tools/networking/veilid/default.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage rec {
     owner = "veilid";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-Gm65fvLImbsAU8kMYQv5VFEjkBQnhBFDqwheddRbtU8=";
+    hash = "sha256-Gm65fvLImbsAU8kMYQv5VFEjkBQnhBFDqwheddRbtU8=";
   };
 
   cargoLock = {

--- a/pkgs/tools/networking/wget2/default.nix
+++ b/pkgs/tools/networking/wget2/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     owner = "gnuwget";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-+xw1nQMBs0m9RlunyrAYaSDPnLY1yRX8zt8hKOMXQT8=";
+    hash = "sha256-+xw1nQMBs0m9RlunyrAYaSDPnLY1yRX8zt8hKOMXQT8=";
   };
 
   # wget2_noinstall contains forbidden reference to /build/

--- a/pkgs/tools/system/tree/default.nix
+++ b/pkgs/tools/system/tree/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     owner = "OldManProgrammer";
     repo = "unix-tree";
     rev = version;
-    sha256 = "sha256-1iBGbzNwjUX7kqkk6XzKISO2e6b05MBH08XgIwR+nyI=";
+    hash = "sha256-1iBGbzNwjUX7kqkk6XzKISO2e6b05MBH08XgIwR+nyI=";
   };
 
   preConfigure = ''

--- a/pkgs/tools/text/highlight/default.nix
+++ b/pkgs/tools/text/highlight/default.nix
@@ -9,7 +9,7 @@ let
       owner = "saalen";
       repo = "highlight";
       rev = "v${version}";
-      sha256 = "sha256-TFMU9owxBGrrbatk7Jj9xP8OEJNjXnjbwnW6Xq34awI=";
+      hash = "sha256-TFMU9owxBGrrbatk7Jj9xP8OEJNjXnjbwnW6Xq34awI=";
     };
 
     enableParallelBuilding = true;

--- a/pkgs/tools/text/seehecht/default.nix
+++ b/pkgs/tools/text/seehecht/default.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage rec {
     owner = "annaaurora";
     repo = "seehecht";
     rev = "v${version}";
-    sha256 = "sha256-KIxK0JYfq/1Bn4LOn+LzWPBUvGYMvOEuqS7GMpDRvW0=";
+    hash = "sha256-KIxK0JYfq/1Bn4LOn+LzWPBUvGYMvOEuqS7GMpDRvW0=";
   };
 
   cargoSha256 = "sha256-AeVUVF4SBS9FG0iezLBKUm4Uk1PPRXPTON93evgL9IA=";

--- a/pkgs/tools/text/sgml/linuxdoc-tools/default.nix
+++ b/pkgs/tools/text/sgml/linuxdoc-tools/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "agmartin";
     repo = "linuxdoc-tools";
     rev = version;
-    sha256 = "sha256-1F3MDYJ9UH7ypgTSfYZV59PfLirlTmw6XBMEnz5Jtyk=";
+    hash = "sha256-1F3MDYJ9UH7ypgTSfYZV59PfLirlTmw6XBMEnz5Jtyk=";
   };
 
   outputs = [ "out" "man" "doc" ];

--- a/pkgs/tools/wayland/swaysome/default.nix
+++ b/pkgs/tools/wayland/swaysome/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     owner = "hyask";
     repo = pname;
     rev = version;
-    sha256 = "sha256-HRLMfpnqjDgkOIaH/7DxeYzoZn/0c0KUAmir8XIwesg=";
+    hash = "sha256-HRLMfpnqjDgkOIaH/7DxeYzoZn/0c0KUAmir8XIwesg=";
   };
 
   cargoHash = "sha256-e5B90tIiXxuaRseok69EN4xuoRlCyiTVgEcAqvVg/dM=";


### PR DESCRIPTION
## Description of changes

This is part of https://github.com/NixOS/nixpkgs/issues/325892, but mainly to show off my brand new treewide script

<details>
<summary>the treewide script</summary>

```bash
#!/usr/bin/env bash

EDITED_LOG=./edited-log
PROBLEM_LOG=./problem-log
SEARCH_CACHE=./search-cache

mkfifo nix_repl_in
mkfifo nix_repl_out

trap "rm -f nix_repl_in nix_repl_out" EXIT

# if replacing more files we can remove 2>/dev/null
nix repl < nix_repl_in > nix_repl_out 2>/dev/null &
NIX_REPL_PID=$!

sleep 2

exec 13>nix_repl_in
exec 14< nix_repl_out

extract_output() {
  output=$(echo $1 | ansi2txt)
  if [[ $output == "\"\"" ]]; then
    return 1
  elif [[ $output =~ ^\"([^\"]+)\"$ ]]; then
    echo "${BASH_REMATCH[1]}"
  elif [[ $output == "null" ]]; then
    echo "null"
  else
    return 1
  fi
}

send_repl() {
  local cmd=$1
  echo "$cmd" >&13
  echo "$cmd" > ./repl_in
  while IFS= read -r -d $'\n' line <&14; do
    if [[ -z "$line" ]]; then
      return 1
    else
      echo "$(extract_output $line)"
      echo "$line" > ./repl_out
    fi
  done
}

replace_hash() {
  local attr_name=$1
  
  local hashAlgo=$(send_repl "${attr_name}.src.outputHashAlgo") || return 1
  # Only to limit scope here, can be adjusted
  local hashHomepage=$(send_repl "${attr_name}.src.meta.homepage") || return 1

  if [[ "$hashAlgo" == "sha256" ]] && [[ "$hashHomepage" == "https://gitlab.com/"* ]]; then
    local hash=$(send_repl "${attr_name}.src.outputHash") || return 1
    # echo "$attr_name hash"
    if [[ "$hash" == "sha256"* ]]; then
      local position=$(send_repl "${attr_name}.meta.position") || return 1

      [[ $position == "null" ]] && return 1
      
      local position_file=${position%%:*}

      grep -q "sha256 = \"$hash\"" $position_file
      if [ $? -eq 0 ]; then
        local outPath=$(send_repl "${attr_name}.outPath") || return 1
        echo "editing: ${attr_name}:${position_file}"
        sed -i "s|sha256 = \"$hash\"|hash = \"$hash\"|" $position_file
        echo "${attr_name}:${position_file}:${outPath}" >> $EDITED_LOG
      fi
    fi
  fi
}

verify_hash() {
  local attr_name=$1
  local position_file=$2
  local outPath=$3

  local new_outPath=$(send_repl "${attr_name}.outPath")
  if [ $? -ne 0 ] || [[ "$outPath" != "$new_outPath" ]]; then
    echo "problem: ${attr_name}:${position_file}"
    # echo "'$outPath' != '$new_outPath'"
    echo "${attr_name}:${position_file}:${outPath}" >> $PROBLEM_LOG
  fi
}

[[ -f "$SEARCH_CACHE" ]] || nix search . ^ --json > $SEARCH_CACHE

pkg_list=($(cat $SEARCH_CACHE | jq --raw-output 'keys_unsorted | @sh'))

send_repl ":l ./."

sleep 1

echo "starting to replace"

for pkg_raw in ${pkg_list[@]}; do
  pkg=${pkg_raw#*.*.}
  pkg=${pkg%\'}
  replace_hash $pkg
done

send_repl ":r"

sleep 1

echo "starting to examine"

while IFS= read -r line; do
  IFS=':' read -r -a parts <<< "$line"
  verify_hash ${parts[@]}
done < "$EDITED_LOG"

```

</details>

TLDR: This bash script connects to nix repl through fifo, inputs the list from nix search into repl in turn, and parses various attributes to filter the valid package and get hash. This script has two restrictions set:

1. From `gitlab.com`
2. Is `sha256 = "sha256-..."`

But with slight modifications we can apply it to other situations. After treewide ends, it goes through all packages and lists those where outPath changed or eval failed (there may be potential problems). There are no problems listed in this PR.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
