### PR TITLE
[24.05] hostapd: apply patch for CVE-2024-3596

### DIFF
--- a/pkgs/os-specific/linux/hostapd/0007-RADIUS-Require-Message-Authenticator-attribute-in-MA.patch
+++ b/pkgs/os-specific/linux/hostapd/0007-RADIUS-Require-Message-Authenticator-attribute-in-MA.patch
@@ -1,0 +1,101 @@
+From 58097123ec5ea6f8276b38cb9b07669ec368a6c1 Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <j@w1.fi>
+Date: Sun, 17 Mar 2024 10:42:56 +0200
+Subject: [PATCH 7/8] RADIUS: Require Message-Authenticator attribute in MAC
+ ACL cases
+
+hostapd required Message-Authenticator attribute to be included in EAP
+authentication cases, but that requirement was not in place for MAC ACL
+cases. Start requiring Message-Authenticator attribute for MAC ACL by
+default. Unlike the EAP case, this can still be disabled with
+radius_require_message_authenticator=1 to maintain compatibility with
+some RADIUS servers when used in a network where the connection to such
+a server is secure.
+
+Signed-off-by: Jouni Malinen <j@w1.fi>
+---
+ hostapd/config_file.c    |  3 +++
+ hostapd/hostapd.conf     | 11 +++++++++++
+ src/ap/ap_config.c       |  1 +
+ src/ap/ap_config.h       |  1 +
+ src/ap/ieee802_11_auth.c |  4 +++-
+ 5 files changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/hostapd/config_file.c b/hostapd/config_file.c
+index 96c28aea2..3fb059770 100644
+--- a/hostapd/config_file.c
++++ b/hostapd/config_file.c
+@@ -2988,6 +2988,9 @@ static int hostapd_config_fill(struct hostapd_config *conf,
+ #endif /* CONFIG_RADIUS_TLS */
+ 	} else if (os_strcmp(buf, "radius_retry_primary_interval") == 0) {
+ 		bss->radius->retry_primary_interval = atoi(pos);
++	} else if (os_strcmp(buf,
++			     "radius_require_message_authenticator") == 0) {
++		bss->radius_require_message_authenticator = atoi(pos);
+ 	} else if (os_strcmp(buf, "radius_acct_interim_interval") == 0) {
+ 		bss->acct_interim_interval = atoi(pos);
+ 	} else if (os_strcmp(buf, "radius_request_cui") == 0) {
+diff --git a/hostapd/hostapd.conf b/hostapd/hostapd.conf
+index e3367b708..3f0e66beb 100644
+--- a/hostapd/hostapd.conf
++++ b/hostapd/hostapd.conf
+@@ -1620,6 +1620,17 @@ own_ip_addr=127.0.0.1
+ # currently used secondary server is still working.
+ #radius_retry_primary_interval=600
+ 
++# Message-Authenticator attribute requirement for non-EAP cases
++# hostapd requires Message-Authenticator attribute to be included in all cases
++# where RADIUS is used for EAP authentication. This is also required for cases
++# where RADIUS is used for MAC ACL (macaddr_acl=2) by default, but that case
++# can be configured to not require this for compatibility with RADIUS servers
++# that do not include the attribute. This is not recommended due to potential
++# security concerns, but can be used as a temporary workaround in networks where
++# the connection to the RADIUS server is secure.
++# 0 = Do not require Message-Authenticator in MAC ACL response
++# 1 = Require Message-Authenticator in all authentication cases (default)
++#radius_require_message_authenticator=1
+ 
+ # Interim accounting update interval
+ # If this is set (larger than 0) and acct_server is configured, hostapd will
+diff --git a/src/ap/ap_config.c b/src/ap/ap_config.c
+index 32b04ab35..0b5a16ef9 100644
+--- a/src/ap/ap_config.c
++++ b/src/ap/ap_config.c
+@@ -122,6 +122,7 @@ void hostapd_config_defaults_bss(struct hostapd_bss_config *bss)
+ #endif /* CONFIG_IEEE80211R_AP */
+ 
+ 	bss->radius_das_time_window = 300;
++	bss->radius_require_message_authenticator = 1;
+ 
+ 	bss->anti_clogging_threshold = 5;
+ 	bss->sae_sync = 5;
+diff --git a/src/ap/ap_config.h b/src/ap/ap_config.h
+index fda937ecf..ced2181ab 100644
+--- a/src/ap/ap_config.h
++++ b/src/ap/ap_config.h
+@@ -309,6 +309,7 @@ struct hostapd_bss_config {
+ 	struct hostapd_ip_addr own_ip_addr;
+ 	char *nas_identifier;
+ 	struct hostapd_radius_servers *radius;
++	int radius_require_message_authenticator;
+ 	int acct_interim_interval;
+ 	int radius_request_cui;
+ 	struct hostapd_radius_attr *radius_auth_req_attr;
+diff --git a/src/ap/ieee802_11_auth.c b/src/ap/ieee802_11_auth.c
+index cc38044d8..913a99597 100644
+--- a/src/ap/ieee802_11_auth.c
++++ b/src/ap/ieee802_11_auth.c
+@@ -508,7 +508,9 @@ hostapd_acl_recv_radius(struct radius_msg *msg, struct radius_msg *req,
+ 	wpa_printf(MSG_DEBUG, "Found matching Access-Request for RADIUS "
+ 		   "message (id=%d)", query->radius_id);
+ 
+-	if (radius_msg_verify(msg, shared_secret, shared_secret_len, req, 0)) {
++	if (radius_msg_verify(
++		    msg, shared_secret, shared_secret_len, req,
++		    hapd->conf->radius_require_message_authenticator)) {
+ 		wpa_printf(MSG_INFO, "Incoming RADIUS packet did not have "
+ 			   "correct authenticator - dropped\n");
+ 		return RADIUS_RX_INVALID_AUTHENTICATOR;
+-- 
+2.45.1
+

--- a/pkgs/os-specific/linux/hostapd/default.nix
+++ b/pkgs/os-specific/linux/hostapd/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkg-config, libnl, openssl, sqlite ? null }:
+{ lib, stdenv, fetchurl, fetchpatch, pkg-config, libnl, openssl, sqlite ? null }:
 
 stdenv.mkDerivation rec {
   pname = "hostapd";
@@ -18,6 +18,53 @@ stdenv.mkDerivation rec {
       # server's URLs containing semicolons. Using the github mirror instead.
       url = "https://raw.githubusercontent.com/openwrt/openwrt/eefed841b05c3cd4c65a78b50ce0934d879e6acf/package/network/services/hostapd/patches/300-noscan.patch";
       sha256 = "08p5frxhpq1rp2nczkscapwwl8g9nc4fazhjpxic5bcbssc3sb00";
+    })
+
+    # Backported security patches for CVE-2024-3596 (https://blastradius.fail),
+    # these can be removed when updating to 2.11.
+
+    # RADIUS: Allow Message-Authenticator attribute as the first attribute
+    (fetchpatch {
+      url = "https://w1.fi/cgit/hostap/patch/?id=adac846bd0e258a0aa50750bbd2b411fa0085c46";
+      hash = "sha256-1jfSeVGL5tyZn8F2wpQ7KwaQaEKWsCOW/bavovMcdz4=";
+    })
+
+    # RADIUS server: Place Message-Authenticator attribute as the first one
+    (fetchpatch {
+      url = "https://w1.fi/cgit/hostap/patch/?id=54abb0d3cf35894e7d86e3f7555e95b106306803";
+      hash = "sha256-fVhQlOVETttVf1M9iKrXJrv7mxpxSjCt3w8kndRal08=";
+    })
+
+    # hostapd: Move Message-Authenticator attribute to be the first one in req
+    (fetchpatch {
+      url = "https://w1.fi/cgit/hostap/patch/?id=37fe8e48ab44d44fe3cf5dd8f52cb0a10be0cd17";
+      hash = "sha256-3eoAkXhieO3f0R5PTlH6g5wcgo/aLQN6XcPSITGgciE=";
+    })
+
+    # RADIUS DAS: Move Message-Authenticator attribute to be the first one
+    (fetchpatch {
+      url = "https://w1.fi/cgit/hostap/patch/?id=f54157077f799d84ce26bed6ad6b01c4a16e31cf";
+      hash = "sha256-dcaghKbKNFVSN6ONNaFt1s0S35mkqox2aykiExEXyPQ=";
+    })
+
+    # Require Message-Authenticator in Access-Reject even without EAP-Message
+    (fetchpatch {
+      url = "https://w1.fi/cgit/hostap/patch/?id=934b0c3a45ce0726560ccefbd992a9d385c36385";
+      hash = "sha256-9GquP/+lsghF81nMhOuRwlSz/pEnmk+mSex8aM3/qdA=";
+    })
+
+    # RADIUS: Require Message-Authenticator attribute in MAC ACL cases
+    #(fetchpatch {
+    #  url = "https://w1.fi/cgit/hostap/patch/?id=58097123ec5ea6f8276b38cb9b07669ec368a6c1";
+    #  hash = "sha256-mW+PAeAkNcrlFPsjxLvZ/1Smq6H6KXq5Le3HuLA2KKw=";
+    #})
+    # Needed to be fixed to apply correctly:
+    ./0007-RADIUS-Require-Message-Authenticator-attribute-in-MA.patch
+
+    # RADIUS: Check Message-Authenticator if it is present even if not required
+    (fetchpatch {
+      url = "https://w1.fi/cgit/hostap/patch/?id=f302d9f9646704cce745734af21d540baa0da65f";
+      hash = "sha256-6i0cq5YBm2w03yMrdYGaEqe1dTsmokZWOs4WPFX36qo=";
     })
   ];
 
@@ -105,7 +152,7 @@ stdenv.mkDerivation rec {
     homepage = "https://w1.fi/hostapd/";
     description = "A user space daemon for access point and authentication servers";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ oddlama ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
## Description of changes

Backport of  #325962

cc @oddlama 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
