### PR TITLE
python312Packages.localstack: fix build

### DIFF
--- a/pkgs/development/python-modules/localstack/default.nix
+++ b/pkgs/development/python-modules/localstack/default.nix
@@ -4,8 +4,10 @@
   fetchFromGitHub,
   apispec,
   boto3,
+  build,
   cachetools,
   click,
+  cryptography,
   localstack-client,
   localstack-ext,
   plux,
@@ -22,7 +24,7 @@
 buildPythonPackage rec {
   pname = "localstack";
   version = "3.5.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "localstack";
@@ -31,18 +33,13 @@ buildPythonPackage rec {
     hash = "sha256-Sd5B4+pvUwNXfP3hsqBkUoHo06YyzUGCUHzc8f77Vx4=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "requests>=2.20.0,<2.26" "requests~=2.20" \
-      --replace "cachetools~=5.0.0" "cachetools~=5.0" \
-      --replace "boto3>=1.20,<1.25.0" "boto3~=1.20"
-  '';
-
-  propagatedBuildInputs = [
+  dependencies = [
     apispec
     boto3
+    build
     cachetools
     click
+    cryptography
     localstack-client
     localstack-ext
     plux
@@ -56,13 +53,20 @@ buildPythonPackage rec {
     tailer
   ];
 
+  pythonRelaxDeps = [ "dill" ];
+
   pythonImportsCheck = [ "localstack" ];
 
   # Test suite requires boto, which has been removed from nixpkgs
   # Just do minimal test, buildPythonPackage maps checkPhase
   # to installCheckPhase, so we can test that entrypoint point works.
   checkPhase = ''
+    runHook preCheck
+
+    export HOME=$(mktemp -d)
     $out/bin/localstack --version
+
+    runHook postCheck
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

https://github.com/NixOS/nixpkgs/pull/325560#issuecomment-2227333212

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
