### PR TITLE
quodlibet: clean up, alternative fix for Python 3.12

### DIFF
--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch,
   tag ? "",
 
   # build time
@@ -61,6 +62,21 @@ python3.pkgs.buildPythonApplication rec {
     rev = "refs/tags/release-${version}";
     hash = "sha256-dkO/CFN7Dk72xhtmcSDcwUciOPMeEjQS2mch+jSfiII=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "python-3.12-startup.patch";
+      url = "https://patch-diff.githubusercontent.com/raw/quodlibet/quodlibet/pull/4358.patch";
+      hash = "sha256-3IjtAX2mKO/Xi/iTwT5WBD5CMTRYFED7XMm/cx+29Zc=";
+    })
+    (fetchpatch {
+      name = "more-python-3.12-fixes.patch";
+      url = "https://patch-diff.githubusercontent.com/raw/quodlibet/quodlibet/pull/4364.patch";
+      hash = "sha256-VRIQ+4e+X0kjZYuxV2wEjrFr+x5biwBtIR50K6hSfCY=";
+      excludes = [ "poetry.lock" ];
+    })
+    ./fix-gdist-python-3.12.patch
+  ];
 
   build-system = [ python3.pkgs.setuptools ];
 

--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -1,47 +1,48 @@
-{ lib
-, fetchFromGitHub
-, tag ? ""
+{
+  lib,
+  fetchFromGitHub,
+  tag ? "",
 
   # build time
-, gettext
-, gobject-introspection
-, wrapGAppsHook3
+  gettext,
+  gobject-introspection,
+  wrapGAppsHook3,
 
   # runtime
-, adwaita-icon-theme
-, gdk-pixbuf
-, glib
-, glib-networking
-, gtk3
-, gtksourceview
-, kakasi
-, keybinder3
-, libappindicator-gtk3
-, libmodplug
-, librsvg
-, libsoup
-, webkitgtk
+  adwaita-icon-theme,
+  gdk-pixbuf,
+  glib,
+  glib-networking,
+  gtk3,
+  gtksourceview,
+  kakasi,
+  keybinder3,
+  libappindicator-gtk3,
+  libmodplug,
+  librsvg,
+  libsoup,
+  webkitgtk,
 
   # optional features
-, withDbusPython ? false
-, withMusicBrainzNgs ? false
-, withPahoMqtt ? false
-, withPypresence ? false
-, withSoco ? false
+  withDbusPython ? false,
+  withMusicBrainzNgs ? false,
+  withPahoMqtt ? false,
+  withPypresence ? false,
+  withSoco ? false,
 
   # backends
-, withGstPlugins ? withGstreamerBackend
-, withGstreamerBackend ? true
-, gst_all_1
-, withXineBackend ? true
-, xine-lib
+  withGstPlugins ? withGstreamerBackend,
+  withGstreamerBackend ? true,
+  gst_all_1,
+  withXineBackend ? true,
+  xine-lib,
 
   # tests
-, dbus
-, glibcLocales
-, hicolor-icon-theme
-, python3
-, xvfb-run
+  dbus,
+  glibcLocales,
+  hicolor-icon-theme,
+  python3,
+  xvfb-run,
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -49,7 +50,10 @@ python3.pkgs.buildPythonApplication rec {
   version = "4.6.0";
   pyproject = true;
 
-  outputs = [ "out" "doc" ];
+  outputs = [
+    "out"
+    "doc"
+  ];
 
   src = fetchFromGitHub {
     owner = "quodlibet";
@@ -60,76 +64,89 @@ python3.pkgs.buildPythonApplication rec {
 
   build-system = [ python3.pkgs.setuptools ];
 
-  nativeBuildInputs = [
-    gettext
-    gobject-introspection
-    wrapGAppsHook3
-  ] ++ (with python3.pkgs; [
-    sphinx-rtd-theme
-    sphinxHook
-  ]);
+  nativeBuildInputs =
+    [
+      gettext
+      gobject-introspection
+      wrapGAppsHook3
+    ]
+    ++ (with python3.pkgs; [
+      sphinx-rtd-theme
+      sphinxHook
+    ]);
 
-  buildInputs = [
-    adwaita-icon-theme
-    gdk-pixbuf
-    glib
-    glib-networking
-    gtk3
-    gtksourceview
-    kakasi
-    keybinder3
-    libappindicator-gtk3
-    libmodplug
-    libsoup
-    webkitgtk
-  ] ++ lib.optionals (withXineBackend) [
-    xine-lib
-  ] ++ lib.optionals (withGstreamerBackend) (with gst_all_1; [
-    gst-plugins-base
-    gstreamer
-  ] ++ lib.optionals (withGstPlugins) [
-    gst-libav
-    gst-plugins-bad
-    gst-plugins-good
-    gst-plugins-ugly
-  ]);
+  buildInputs =
+    [
+      adwaita-icon-theme
+      gdk-pixbuf
+      glib
+      glib-networking
+      gtk3
+      gtksourceview
+      kakasi
+      keybinder3
+      libappindicator-gtk3
+      libmodplug
+      libsoup
+      webkitgtk
+    ]
+    ++ lib.optionals (withXineBackend) [ xine-lib ]
+    ++ lib.optionals (withGstreamerBackend) (
+      with gst_all_1;
+      [
+        gst-plugins-base
+        gstreamer
+      ]
+      ++ lib.optionals (withGstPlugins) [
+        gst-libav
+        gst-plugins-bad
+        gst-plugins-good
+        gst-plugins-ugly
+      ]
+    );
 
-  dependencies = with python3.pkgs; [
-    feedparser
-    gst-python
-    mutagen
-    pycairo
-    pygobject3
-  ]
-  ++ lib.optionals withDbusPython [ dbus-python ]
-  ++ lib.optionals withMusicBrainzNgs [ musicbrainzngs ]
-  ++ lib.optionals withPahoMqtt [ paho-mqtt ]
-  ++ lib.optionals withPypresence [ pypresence ]
-  ++ lib.optionals withSoco [ soco ];
+  dependencies =
+    with python3.pkgs;
+    [
+      feedparser
+      gst-python
+      mutagen
+      pycairo
+      pygobject3
+    ]
+    ++ lib.optionals withDbusPython [ dbus-python ]
+    ++ lib.optionals withMusicBrainzNgs [ musicbrainzngs ]
+    ++ lib.optionals withPahoMqtt [ paho-mqtt ]
+    ++ lib.optionals withPypresence [ pypresence ]
+    ++ lib.optionals withSoco [ soco ];
 
-  nativeCheckInputs = [
-    dbus
-    gdk-pixbuf
-    glibcLocales
-    hicolor-icon-theme
-    xvfb-run
-  ] ++ (with python3.pkgs; [
-    polib
-    pytest
-    pytest-xdist
-  ]);
+  nativeCheckInputs =
+    [
+      dbus
+      gdk-pixbuf
+      glibcLocales
+      hicolor-icon-theme
+      xvfb-run
+    ]
+    ++ (with python3.pkgs; [
+      polib
+      pytest
+      pytest-xdist
+    ]);
 
-  pytestFlags = [
-    # missing translation strings in potfiles
-    "--deselect=tests/test_po.py::TPOTFILESIN::test_missing"
-    # require networking
-    "--deselect=tests/plugin/test_covers.py::test_live_cover_download"
-    "--deselect=tests/test_browsers_iradio.py::TInternetRadio::test_click_add_station"
-    # upstream does actually not enforce source code linting
-    "--ignore=tests/quality"
-  ] ++ lib.optionals (withXineBackend || !withGstPlugins) [
-    "--ignore=tests/plugin/test_replaygain.py"
-  ];
+  pytestFlags =
+    [
+      # missing translation strings in potfiles
+      "--deselect=tests/test_po.py::TPOTFILESIN::test_missing"
+      # require networking
+      "--deselect=tests/plugin/test_covers.py::test_live_cover_download"
+      "--deselect=tests/test_browsers_iradio.py::TInternetRadio::test_click_add_station"
+      # upstream does actually not enforce source code linting
+      "--ignore=tests/quality"
+    ]
+    ++ lib.optionals (withXineBackend || !withGstPlugins) [
+      "--ignore=tests/plugin/test_replaygain.py"
+    ];
 
   env.LC_ALL = "en_US.UTF-8";
 
@@ -170,6 +187,9 @@ python3.pkgs.buildPythonApplication rec {
     '';
     homepage = "https://quodlibet.readthedocs.io/en/latest";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ coroa pbogdan ];
+    maintainers = with maintainers; [
+      coroa
+      pbogdan
+    ];
   };
 }

--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -26,7 +26,6 @@
 , withDbusPython ? false
 , withMusicBrainzNgs ? false
 , withPahoMqtt ? false
-, withPyInotify ? false
 , withPypresence ? false
 , withSoco ? false
 
@@ -104,7 +103,6 @@ python3.pkgs.buildPythonApplication rec {
   ++ lib.optionals withDbusPython [ dbus-python ]
   ++ lib.optionals withMusicBrainzNgs [ musicbrainzngs ]
   ++ lib.optionals withPahoMqtt [ paho-mqtt ]
-  ++ lib.optionals withPyInotify [ pyinotify ]
   ++ lib.optionals withPypresence [ pypresence ]
   ++ lib.optionals withSoco [ soco ];
 

--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -47,7 +47,7 @@
 python3.pkgs.buildPythonApplication rec {
   pname = "quodlibet${tag}";
   version = "4.6.0";
-  format = "pyproject";
+  pyproject = true;
 
   outputs = [ "out" "doc" ];
 
@@ -58,6 +58,8 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-dkO/CFN7Dk72xhtmcSDcwUciOPMeEjQS2mch+jSfiII=";
   };
 
+  build-system = [ python3.pkgs.setuptools ];
+
   nativeBuildInputs = [
     gettext
     gobject-introspection
@@ -65,7 +67,6 @@ python3.pkgs.buildPythonApplication rec {
   ] ++ (with python3.pkgs; [
     sphinx-rtd-theme
     sphinxHook
-    setuptools
   ]);
 
   buildInputs = [
@@ -93,7 +94,7 @@ python3.pkgs.buildPythonApplication rec {
     gst-plugins-ugly
   ]);
 
-  propagatedBuildInputs = with python3.pkgs; [
+  dependencies = with python3.pkgs; [
     feedparser
     gst-python
     mutagen

--- a/pkgs/applications/audio/quodlibet/fix-gdist-python-3.12.patch
+++ b/pkgs/applications/audio/quodlibet/fix-gdist-python-3.12.patch
@@ -1,0 +1,23 @@
+From b3980cf4c8766815e4c13ee1695cebfbf473a2e6 Mon Sep 17 00:00:00 2001
+From: Pavel Sobolev <contact@paveloom.dev>
+Date: Sun, 14 Jul 2024 11:30:11 +0300
+Subject: [PATCH] Import `setuptools` before importing `distutils`.
+
+---
+ gdist/__init__.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/gdist/__init__.py b/gdist/__init__.py
+index 71814af49..a54aac653 100644
+--- a/gdist/__init__.py
++++ b/gdist/__init__.py
+@@ -31,6 +31,7 @@ Also supports setuptools but needs to be imported after setuptools
+ (which does some monkey patching)
+ """
+
++import setuptools
+ import sys
+
+ from distutils.core import setup
+--
+2.45.2

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33617,7 +33617,6 @@ with pkgs;
     withDbusPython = true;
     withMusicBrainzNgs = true;
     withPahoMqtt = true;
-    withPyInotify = true;
     withPypresence = true;
     withSoco = true;
   };


### PR DESCRIPTION
## Description of changes

The first three commits are a cleanup/update of the derivation.
The fourth commit is a possible alternative to https://github.com/NixOS/nixpkgs/pull/326051 as a fix for https://github.com/NixOS/nixpkgs/issues/325537, but I'm not sure why I have to disable the `test_cover_path_lastfm` test.

I'm not a power user, but I can run the program and play mp3s again.

Maybe @pbogdan @paveloom have more insight?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
