### PR TITLE
flameshot: 12.1.0 -> 12.1.0-unstable-2024-07-02; allow enabling wlroots support

### DIFF
--- a/pkgs/by-name/fl/flameshot/package.nix
+++ b/pkgs/by-name/fl/flameshot/package.nix
@@ -7,23 +7,24 @@
 , fetchpatch
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "flameshot";
-  version = "12.1.0";
+  version = "12.1.0-unstable-2024-07-02";
 
   src = fetchFromGitHub {
     owner = "flameshot-org";
     repo = "flameshot";
-    rev = "v12.1.0";
-    sha256 = "sha256-omyMN8d+g1uYsEw41KmpJCwOmVWLokEfbW19vIvG79w=";
+    rev = "ccb5a27b136a633911b3b1006185530d9beeea5d";
+    hash = "sha256-JIXsdVUR/4183aJ0gvNGYPTyCzX7tCrk8vRtR8bcdhE=";
   };
 
   patches = [
     # https://github.com/flameshot-org/flameshot/pull/3166
+    # fixes fractional scaling calculations on wayland
     (fetchpatch {
       name = "10-fix-wayland.patch";
       url = "https://github.com/flameshot-org/flameshot/commit/5fea9144501f7024344d6f29c480b000b2dcd5a6.patch";
-      sha256 = "sha256-SnjVbFMDKD070vR4vGYrwLw6scZAFaQA4b+MbI+0W9E=";
+      hash = "sha256-SnjVbFMDKD070vR4vGYrwLw6scZAFaQA4b+MbI+0W9E=";
     })
   ];
 

--- a/pkgs/by-name/fl/flameshot/package.nix
+++ b/pkgs/by-name/fl/flameshot/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "flameshot-org";
     repo = "flameshot";
-    rev = "v${version}";
+    rev = "v12.1.0";
     sha256 = "sha256-omyMN8d+g1uYsEw41KmpJCwOmVWLokEfbW19vIvG79w=";
   };
 
@@ -28,7 +28,9 @@ stdenv.mkDerivation rec {
   ];
 
   passthru = {
-    updateScript = nix-update-script { };
+    updateScript = nix-update-script {
+      extraArgs = [ "--version=branch" ];
+    };
   };
 
   cmakeFlags = [

--- a/pkgs/by-name/fl/flameshot/package.nix
+++ b/pkgs/by-name/fl/flameshot/package.nix
@@ -1,16 +1,13 @@
-{ mkDerivation
+{ libsForQt5
+, stdenv
 , lib
 , fetchFromGitHub
-, qtbase
 , cmake
-, qttools
-, qtsvg
 , nix-update-script
 , fetchpatch
-, kguiaddons
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "flameshot";
   version = "12.1.0";
 
@@ -38,8 +35,17 @@ mkDerivation rec {
     (lib.cmakeBool "USE_WAYLAND_CLIPBOARD" true)
   ];
 
-  nativeBuildInputs = [ cmake qttools qtsvg ];
-  buildInputs = [ qtbase kguiaddons ];
+  nativeBuildInputs = [
+    cmake
+    libsForQt5.qttools
+    libsForQt5.qtsvg
+    libsForQt5.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    libsForQt5.qtbase
+    libsForQt5.kguiaddons
+  ];
 
   meta = with lib; {
     description = "Powerful yet simple to use screenshot software";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30692,8 +30692,6 @@ with pkgs;
 
   redoflacs = callPackage ../applications/audio/redoflacs { };
 
-  flameshot = libsForQt5.callPackage ../tools/misc/flameshot { };
-
   flex-ncat = callPackage ../applications/radio/flex-ncat { };
 
   flex-ndax = callPackage ../applications/radio/flex-ndax { };


### PR DESCRIPTION
## Description of changes

- **flameshot: move to by-name**
- **flameshot: use unstable version in update script**
- **flameshot: 12.1.0 -> 12.1.0-unstable-2024-07-02**
- **flameshot: add flag for wlr support**
  - disabled by default
  - fixes #292700
  - fixes nix-community/home-manager#4187
  - requires using `(pkgs.flameshot.override { enableWlrSupport = true; })` in config
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
