### PR TITLE
verilator: 5.022 -> 5.026

### DIFF
--- a/pkgs/applications/science/electronics/verilator/default.nix
+++ b/pkgs/applications/science/electronics/verilator/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   perl,
   flex,
   bison,
@@ -17,27 +16,23 @@
   systemc,
   git,
   numactl,
+  coreutils,
 }:
 
 stdenv.mkDerivation rec {
   pname = "verilator";
-  version = "5.022";
+  version = "5.026";
+
+  # Verilator gets the version from this environment variable
+  # if it can't do git describe while building.
+  VERILATOR_SRC_VERSION = "v${version}";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-Ya3lqK8BfvMVLZUrD2Et6OmptteWXp5VmZb2x2G/V/E=";
+    hash = "sha256-Ds6w95tqlKjIFnkq2kKyslprKCwMOtBOoy7LuTon3KM=";
   };
-
-  patches = [
-    (fetchpatch {
-      # Fix try-lock spuriously fail in V3ThreadPool destructor
-      # https://github.com/verilator/verilator/pull/4938
-      url = "https://github.com/verilator/verilator/commit/4b9cce4369c78423779238e585ed693c456d464e.patch";
-      hash = "sha256-sGrk/pxqZqUcmJdzQoPlzXMmYqHCOmd9Y2n6ieVNg1U=";
-    })
-  ];
 
   enableParallelBuilding = true;
   buildInputs = [
@@ -57,6 +52,7 @@ stdenv.mkDerivation rec {
   nativeCheckInputs = [
     which
     numactl
+    coreutils
     # cmake
   ];
 
@@ -69,15 +65,11 @@ stdenv.mkDerivation rec {
     patchShebangs bin/* src/* nodist/* docs/bin/* examples/xml_py/* \
     test_regress/{driver.pl,t/*.{pl,pf}} \
     ci/* ci/docker/run/* ci/docker/run/hooks/* ci/docker/buildenv/build.sh
+    # verilator --gdbbt uses /bin/echo to test if gdb works.
+    sed -i 's|/bin/echo|${coreutils}\/bin\/echo|' bin/verilator
   '';
   # grep '^#!/' -R . | grep -v /nix/store | less
   # (in nix-shell after patchPhase)
-
-  postInstall = lib.optionalString stdenv.isLinux ''
-    for x in $(ls $out/bin/verilator*); do
-      wrapProgram "$x" --set LOCALE_ARCHIVE "${glibcLocales}/lib/locale/locale-archive"
-    done
-  '';
 
   env = {
     SYSTEMC_INCLUDE = "${lib.getDev systemc}/include";

--- a/pkgs/applications/science/electronics/verilator/default.nix
+++ b/pkgs/applications/science/electronics/verilator/default.nix
@@ -1,6 +1,23 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, perl, flex, bison, python3, autoconf,
-  which, cmake, ccache, help2man, makeWrapper, glibcLocales,
-  systemc, git, numactl }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  perl,
+  flex,
+  bison,
+  python3,
+  autoconf,
+  which,
+  cmake,
+  ccache,
+  help2man,
+  makeWrapper,
+  glibcLocales,
+  systemc,
+  git,
+  numactl,
+}:
 
 stdenv.mkDerivation rec {
   pname = "verilator";
@@ -23,9 +40,25 @@ stdenv.mkDerivation rec {
   ];
 
   enableParallelBuilding = true;
-  buildInputs = [ perl python3 systemc ];  # ccache
-  nativeBuildInputs = [ makeWrapper flex bison autoconf help2man git ];
-  nativeCheckInputs = [ which numactl ];  # cmake
+  buildInputs = [
+    perl
+    python3
+    systemc
+    # ccache
+  ];
+  nativeBuildInputs = [
+    makeWrapper
+    flex
+    bison
+    autoconf
+    help2man
+    git
+  ];
+  nativeCheckInputs = [
+    which
+    numactl
+    # cmake
+  ];
 
   doCheck = stdenv.isLinux; # darwin tests are broken for now...
   checkTarget = "test";
@@ -53,9 +86,15 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Fast and robust (System)Verilog simulator/compiler and linter";
-    homepage    = "https://www.veripool.org/verilator";
-    license     = with licenses; [ lgpl3Only artistic2 ];
-    platforms   = platforms.unix;
-    maintainers = with maintainers; [ thoughtpolice amiloradovsky ];
+    homepage = "https://www.veripool.org/verilator";
+    license = with licenses; [
+      lgpl3Only
+      artistic2
+    ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [
+      thoughtpolice
+      amiloradovsky
+    ];
   };
 }


### PR DESCRIPTION
## Description of changes
 
Two commits
  * Run `nixfmt` on *.nix file (separate commit)
  * Update verilator 5.022 -> 5.026
  * Improve output of `verilator --version` (it can't do `git describe` during build)
  * Remove wrapping that actually made the binaries fail to work (so does not seem to be needed anymore)
  * Fix `verilator --gdbbt` : that uses a `/bin/echo` exec to test for gdb capabililty. Replace that with actual path.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
