### PR TITLE
revolver: init at 0.2.4-unstable-2020-09-30

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4686,6 +4686,11 @@
     githubId = 3179832;
     name = "D. Bohdan";
   };
+  d-brasher = {
+    github = "d-brasher";
+    githubId = 175485311;
+    name = "D. Brasher";
+  };
   dbrgn = {
     email = "nix@dbrgn.ch";
     github = "dbrgn";

--- a/pkgs/by-name/re/revolver/no-external-call.patch
+++ b/pkgs/by-name/re/revolver/no-external-call.patch
@@ -1,0 +1,16 @@
+Replace call to "revolver" with call to internal function.
+Useful when "revolver" is not defined in PATH.
+--- a/revolver
++++ b/revolver
+@@ -255,9 +255,9 @@
+ ###
+ function _revolver_demo() {
+   for style in "${(@k)_revolver_spinners[@]}"; do
+-    revolver --style $style start $style
++    _revolver --style $style start $style
+     sleep 2
+-    revolver stop
++    _revolver stop
+   done
+ }
+ 

--- a/pkgs/by-name/re/revolver/package.nix
+++ b/pkgs/by-name/re/revolver/package.nix
@@ -1,0 +1,94 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  zsh,
+  installShellFiles,
+  ncurses,
+  nix-update-script,
+  testers,
+  runCommand,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "revolver";
+  version = "0.2.4-unstable-2020-09-30";
+
+  src = fetchFromGitHub {
+    owner = "molovo";
+    repo = "revolver";
+    rev = "6424e6cb14da38dc5d7760573eb6ecb2438e9661";
+    hash = "sha256-2onqjtPIsgiEJj00oP5xXGkPZGQpGPVwcBOhmicqKcs=";
+  };
+
+  strictDeps = true;
+  doInstallCheck = true;
+
+  nativeBuildInputs = [ installShellFiles ];
+  buildInputs = [
+    zsh
+    ncurses
+  ];
+  nativeInstallCheckInputs = [ zsh ];
+
+  patches = [ ./no-external-call.patch ];
+
+  postPatch = ''
+    substituteInPlace revolver \
+      --replace-fail "tput cols" "${ncurses}/bin/tput cols"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D revolver $out/bin/revolver
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    installShellCompletion --cmd revolver --zsh revolver.zsh-completion
+  '';
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    PATH=$PATH:$out/bin revolver --help
+
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    tests = {
+      demo = runCommand "revolver-demo" { nativeBuildInputs = [ finalAttrs.finalPackage ]; } ''
+        export HOME="$TEMPDIR"
+
+        # Drop stdout, redirect stderr to stdout and check if it's not empty
+        exec 9>&1
+        echo "Running revolver demo..."
+        if [[ $(revolver demo 2>&1 1>/dev/null | tee >(cat - >&9)) ]]; then
+          exit 1
+        fi
+        echo "Demo done!"
+
+        mkdir $out
+      '';
+      version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+        # Wrong '0.2.0' version in the code
+        version = "0.2.0";
+      };
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Progress spinner for ZSH scripts";
+    homepage = "https://github.com/molovo/revolver";
+    downloadPage = "https://github.com/molovo/revolver/releases";
+    license = lib.licenses.mit;
+    mainProgram = "revolver";
+    inherit (zsh.meta) platforms;
+    maintainers = with lib.maintainers; [ d-brasher ];
+  };
+})


### PR DESCRIPTION
## Description of changes

[Revolver](https://github.com/molovo/revolver) is a simple script for the ZSH shell showing a progress spinner. 

Although the last commit is 4 years old, it is a dependency of [zunit](https://github.com/zunit-zsh/zunit) (https://github.com/NixOS/nixpkgs/pull/328451), a testing framework for ZSH projects (for example some ZSH plugins), that I'm planning to package next (mainly to enable testing of such still unpackaged but quite popular plugins).

Since this is my first PR here, I appreciate any critics, as I try to follow the best practices :tm: as closely as possible.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes https://github.com/NixOS/nixpkgs/issues/263959

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
