### PR TITLE
kodiPackages.jellyfin: 1.0.3 -> 1.0.4

### DIFF
--- a/pkgs/applications/video/kodi/addons/jellyfin/default.nix
+++ b/pkgs/applications/video/kodi/addons/jellyfin/default.nix
@@ -1,28 +1,35 @@
-{ lib, addonDir, buildKodiAddon, fetchFromGitHub, kodi, requests, dateutil, six, kodi-six, signals, websocket }:
+{
+  lib,
+  addonDir,
+  buildKodiAddon,
+  fetchFromGitHub,
+  kodi,
+  requests,
+  dateutil,
+  six,
+  kodi-six,
+  signals,
+  websocket,
+}:
 let
   python = kodi.pythonPackages.python.withPackages (p: with p; [ pyyaml ]);
 in
 buildKodiAddon rec {
   pname = "jellyfin";
   namespace = "plugin.video.jellyfin";
-  version = "1.0.3";
+  version = "1.0.4";
 
   src = fetchFromGitHub {
     owner = "jellyfin";
     repo = "jellyfin-kodi";
     rev = "v${version}";
-    sha256 = "sha256-Uyo8GClJU2/gdk4PeFNnoyvxOhooaxeXN3Wc5YGuCiM=";
+    sha256 = "sha256-N5ZNGeLf3P4p3RQimSaZteddKjqXE274mWpo7W9xqPs=";
   };
 
-  nativeBuildInputs = [
-    python
-  ];
+  nativeBuildInputs = [ python ];
 
-  prePatch = ''
-    # ZIP does not support timestamps before 1980 - https://bugs.python.org/issue34097
-    substituteInPlace build.py \
-      --replace "with zipfile.ZipFile('{}/{}'.format(target, archive_name), 'w') as z:" "with zipfile.ZipFile('{}/{}'.format(target, archive_name), 'w', strict_timestamps=False) as z:"
-  '';
+  # ZIP does not support timestamps before 1980 - https://bugs.python.org/issue34097
+  patches = [ ./no-strict-zip-timestamp.patch ];
 
   buildPhase = ''
     ${python}/bin/python3 build.py --version=py3

--- a/pkgs/applications/video/kodi/addons/jellyfin/no-strict-zip-timestamp.patch
+++ b/pkgs/applications/video/kodi/addons/jellyfin/no-strict-zip-timestamp.patch
@@ -1,0 +1,15 @@
+diff --git a/build.py b/build.py
+index 148441f3..2aa0f1ea 100755
+--- a/build.py
++++ b/build.py
+@@ -69,7 +69,9 @@ def zip_files(py_version: str, source: str, target: str, dev: bool) -> None:
+     """
+     archive_name = "plugin.video.jellyfin+{}.zip".format(py_version)
+ 
+-    with zipfile.ZipFile("{}/{}".format(target, archive_name), "w") as z:
++    with zipfile.ZipFile(
++        "{}/{}".format(target, archive_name), "w", strict_timestamps=False
++    ) as z:
+         for root, dirs, files in os.walk(args.source):
+             for filename in filter(file_filter, files):
+                 file_path = os.path.join(root, filename)


### PR DESCRIPTION
## Description of changes

Fixes missing distutils module. Right now version 1.0.3 doesn't work due to the Python3.12 update.

Moved the zip fix to a patch, because the `build.py` file moved, and the sed command silently did nothing.

Changelog: https://github.com/jellyfin/jellyfin-kodi/releases/tag/v1.0.4

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
