### PR TITLE
electron: 29.4.2 -> 29.4.4, 30.1.1 -> 30.2.0

### DIFF
--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -45,13 +45,13 @@
     },
     "30": {
         "hashes": {
-            "aarch64-darwin": "7497d7926a094d6e1bf34f70ef206c4f2d9df072b1f9fa8cd431f6ea4fab680c",
-            "aarch64-linux": "bdb3485cd87861bb1d99f6b417f979ac899974a4322191a648efc311af9f8c5c",
-            "armv7l-linux": "3941ab1f23576d8f55fdf525e40387f97c2c9809173a8a933402b62ec95a592f",
-            "headers": "1jz8grs7sjncg68s34hf7rhd830414avxs1xg5lng5n7wmwfiw8i",
-            "x86_64-darwin": "bdadef26dac934416b17fa2af6bcd55424eb8b1ceb5f6fae068dbd5fd8b0d357",
-            "x86_64-linux": "4d00e8cd5f37962dc8fbefe2941d89dcb1c180f1568bb32122c7eb40d21f39c4"
+            "aarch64-darwin": "4f435480c1316035bfc114dfd75c2da70eeadec3fabe8c9b3e0d8b320bc60e07",
+            "aarch64-linux": "d347b5f1ed111e54eb25919ddf45cb656d6c4180725c48354d21b47a5f7631c4",
+            "armv7l-linux": "36fdf7c3e57cb9bc0d1ff886913a39724cea2aaa2b75524e31daa09a66e8f767",
+            "headers": "1y8nyib0a9k5q01smy55ddkj9sl01rj625afx32h5pf815r5asmf",
+            "x86_64-darwin": "09d0d625d1f87e200e65c0ad5a4bdd74e7e66c4a198a074d3df272cd0abac277",
+            "x86_64-linux": "af23e79a2ec173d4f94d78e3fcad38fc40de9c4301dd3e7e314cb4e0b51a9aa3"
         },
-        "version": "30.1.1"
+        "version": "30.2.0"
     }
 }

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -34,14 +34,14 @@
     },
     "29": {
         "hashes": {
-            "aarch64-darwin": "e9934a8eaecaab05dcc572b47576cdba78491c144c19348c9c9e9524c8c5917b",
-            "aarch64-linux": "a5c2bc148d3f6c3ee2bd15289243a1b75093afde3753d0aa1125d2cb621f5b59",
-            "armv7l-linux": "a75e2487ea1a1b292fbc160618167c204f161c602780f2b997b75d6ef5bbe539",
-            "headers": "0z4n8c95z48n54d1fph2p2i6cb43gk202zg09vmv168ajpspi2rr",
-            "x86_64-darwin": "b875c884efe86eb2e1922781f55193d82520e923510f19af87a58dfe07d21562",
-            "x86_64-linux": "eb07a8137fde970450242c51e0c2f8ef6556f377a21c357584aa2632ee9e1d3f"
+            "aarch64-darwin": "07cb1c196db721f2094930e672cede0e55cbb2249d61bf856d98972e4dfb396b",
+            "aarch64-linux": "2d48177564b32b7a747798b4a10e8d8b65bc66d607be17910016d9edd40050cc",
+            "armv7l-linux": "d99590901a11e665c5d40cc2b7f11b151d4be47210ee7eea7ff732f807e63058",
+            "headers": "194vq6lcppf76ly7cz4b1299h8wfw6xvwfgfndqsqm1sg6g1hrmg",
+            "x86_64-darwin": "6ba1127154c444c1dee32872efb6f183659634a1ccae627fb0142f744938b3aa",
+            "x86_64-linux": "85ab5686909f131061d4a20f14f5bc2e95abe2aa51babcf90a2d54b60fe759d4"
         },
-        "version": "29.4.2"
+        "version": "29.4.4"
     },
     "30": {
         "hashes": {

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -47,10 +47,10 @@
             },
             "src/electron": {
                 "fetcher": "fetchFromGitHub",
-                "hash": "sha256-hyk8RsG2hIsAZRiJuYRF6HC+K7TyA76qiYsc2sH0Apw=",
+                "hash": "sha256-nWCGQvQEXcImYaTWv+C3WjseqeSYtPvIRX6maD+BoGk=",
                 "owner": "electron",
                 "repo": "electron",
-                "rev": "v29.4.2"
+                "rev": "v29.4.4"
             },
             "src/media/cdm/api": {
                 "fetcher": "fetchFromGitiles",
@@ -899,10 +899,10 @@
                 "url": "https://chromium.googlesource.com/v8/v8.git"
             }
         },
-        "electron_yarn_hash": "0f868gk3d2cablpczav8a4vhk4nfirph45yzjz18mgzgday7w8hf",
+        "electron_yarn_hash": "0w41mjfnrhmkf2qy4lk5zwhc7afkaiqypxs4379s4ay1r6zpvf6q",
         "modules": "121",
         "node": "20.9.0",
-        "version": "29.4.2"
+        "version": "29.4.4"
     },
     "30": {
         "chrome": "124.0.6367.243",

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -952,10 +952,10 @@
             },
             "src/electron": {
                 "fetcher": "fetchFromGitHub",
-                "hash": "sha256-VWc9I5wpQYv13I1xgLQVqDg6IfXMinrzJmkMaIsEY90=",
+                "hash": "sha256-6afs+tP0cGpqW8l2R0Zev/QwHCzOfMYfmJp2/Ad9w0w=",
                 "owner": "electron",
                 "repo": "electron",
-                "rev": "v30.1.1"
+                "rev": "v30.2.0"
             },
             "src/media/cdm/api": {
                 "fetcher": "fetchFromGitiles",
@@ -1181,10 +1181,10 @@
             },
             "src/third_party/electron_node": {
                 "fetcher": "fetchFromGitHub",
-                "hash": "sha256-15RUrS+zjp0nOveBnZB3bvEv36noZr2ergtNL7ky8iQ=",
+                "hash": "sha256-48NsBhaiCwnsXEQah/rWPvAmz1LIJUsUKMTkjMQCW0Q=",
                 "owner": "nodejs",
                 "repo": "node",
-                "rev": "v20.14.0"
+                "rev": "v20.15.0"
             },
             "src/third_party/emoji-segmenter/src": {
                 "fetcher": "fetchFromGitiles",
@@ -1816,9 +1816,9 @@
                 "url": "https://chromium.googlesource.com/v8/v8.git"
             }
         },
-        "electron_yarn_hash": "0w41mjfnrhmkf2qy4lk5zwhc7afkaiqypxs4379s4ay1r6zpvf6q",
+        "electron_yarn_hash": "0vq12z09hcm6xdrd34b01vx1c47r4zdaqrkw9db6r612xrp2xi0c",
         "modules": "123",
-        "node": "20.14.0",
-        "version": "30.1.1"
+        "node": "20.15.0",
+        "version": "30.2.0"
     }
 }


### PR DESCRIPTION
## Description of changes
### Electron 29
- Changelog: https://github.com/electron/electron/releases/tag/v29.4.4
- Diff: https://github.com/electron/electron/compare/refs/tags/v29.4.2...v29.4.4
- Fixes CVE-2024-6290
- Fixes CVE-2024-6291
- Fixes CVE-2024-6292
- Fixes CVE-2024-6293

### Electron 30
- Changelog: https://github.com/electron/electron/releases/tag/v30.2.0
- Diff: https://github.com/electron/electron/compare/refs/tags/v30.1.1...v30.2.0
- Fixes CVE-2024-5493
- Fixes CVE-2024-5831
- Fixes CVE-2024-5832
- Fixes CVE-2024-6100
- Fixes CVE-2024-6101
- Fixes CVE-2024-6103
- Fixes CVE-2024-6290
- Fixes CVE-2024-6291
- Fixes CVE-2024-6292
- Fixes CVE-2024-6293
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
