### PR TITLE
mongodb-5_0: fix building on aarch64-linux

### DIFF
--- a/pkgs/servers/nosql/mongodb/5.0.nix
+++ b/pkgs/servers/nosql/mongodb/5.0.nix
@@ -31,6 +31,10 @@ buildMongoDB {
     ./fix-gcc-Wno-exceptions-5.0.patch
     # Fix building with python 3.12 since the imp module was removed
     ./mongodb-python312.patch
-  ] ++ variants.patches;
+  ] ++ variants.patches
+    ++ lib.optionals (stdenv.hostPlatform.system == "aarch64-linux") [
+    # src/mongo/db/stats/counters.h:224:47: error: static assertion failed: cache line spill
+    ./mongodb-4.4.15-adjust-cache-alignment-assumptions.patch
+  ];
   passthru.tests = { inherit (nixosTests) mongodb; };
 }

--- a/pkgs/servers/nosql/mongodb/mongodb-4.4.15-adjust-cache-alignment-assumptions.patch
+++ b/pkgs/servers/nosql/mongodb/mongodb-4.4.15-adjust-cache-alignment-assumptions.patch
@@ -1,0 +1,37 @@
+From 5c9e0d0fc9188bab0ae09c9c33df01938b0c1b6c Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 14 Apr 2022 09:25:33 -0700
+Subject: [PATCH] server: Adjust the cache alignment assumptions
+
+aarch64 has 256 for hardware_destructive_interference_size and gcc 12
+has added a warning to complain about mismatches which results in
+static_assert failures
+
+In file included from src/mongo/s/commands/cluster_find_cmd.cpp:39:
+src/mongo/db/stats/counters.h:185:47: error: static assertion failed: cache line spill
+ 185 |     static_assert(sizeof(decltype(_together)) <= stdx::hardware_constructive_interference_size,
+     |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The structure need to ensure true sharing for both the elements
+so align it to hardware_constructive_interference_size instead
+
+Upstream-Status: Reported [https://jira.mongodb.org/browse/SERVER-65664]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/mongo/db/stats/counters.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/src/mongo/db/stats/counters.h
++++ b/src/mongo/db/stats/counters.h
+@@ -182,8 +182,8 @@ private:
+         AtomicWord<long long> requests{0};
+     };
+     CacheAligned<Together> _together{};
+-    static_assert(sizeof(decltype(_together)) <= stdx::hardware_constructive_interference_size,
+-                  "cache line spill");
++    static_assert(sizeof(Together) <= stdx::hardware_constructive_interference_size,
++                   "cache line spill");
+
+     CacheAligned<AtomicWord<long long>> _logicalBytesOut{0};
+


### PR DESCRIPTION
## Description of changes

Fixes https://github.com/NixOS/nixpkgs/issues/327078

```
src/mongo/db/stats/counters.h:224:47: error: static assertion failed: cache line spill
  224 |     static_assert(sizeof(decltype(_together)) <= stdx::hardware_constructive_interference_size,
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Compiled with `nix build --impure .#pkgsCross.aarch64-multiplatform.mongodb-5_0`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux (pkgsCross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
