### PR TITLE
llvmPackages_13.compiler-rt-libc: fix python3 setuptools dependency

### DIFF
--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -149,7 +149,13 @@ stdenv.mkDerivation ({
       --replace "#include <assert.h>" ""
     substituteInPlace lib/builtins/cpu_model${lib.optionalString (lib.versionAtLeast version "18") "/x86"}.c \
       --replace "#include <assert.h>" ""
-  ''));
+  '')) + lib.optionalString (lib.versionAtLeast release_version "13" && lib.versionOlder release_version "14") ''
+    # https://github.com/llvm/llvm-project/blob/llvmorg-14.0.6/libcxx/utils/merge_archives.py
+    # Seems to only be used in v13 though it's present in v12 and v14, and dropped in v15.
+    substituteInPlace ../libcxx/utils/merge_archives.py \
+      --replace-fail "import distutils.spawn" "from shutil import which as find_executable" \
+      --replace-fail "distutils.spawn." ""
+  '';
 
   # Hack around weird upsream RPATH bug
   postInstall = lib.optionalString (stdenv.hostPlatform.isDarwin) ''


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixing LLVM 13 breakage due to setuptools removal in https://github.com/NixOS/nixpkgs/pull/320924.

Partially resolves https://github.com/NixOS/nixpkgs/issues/326927

Build of `llvmPackages_13.compiler-rt-libc` fails at the tail end with:

```
Traceback (most recent call last):
  File "/build/source/libcxx/utils/merge_archives.py", line 12, in <module>
    import distutils.spawn
ModuleNotFoundError: No module named 'distutils'
make[5]: *** [cxx/src/CMakeFiles/cxx_static.dir/build.make:739: /build/source/compiler-rt/build/lib/fuzzer/libcxx_fuzzer_x86_64/lib/libc++.a] Error 1
make[5]: *** Deleting file '/build/source/compiler-rt/build/lib/fuzzer/libcxx_fuzzer_x86_64/lib/libc++.a'
make[4]: *** [CMakeFiles/Makefile2:444: cxx/src/CMakeFiles/cxx_static.dir/all] Error 2
make[3]: *** [Makefile:136: all] Error 2
make[2]: *** [lib/fuzzer/CMakeFiles/libcxx_fuzzer_x86_64-build.dir/build.make:73: lib/fuzzer/libcxx_fuzzer_x86_64-stamps/libcxx_fuzzer_x86_64-build] Error 2
make[1]: *** [CMakeFiles/Makefile2:8967: lib/fuzzer/CMakeFiles/libcxx_fuzzer_x86_64-build.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 96%] Built target RTAsan_dynamic.x86_64
[ 96%] Built target RTAsan.x86_64
make: *** [Makefile:136: all] Error 2
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
