### PR TITLE
clippy-sarif: 0.4.2 -> 0.5.0

### DIFF
--- a/pkgs/by-name/cl/clippy-sarif/package.nix
+++ b/pkgs/by-name/cl/clippy-sarif/package.nix
@@ -4,6 +4,7 @@
   rustPlatform,
   clippy,
   clippy-sarif,
+  nix-update-script,
   testers,
 }:
 rustPlatform.buildRustPackage rec {
@@ -19,14 +20,15 @@ rustPlatform.buildRustPackage rec {
 
   passthru = {
     tests.version = testers.testVersion { package = clippy-sarif; };
+    updateScript = nix-update-script { };
   };
 
   meta = {
     description = "A CLI tool to convert clippy diagnostics into SARIF";
-    mainProgram = "clippy-sarif";
     homepage = "https://psastras.github.io/sarif-rs";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ getchoo ];
+    mainProgram = "clippy-sarif";
     inherit (clippy.meta) platforms;
   };
 }

--- a/pkgs/by-name/cl/clippy-sarif/package.nix
+++ b/pkgs/by-name/cl/clippy-sarif/package.nix
@@ -8,16 +8,16 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "clippy-sarif";
-  version = "0.4.2";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "psastras";
     repo = "sarif-rs";
     rev = "clippy-sarif-v${version}";
-    hash = "sha256-EzWzDeIeSJ11CVcVyAhMjYQJcKHnieRrFkULc5eXAno=";
+    hash = "sha256-RnoJfmkrqdhOioGkB7rTzHQ3kx9vIRfWDJN30/8JAvM=";
   };
 
-  cargoHash = "sha256-F3NrqkqLdvMRIuozCMMqwlrrf5QrnmcEhy4TGSzPhiU=";
+  cargoHash = "sha256-F97Cwk87M3SpLqXSECH5nZ8x+3c3oz28zxlPvQUZWlg=";
   cargoBuildFlags = [
     "--package"
     "clippy-sarif"

--- a/pkgs/by-name/cl/clippy-sarif/package.nix
+++ b/pkgs/by-name/cl/clippy-sarif/package.nix
@@ -3,9 +3,8 @@
   fetchCrate,
   rustPlatform,
   clippy,
-  clippy-sarif,
   nix-update-script,
-  testers,
+  versionCheckHook,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "clippy-sarif";
@@ -18,8 +17,10 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-O0bLgj7rWwbEswVMfexsBGgJyObxseOohYht21Y6HpU=";
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
-    tests.version = testers.testVersion { package = clippy-sarif; };
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/cl/clippy-sarif/package.nix
+++ b/pkgs/by-name/cl/clippy-sarif/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitHub,
+  fetchCrate,
   rustPlatform,
   clippy,
   clippy-sarif,
@@ -10,19 +10,12 @@ rustPlatform.buildRustPackage rec {
   pname = "clippy-sarif";
   version = "0.5.0";
 
-  src = fetchFromGitHub {
-    owner = "psastras";
-    repo = "sarif-rs";
-    rev = "clippy-sarif-v${version}";
-    hash = "sha256-RnoJfmkrqdhOioGkB7rTzHQ3kx9vIRfWDJN30/8JAvM=";
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-ylfL4N1BtbB1R7+Glwtgn5E6/v3wQ6oXWdmeyKNHdOw=";
   };
 
-  cargoHash = "sha256-F97Cwk87M3SpLqXSECH5nZ8x+3c3oz28zxlPvQUZWlg=";
-  cargoBuildFlags = [
-    "--package"
-    "clippy-sarif"
-  ];
-  cargoTestFlags = cargoBuildFlags;
+  cargoHash = "sha256-O0bLgj7rWwbEswVMfexsBGgJyObxseOohYht21Y6HpU=";
 
   passthru = {
     tests.version = testers.testVersion { package = clippy-sarif; };


### PR DESCRIPTION
## Description of changes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
