### PR TITLE
linode-cli: 5.45.0 -> 5.50.0

### DIFF
--- a/pkgs/development/python-modules/linode-metadata/default.nix
+++ b/pkgs/development/python-modules/linode-metadata/default.nix
@@ -1,0 +1,44 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  httpx,
+  lib,
+  linode-cli,
+  pytest,
+  pytest-asyncio,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "linode-metadata";
+  version = "0.3.0";
+
+  src = fetchPypi {
+    pname = "linode_metadata";
+    inherit version;
+    hash = "sha256-ZFCv9f4hbiBaJuKvzs/BGFoP+mAFwVa8OFF22b22voI=";
+  };
+
+  pyproject = true;
+
+  dependencies = [
+    httpx
+    setuptools
+  ];
+
+  checkInputs = [
+    pytest
+    pytest-asyncio
+  ];
+
+  pythonImportsCheck = [ "linode_metadata" ];
+
+  meta = {
+    description = "Python package for interacting with the Linode Metadata Service";
+    downloadPage = "https://pypi.org/project/linode-metadata/";
+    homepage = "https://github.com/linode/py-metadata";
+    changelog = "https://github.com/linode/py-metadata/releases/tag/v${version}";
+    license = lib.licenses.bsd3;
+    maintainers = linode-cli.meta.maintainers;
+  };
+}

--- a/pkgs/tools/virtualization/linode-cli/default.nix
+++ b/pkgs/tools/virtualization/linode-cli/default.nix
@@ -71,7 +71,10 @@ buildPythonApplication rec {
 
   nativeBuildInputs = [ installShellFiles ];
   postInstall = ''
-    installShellCompletion --cmd linode-cli --bash <($out/bin/linode-cli --skip-config completion bash)
+    for shell in bash fish; do
+      installShellCompletion --cmd linode-cli \
+        --$shell <($out/bin/linode-cli --skip-config completion $shell)
+      done
   '';
 
   passthru.updateScript = ./update.sh;

--- a/pkgs/tools/virtualization/linode-cli/default.nix
+++ b/pkgs/tools/virtualization/linode-cli/default.nix
@@ -79,11 +79,12 @@ buildPythonApplication rec {
 
   passthru.updateScript = ./update.sh;
 
-  meta = with lib; {
-    mainProgram = "linode-cli";
+  meta = {
     description = "Linode Command Line Interface";
+    changelog = "https://github.com/linode/linode-cli/releases/tag/v${version}";
     homepage = "https://github.com/linode/linode-cli";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ ryantm techknowlogick ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ryantm techknowlogick ];
+    mainProgram = "linode-cli";
   };
 }

--- a/pkgs/tools/virtualization/linode-cli/default.nix
+++ b/pkgs/tools/virtualization/linode-cli/default.nix
@@ -1,17 +1,18 @@
-{ buildPythonApplication
-, colorclass
-, fetchPypi
-, fetchurl
-, installShellFiles
-, lib
-, linode-metadata
-, openapi3
-, packaging
-, pyyaml
-, requests
-, rich
-, setuptools
-, terminaltables
+{
+  buildPythonApplication,
+  colorclass,
+  fetchPypi,
+  fetchurl,
+  installShellFiles,
+  lib,
+  linode-metadata,
+  openapi3,
+  packaging,
+  pyyaml,
+  requests,
+  rich,
+  setuptools,
+  terminaltables,
 }:
 
 let
@@ -37,9 +38,7 @@ buildPythonApplication rec {
     hash = "sha256-OCnO7Bf2tDnC4g7kYS0WFlV9plAS25GbzRO6mpDYYxk=";
   };
 
-  patches = [
-    ./remove-update-check.patch
-  ];
+  patches = [ ./remove-update-check.patch ];
 
   # remove need for git history
   prePatch = ''
@@ -87,7 +86,10 @@ buildPythonApplication rec {
     downloadPage = "https://pypi.org/project/linode-cli";
     homepage = "https://github.com/linode/linode-cli";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ ryantm techknowlogick ];
+    maintainers = with lib.maintainers; [
+      ryantm
+      techknowlogick
+    ];
     mainProgram = "linode-cli";
   };
 }

--- a/pkgs/tools/virtualization/linode-cli/default.nix
+++ b/pkgs/tools/virtualization/linode-cli/default.nix
@@ -47,6 +47,14 @@ buildPythonApplication rec {
       --replace "version = get_version()" "version='${version}',"
   '';
 
+  postConfigure = ''
+    python3 -m linodecli bake ${spec} --skip-config
+    cp data-3 linodecli/
+    echo "${version}" > baked_version
+  '';
+
+  nativeBuildInputs = [ installShellFiles ];
+
   propagatedBuildInputs = [
     colorclass
     pyyaml
@@ -58,18 +66,11 @@ buildPythonApplication rec {
     packaging
   ];
 
-  postConfigure = ''
-    python3 -m linodecli bake ${spec} --skip-config
-    cp data-3 linodecli/
-    echo "${version}" > baked_version
-  '';
-
   doInstallCheck = true;
   installCheckPhase = ''
     $out/bin/linode-cli --skip-config --version | grep ${version} > /dev/null
   '';
 
-  nativeBuildInputs = [ installShellFiles ];
   postInstall = ''
     for shell in bash fish; do
       installShellCompletion --cmd linode-cli \

--- a/pkgs/tools/virtualization/linode-cli/default.nix
+++ b/pkgs/tools/virtualization/linode-cli/default.nix
@@ -1,23 +1,24 @@
-{ lib
-, fetchFromGitHub
-, fetchurl
-, buildPythonApplication
+{ buildPythonApplication
 , colorclass
+, fetchPypi
+, fetchurl
 , installShellFiles
-, pyyaml
-, requests
-, setuptools
-, terminaltables
-, rich
+, lib
+, linode-metadata
 , openapi3
 , packaging
+, pyyaml
+, requests
+, rich
+, setuptools
+, terminaltables
 }:
 
 let
-  hash = "sha256-J0L+FTVzYuAqTDOwpoH12lQr03UNo5dsQpd/iUKR40Q=";
+  hash = "sha256-IXltDBgabTBDw0y7IXgRGpAWVUyqeJI8EfxkZ5YuQrU=";
   # specVersion taken from: https://www.linode.com/docs/api/openapi.yaml at `info.version`.
-  specVersion = "4.166.0";
-  specHash = "sha256-rUwKQt3y/ALZUoW3eJiiIDJYLQpUHO7Abm0h09ra02g=";
+  specVersion = "4.176.0";
+  specHash = "sha256-P1E8Ga5ckrsw/CX0kxFef5fe8/p/pDCLuleX9wR5l48=";
   spec = fetchurl {
     url = "https://raw.githubusercontent.com/linode/linode-api-docs/v${specVersion}/openapi.yaml";
     hash = specHash;
@@ -27,14 +28,13 @@ in
 
 buildPythonApplication rec {
   pname = "linode-cli";
-  version = "5.45.0";
+  version = "5.50.0";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "linode";
-    repo = pname;
-    rev = "v${version}";
-    inherit hash;
+  src = fetchPypi {
+    pname = "linode_cli";
+    inherit version;
+    hash = "sha256-OCnO7Bf2tDnC4g7kYS0WFlV9plAS25GbzRO6mpDYYxk=";
   };
 
   patches = [
@@ -57,6 +57,7 @@ buildPythonApplication rec {
 
   propagatedBuildInputs = [
     colorclass
+    linode-metadata
     pyyaml
     requests
     setuptools
@@ -83,6 +84,7 @@ buildPythonApplication rec {
   meta = {
     description = "Linode Command Line Interface";
     changelog = "https://github.com/linode/linode-cli/releases/tag/v${version}";
+    downloadPage = "https://pypi.org/project/linode-cli";
     homepage = "https://github.com/linode/linode-cli";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ ryantm techknowlogick ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6996,6 +6996,8 @@ self: super: with self; {
 
   linode-api = callPackage ../development/python-modules/linode-api { };
 
+  linode-metadata = callPackage ../development/python-modules/linode-metadata { };
+
   linode = callPackage ../development/python-modules/linode { };
 
   linuxfd = callPackage ../development/python-modules/linuxfd { };


### PR DESCRIPTION
linode-cli: 5.45.0 -> 5.50.0

- python3Packages.linode-metadata: init at 0.3.0 (required for upgrade)
- add fish shell
- add changelog
- nixfmt
- refactor