### PR TITLE
home-assistant: support aquacell component

### DIFF
--- a/pkgs/development/python-modules/aioaquacell/default.nix
+++ b/pkgs/development/python-modules/aioaquacell/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  aiobotocore,
+  aiohttp,
+  attr,
+  aws-request-signer,
+  botocore,
+  requests-aws4auth,
+  pycognito,
+}:
+
+buildPythonPackage rec {
+  pname = "aioaquacell";
+  version = "0.2.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-n2kPD1t5d/nf43rB0q1hNNYdHeaBiadsFWTmu1bYN1A=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiohttp
+    aiobotocore
+    attr
+    aws-request-signer
+    botocore
+    requests-aws4auth
+    pycognito
+  ];
+
+  pythonImportsCheck = [ "aioaquacell" ];
+
+  doCheck = false;
+
+  meta = {
+    changelog = "https://github.com/Jordi1990/aioaquacell/releases/tag/v${version}";
+    description = "Asynchronous library to retrieve details of your Aquacell water softener device.";
+    homepage = "https://github.com/Jordi1990/aioaquacell";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ pyrox0 ];
+  };
+}

--- a/pkgs/development/python-modules/attr/default.nix
+++ b/pkgs/development/python-modules/attr/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  python,
+}:
+
+buildPythonPackage rec {
+  pname = "attr";
+  version = "0.3.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "denis-ryzhkov";
+    repo = "attr";
+    rev = version;
+    hash = "sha256-1gOAONDuZb7xEPFZJc00BRtFF06uX65S8b3RRRNGeSo=";
+  };
+
+  build-system = [ setuptools ];
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} -c "import dry_attr; dry_attr.test()"
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Simple decorator to set attributes of target function or class in a DRY way.";
+    homepage = "https://github.com/denis-ryzhkov/attr";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pyrox0 ];
+  };
+}

--- a/pkgs/development/python-modules/aws-request-signer/default.nix
+++ b/pkgs/development/python-modules/aws-request-signer/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  poetry-core,
+  requests,
+  requests-toolbelt,
+}:
+
+buildPythonPackage rec {
+  pname = "aws-request-signer";
+  version = "1.2.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "aws_request_signer";
+    hash = "sha256-DVorDO0wz94Fhduax7VsQZ5B5SnBfsHQoLoW4m6Ce+U=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "poetry>=0.12" poetry-core \
+      --replace-fail poetry.masonry.api poetry.core.masonry.api
+  '';
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    requests
+    requests-toolbelt
+  ];
+
+  doCheck = false;
+
+  meta = {
+    changelog = "https://github.com/iksteen/aws-request-signer/releases/tag/${version}";
+    description = "Python library to sign AWS requests using AWS Signature V4.";
+    homepage = "https://github.com/iksteen/aws-request-signer";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pyrox0 ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -219,11 +219,12 @@
       apsystems-ez1
     ];
     "aquacell" = ps: with ps; [
+      aioaquacell
       fnv-hash-fast
       ifaddr
       psutil-home-assistant
       sqlalchemy
-    ]; # missing inputs: aioaquacell
+    ];
     "aqualogic" = ps: with ps; [
       aqualogic
     ];
@@ -5274,6 +5275,7 @@
     "aprilaire"
     "aprs"
     "apsystems"
+    "aquacell"
     "aranet"
     "arcam_fmj"
     "aseko_pool_live"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1064,6 +1064,8 @@ self: super: with self; {
 
   aws-lambda-builders = callPackage ../development/python-modules/aws-lambda-builders { };
 
+  aws-request-signer = callPackage ../development/python-modules/aws-request-signer { };
+
   aws-sam-translator = callPackage ../development/python-modules/aws-sam-translator { };
 
   aws-secretsmanager-caching = callPackage ../development/python-modules/aws-secretsmanager-caching { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -157,6 +157,8 @@ self: super: with self; {
 
   aioapns = callPackage ../development/python-modules/aioapns { };
 
+  aioaquacell = callPackage ../development/python-modules/aioaquacell { };
+
   aiocron = callPackage ../development/python-modules/aiocron { };
 
   ailment = callPackage ../development/python-modules/ailment { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -945,6 +945,8 @@ self: super: with self; {
 
   attacut = callPackage ../development/python-modules/attacut { };
 
+  attr = callPackage ../development/python-modules/attr { };
+
   attrdict = callPackage ../development/python-modules/attrdict { };
 
   attrs = callPackage ../development/python-modules/attrs { };


### PR DESCRIPTION
## Description of changes
Adds the aioaquacell package, which depends on aws-request-signer and attr, that were not previously packaged, so added here.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
