### PR TITLE
paperwork: unbreak

### DIFF
--- a/pkgs/development/python-modules/fabulous/default.nix
+++ b/pkgs/development/python-modules/fabulous/default.nix
@@ -2,14 +2,16 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
   pillow,
+  setuptools,
   python,
 }:
 
 buildPythonPackage rec {
   pname = "fabulous";
   version = "0.4.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jart";
@@ -18,9 +20,18 @@ buildPythonPackage rec {
     hash = "sha256-hchlxuB5QP+VxCx+QZ2739/mR5SQmYyE+9kXLKJ2ij4=";
   };
 
-  patches = [ ./relative_import.patch ];
+  patches = [
+    ./relative_import.patch
+    # https://github.com/jart/fabulous/pull/22
+    (fetchpatch2 {
+      url = "https://github.com/jart/fabulous/commit/5779f2dfbc88fd81b5b5865247913d4775e67959.patch?full_index=1";
+      hash = "sha256-miWFt4vDpwWhSUgnWDjWUXoibijcDa1c1dDOSkfWoUg=";
+    })
+  ];
 
-  propagatedBuildInputs = [ pillow ];
+  build-system = [ setuptools ];
+
+  dependencies = [ pillow ];
 
   checkPhase = ''
     for i in tests/*.py; do
@@ -28,10 +39,10 @@ buildPythonPackage rec {
     done
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Make the output of terminal applications look fabulous";
     homepage = "https://jart.github.io/fabulous";
-    license = licenses.asl20;
-    maintainers = [ maintainers.symphorien ];
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.symphorien ];
   };
 }

--- a/pkgs/development/python-modules/pypillowfight/default.nix
+++ b/pkgs/development/python-modules/pypillowfight/default.nix
@@ -2,44 +2,39 @@
   lib,
   buildPythonPackage,
   fetchFromGitLab,
-  nose,
   pillow,
-  isPy3k,
-  isPyPy,
+  pytestCheckHook,
+  setuptools,
 }:
 buildPythonPackage rec {
   pname = "pypillowfight";
-  version = "0.3.0";
-  format = "setuptools";
+  version = "0.3.0-unstable-2024-07-07";
+  pyproject = true;
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     group = "World";
     owner = "OpenPaperwork";
     repo = "libpillowfight";
-    rev = version;
-    sha256 = "096242v425mlqqj5g1giy59p7grxp05g78w6bk37vzph98jrgv3w";
+    # Currently no tagged release past 0.3.0 and we need these patches to fix Python 3.12 compat
+    rev = "4d5f739b725530cd61e709071d31e9f707c64bd6";
+    hash = "sha256-o5FzUSDq0lwkXGXRMsS5NB/Mp4Ie833wkxKPziR23f4=";
   };
 
   prePatch = ''
     echo '#define INTERNAL_PILLOWFIGHT_VERSION "${version}"' > src/pillowfight/_version.h
   '';
 
-  # Disable tests because they're designed to only work on Debian:
-  # https://github.com/jflesch/libpillowfight/issues/2#issuecomment-268259174
-  doCheck = false;
+  build-system = [ setuptools ];
 
-  # Python 2.x is not supported, see:
-  # https://github.com/jflesch/libpillowfight/issues/1
-  disabled = !isPy3k && !isPyPy;
+  dependencies = [ pillow ];
 
-  # This is needed by setup.py regardless of whether tests are enabled.
-  buildInputs = [ nose ];
-  propagatedBuildInputs = [ pillow ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
-  meta = with lib; {
+  meta = {
     description = "Library containing various image processing algorithms";
     inherit (src.meta) homepage;
-    license = licenses.gpl3Plus;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ pyrox0 ];
   };
 }


### PR DESCRIPTION
## Description of changes
As reported [here](https://github.com/NixOS/nixpkgs/issues/326513#issuecomment-2227482251), `paperwork` was broken due to both `pypillowfight` and `fabulous` being broken. This fixes both of them, by:
- Updating `pypillowfight` to a recent commit that removes nose tests, allowing it to work on recent python versions. The tests also pass now, so there's no reason to have `doCheck = false;` now.
- Adds a patch(also submitted upstream) to fabulous that unbreaks its tests, as it was using deprecated and now-removed function aliases from python's unittest library.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
