### PR TITLE
nixos/goatcounter: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -20,6 +20,8 @@
 
 - [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr), proxy server to bypass Cloudflare protection. Available as [services.flaresolverr](#opt-services.flaresolverr.enable) service.
 
+- [Goatcounter](https://www.goatcounter.com/), Easy web analytics. No tracking of personal data. Available as [services.goatcounter](options.html#opt-services.goatcocunter.enable).
+
 - [Open-WebUI](https://github.com/open-webui/open-webui), a user-friendly WebUI
   for LLMs. Available as [services.open-webui](#opt-services.open-webui.enable)
   service.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1397,6 +1397,7 @@
   ./services/web-apps/gotosocial.nix
   ./services/web-apps/grocy.nix
   ./services/web-apps/pixelfed.nix
+  ./services/web-apps/goatcounter.nix
   ./services/web-apps/guacamole-client.nix
   ./services/web-apps/guacamole-server.nix
   ./services/web-apps/healthchecks.nix

--- a/nixos/modules/services/web-apps/goatcounter.nix
+++ b/nixos/modules/services/web-apps/goatcounter.nix
@@ -1,0 +1,80 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib) types;
+  cfg = config.services.goatcounter;
+  stateDir = "goatcounter";
+in
+
+{
+  options = {
+    services.goatcounter = {
+      enable = lib.mkEnableOption "goatcounter";
+
+      package = lib.mkPackageOption pkgs "goatcounter" { };
+
+      address = lib.mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = "Web interface address.";
+      };
+
+      port = lib.mkOption {
+        type = types.port;
+        default = 8081;
+        description = "Web interface port.";
+      };
+
+      proxy = lib.mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether Goatcounter service is running behind a reverse proxy. Will listen for HTTPS if `false`.
+          Refer to [documentation](https://github.com/arp242/goatcounter?tab=readme-ov-file#running) for more details.
+        '';
+      };
+
+      extraArgs = lib.mkOption {
+        type = with types; listOf str;
+        default = [ ];
+        description = ''
+          List of extra arguments to be passed to goatcounter cli.
+          See {command}`goatcounter help serve` for more information.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.goatcounter = {
+      description = "Easy web analytics. No tracking of personal data.";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = lib.escapeShellArgs (
+          [
+            (lib.getExe cfg.package)
+            "serve"
+            "-listen"
+            "${cfg.address}:${toString cfg.port}"
+          ]
+          ++ lib.optionals cfg.proxy [
+            "-tls"
+            "proxy"
+          ]
+          ++ cfg.extraArgs
+        );
+        DynamicUser = true;
+        StateDirectory = stateDir;
+        WorkingDirectory = "%S/${stateDir}";
+        Restart = "always";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ bhankas ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -375,6 +375,7 @@ in {
   gnome-xorg = handleTest ./gnome-xorg.nix {};
   gns3-server = handleTest ./gns3-server.nix {};
   gnupg = handleTest ./gnupg.nix {};
+  goatcounter = handleTest ./goatcounter.nix {};
   go-neb = handleTest ./go-neb.nix {};
   gobgpd = handleTest ./gobgpd.nix {};
   gocd-agent = handleTest ./gocd-agent.nix {};

--- a/nixos/tests/goatcounter.nix
+++ b/nixos/tests/goatcounter.nix
@@ -1,0 +1,32 @@
+import ./make-test-python.nix (
+  { lib, pkgs, ... }:
+
+  {
+    name = "goatcounter";
+
+    meta.maintainers = with lib.maintainers; [ bhankas ];
+
+    nodes.machine =
+      { config, ... }:
+      {
+        virtualisation.memorySize = 2048;
+
+        services.goatcounter = {
+          enable = true;
+          proxy = true;
+        };
+      };
+
+    testScript = ''
+      start_all()
+      machine.wait_for_unit("goatcounter.service")
+      # wait for goatcounter to fully come up
+
+      with subtest("goatcounter service starts"):
+          machine.wait_until_succeeds(
+              "curl -sSfL http://localhost:8081/ > /dev/null",
+              timeout=30
+          )
+    '';
+  }
+)

--- a/pkgs/by-name/go/goatcounter/package.nix
+++ b/pkgs/by-name/go/goatcounter/package.nix
@@ -1,8 +1,10 @@
-{ lib
-, buildGoModule
-, fetchFromGitHub
-, testers
-, goatcounter
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  testers,
+  goatcounter,
+  nixosTests,
 }:
 
 buildGoModule rec {
@@ -31,10 +33,13 @@ buildGoModule rec {
     "-X zgo.at/goatcounter/v2.Version=${src.rev}"
   ];
 
-  passthru.tests.version = testers.testVersion {
-    package = goatcounter;
-    command = "goatcounter version";
-    version = "v${version}";
+  passthru.tests = {
+    moduleTest = nixosTests.goatcounter;
+    version = testers.testVersion {
+      package = goatcounter;
+      command = "goatcounter version";
+      version = "v${version}";
+    };
   };
 
   meta = {


### PR DESCRIPTION
## Description of changes

Initial implementation of [goatcounter](https://www.goatcounter.com/) service. Also includes rudimentary module test.

Currently uses sqlite by default, postgres support can be included in future update.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
