### PR TITLE
fabulous: add assertions patch for python 3.12

### DIFF
--- a/pkgs/development/python-modules/fabulous/assert.patch
+++ b/pkgs/development/python-modules/fabulous/assert.patch
@@ -1,0 +1,54 @@
+diff --git a/tests/casts_test.py b/tests/casts_test.py
+index 8146e94..b8c6674 100755
+--- a/tests/casts_test.py
++++ b/tests/casts_test.py
+@@ -21,15 +21,15 @@ from fabulous import casts
+ class TestControl(unittest.TestCase):
+ 
+     def test_casts_yes_no(self):
+-        self.failUnlessEqual(casts.yes_no('y'), True)
+-        self.failUnlessEqual(casts.yes_no('n'), False)
+-        self.failUnlessEqual(casts.yes_no('Yes'), True)
+-        self.failUnlessEqual(casts.yes_no('nO'), False)
+-        self.failUnlessRaises(ValueError, casts.yes_no, 'spam')
++        self.assertEqual(casts.yes_no('y'), True)
++        self.assertEqual(casts.yes_no('n'), False)
++        self.assertEqual(casts.yes_no('Yes'), True)
++        self.assertEqual(casts.yes_no('nO'), False)
++        self.assertRaises(ValueError, casts.yes_no, 'spam')
+         
+     def test_casts_file(self):
+-        self.failUnlessEqual( type(casts.file(__file__)), type(open(__file__)) )
+-        self.failUnlessRaises(ValueError, casts.file, '')
++        self.assertEqual( type(casts.file(__file__)), type(open(__file__)) )
++        self.assertRaises(ValueError, casts.file, '')
+         
+ 
+ if __name__ == '__main__':
+diff --git a/tests/rlcomplete_test.py b/tests/rlcomplete_test.py
+index 4f19b1d..c665a9f 100755
+--- a/tests/rlcomplete_test.py
++++ b/tests/rlcomplete_test.py
+@@ -21,16 +21,16 @@ class TestControl(unittest.TestCase):
+ 
+     def test_ListCompleter(self):
+         c = rlcomplete.ListCompleter(['foo','bar','baz'], True)
+-        self.failUnlessEqual(c.completelist('a'), [])
+-        self.failUnlessEqual(c.completelist('B'), ['bar','baz'])
+-        self.failUnlessEqual(c.completelist('f'), ['foo'])
++        self.assertEqual(c.completelist('a'), [])
++        self.assertEqual(c.completelist('B'), ['bar','baz'])
++        self.assertEqual(c.completelist('f'), ['foo'])
+         c = rlcomplete.ListCompleter(['foo','bar','baz'], False)
+-        self.failUnlessEqual(c.completelist('B'), [])
+-        self.failUnlessEqual(c.completelist('b'), ['bar','baz'])
++        self.assertEqual(c.completelist('B'), [])
++        self.assertEqual(c.completelist('b'), ['bar','baz'])
+ 
+     def test_PathCompleter(self):
+         #c = rlcomplete.PathCompleter()
+-        #self.failUnlessEqual(c.completelist('m'), ['manual/'])
++        #self.assertEqual(c.completelist('m'), ['manual/'])
+         pass
+         
+ if __name__ == '__main__':

--- a/pkgs/development/python-modules/fabulous/default.nix
+++ b/pkgs/development/python-modules/fabulous/default.nix
@@ -18,7 +18,10 @@ buildPythonPackage rec {
     hash = "sha256-hchlxuB5QP+VxCx+QZ2739/mR5SQmYyE+9kXLKJ2ij4=";
   };
 
-  patches = [ ./relative_import.patch ];
+  patches = [
+    ./relative_import.patch
+    ./assert.patch
+  ];
 
   propagatedBuildInputs = [ pillow ];
 


### PR DESCRIPTION
## Description of changes

@symphorien 

Added a patch to the python fabulous package that replaces removed assertion `failUnless*` aliases with their canonical `assert*` names.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
