### PR TITLE
i3pystatus: unstable-2020-06-12 -> 3.35-unstable-2024-06-13, fix tests, move to by-name

### DIFF
--- a/pkgs/by-name/i3/i3pystatus/package.nix
+++ b/pkgs/by-name/i3/i3pystatus/package.nix
@@ -4,6 +4,7 @@
 , libnotify
 , gobject-introspection
 , python3Packages
+, unstableGitUpdater
 , extraLibs ? [] }:
 
 python3Packages.buildPythonApplication rec {
@@ -48,6 +49,8 @@ python3Packages.buildPythonApplication rec {
   # no tests in tarball
   doCheck = false;
 
+  passthru.updateScript = unstableGitUpdater {};
+
   meta = with lib; {
     homepage = "https://github.com/enkore/i3pystatus";
     description = "Complete replacement for i3status";
@@ -57,6 +60,6 @@ python3Packages.buildPythonApplication rec {
     '';
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = [ maintainers.igsha ];
+    maintainers = [ maintainers.igsha maintainers.lucasew ];
   };
 }

--- a/pkgs/by-name/i3/i3pystatus/package.nix
+++ b/pkgs/by-name/i3/i3pystatus/package.nix
@@ -10,14 +10,14 @@
 python3Packages.buildPythonApplication rec {
   # i3pystatus moved to rolling release:
   # https://github.com/enkore/i3pystatus/issues/584
-  version = "unstable-2020-06-12";
+  version = "3.35-unstable-2024-06-13";
   pname = "i3pystatus";
 
   src = fetchFromGitHub {
     owner = "enkore";
     repo = "i3pystatus";
-    rev = "dad5eb0c5c8a2ecd20c37ade4732586c6e53f44b";
-    sha256 = "18ygvkl92yr69kxsym57k1mc90asdxpz4b943i61qr0s4fc5n4mq";
+    rev = "f3c539ad78ad1c54fc36e8439bf3905a784ccb34";
+    sha256 = "3AGREY+elHQk8kaoFp8AHEzk2jNC/ICGYPh2hXo2G/w=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/i3/i3pystatus/package.nix
+++ b/pkgs/by-name/i3/i3pystatus/package.nix
@@ -5,6 +5,7 @@
 , gobject-introspection
 , python3Packages
 , unstableGitUpdater
+, fetchpatch
 , extraLibs ? [] }:
 
 python3Packages.buildPythonApplication rec {
@@ -20,11 +21,27 @@ python3Packages.buildPythonApplication rec {
     sha256 = "3AGREY+elHQk8kaoFp8AHEzk2jNC/ICGYPh2hXo2G/w=";
   };
 
-  nativeBuildInputs = [
-    gobject-introspection
+  patches = [
+    # absolutifies the path to the test data in buds test so it can be run from anywhere
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/enkore/i3pystatus/pull/869.patch";
+      hash = "sha256-irrD+yQui9GV+tnsDD3Gr9zJNJxWtvMIw+Hm0cUt7og=";
+    })
   ];
 
-  buildInputs = [ libpulseaudio libnotify ];
+  nativeBuildInputs = [
+    gobject-introspection
+    python3Packages.pytestCheckHook
+  ];
+
+  buildInputs = [
+    libpulseaudio
+    libnotify
+  ];
+
+  checkInputs = [
+    python3Packages.requests
+  ];
 
   propagatedBuildInputs = with python3Packages; [
     keyring colour netifaces psutil basiciw pygobject3
@@ -46,12 +63,10 @@ python3Packages.buildPythonApplication rec {
       ''${makeWrapperArgs[@]}
   '';
 
-  # no tests in tarball
-  doCheck = false;
-
   passthru.updateScript = unstableGitUpdater {};
 
   meta = with lib; {
+    mainProgram = "i3pystatus";
     homepage = "https://github.com/enkore/i3pystatus";
     description = "Complete replacement for i3status";
     longDescription = ''

--- a/pkgs/by-name/i3/i3pystatus/package.nix
+++ b/pkgs/by-name/i3/i3pystatus/package.nix
@@ -6,7 +6,7 @@
   gobject-introspection,
   python3Packages,
   unstableGitUpdater,
-  fetchpatch,
+  fetchpatch2,
   extraLibs ? [ ],
 }:
 
@@ -15,6 +15,8 @@ python3Packages.buildPythonApplication rec {
   # https://github.com/enkore/i3pystatus/issues/584
   version = "3.35-unstable-2024-06-13";
   pname = "i3pystatus";
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
 
   src = fetchFromGitHub {
     owner = "enkore";
@@ -25,21 +27,21 @@ python3Packages.buildPythonApplication rec {
 
   patches = [
     # absolutifies the path to the test data in buds test so it can be run from anywhere
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/enkore/i3pystatus/pull/869.patch";
-      hash = "sha256-irrD+yQui9GV+tnsDD3Gr9zJNJxWtvMIw+Hm0cUt7og=";
+    (fetchpatch2 {
+      # https://github.com/enkore/i3pystatus/pull/869
+      url = "https://github.com/enkore/i3pystatus/commit/7a39c3527566411eb1b3e4f79191839ac4b0424e.patch";
+      hash = "sha256-kSf2Nrypw8CCHC7acDkQXI27178HA3NJlyRWkHyYOGs=";
     })
   ];
 
-  nativeBuildInputs = [
-    gobject-introspection
-    python3Packages.pytestCheckHook
-  ];
+  nativeBuildInputs = [ gobject-introspection ];
 
   buildInputs = [
     libpulseaudio
     libnotify
   ];
+
+  nativeCheckInputs = [ python3Packages.pytestCheckHook ];
 
   checkInputs = [ python3Packages.requests ];
 
@@ -78,7 +80,7 @@ python3Packages.buildPythonApplication rec {
 
   passthru.updateScript = unstableGitUpdater { };
 
-  meta = with lib; {
+  meta = {
     mainProgram = "i3pystatus";
     homepage = "https://github.com/enkore/i3pystatus";
     description = "Complete replacement for i3status";
@@ -86,11 +88,11 @@ python3Packages.buildPythonApplication rec {
       i3pystatus is a growing collection of python scripts for status output compatible
       to i3status / i3bar of the i3 window manager.
     '';
-    license = licenses.mit;
-    platforms = platforms.linux;
-    maintainers = [
-      maintainers.igsha
-      maintainers.lucasew
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      igsha
+      lucasew
     ];
   };
 }

--- a/pkgs/by-name/i3/i3pystatus/package.nix
+++ b/pkgs/by-name/i3/i3pystatus/package.nix
@@ -1,12 +1,14 @@
-{ lib
-, fetchFromGitHub
-, libpulseaudio
-, libnotify
-, gobject-introspection
-, python3Packages
-, unstableGitUpdater
-, fetchpatch
-, extraLibs ? [] }:
+{
+  lib,
+  fetchFromGitHub,
+  libpulseaudio,
+  libnotify,
+  gobject-introspection,
+  python3Packages,
+  unstableGitUpdater,
+  fetchpatch,
+  extraLibs ? [ ],
+}:
 
 python3Packages.buildPythonApplication rec {
   # i3pystatus moved to rolling release:
@@ -39,18 +41,29 @@ python3Packages.buildPythonApplication rec {
     libnotify
   ];
 
-  checkInputs = [
-    python3Packages.requests
-  ];
+  checkInputs = [ python3Packages.requests ];
 
-  propagatedBuildInputs = with python3Packages; [
-    keyring colour netifaces psutil basiciw pygobject3
-  ] ++ extraLibs;
+  propagatedBuildInputs =
+    with python3Packages;
+    [
+      keyring
+      colour
+      netifaces
+      psutil
+      basiciw
+      pygobject3
+    ]
+    ++ extraLibs;
 
   makeWrapperArgs = [
     # LC_TIME != C results in locale.Error: unsupported locale setting
-    "--set" "LC_TIME" "C"
-    "--suffix" "LD_LIBRARY_PATH" ":" "${lib.makeLibraryPath [ libpulseaudio ]}"
+    "--set"
+    "LC_TIME"
+    "C"
+    "--suffix"
+    "LD_LIBRARY_PATH"
+    ":"
+    "${lib.makeLibraryPath [ libpulseaudio ]}"
   ];
 
   postPatch = ''
@@ -63,7 +76,7 @@ python3Packages.buildPythonApplication rec {
       ''${makeWrapperArgs[@]}
   '';
 
-  passthru.updateScript = unstableGitUpdater {};
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = with lib; {
     mainProgram = "i3pystatus";
@@ -75,6 +88,9 @@ python3Packages.buildPythonApplication rec {
     '';
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = [ maintainers.igsha maintainers.lucasew ];
+    maintainers = [
+      maintainers.igsha
+      maintainers.lucasew
+    ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31429,8 +31429,6 @@ with pkgs;
 
   i3nator = callPackage ../tools/misc/i3nator { };
 
-  i3pystatus = callPackage ../applications/window-managers/i3/pystatus.nix { };
-
   i3status = callPackage ../applications/window-managers/i3/status.nix { };
 
   i3status-rust = callPackage ../applications/window-managers/i3/status-rust.nix { };


### PR DESCRIPTION
## Description of changes

- **i3pystatus: move to by-name**
- **i3pystatus: unstable-2020-06-12 -> 3.35-unstable-2024-06-13**
- **i3pystatus: fix tests**


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
