### PR TITLE
python36Packages.memory-tempfile: init at 2.2.3, python311Packages.music-assistant: init at 2.0.7, python3Packages.music-assistant-frontend: init at 2.6.3

### DIFF
--- a/pkgs/development/python-modules/memory-tempfile/default.nix
+++ b/pkgs/development/python-modules/memory-tempfile/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  pythonOlder,
+  # tests
+  pytestCheckHook,
+  pytest-benchmark,
+}:
+
+buildPythonPackage rec {
+  pname = "memory-tempfile";
+  version = "2.2.3";
+  pyproject = true;
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "mbello";
+    repo = "memory-tempfile";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-4fz2CLkZdy2e1GwGw/afG54LkUVJ4cza70jcbX3rVlQ=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+    --replace poetry.masonry.api poetry.core.masonry.api \
+    --replace "poetry>=" "poetry-core>="
+  '';
+
+  # Disable the check phase
+  # Unfortunately - memory temp file wants to run tests - but not all hosts have a tmpfs file system
+  # And the test does not have the fallback feature enabled. Instead, just skip the test.
+  doCheck = false;
+
+  nativeBuildInputs = [ poetry-core ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-benchmark
+  ];
+
+  pythonImportsCheck = [ "memory_tempfile" ];
+
+  meta = with lib; {
+    description = "Helper functions to identify and use paths on the OS (Linux-only for now) where RAM-based tempfiles can be created.";
+    license = licenses.mit;
+    homepage = "https://github.com/mbello/memory-tempfile";
+  };
+}

--- a/pkgs/development/python-modules/music-assistant-frontend/default.nix
+++ b/pkgs/development/python-modules/music-assistant-frontend/default.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pytestCheckHook,
+  pythonOlder,
+}:
+
+buildPythonPackage rec {
+  pname = "music_assistant_frontend";
+  version = "2.6.3";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname version format;
+    dist = "py3";
+    python = "py3";
+    hash = "sha256-A4swDf6ojywTExsGn1V5ra7BK55p439qiKnrDpHOZMI=";
+  };
+
+  pythonImportsCheck = [ "music_assistant_frontend" ];
+
+  meta = with lib; {
+    description = "Frontend module for Music Assistant";
+    homepage = "https://github.com/music-assistant/frontend";
+    changelog = "https://github.com/music-assistant/frontend/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mindstorms6 ];
+  };
+}

--- a/pkgs/development/python-modules/music-assistant/default.nix
+++ b/pkgs/development/python-modules/music-assistant/default.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  aiodns,
+  aiofiles,
+  aiohttp,
+  aioresponses,
+  aiorun,
+  aiosqlite,
+  asyncio-throttle,
+  brotli,
+  buildPythonPackage,
+  certifi,
+  colorlog,
+  cryptography,
+  eyed3,
+  faust-cchardet,
+  fetchFromGitHub,
+  isort,
+  mashumaro,
+  memory-tempfile,
+  music-assistant-frontend,
+  mypy,
+  orjson,
+  pillow,
+  pkgs,
+  poetry-core,
+  pre-commit-hooks,
+  pre-commit,
+  pylint,
+  pytest-aiohttp,
+  pytestCheckHook,
+  pythonOlder,
+  ruff,
+  setuptools,
+  shortuuid,
+  syrupy,
+  tomli,
+  unidecode,
+  zeroconf,
+}:
+
+buildPythonPackage rec {
+  pname = "music_assistant";
+  version = "2.0.7";
+  pyproject = true;
+
+  disabled = pythonOlder "3.11";
+
+  src = fetchFromGitHub {
+    owner = "music-assistant";
+    repo = "server";
+    rev = "refs/tags/${version}";
+    hash = "sha256-JtdlZ3hH4fRU5TjmMUlrdSSCnLrIGCuSwSSrnLgjYEs=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "--cov" ""
+  '';
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    aiodns
+    aiofiles
+    aiohttp
+    aiorun
+    aiosqlite
+    asyncio-throttle
+    brotli
+    certifi
+    colorlog
+    cryptography
+    mashumaro
+    memory-tempfile
+    music-assistant-frontend
+    orjson
+    pillow
+    pkgs.ffmpeg
+    shortuuid
+    unidecode
+    zeroconf
+  ];
+
+  nativeBuildInputs = [ setuptools ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pkgs.codespell
+    pkgs.ffmpeg
+    isort
+    mypy
+    pre-commit-hooks
+    pre-commit
+    pylint
+    pytest-aiohttp
+    syrupy
+    tomli
+    ruff
+  ];
+
+  pythonImportsCheck = [ "music_assistant.server" ];
+
+  meta = with lib; {
+    description = "Module for Music Assistant";
+    homepage = "https://github.com/music-assistant/server";
+    changelog = "https://github.com/music-assistant/server/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mindstorms6 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7498,6 +7498,8 @@ self: super: with self; {
 
   memory-profiler = callPackage ../development/python-modules/memory-profiler { };
 
+  memory-tempfile = callPackage ../development/python-modules/memory-tempfile { };
+
   meraki = callPackage ../development/python-modules/meraki { };
 
   mercadopago = callPackage ../development/python-modules/mercadopago { };
@@ -7962,6 +7964,10 @@ self: super: with self; {
   murmurhash = callPackage ../development/python-modules/murmurhash { };
 
   muscima = callPackage ../development/python-modules/muscima { };
+
+  music-assistant = callPackage ../development/python-modules/music-assistant { };
+
+  music-assistant-frontend = callPackage ../development/python-modules/music-assistant-frontend { };
 
   musicbrainzngs = callPackage ../development/python-modules/musicbrainzngs { };
 


### PR DESCRIPTION
## Description of changes

Add music-assistant, music-assistant-frontend, and memory-tempfile (dependency of music-assistant)

Resolves #310509

Will ultimately be used to get the MusicAssistant plugin in Home Assistant working. 


https://music-assistant.io/
https://github.com/music-assistant/server/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
