### PR TITLE
python3Packages.jupysql: 0.10.11 -> 0.10.12

### DIFF
--- a/pkgs/development/python-modules/jupysql-plugin/default.nix
+++ b/pkgs/development/python-modules/jupysql-plugin/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "jupysql-plugin";
-  version = "0.4.4";
+  version = "0.4.5";
 
   pyproject = true;
   disabled = pythonOlder "3.6";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "jupysql_plugin";
     inherit version;
-    hash = "sha256-kuaKknbc00nLGwCUsULgUFT52yoptUH2mnUyGYbYYKk=";
+    hash = "sha256-cIXheImO4BL00zn101ZDIzKl2qkIDsTNswZOCs54lNY=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/jupysql/default.nix
+++ b/pkgs/development/python-modules/jupysql/default.nix
@@ -31,7 +31,7 @@
 
 buildPythonPackage rec {
   pname = "jupysql";
-  version = "0.10.11";
+  version = "0.10.12";
 
   pyproject = true;
   disabled = pythonOlder "3.7";
@@ -40,10 +40,8 @@ buildPythonPackage rec {
     owner = "ploomber";
     repo = "jupysql";
     rev = "refs/tags/${version}";
-    hash = "sha256-A9zTjH+9RYKcgy4mI6uOMHOc46om06y1zK3IbxeVcWE=";
+    hash = "sha256-xq4yLJTqqqiN8L85jrUnVxAZHfmR3LS0/gwqtF89qJE=";
   };
-
-  pythonRelaxDeps = [ "sqlalchemy" ];
 
   build-system = [ setuptools ];
 


### PR DESCRIPTION
## Description of changes

This updates jupysql to the latest release.

The SQLalchemy version upper bound has been removed,
so `pythonRelaxDeps` is no longer needed and has been removed


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
