### PR TITLE
kodiPackages.sendtokodi: remove dependency on youtube_dl

### DIFF
--- a/pkgs/applications/video/kodi/addons/sendtokodi/default.nix
+++ b/pkgs/applications/video/kodi/addons/sendtokodi/default.nix
@@ -13,7 +13,10 @@ buildKodiAddon rec {
   };
 
   patches = [
-    ./use-packaged-deps.patch
+    # Unconditionally depend on packaged yt-dlp. This removes the ability to
+    # use youtube_dl, which is unmaintained and considered vulnerable (see
+    # CVE-2024-38519).
+    ./use-packaged-yt-dlp.patch
   ];
 
   propagatedBuildInputs = [
@@ -26,14 +29,14 @@ buildKodiAddon rec {
   '';
 
   passthru = {
-    # Instead of the vendored libraries, we propagate youtube-dl and yt-dlp via
-    # the Python path.
-    pythonPath = with kodi.pythonPackages; makePythonPath [ youtube-dl yt-dlp ];
+    # Instead of the vendored libraries, we propagate yt-dlp via the Python
+    # path.
+    pythonPath = with kodi.pythonPackages; makePythonPath [ yt-dlp ];
   };
 
   meta = with lib; {
     homepage = "https://github.com/firsttris/plugin.video.sendtokodi";
-    description = "Plays various stream sites on Kodi using youtube-dl";
+    description = "Plays various stream sites on Kodi using yt-dlp";
     license = licenses.mit;
     maintainers = teams.kodi.members ++ [ maintainers.pks ];
   };

--- a/pkgs/applications/video/kodi/addons/sendtokodi/use-packaged-yt-dlp.patch
+++ b/pkgs/applications/video/kodi/addons/sendtokodi/use-packaged-yt-dlp.patch
@@ -1,16 +1,18 @@
 diff --git a/service.py b/service.py
-index 1d7b6e4..9782993 100644
+index 024ad9a..6ef71dd 100644
 --- a/service.py
 +++ b/service.py
-@@ -241,9 +241,9 @@ def playlistIndex(url, playlist):
+@@ -243,11 +243,8 @@ def playlistIndex(url, playlist):
+ 
  
  # Use the chosen resolver while forcing to use youtube_dl on legacy python 2 systems (dlp is python 3.6+)
- if xbmcplugin.getSetting(int(sys.argv[1]),"resolver") == "0" or sys.version_info[0] == 2:
+-if xbmcplugin.getSetting(int(sys.argv[1]),"resolver") == "0" or sys.version_info[0] == 2:
 -    from lib.youtube_dl import YoutubeDL
-+    from youtube_dl import YoutubeDL
- else:
+-else:
 -    from lib.yt_dlp import YoutubeDL
-+    from yt_dlp import YoutubeDL
-     
+-    
++from yt_dlp import YoutubeDL
++
  # patch broken strptime (see above)
  patch_strptime()
+ 


### PR DESCRIPTION
## Description of changes

The sendtokodi plugin for Kodi can use both yt-dlp and youtube_dl to play back various URLs. Both of these packages have been susceptible to CVE-2024-38519. But while yt-dlp is still maintained and was patched, youtube_dl is unmaintained and thus known-vulnerable.

Patch out the dependency on youtube_dl so that sendtokodi will only ever use yt-dlp to resolve URLs.

Closes https://github.com/NixOS/nixpkgs/issues/326548.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Note that this only fixes one recent issue with the sendtokodi plugin. To make it fully working, https://github.com/NixOS/nixpkgs/pull/327479 needs to be merged as well since it transitively depends on inputstreamhelper.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
