### PR TITLE
openmpi: 4.1.6 -> 5.0.3

### DIFF
--- a/pkgs/by-name/pr/prrte/package.nix
+++ b/pkgs/by-name/pr/prrte/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenv,
+  removeReferencesTo,
+  fetchFromGitHub,
+  autoconf,
+  automake,
+  libtool,
+  gitMinimal,
+  perl,
+  python3,
+  flex,
+  hwloc,
+  libevent,
+  zlib,
+  pmix,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "prrte";
+  version = "3.0.5";
+
+  src = fetchFromGitHub {
+    owner = "openpmix";
+    repo = "prrte";
+    rev = "v${version}";
+    sha256 = "sha256-RDxd4veLGbN+T7xCDnNp2lbOM7mwKKD+SKdPmExr1C8=";
+    fetchSubmodules = true;
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  postPatch = ''
+    patchShebangs ./autogen.pl ./config
+  '';
+
+  preConfigure = ''
+    ./autogen.pl
+  '';
+
+  postInstall = ''
+    moveToOutput "bin/prte_info" "''${!outputDev}"
+    # Fix a broken symlink, created due to FHS assumptions
+    rm "$out/bin/pcc"
+    ln -s ${lib.getDev pmix}/bin/pmixcc "''${!outputDev}"/bin/pcc
+
+    remove-references-to -t "''${!outputDev}" $(readlink -f $out/lib/libprrte${stdenv.hostPlatform.extensions.library})
+  '';
+
+  nativeBuildInputs = [
+    removeReferencesTo
+    perl
+    python3
+    autoconf
+    automake
+    libtool
+    flex
+    gitMinimal
+  ];
+
+  buildInputs = [
+    libevent
+    hwloc
+    zlib
+    pmix
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "PMIx Reference Runtime Environment";
+    homepage = "https://docs.prrte.org/";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ markuskowa ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -1,31 +1,47 @@
-{ lib, stdenv, fetchurl, removeReferencesTo, gfortran, perl, libnl
-, rdma-core, zlib, numactl, libevent, hwloc, targetPackages
-, libpsm2, libfabric, pmix, ucx, ucc, makeWrapper
-, config
-# Enable CUDA support
-, cudaSupport ? config.cudaSupport, cudaPackages
-
-# Enable the Sun Grid Engine bindings
-, enableSGE ? false
-
-# Pass PATH/LD_LIBRARY_PATH to point to current mpirun by default
-, enablePrefix ? false
-
-# Enable libfabric support (necessary for Omnipath networks) on x86_64 linux
-, fabricSupport ? stdenv.isLinux && stdenv.isx86_64
-
-# Enable Fortran support
-, fortranSupport ? true
+{
+  lib,
+  stdenv,
+  fetchurl,
+  removeReferencesTo,
+  gfortran,
+  perl,
+  libnl,
+  rdma-core,
+  zlib,
+  numactl,
+  libevent,
+  hwloc,
+  targetPackages,
+  libpsm2,
+  libfabric,
+  pmix,
+  ucx,
+  ucc,
+  makeWrapper,
+  config,
+  # Enable CUDA support
+  cudaSupport ? config.cudaSupport,
+  cudaPackages,
+  # Enable the Sun Grid Engine bindings
+  enableSGE ? false,
+  # Pass PATH/LD_LIBRARY_PATH to point to current mpirun by default
+  enablePrefix ? false,
+  # Enable libfabric support (necessary for Omnipath networks) on x86_64 linux
+  fabricSupport ? stdenv.isLinux && stdenv.isx86_64,
+  # Enable Fortran support
+  fortranSupport ? true,
 }:
 
 stdenv.mkDerivation rec {
   pname = "openmpi";
   version = "4.1.6";
 
-  src = with lib.versions; fetchurl {
-    url = "https://www.open-mpi.org/software/ompi/v${major version}.${minor version}/downloads/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-90CZRIVRbetjtTEa8SLCZRefUyig2FelZ7hdsAsR5BU=";
-  };
+  src =
+    with lib.versions;
+    fetchurl {
+      url = "https://www.open-mpi.org/software/ompi/v${major version}.${minor version}/downloads/${pname}-${version}.tar.bz2";
+      sha256 = "sha256-90CZRIVRbetjtTEa8SLCZRefUyig2FelZ7hdsAsR5BU=";
+    };
 
   postPatch = ''
     patchShebangs ./
@@ -38,34 +54,63 @@ stdenv.mkDerivation rec {
     find -name "Makefile.in" -exec sed -i "s/\`date\`/$ts/" \{} \;
   '';
 
-  outputs = [ "out" "man" "dev" ];
+  outputs = [
+    "out"
+    "man"
+    "dev"
+  ];
 
-  buildInputs = [ zlib ]
-    ++ lib.optionals stdenv.isLinux [ libnl numactl pmix ucx ucc ]
+  buildInputs =
+    [ zlib ]
+    ++ lib.optionals stdenv.isLinux [
+      libnl
+      numactl
+      pmix
+      ucx
+      ucc
+    ]
     ++ lib.optionals cudaSupport [ cudaPackages.cuda_cudart ]
-    ++ [ libevent hwloc ]
+    ++ [
+      libevent
+      hwloc
+    ]
     ++ lib.optional (stdenv.isLinux || stdenv.isFreeBSD) rdma-core
-    ++ lib.optionals fabricSupport [ libpsm2 libfabric ];
+    ++ lib.optionals fabricSupport [
+      libpsm2
+      libfabric
+    ];
 
-  nativeBuildInputs = [ perl removeReferencesTo makeWrapper ]
+  nativeBuildInputs =
+    [
+      perl
+      removeReferencesTo
+      makeWrapper
+    ]
     ++ lib.optionals cudaSupport [ cudaPackages.cuda_nvcc ]
     ++ lib.optionals fortranSupport [ gfortran ];
 
-  configureFlags = lib.optional (!cudaSupport) "--disable-mca-dso"
+  configureFlags =
+    lib.optional (!cudaSupport) "--disable-mca-dso"
     ++ lib.optional (!fortranSupport) "--disable-mpi-fortran"
-    ++ lib.optionals stdenv.isLinux  [
+    ++ lib.optionals stdenv.isLinux [
       "--with-libnl=${lib.getDev libnl}"
       "--with-pmix=${lib.getDev pmix}"
       "--with-pmix-libdir=${pmix}/lib"
       "--enable-mpi-cxx"
-    ] ++ lib.optional enableSGE "--with-sge"
+    ]
+    ++ lib.optional enableSGE "--with-sge"
     ++ lib.optional enablePrefix "--enable-mpirun-prefix-by-default"
     # TODO: add UCX support, which is recommended to use with cuda for the most robust OpenMPI build
     # https://github.com/openucx/ucx
     # https://www.open-mpi.org/faq/?category=buildcuda
-    ++ lib.optionals cudaSupport [ "--with-cuda=${lib.getDev cudaPackages.cuda_cudart}" "--enable-dlopen" ]
-    ++ lib.optionals fabricSupport [ "--with-psm2=${lib.getDev libpsm2}" "--with-libfabric=${lib.getDev libfabric}" ]
-    ;
+    ++ lib.optionals cudaSupport [
+      "--with-cuda=${lib.getDev cudaPackages.cuda_cudart}"
+      "--enable-dlopen"
+    ]
+    ++ lib.optionals fabricSupport [
+      "--with-psm2=${lib.getDev libpsm2}"
+      "--with-libfabric=${lib.getDev libfabric}"
+    ];
 
   enableParallelBuilding = true;
 
@@ -85,38 +130,40 @@ stdenv.mkDerivation rec {
     done
 
     moveToOutput "share/openmpi/ortecc-wrapper-data.txt" "''${!outputDev}"
-   '';
-
-  postFixup = ''
-    remove-references-to -t $dev $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.sharedLibrary})
-    remove-references-to -t $man $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.sharedLibrary})
-
-    # The path to the wrapper is hard coded in libopen-pal.so, which we just cleared.
-    wrapProgram $dev/bin/opal_wrapper \
-      --set OPAL_INCLUDEDIR $dev/include \
-      --set OPAL_PKGDATADIR $dev/share/openmpi
-
-    # default compilers should be indentical to the
-    # compilers at build time
-
-    echo "$dev/share/openmpi/mpicc-wrapper-data.txt"
-    sed -i 's:compiler=.*:compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc:' \
-      $dev/share/openmpi/mpicc-wrapper-data.txt
-
-    echo "$dev/share/openmpi/ortecc-wrapper-data.txt"
-    sed -i 's:compiler=.*:compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc:' \
-       $dev/share/openmpi/ortecc-wrapper-data.txt
-
-    echo "$dev/share/openmpi/mpic++-wrapper-data.txt"
-    sed -i 's:compiler=.*:compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}c++:' \
-       $dev/share/openmpi/mpic++-wrapper-data.txt
-  '' + lib.optionalString fortranSupport ''
-
-    echo "$dev/share/openmpi/mpifort-wrapper-data.txt"
-    sed -i 's:compiler=.*:compiler=${gfortran}/bin/${gfortran.targetPrefix}gfortran:'  \
-       $dev/share/openmpi/mpifort-wrapper-data.txt
-
   '';
+
+  postFixup =
+    ''
+      remove-references-to -t $dev $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.sharedLibrary})
+      remove-references-to -t $man $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.sharedLibrary})
+
+      # The path to the wrapper is hard coded in libopen-pal.so, which we just cleared.
+      wrapProgram $dev/bin/opal_wrapper \
+        --set OPAL_INCLUDEDIR $dev/include \
+        --set OPAL_PKGDATADIR $dev/share/openmpi
+
+      # default compilers should be indentical to the
+      # compilers at build time
+
+      echo "$dev/share/openmpi/mpicc-wrapper-data.txt"
+      sed -i 's:compiler=.*:compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc:' \
+        $dev/share/openmpi/mpicc-wrapper-data.txt
+
+      echo "$dev/share/openmpi/ortecc-wrapper-data.txt"
+      sed -i 's:compiler=.*:compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc:' \
+         $dev/share/openmpi/ortecc-wrapper-data.txt
+
+      echo "$dev/share/openmpi/mpic++-wrapper-data.txt"
+      sed -i 's:compiler=.*:compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}c++:' \
+         $dev/share/openmpi/mpic++-wrapper-data.txt
+    ''
+    + lib.optionalString fortranSupport ''
+
+      echo "$dev/share/openmpi/mpifort-wrapper-data.txt"
+      sed -i 's:compiler=.*:compiler=${gfortran}/bin/${gfortran.targetPrefix}gfortran:'  \
+         $dev/share/openmpi/mpifort-wrapper-data.txt
+
+    '';
 
   doCheck = true;
 

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -168,7 +168,7 @@ stdenv.mkDerivation (finalAttrs: {
       substituteInPlace ''${!outputDev}/share/openmpi/mpifort-wrapper-data.txt \
         --replace-fail \
           compiler=gfortran \
-          compiler=${gfortran}/bin/${gfortran.targetPrefix}gfortran
+          compiler=${targetPackages.gfortran}/bin/${targetPackages.gfortran.targetPrefix}gfortran
 
     '';
 

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -145,22 +145,30 @@ stdenv.mkDerivation (finalAttrs: {
       # compilers at build time
 
       echo "''${!outputDev}/share/openmpi/mpicc-wrapper-data.txt"
-      sed -i 's:compiler=.*:compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc:' \
-        ''${!outputDev}/share/openmpi/mpicc-wrapper-data.txt
+      substituteInPlace ''${!outputDev}/share/openmpi/mpicc-wrapper-data.txt \
+        --replace-fail \
+          compiler=gcc \
+          compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc
 
       echo "''${!outputDev}/share/openmpi/ortecc-wrapper-data.txt"
-      sed -i 's:compiler=.*:compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc:' \
-         ''${!outputDev}/share/openmpi/ortecc-wrapper-data.txt
+      substituteInPlace ''${!outputDev}/share/openmpi/ortecc-wrapper-data.txt \
+        --replace-fail \
+          compiler=gcc \
+          compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc
 
       echo "''${!outputDev}/share/openmpi/mpic++-wrapper-data.txt"
-      sed -i 's:compiler=.*:compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}c++:' \
-         ''${!outputDev}/share/openmpi/mpic++-wrapper-data.txt
+      substituteInPlace ''${!outputDev}/share/openmpi/mpic++-wrapper-data.txt \
+        --replace-fail \
+          compiler=g++ \
+          compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}c++
     ''
     + lib.optionalString fortranSupport ''
 
       echo "''${!outputDev}/share/openmpi/mpifort-wrapper-data.txt"
-      sed -i 's:compiler=.*:compiler=${gfortran}/bin/${gfortran.targetPrefix}gfortran:'  \
-         ''${!outputDev}/share/openmpi/mpifort-wrapper-data.txt
+      substituteInPlace ''${!outputDev}/share/openmpi/mpifort-wrapper-data.txt \
+        --replace-fail \
+          compiler=gfortran \
+          compiler=${gfortran}/bin/${gfortran.targetPrefix}gfortran
 
     '';
 

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -59,7 +59,11 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs =
-    [ zlib ]
+    [
+      zlib
+      libevent
+      hwloc
+    ]
     ++ lib.optionals stdenv.isLinux [
       libnl
       numactl
@@ -68,10 +72,6 @@ stdenv.mkDerivation (finalAttrs: {
       ucc
     ]
     ++ lib.optionals cudaSupport [ cudaPackages.cuda_cudart ]
-    ++ [
-      libevent
-      hwloc
-    ]
     ++ lib.optional (stdenv.isLinux || stdenv.isFreeBSD) rdma-core
     ++ lib.optionals fabricSupport [
       libpsm2

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -107,114 +107,115 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  postInstall = let
-    # The file names we need to iterate are a combination of ${p}${s}, and there
-    # are 7x3 such options. We use lib.mapCartesianProduct to iterate them all.
-    fileNamesToIterate = {
-      p = [
-        "mpi"
-        "shmem"
-        "osh"
-      ];
-      s =
-        [
-          "CC"
-          "c++"
-          "cxx"
-          "cc"
-        ]
-        ++ lib.optionals fortranSupport [
-          "f77"
-          "f90"
-          "fort"
+  postInstall =
+    let
+      # The file names we need to iterate are a combination of ${p}${s}, and there
+      # are 7x3 such options. We use lib.mapCartesianProduct to iterate them all.
+      fileNamesToIterate = {
+        p = [
+          "mpi"
+          "shmem"
+          "osh"
         ];
-    };
-    wrapperDataSubstitutions =
-      {
-        # The attr key is the filename prefix. The list's 1st value is the
-        # compiler=_ line that should be replaced by a compiler=#2 string, where
-        # #2 is the 2nd value in the list.
-        "cc" = [
-          "gcc"
-          "${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc"
-        ];
-        "c++" = [
-          "g++"
-          "${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}c++"
-        ];
-      }
-      // lib.optionalAttrs fortranSupport {
-        "fort" = [
-          "gfortran"
-          "${targetPackages.gfortran}/bin/${targetPackages.gfortran.targetPrefix}gfortran"
-        ];
+        s =
+          [
+            "CC"
+            "c++"
+            "cxx"
+            "cc"
+          ]
+          ++ lib.optionals fortranSupport [
+            "f77"
+            "f90"
+            "fort"
+          ];
       };
-    # The -wrapper-data.txt files that are not symlinks, need to be iterated as
-    # well, here they start withw ${part1}${part2}, and we use
-    # lib.mapCartesianProduct as well.
-    wrapperDataFileNames = {
-      part1 = [
-        "mpi"
-        "shmem"
-      ];
-      part2 = builtins.attrNames wrapperDataSubstitutions;
-    };
-  in ''
-    find $out/lib/ -name "*.la" -exec rm -f \{} \;
-
-    # The main wrapper that all the rest of the commonly used binaries are
-    # symlinked to
-    moveToOutput "bin/opal_wrapper" "''${!outputDev}"
-    # All of the following files are symlinks to opal_wrapper
-    ${lib.pipe fileNamesToIterate [
-      (lib.mapCartesianProduct (
-        { p, s }:
-        ''
-          echo "handling ${p}${s}"
-          moveToOutput "bin/${p}${s}" "''${!outputDev}"
-          moveToOutput "share/openmpi/${p}${s}-wrapper-data.txt" "''${!outputDev}"
-        ''
-      ))
-      (lib.concatStringsSep "\n")
-    ]}
-    # default compilers should be indentical to the
-    # compilers at build time
-    ${lib.pipe wrapperDataFileNames [
-      (lib.mapCartesianProduct (
-        { part1, part2 }:
-        ''
-          substituteInPlace "''${!outputDev}/share/openmpi/${part1}${part2}-wrapper-data.txt" \
-            --replace-fail \
-              compiler=${lib.elemAt wrapperDataSubstitutions.${part2} 0} \
-              compiler=${lib.elemAt wrapperDataSubstitutions.${part2} 1}
-        ''
-      ))
-      (lib.concatStringsSep "\n")
-    ]}
-    # ortecc's files don't have c++ and fort companions so it is handled
-    # outside the Nix concatenations above.
-    moveToOutput "bin/ortecc" "''${!outputDev}"
-    moveToOutput "share/openmpi/ortecc-wrapper-data.txt" "''${!outputDev}"
-    substituteInPlace "''${!outputDev}/share/openmpi/ortecc-wrapper-data.txt" \
-      --replace-fail \
-        compiler=${lib.elemAt wrapperDataSubstitutions.cc 0} \
-        compiler=${lib.elemAt wrapperDataSubstitutions.cc 1}
-
-    for i in orte-info ompi_info oshmem_info; do
-      moveToOutput "bin/$i" "''${!outputDev}"
-    done
-  '';
-
-  postFixup =
+      wrapperDataSubstitutions =
+        {
+          # The attr key is the filename prefix. The list's 1st value is the
+          # compiler=_ line that should be replaced by a compiler=#2 string, where
+          # #2 is the 2nd value in the list.
+          "cc" = [
+            "gcc"
+            "${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc"
+          ];
+          "c++" = [
+            "g++"
+            "${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}c++"
+          ];
+        }
+        // lib.optionalAttrs fortranSupport {
+          "fort" = [
+            "gfortran"
+            "${targetPackages.gfortran}/bin/${targetPackages.gfortran.targetPrefix}gfortran"
+          ];
+        };
+      # The -wrapper-data.txt files that are not symlinks, need to be iterated as
+      # well, here they start withw ${part1}${part2}, and we use
+      # lib.mapCartesianProduct as well.
+      wrapperDataFileNames = {
+        part1 = [
+          "mpi"
+          "shmem"
+        ];
+        part2 = builtins.attrNames wrapperDataSubstitutions;
+      };
+    in
     ''
-      remove-references-to -t "''${!outputDev}" $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.sharedLibrary})
-      remove-references-to -t "''${!outputMan}" $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.sharedLibrary})
+      find $out/lib/ -name "*.la" -exec rm -f \{} \;
 
-      # The path to the wrapper is hard coded in libopen-pal.so, which we just cleared.
-      wrapProgram "''${!outputDev}/bin/opal_wrapper" \
-        --set OPAL_INCLUDEDIR "''${!outputDev}/include" \
-        --set OPAL_PKGDATADIR "''${!outputDev}/share/openmpi"
+      # The main wrapper that all the rest of the commonly used binaries are
+      # symlinked to
+      moveToOutput "bin/opal_wrapper" "''${!outputDev}"
+      # All of the following files are symlinks to opal_wrapper
+      ${lib.pipe fileNamesToIterate [
+        (lib.mapCartesianProduct (
+          { p, s }:
+          ''
+            echo "handling ${p}${s}"
+            moveToOutput "bin/${p}${s}" "''${!outputDev}"
+            moveToOutput "share/openmpi/${p}${s}-wrapper-data.txt" "''${!outputDev}"
+          ''
+        ))
+        (lib.concatStringsSep "\n")
+      ]}
+      # default compilers should be indentical to the
+      # compilers at build time
+      ${lib.pipe wrapperDataFileNames [
+        (lib.mapCartesianProduct (
+          { part1, part2 }:
+          ''
+            substituteInPlace "''${!outputDev}/share/openmpi/${part1}${part2}-wrapper-data.txt" \
+              --replace-fail \
+                compiler=${lib.elemAt wrapperDataSubstitutions.${part2} 0} \
+                compiler=${lib.elemAt wrapperDataSubstitutions.${part2} 1}
+          ''
+        ))
+        (lib.concatStringsSep "\n")
+      ]}
+      # ortecc's files don't have c++ and fort companions so it is handled
+      # outside the Nix concatenations above.
+      moveToOutput "bin/ortecc" "''${!outputDev}"
+      moveToOutput "share/openmpi/ortecc-wrapper-data.txt" "''${!outputDev}"
+      substituteInPlace "''${!outputDev}/share/openmpi/ortecc-wrapper-data.txt" \
+        --replace-fail \
+          compiler=${lib.elemAt wrapperDataSubstitutions.cc 0} \
+          compiler=${lib.elemAt wrapperDataSubstitutions.cc 1}
+
+      for i in orte-info ompi_info oshmem_info; do
+        moveToOutput "bin/$i" "''${!outputDev}"
+      done
     '';
+
+  postFixup = ''
+    remove-references-to -t "''${!outputDev}" $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.sharedLibrary})
+    remove-references-to -t "''${!outputMan}" $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.sharedLibrary})
+
+    # The path to the wrapper is hard coded in libopen-pal.so, which we just cleared.
+    wrapProgram "''${!outputDev}/bin/opal_wrapper" \
+      --set OPAL_INCLUDEDIR "''${!outputDev}/include" \
+      --set OPAL_PKGDATADIR "''${!outputDev}/share/openmpi"
+  '';
 
   doCheck = true;
 

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -32,14 +32,14 @@
   fortranSupport ? true,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "openmpi";
   version = "4.1.6";
 
   src =
     with lib.versions;
     fetchurl {
-      url = "https://www.open-mpi.org/software/ompi/v${major version}.${minor version}/downloads/${pname}-${version}.tar.bz2";
+      url = "https://www.open-mpi.org/software/ompi/v${major finalAttrs.version}.${minor finalAttrs.version}/downloads/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
       sha256 = "sha256-90CZRIVRbetjtTEa8SLCZRefUyig2FelZ7hdsAsR5BU=";
     };
 
@@ -180,4 +180,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -110,6 +110,9 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     find $out/lib/ -name "*.la" -exec rm -f \{} \;
 
+    # The main wrapper that all the rest of the commonly used binaries are
+    # symlinked to
+    moveToOutput "bin/opal_wrapper" "''${!outputDev}"
     for f in mpi shmem osh; do
       for i in f77 f90 CC c++ cxx cc fort; do
         moveToOutput "bin/$f$i" "''${!outputDev}"
@@ -118,7 +121,7 @@ stdenv.mkDerivation (finalAttrs: {
       done
     done
 
-    for i in ortecc orte-info ompi_info oshmem_info opal_wrapper; do
+    for i in ortecc orte-info ompi_info oshmem_info; do
       moveToOutput "bin/$i" "''${!outputDev}"
     done
 

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -172,12 +172,12 @@ stdenv.mkDerivation rec {
     cudatoolkit = cudaPackages.cudatoolkit; # For backward compatibility only
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://www.open-mpi.org/";
     description = "Open source MPI-3 implementation";
     longDescription = "The Open MPI Project is an open source MPI-3 implementation that is developed and maintained by a consortium of academic, research, and industry partners. Open MPI is therefore able to combine the expertise, technologies, and resources from all across the High Performance Computing community in order to build the best MPI library available. Open MPI offers advantages for system and software vendors, application developers and computer science researchers.";
-    maintainers = with maintainers; [ markuskowa ];
-    license = licenses.bsd3;
-    platforms = platforms.unix;
+    maintainers = with lib.maintainers; [ markuskowa ];
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
       ucc
     ]
     ++ lib.optionals cudaSupport [ cudaPackages.cuda_cudart ]
-    ++ lib.optional (stdenv.isLinux || stdenv.isFreeBSD) rdma-core
+    ++ lib.optionals (stdenv.isLinux || stdenv.isFreeBSD) [ rdma-core ]
     ++ lib.optionals fabricSupport [
       libpsm2
       libfabric
@@ -88,8 +88,8 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals fortranSupport [ gfortran ];
 
   configureFlags =
-    lib.optional (!cudaSupport) "--disable-mca-dso"
-    ++ lib.optional (!fortranSupport) "--disable-mpi-fortran"
+    lib.optionals (!cudaSupport) [ "--disable-mca-dso" ]
+    ++ lib.optionals (!fortranSupport) [ "--disable-mpi-fortran"]
     ++ lib.optionals stdenv.isLinux [
       "--with-libnl=${lib.getDev libnl}"
       "--with-pmix=${lib.getDev pmix}"

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -127,34 +127,34 @@ stdenv.mkDerivation (finalAttrs: {
 
   postFixup =
     ''
-      remove-references-to -t $dev $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.sharedLibrary})
-      remove-references-to -t $man $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.sharedLibrary})
+      remove-references-to -t "''${!outputDev}" $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.sharedLibrary})
+      remove-references-to -t "''${!outputMan}" $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.sharedLibrary})
 
       # The path to the wrapper is hard coded in libopen-pal.so, which we just cleared.
-      wrapProgram $dev/bin/opal_wrapper \
-        --set OPAL_INCLUDEDIR $dev/include \
-        --set OPAL_PKGDATADIR $dev/share/openmpi
+      wrapProgram "''${!outputDev}/bin/opal_wrapper" \
+        --set OPAL_INCLUDEDIR "''${!outputDev}/include" \
+        --set OPAL_PKGDATADIR "''${!outputDev}/share/openmpi"
 
       # default compilers should be indentical to the
       # compilers at build time
 
-      echo "$dev/share/openmpi/mpicc-wrapper-data.txt"
+      echo "''${!outputDev}/share/openmpi/mpicc-wrapper-data.txt"
       sed -i 's:compiler=.*:compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc:' \
-        $dev/share/openmpi/mpicc-wrapper-data.txt
+        ''${!outputDev}/share/openmpi/mpicc-wrapper-data.txt
 
-      echo "$dev/share/openmpi/ortecc-wrapper-data.txt"
+      echo "''${!outputDev}/share/openmpi/ortecc-wrapper-data.txt"
       sed -i 's:compiler=.*:compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc:' \
-         $dev/share/openmpi/ortecc-wrapper-data.txt
+         ''${!outputDev}/share/openmpi/ortecc-wrapper-data.txt
 
-      echo "$dev/share/openmpi/mpic++-wrapper-data.txt"
+      echo "''${!outputDev}/share/openmpi/mpic++-wrapper-data.txt"
       sed -i 's:compiler=.*:compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}c++:' \
-         $dev/share/openmpi/mpic++-wrapper-data.txt
+         ''${!outputDev}/share/openmpi/mpic++-wrapper-data.txt
     ''
     + lib.optionalString fortranSupport ''
 
-      echo "$dev/share/openmpi/mpifort-wrapper-data.txt"
+      echo "''${!outputDev}/share/openmpi/mpifort-wrapper-data.txt"
       sed -i 's:compiler=.*:compiler=${gfortran}/bin/${gfortran.targetPrefix}gfortran:'  \
-         $dev/share/openmpi/mpifort-wrapper-data.txt
+         ''${!outputDev}/share/openmpi/mpifort-wrapper-data.txt
 
     '';
 

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -121,11 +121,14 @@ stdenv.mkDerivation (finalAttrs: {
       done
     done
 
-    for i in ortecc orte-info ompi_info oshmem_info; do
+    # ortecc's files don't have c++ and fort companions so it is handled
+    # outside the for loops above
+    moveToOutput "bin/ortecc" "''${!outputDev}"
+    moveToOutput "share/openmpi/ortecc-wrapper-data.txt" "''${!outputDev}"
+
+    for i in orte-info ompi_info oshmem_info; do
       moveToOutput "bin/$i" "''${!outputDev}"
     done
-
-    moveToOutput "share/openmpi/ortecc-wrapper-data.txt" "''${!outputDev}"
   '';
 
   postFixup =

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -36,12 +36,10 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "openmpi";
   version = "4.1.6";
 
-  src =
-    with lib.versions;
-    fetchurl {
-      url = "https://www.open-mpi.org/software/ompi/v${major finalAttrs.version}.${minor finalAttrs.version}/downloads/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
-      sha256 = "sha256-90CZRIVRbetjtTEa8SLCZRefUyig2FelZ7hdsAsR5BU=";
-    };
+  src = fetchurl {
+    url = "https://www.open-mpi.org/software/ompi/v${lib.versions.majorMinor finalAttrs.version}/downloads/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
+    sha256 = "sha256-90CZRIVRbetjtTEa8SLCZRefUyig2FelZ7hdsAsR5BU=";
+  };
 
   postPatch = ''
     patchShebangs ./

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "5.0.3";
 
   src = fetchurl {
-    url = "https://www.open-mpi.org/software/ompi/v${lib.versions.majorMinor finalAttrs.version}/downloads/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
+    url = "https://www.open-mpi.org/software/ompi/v${lib.versions.majorMinor finalAttrs.version}/downloads/openmpi-${finalAttrs.version}.tar.bz2";
     sha256 = "sha256-mQWC8gazqzLpOKoxu/B8Y5No5EBdyhlvq+fw927tqQs=";
   };
 

--- a/pkgs/development/libraries/pmix/default.nix
+++ b/pkgs/development/libraries/pmix/default.nix
@@ -71,8 +71,9 @@ stdenv.mkDerivation rec {
 
     # Pin the compiler to the current version in a cross compiler friendly way.
     # Same pattern as for openmpi (see https://github.com/NixOS/nixpkgs/pull/58964#discussion_r275059427).
-    sed -i 's:compiler=.*:compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc:' \
-      $dev/share/pmix/pmixcc-wrapper-data.txt
+    substituteInPlace $dev/share/pmix/pmixcc-wrapper-data.txt \
+      --replace-fail compiler=gcc \
+        compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
