### PR TITLE
dotnet: write content hash in fetchNuget

### DIFF
--- a/pkgs/build-support/dotnet/make-nuget-deps/default.nix
+++ b/pkgs/build-support/dotnet/make-nuget-deps/default.nix
@@ -2,7 +2,8 @@
 { name, nugetDeps ? import sourceFile, sourceFile ? null }:
 linkFarmFromDrvs "${name}-nuget-deps" (nugetDeps {
   fetchNuGet = { pname, version, sha256 ? "", hash ? ""
-    , url ? "https://www.nuget.org/api/v2/package/${pname}/${version}" }:
+    , url ? "https://www.nuget.org/api/v2/package/${pname}/${version}"
+    , ... }:
     let
       src = fetchurl {
         name = "${pname}.${version}.nupkg";

--- a/pkgs/build-support/dotnet/nuget-to-nix/default.nix
+++ b/pkgs/build-support/dotnet/nuget-to-nix/default.nix
@@ -9,6 +9,7 @@
 , curl
 , gnugrep
 , gawk
+, zip
 , dotnet-sdk
 }:
 
@@ -26,6 +27,7 @@ runCommandLocal "nuget-to-nix" {
       gnugrep
       gawk
       dotnet-sdk
+      zip
     ];
   };
 


### PR DESCRIPTION
## Description of changes

Ref: #326345

Should I run this to regenerate all the deps files in nixpkgs? I tried it on azure-functions-core-tools, [which failed](https://github.com/NixOS/nixpkgs/issues/327489) for unrelated reasons; I tried it on jackett and that seems to have worked.

The diff to one of my tiny projects after this change (after autoformatting) is:

```diff
diff --git a/nix/deps.nix b/nix/deps.nix
index 97c5136..158c7c2 100644
--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -4,21 +4,25 @@
   (fetchNuGet {
     pname = "fantomas";
     version = "6.3.9";
+    source_independent_hash = "sha256-5Vjr3VzqjQPsej3QpHF6QanPoG0Kgu0whJyFj5i3hCc=";
     hash = "sha256-XRPC5cXMoTJLLHe3f5A3+uXakbL+D7DlX0sA52KMZKw=";
   })
   (fetchNuGet {
     pname = "fsharp-analyzers";
     version = "0.26.0";
+    source_independent_hash = "sha256-adYPDOiZGJx/BCo21YZX1hlnigoZGJmaIZTraawGQ+w=";
     hash = "sha256-60Bl36LOb/zVNdH2SBSuQ5O41lP9dKTNZbs5vvYs+3U=";
   })
   (fetchNuGet {
     pname = "Newtonsoft.Json";
     version = "13.0.3";
+    source_independent_hash = "sha256-kKY5BSeoECWzt+AymGOI4vovLnMgqU+Tty7ELJN8O+4=";
     hash = "sha256-hy/BieY4qxBWVVsDqqOPaLy1QobiIapkbrESm6v2PHc=";
   })
   (fetchNuGet {
     pname = "WoofWare.Test.Thing";
     version = "0.0.4";
+    source_independent_hash = "sha256-mb75OrLfvHuLBZGDGY3/tF91ucmqR+df2Cxm21XDWrs=";
     hash = "sha256-UIG6tpyG5f+qcuPCczlJm1OgBiLy/INMVnpzEtHQ2kk=";
   })
 ]
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
