### PR TITLE
zoom-us: fixup ZoomWebviewHost cannot launch

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -158,7 +158,7 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/share/applications/Zoom.desktop \
         --replace "Exec=/usr/bin/zoom" "Exec=$out/bin/zoom"
 
-    for i in aomhost zopen zoom ZoomLauncher; do
+    for i in aomhost zopen zoom ZoomLauncher ZoomWebviewHost; do
       patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/opt/zoom/$i
     done
 
@@ -166,6 +166,10 @@ stdenv.mkDerivation rec {
     # IPC breaks if the executable name does not end in 'zoom'
     mv $out/opt/zoom/zoom $out/opt/zoom/.zoom
     makeWrapper $out/opt/zoom/.zoom $out/opt/zoom/zoom \
+      --prefix LD_LIBRARY_PATH ":" ${libs}
+
+    mv $out/opt/zoom/ZoomWebviewHost $out/opt/zoom/.ZoomWebviewHost
+    makeWrapper $out/opt/zoom/.ZoomWebviewHost $out/opt/zoom/ZoomWebviewHost \
       --prefix LD_LIBRARY_PATH ":" ${libs}
 
     rm $out/bin/zoom


### PR DESCRIPTION
## Description of changes

When launch zoom, the `ZoomWebviewHost` cannot launched:
```
loadZoomWebviewHostProcess newPath is /nix/store/gfch2yy2j0fazxkdnsgcd77byl1bsx3b-zoom-6.1.1.443/opt/zoom/ZoomWebviewHost
loadZoomWebviewHostProcess libpath is /nix/store/gfch2yy2j0fazxkdnsgcd77byl1bsx3b-zoom-6.1.1.443/opt/zoom/Qt/lib:/nix/store/gfch2yy2j0fazxkdnsgcd77byl1bsx3b-zoom-6.1.1.443/opt/zoom/cef:/nix/store/gfch2yy2j0fazxkdnsgcd77byl1bsx3b-zoom-6.1.1.443/opt/zoom
Start subprocess: /nix/store/gfch2yy2j0fazxkdnsgcd77byl1bsx3b-zoom-6.1.1.443/opt/zoom/ZoomWebviewHost sucessfully,  process pid: 2759438 
Could not start dynamically linked executable: /nix/store/gfch2yy2j0fazxkdnsgcd77byl1bsx3b-zoom-6.1.1.443/opt/zoom/ZoomWebviewHost
NixOS cannot run dynamically linked executables intended for generic
linux environments out of the box. For more information, see:
https://nix.dev/permalink/stub-ld
```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

make a Wrapper of `ZoomWebviewHost`

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
