### PR TITLE
lib: add getFirstOutput

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1764,6 +1764,7 @@ rec {
   /**
     Get a package output.
     If no output is found, fallback to `.out` and then to the default.
+    The function is idempotent: `getOutput "b" (getOutput "a" p) == getOutput "a" p`.
 
 
     # Inputs
@@ -1779,7 +1780,7 @@ rec {
     # Type
 
     ```
-    getOutput :: String -> Derivation -> String
+    getOutput :: String -> :: Derivation -> Derivation
     ```
 
     # Examples
@@ -1787,7 +1788,7 @@ rec {
     ## `lib.attrsets.getOutput` usage example
 
     ```nix
-    getOutput "dev" pkgs.openssl
+    "${getOutput "dev" pkgs.openssl}"
     => "/nix/store/9rz8gxhzf8sw4kf2j2f1grr49w8zx5vj-openssl-1.0.1r-dev"
     ```
 
@@ -1799,8 +1800,9 @@ rec {
       else pkg;
 
   /**
-    Like `getOutput` but with a list of fallback output names.
+    Get the first of the `outputs` provided by the package, or the default.
     This function is alligned with `_overrideFirst()` from the `multiple-outputs.sh` setup hook.
+    Like `getOutput`, the function is idempotent.
 
     # Inputs
 
@@ -1815,7 +1817,7 @@ rec {
     # Type
 
     ```
-    getFirstOutput :: [String] -> Derivation -> String
+    getFirstOutput :: [String] -> Derivation -> Derivation
     ```
 
     # Examples
@@ -1823,7 +1825,7 @@ rec {
     ## `lib.attrsets.getFirstOutput` usage example
 
     ```nix
-    getFirstOutput [ "include" "dev" ] pkgs.openssl
+    "${getFirstOutput [ "include" "dev" ] pkgs.openssl}"
     => "/nix/store/00000000000000000000000000000000-openssl-1.0.1r-dev"
     ```
 
@@ -1853,7 +1855,7 @@ rec {
     # Type
 
     ```
-    getBin :: Derivation -> String
+    getBin :: Derivation -> Derivation
     ```
 
     # Examples
@@ -1861,7 +1863,7 @@ rec {
     ## `lib.attrsets.getBin` usage example
 
     ```nix
-    getBin pkgs.openssl
+    "${getBin pkgs.openssl}"
     => "/nix/store/00000000000000000000000000000000-openssl-1.0.1r"
     ```
 
@@ -1883,7 +1885,7 @@ rec {
     # Type
 
     ```
-    getLib :: Derivation -> String
+    getLib :: Derivation -> Derivation
     ```
 
     # Examples
@@ -1891,7 +1893,7 @@ rec {
     ## `lib.attrsets.getLib` usage example
 
     ```nix
-    getLib pkgs.openssl
+    "${getLib pkgs.openssl}"
     => "/nix/store/9rz8gxhzf8sw4kf2j2f1grr49w8zx5vj-openssl-1.0.1r-lib"
     ```
 
@@ -1913,7 +1915,7 @@ rec {
     # Type
 
     ```
-    getDev :: Derivation -> String
+    getDev :: Derivation -> Derivation
     ```
 
     # Examples
@@ -1921,7 +1923,7 @@ rec {
     ## `lib.attrsets.getDev` usage example
 
     ```nix
-    getDev pkgs.openssl
+    "${getDev pkgs.openssl}"
     => "/nix/store/9rz8gxhzf8sw4kf2j2f1grr49w8zx5vj-openssl-1.0.1r-dev"
     ```
 
@@ -1942,7 +1944,7 @@ rec {
     # Type
 
     ```
-    getInclude :: Derivation -> String
+    getInclude :: Derivation -> Derivation
     ```
 
     # Examples
@@ -1950,7 +1952,7 @@ rec {
     ## `lib.attrsets.getInclude` usage example
 
     ```nix
-    getInclude pkgs.openssl
+    "${getInclude pkgs.openssl}"
     => "/nix/store/00000000000000000000000000000000-openssl-1.0.1r-dev"
     ```
 
@@ -1972,7 +1974,7 @@ rec {
     # Type
 
     ```
-    getMan :: Derivation -> String
+    getMan :: Derivation -> Derivation
     ```
 
     # Examples
@@ -1980,7 +1982,7 @@ rec {
     ## `lib.attrsets.getMan` usage example
 
     ```nix
-    getMan pkgs.openssl
+    "${getMan pkgs.openssl}"
     => "/nix/store/9rz8gxhzf8sw4kf2j2f1grr49w8zx5vj-openssl-1.0.1r-man"
     ```
 
@@ -2000,7 +2002,7 @@ rec {
     # Type
 
     ```
-    chooseDevOutputs :: [Derivation] -> [String]
+    chooseDevOutputs :: [Derivation] -> [Derivation]
     ```
   */
   chooseDevOutputs = builtins.map getDev;

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1901,6 +1901,35 @@ rec {
   */
   getLib = getOutput "lib";
 
+  /**
+    Get a package's `static` output.
+    If the output does not exist, fallback to `.lib`, then to `.out`, and then to the default.
+
+    # Inputs
+
+    `pkg`
+
+    : The package whose `static` output will be retrieved.
+
+    # Type
+
+    ```
+    getStatic :: Derivation -> Derivation
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.attrsets.getStatic` usage example
+
+    ```nix
+    "${lib.getStatic pkgs.glibc}"
+    => "/nix/store/00000000000000000000000000000000-glibc-2.39-52-static"
+    ```
+
+    :::
+  */
+  getStatic = getFirstOutput [ "static" "lib" "out" ];
+
 
   /**
     Get a package's `dev` output.

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1799,6 +1799,48 @@ rec {
       else pkg;
 
   /**
+    Like `getOutput` but with a list of fallback output names.
+    This function is alligned with `_overrideFirst()` from the `multiple-outputs.sh` setup hook.
+
+    # Inputs
+
+    `outputs`
+
+    : 1\. Function argument
+
+    `pkg`
+
+    : 2\. Function argument
+
+    # Type
+
+    ```
+    getFirstOutput :: [String] -> Derivation -> String
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.attrsets.getFirstOutput` usage example
+
+    ```nix
+    getFirstOutput [ "include" "dev" ] pkgs.openssl
+    => "/nix/store/00000000000000000000000000000000-openssl-1.0.1r-dev"
+    ```
+
+    :::
+  */
+  getFirstOutput =
+    candidates: pkg:
+    let
+      outputs = builtins.filter (name: hasAttr name pkg) candidates;
+      output = builtins.head outputs;
+    in
+    if pkg.outputSpecified or false || outputs == [ ] then
+      pkg
+    else
+      pkg.${output};
+
+  /**
     Get a package's `bin` output.
     If the output does not exist, fallback to `.out` and then to the default.
 
@@ -1820,7 +1862,7 @@ rec {
 
     ```nix
     getBin pkgs.openssl
-    => "/nix/store/9rz8gxhzf8sw4kf2j2f1grr49w8zx5vj-openssl-1.0.1r"
+    => "/nix/store/00000000000000000000000000000000-openssl-1.0.1r"
     ```
 
     :::
@@ -1886,6 +1928,35 @@ rec {
     :::
   */
   getDev = getOutput "dev";
+
+  /**
+    Get a package's `include` output.
+    If the output does not exist, fallback to `.dev`, then to `.out`, and then to the default.
+
+    # Inputs
+
+    `pkg`
+
+    : The package whose `include` output will be retrieved.
+
+    # Type
+
+    ```
+    getInclude :: Derivation -> String
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.attrsets.getInclude` usage example
+
+    ```nix
+    getInclude pkgs.openssl
+    => "/nix/store/00000000000000000000000000000000-openssl-1.0.1r-dev"
+    ```
+
+    :::
+  */
+  getInclude = getFirstOutput [ "include" "dev" "out" ];
 
 
   /**

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -87,7 +87,7 @@ let
       mapAttrsRecursiveCond genAttrs isDerivation toDerivation optionalAttrs
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
       recursiveUpdate matchAttrs mergeAttrsList overrideExisting showAttrPath getOutput getFirstOutput
-      getBin getLib getDev getInclude getMan chooseDevOutputs zipWithNames zip
+      getBin getLib getStatic getDev getInclude getMan chooseDevOutputs zipWithNames zip
       recurseIntoAttrs dontRecurseIntoAttrs cartesianProduct cartesianProductOfSets
       mapCartesianProduct updateManyAttrsByPath listToAttrs hasAttr getAttr isAttrs intersectAttrs removeAttrs;
     inherit (self.lists) singleton forEach map foldr fold foldl foldl' imap0 imap1

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -86,8 +86,8 @@ let
       mapAttrs' mapAttrsToList attrsToList concatMapAttrs mapAttrsRecursive
       mapAttrsRecursiveCond genAttrs isDerivation toDerivation optionalAttrs
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
-      recursiveUpdate matchAttrs mergeAttrsList overrideExisting showAttrPath getOutput
-      getBin getLib getDev getMan chooseDevOutputs zipWithNames zip
+      recursiveUpdate matchAttrs mergeAttrsList overrideExisting showAttrPath getOutput getFirstOutput
+      getBin getLib getDev getInclude getMan chooseDevOutputs zipWithNames zip
       recurseIntoAttrs dontRecurseIntoAttrs cartesianProduct cartesianProductOfSets
       mapCartesianProduct updateManyAttrsByPath listToAttrs hasAttr getAttr isAttrs intersectAttrs removeAttrs;
     inherit (self.lists) singleton forEach map foldr fold foldl foldl' imap0 imap1


### PR DESCRIPTION
## Description of changes

My main motivation is to be able to ship headers separately from `propagatedBuildOutputs` (e.g. in case of CUDA, when these include multi-gigabyte static archives). I also find it inconsistent that `multiple-outputs-sh` offers more "outputs" than the nix-lang `lib`. Or in case of python, where `dev` is currently abused for "dependencies"

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
