### PR TITLE
Support OSX ARM64 for Nwjs

### DIFF
--- a/pkgs/development/tools/nwjs/default.nix
+++ b/pkgs/development/tools/nwjs/default.nix
@@ -1,146 +1,191 @@
-{ alsa-lib
-, at-spi2-core
-, atk
-, autoPatchelfHook
-, buildEnv
-, cairo
-, cups
-, dbus
-, expat
-, fetchurl
-, ffmpeg
-, fontconfig
-, freetype
-, gdk-pixbuf
-, glib
-, gtk3
-, lib
-, libcap
-, libdrm
-, libGL
-, libnotify
-, libuuid
-, libxcb
-, libxkbcommon
-, makeWrapper
-, mesa
-, nspr
-, nss
-, pango
-, sdk ? false
-, sqlite
-, stdenv
-, systemd
-, udev
-, wrapGAppsHook3
-, xorg
+{ 
+  alsa-lib
+  , at-spi2-core
+  , atk
+  , autoPatchelfHook
+  , buildEnv
+  , cairo
+  , cups
+  , dbus
+  , expat
+  , fetchurl
+  , ffmpeg
+  , fontconfig
+  , freetype
+  , gdk-pixbuf
+  , glib
+  , gtk3
+  , lib
+  , libcap
+  , libdrm
+  , libGL
+  , libnotify
+  , libuuid
+  , libxcb
+  , libxkbcommon
+  , makeWrapper
+  , mesa
+  , nspr
+  , nss
+  , pango
+  , sdk ? false
+  , sqlite
+  , stdenv
+  , systemd
+  , udev
+  , wrapGAppsHook3
+  , xorg
+  , unzip
 }:
 
 let
-  bits = if stdenv.hostPlatform.system == "x86_64-linux" then "x64" else "ia32";
+  bits = if stdenv.hostPlatform.system == "x86_64-linux" then "x64" 
+  else if stdenv.hostPlatform.system == "aarch64-darwin" then "arm64" 
+  else "ia32";
+
+  os = if stdenv.hostPlatform.system == "aarch64-darwin"  then "osx" else "linux"; 
+  dlextension = if stdenv.hostPlatform.system == "aarch64-darwin"  then "zip" else "tar.gz"; 
+  flavor = if sdk then "sdk-" else "";
+
+  nwEnvPaths = if os != "osx" then [
+    alsa-lib
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    gtk3
+    libcap
+    libdrm
+    libGL
+    libnotify
+    libxkbcommon
+    mesa
+    nspr
+    nss
+    pango
+    xorg.libX11
+    xorg.libXScrnSaver
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+    xorg.libxshmfence
+    # libnw-specific (not chromium dependencies)
+    ffmpeg
+    libxcb
+    # chromium runtime deps (dlopen’d)
+    libuuid
+    sqlite
+    udev
+  ] else [
+    # libnw-specific (not chromium dependencies)
+    ffmpeg
+    libxcb
+  ];
 
   nwEnv = buildEnv {
     name = "nwjs-env";
-    paths = [
-      alsa-lib
-      at-spi2-core
-      atk
-      cairo
-      cups
-      dbus
-      expat
-      fontconfig
-      freetype
-      gdk-pixbuf
-      glib
-      gtk3
-      libcap
-      libdrm
-      libGL
-      libnotify
-      libxkbcommon
-      mesa
-      nspr
-      nss
-      pango
-      xorg.libX11
-      xorg.libXScrnSaver
-      xorg.libXcomposite
-      xorg.libXcursor
-      xorg.libXdamage
-      xorg.libXext
-      xorg.libXfixes
-      xorg.libXi
-      xorg.libXrandr
-      xorg.libXrender
-      xorg.libXtst
-      xorg.libxshmfence
-      # libnw-specific (not chromium dependencies)
-      ffmpeg
-      libxcb
-      # chromium runtime deps (dlopen’d)
-      libuuid
-      sqlite
-      udev
-    ];
-
+    paths = nwEnvPaths;
     extraOutputsToInstall = [ "lib" "out" ];
   };
 
-  version = "0.89.0";
+  version = "0.88.0";
 in
-stdenv.mkDerivation {
-  pname = "nwjs";
-  inherit version;
+  stdenv.mkDerivation {
+    pname = "nwjs";
+    inherit version;
 
-  src =
-    let flavor = if sdk then "sdk-" else "";
-    in fetchurl {
-      url = "https://dl.nwjs.io/v${version}/nwjs-${flavor}v${version}-linux-${bits}.tar.gz";
-      hash = {
-        "sdk-ia32" = "sha256-gHZLxZRborfbwmblKQrgr6tf+Rwt1YqxrGELAHPM0so=";
-        "sdk-x64" = "sha256-NOQGS3jEdZumTwCmi0DUtnGlOaSAZi2rGYSLVioJDdg=";
-        "ia32" = "sha256-L3PGK2YZCUo+KfkakL9AjkPcnUWPFOn4S2GePi+rph0=";
-        "x64" = "sha256-epsbDjrpq4K7NnNDAcKoEJMcjfdehU2JjFcmA5exug8=";
-      }."${flavor + bits}";
-    };
+    src =
+      fetchurl {
+        url = "https://dl.nwjs.io/v${version}/nwjs-${flavor}v${version}-${os}-${bits}.${dlextension}";
+        hash = {
+          "sdk-ia32" = "sha256-pk8Fdzw8zBBF4xeU5BlmkF1gbf7HIn8jheSjbdV4hI0=";
+          "sdk-x64" = "sha256-51alZRf/+bpKfVLUQuy1VtLHCgkVuptQaJgupt7zxcU=";
+          "sdk-arm64" = "sha256-2momE5W+MOAEbh8LPz4MkP9GyInX3Xt6OcMZagvMFmQ=";
+          "ia32" = "sha256-OLkOJo3xDZ6WKbf6zPeY+KcgzoEjYWMIV7YWWbESjPo=";
+          "x64" = "sha256-KSsaTs0W8m2dI+0ByLqU4H4ai/PXUt6LtroZIBeymgs=";
+          "arm64" = "sha256-kvdI+3oYYXMH0oVON422Nfbtr9+QhJ0RQ+62vdRgUvM=";
+        }."${flavor + bits}";
+      };
 
-  nativeBuildInputs = [
-    autoPatchelfHook
+  #  Disable autoPatchelfHook en macOS
+  nativeBuildInputs = if stdenv.isDarwin then [] else [ 
+
+    autoPatchelfHook 
     (wrapGAppsHook3.override { inherit makeWrapper; })
   ];
 
-  buildInputs = [ nwEnv ];
-  appendRunpaths = map (pkg: (lib.getLib pkg) + "/lib") [ nwEnv stdenv.cc.libc stdenv.cc.cc ];
+  buildInputs = if os != "osx" then [ nwEnv ] else [ unzip  ffmpeg libxcb ];
+  appendRunpaths = if os != "osx" then map (pkg: (lib.getLib pkg) + "/lib") [ nwEnv stdenv.cc.libc stdenv.cc.cc ] else [];
 
   preFixup = ''
-    gappsWrapperArgs+=(
+
+    if [ "${os}" = "osx" ]; then
+      # Flags for OSX
+      gappsWrapperArgs+=(
+          --add-flags "--ozone-platform-hint=auto"
+        )
+    else 
+      gappsWrapperArgs+=(
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
     )
+    fi
   '';
+
+  # Define la fase de desempacado condicionalmente
+  unpackPhase = ''
+    if [ "${os}" = "osx" ]; then
+      echo "Unpacking on macOS using unzip..."
+      mkdir -p $out
+      unzip $src -d $out
+    else
+      echo "Using default unpackPhase..."
+      runHook unpackPhase
+    fi
+  '';
+
 
   installPhase = ''
       runHook preInstall
 
-      mkdir -p $out/share/nwjs
-      cp -R * $out/share/nwjs
-      find $out/share/nwjs
+      if [ "${os}" = "osx" ]; then
+        echo "Install OSX bundle"
+      else
+        mkdir -p $out/share/nwjs
+        cp -R * $out/share/nwjs
+        find $out/share/nwjs
+        mkdir -p $out/bin
 
-      ln -s ${lib.getLib systemd}/lib/libudev.so $out/share/nwjs/libudev.so.0
 
-      mkdir -p $out/bin
-      ln -s $out/share/nwjs/nw $out/bin
+        create_symlink() {
+            ln -s $(lib.getLib systemd)/lib/libudev.so $out/share/nwjs/libudev.so.0
+         }
+         create_symlink
+         ln -s $out/share/nwjs/nw $out/bin
 
-      mkdir $out/lib
-      ln -s $out/share/nwjs/lib/libnw.so $out/lib/libnw.so
+         mkdir $out/lib
+         ln -s $out/share/nwjs/lib/libnw.so $out/lib/libnw.so
 
-      runHook postInstall
-    '';
+       fi
+
+       runHook postInstall
+  '';
 
   meta = with lib; {
     description = "App runtime based on Chromium and node.js";
     homepage = "https://nwjs.io/";
-    platforms = [ "i686-linux" "x86_64-linux" ];
+    platforms = [ "i686-linux" "x86_64-linux" "aarch64-darwin" ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     maintainers = [ maintainers.mikaelfangel ];
     mainProgram = "nw";

--- a/pkgs/development/tools/nwjs/default.nix
+++ b/pkgs/development/tools/nwjs/default.nix
@@ -1,5 +1,4 @@
-{ 
-  alsa-lib
+{ alsa-lib
   , at-spi2-core
   , atk
   , autoPatchelfHook
@@ -39,10 +38,7 @@
 }:
 
 let
-  bits = if stdenv.hostPlatform.system == "x86_64-linux" then "x64" 
-  else if stdenv.hostPlatform.system == "aarch64-darwin" then "arm64" 
-  else "ia32";
-
+  bits = if stdenv.hostPlatform.system == "x86_64-linux" then "x64"  else if stdenv.hostPlatform.system == "aarch64-darwin" then "arm64"  else "ia32";
   os = if stdenv.hostPlatform.system == "aarch64-darwin"  then "osx" else "linux"; 
   dlextension = if stdenv.hostPlatform.system == "aarch64-darwin"  then "zip" else "tar.gz"; 
   flavor = if sdk then "sdk-" else "";
@@ -119,18 +115,11 @@ in
         }."${flavor + bits}";
       };
 
-  #  Disable autoPatchelfHook en macOS
-  nativeBuildInputs = if stdenv.isDarwin then [] else [ 
-
-    autoPatchelfHook 
-    (wrapGAppsHook3.override { inherit makeWrapper; })
-  ];
-
+  nativeBuildInputs = if stdenv.isDarwin then [] else [  autoPatchelfHook (wrapGAppsHook3.override { inherit makeWrapper; }) ];
   buildInputs = if os != "osx" then [ nwEnv ] else [ unzip  ffmpeg libxcb ];
   appendRunpaths = if os != "osx" then map (pkg: (lib.getLib pkg) + "/lib") [ nwEnv stdenv.cc.libc stdenv.cc.cc ] else [];
 
   preFixup = ''
-
     if [ "${os}" = "osx" ]; then
       # Flags for OSX
       gappsWrapperArgs+=(
@@ -143,7 +132,6 @@ in
     fi
   '';
 
-  # Define la fase de desempacado condicionalmente
   unpackPhase = ''
     if [ "${os}" = "osx" ]; then
       echo "Unpacking on macOS using unzip..."
@@ -155,7 +143,6 @@ in
     fi
   '';
 
-
   installPhase = ''
       runHook preInstall
 
@@ -166,19 +153,14 @@ in
         cp -R * $out/share/nwjs
         find $out/share/nwjs
         mkdir -p $out/bin
-
-
         create_symlink() {
             ln -s $(lib.getLib systemd)/lib/libudev.so $out/share/nwjs/libudev.so.0
          }
          create_symlink
          ln -s $out/share/nwjs/nw $out/bin
-
          mkdir $out/lib
          ln -s $out/share/nwjs/lib/libnw.so $out/lib/libnw.so
-
        fi
-
        runHook postInstall
   '';
 

--- a/pkgs/development/tools/nwjs/default.nix
+++ b/pkgs/development/tools/nwjs/default.nix
@@ -38,9 +38,9 @@
 }:
 
 let
-  bits = if stdenv.hostPlatform.system == "x86_64-linux" then "x64"  else if stdenv.hostPlatform.system == "aarch64-darwin" then "arm64"  else "ia32";
-  os = if stdenv.hostPlatform.system == "aarch64-darwin"  then "osx" else "linux"; 
-  dlextension = if stdenv.hostPlatform.system == "aarch64-darwin"  then "zip" else "tar.gz"; 
+  bits = if stdenv.hostPlatform.system == "x86_64-linux" then "x64" else if stdenv.hostPlatform.system == "aarch64-darwin" then "arm64" else "ia32";
+  os = if stdenv.hostPlatform.system == "aarch64-darwin" then "osx" else "linux";
+  dlextension = if stdenv.hostPlatform.system == "aarch64-darwin" then "zip" else "tar.gz";
   flavor = if sdk then "sdk-" else "";
 
   nwEnvPaths = if os != "osx" then [
@@ -125,7 +125,7 @@ in
       gappsWrapperArgs+=(
           --add-flags "--ozone-platform-hint=auto"
         )
-    else 
+    else
       gappsWrapperArgs+=(
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
     )


### PR DESCRIPTION
## Description of changes

Minimal modifications to support NWJs package for OSX with ARM cpu

Changelog:
========

pkgs/development/tools/nwjs/default.nix

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
