### PR TITLE
python311Packages: Add a few -numpy_2 packages

### DIFF
--- a/pkgs/development/python-modules/h5py/default.nix
+++ b/pkgs/development/python-modules/h5py/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
 
   # avoid strict pinning of numpy, can't be replaced with pythonRelaxDepsHook,
   # see: https://github.com/NixOS/nixpkgs/issues/327941
-  postPatch = ''
+  postPatch = lib.optionalString (!numpy.isNumpy2) ''
     substituteInPlace pyproject.toml \
       --replace-fail "numpy >=2.0.0rc1" "numpy"
   '';

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -115,9 +115,13 @@ buildPythonPackage rec {
   # With the following patch we just hard-code these paths into the install
   # script.
   postPatch =
-    ''
+    # Allows you to override it with numpy_2 and be sure you use a consistent
+    # numpy in the build
+    lib.optionalString (!numpy.isNumpy2) ''
       substituteInPlace pyproject.toml \
         --replace-fail '"numpy>=2.0.0rc1,<2.3",' ""
+    ''
+    + ''
       patchShebangs tools
     ''
     + lib.optionalString (stdenv.isLinux && interactive) ''

--- a/pkgs/development/python-modules/numpy/1.nix
+++ b/pkgs/development/python-modules/numpy/1.nix
@@ -185,6 +185,7 @@ buildPythonPackage rec {
     blas = blas.provider;
     blasImplementation = blas.implementation;
     inherit cfg;
+    isNumpy2 = false;
     tests = {
       inherit sage;
     };

--- a/pkgs/development/python-modules/numpy/1.nix
+++ b/pkgs/development/python-modules/numpy/1.nix
@@ -186,6 +186,7 @@ buildPythonPackage rec {
     blasImplementation = blas.implementation;
     inherit cfg;
     isNumpy2 = false;
+    coreIncludeDir = "${python.sitePackages}/numpy/core/include";
     tests = {
       inherit sage;
     };

--- a/pkgs/development/python-modules/numpy/2.nix
+++ b/pkgs/development/python-modules/numpy/2.nix
@@ -166,6 +166,7 @@ buildPythonPackage rec {
     blas = blas.provider;
     blasImplementation = blas.implementation;
     inherit cfg;
+    isNumpy2 = true;
     tests = {
       inherit sage;
     };

--- a/pkgs/development/python-modules/numpy/2.nix
+++ b/pkgs/development/python-modules/numpy/2.nix
@@ -167,6 +167,7 @@ buildPythonPackage rec {
     blasImplementation = blas.implementation;
     inherit cfg;
     isNumpy2 = true;
+    coreIncludeDir = "${python.sitePackages}/numpy/_core/include";
     tests = {
       inherit sage;
     };

--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -58,7 +58,7 @@ let
   # Additional cross compilation related properties that scipy reads in scipy/meson.build
   crossFileScipy = writeText "cross-file-scipy.conf" ''
     [properties]
-    numpy-include-dir = '${numpy}/${python.sitePackages}/numpy/core/include'
+    numpy-include-dir = '${numpy}/${numpy.coreIncludeDir}'
     pythran-include-dir = '${pythran}/${python.sitePackages}/pythran'
     host-python-path = '${python.interpreter}'
     host-python-version = '${python.pythonVersion}'
@@ -89,7 +89,7 @@ buildPythonPackage {
   # both numpy 2 and numpy 1 should work, but they seem to worry about numpy
   # incompatibilities that we here with Nixpkgs' Python ecosystem, shouldn't
   # experience.
-  postPatch = ''
+  postPatch = lib.optionalString (!numpy.isNumpy2) ''
     substituteInPlace pyproject.toml \
       --replace-fail 'numpy>=2.0.0rc1,' 'numpy' \
   '';

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2521,6 +2521,10 @@ self: super: with self; {
 
   contourpy = callPackage ../development/python-modules/contourpy { };
 
+  contourpy-numpy_2 = contourpy.override {
+    numpy = numpy_2;
+  };
+
   controku = callPackage ../development/python-modules/controku { };
 
   convertdate = callPackage ../development/python-modules/convertdate { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13956,6 +13956,11 @@ self: super: with self; {
 
   scipy = callPackage ../development/python-modules/scipy { };
 
+  scipy-numpy_2 = self.scipy.override {
+    numpy = numpy_2;
+    pythran = pythran-numpy_2;
+  };
+
   scmrepo = callPackage ../development/python-modules/scmrepo { };
 
   scour = callPackage ../development/python-modules/scour { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12910,6 +12910,10 @@ self: super: with self; {
     inherit (pkgs.llvmPackages) openmp;
   };
 
+  pythran-numpy_2 = self.pythran.override {
+    numpy = numpy_2;
+  };
+
   pyeapi = callPackage ../development/python-modules/pyeapi { };
 
   pyeverlights = callPackage ../development/python-modules/pyeverlights { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5389,6 +5389,10 @@ self: super: with self; {
 
   h5py = callPackage ../development/python-modules/h5py { };
 
+  h5py-numpy_2 = self.h5py.override {
+    numpy = numpy_2;
+  };
+
   h5py-mpi = self.h5py.override {
     hdf5 = pkgs.hdf5-mpi;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7456,6 +7456,10 @@ self: super: with self; {
     inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa;
     ghostscript = pkgs.ghostscript_headless;
   };
+  matplotlib-numpy_2 = matplotlib.override {
+    numpy = numpy_2;
+    contourpy = contourpy-numpy_2;
+  };
 
   matplotlib-inline = callPackage ../development/python-modules/matplotlib-inline { };
 


### PR DESCRIPTION
Sometimes it may not be trivial to choose to use numpy_2 in your Python setup, either because the expressions don't support the `numpy = numpy_2` argument out of the box, or in case the build takes a lot of resources.

## Description of changes

Add a few new `-numpy_2` attributes for Python packages that support both numpy versions. In principal, more attributes could be added (these are just the ones that I personally felt the need for).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
