### PR TITLE
ganv: unstable-2019-12-30 -> 1.8.2

### DIFF
--- a/pkgs/development/libraries/ganv/default.nix
+++ b/pkgs/development/libraries/ganv/default.nix
@@ -1,18 +1,45 @@
-{ lib, stdenv, fetchgit, graphviz, gtk2, gtkmm2, pkg-config, python3, wafHook }:
+{
+  lib,
+  stdenv,
+  fetchgit,
+  meson,
+  ninja,
+  pkg-config,
+  gobject-introspection,
+  graphviz,
+  gtk2,
+  gtkmm2,
+}:
 
 stdenv.mkDerivation rec {
   pname = "ganv";
-  version = "unstable-2019-12-30";
+  version = "1.8.2";
 
   src = fetchgit {
     url = "https://gitlab.com/drobilla/${pname}.git";
     fetchSubmodules = true;
-    rev = "90bd022f8909f92cc5290fdcfc76c626749e1186";
-    sha256 = "01znnalirbqxpz62fbw2c14c8xn117jc92xv6dhb3hln92k9x37f";
+    rev = "v${version}";
+    hash = "sha256-u9U8uMgDAhvriq4xrzqcwDxtaTBhEROB4yyrI5G1PDg=";
   };
 
-  nativeBuildInputs = [ pkg-config wafHook python3 gtk2 ];
-  buildInputs = [ graphviz gtkmm2 ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    graphviz
+    gtk2
+    gtkmm2
+  ];
+
+  mesonFlags = [
+    # Can't figure out how to make meson find 'libintl'
+    # for native language support
+    (lib.mesonEnable "nls" false)
+  ];
 
   strictDeps = true;
 
@@ -24,4 +51,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.goibhniu ];
     platforms = platforms.linux;
   };
-  }
+}


### PR DESCRIPTION
## Description of changes

Upstream changed their build system to meson,
which fixes the waf build issue with Python3.12, so this PR fixes the ganv build.

nixpkgs-review says the `ingen` package is broken, that's because it depends on the `raul` package, and both `ingen` and `raul` have the same `waf` issue.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>ingen</li>
  </ul>
</details>
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>ganv</li>
    <li>patchage</li>
  </ul>
</details>


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

cc @cillianderoiste

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
