### PR TITLE
find-my-device-server: init at 0.5.0-unstable-2024-07-17

### DIFF
--- a/pkgs/by-name/fi/find-my-device-server/package.nix
+++ b/pkgs/by-name/fi/find-my-device-server/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitLab,
+  objectbox-c,
+  nix-update-script,
+  buildNpmPackage,
+}:
+let
+  pname = "find-my-device-server";
+  version = "0.5.0-unstable-2024-07-17";
+
+  src = fetchFromGitLab {
+    owner = "Nulide";
+    repo = "FindMyDeviceServer";
+    rev = "688c5fa945510681a470c8a30e8729e267ec8f3e";
+    hash = "sha256-k3qoRxDLGrdoLwAeVCXaghJoPHQoPASp5sB6lycKE3I=";
+  };
+
+  frontend = buildNpmPackage {
+    inherit version;
+    pname = "${pname}-webapp";
+    src = "${src}/web";
+
+    npmDepsHash = "sha256-0YUd2SEd4X9tyqI5qtt6FlBlLPUKjehNNM2dTL8ctTQ=";
+
+    buildPhase = ''
+      runHook preBuild
+
+      npm install
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -r * -t $out
+
+      runHook postInstall
+    '';
+
+  };
+in
+
+buildGoModule {
+  inherit pname version src;
+
+  vendorHash = "sha256-GRgj4ulY+fYzz2Ymk1jbMlV6M0U/OsKWT5Ci6rWnVLA=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  buildInputs = [ objectbox-c ];
+
+  postInstall = ''
+    mv $out/bin/{cmd,fmdserver}
+
+    mkdir -p $out/share/find-my-device-server/
+    cp -r ${frontend}/* -t $out/share/find-my-device-server/
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "Server to communicate with the FindMyDevice app and save the latest (encrypted) location";
+    homepage = "https://gitlab.com/Nulide/FindMyDeviceServer";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ eclairevoyant ];
+    mainProgram = "fmd";
+  };
+}

--- a/pkgs/by-name/ob/objectbox-c/package.nix
+++ b/pkgs/by-name/ob/objectbox-c/package.nix
@@ -1,0 +1,60 @@
+{
+  autoPatchelfHook,
+  lib,
+  fetchzip,
+  stdenv,
+}:
+
+let
+  releases = {
+    x86_64-linux = {
+      suffix = "linux-x64.tar.gz";
+      hash = "sha256-ggsMj5Epx2i9yGCLm9dbdV7EC49Trd0dO11goE+vwqA=";
+    };
+    aarch64-linux = {
+      suffix = "linux-aarch64.tar.gz";
+      hash = "sha256-FqTcDzKs9SAn4rHq8YpjDLjvwlxcZzC6RYYoBQlkg+s=";
+    };
+  };
+  release =
+    releases.${stdenv.hostPlatform.system}
+      or (throw "objectbox-c is not supported for ${stdenv.hostPlatform.system}");
+in
+stdenv.mkDerivation rec {
+  pname = "objectbox-c";
+  version = "4.0.1";
+
+  src = fetchzip {
+    url = "https://github.com/objectbox/objectbox-c/releases/download/v${version}/objectbox-${release.suffix}";
+    inherit (release) hash;
+    stripRoot = false;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [ stdenv.cc.cc.lib ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    cp -r * $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "C and C++ database for objects and structs";
+    homepage = "https://github.com/objectbox/objectbox-c";
+    changelog = "https://github.com/objectbox/objectbox-c/blob/${version}/CHANGELOG.md";
+    # lib is closed-source, and its usage is mediated by asl20
+    # https://github.com/objectbox/objectbox-c/issues/6
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ eclairevoyant ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = builtins.attrNames releases;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds [FindMyDeviceServer](https://gitlab.com/Nulide/FindMyDeviceServer), a server to communicate with the [FindMyDevice](https://gitlab.com/Nulide/findmydevice/-/wikis/home) app and save the latest (encrypted) location.

Fixes #326773

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
