### PR TITLE
z3: 4.8.17 -> 4.13.4; z3_4_12: 4.12.5 -> 4.12.6

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -928,6 +928,8 @@
 
 - `buildNimSbom` was added as an alternative to `buildNimPackage`. `buildNimSbom` uses [SBOMs](https://cyclonedx.org/) to generate packages whereas `buildNimPackage` uses a custom JSON lockfile format.
 
+- The default version of `z3` has been updated from 4.8 to 4.13. There are still a few packages that need specific 4.8 versions; those will continue to be maintained.
+
 ## Detailed Migration Information {#sec-release-24.11-migration}
 
 ### `sound` options removal {#sec-release-24.11-migration-sound}

--- a/pkgs/applications/science/logic/z3/4-8-5-typos.diff
+++ b/pkgs/applications/science/logic/z3/4-8-5-typos.diff
@@ -1,0 +1,26 @@
+diff --git a/src/util/lp/lp_core_solver_base.h b/src/util/lp/lp_core_solver_base.h
+index 4c17df2..4c3c311 100644
+--- a/src/util/lp/lp_core_solver_base.h
++++ b/src/util/lp/lp_core_solver_base.h
+@@ -600,8 +600,6 @@ public:
+            out << " \n";
+     }
+ 
+-    bool column_is_free(unsigned j) const { return this->m_column_type[j] == free; }
+-
+     bool column_has_upper_bound(unsigned j) const {
+         switch(m_column_types[j]) {
+         case column_type::free_column:
+diff --git a/src/util/lp/static_matrix_def.h b/src/util/lp/static_matrix_def.h
+index 7949573..2f1cb42 100644
+--- a/src/util/lp/static_matrix_def.h
++++ b/src/util/lp/static_matrix_def.h
+@@ -86,7 +86,7 @@ static_matrix<T, X>::static_matrix(static_matrix const &A, unsigned * /* basis *
+     init_row_columns(m, m);
+     while (m--) {
+         for (auto & col : A.m_columns[m]){
+-            set(col.var(), m, A.get_value_of_column_cell(col));
++            set(col.var(), m, A.get_column_cell(col));
+         }
+     }
+ }

--- a/pkgs/applications/science/logic/z3/default.nix
+++ b/pkgs/applications/science/logic/z3/default.nix
@@ -95,8 +95,8 @@ let common = { version, sha256, patches ? [ ], tag ? "z3" }:
 in
 {
   z3_4_12 = common {
-    version = "4.12.5";
-    sha256 = "sha256-Qj9w5s02OSMQ2qA7HG7xNqQGaUacA1d4zbOHynq5k+A=";
+    version = "4.12.6";
+    sha256 = "sha256-X4wfPWVSswENV0zXJp/5u9SQwGJWocLKJ/CNv57Bt+E=";
   };
   z3_4_11 = common {
     version = "4.11.2";

--- a/pkgs/applications/science/logic/z3/default.nix
+++ b/pkgs/applications/science/logic/z3/default.nix
@@ -89,7 +89,7 @@ let common = { version, sha256, patches ? [ ], tag ? "z3" }:
       changelog = "https://github.com/Z3Prover/z3/releases/tag/z3-${version}";
       license = licenses.mit;
       platforms = platforms.unix;
-      maintainers = with maintainers; [ thoughtpolice ttuegel ];
+      maintainers = with maintainers; [ thoughtpolice ttuegel numinit ];
     };
   };
 in

--- a/pkgs/applications/science/logic/z3/default.nix
+++ b/pkgs/applications/science/logic/z3/default.nix
@@ -41,6 +41,13 @@ let common = { version, sha256, patches ? [ ], tag ? "z3" }:
     postPatch = lib.optionalString ocamlBindings ''
       export OCAMLFIND_DESTDIR=$ocaml/lib/ocaml/${ocaml.version}/site-lib
       mkdir -p $OCAMLFIND_DESTDIR/stublibs
+    '' + lib.optionalString ((lib.versionAtLeast python.version "3.12") && (lib.versionOlder version "4.8.14")) ''
+      # See https://github.com/Z3Prover/z3/pull/5729. This is a specialization of this patch for 4.8.5.
+      for file in scripts/mk_util.py src/api/python/CMakeLists.txt; do
+        substituteInPlace "$file" \
+          --replace-fail "distutils.sysconfig.get_python_lib()" "sysconfig.get_path('purelib')" \
+          --replace-fail "distutils.sysconfig" "sysconfig"
+      done
     '';
 
     configurePhase = lib.concatStringsSep " "

--- a/pkgs/applications/science/logic/z3/default.nix
+++ b/pkgs/applications/science/logic/z3/default.nix
@@ -16,7 +16,7 @@
 assert javaBindings -> jdk != null;
 assert ocamlBindings -> ocaml != null && findlib != null && zarith != null;
 
-let common = { version, sha256, patches ? [ ], tag ? "z3" }:
+let common = { version, sha256, patches ? [ ], tag ? "z3", doCheck ? true }:
   stdenv.mkDerivation rec {
     pname = "z3";
     inherit version sha256 patches;
@@ -58,9 +58,9 @@ let common = { version, sha256, patches ? [ ], tag ? "z3" }:
           ++ lib.optional pythonBindings "--python --pypkgdir=$out/${python.sitePackages}"
       ) + "\n" + "cd build";
 
-    doCheck = true;
+    inherit doCheck;
     checkPhase = ''
-      make test
+      make -j $NIX_BUILD_CORES test
       ./test-z3 -a
     '';
 
@@ -94,6 +94,10 @@ let common = { version, sha256, patches ? [ ], tag ? "z3" }:
   };
 in
 {
+  z3_4_13 = common {
+    version = "4.13.4";
+    sha256 = "sha256-8hWXCr6IuNVKkOegEmWooo5jkdmln9nU7wI8T882BSE=";
+  };
   z3_4_12 = common {
     version = "4.12.6";
     sha256 = "sha256-X4wfPWVSswENV0zXJp/5u9SQwGJWocLKJ/CNv57Bt+E=";

--- a/pkgs/applications/science/logic/z3/default.nix
+++ b/pkgs/applications/science/logic/z3/default.nix
@@ -101,6 +101,11 @@ let
           moveToOutput "lib/libz3java.${stdenv.hostPlatform.extensions.sharedLibrary}" "$java"
         '';
 
+      doInstallCheck = true;
+      installCheckPhase = ''
+        $out/bin/z3 -version 2>&1 | grep -F "Z3 version $version"
+      '';
+
       outputs =
         [
           "out"

--- a/pkgs/applications/science/logic/z3/lower-bound-typo.diff
+++ b/pkgs/applications/science/logic/z3/lower-bound-typo.diff
@@ -1,0 +1,13 @@
+diff --git a/src/@dir@/lp/column_info.h b/src/@dir@/lp/column_info.h
+index 1dc0c60..9cbeea6 100644
+--- a/src/@dir@/lp/column_info.h
++++ b/src/@dir@/lp/column_info.h
+@@ -47,7 +47,7 @@ public:
+             m_lower_bound_is_strict == c.m_lower_bound_is_strict &&
+             m_upper_bound_is_set == c.m_upper_bound_is_set&&
+             m_upper_bound_is_strict == c.m_upper_bound_is_strict&&
+-            (!m_lower_bound_is_set || m_lower_bound == c.m_low_bound) &&
++            (!m_lower_bound_is_set || m_lower_bound == c.m_lower_bound) &&
+             (!m_upper_bound_is_set || m_upper_bound == c.m_upper_bound) &&
+             m_cost == c.m_cost &&
+             m_is_fixed == c.m_is_fixed &&

--- a/pkgs/applications/science/logic/z3/tail-matrix.diff
+++ b/pkgs/applications/science/logic/z3/tail-matrix.diff
@@ -1,0 +1,12 @@
+diff --git a/src/@dir@/lp/tail_matrix.h b/src/@dir@/lp/tail_matrix.h
+index 2047e8c..c84340e 100644
+--- a/src/@dir@/lp/tail_matrix.h
++++ b/src/@dir@/lp/tail_matrix.h
+@@ -43,7 +43,6 @@ public:
+         const tail_matrix & m_A;
+         unsigned m_row;
+         ref_row(const tail_matrix& m, unsigned row): m_A(m), m_row(row) {}
+-        T operator[](unsigned j) const { return m_A.get_elem(m_row, j);}
+     };
+     ref_row operator[](unsigned i) const { return ref_row(*this, i);}
+ };

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1196,6 +1196,21 @@ self: super: {
     '';
   }) super.cryptol;
 
+  # Z3 removed aliases for boolean types in 4.12
+  inherit (
+    let
+      fixZ3 = appendConfigureFlags [
+        "--hsc2hs-option=-DZ3_Bool=bool"
+        "--hsc2hs-option=-DZ3_TRUE=true"
+        "--hsc2hs-option=-DZ3_FALSE=false"
+      ];
+    in
+    {
+      z3 = fixZ3 super.z3;
+      hz3 = fixZ3 super.hz3;
+    }
+  ) z3 hz3;
+
   # Tests try to invoke external process and process == 1.4
   grakn = dontCheck (doJailbreak super.grakn);
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17303,12 +17303,12 @@ with pkgs;
   };
 
   inherit (callPackages ../applications/science/logic/z3 { python = python3; })
+    z3_4_13
     z3_4_12
     z3_4_11
-    z3_4_8;
-  inherit (callPackages ../applications/science/logic/z3 { python = python311; })
+    z3_4_8
     z3_4_8_5;
-  z3 = z3_4_8;
+  z3 = z3_4_13;
   z3-tptp = callPackage ../applications/science/logic/z3/tptp.nix { };
 
   tlaplus = callPackage ../applications/science/logic/tlaplus {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- nixpkgs z3 default is now 4.13 instead of 4.8.
- Fixing breakage due to setuptools removal in #320924 for z3 4.8
- Adding more z3 versions and updating existing ones
- Making the checkPhase go faster

Resolves #326120.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
