### PR TITLE
linuxKernel/rtl8812au: update driver source for kernel 6.7+

### DIFF
--- a/pkgs/os-specific/linux/rtl8812au/default.nix
+++ b/pkgs/os-specific/linux/rtl8812au/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "rtl8812au";
-  version = "${kernel.version}-unstable-2024-03-20";
+  version = "${kernel.version}-unstable-2024-06-13";
 
   src = fetchFromGitHub {
     owner = "morrownr";
-    repo = "8812au-20210629";
-    rev = "8be3a1d7acf60f77c5d9c33b690b8d7301bdf127";
-    hash = "sha256-HchnRezJNzimOB72Sv5BwL4oXuxPxloAHVuaL+warj8=";
+    repo = "8812au-20210820";
+    rev = "c0efee9cd121d9f0c815d9771475f76339a8f7d3";
+    hash = "sha256-ZS0iUb77XnXR5BUMeQ1EDuly7hStRt430ECueFW4v4w=";
   };
 
   nativeBuildInputs = [ bc nukeReferences ] ++ kernel.moduleBuildDependencies;
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Driver for Realtek 802.11ac, rtl8812au, provides the 8812au mod";
-    homepage = "https://github.com/morrownr/8812au-20210629";
+    homepage = "https://github.com/morrownr/8812au-20210820";
     license = licenses.gpl2Only;
     platforms = platforms.linux;
     maintainers = with maintainers; [ moni ];


### PR DESCRIPTION
## Description of changes

Current rlt8812au commit does not compile on kernels 6.7+. Upstream maintainer switched repos and added support for 6.7-6.10 in the new repo. The old repo 8812au-20210629 currently 404s, and I believe used to have a deprecation notice before the repo was removed. [Notes on the main repo were updated to reflect this change](https://github.com/morrownr/8812au/commit/c78f75f76300cf8fa8525ce09e7269c0324276d4). I tested compilation and basic functionality on 6.6, 6.8, and 6.9. 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
