### PR TITLE
jetty_11: 11.0.20 -> 11.0.22, jetty_12: 12.0.9 -> 12.0.11

### DIFF
--- a/pkgs/servers/http/jetty/11.x.nix
+++ b/pkgs/servers/http/jetty/11.x.nix
@@ -1,4 +1,4 @@
 import ./common.nix {
-  version = "11.0.20";
-  hash = "sha256-qOpIWht7Q8zjNRiHvpN5SBy+hOhddhgor5S55gWxHlQ=";
+  version = "11.0.22";
+  hash = "sha256-afFuUZ1csDuE60m+WKMriU/wObBZleTORLOCFU8qcJk=";
 }

--- a/pkgs/servers/http/jetty/12.x.nix
+++ b/pkgs/servers/http/jetty/12.x.nix
@@ -1,4 +1,4 @@
 import ./common.nix {
-  version = "12.0.9";
-  hash = "sha256-+/pn6Q24QDTaK+Slr+B17fshEXXh6sO1DWRuFGfi2h0=";
+  version = "12.0.11";
+  hash = "sha256-5fZMHb2ZpkoAFY/v124F+99Kq9vZypSYrG8QmQ/RK6k=";
 }

--- a/pkgs/servers/http/jetty/common.nix
+++ b/pkgs/servers/http/jetty/common.nix
@@ -27,8 +27,9 @@ stdenvNoCC.mkDerivation rec {
   };
 
   meta = with lib; {
+    changelog = "https://github.com/jetty/jetty.project/releases/tag/jetty-${version}";
     description = "Web server and javax.servlet container";
-    homepage = "https://eclipse.dev/jetty/";
+    homepage = "https://jetty.org/";
     platforms = platforms.all;
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = with licenses; [ asl20 epl10 ];

--- a/pkgs/servers/http/jetty/common.nix
+++ b/pkgs/servers/http/jetty/common.nix
@@ -1,6 +1,6 @@
 { version, hash }:
 
-{ lib, stdenvNoCC, fetchurl }:
+{ lib, stdenvNoCC, fetchurl, gitUpdater }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "jetty";
@@ -18,6 +18,13 @@ stdenvNoCC.mkDerivation rec {
     mkdir -p $out
     mv etc lib modules start.jar $out
   '';
+
+  passthru.updateScript = gitUpdater {
+    url = "https://github.com/jetty/jetty.project.git";
+    allowedVersions = "^${lib.versions.major version}\\.";
+    ignoredVersions = "(alpha|beta).*";
+    rev-prefix = "jetty-";
+  };
 
   meta = with lib; {
     description = "Web server and javax.servlet container";


### PR DESCRIPTION
## Description of changes

https://github.com/jetty/jetty.project/releases/tag/jetty-11.0.22
https://github.com/jetty/jetty.project/releases/tag/jetty-12.0.11

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
