### PR TITLE
nixos/nix-ld: Support 32-bit portability

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -125,7 +125,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [nifi](https://nifi.apache.org), an easy to use, powerful, and reliable system to process and distribute data. Available as [services.nifi](#opt-services.nifi.enable).
 
-- [nix-ld](https://github.com/Mic92/nix-ld), Run unpatched dynamic binaries on NixOS. Available as [programs.nix-ld](#opt-programs.nix-ld.enable).
+- [nix-ld](https://github.com/Mic92/nix-ld), Run unpatched dynamic binaries on NixOS. Available as [programs.nix-ld](#opt-programs.nix-ld.systems).
 
 - [NNCP](http://www.nncpgo.org), NNCP (Node to Node copy) utilities and configuration, Available as [programs.nncp](#opt-programs.nncp.enable).
 

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -304,6 +304,8 @@
 
 - `programs.less.lessopen` is now null by default. To restore the previous behaviour, set it to `''|${lib.getExe' pkgs.lesspipe "lesspipe.sh"} %s''`.
 
+- `programs.nix-ld` is now `programs.nix-ld.${system}`, to allow 32-bit nix-ld, or `binfmt` nix-ld.
+
 - `hardware.pulseaudio` has been renamed to `services.pulseaudio`.  The deprecated option names will continue to work, but causes a warning.
 
 - `services.nextcloud` now uses systemd's credential mechanism to read in secret files. The `nextcloud-occ` wrapper script implements this using `systemd-run`, as such it now also requires root privileges or `$CREDENTIALS_DIRECTORY` set where running it as user `nextcloud` was enough previously.

--- a/nixos/modules/programs/nix-ld.nix
+++ b/nixos/modules/programs/nix-ld.nix
@@ -5,62 +5,148 @@
   ...
 }:
 let
-  cfg = config.programs.nix-ld;
+  inherit (lib)
+    literalExpression
+    mergeAttrsList
+    mkEnableOption
+    mkOption
+    mkPackageOption
+    mkAliasOptionModule
+    types
+    ;
 
-  nix-ld-libraries = pkgs.buildEnv {
-    name = "ld-library-path";
-    pathsToLink = [ "/lib" ];
-    paths = map lib.getLib cfg.libraries;
-    # TODO make glibc here configurable?
-    postBuild = ''
-      ln -s ${pkgs.stdenv.cc.bintools.dynamicLinker} $out/share/nix-ld/lib/ld.so
-    '';
-    extraPrefix = "/share/nix-ld";
-    ignoreCollisions = true;
-  };
+  cfg = config.programs.nix-ld.systems;
+
+  share-path = system: "share/nix-ld-${system}";
+
+  nix-ld-libraries =
+    system: cfg:
+    cfg.pkgs.buildEnv {
+      name = "ld-library-path";
+      pathsToLink = [ "/lib" ];
+      paths = map lib.getLib cfg.libraries;
+      # TODO make glibc here configurable?
+      postBuild = ''
+        ln -s ${cfg.pkgs.stdenv.cc.bintools.dynamicLinker} $out/${share-path system}/lib/ld.so
+      '';
+      extraPrefix = "/${share-path system}";
+      ignoreCollisions = true;
+    };
 in
 {
   meta.maintainers = [ lib.maintainers.mic92 ];
-  options.programs.nix-ld = {
-    enable = lib.mkEnableOption ''nix-ld, Documentation: <https://github.com/nix-community/nix-ld>'';
-    package = lib.mkPackageOption pkgs "nix-ld" { };
-    libraries = lib.mkOption {
-      type = lib.types.listOf lib.types.package;
-      description = "Libraries that automatically become available to all programs. The default set includes common libraries.";
-      default = [ ];
-      defaultText = lib.literalExpression "baseLibraries derived from systemd and nix dependencies.";
-    };
-  };
 
-  config = lib.mkIf config.programs.nix-ld.enable {
-    environment.ldso = "${cfg.package}/libexec/nix-ld";
-
-    environment.systemPackages = [ nix-ld-libraries ];
-
-    environment.pathsToLink = [ "/share/nix-ld" ];
-
-    environment.sessionVariables = {
-      NIX_LD = "/run/current-system/sw/share/nix-ld/lib/ld.so";
-      NIX_LD_LIBRARY_PATH = "/run/current-system/sw/share/nix-ld/lib";
-    };
-
-    # We currently take all libraries from systemd and nix as the default.
-    # Is there a better list?
-    programs.nix-ld.libraries = with pkgs; [
-      zlib
-      zstd
-      stdenv.cc.cc
-      curl
-      openssl
-      attr
-      libssh
-      bzip2
-      libxml2
-      acl
-      libsodium
-      util-linux
-      xz
-      systemd
+  imports =
+    let
+      # For generating the documentation, we don't have access to the system,
+      # and it also reads better
+      system = pkgs.system or ''''${pkgs.system}'';
+    in
+    [
+      (mkAliasOptionModule
+        [ "programs" "nix-ld" "enable" ]
+        [ "programs" "nix-ld" "systems" system "enable" ]
+      )
+      (mkAliasOptionModule
+        [ "programs" "nix-ld" "package" ]
+        [ "programs" "nix-ld" "systems" system "package" ]
+      )
+      (mkAliasOptionModule
+        [ "programs" "nix-ld" "libraries" ]
+        [ "programs" "nix-ld" "systems" system "libraries" ]
+      )
     ];
+
+  options.programs.nix-ld.systems = mkOption {
+    default = { };
+    description = ''
+      Configure nix-ld for the given system. Documentation: <https://github.com/nix-community/nix-ld>
+    '';
+    type = types.attrsOf (
+      types.submodule (
+        { config, ... }:
+        {
+          options = {
+            # Since the submodule is by default `{}`, we can default `enable`
+            # to true
+            enable = mkEnableOption "nix-ld for the given system" // {
+              default = true;
+              example = false;
+            };
+            package = mkPackageOption config.pkgs "nix-ld" { };
+
+            pkgs = mkOption {
+              type = types.pkgs;
+              default = pkgs;
+              defaultText = "pkgs";
+              description = "Package set to use";
+            };
+
+            ldso = mkOption {
+              type = types.str;
+              description = ''
+                Which runtime loader to override, either `ldso` or `ldso32`, see
+                `environment.ldso` and `environment.ldso32`.
+              '';
+              default = "ldso";
+            };
+
+            libraries = mkOption {
+              type = types.listOf types.package;
+              description = ''
+                Libraries that automatically become available to all programs. The
+                default set includes common libraries.
+              '';
+              defaultText = literalExpression "baseLibraries derived from systemd and nix dependencies.";
+              # We currently take all libraries from systemd and nix as the default.
+              # Is there a better list?
+              default = [
+                config.pkgs.zlib
+                config.pkgs.zstd
+                config.pkgs.stdenv.cc.cc
+                config.pkgs.curl
+                config.pkgs.openssl
+                config.pkgs.attr
+                config.pkgs.libssh
+                config.pkgs.bzip2
+                config.pkgs.libxml2
+                config.pkgs.acl
+                config.pkgs.libsodium
+                config.pkgs.util-linux
+                config.pkgs.xz
+                config.pkgs.systemd
+              ];
+            };
+          };
+        }
+      )
+    );
   };
+
+  config =
+    let
+      systems = builtins.attrNames cfg;
+      forSystem = f: map (system: f system cfg.${system}) systems;
+      attrsForSystem = f: mergeAttrsList (forSystem f);
+    in
+    {
+      environment =
+        {
+          systemPackages = forSystem nix-ld-libraries;
+          pathsToLink = forSystem (system: cfg: "/${share-path system}");
+          variables = attrsForSystem (
+            system: cfg: {
+              "NIX_LD_${builtins.replaceStrings [ "-" ] [ "_" ] system}" =
+                "/run/current-system/sw/${share-path system}/lib/ld.so";
+              "NIX_LD_LIBRARY_PATH_${builtins.replaceStrings [ "-" ] [ "_" ] system}" =
+                "/run/current-system/sw/${share-path system}/lib";
+            }
+          );
+        }
+        // attrsForSystem (
+          system: cfg: {
+            ${cfg.ldso} = "${cfg.package}/libexec/nix-ld";
+          }
+        );
+    };
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -913,6 +913,7 @@ in
   nitter = handleTest ./nitter.nix { };
   nix-config = handleTest ./nix-config.nix { };
   nix-ld = runTest ./nix-ld.nix;
+  nix-ld-32bit = runTest ./nix-ld-32bit.nix;
   nix-misc = handleTest ./nix/misc.nix { };
   nix-upgrade = handleTest ./nix/upgrade.nix { inherit (pkgs) nixVersions; };
   nix-required-mounts = runTest ./nix-required-mounts;

--- a/nixos/tests/nix-ld-32bit.nix
+++ b/nixos/tests/nix-ld-32bit.nix
@@ -1,0 +1,30 @@
+{ ... }:
+{
+  name = "nix-ld-32bit";
+
+  nodes.machine = {
+    imports = [
+      (
+        { config, pkgs, ... }:
+        let
+          system = "i686-linux";
+          inherit (config.programs.nix-ld.systems.${system}) package;
+        in
+        {
+          programs.nix-ld.systems.i686-linux.ldso = "ldso32";
+          programs.nix-ld.systems.i686-linux.pkgs = pkgs.pkgsi686Linux;
+          environment.systemPackages = [
+            (pkgs.runCommand "patched-hello" { } ''
+              install -D -m755 ${pkgs.pkgsi686Linux.hello}/bin/hello $out/bin/hello
+              patchelf $out/bin/hello --set-interpreter $(cat ${package}/nix-support/ldpath)
+            '')
+          ];
+        }
+      )
+    ];
+  };
+  testScript = ''
+    start_all()
+    machine.succeed("hello")
+  '';
+}

--- a/pkgs/by-name/ni/nix-ld/package.nix
+++ b/pkgs/by-name/ni/nix-ld/package.nix
@@ -43,7 +43,7 @@ rustPlatform.buildRustPackage rec {
     EOF
   '';
 
-  passthru.tests = nixosTests.nix-ld;
+  passthru.tests = { inherit (nixosTests) nix-ld nix-ld-32bit; };
 
   meta = {
     description = "Run unpatched dynamic binaries on NixOS";


### PR DESCRIPTION
This now supports arbitrary `nix-ld`

Notes for reviewers:
- I could not find a natural way to select the 32-bit equivalent of a 64-bit system, so no `support32Bit` currently.
- Defaults for `libraries` do now get selected from the corresponding `pkgs`
  - This has one remaining design point, see also https://discourse.nixos.org/t/nix-ld-32bit-merging-defaults-to-generated-attrsets/63433

Cross-referencing
- https://github.com/Mic92/nix-ld/issues/28
- https://github.com/nix-community/nix-ld-rs/issues/67

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
