### PR TITLE
dxvk_2: 2.3.1 -> 2.4

### DIFF
--- a/pkgs/by-name/dx/dxvk/package.nix
+++ b/pkgs/by-name/dx/dxvk/package.nix
@@ -70,7 +70,9 @@ stdenvNoCC.mkDerivation (
       done
     '';
 
-    passthru = { inherit dxvk32 dxvk64; };
+    passthru = {
+      inherit dxvk32 dxvk64;
+    };
 
     __structuredAttrs = true;
 

--- a/pkgs/by-name/dx/dxvk/setup_dxvk.sh
+++ b/pkgs/by-name/dx/dxvk/setup_dxvk.sh
@@ -12,6 +12,7 @@ set -eu -o pipefail
 ## Defaults
 
 declare -A dlls=(
+    [d3d8]="dxvk/d3d8.dll"
     [d3d9]="dxvk/d3d9.dll"
     [d3d10]="dxvk/d3d10.dll dxvk/d3d10_1.dll dxvk/d3d10core.dll"
     [d3d11]="dxvk/d3d11.dll"
@@ -22,7 +23,7 @@ declare -A obsolete_dlls=(
     [mcfgthreads]="mcfgthreads/mcfgthread-12.dll"
 )
 
-declare -A targets=([d3d9]=1 [d3d11]=1 [dxgi]=1)
+declare -A targets=([d3d8]=1 [d3d9]=1 [d3d11]=1 [dxgi]=1)
 
 
 # Option variables

--- a/pkgs/by-name/dx/dxvk_2/package.nix
+++ b/pkgs/by-name/dx/dxvk_2/package.nix
@@ -6,38 +6,62 @@
   glslang,
   meson,
   ninja,
+  pkg-config,
   windows,
   spirv-headers,
   vulkan-headers,
   SDL2,
   glfw,
   gitUpdater,
-  sdl2Support ? true,
-  glfwSupport ? false,
+  sdl2Support ? (!stdenv.hostPlatform.isWindows),
+  glfwSupport ? (!stdenv.hostPlatform.isWindows),
 }:
 
-# SDL2 and GLFW support are mutually exclusive.
-assert !sdl2Support || !glfwSupport;
+assert stdenv.hostPlatform.isWindows -> !glfwSupport && !sdl2Support;
 
 let
-  isWindows = stdenv.hostPlatform.uname.system == "Windows";
+  inherit (stdenv) hostPlatform;
+
+  libPrefix = lib.optionalString (!hostPlatform.isWindows) "lib";
+  soVersion =
+    version:
+    if hostPlatform.isDarwin then
+      ".${version}${hostPlatform.extensions.sharedLibrary}"
+    else if hostPlatform.isWindows then
+      hostPlatform.extensions.sharedLibrary
+    else
+      "${hostPlatform.extensions.sharedLibrary}.${version}";
+
+  libglfw = "${libPrefix}glfw${soVersion "3"}";
+  libSDL2 = "${libPrefix}SDL2${lib.optionalString (!hostPlatform.isWindows) "-2.0"}${soVersion "0"}";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "dxvk";
-  version = "2.3.1";
+  version = "2.4";
 
   src = fetchFromGitHub {
     owner = "doitsujin";
     repo = "dxvk";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-lUzD1NHFLO4UqOg/BUr7PnYMJCMr1KBh3VNx8etbt8c=";
+    hash = "sha256-4U0Z1oR0BKIHZ6YNT/+8sFe2I/ZKmPecInMXUho4MHg=";
     fetchSubmodules = true; # Needed for the DirectX headers and libdisplay-info
   };
 
-  postPatch = ''
-    substituteInPlace "subprojects/libdisplay-info/tool/gen-search-table.py" \
-      --replace "/usr/bin/env python3" "${lib.getBin pkgsBuildHost.python3}/bin/python3"
-  '';
+  postPatch =
+    ''
+      substituteInPlace meson.build \
+        --replace-fail "dependency('glfw'" "dependency('glfw3'"
+      substituteInPlace subprojects/libdisplay-info/tool/gen-search-table.py \
+        --replace-fail "/usr/bin/env python3" "${lib.getBin pkgsBuildHost.python3}/bin/python3"
+    ''
+    + lib.optionalString glfwSupport ''
+      substituteInPlace src/wsi/glfw/wsi_platform_glfw.cpp \
+        --replace-fail '${libglfw}' '${lib.getLib glfw}/lib/${libglfw}'
+    ''
+    + lib.optionalString sdl2Support ''
+      substituteInPlace src/wsi/sdl2/wsi_platform_sdl2.cpp \
+        --replace-fail '${libSDL2}' '${lib.getLib SDL2}/lib/${libSDL2}'
+    '';
 
   strictDeps = true;
 
@@ -45,15 +69,16 @@ stdenv.mkDerivation (finalAttrs: {
     glslang
     meson
     ninja
-  ];
+  ] ++ lib.optionals (glfwSupport || sdl2Support) [ pkg-config ];
+
   buildInputs =
     [
       spirv-headers
       vulkan-headers
     ]
-    ++ lib.optionals (!isWindows && sdl2Support) [ SDL2 ]
-    ++ lib.optionals (!isWindows && glfwSupport) [ glfw ]
-    ++ lib.optionals isWindows [ windows.pthreads ];
+    ++ lib.optionals sdl2Support [ SDL2 ]
+    ++ lib.optionals glfwSupport [ glfw ]
+    ++ lib.optionals hostPlatform.isWindows [ windows.pthreads ];
 
   # Build with the Vulkan SDK in nixpkgs.
   preConfigure = ''
@@ -63,8 +88,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   mesonBuildType = "release";
 
-  mesonFlags = lib.optionals glfwSupport [ "-Ddxvk_native_wsi=glfw" ];
-
   doCheck = true;
 
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
@@ -72,11 +95,12 @@ stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
 
   meta = {
-    description = "Vulkan-based translation layer for Direct3D 9/10/11";
+    description = "Vulkan-based translation layer for Direct3D 8/9/10/11";
     homepage = "https://github.com/doitsujin/dxvk";
     changelog = "https://github.com/doitsujin/dxvk/releases";
     maintainers = [ lib.maintainers.reckenrode ];
     license = lib.licenses.zlib;
-    platforms = lib.platforms.windows ++ lib.platforms.linux;
+    badPlatforms = lib.platforms.darwin;
+    platforms = lib.platforms.windows ++ lib.platforms.unix;
   };
 })


### PR DESCRIPTION
## Description of changes

https://github.com/doitsujin/dxvk/releases/tag/v2.4

Closes #326896

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
