### PR TITLE
ios-safari-remote-debug: init at unstable-2024-09-09

### DIFF
--- a/pkgs/by-name/io/ios-safari-remote-debug/add-permissions-to-the-output-directory.patch
+++ b/pkgs/by-name/io/ios-safari-remote-debug/add-permissions-to-the-output-directory.patch
@@ -1,0 +1,25 @@
+From 16ea1a197c4b154fcd481728fbea24a4722ba5d3 Mon Sep 17 00:00:00 2001
+From: Pavel Sobolev <contact@paveloom.dev>
+Date: Sat, 13 Jul 2024 18:44:36 +0300
+Subject: [PATCH] Add permissions to the output directory.
+
+---
+ build/build.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build/build.go b/build/build.go
+index 3ee59ab..97932ed 100644
+--- a/build/build.go
++++ b/build/build.go
+@@ -67,7 +67,7 @@ func Build(cloneDir string, outputDir string) error {
+	log.Debug().TimeDiff("getRelevantFiles", time.Now(), getRelevantFilesTime).Send()
+	bundleTime := time.Now()
+
+-	cp.Copy("views", outputDir)
++	cp.Copy("views", outputDir, cp.Options{PermissionControl: cp.AddPermission(0200)})
+	os.Mkdir(fmt.Sprintf("%s/debug", outputDir), os.ModePerm)
+	os.Mkdir(fmt.Sprintf("%s/debug/Lib", outputDir), os.ModePerm)
+	os.Mkdir(fmt.Sprintf("%s/debug/Protocols", outputDir), os.ModePerm)
+--
+2.45.2
+

--- a/pkgs/by-name/io/ios-safari-remote-debug/package.nix
+++ b/pkgs/by-name/io/ios-safari-remote-debug/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitea,
+}:
+
+buildGoModule rec {
+  pname = "ios-safari-remote-debug";
+  version = "unstable-2024-09-09";
+
+  src = fetchFromGitea {
+    domain = "git.gay";
+    owner = "besties";
+    repo = "ios-safari-remote-debug";
+    rev = "b3c69873997c08fce83c48a5ab42f5a2354efdf2";
+    hash = "sha256-Hh/CeH0ba4uPMlEo+OZ3w36pTpsW6OLtYIE5v6dkUjo=";
+  };
+
+  vendorHash = "sha256-O8Dr4UAISZmCUGao0cBnAx4dUJm6+u4Swiw0H5NVeeA=";
+
+  patches = [ ./add-permissions-to-the-output-directory.patch ];
+
+  postPatch = ''
+    substituteInPlace build/build.go \
+      --replace-fail 'cp.Copy("' 'cp.Copy("${placeholder "out"}/share/${pname}/'
+  '';
+
+  postBuild = ''
+    mkdir -p $out/share/${pname}
+    cp -r injectedCode views $out/share/${pname}
+  '';
+
+  meta = {
+    description = "Remote debugger for iOS Safari";
+    homepage = "https://git.gay/besties/ios-safari-remote-debug";
+    license = lib.licenses.agpl3Plus;
+    mainProgram = "ios-safari-remote-debug";
+    maintainers = with lib.maintainers; [ paveloom ];
+  };
+}


### PR DESCRIPTION
## Description of changes

https://git.gay/besties/ios-safari-remote-debug

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
