### PR TITLE
home-assistant-custom-components.samsungtv-smart: init at 0.13.5

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -42,6 +42,8 @@
 
   prometheus_sensor = callPackage ./prometheus_sensor {};
 
+  samsungtv-smart = callPackage ./samsungtv-smart {};
+
   sensi = callPackage ./sensi {};
 
   smartir = callPackage ./smartir {};

--- a/pkgs/servers/home-assistant/custom-components/samsungtv-smart/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/samsungtv-smart/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildHomeAssistantComponent,
+  aiofiles,
+  casttube,
+  websocket-client,
+  wakeonlan,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "ollo69";
+  domain = "samsungtv_smart";
+  version = "0.13.5";
+
+  src = fetchFromGitHub {
+    owner = "ollo69";
+    repo = "ha-samsungtv-smart";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-12wx8HaTEFQZOnxfcuAKFOXPdDpfAl608N1E6gmWqBI=";
+  };
+
+  dependencies = [
+    aiofiles
+    casttube
+    websocket-client
+    wakeonlan
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/ollo69/ha-samsungtv-smart/releases/tag/v${version}";
+    description = "Home Assistant Samsung TV Integration ";
+    homepage = "https://github.com/ollo69/ha-samsungtv-smart";
+    maintainers = with maintainers; [ mindstorms6 ];
+    license = licenses.asl20;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds custom component for samsungtv-smart - an alternative to the built in Samsung TV integration.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
