### PR TITLE
eliot{,-tree}: make usable with Python 3.12

### DIFF
--- a/pkgs/development/python-modules/eliot/default.nix
+++ b/pkgs/development/python-modules/eliot/default.nix
@@ -1,45 +1,62 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   pythonOlder,
-  aiocontextvars,
-  boltons,
-  hypothesis,
-  pyrsistent,
-  pytestCheckHook,
+  pythonAtLeast,
+
   setuptools,
-  six,
-  testtools,
+
+  boltons,
+  orjson,
+  pyrsistent,
   zope-interface,
+
+  daemontools,
+  dask,
+  distributed,
+  hypothesis,
+  pandas,
+  pytestCheckHook,
+  testtools,
+  twisted,
 }:
 
 buildPythonPackage rec {
   pname = "eliot";
-  version = "1.14.0";
-  format = "setuptools";
+  version = "1.15.0";
+  pyproject = true;
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.8" || pythonAtLeast "3.13";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-wvCZo+jV7PwidFdm58xmSkjbZLa4nZht/ycEkdhoMUk=";
+  src = fetchFromGitHub {
+    owner = "itamarst";
+    repo = "eliot";
+    rev = "refs/tags/${version}";
+    hash = "sha256-Ur7q7PZ5HH4ttD3b0HyBTe1B7eQ2nEWcTBR/Hjeg9yw=";
   };
 
-  propagatedBuildInputs = [
-    aiocontextvars
+  build-system = [ setuptools ];
+
+  dependencies = [
     boltons
+    orjson
     pyrsistent
-    setuptools
-    six
     zope-interface
   ];
 
   nativeCheckInputs = [
+    dask
+    distributed
     hypothesis
+    pandas
     pytestCheckHook
     testtools
-  ];
+    twisted
+  ] ++ lib.optionals stdenv.isLinux [ daemontools ];
+
+  __darwinAllowLocalNetworking = true;
 
   pythonImportsCheck = [ "eliot" ];
 
@@ -48,17 +65,12 @@ buildPythonPackage rec {
     export PATH=$out/bin:$PATH
   '';
 
-  disabledTests = [
-    "test_parse_stream"
-    # AttributeError: module 'inspect' has no attribute 'getargspec'
-    "test_default"
-  ];
-
-  meta = with lib; {
+  meta = {
     homepage = "https://eliot.readthedocs.io";
     description = "Logging library that tells you why it happened";
+    changelog = "https://github.com/itamarst/eliot/blob/${version}/docs/source/news.rst";
     mainProgram = "eliot-prettyprint";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ dpausp ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ dpausp ];
   };
 }

--- a/pkgs/development/tools/eliot-tree/default.nix
+++ b/pkgs/development/tools/eliot-tree/default.nix
@@ -1,39 +1,54 @@
-{ lib, python3Packages, fetchPypi }:
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+}:
 
 python3Packages.buildPythonApplication rec {
   pname = "eliot-tree";
   version = "21.0.0";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-hTl+r+QJPPQ7ss73lty3Wm7DLy2SKGmmgIuJx38ilO8=";
   };
 
-  nativeCheckInputs = with python3Packages; [
-    testtools
-    pytest
-   ];
+  # Patch Python 3.12 incompatibilities in versioneer.py.
+  postPatch = ''
+    substituteInPlace versioneer.py \
+      --replace-fail SafeConfigParser ConfigParser \
+      --replace-fail readfp read_file
+  '';
 
-  propagatedBuildInputs = with python3Packages; [
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
     colored
     eliot
     iso8601
     jmespath
-    setuptools
     toolz
   ];
 
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    testtools
+  ];
+
   # Tests run eliot-tree in out/bin.
-  checkPhase = ''
+  preCheck = ''
     export PATH=$out/bin:$PATH
-    pytest
   '';
 
-  meta = with lib; {
+  pythonImportsCheck = [ "eliottree" ];
+
+  meta = {
     homepage = "https://github.com/jonathanj/eliottree";
+    changelog = "https://github.com/jonathanj/eliottree/blob/${version}/NEWS.rst";
     description = "Render Eliot logs as an ASCII tree";
     mainProgram = "eliot-tree";
-    license = licenses.mit;
-    maintainers = [ maintainers.dpausp ];
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.dpausp ];
   };
 }


### PR DESCRIPTION
## Description of changes

eliot: update to 1.15.0
eliot-tree: apply patch for compatibility with Python 3.12

build failure of taheo-lafs is adressed in #327066

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>4 packages failed to build:</summary>
  <ul>
    <li>tahoe-lafs</li>
    <li>tahoe-lafs.dist</li>
    <li>tahoe-lafs.doc</li>
    <li>tahoe-lafs.info</li>
  </ul>
</details>
<details>
  <summary>6 packages built:</summary>
  <ul>
    <li>eliot-tree</li>
    <li>eliot-tree.dist</li>
    <li>python311Packages.eliot</li>
    <li>python311Packages.eliot.dist</li>
    <li>python312Packages.eliot</li>
    <li>python312Packages.eliot.dist</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc