### PR TITLE
scfbuild: fix runtime error on Python 3.12

### DIFF
--- a/pkgs/tools/misc/scfbuild/default.nix
+++ b/pkgs/tools/misc/scfbuild/default.nix
@@ -1,4 +1,13 @@
-{ lib, buildPythonApplication, fetchFromGitHub, python, pyyaml, fonttools, fontforge }:
+{
+  lib,
+  buildPythonApplication,
+  fetchFromGitHub,
+  python,
+  pyyaml,
+  fonttools,
+  fontforge,
+  setuptools,
+}:
 
 buildPythonApplication {
   pname = "scfbuild";
@@ -13,7 +22,12 @@ buildPythonApplication {
     sha256 = "0wkyzkhshlax9rvdmn441gv87n9abfr0qqmgs8bkg9kbcjb4bhad";
   };
 
-  propagatedBuildInputs = [ pyyaml fonttools fontforge ];
+  propagatedBuildInputs = [
+    pyyaml
+    fonttools
+    fontforge
+    setuptools
+  ];
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
## Description of changes

Error before fix:
```text
./result/bin/scfbuild
Traceback (most recent call last):
  File "/nix/store/s2awm6j1s0xpvbwn34702dizrn8hin25-scfbuild-2.0.0/bin/.scfbuild-wrapped", line 15, in <module>
    from scfbuild.main import main
  File "/nix/store/s2awm6j1s0xpvbwn34702dizrn8hin25-scfbuild-2.0.0/lib/python3.12/site-packages/scfbuild/main.py", line 18, in <module>
    from .builder import Builder
  File "/nix/store/s2awm6j1s0xpvbwn34702dizrn8hin25-scfbuild-2.0.0/lib/python3.12/site-packages/scfbuild/builder.py", line 14, in <module>
    from distutils.version import LooseVersion
ModuleNotFoundError: No module named 'distutils'
```

Fixes #326959 (build of `emojione` that depends on `scfbuild`)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
