### PR TITLE
lz4json: init at 2-unstable-2019-12-29

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -603,6 +603,11 @@
     githubId = 10677343;
     name = "Eugene";
   };
+  afermg = {
+    github = "afermg";
+    githubId = 14353896;
+    name = "Alan Munoz";
+  };
   afh = {
     email = "surryhill+nix@gmail.com";
     github = "afh";

--- a/pkgs/by-name/lz/lz4json/package.nix
+++ b/pkgs/by-name/lz/lz4json/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  lz4,
+  pkg-config,
+}:
+
+stdenv.mkDerivation {
+
+  pname = "lz4json";
+  version = "2-unstable-2019-12-29";
+  src = fetchFromGitHub {
+    owner = "andikleen";
+    repo = "lz4json";
+    rev = "c44c51005c505de2636cc1e59cde764490de7632";
+    sha256 = "sha256-rLjJ7qy7Tx0htW1VxrfCCqVbC6jNCr9H2vdDAfosxCA=";
+  };
+
+  buildInputs = [
+    lz4
+    pkg-config
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -D lz4jsoncat $out/bin/lz4jsoncat
+  '';
+
+  meta = {
+    description = "LZ4 JSON compressor for Mozilla proprietary format";
+    homepage = "https://github.com/andikleen/lz4json";
+    license = lib.licenses.unfree;
+    maintainers = [ lib.maintainers.afermg ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Added lz4json, a package useful to convert automatically-backed up mlz4json files from Firefox, such as bookmarks.

## Things done
I created a minimal derivation. 

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - [X] or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--