### PR TITLE
kdePackages: two small backports

### DIFF
--- a/pkgs/kde/frameworks/kio/default.nix
+++ b/pkgs/kde/frameworks/kio/default.nix
@@ -1,5 +1,6 @@
 {
   mkKdeDerivation,
+  fetchpatch,
   qt5compat,
   qttools,
   acl,
@@ -11,6 +12,13 @@ mkKdeDerivation {
   patches = [
     # Remove hardcoded smbd search path
     ./0001-Remove-impure-smbd-search-path.patch
+
+    # Backport fix for drag and drop
+    # FIXME: remove in next update
+    (fetchpatch {
+      url = "https://invent.kde.org/frameworks/kio/-/commit/e0ea91afdf0dccef7e3afbf23a159bf5a8d6b249.patch";
+      hash = "sha256-YtklZr4DwV8wNABIAUm969w90hi4iEk5aW7a3n6yQeM=";
+    })
   ];
 
   extraBuildInputs = [qt5compat qttools acl attr];

--- a/pkgs/kde/gear/ark/default.nix
+++ b/pkgs/kde/gear/ark/default.nix
@@ -1,10 +1,20 @@
 {
   mkKdeDerivation,
+  fetchpatch,
   libarchive,
   libzip,
 }:
 mkKdeDerivation {
   pname = "ark";
+
+  # Backport fix to clean up temporary folders with Qt 6.7
+  # FIXME: remove in next update
+  patches = [
+    (fetchpatch {
+      url = "https://invent.kde.org/utilities/ark/-/commit/85c5e26f581cf011638a53e62b92e1da8fd55fcd.patch";
+      hash = "sha256-ZjVdKgFoGE0Jme8JhGVn7+PODJqdwHQhglrHzsxePf8=";
+    })
+  ];
 
   extraBuildInputs = [libarchive libzip];
   meta.mainProgram = "ark";


### PR DESCRIPTION
## Description of changes

Both recommended on distributions@, sending in one PR because both changes are tiny.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
