### PR TITLE
downonspot: unstable-2024-04-30 -> 0.5.0

### DIFF
--- a/pkgs/by-name/do/downonspot/Cargo.lock.patch
+++ b/pkgs/by-name/do/downonspot/Cargo.lock.patch
@@ -1,8 +1,8 @@
 diff --git a/Cargo.lock b/Cargo.lock
-index e6f1267..3bf16a5 100644
+index cccafd9..75d2a85 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -1632,7 +1632,8 @@ dependencies = [
+@@ -1655,7 +1655,8 @@ dependencies = [
  [[package]]
  name = "librespot"
  version = "0.4.2"
@@ -12,7 +12,7 @@ index e6f1267..3bf16a5 100644
  dependencies = [
   "base64 0.13.1",
   "env_logger",
-@@ -1658,7 +1659,8 @@ dependencies = [
+@@ -1681,7 +1682,8 @@ dependencies = [
  [[package]]
  name = "librespot-audio"
  version = "0.4.2"
@@ -22,7 +22,7 @@ index e6f1267..3bf16a5 100644
  dependencies = [
   "aes-ctr",
   "byteorder",
-@@ -1673,7 +1675,8 @@ dependencies = [
+@@ -1696,7 +1698,8 @@ dependencies = [
  [[package]]
  name = "librespot-connect"
  version = "0.4.2"
@@ -32,7 +32,7 @@ index e6f1267..3bf16a5 100644
  dependencies = [
   "form_urlencoded",
   "futures-util",
-@@ -1693,7 +1696,8 @@ dependencies = [
+@@ -1716,7 +1719,8 @@ dependencies = [
  [[package]]
  name = "librespot-core"
  version = "0.4.2"
@@ -42,7 +42,7 @@ index e6f1267..3bf16a5 100644
  dependencies = [
   "aes",
   "base64 0.13.1",
-@@ -1733,7 +1737,8 @@ dependencies = [
+@@ -1756,7 +1760,8 @@ dependencies = [
  [[package]]
  name = "librespot-discovery"
  version = "0.4.2"
@@ -52,7 +52,7 @@ index e6f1267..3bf16a5 100644
  dependencies = [
   "aes-ctr",
   "base64 0.13.1",
-@@ -1754,7 +1759,8 @@ dependencies = [
+@@ -1777,7 +1782,8 @@ dependencies = [
  [[package]]
  name = "librespot-metadata"
  version = "0.4.2"
@@ -62,7 +62,7 @@ index e6f1267..3bf16a5 100644
  dependencies = [
   "async-trait",
   "byteorder",
-@@ -1767,7 +1773,8 @@ dependencies = [
+@@ -1790,7 +1796,8 @@ dependencies = [
  [[package]]
  name = "librespot-playback"
  version = "0.4.2"
@@ -72,7 +72,7 @@ index e6f1267..3bf16a5 100644
  dependencies = [
   "byteorder",
   "cpal",
-@@ -1792,7 +1799,8 @@ dependencies = [
+@@ -1815,7 +1822,8 @@ dependencies = [
  [[package]]
  name = "librespot-protocol"
  version = "0.4.2"
@@ -83,15 +83,15 @@ index e6f1267..3bf16a5 100644
   "glob",
   "protobuf 2.28.0",
 diff --git a/Cargo.toml b/Cargo.toml
-index 40ca2c1..734a3fb 100644
+index c7e2fe2..28e895a 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -29,7 +29,7 @@ reqwest = "0.11"
+@@ -30,7 +30,7 @@ reqwest = "0"
  colored = "2"
- lame = "0.1"
- aspotify = "0.7.1"
+ lame = "0"
+ aspotify = "0"
 -librespot = { git = "ssh://git@github.com/oSumAtrIX/free-librespot.git" }
 +librespot = "0.4.2"
- async-std = { version = "1.12", features = ["attributes", "tokio1"] }
- serde_json = "1.0"
- async-stream = "0.3"
+ async-std = { version = "1", features = ["attributes", "tokio1"] }
+ serde_json = "1"
+ async-stream = "0"

--- a/pkgs/by-name/do/downonspot/package.nix
+++ b/pkgs/by-name/do/downonspot/package.nix
@@ -10,19 +10,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "downonspot";
-  version = "unstable-2024-04-30";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "oSumAtrIX";
     repo = "DownOnSpot";
-    rev = "669dbb18e105129fff4886ba3710596d54a5f33a";
-    hash = "sha256-sUptn+tmQoI2i9WBpJU23MkdQ9h+Lmx590+2+0XXC7w=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-PA11R/hVAmismayE8uU03P0eeNnrgpD2HxbMW0vlk3k=";
   };
 
   # Use official public librespot version
   cargoPatches = [ ./Cargo.lock.patch ];
 
-  cargoHash = "sha256-GHhijwgTge7jzdkn0qynQIBNYeqtY26C5BaLpQ/UWgQ=";
+  cargoHash = "sha256-jdscYr4Emm2+mWXbxfhU1rp855tsGY5hrdJsDEfXeUo=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
## Description of changes

Changelog https://github.com/oSumAtrIX/DownOnSpot/releases/tag/v0.5.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
