### PR TITLE
argyllcms: refactor and fix build on darwin

### DIFF
--- a/pkgs/tools/graphics/argyllcms/default.nix
+++ b/pkgs/tools/graphics/argyllcms/default.nix
@@ -1,7 +1,26 @@
-{ stdenv, fetchzip, jam, unzip, libX11, libXxf86vm, libXrandr, libXinerama
-, libXrender, libXext, libtiff, libjpeg, libpng, libXScrnSaver, writeText
-, libXdmcp, libXau, lib, openssl
-, buildPackages, substituteAll, writeScript
+{
+  stdenv,
+  fetchzip,
+  jam,
+  unzip,
+  libX11,
+  libXxf86vm,
+  libXrandr,
+  libXinerama,
+  libXrender,
+  libXext,
+  libtiff,
+  libjpeg,
+  libpng,
+  libXScrnSaver,
+  writeText,
+  libXdmcp,
+  libXau,
+  lib,
+  openssl,
+  buildPackages,
+  substituteAll,
+  writeScript,
 }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +34,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-t2dvbYFHEz9IUYpcM5HqDju4ugHrD7seG3QxumspxDg=";
   };
 
-  nativeBuildInputs = [ jam unzip ];
+  nativeBuildInputs = [
+    jam
+    unzip
+  ];
 
   patches = lib.optional (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) (
     # Build process generates files by compiling and then invoking an executable.
@@ -30,93 +52,104 @@ stdenv.mkDerivation rec {
       --replace "-m64" ""
   '';
 
-  preConfigure = let
-    # The contents of this file comes from the Jamtop file from the
-    # root of the ArgyllCMS distribution, rewritten to pick up Nixpkgs
-    # library paths. When ArgyllCMS is updated, make sure that changes
-    # in that file is reflected here.
-    jamTop = writeText "argyllcms_jamtop" ''
-      DESTDIR = "/" ;
-      REFSUBDIR = "share/argyllcms" ;
+  preConfigure =
+    let
+      # The contents of this file comes from the Jamtop file from the
+      # root of the ArgyllCMS distribution, rewritten to pick up Nixpkgs
+      # library paths. When ArgyllCMS is updated, make sure that changes
+      # in that file is reflected here.
+      jamTop = writeText "argyllcms_jamtop" ''
+        DESTDIR = "/" ;
+        REFSUBDIR = "share/argyllcms" ;
 
-      # Keep this DESTDIR anchored to Jamtop. PREFIX is used literally
-      ANCHORED_PATH_VARS = DESTDIR ;
+        # Keep this DESTDIR anchored to Jamtop. PREFIX is used literally
+        ANCHORED_PATH_VARS = DESTDIR ;
 
-      # Tell standalone libraries that they are part of Argyll:
-      DEFINES += ARGYLLCMS ;
+        # Tell standalone libraries that they are part of Argyll:
+        DEFINES += ARGYLLCMS ;
 
-      # enable serial instruments & support
-      USE_SERIAL = true ;
+        # enable serial instruments & support
+        USE_SERIAL = true ;
 
-      # enable fast serial instruments & support
-      USE_FAST_SERIAL = true ;                # (Implicit in USE_SERIAL too)
+        # enable fast serial instruments & support
+        USE_FAST_SERIAL = true ;                # (Implicit in USE_SERIAL too)
 
-      # enable USB instruments & support
-      USE_USB = true ;
+        # enable USB instruments & support
+        USE_USB = true ;
 
-      # enable dummy Demo Instrument (only if code is available)
-      USE_DEMOINST = true ;
+        # enable dummy Demo Instrument (only if code is available)
+        USE_DEMOINST = true ;
 
-      # enable Video Test Patch Generator and 3DLUT device support
-      # (V2.0.0 and above)
-      USE_VTPGLUT = false ;
+        # enable Video Test Patch Generator and 3DLUT device support
+        # (V2.0.0 and above)
+        USE_VTPGLUT = false ;
 
-      # enable Printer device support
-      USE_PRINTER = false ;
+        # enable Printer device support
+        USE_PRINTER = false ;
 
-      # enable CMF Measurement device and accessory support (if present)
-      USE_CMFM = false ;
+        # enable CMF Measurement device and accessory support (if present)
+        USE_CMFM = false ;
 
-      # Use ArgyllCMS version of libusb (deprecated - don't use)
-      USE_LIBUSB = false ;
+        # Use ArgyllCMS version of libusb (deprecated - don't use)
+        USE_LIBUSB = false ;
 
-      # Compile in graph plotting code (Not fully implemented)
-      USE_PLOT = true ;		# [true]
+        # Compile in graph plotting code (Not fully implemented)
+        USE_PLOT = true ;		# [true]
 
-      JPEGLIB = ;
-      JPEGINC = ;
-      HAVE_JPEG = true ;
+        JPEGLIB = ;
+        JPEGINC = ;
+        HAVE_JPEG = true ;
 
-      TIFFLIB = ;
-      TIFFINC = ;
-      HAVE_TIFF = true ;
+        TIFFLIB = ;
+        TIFFINC = ;
+        HAVE_TIFF = true ;
 
-      PNGLIB = ;
-      PNGINC = ;
-      HAVE_PNG = true ;
+        PNGLIB = ;
+        PNGINC = ;
+        HAVE_PNG = true ;
 
-      ZLIB = ;
-      ZINC = ;
-      HAVE_Z = true ;
+        ZLIB = ;
+        ZINC = ;
+        HAVE_Z = true ;
 
-      SSLLIB = ;
-      SSLINC = ;
-      HAVE_SSL = true ;
+        SSLLIB = ;
+        SSLINC = ;
+        HAVE_SSL = true ;
 
-      LINKFLAGS +=
-        ${lib.concatStringsSep " " (map (x: "-L${x}/lib") buildInputs)}
-        -lrt -lX11 -lXext -lXxf86vm -lXinerama -lXrandr -lXau -lXdmcp -lXss
-        -ljpeg -ltiff -lpng -lssl ;
+        LINKFLAGS +=
+          ${lib.concatStringsSep " " (map (x: "-L${x}/lib") buildInputs)}
+          -lrt -lX11 -lXext -lXxf86vm -lXinerama -lXrandr -lXau -lXdmcp -lXss
+          -ljpeg -ltiff -lpng -lssl ;
+      '';
+    in
+    ''
+      cp ${jamTop} Jamtop
+      substituteInPlace Makefile --replace "-j 3" "-j $NIX_BUILD_CORES"
+      # Remove tiff, jpg and png to be sure the nixpkgs-provided ones are used
+      rm -rf tiff jpg png
+
+      export AR="$AR rusc"
     '';
-  in ''
-    cp ${jamTop} Jamtop
-    substituteInPlace Makefile --replace "-j 3" "-j $NIX_BUILD_CORES"
-    # Remove tiff, jpg and png to be sure the nixpkgs-provided ones are used
-    rm -rf tiff jpg png
-
-    export AR="$AR rusc"
-  '';
 
   buildInputs = [
-    libtiff libjpeg libpng libX11 libXxf86vm libXrandr libXinerama libXext
-    libXrender libXScrnSaver libXdmcp libXau openssl
+    libtiff
+    libjpeg
+    libpng
+    libX11
+    libXxf86vm
+    libXrandr
+    libXinerama
+    libXext
+    libXrender
+    libXScrnSaver
+    libXdmcp
+    libXau
+    openssl
   ];
 
   buildFlags = [ "all" ];
 
-  makeFlags = [
-    "PREFIX=${placeholder "out"}"
-  ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   # Install udev rules, but remove lines that set up the udev-acl
   # stuff, since that is handled by udev's own rules (70-udev-acl.rules)
@@ -148,7 +181,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.argyllcms.com/";
     description = "Color management system (compatible with ICC)";
     license = licenses.gpl3;
-    maintainers = [];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
## Description of changes

The goal is to make the build pass on `aarch64-darwin`.

- I replaced the not-so-maintainable complete replacement of `Jamtop` (it doesn't seem to be a very common build tool either) with some manual overrides at the end of it. If upstream changes some logic in `Jamtop`, there is most likely less (or none) maintenance on nixpkgs needed.
- I added the necessary libraries and flags for `darwin`.
- I now set also `DESTDIR` to be the derivation output, with an empty `PREFIX`. This produces the desired output, both in output and the logs (no double slashes, e.g. `//nix/store/...`).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
