### PR TITLE
mk-python-derivation: don't expose check args when doCheck = false

### DIFF
--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -62,7 +62,7 @@ let
 
   cleanAttrs = lib.flip removeAttrs [
     "disabled" "checkPhase" "checkInputs" "nativeCheckInputs" "doCheck" "doInstallCheck" "dontWrapPythonPrograms" "catchConflicts" "pyproject" "format"
-    "disabledTestPaths" "outputs" "stdenv"
+    "disabledTestPaths" "disabledTests" "pytestFlagsArray" "unittestFlagsArray" "outputs" "stdenv"
     "dependencies" "optional-dependencies" "build-system"
   ];
 
@@ -342,9 +342,19 @@ let
     # If given use the specified checkPhase, otherwise use the setup hook.
     # Longer-term we should get rid of `checkPhase` and use `installCheckPhase`.
     installCheckPhase = attrs.checkPhase;
-  } //  optionalAttrs (disabledTestPaths != []) {
+  } // optionalAttrs (attrs.doCheck or true) (
+    optionalAttrs (disabledTestPaths != []) {
       disabledTestPaths = escapeShellArgs disabledTestPaths;
-  }));
+    } // optionalAttrs (attrs ? disabledTests) {
+      # `escapeShellArgs` should be used as well as `disabledTestPaths`,
+      # but some packages rely on existing raw strings.
+      disabledTests = attrs.disabledTests;
+    } // optionalAttrs (attrs ? pytestFlagsArray) {
+      pytestFlagsArray = attrs.pytestFlagsArray;
+    } // optionalAttrs (attrs ? unittestFlagsArray) {
+      unittestFlagsArray = attrs.unittestFlagsArray;
+    }
+  )));
 
 in extendDerivation
   (disabled -> throw "${name} not supported for interpreter ${python.executable}")


### PR DESCRIPTION
## Description of changes

This change prevents rebuilds if we change check flags when doCheck = false. It's useful, for example, when tests are separated in `passthru.tests`.

Perhaps this concern will be addressed.
https://github.com/NixOS/nixpkgs/pull/272177#discussion_r1495523532

Note: This PR should target staging, but I'm targeting master to reduce rebuilds during the review.

### before

get caches from cache.nixos.org (no rebuild)
```
nix-build -E 'with import <nixpkgs> { }; python312Packages.sudachipy' -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/4530ffc439786922b453390f23db14923abd8a08.tar.gz
```

rebuild `sudachipy` even though pytest is not run
```
nix-build -E 'with import <nixpkgs> { }; python312Packages.sudachipy.overrideAttrs (_: { pytestFlagsArray = [ "-vv" ]; })' -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/4530ffc439786922b453390f23db14923abd8a08.tar.gz
```

### after

rebuild `sudachipy` with some dependencies
```
nix-build -E 'with import <nixpkgs> { }; python312Packages.sudachipy' -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/d15b1126bfa4fb929ebf97a927d3ae1bc34f27ab.tar.gz
```

No rebuild even if overridden to add `pytestFlagsArray`.
```
nix-build -E 'with import <nixpkgs> { }; python312Packages.sudachipy.overrideAttrs (_: { pytestFlagsArray = [ "-vv" ]; })' -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/d15b1126bfa4fb929ebf97a927d3ae1bc34f27ab.tar.gz
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
