### PR TITLE
drumkv1: 0.9.23 -> 1.0.0 (+fix LV2 Qt UI issues)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22207,6 +22207,13 @@
     name = "Rouven Seifert";
     keys = [ { fingerprint = "1169 87A8 DD3F 78FF 8601  BF4D B95E 8FE6 B11C 4D09"; } ];
   };
+  theredstonedev = {
+    email = "theredstonedev@devellight.space";
+    matrix = "@theredstonedev_de:matrix.devellight.space";
+    github = "TheRedstoneDEV-DE";
+    githubId = 75328096;
+    name = "Robert Richter";
+  };
   therishidesai = {
     email = "desai.rishi1@gmail.com";
     github = "therishidesai";

--- a/pkgs/applications/audio/drumkv1/default.nix
+++ b/pkgs/applications/audio/drumkv1/default.nix
@@ -1,17 +1,51 @@
-{ mkDerivation, lib, fetchurl, pkg-config, libjack2, alsa-lib, libsndfile, liblo, lv2, qt5 }:
+{
+  stdenv,
+  lib,
+  pkg-config,
+  fetchurl,
+  cmake,
+  libjack2,
+  alsa-lib,
+  libsndfile,
+  liblo,
+  lv2,
+  qt6,
+  xorg,
+}:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "drumkv1";
-  version = "0.9.23";
+  version = "1.0.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/drumkv1/${pname}-${version}.tar.gz";
-    sha256 = "sha256-gNscsqGpEfU1CNJDlBAzum9M0vzJSm6Wx5b/zhOt+sk=";
+    url = "mirror://sourceforge/drumkv1/drumkv1-${version}.tar.gz";
+    hash = "sha256-vi//84boqaVxC/KCg+HF76vB4Opch02LU4RtbVaxaX4=";
   };
 
-  buildInputs = [ libjack2 alsa-lib libsndfile liblo lv2 qt5.qtbase qt5.qttools ];
+  buildInputs = [
+    libjack2
+    alsa-lib
+    libsndfile
+    liblo
+    lv2
+    xorg.libX11
+    qt6.qtbase
+    qt6.qtwayland
+    qt6.qtsvg
+  ];
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    qt6.wrapQtAppsHook
+  ];
+
+  cmakeFlags = [
+    # disable experimental feature "LV2 port change request"
+    "-DCONFIG_LV2_PORT_CHANGE_REQUEST=false"
+    # override libdir -- temporary until upstream fixes CMakeLists.txt
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+  ];
 
   meta = with lib; {
     description = "Old-school drum-kit sampler synthesizer with stereo fx";
@@ -19,6 +53,6 @@ mkDerivation rec {
     homepage = "http://drumkv1.sourceforge.net/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = [ ];
+    maintainers = [ maintainers.theredstonedev ];
   };
 }


### PR DESCRIPTION
## Description of changes
Updated the drumkv1 drum sampler from version 0.9.23 to 1.0.0 (changelog: https://drumkv1.sourceforge.io/drumkv1-downloads.html, couldn't find any better one) and added xorg.libX11 to the dependencies. 
As this is my first pull-request I hope I didn't do anything completely wrong, met all guidelines and don't cause a huge waste of time.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- changed version to 1.0.0 and added corresponding checksum
- added xorg.libX11to dependencies (it is used to enable LV2 X11 UI support)
- updated nix file in general (was not able to be built before)
- added wrapQtAppsHook
- update to Qt6 dependency
- added a cmake flag to disable the  experimental feature "LV2 port change request"
- added workaround to get it to package correctly
- (Wayland support remains disabled, because it is experimental)
#### After I found out that the original maintainer was gone:
- add myself to maintainer-list.nix
- add myself as maintainer of this package
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
