### PR TITLE
vimPluginsUpdater: allow development with `nix develop`

### DIFF
--- a/maintainers/scripts/pluginupdate.py
+++ b/maintainers/scripts/pluginupdate.py
@@ -142,7 +142,7 @@ class Repo:
         return loaded
 
     def prefetch(self, ref: Optional[str]) -> str:
-        print("Prefetching")
+        print("Prefetching %s", self.uri)
         loaded = self._prefetch(ref)
         return loaded["sha256"]
 
@@ -266,6 +266,7 @@ class PluginDesc:
 
     @staticmethod
     def load_from_csv(config: FetchConfig, row: Dict[str, str]) -> "PluginDesc":
+        log.debug("Loading row %s", row)
         branch = row["branch"]
         repo = make_repo(row["repo"], branch.strip())
         repo.token = config.github_token
@@ -328,7 +329,7 @@ def load_plugins_from_csv(
 
 
 
-def run_nix_expr(expr, nixpkgs: str):
+def run_nix_expr(expr, nixpkgs: str, **args):
     '''
     :param expr nix expression to fetch current plugins
     :param nixpkgs Path towards a nixpkgs checkout
@@ -347,7 +348,7 @@ def run_nix_expr(expr, nixpkgs: str):
             nix_path,
         ]
         log.debug("Running command: %s", " ".join(cmd))
-        out = subprocess.check_output(cmd, timeout=90)
+        out = subprocess.check_output(cmd, **args)
         data = json.loads(out)
         return data
 
@@ -736,6 +737,7 @@ def rewrite_input(
     redirects: Redirects = {},
     append: List[PluginDesc] = [],
 ):
+    log.info("Rewriting input file %s", input_file)
     plugins = load_plugins_from_csv(
         config,
         input_file,
@@ -744,10 +746,14 @@ def rewrite_input(
     plugins.extend(append)
 
     if redirects:
+        log.debug("Dealing with deprecated plugins listed in %s", deprecated)
+
         cur_date_iso = datetime.now().strftime("%Y-%m-%d")
         with open(deprecated, "r") as f:
             deprecations = json.load(f)
+        # TODO parallelize this step
         for pdesc, new_repo in redirects.items():
+            log.info("Rewriting input file %s", input_file)
             new_pdesc = PluginDesc(new_repo, pdesc.branch, pdesc.alias)
             old_plugin, _ = prefetch_plugin(pdesc)
             new_plugin, _ = prefetch_plugin(new_pdesc)
@@ -791,7 +797,7 @@ def update_plugins(editor: Editor, args):
     start_time = time.time()
     redirects = update()
     duration = time.time() - start_time
-    print(f"The plugin update took {duration}s.")
+    print(f"The plugin update took {duration:.2f}s.")
     editor.rewrite_input(fetch_config, args.input_file, editor.deprecated, redirects)
 
     autocommit = not args.no_commit

--- a/pkgs/applications/editors/vim/plugins/updater.nix
+++ b/pkgs/applications/editors/vim/plugins/updater.nix
@@ -7,13 +7,13 @@
 , nurl
 
 # optional
-, vimPlugins
-, neovim
+, neovim-unwrapped
 }:
 buildPythonApplication {
-  format = "other";
   pname = "vim-plugins-updater";
   version = "0.1";
+
+  format = "other";
 
   nativeBuildInputs = [
     makeWrapper
@@ -29,15 +29,17 @@ buildPythonApplication {
   installPhase = ''
     mkdir -p $out/bin $out/lib
     cp ${./update.py} $out/bin/vim-plugins-updater
-    cp ${./get-plugins.nix} $out/get-plugins.nix
-    cp ${./nvim-treesitter/update.py} $out/lib/treesitter.py
-    cp ${../../../../../maintainers/scripts/pluginupdate.py} $out/lib/pluginupdate.py
+    cp ${./get-plugins.nix} $out/bin/get-plugins.nix
 
     # wrap python scripts
     makeWrapperArgs+=( --prefix PATH : "${lib.makeBinPath [
-      nix nix-prefetch-git neovim nurl ]}" --prefix PYTHONPATH : "$out/lib" )
+      nix nix-prefetch-git neovim-unwrapped nurl ]}" --prefix PYTHONPATH : "${./.}:${../../../../../maintainers/scripts}" )
     wrapPythonPrograms
   '';
+
+  shellHook = ''
+    export PYTHONPATH=pkgs/applications/editors/vim/plugins:maintainers/scripts:$PYTHONPATH
+    '';
 
   meta.mainProgram = "vim-plugins-updater";
 }

--- a/pkgs/development/lua-modules/updater/updater.py
+++ b/pkgs/development/lua-modules/updater/updater.py
@@ -177,7 +177,7 @@ def generate_pkg_nix(plug: LuaPlugin):
                 "'version' and 'ref' will be ignored as the rockspec is hardcoded for package %s"
                 % plug.name
             )
-            log.warn(msg)
+            log.warning(msg)
 
         log.debug("Updating from rockspec %s", plug.rockspec)
         cmd.append(plug.rockspec)


### PR DESCRIPTION
## Description of changes

`nix develop .#vimPluginsUpdater` now lets you enter a shell where you can run `pkgs/applications/editors/vim/plugins/update.py` and iteratively develop !

- removed `warn` warning from python by using `warning` instead
- `plugin2nix` was calling the same bit of code over and over thus slowing down the generator by a lot. I now run only it once so the initial part takes 60sec (from I dunno but seemed like it was 200s before)

I noticed that the slow part now is the "redirect" thing because it's not parallelized, in case you wanna have a look @GaetanLepage 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

When trying to run this, I got the seemingly unrelated:
```
pkgs/applications/editors/vim/plugins/generated.nix
committing to nixpkgs "vimPlugins: update on 2024-07-14"
path is '/nix/store/x0z1frzrzm44zly6b3dzw7mpckbgzsd6-d36f722f114dfdafc8098496e9b5dcbd9f8fc3e8.tar.gz'
1464 plugins were checked
updated pkgs/applications/editors/vim/plugins/generated.nix
committing to nixpkgs "vimPlugins: resolve github repository redirects"
updating nvim-treesitter grammars
note: keeping build directory '/tmp/nix-build-source.drv-0/build'
error: hash mismatch in fixed-output derivation '/nix/store/wz4h3p9wwvirm3i2rf2dq5kbh025qba5-source.drv':
         specified: sha256-m7iG9evG/zYeqv9pKEMCBLBSWGCP4FGAHudGXIiu594=
            got:    sha256-l2niYYNNlGoqHioXOQd0vPmGWDSRHwFckSeAJZjOxS0=
```



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
