### PR TITLE
birdtray: fix PATH handling, move to by-name

### DIFF
--- a/pkgs/by-name/bi/birdtray/package.nix
+++ b/pkgs/by-name/bi/birdtray/package.nix
@@ -4,6 +4,8 @@
 , cmake
 , pkg-config
 , libsForQt5
+, fetchpatch
+, thunderbird
 }:
 
 stdenv.mkDerivation rec {
@@ -27,6 +29,18 @@ stdenv.mkDerivation rec {
     libsForQt5.qtbase
     libsForQt5.qttools
     libsForQt5.qtx11extras
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "OPT_THUNDERBIRD_CMDLINE" "thunderbird") # get thunderbird from PATH
+  ];
+
+  patches = [
+    (fetchpatch {
+      name = "fix-path-handling.patch";
+      url = "https://github.com/gyunaev/birdtray/commit/54b304d92188429792c264b07ff45897699f2d3e.patch";
+      hash = "sha256-ME635Kt1b9RJKCqtAZBFa93OIA0u2Z4tWIlGcI374j0=";
+    })
   ];
 
   # Wayland support is broken.

--- a/pkgs/by-name/bi/birdtray/package.nix
+++ b/pkgs/by-name/bi/birdtray/package.nix
@@ -1,15 +1,12 @@
-{ mkDerivation
-  , lib
-  , fetchFromGitHub
-
-  , cmake
-  , pkg-config
-  , qtbase
-  , qttools
-  , qtx11extras
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libsForQt5
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "birdtray";
   version = "1.11.4";
 
@@ -20,9 +17,16 @@ mkDerivation rec {
     sha256 = "sha256-rj8tPzZzgW0hXmq8c1LiunIX1tO/tGAaqDGJgCQda5M=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    libsForQt5.wrapQtAppsHook
+  ];
+
   buildInputs = [
-    qtbase qttools qtx11extras
+    libsForQt5.qtbase
+    libsForQt5.qttools
+    libsForQt5.qtx11extras
   ];
 
   # Wayland support is broken.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4213,8 +4213,6 @@ with pkgs;
 
   binwalk = with python3Packages; toPythonApplication binwalk;
 
-  birdtray = libsForQt5.callPackage ../applications/misc/birdtray { };
-
   blitz = callPackage ../development/libraries/blitz { };
 
   blockbook = callPackage ../servers/blockbook { };


### PR DESCRIPTION
## Description of changes

- **birdtray: move to by-name**
- **birdtray: fix PATH handling**
  - fixes #291745
  - allows using `thunderbird` as the setting for the thunderbird binary, which will allow searching `PATH` for the binary
  - also wraps `birdtray` with `thunderbird`
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
