### PR TITLE
networkd-notify: fix gobject-introspection typelib lookup

### DIFF
--- a/pkgs/tools/networking/networkd-notify/default.nix
+++ b/pkgs/tools/networking/networkd-notify/default.nix
@@ -5,6 +5,7 @@
 , pygobject3
 , systemd
 , wirelesstools
+, wrapGAppsNoGuiHook
 }:
 
 buildPythonApplication rec {
@@ -20,6 +21,9 @@ buildPythonApplication rec {
     hash = "sha256-fanP1EWERT2Jy4OnMo8OMdR9flginYUgMw+XgmDve3o=";
   };
 
+  nativeBuildInputs = [
+    wrapGAppsNoGuiHook
+  ];
   propagatedBuildInputs = [
     dbus-python
     pygobject3
@@ -37,6 +41,13 @@ buildPythonApplication rec {
   installPhase = ''
     install -D networkd-notify -t "$out/bin/"
     install -D -m0644 networkd-notify.desktop -t "$out/share/applications/"
+  '';
+
+  # Let the Python wrapper add gappsWrapperArgs, to avoid two layers of wrapping.
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
 
   meta = with lib; {

--- a/pkgs/tools/networking/networkd-notify/default.nix
+++ b/pkgs/tools/networking/networkd-notify/default.nix
@@ -24,6 +24,7 @@ buildPythonApplication rec {
   nativeBuildInputs = [
     wrapGAppsNoGuiHook
   ];
+
   propagatedBuildInputs = [
     dbus-python
     pygobject3


### PR DESCRIPTION
## Description of changes

Similar to PR #309377, PR #310514, etc. Use wrapGAppsNoGuiHook to let gobject-introspection find the GLib typelib. Otherwise networkd-notify crashes like this:

    Traceback (most recent call last):
      File "/nix/store/7rh628ajc4f0jlrwk3pnm43s7nk8pgg9-networkd-notify-unstable-2022-11-29/bin/.networkd-notify-wrapped", line 14, in <module>
        from gi.repository import GLib as glib
      File "/nix/store/0x1rkqvaiddldc1si8wjwphz7wbny269-python3.11-pygobject-3.48.2/lib/python3.11/site-packages/gi/importer.py", line 133, in create_module
        raise ImportError('cannot import name %s, '
    ImportError: cannot import name GLib, introspection typelib not found
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- ~For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~
  - ~[ ] `sandbox = relaxed`~
  - ~[ ] `sandbox = true`~
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - ~[ ] (Package updates) Added a release notes entry if the change is major or breaking~
  - ~[ ] (Module updates) Added a release notes entry if the change is significant~
  - ~[ ] (Module addition) Added a release notes entry if adding a new NixOS module~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
