### PR TITLE
stalwart-mail: Enable tests

### DIFF
--- a/pkgs/by-name/st/stalwart-mail/package.nix
+++ b/pkgs/by-name/st/stalwart-mail/package.nix
@@ -1,18 +1,20 @@
-{ lib
-, rustPlatform
-, fetchFromGitHub
-, fetchpatch
-, pkg-config
-, protobuf
-, bzip2
-, openssl
-, sqlite
-, zstd
-, stdenv
-, darwin
-, nix-update-script
-, nixosTests
-, rocksdb_8_11
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchpatch,
+  pkg-config,
+  protobuf,
+  bzip2,
+  openssl,
+  sqlite,
+  zstd,
+  stdenv,
+  darwin,
+  nix-update-script,
+  nixosTests,
+  rocksdb_8_11,
+  callPackage,
 }:
 
 let
@@ -84,8 +86,43 @@ rustPlatform.buildRustPackage {
       --replace "__PATH__" "$out"
   '';
 
-  # Tests require reading to /etc/resolv.conf
-  doCheck = false;
+  checkFlags = [
+    # Require running mysql, postgresql daemon
+    "--skip=directory::imap::imap_directory"
+    "--skip=directory::internal::internal_directory"
+    "--skip=directory::ldap::ldap_directory"
+    "--skip=directory::sql::sql_directory"
+    "--skip=store::blob::blob_tests"
+    "--skip=store::lookup::lookup_tests"
+    # thread 'directory::smtp::lmtp_directory' panicked at tests/src/store/mod.rs:122:44:
+    # called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
+    "--skip=directory::smtp::lmtp_directory"
+    # thread 'imap::imap_tests' panicked at tests/src/imap/mod.rs:436:14:
+    # Missing store type. Try running `STORE=<store_type> cargo test`: NotPresent
+    "--skip=imap::imap_tests"
+    # thread 'jmap::jmap_tests' panicked at tests/src/jmap/mod.rs:303:14:
+    # Missing store type. Try running `STORE=<store_type> cargo test`: NotPresent
+    "--skip=jmap::jmap_tests"
+    # Failed to read system DNS config: io error: No such file or directory (os error 2)
+    "--skip=smtp::inbound::data::data"
+    # Expected "X-My-Header: true" but got Received: from foobar.net (unknown [10.0.0.123])
+    "--skip=smtp::inbound::scripts::sieve_scripts"
+    # panicked at tests/src/smtp/outbound/smtp.rs:173:5:
+    "--skip=smtp::outbound::smtp::smtp_delivery"
+    # thread 'smtp::queue::retry::queue_retry' panicked at tests/src/smtp/queue/retry.rs:119:5:
+    # assertion `left == right` failed
+    #   left: [1, 2, 2]
+    #  right: [1, 2, 3]
+    "--skip=smtp::queue::retry::queue_retry"
+    # Missing store type. Try running `STORE=<store_type> cargo test`: NotPresent
+    "--skip=store::store_tests"
+    # thread 'config::parser::tests::toml_parse' panicked at crates/utils/src/config/parser.rs:463:58:
+    # called `Result::unwrap()` on an `Err` value: "Expected ['\\n'] but found '!' in value at line 70."
+    "--skip=config::parser::tests::toml_parse"
+    # error[E0432]: unresolved import `r2d2_sqlite`
+    # use of undeclared crate or module `r2d2_sqlite`
+    "--skip=backend::sqlite::pool::SqliteConnectionManager::with_init"
+  ];
 
   passthru = {
     update-script = nix-update-script { };


### PR DESCRIPTION
## Description of changes

Enable 50+ tests and disable the failing ones

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
