### PR TITLE
chawan: 0-unstable-2024-03-01 -> 0-unstable-2024-07-14; set updateScript

### DIFF
--- a/pkgs/by-name/ch/chawan/mancha-augment-path.diff
+++ b/pkgs/by-name/ch/chawan/mancha-augment-path.diff
@@ -1,15 +1,13 @@
-Add the -m option to man's command line to augment the list of paths
-searched by man. The string "OUT" must be substituted with chawan's $out
-path after patching.
+Add the -m option to man's command line to augment the list of paths searched by man.
 The required -m option is only available in the mandoc implementation.
---- a/adapter/protocol/man
-+++ b/adapter/protocol/man
-@@ -75,7 +75,7 @@ EOF
+--- a/adapter/protocol/man.nim
++++ b/adapter/protocol/man.nim
+@@ -264,7 +264,7 @@ proc myOpen(cmd: string): tuple[ofile, efile: File] =
  
-   $section =~ s:([^-\w\200-\377.,])::g;
-   $man =~ s:([^-\w\200-\377.,])::g;
--  open(F, "GROFF_NO_SGR=1 MAN_KEEP_FORMATTING=1 $MAN $section $man 2> /dev/null |");
-+  open(F, "GROFF_NO_SGR=1 MAN_KEEP_FORMATTING=1 $MAN -m OUT/share/man $section $man 2> /dev/null |");
- }
- 
- $ok = 0;
+ proc doMan(man, keyword, section: string) =
+   let sectionOpt = if section == "": "" else: ' ' & quoteShellPosix(section)
+   let cmd = "MANCOLOR=1 GROFF_NO_SGR=1 MAN_KEEP_FORMATTING=1 " &
+-    man & sectionOpt & ' ' & quoteShellPosix(keyword)
++    man & sectionOpt & " -m @out@ " & quoteShellPosix(keyword)
+   let (ofile, efile) = myOpen(cmd)
+   if ofile == nil:

--- a/pkgs/by-name/ch/chawan/package.nix
+++ b/pkgs/by-name/ch/chawan/package.nix
@@ -10,6 +10,7 @@
 , perl
 , pkg-config
 , zlib
+, unstableGitUpdater
 }:
 
 stdenv.mkDerivation {
@@ -63,6 +64,8 @@ stdenv.mkDerivation {
     wrapProgram $out/bin/cha ${makeWrapperArgs}
     wrapProgram $out/bin/mancha ${makeWrapperArgs}
   '';
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     description = "Lightweight and featureful terminal web browser";

--- a/pkgs/by-name/ch/chawan/package.nix
+++ b/pkgs/by-name/ch/chawan/package.nix
@@ -7,34 +7,37 @@
 , ncurses
 , nim
 , pandoc
-, perl
 , pkg-config
 , zlib
 , unstableGitUpdater
+, libseccomp
+, substituteAll
 }:
 
 stdenv.mkDerivation {
   pname = "chawan";
-  version = "0-unstable-2024-03-01";
+  version = "0-unstable-2024-07-14";
 
   src = fetchFromSourcehut {
     owner = "~bptato";
     repo = "chawan";
-    rev = "87ba9a87be15abbe06837f1519cfb76f4bf759f3";
-    hash = "sha256-Xs+Mxe5/uoxPMf4FuelpO+bRJ1KdfASVI7rWqtboJZw=";
+    rev = "0e3d67f31df2c2d53aa0e578439852731e5f5af9";
+    hash = "sha256-eVoZisQyaebWO58a0a0KR7fwsL1kTmPX1SayqdnmSuk=";
     fetchSubmodules = true;
   };
 
   patches = [
     # Include chawan's man pages in mancha's search path
-    ./mancha-augment-path.diff
+    (substituteAll {
+      src = ./mancha-augment-path.diff;
+      out = placeholder "out";
+    })
   ];
 
   env.NIX_CFLAGS_COMPILE = toString (
     lib.optional stdenv.cc.isClang "-Wno-error=implicit-function-declaration"
   );
 
-  buildInputs = [ curlMinimal ncurses perl zlib ];
   nativeBuildInputs = [
     makeBinaryWrapper
     nim
@@ -42,10 +45,12 @@ stdenv.mkDerivation {
     pkg-config
   ];
 
-  postPatch = ''
-    substituteInPlace adapter/protocol/man \
-      --replace-fail "OUT" $out
-  '';
+  buildInputs = [
+    curlMinimal
+    libseccomp
+    ncurses
+    zlib
+  ];
 
   buildFlags = [ "all" "manpage" ];
   installFlags = [


### PR DESCRIPTION
## Description of changes

Set updateScript and run it.
Also, remove perl as it was used to generate the manpages via an older process - necessitating changing the patch as well.

Also fixes the build failure - fixes #327404 (highlighted also in https://github.com/NixOS/nixpkgs/pull/321092#issuecomment-2179961895)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
