### PR TITLE
pkgs/by-name: `testVersion` -> `versionCheckHook` where applicable

### DIFF
--- a/pkgs/by-name/al/alephone/package.nix
+++ b/pkgs/by-name/al/alephone/package.nix
@@ -26,10 +26,10 @@
   SDL2_ttf,
   speex,
   unzip,
+  versionCheckHook,
   zlib,
   zziplib,
   alephone,
-  testers,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -86,6 +86,10 @@ stdenv.mkDerivation (finalAttrs: {
     zziplib
   ];
 
+  # test that the version is correct
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ];
   makeFlags = [ "AR:=$(AR)" ];
 
@@ -100,10 +104,6 @@ stdenv.mkDerivation (finalAttrs: {
     done
     popd
   '';
-
-  passthru.tests.version =
-    # test that the version is correct
-    testers.testVersion { package = alephone; };
 
   meta = {
     description = "Aleph One is the open source continuation of Bungie’s Marathon 2 game engine";

--- a/pkgs/by-name/am/amazon-ssm-agent/package.nix
+++ b/pkgs/by-name/am/amazon-ssm-agent/package.nix
@@ -12,8 +12,7 @@
 , bashInteractive
 , nix-update-script
 , nixosTests
-, testers
-, amazon-ssm-agent
+, versionCheckHook
 }:
 
 let
@@ -143,13 +142,12 @@ buildGoModule rec {
       --prefix PATH : "${lib.makeBinPath [ bashInteractive ]}"
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     tests = {
       inherit (nixosTests) amazon-ssm-agent;
-      version = testers.testVersion {
-        package = amazon-ssm-agent;
-        command = "amazon-ssm-agent --version";
-      };
     };
     updateScript = nix-update-script { };
   };

--- a/pkgs/by-name/an/ansible-cmdb/package.nix
+++ b/pkgs/by-name/an/ansible-cmdb/package.nix
@@ -3,8 +3,7 @@
   fetchFromGitHub,
   substituteAll,
   python3Packages,
-  testers,
-  ansible-cmdb,
+  versionCheckHook,
 }:
 let
   inherit (python3Packages)
@@ -45,10 +44,7 @@ buildPythonApplication {
     jsonxs
   ];
 
-  passthru.tests.version = testers.testVersion {
-    package = ansible-cmdb;
-    version = "v${version}";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {
     description = "Generate host overview from ansible fact gathering output";

--- a/pkgs/by-name/ap/aphorme/package.nix
+++ b/pkgs/by-name/ap/aphorme/package.nix
@@ -5,9 +5,8 @@
 , libxkbcommon
 , libGL
 , stdenv
-, testers
-, aphorme
 , autoPatchelfHook
+, versionCheckHook
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -35,11 +34,8 @@ rustPlatform.buildRustPackage rec {
     libxkbcommon
   ];
 
-  passthru.tests.version = testers.testVersion {
-    package = aphorme;
-    command = "aphorme --version";
-    version = "aphorme ${version}";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Program launcher for window managers, written in Rust";

--- a/pkgs/by-name/ap/apvlv/package.nix
+++ b/pkgs/by-name/ap/apvlv/package.nix
@@ -15,12 +15,11 @@
   libxml2,
   libxshmfence,
   man,
-  nix-update-script,
   pcre,
   pkg-config,
   poppler,
   stdenv,
-  testers,
+  versionCheckHook,
   webkitgtk,
   wrapGAppsHook3,
 }:
@@ -89,13 +88,10 @@ stdenv.mkDerivation (finalAttrs: {
     "../apvlv.desktop"
   ];
 
-  passthru = {
-    tests.version = testers.testVersion {
-      command = "${lib.getExe finalAttrs.finalPackage} -v";
-      package = finalAttrs.finalPackage;
-      version = "${finalAttrs.version}-rel";
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "-v";
 
   meta = {
     changelog = "https://github.com/naihe2010/apvlv/blob/v${finalAttrs.version}/NEWS";

--- a/pkgs/by-name/ar/artalk/package.nix
+++ b/pkgs/by-name/ar/artalk/package.nix
@@ -2,11 +2,10 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  artalk,
   fetchurl,
   installShellFiles,
   stdenv,
-  testers,
+  versionCheckHook,
 }:
 buildGoModule rec {
   pname = "artalk";
@@ -41,6 +40,9 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   postInstall =
     ''
       # work around case insensitive file systems
@@ -53,10 +55,6 @@ buildGoModule rec {
         --fish <($out/bin/artalk completion fish) \
         --zsh <($out/bin/artalk completion zsh)
     '';
-
-  passthru.tests = {
-    version = testers.testVersion { package = artalk; };
-  };
 
   meta = {
     description = "Self-hosted comment system";

--- a/pkgs/by-name/at/athens/package.nix
+++ b/pkgs/by-name/at/athens/package.nix
@@ -1,8 +1,7 @@
 { lib
 , fetchFromGitHub
 , buildGoModule
-, testers
-, athens
+, versionCheckHook
 }:
 buildGoModule rec {
   pname = "athens";
@@ -26,11 +25,8 @@ buildGoModule rec {
     mv $out/bin/proxy $out/bin/athens
   '';
 
-  passthru = {
-    tests.version = testers.testVersion {
-      package = athens;
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Go module datastore and proxy";

--- a/pkgs/by-name/aw/awscli2/package.nix
+++ b/pkgs/by-name/aw/awscli2/package.nix
@@ -7,8 +7,7 @@
 , fetchpatch
 , installShellFiles
 , nix-update-script
-, testers
-, awscli2
+, versionCheckHook
 }:
 
 let
@@ -121,6 +120,8 @@ py.pkgs.buildPythonApplication rec {
     pytestCheckHook
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
   postInstall = ''
     installShellCompletion --cmd aws \
       --bash <(echo "complete -C $out/bin/aws_completer aws") \
@@ -154,16 +155,13 @@ py.pkgs.buildPythonApplication rec {
     "awscli"
   ];
 
+  versionCheckProgram = "${placeholder "out"}/bin/aws";
+
   passthru = {
     python = py; # for aws_shell
     updateScript = nix-update-script {
       # Excludes 1.x versions from the Github tags list
       extraArgs = [ "--version-regex" "^(2\.(.*))" ];
-    };
-    tests.version = testers.testVersion {
-      package = awscli2;
-      command = "aws --version";
-      inherit version;
     };
   };
 

--- a/pkgs/by-name/ba/basedpyright/package.nix
+++ b/pkgs/by-name/ba/basedpyright/package.nix
@@ -6,8 +6,7 @@
   buildNpmPackage,
   python3,
   stdenvNoCC,
-  testers,
-  basedpyright,
+  versionCheckHook
 }:
 
 let
@@ -112,9 +111,11 @@ buildNpmPackage rec {
 
   dontNpmBuild = true;
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     updateScript = ./update.sh;
-    tests.version = testers.testVersion { package = basedpyright; };
   };
 
   meta = {

--- a/pkgs/by-name/be/benchexec/package.nix
+++ b/pkgs/by-name/be/benchexec/package.nix
@@ -39,6 +39,7 @@ python3.pkgs.buildPythonApplication rec {
 
   passthru.tests =
     let
+      # TODO: maybe allow `versionCheckHook` to support doing this?
       testVersion = result: testers.testVersion {
         command = "${result} --version";
         package = benchexec;

--- a/pkgs/by-name/bl/blade-formatter/package.nix
+++ b/pkgs/by-name/bl/blade-formatter/package.nix
@@ -7,6 +7,7 @@
   runCommand,
   blade-formatter,
   nodejs,
+  versionCheckHook,
 }:
 
 buildNpmPackage rec {
@@ -26,14 +27,12 @@ buildNpmPackage rec {
 
   npmDepsHash = "sha256-wEz0DTbg+Fdmsf0Qyeu9QS+I8gkPJeaJC/3HuP913og=";
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     updateScript = ./update.sh;
     tests = {
-      version = testers.testVersion {
-        package = blade-formatter;
-        command = "blade-formatter --version";
-      };
-
       simple = testers.testEqualContents {
         assertion = "blade-formatter formats a basic blade file";
         expected = writeText "expected" ''

--- a/pkgs/by-name/bl/blastem/package.nix
+++ b/pkgs/by-name/bl/blastem/package.nix
@@ -59,6 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  # TODO: use `versionCheckHook` when possible
   passthru.tests.version = testers.testVersion {
     package = finalAttrs.finalPackage;
     command = "blastem -v";

--- a/pkgs/by-name/bl/blueutil/package.nix
+++ b/pkgs/by-name/bl/blueutil/package.nix
@@ -3,8 +3,8 @@
   stdenv,
   fetchFromGitHub,
   darwin,
-  testers,
   nix-update-script,
+  versionCheckHook
 }:
 
 let
@@ -37,8 +37,10 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
-    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/ca/caddy/package.nix
+++ b/pkgs/by-name/ca/caddy/package.nix
@@ -2,10 +2,9 @@
 , buildGoModule
 , fetchFromGitHub
 , nixosTests
-, caddy
-, testers
 , installShellFiles
 , stdenv
+, versionCheckHook
 }:
 let
   version = "2.8.4";
@@ -61,12 +60,13 @@ buildGoModule {
       --zsh <($out/bin/caddy completion zsh)
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "version";
+
   passthru.tests = {
     inherit (nixosTests) caddy;
-    version = testers.testVersion {
-      command = "${caddy}/bin/caddy version";
-      package = caddy;
-    };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/ca/cargo-shear/package.nix
+++ b/pkgs/by-name/ca/cargo-shear/package.nix
@@ -2,8 +2,7 @@
   fetchFromGitHub,
   lib,
   rustPlatform,
-  testers,
-  cargo-shear,
+  versionCheckHook
 }:
 let
   version = "1.0.0";
@@ -23,9 +22,9 @@ rustPlatform.buildRustPackage {
 
   # https://github.com/Boshen/cargo-shear/blob/a0535415a3ea94c86642f39f343f91af5cdc3829/src/lib.rs#L20-L23
   SHEAR_VERSION = version;
-  passthru.tests.version = testers.testVersion {
-    package = cargo-shear;
-  };
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Detect and remove unused dependencies from Cargo.toml";

--- a/pkgs/by-name/ca/castxml/package.nix
+++ b/pkgs/by-name/ca/castxml/package.nix
@@ -7,7 +7,7 @@
   llvmPackages,
   python3,
   stdenv,
-  testers,
+  versionCheckHook,
   zlib,
   # Boolean flags
   withHTML ? true,
@@ -59,9 +59,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  passthru.tests = testers.testVersion {
-    package = finalAttrs.finalPackage;
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     homepage = "https://github.com/CastXML/CastXML";

--- a/pkgs/by-name/ce/cemu/package.nix
+++ b/pkgs/by-name/ce/cemu/package.nix
@@ -25,7 +25,7 @@
   pugixml,
   rapidjson,
   stdenv,
-  testers,
+  versionCheckHook,
   vulkan-headers,
   vulkan-loader,
   wayland,
@@ -144,13 +144,11 @@ in stdenv.mkDerivation (finalAttrs: {
     )
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     updateScript = nix-update-script { };
-    tests = {
-      version = testers.testVersion {
-        package = finalAttrs.finalPackage;
-      };
-    };
   };
 
   meta = {

--- a/pkgs/by-name/ce/centrifugo/package.nix
+++ b/pkgs/by-name/ce/centrifugo/package.nix
@@ -3,8 +3,7 @@
 , fetchFromGitHub
 , nix-update-script
 , nixosTests
-, testers
-, centrifugo
+, versionCheckHook
 }:
 let
   # Inspect build flags with `go version -m centrifugo`.
@@ -37,15 +36,15 @@ buildGoModule rec {
     "./internal/gen/api"
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "version";
+
   passthru = {
     updateScript = nix-update-script { };
     tests = {
       inherit (nixosTests) centrifugo;
-      version = testers.testVersion {
-        package = centrifugo;
-        command = "${pname} version";
-        version = "v${version}";
-      };
     };
   };
 

--- a/pkgs/by-name/cl/cljfmt/package.nix
+++ b/pkgs/by-name/cl/cljfmt/package.nix
@@ -2,8 +2,7 @@
 , buildGraalvmNativeImage
 , fetchurl
 , nix-update-script
-, testers
-, cljfmt
+, versionCheckHook
 }:
 
 buildGraalvmNativeImage rec {
@@ -26,11 +25,8 @@ buildGraalvmNativeImage rec {
 
   passthru.updateScript = nix-update-script { };
 
-  passthru.tests.version = testers.testVersion {
-    inherit version;
-    package = cljfmt;
-    command = "cljfmt --version";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     mainProgram = "cljfmt";

--- a/pkgs/by-name/cl/clojure-lsp/package.nix
+++ b/pkgs/by-name/cl/clojure-lsp/package.nix
@@ -6,8 +6,7 @@
   fetchFromGitHub,
   clojure,
   writeScript,
-  testers,
-  clojure-lsp,
+  versionCheckHook
 }:
 
 buildGraalvmNativeImage rec {
@@ -48,11 +47,8 @@ buildGraalvmNativeImage rec {
       runHook postCheck
     '';
 
-  passthru.tests.version = testers.testVersion {
-    inherit version;
-    package = clojure-lsp;
-    command = "clojure-lsp --version";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   passthru.updateScript = writeScript "update-clojure-lsp" ''
     #!/usr/bin/env nix-shell

--- a/pkgs/by-name/cm/cmake-lint/package.nix
+++ b/pkgs/by-name/cm/cmake-lint/package.nix
@@ -2,8 +2,7 @@
   lib,
   fetchFromGitHub,
   python3Packages,
-  testers,
-  cmake-lint,
+  versionCheckHook
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -27,13 +26,13 @@ python3Packages.buildPythonApplication rec {
     nose
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
   checkPhase = ''
     nosetests
   '';
 
-  passthru.tests = {
-    version = testers.testVersion { package = cmake-lint; };
-  };
+  versionCheckProgram = "cmakelint";
 
   meta = {
     description = "Static code checker for CMake files";

--- a/pkgs/by-name/co/codefresh/package.nix
+++ b/pkgs/by-name/co/codefresh/package.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchYarnDeps, yarnConfigHook, npmHooks, nodejs, testers }:
+{ lib, stdenv, fetchFromGitHub, fetchYarnDeps, yarnConfigHook, npmHooks, nodejs, versionCheckHook }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "codefresh";
@@ -23,11 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
   # Tries to fetch stuff from the internet
   dontNpmPrune = true;
 
-  passthru.tests.version = testers.testVersion {
-    package = finalAttrs.finalPackage;
-    # codefresh needs to read a config file, this is faked out with a subshell
-    command = "codefresh --cfconfig <(echo 'contexts:') version";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "--cfconfig <(echo 'contexts:') version";
 
   meta = {
     changelog = "https://github.com/codefresh-io/cli/releases/tag/v${finalAttrs.version}";

--- a/pkgs/by-name/co/commitlint-rs/package.nix
+++ b/pkgs/by-name/co/commitlint-rs/package.nix
@@ -3,8 +3,7 @@
   lib,
   nix-update-script,
   rustPlatform,
-  testers,
-  commitlint-rs,
+  versionCheckHook,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "commitlint-rs";
@@ -18,9 +17,11 @@ rustPlatform.buildRustPackage rec {
   };
   cargoHash = "sha256-W6HkLCUoylgQQc2fFprmJeLH8KtpVUD4+BXWbNECVZ4=";
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion { package = commitlint-rs; };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/co/commitmsgfmt/package.nix
+++ b/pkgs/by-name/co/commitmsgfmt/package.nix
@@ -1,8 +1,7 @@
 { lib
 , rustPlatform
 , fetchFromGitLab
-, testers
-, commitmsgfmt
+, versionCheckHook
 }:
 rustPlatform.buildRustPackage rec {
   pname = "commitmsgfmt";
@@ -16,10 +15,10 @@ rustPlatform.buildRustPackage rec {
   };
   cargoHash = "sha256-jTRB9ogFQGVC4C9xpGxsJYV3cnWydAJLMcjhzUPULTE=";
 
-  passthru.tests.version = testers.testVersion {
-    package = commitmsgfmt;
-    command = "commitmsgfmt -V";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "-V";
 
   meta = with lib; {
     homepage = "https://gitlab.com/mkjeldsen/commitmsgfmt";

--- a/pkgs/by-name/co/committed/package.nix
+++ b/pkgs/by-name/co/committed/package.nix
@@ -3,9 +3,8 @@
 , fetchFromGitHub
 , rustPlatform
 , darwin
-, testers
 , nix-update-script
-, committed
+, versionCheckHook
 }:
 let
   version = "1.0.20";
@@ -24,8 +23,10 @@ rustPlatform.buildRustPackage {
 
   buildInputs = lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
-    tests.version = testers.testVersion { package = committed; };
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/co/corrscope/package.nix
+++ b/pkgs/by-name/co/corrscope/package.nix
@@ -4,8 +4,7 @@
 , fetchFromGitHub
 , ffmpeg
 , libsForQt5
-, testers
-, corrscope
+, versionCheckHook
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -60,13 +59,16 @@ python3Packages.buildPythonApplication rec {
     )
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = corrscope;
-    # Tries writing to
-    # - $HOME/.local/share/corrscope on Linux
-    # - $HOME/Library/Application Support/corrscope on Darwin
-    command = "env HOME=$TMPDIR ${lib.getExe corrscope} --version";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "corr";
+  # Tries writing to
+  # - $HOME/.local/share/corrscope on Linux
+  # - $HOME/Library/Application Support/corrscope on Darwin
+  preVersionCheck = ''
+    export HOME=$(mktemp -d)
+  '';
 
   meta = with lib; {
     description = "Render wave files into oscilloscope views, featuring advanced correlation-based triggering algorithm";

--- a/pkgs/by-name/cr/crc/package.nix
+++ b/pkgs/by-name/cr/crc/package.nix
@@ -1,9 +1,8 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
-, testers
-, crc
 , coreutils
+, versionCheckHook
 }:
 
 let
@@ -53,13 +52,14 @@ buildGoModule rec {
     export HOME=$(mktemp -d)
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = crc;
-    command = ''
-      export HOME=$(mktemp -d)
-      crc version
-    '';
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  preVersionCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+  versionCheckProgramArg = "version";
+
   passthru.updateScript = ./update.sh;
 
   meta = with lib; {

--- a/pkgs/by-name/cr/cringify/package.nix
+++ b/pkgs/by-name/cr/cringify/package.nix
@@ -2,8 +2,7 @@
 , rustPlatform
 , fetchFromGitHub
 , python3
-, testers
-, cringify
+, versionCheckHook
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -29,7 +28,8 @@ rustPlatform.buildRustPackage rec {
   # No tests are present in the repository
   doCheck = false;
 
-  passthru.tests.version = testers.testVersion { package = cringify; };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Annoy your friends with the cringified text";

--- a/pkgs/by-name/cr/criterion/package.nix
+++ b/pkgs/by-name/cr/criterion/package.nix
@@ -94,6 +94,7 @@ stdenv.mkDerivation rec {
   ];
 
   passthru.tests.version =
+    # TODO: Use `versionCheckHook`
     let
       tester = callPackage ./tests/001-version.nix {};
     in

--- a/pkgs/by-name/cr/crossplane-cli/package.nix
+++ b/pkgs/by-name/cr/crossplane-cli/package.nix
@@ -2,8 +2,7 @@
 , buildGoModule
 , fetchFromGitHub
 , nix-update-script
-, testers
-, crossplane-cli
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -31,11 +30,11 @@ buildGoModule rec {
     mv $out/bin/crank $out/bin/crossplane
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = crossplane-cli;
-    command = "crossplane version || true";
-    version = "v${version}";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "${placeholder "out"}/bin/crossplane";
+  versionCheckProgramArg = "version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/cs/csvq/package.nix
+++ b/pkgs/by-name/cs/csvq/package.nix
@@ -1,4 +1,4 @@
-{ buildGoModule, fetchFromGitHub, testers, lib, csvq }:
+{ buildGoModule, fetchFromGitHub, lib, versionCheckHook }:
 
 buildGoModule rec {
   pname = "csvq";
@@ -13,10 +13,8 @@ buildGoModule rec {
 
   vendorHash = "sha256-byBYp+iNnnsAXR+T3XmdwaeeBG8oB1EgNkDabzgUC98=";
 
-  passthru.tests.version = testers.testVersion {
-    package = csvq;
-    version = "csvq version ${version}";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "SQL-like query language for CSV";

--- a/pkgs/by-name/cu/cue/package.nix
+++ b/pkgs/by-name/cu/cue/package.nix
@@ -2,8 +2,7 @@
 , fetchFromGitHub
 , lib
 , installShellFiles
-, testers
-, cue
+, versionCheckHook
 , callPackage
 }:
 
@@ -37,15 +36,15 @@ buildGoModule rec {
       --zsh <($out/bin/cue completion zsh)
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "version";
+
   passthru = {
     writeCueValidator = callPackage ./validator.nix { };
     tests = {
       test-001-all-good = callPackage ./tests/001-all-good.nix { };
-      version = testers.testVersion {
-        package = cue;
-        command = "cue version";
-        version = "v${version}";
-      };
     };
   };
 

--- a/pkgs/by-name/cy/cyme/package.nix
+++ b/pkgs/by-name/cy/cyme/package.nix
@@ -7,8 +7,7 @@
 , darwin
 , libusb1
 , nix-update-script
-, testers
-, cyme
+, versionCheckHook
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -42,11 +41,11 @@ rustPlatform.buildRustPackage rec {
     "--skip=test_run"
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion {
-      package = cyme;
-    };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/cz/czkawka/package.nix
+++ b/pkgs/by-name/cz/czkawka/package.nix
@@ -2,7 +2,6 @@
 , stdenv
 , atk
 , cairo
-, czkawka
 , darwin
 , fetchFromGitHub
 , gdk-pixbuf
@@ -13,7 +12,7 @@
 , overrideSDK
 , pkg-config
 , rustPlatform
-, testers
+, versionCheckHook
 , wrapGAppsHook4
 , xvfb-run
 }:
@@ -70,10 +69,10 @@ buildRustPackage' {
   doCheck = stdenv.hostPlatform.isLinux
           && (stdenv.hostPlatform == stdenv.buildPlatform);
 
-  passthru.tests.version = testers.testVersion {
-    package = czkawka;
-    command = "czkawka_cli --version";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "czkawka_cli";
 
   # Desktop items, icons and metainfo are not installed automatically
   postInstall = ''

--- a/pkgs/by-name/da/dart-sass/package.nix
+++ b/pkgs/by-name/da/dart-sass/package.nix
@@ -7,6 +7,7 @@
   testers,
   dart-sass,
   runCommand,
+  versionCheckHook,
   writeText,
 }:
 
@@ -46,15 +47,13 @@ buildDartApplication rec {
 
   dartCompileFlags = [ "--define=version=${version}" ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     inherit embedded-protocol-version embedded-protocol;
     updateScript = ./update.sh;
     tests = {
-      version = testers.testVersion {
-        package = dart-sass;
-        command = "dart-sass --version";
-      };
-
       simple = testers.testEqualContents {
         assertion = "dart-sass compiles a basic scss file";
         expected = writeText "expected" ''

--- a/pkgs/by-name/de/dependabot-cli/package.nix
+++ b/pkgs/by-name/de/dependabot-cli/package.nix
@@ -1,9 +1,8 @@
 { buildGoModule
-, dependabot-cli
 , fetchFromGitHub
 , installShellFiles
 , lib
-, testers
+, versionCheckHook
 }:
 let
   pname = "dependabot-cli";
@@ -40,16 +39,10 @@ buildGoModule {
     "-skip=TestIntegration|TestNewProxy_customCert|TestRun"
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
-  installCheckPhase = ''
-    $out/bin/dependabot --help
-  '';
 
-  passthru.tests.version = testers.testVersion {
-    package = dependabot-cli;
-    command = "dependabot --version";
-    version = "v${version}";
-  };
+  versionCheckProgram = "dependabot";
 
   meta = with lib; {
     changelog = "https://github.com/dependabot/cli/releases/tag/v${version}";

--- a/pkgs/by-name/de/devenv/package.nix
+++ b/pkgs/by-name/de/devenv/package.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , makeWrapper
 , rustPlatform
-, testers
+, versionCheckHook
 
 , cachix
 , darwin
@@ -11,8 +11,6 @@
 , nix
 , openssl
 , pkg-config
-
-, devenv  # required to run version test
 }:
 
 let
@@ -53,12 +51,12 @@ in rustPlatform.buildRustPackage {
     wrapProgram $out/bin/devenv --set DEVENV_NIX ${devenv_nix} --prefix PATH ":" "$out/bin:${cachix}/bin"
   '';
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = devenv;
-      command = "export XDG_DATA_HOME=$PWD; devenv version";
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  preVersionCheck = ''
+    export XDG_DATA_HOME=$(mktemp -d)
+  '';
 
   meta = {
     changelog = "https://github.com/cachix/devenv/releases/tag/v${version}";

--- a/pkgs/by-name/di/diesel-cli/package.nix
+++ b/pkgs/by-name/di/diesel-cli/package.nix
@@ -12,9 +12,8 @@
   pkg-config,
   postgresql,
   sqlite,
-  testers,
+  versionCheckHook,
   zlib,
-  diesel-cli,
   sqliteSupport ? true,
   postgresqlSupport ? true,
   mysqlSupport ? true,
@@ -53,6 +52,9 @@ rustPlatform.buildRustPackage rec {
       zlib
     ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   buildNoDefaultFeatures = true;
   buildFeatures =
     lib.optional sqliteSupport "sqlite"
@@ -87,8 +89,9 @@ rustPlatform.buildRustPackage rec {
   # DSO missing from command line" errors for libz and libssl.
   env.NIX_LDFLAGS = lib.optionalString mysqlSupport "-lz -lssl -lcrypto";
 
+  versionCheckProgram = "${placeholder "out"}/bin/diesel";
+
   passthru = {
-    tests.version = testers.testVersion { package = diesel-cli; };
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/di/diffedit3/package.nix
+++ b/pkgs/by-name/di/diffedit3/package.nix
@@ -1,5 +1,5 @@
 { lib, rustPlatform, fetchCrate
-, testers, nix-update-script, diffedit3
+, nix-update-script, versionCheckHook
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -13,11 +13,11 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-e5bm8GLubA9BzH9oKKSC/Ysh+O+GJA8x6W576vKIIUA=";
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     updateScript = nix-update-script { };
-    tests = testers.testVersion {
-      package = diffedit3;
-    };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/di/discordchatexporter-cli/package.nix
+++ b/pkgs/by-name/di/discordchatexporter-cli/package.nix
@@ -2,8 +2,7 @@
 , buildDotnetModule
 , dotnetCorePackages
 , fetchFromGitHub
-, testers
-, discordchatexporter-cli
+, versionCheckHook
 }:
 
 buildDotnetModule rec {
@@ -26,12 +25,11 @@ buildDotnetModule rec {
     ln -s $out/bin/DiscordChatExporter.Cli $out/bin/discordchatexporter-cli
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     updateScript = ./updater.sh;
-    tests.version = testers.testVersion {
-      package = discordchatexporter-cli;
-      version = "v${version}";
-    };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/di/distribution/package.nix
+++ b/pkgs/by-name/di/distribution/package.nix
@@ -3,8 +3,7 @@
 , fetchFromGitHub
 , fetchpatch
 , nix-update-script
-, testers
-, distribution
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -41,11 +40,12 @@ buildGoModule rec {
     "-skip=^TestHTTPChecker$|^TestInMemoryDriverSuite$"
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "${placeholder "out"}/bin/registry";
+
   passthru = {
-    tests.version = testers.testVersion {
-      package = distribution;
-      version = "v${version}";
-    };
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/dm/dmalloc/package.nix
+++ b/pkgs/by-name/dm/dmalloc/package.nix
@@ -1,8 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, testers
-, dmalloc
+, versionCheckHook
 }:
 
 stdenv.mkDerivation rec {
@@ -22,9 +21,8 @@ stdenv.mkDerivation rec {
     "--enable-threads"
   ];
 
-  passthru.tests.version = testers.testVersion {
-    package = dmalloc;
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Debug Malloc memory allocation debugging C library";

--- a/pkgs/by-name/do/docfd/package.nix
+++ b/pkgs/by-name/do/docfd/package.nix
@@ -9,8 +9,7 @@
   makeWrapper,
   pandoc,
   poppler_utils,
-  testers,
-  docfd,
+  versionCheckHook,
 }:
 
 let
@@ -66,7 +65,8 @@ buildDunePackage' rec {
     }"
   '';
 
-  passthru.tests.version = testers.testVersion { package = docfd; };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "TUI multiline fuzzy document finder";

--- a/pkgs/by-name/do/docker-credential-gcr/package.nix
+++ b/pkgs/by-name/do/docker-credential-gcr/package.nix
@@ -1,10 +1,9 @@
 {
   buildGoModule,
-  docker-credential-gcr,
   fetchFromGitHub,
   lib,
   nix-update-script,
-  testers,
+  versionCheckHook,
 }:
 
 buildGoModule rec {
@@ -32,11 +31,12 @@ buildGoModule rec {
     "-X github.com/GoogleCloudPlatform/docker-credential-gcr/v2/config.Version=${version}"
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "version";
+
   passthru = {
-    tests.version = testers.testVersion {
-      package = docker-credential-gcr;
-      command = "docker-credential-gcr version";
-    };
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/do/dooit/package.nix
+++ b/pkgs/by-name/do/dooit/package.nix
@@ -1,9 +1,8 @@
 { lib
 , fetchFromGitHub
-, dooit
 , python3
-, testers
 , nix-update-script
+, versionCheckHook
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -39,12 +38,14 @@ python3.pkgs.buildPythonApplication rec {
   # No tests available
   doCheck = false;
 
-  passthru = {
-    tests.version = testers.testVersion {
-      package = dooit;
-      command = "HOME=$(mktemp -d) dooit --version";
-    };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
+  preVersionCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  passthru = {
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/do/doppler/package.nix
+++ b/pkgs/by-name/do/doppler/package.nix
@@ -1,9 +1,8 @@
 { buildGoModule
-, doppler
 , fetchFromGitHub
 , installShellFiles
 , lib
-, testers
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -34,10 +33,8 @@ buildGoModule rec {
       --zsh <($out/bin/doppler completion zsh)
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = doppler;
-    version = "v${version}";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Official CLI for interacting with your Doppler Enclave secrets and configuration";

--- a/pkgs/by-name/do/dosbox-staging/package.nix
+++ b/pkgs/by-name/do/dosbox-staging/package.nix
@@ -28,7 +28,7 @@
   pkg-config,
   speexdsp,
   stdenv,
-  testers,
+  versionCheckHook,
   zlib-ng,
 }:
 
@@ -109,13 +109,12 @@ stdenv.mkDerivation (finalAttrs: {
     popd
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "${placeholder "out"}/bin/dosbox";
+
   passthru = {
-    tests = {
-      version = testers.testVersion {
-        package = finalAttrs.finalPackage;
-        command = "dosbox --version";
-      };
-    };
     updateScript = gitUpdater {
       rev-prefix = "v";
     };

--- a/pkgs/by-name/do/dotenvx/package.nix
+++ b/pkgs/by-name/do/dotenvx/package.nix
@@ -2,8 +2,7 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
-  testers,
-  dotenvx,
+  versionCheckHook,
 }:
 
 buildNpmPackage rec {
@@ -21,13 +20,12 @@ buildNpmPackage rec {
 
   dontNpmBuild = true;
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = dotenvx;
-      # access to the home directory
-      command = "HOME=$TMPDIR dotenvx --version";
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  preVersionCheck = ''
+    export HOME=$(mktemp -d)
+  '';
 
   meta = {
     description = "Better dotenv–from the creator of `dotenv";

--- a/pkgs/by-name/do/dotslash/package.nix
+++ b/pkgs/by-name/do/dotslash/package.nix
@@ -1,5 +1,5 @@
 { lib, rustPlatform, fetchCrate
-, testers, nix-update-script, dotslash
+, nix-update-script, versionCheckHook
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -14,11 +14,11 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-URZ6HfyfY2Fh4iVMoG4OkQFFuLIRV7s5hlZLUFzeUvA=";
   doCheck = false; # http tests
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     updateScript = nix-update-script { };
-    tests = testers.testVersion {
-      package = dotslash;
-    };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/du/dualsensectl/package.nix
+++ b/pkgs/by-name/du/dualsensectl/package.nix
@@ -6,7 +6,7 @@
   dbus,
   hidapi,
   udev,
-  testers,
+  versionCheckHook,
   nix-update-script,
 }:
 
@@ -35,8 +35,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   makeFlags = [ "DESTDIR=$(out)" ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
-    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/du/dunst/package.nix
+++ b/pkgs/by-name/du/dunst/package.nix
@@ -22,8 +22,7 @@
 , pango
 , xorgproto
 , librsvg
-, testers
-, dunst
+, versionCheckHook
 , withX11 ? true
 , withWayland ? true
 }:
@@ -89,7 +88,8 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "jq" "${lib.getExe jq}"
   '';
 
-  passthru.tests.version = testers.testVersion { package = dunst; };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Lightweight and customizable notification daemon";

--- a/pkgs/by-name/dy/dynamodb-local/package.nix
+++ b/pkgs/by-name/dy/dynamodb-local/package.nix
@@ -7,9 +7,8 @@
 , curl
 , jq
 , yq
-, dynamodb-local
-, testers
 , common-updater-scripts
+, versionCheckHook
 , writeShellScript
 }:
 let
@@ -49,10 +48,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
-    tests.version = testers.testVersion {
-      package = dynamodb-local;
-    };
     updateScript = writeShellScript "update-dynamodb-local" ''
       set -o errexit
       export PATH="${lib.makeBinPath [ curl jq yq common-updater-scripts ]}:$PATH"

--- a/pkgs/by-name/ej/ejsonkms/package.nix
+++ b/pkgs/by-name/ej/ejsonkms/package.nix
@@ -2,8 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  testers,
-  ejsonkms,
+  versionCheckHook
 }:
 
 buildGoModule rec {
@@ -25,12 +24,8 @@ buildGoModule rec {
 
   doCheck = false;
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = ejsonkms;
-      version = "v${version}";
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Integrates EJSON with AWS KMS";

--- a/pkgs/by-name/el/elasticsearch-curator/package.nix
+++ b/pkgs/by-name/el/elasticsearch-curator/package.nix
@@ -1,10 +1,9 @@
 {
   lib,
-  elasticsearch-curator,
   fetchFromGitHub,
   nix-update-script,
   python3,
-  testers,
+  versionCheckHook,
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -68,11 +67,11 @@ python3.pkgs.buildPythonApplication rec {
     "test_api_key_set"
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  versionCheckProgram = "${placeholder "out"}/bin/curator";
+
   passthru = {
-    tests.version = testers.testVersion {
-      package = elasticsearch-curator;
-      command = "${lib.getExe elasticsearch-curator} --version";
-    };
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/ev/evdevhook2/package.nix
+++ b/pkgs/by-name/ev/evdevhook2/package.nix
@@ -10,7 +10,7 @@
   libevdev,
   libgee,
   udev,
-  testers,
+  versionCheckHook,
   nix-update-script,
 }:
 
@@ -56,12 +56,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   mesonBuildType = "release";
 
-  passthru = {
-    tests.version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-      version = "Evdevhook ${finalAttrs.version}";
-    };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
+  passthru = {
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/fa/facter/package.nix
+++ b/pkgs/by-name/fa/facter/package.nix
@@ -46,6 +46,7 @@ bundlerApp {
     '';
 
   passthru = {
+    # TODO: use `versionCheckHook`
     tests.version = testers.testVersion {
       command = "${lib.getExe facter} --version";
       package = facter;

--- a/pkgs/by-name/fa/fastfetch/package.nix
+++ b/pkgs/by-name/fa/fastfetch/package.nix
@@ -29,8 +29,8 @@
 , python3
 , rpm
 , sqlite
-, testers
 , util-linux
+, versionCheckHook
 , vulkan-loader
 , wayland
 , xfce
@@ -118,6 +118,9 @@ stdenv'.mkDerivation (finalAttrs: {
     darwin.moltenvk
   ]);
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   cmakeFlags = [
     (lib.cmakeOptionType "filepath" "CMAKE_INSTALL_SYSCONFDIR" "${placeholder "out"}/etc")
     (lib.cmakeBool "ENABLE_DIRECTX_HEADERS" false)
@@ -152,11 +155,6 @@ stdenv'.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-      command = "fastfetch -v | cut -d '(' -f 1";
-      version = "fastfetch ${finalAttrs.version}";
-    };
   };
 
   meta = {

--- a/pkgs/by-name/fa/fastqc/package.nix
+++ b/pkgs/by-name/fa/fastqc/package.nix
@@ -8,7 +8,7 @@
   makeDesktopItem,
   copyDesktopItems,
   desktopToDarwinBundle,
-  testers
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -55,10 +55,8 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper $out/FastQC/fastqc $out/bin/fastqc --prefix PATH : ${jre}/bin
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = finalAttrs.finalPackage;
-    version = "v${finalAttrs.version}";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "A quality control application for high throughput sequence data";

--- a/pkgs/by-name/fe/feather/package.nix
+++ b/pkgs/by-name/fe/feather/package.nix
@@ -14,9 +14,9 @@
 , qt6
 , readline
 , stdenv
-, testers
 , tor
 , unbound
+, versionCheckHook
 , zxing-cpp
 }:
 
@@ -69,12 +69,12 @@ stdenv.mkDerivation (finalAttrs: {
     "-DTOR_VERSION=${tor.version}"
   ];
 
-  passthru.tests.version = testers.testVersion {
-    package = finalAttrs.finalPackage;
-    command = ''
-      QT_QPA_PLATFORM=minimal ${finalAttrs.finalPackage.meta.mainProgram} --version
-    '';
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  preVersionCheck = ''
+    export QT_QPA_PLATFORM=minimal
+  '';
 
   meta = with lib; {
     description = "Free Monero desktop wallet";

--- a/pkgs/by-name/fi/files-cli/package.nix
+++ b/pkgs/by-name/fi/files-cli/package.nix
@@ -1,8 +1,7 @@
 { lib
 , fetchFromGitHub
 , buildGoModule
-, testers
-, files-cli
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -24,23 +23,10 @@ buildGoModule rec {
     "-X main.version=${version}"
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
 
-  installCheckPhase = ''
-    runHook preInstallCheck
-
-    $out/bin/files-cli --help
-
-    runHook postInstallCheck
-  '';
-
-  passthru.tests = {
-    version = testers.testVersion {
-      package = files-cli;
-      command = "files-cli -v";
-      version = "files-cli version ${version}";
-    };
-  };
+  versionCheckProgramArg = "-v";
 
   meta = with lib; {
     description = "Files.com Command Line App for Windows, Linux, and macOS";

--- a/pkgs/by-name/fl/flatpak/package.nix
+++ b/pkgs/by-name/fl/flatpak/package.nix
@@ -45,8 +45,8 @@
   socat,
   substituteAll,
   systemd,
-  testers,
   valgrind,
+  versionCheckHook,
   which,
   wrapGAppsNoGuiHook,
   xdg-dbus-proxy,
@@ -170,6 +170,9 @@ stdenv.mkDerivation (finalAttrs: {
   # TODO: some issues with temporary files
   doCheck = false;
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   NIX_LDFLAGS = "-lpthread";
 
   enableParallelBuilding = true;
@@ -219,8 +222,6 @@ stdenv.mkDerivation (finalAttrs: {
 
         grep format=svg "$out"
       '';
-
-      version = testers.testVersion { package = finalAttrs.finalPackage; };
     };
   };
 

--- a/pkgs/by-name/fl/flite/package.nix
+++ b/pkgs/by-name/fl/flite/package.nix
@@ -5,7 +5,7 @@
   fetchpatch,
   alsa-lib,
   libpulseaudio,
-  testers,
+  versionCheckHook,
   audioBackend ? "pulseaudio",
 }:
 assert lib.assertOneOf "audioBackend" audioBackend [
@@ -48,6 +48,9 @@ stdenv.mkDerivation (finalAttrs: {
     .${audioBackend} or (throw "${audioBackend} is not a supported backend!")
   );
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   configureFlags = [
     "--enable-shared"
   ] ++ lib.optionals stdenv.isLinux [ "--with-audio=${audioBackend}" ];
@@ -55,14 +58,6 @@ stdenv.mkDerivation (finalAttrs: {
   # main/Makefile creates and removes 'flite_voice_list.c' from multiple targets:
   # make[1]: *** No rule to make target 'flite_voice_list.c', needed by 'all'.  Stop
   enableParallelBuilding = false;
-
-  passthru = {
-    tests.version = testers.testVersion {
-      # `flite` does have a `--version` command, but it returns 1
-      command = "flite --help";
-      package = finalAttrs.finalPackage;
-    };
-  };
 
   meta = {
     description = "Small, fast run-time speech synthesis engine";

--- a/pkgs/by-name/fo/forgejo-runner/package.nix
+++ b/pkgs/by-name/fo/forgejo-runner/package.nix
@@ -1,9 +1,8 @@
 { lib
 , buildGoModule
 , fetchFromGitea
-, testers
-, forgejo-runner
 , nixosTests
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -28,12 +27,13 @@ buildGoModule rec {
 
   doCheck = false; # Test try to lookup code.forgejo.org.
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "act_runner";
+
   passthru.tests = {
     inherit (nixosTests.forgejo) sqlite3;
-    version = testers.testVersion {
-      package = forgejo-runner;
-      version = src.rev;
-    };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/fr/frankenphp/package.nix
+++ b/pkgs/by-name/fr/frankenphp/package.nix
@@ -4,13 +4,13 @@
 , fetchFromGitHub
 , php
 , brotli
-, testers
 , frankenphp
 , darwin
 , libiconv
 , pkg-config
 , makeBinaryWrapper
 , runCommand
+, versionCheckHook
 , writeText
 }:
 
@@ -77,15 +77,15 @@ in buildGoModule rec {
 
   doCheck = false;
 
+  # TODO: real NixOS test with Symfony application
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "version";
+
   passthru = {
     php = phpEmbedWithZts;
     tests = {
-      # TODO: real NixOS test with Symfony application
-      version = testers.testVersion {
-        inherit version;
-        package = frankenphp;
-        command = "frankenphp version";
-      };
       phpinfo = runCommand "php-cli-phpinfo" {
         phpScript = writeText "phpinfo.php" ''
           <?php phpinfo();

--- a/pkgs/by-name/fu/furmark/package.nix
+++ b/pkgs/by-name/fu/furmark/package.nix
@@ -10,7 +10,7 @@
   makeDesktopItem,
   makeWrapper,
   stdenv,
-  testers,
+  versionCheckHook,
   vulkan-loader,
 }:
 
@@ -91,12 +91,8 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  passthru = {
-    tests.version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-      command = "furmark --version";
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     homepage = "https://www.geeks3d.com/furmark/v2/";

--- a/pkgs/by-name/fu/furnace/package.nix
+++ b/pkgs/by-name/fu/furnace/package.nix
@@ -1,8 +1,7 @@
 { stdenv
 , lib
-, testers
-, furnace
 , fetchFromGitHub
+, versionCheckHook
 , cmake
 , pkg-config
 , makeWrapper
@@ -109,11 +108,11 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r ../demos $out/share/furnace/
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     updateScript = ./update.sh;
-    tests.version = testers.testVersion {
-      package = furnace;
-    };
   };
 
   meta = {

--- a/pkgs/by-name/fz/fzf/package.nix
+++ b/pkgs/by-name/fz/fzf/package.nix
@@ -5,8 +5,7 @@
 , installShellFiles
 , bc
 , ncurses
-, testers
-, fzf
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -75,9 +74,8 @@ buildGoModule rec {
     chmod +x $out/bin/fzf-share
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = fzf;
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     changelog = "https://github.com/junegunn/fzf/blob/${src.rev}/CHANGELOG.md";

--- a/pkgs/by-name/ge/gemmi/package.nix
+++ b/pkgs/by-name/ge/gemmi/package.nix
@@ -6,7 +6,7 @@
   zlib,
   enablePython ? true,
   python3Packages,
-  testers,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -42,15 +42,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   pythonImportsCheck = [ "gemmi" ];
 
-  doInstallCheck = enablePython;
-
-  nativeInstallCheckInputs = [ python3Packages.pytestCheckHook ];
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ] ++ lib.optional enablePython python3Packages.pytestCheckHook;
 
   pytestFlagsArray = [ "../tests" ];
-
-  passthru.tests = {
-    version = testers.testVersion { package = finalAttrs.finalPackage; };
-  };
 
   meta = {
     description = "Macromolecular crystallography library and utilities";

--- a/pkgs/by-name/gi/git-pw/package.nix
+++ b/pkgs/by-name/gi/git-pw/package.nix
@@ -46,6 +46,7 @@ python3.pkgs.buildPythonApplication rec {
   # This is needed because `git-pw` always rely on an ambiant git.
   # Furthermore, this doesn't really make sense to resholve git inside this derivation.
   # As `testVersion` does not offer the right knob, we can just `overrideAttrs`-it ourselves.
+  # TODO: maybe use `versionCheckHook`?
   passthru.tests.version = (testers.testVersion { package = git-pw; }).overrideAttrs (old: {
     buildInputs = (old.buildInputs or [ ]) ++ [ git ];
   });

--- a/pkgs/by-name/gi/githooks/package.nix
+++ b/pkgs/by-name/gi/githooks/package.nix
@@ -3,9 +3,8 @@
   buildGoModule,
   fetchFromGitHub,
   git,
-  testers,
   makeWrapper,
-  githooks
+  versionCheckHook
 }:
 buildGoModule rec {
   pname = "githooks";
@@ -70,11 +69,10 @@ buildGoModule rec {
     wrapProgram "$out/bin/githooks-runner" --prefix PATH : ${lib.makeBinPath [ git ]}
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = githooks;
-    command = "githooks-cli --version";
-    inherit version;
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "githooks-cli";
 
   meta = with lib; {
     description = "Git hooks manager with per-repo and shared Git hooks including version control";

--- a/pkgs/by-name/gi/gitmoji-cli/package.nix
+++ b/pkgs/by-name/gi/gitmoji-cli/package.nix
@@ -6,7 +6,7 @@
 , nodejs
 , fixup-yarn-lock
 , yarn
-, testers
+, versionCheckHook
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -66,11 +66,10 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "gitmoji";
 
   meta = {
     description = "Gitmoji client for using emojis on commit messages";

--- a/pkgs/by-name/go/go-critic/package.nix
+++ b/pkgs/by-name/go/go-critic/package.nix
@@ -1,9 +1,8 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
-, testers
 , nix-update-script
-, go-critic
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -29,11 +28,13 @@ buildGoModule rec {
     "-X main.Version=${version}"
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "gocritic";
+  versionCheckProgramArg = "version";
+
   passthru = {
-    tests.version = testers.testVersion {
-      package = go-critic;
-      command = "gocritic version";
-    };
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/go/goatcounter/package.nix
+++ b/pkgs/by-name/go/goatcounter/package.nix
@@ -1,8 +1,7 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
-, testers
-, goatcounter
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -31,11 +30,10 @@ buildGoModule rec {
     "-X zgo.at/goatcounter/v2.Version=${src.rev}"
   ];
 
-  passthru.tests.version = testers.testVersion {
-    package = goatcounter;
-    command = "goatcounter version";
-    version = "v${version}";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "version";
 
   meta = {
     description = "Easy web analytics. No tracking of personal data";

--- a/pkgs/by-name/go/gofumpt/package.nix
+++ b/pkgs/by-name/go/gofumpt/package.nix
@@ -2,8 +2,7 @@
 , buildGoModule
 , fetchFromGitHub
 , nix-update-script
-, testers
-, gofumpt
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -32,12 +31,11 @@ buildGoModule rec {
     "-skip=^TestScript/diagnose$"
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion {
-      package = gofumpt;
-      version = "v${version}";
-    };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/go/gomarkdoc/package.nix
+++ b/pkgs/by-name/go/gomarkdoc/package.nix
@@ -2,8 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  testers,
-  gomarkdoc
+  versionCheckHook
 }:
 
 buildGoModule rec {
@@ -28,11 +27,8 @@ buildGoModule rec {
     "-X main.commit=${src.rev}"
   ];
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = gomarkdoc;
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Generate markdown documentation for Go (golang) code";

--- a/pkgs/by-name/go/goss/package.nix
+++ b/pkgs/by-name/go/goss/package.nix
@@ -2,14 +2,13 @@
 , buildGoModule
 , fetchFromGitHub
 , getent
-, goss
 , lib
 , makeWrapper
 , nix-update-script
 , nixosTests
 , stdenv
 , systemd
-, testers
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -43,14 +42,12 @@ buildGoModule rec {
       --prefix PATH : "${lib.makeBinPath runtimeDependencies}"
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     tests = {
       inherit (nixosTests) goss;
-      version = testers.testVersion {
-        command = "goss --version";
-        package = goss;
-        version = "v${version}";
-      };
     };
     updateScript = nix-update-script { };
   };

--- a/pkgs/by-name/go/got/package.nix
+++ b/pkgs/by-name/go/got/package.nix
@@ -12,7 +12,7 @@
 , ncurses
 , bison
 , autoPatchelfHook
-, testers
+, versionCheckHook
 , signify
 , withSsh ? true, openssh
 # Default editor to use when neither VISUAL nor EDITOR are defined
@@ -59,9 +59,8 @@ stdenv.mkDerivation (finalAttrs: {
     "-include getopt.h"
   ]);
 
-  passthru.tests.version = testers.testVersion {
-    package = finalAttrs.finalPackage;
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     changelog = "https://gameoftrees.org/releases/CHANGES";

--- a/pkgs/by-name/gr/grafana-alloy/package.nix
+++ b/pkgs/by-name/gr/grafana-alloy/package.nix
@@ -7,11 +7,10 @@
 , yarn
 , fixup-yarn-lock
 , nodejs
-, grafana-alloy
 , nixosTests
 , nix-update-script
 , installShellFiles
-, testers
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -102,13 +101,14 @@ buildGoModule rec {
       --zsh <($out/bin/alloy completion zsh)
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "${placeholder "out"}/bin/alloy";
+
   passthru = {
     tests = {
       inherit (nixosTests) alloy;
-      version = testers.testVersion {
-        version = "v${version}";
-        package = grafana-alloy;
-      };
     };
     updateScript = nix-update-script { };
     # alias for nix-update to be able to find and update this attribute

--- a/pkgs/by-name/gu/guile-chickadee/package.nix
+++ b/pkgs/by-name/gu/guile-chickadee/package.nix
@@ -3,7 +3,7 @@
 , fetchurl
 , autoreconfHook
 , makeWrapper
-, testers
+, versionCheckHook
 , guile
 , pkg-config
 , texinfo
@@ -16,7 +16,6 @@
 , readline
 , guile-opengl
 , guile-sdl2
-, guile-chickadee
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "guile-chickadee";
@@ -61,10 +60,11 @@ stdenv.mkDerivation (finalAttrs: {
       --prefix GUILE_LOAD_COMPILED_PATH : "$out/${guile.siteCcacheDir}:$GUILE_LOAD_COMPILED_PATH"
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = guile-chickadee;
-    command = "chickadee -v";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "${placeholder "out"}/bin/chickadee";
+  versionCheckProgramArg = "-v";
 
   doCheck = !stdenv.isDarwin;
 

--- a/pkgs/by-name/ht/httpdirfs/package.nix
+++ b/pkgs/by-name/ht/httpdirfs/package.nix
@@ -10,7 +10,7 @@
   nix-update-script,
   pkg-config,
   stdenv,
-  testers,
+  versionCheckHook
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -47,14 +47,11 @@ stdenv.mkDerivation (finalAttrs: {
     make man
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  # Disabled for Darwin because requires macFUSE installed outside NixOS
+  doInstallCheck = stdenv.isLinux;
+
   passthru = {
-    # Disabled for Darwin because requires macFUSE installed outside NixOS
-    tests.version = lib.optionalAttrs stdenv.isLinux (
-      testers.testVersion {
-        command = "${lib.getExe finalAttrs.finalPackage} --version";
-        package = finalAttrs.finalPackage;
-      }
-    );
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/ht/httping/package.nix
+++ b/pkgs/by-name/ht/httping/package.nix
@@ -9,7 +9,7 @@
   nix-update-script,
   openssl,
   stdenv,
-  testers,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -45,11 +45,10 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
-    tests.version = testers.testVersion {
-      command = "${lib.getExe finalAttrs.finalPackage} --version";
-      package = finalAttrs.finalPackage;
-    };
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/hu/hugo/package.nix
+++ b/pkgs/by-name/hu/hugo/package.nix
@@ -4,8 +4,7 @@
 , fetchFromGitHub
 , installShellFiles
 , buildPackages
-, testers
-, hugo
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -42,11 +41,10 @@ buildGoModule rec {
       --zsh  <(${emulator} $out/bin/hugo completion zsh)
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = hugo;
-    command = "hugo version";
-    version = "v${version}";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "version";
 
   meta = {
     changelog = "https://github.com/gohugoio/hugo/releases/tag/v${version}";

--- a/pkgs/by-name/ic/icloudpd/package.nix
+++ b/pkgs/by-name/ic/icloudpd/package.nix
@@ -2,8 +2,7 @@
 , python3Packages
 , fetchFromGitHub
 , nix-update-script
-, testers
-, icloudpd
+, versionCheckHook
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -59,9 +58,11 @@ python3Packages.buildPythonApplication rec {
     "test_autodelete_invalid_creation_date"
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     updateScript = nix-update-script { };
-    tests = testers.testVersion { package = icloudpd; };
   };
 
   preBuild = ''

--- a/pkgs/by-name/im/immich-go/package.nix
+++ b/pkgs/by-name/im/immich-go/package.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, nix-update-script, testers, immich-go }:
+{ lib, buildGoModule, fetchFromGitHub, nix-update-script, versionCheckHook }:
 buildGoModule rec {
   pname = "immich-go";
   version = "0.19.1";
@@ -40,13 +40,11 @@ buildGoModule rec {
     ldflags+=" -X main.date=$(cat SOURCE_DATE)"
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     updateScript = nix-update-script { };
-    tests.versionTest = testers.testVersion {
-      package = immich-go;
-      command = "immich-go -version";
-      version = version;
-    };
   };
 
   meta = {

--- a/pkgs/by-name/ja/jankyborders/package.nix
+++ b/pkgs/by-name/ja/jankyborders/package.nix
@@ -4,8 +4,8 @@
 , pkgs
 , overrideSDK
 , darwin
-, testers
 , nix-update-script
+, versionCheckHook
 }:
 let
   stdenv = overrideSDK pkgs.stdenv "11.0";
@@ -42,12 +42,12 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru = {
-    tests.version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-      version = "borders-v${finalAttrs.version}";
-    };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
+  versionCheckProgram = "${placeholder "out"}/bin/borders";
+
+  passthru = {
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/ja/jazz2/package.nix
+++ b/pkgs/by-name/ja/jazz2/package.nix
@@ -7,7 +7,7 @@
 , openal
 , SDL2
 , stdenv
-, testers
+, versionCheckHook
 , zlib
 }:
 
@@ -33,9 +33,8 @@ stdenv.mkDerivation (finalAttrs: {
     "-DNCINE_OVERRIDE_CONTENT_PATH=${jazz2-content}"
   ];
 
-  passthru.tests.version = testers.testVersion {
-    package = finalAttrs.finalPackage;
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Open-source Jazz Jackrabbit 2 reimplementation";

--- a/pkgs/by-name/ka/karmor/package.nix
+++ b/pkgs/by-name/ka/karmor/package.nix
@@ -2,8 +2,7 @@
 , buildGoModule
 , fetchFromGitHub
 , installShellFiles
-, testers
-, karmor
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -39,12 +38,10 @@ buildGoModule rec {
       --zsh  <($out/bin/karmor completion zsh)
   '';
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = karmor;
-      command = "karmor version || true";
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "version";
 
   meta = with lib; {
     description = "Client tool to help manage KubeArmor";

--- a/pkgs/by-name/ka/kas/package.nix
+++ b/pkgs/by-name/ka/kas/package.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, python3, testers, kas }:
+{ lib, fetchFromGitHub, python3, versionCheckHook }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "kas";
@@ -15,10 +15,8 @@ python3.pkgs.buildPythonApplication rec {
 
   # Tests require network as they try to clone repos
   doCheck = false;
-  passthru.tests.version = testers.testVersion {
-    package = kas;
-    command = "${pname} --version";
-  };
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = with lib; {
     homepage = "https://github.com/siemens/kas";

--- a/pkgs/by-name/ki/kickstart/package.nix
+++ b/pkgs/by-name/ki/kickstart/package.nix
@@ -2,8 +2,7 @@
 , rustPlatform
 , fetchFromGitHub
 , nix-update-script
-, testers
-, kickstart
+, versionCheckHook
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -25,11 +24,11 @@ rustPlatform.buildRustPackage rec {
     "--skip=generation::tests::can_generate_from_remote_repo"
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion {
-      package = kickstart;
-    };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/ki/kitex/package.nix
+++ b/pkgs/by-name/ki/kitex/package.nix
@@ -1,8 +1,7 @@
 { buildGoModule
 , fetchFromGitHub
 , lib
-, testers
-, kitex
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -27,10 +26,8 @@ buildGoModule rec {
     ln -s $out/bin/kitex $out/bin/thrift-gen-kitex
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = kitex;
-    version = "v${version}";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib;  {
     description = "A high-performance and strong-extensibility Golang RPC framework";

--- a/pkgs/by-name/ko/komac/package.nix
+++ b/pkgs/by-name/ko/komac/package.nix
@@ -5,8 +5,7 @@
 , openssl
 , rustPlatform
 , darwin
-, testers
-, komac
+, versionCheckHook
 }:
 
 let
@@ -33,12 +32,8 @@ rustPlatform.buildRustPackage {
     darwin.apple_sdk.frameworks.SystemConfiguration
   ];
 
-  passthru.tests.version = testers.testVersion {
-    inherit version;
-
-    package = komac;
-    command = "komac --version";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Community Manifest Creator for WinGet";

--- a/pkgs/by-name/kr/krr/package.nix
+++ b/pkgs/by-name/kr/krr/package.nix
@@ -1,8 +1,7 @@
 { lib
 , python3
 , fetchFromGitHub
-, testers
-, krr
+, versionCheckHook
 }:
 
 python3.pkgs.buildPythonPackage rec {
@@ -50,10 +49,10 @@ python3.pkgs.buildPythonPackage rec {
     "robusta_krr"
   ];
 
-  passthru.tests.version = testers.testVersion {
-    package = krr;
-    command = "krr version";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "version";
 
   meta = with lib; {
     description = "Prometheus-based Kubernetes resource recommendations";

--- a/pkgs/by-name/la/latexminted/package.nix
+++ b/pkgs/by-name/la/latexminted/package.nix
@@ -1,8 +1,7 @@
 { lib
 , fetchPypi
 , python3Packages
-, latexminted
-, testers
+, versionCheckHook
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -24,9 +23,8 @@ python3Packages.buildPythonApplication rec {
     latex2pydata
   ];
 
-  passthru = {
-    tests.version = testers.testVersion { package = latexminted; };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Python executable for LaTeX minted package";

--- a/pkgs/by-name/la/lazygit/package.nix
+++ b/pkgs/by-name/la/lazygit/package.nix
@@ -2,8 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  lazygit,
-  testers,
+  versionCheckHook
 }:
 buildGoModule rec {
   pname = "lazygit";
@@ -24,7 +23,8 @@ buildGoModule rec {
     "-X main.buildSource=nix"
   ];
 
-  passthru.tests.version = testers.testVersion { package = lazygit; };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Simple terminal UI for git commands";

--- a/pkgs/by-name/lg/lgogdownloader/package.nix
+++ b/pkgs/by-name/lg/lgogdownloader/package.nix
@@ -14,8 +14,7 @@
   help2man,
   html-tidy,
   libsForQt5,
-  testers,
-  lgogdownloader,
+  versionCheckHook,
 
   enableGui ? true,
 }:
@@ -55,9 +54,8 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = lib.optional enableGui "-DUSE_QT_GUI=ON";
 
-  passthru.tests = {
-    version = testers.testVersion { package = lgogdownloader; };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Unofficial downloader to GOG.com for Linux users. It uses the same API as the official GOGDownloader";

--- a/pkgs/by-name/li/lint-staged/package.nix
+++ b/pkgs/by-name/li/lint-staged/package.nix
@@ -1,4 +1,4 @@
-{ lib, buildNpmPackage, fetchFromGitHub, testers, lint-staged }:
+{ lib, buildNpmPackage, fetchFromGitHub, versionCheckHook }:
 
 buildNpmPackage rec {
   pname = "lint-staged";
@@ -22,7 +22,8 @@ buildNpmPackage rec {
       '"version": "${version}"'
   '';
 
-  passthru.tests.version = testers.testVersion { package = lint-staged; };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Run linters on git staged files";

--- a/pkgs/by-name/li/little_boxes/package.nix
+++ b/pkgs/by-name/li/little_boxes/package.nix
@@ -2,8 +2,7 @@
 , rustPlatform
 , fetchFromGitHub
 , installShellFiles
-, testers
-, little_boxes
+, versionCheckHook
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -30,10 +29,8 @@ rustPlatform.buildRustPackage rec {
     installShellCompletion --zsh $extrasPath/_little_boxes
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = little_boxes;
-    command = "little_boxes --version";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Add boxes are input text";

--- a/pkgs/by-name/lo/local-ai/package.nix
+++ b/pkgs/by-name/lo/local-ai/package.nix
@@ -17,6 +17,7 @@
 , buildGoModule
 , makeWrapper
 , ncurses
+, versionCheckHook
 
   # apply feature parameter names according to
   # https://github.com/NixOS/rfcs/pull/169
@@ -525,6 +526,9 @@ let
         --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath LD_LIBRARY_PATH}" \
         --prefix PATH : "${ffmpeg}/bin"
       '';
+
+    nativeInstallCheckInputs = [ versionCheckHook ];
+    doInstallCheck = true;
 
     passthru.local-packages = {
       inherit

--- a/pkgs/by-name/lo/local-ai/tests.nix
+++ b/pkgs/by-name/lo/local-ai/tests.nix
@@ -22,12 +22,6 @@ let
   inherit (self.lib) genModels;
 in
 {
-  version = testers.testVersion {
-    package = self;
-    version = "v" + self.version;
-    command = "local-ai --help";
-  };
-
   health = testers.runNixOSTest {
     name = self.name + "-health";
     nodes.machine = common-config;

--- a/pkgs/by-name/ma/manticoresearch/package.nix
+++ b/pkgs/by-name/ma/manticoresearch/package.nix
@@ -11,8 +11,7 @@
 , mariadb-connector-c
 , re2
 , nlohmann_json
-, testers
-, manticoresearch
+, versionCheckHook
 }:
 
 let
@@ -109,11 +108,10 @@ stdenv.mkDerivation (finalAttrs: {
       --replace "@CMAKE_INSTALL_FULL_SYSCONFDIR@" "$out/etc"
   '';
 
-  passthru.tests.version = testers.testVersion {
-    inherit (finalAttrs) version;
-    package = manticoresearch;
-    command = "searchd --version";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "${placeholder "out"}/bin/searchd";
 
   meta = with lib; {
     description = "Easy to use open source fast database for search";

--- a/pkgs/by-name/ma/maturin/package.nix
+++ b/pkgs/by-name/ma/maturin/package.nix
@@ -6,9 +6,8 @@
   rustPlatform,
   darwin,
   libiconv,
-  testers,
   nix-update-script,
-  maturin,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -29,12 +28,15 @@ rustPlatform.buildRustPackage rec {
     libiconv
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
   # Requires network access, fails in sandbox.
   doCheck = false;
 
+  doInstallCheck = true;
+
   passthru = {
     tests = {
-      version = testers.testVersion { package = maturin; };
       pyo3 = callPackage ./pyo3-test { };
     };
 

--- a/pkgs/by-name/mc/mcdreforged/package.nix
+++ b/pkgs/by-name/mc/mcdreforged/package.nix
@@ -2,8 +2,7 @@
   lib,
   fetchFromGitHub,
   python3,
-  testers,
-  mcdreforged,
+  versionCheckHook,
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -35,9 +34,8 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeCheckInputs = [ python3.pkgs.pytestCheckHook ];
 
-  passthru.tests = {
-    version = testers.testVersion { package = mcdreforged; };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Rewritten version of MCDaemon, a python tool to control your Minecraft server";

--- a/pkgs/by-name/mc/mcomix/package.nix
+++ b/pkgs/by-name/mc/mcomix/package.nix
@@ -3,9 +3,8 @@
 , gdk-pixbuf
 , gobject-introspection
 , gtk3
-, mcomix
 , python3
-, testers
+, versionCheckHook
 , wrapGAppsHook3
 
   # Recommended Dependencies:
@@ -62,9 +61,8 @@ python3.pkgs.buildPythonApplication rec {
     cp -a share $out/
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = mcomix;
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Comic book reader and image viewer";

--- a/pkgs/by-name/me/menulibre/package.nix
+++ b/pkgs/by-name/me/menulibre/package.nix
@@ -7,8 +7,7 @@
 , gobject-introspection
 , wrapGAppsHook3
 , nix-update-script
-, testers
-, menulibre
+, versionCheckHook
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -36,6 +35,8 @@ python3Packages.buildPythonApplication rec {
     wrapGAppsHook3
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
   postPatch = ''
     substituteInPlace setup.py \
       --replace-fail 'data_dir =' "data_dir = '$out/share/menulibre' #" \
@@ -46,12 +47,12 @@ python3Packages.buildPythonApplication rec {
     export HOME=$TMPDIR
   '';
 
+  preVersionCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion {
-      package = menulibre;
-      command = "HOME=$TMPDIR menulibre --version | cut -d' ' -f2";
-    };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/me/mercure/package.nix
+++ b/pkgs/by-name/me/mercure/package.nix
@@ -2,8 +2,7 @@
 , buildGoModule
 , fetchFromGitHub
 , nix-update-script
-, testers
-, mercure
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -32,13 +31,13 @@ buildGoModule rec {
 
   doCheck = false;
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "version";
+
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion {
-      version = "v${version}";
-      package = mercure;
-      command = "mercure version";
-    };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/me/mesonlsp/package.nix
+++ b/pkgs/by-name/me/mesonlsp/package.nix
@@ -18,9 +18,8 @@
   nlohmann_json,
   pkgsStatic,
 
-  mesonlsp,
   nix-update-script,
-  testers,
+  versionCheckHook
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -147,12 +146,11 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs src/libtypenamespace
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion {
-      package = mesonlsp;
-      version = "v${finalAttrs.version}";
-    };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/mg/mgitstatus/package.nix
+++ b/pkgs/by-name/mg/mgitstatus/package.nix
@@ -1,7 +1,7 @@
 { fetchFromGitHub
 , lib
 , stdenvNoCC
-, testers
+, versionCheckHook
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -19,10 +19,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     "PREFIX=$(out)"
   ];
 
-  passthru.tests.version = testers.testVersion {
-    package = finalAttrs.finalPackage;
-    version = "v${finalAttrs.version}";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Show uncommitted, untracked and unpushed changes for multiple Git repos";

--- a/pkgs/by-name/mi/mini-calc/package.nix
+++ b/pkgs/by-name/mi/mini-calc/package.nix
@@ -4,8 +4,7 @@
   fetchFromGitHub,
   gnuplot,
   makeWrapper,
-  testers,
-  mini-calc,
+  versionCheckHook,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "mini-calc";
@@ -26,12 +25,11 @@ rustPlatform.buildRustPackage rec {
       --prefix PATH : "${lib.makeBinPath [ gnuplot ]}"
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = mini-calc;
-    # `mini-calc -v` does not output in the test env, fallback to pipe
-    command = "echo -v | mini-calc";
-    version = "v${version}";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "echo -v | mini-calc";
+  versionCheckProgramArg = "";
 
   meta = {
     description = "Fully-featured minimalistic configurable calculator written in Rust";

--- a/pkgs/by-name/mi/mistral-rs/package.nix
+++ b/pkgs/by-name/mi/mistral-rs/package.nix
@@ -17,7 +17,7 @@
   # env
   fetchurl,
 
-  testers,
+  versionCheckHook,
   mistral-rs,
 
   cudaPackages,
@@ -172,10 +172,11 @@ rustPlatform.buildRustPackage rec {
     "--skip=sampler::tests::test_gumbel_speculative"
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     tests = {
-      version = testers.testVersion { package = mistral-rs; };
-
       withMkl = mistral-rs.override { acceleration = "mkl"; };
       withCuda = mistral-rs.override { acceleration = "cuda"; };
       withMetal = mistral-rs.override { acceleration = "metal"; };

--- a/pkgs/by-name/mo/mods/package.nix
+++ b/pkgs/by-name/mo/mods/package.nix
@@ -4,8 +4,7 @@
   installShellFiles,
   fetchFromGitHub,
   gitUpdater,
-  testers,
-  mods,
+  versionCheckHook
 }:
 
 buildGoModule rec {
@@ -39,12 +38,15 @@ buildGoModule rec {
       rev-prefix = "v";
       ignoredVersions = ".(rc|beta).*";
     };
-
-    tests.version = testers.testVersion {
-      package = mods;
-      command = "HOME=$(mktemp -d) mods -v";
-    };
   };
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  preVersionCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+  versionCheckProgramArg = "-v";
 
   postInstall = ''
     export HOME=$(mktemp -d)

--- a/pkgs/by-name/mo/mold/package.nix
+++ b/pkgs/by-name/mo/mold/package.nix
@@ -14,10 +14,9 @@
 , clangStdenv
 , gccStdenv
 , hello
-, mold
 , mold-wrapped
 , runCommandCC
-, testers
+, versionCheckHook
 , useMoldLinker
 }:
 
@@ -54,6 +53,9 @@ stdenv.mkDerivation rec {
     "-faligned-allocation"
   ]);
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     updateScript = nix-update-script { };
     tests =
@@ -88,10 +90,7 @@ stdenv.mkDerivation rec {
               fi
             ''
         ;
-      in
-      {
-        version = testers.testVersion { package = mold; };
-      } // lib.optionalAttrs stdenv.isLinux {
+      in lib.optionalAttrs stdenv.isLinux {
         adapter-gcc = helloTest "adapter-gcc" (hello.override (old: { stdenv = useMoldLinker gccStdenv; }));
         adapter-llvm = helloTest "adapter-llvm" (hello.override (old: { stdenv = useMoldLinker clangStdenv; }));
         wrapped = helloTest "wrapped" (hello.overrideAttrs (previousAttrs: {

--- a/pkgs/by-name/mo/mosdepth/package.nix
+++ b/pkgs/by-name/mo/mosdepth/package.nix
@@ -1,4 +1,4 @@
-{ lib, buildNimPackage, fetchFromGitHub, pcre, testers }:
+{ lib, buildNimPackage, fetchFromGitHub, pcre, versionCheckHook }:
 
 buildNimPackage (finalAttrs: {
   pname = "mosdepth";
@@ -17,11 +17,8 @@ buildNimPackage (finalAttrs: {
 
   buildInputs = [ pcre ];
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "fast BAM/CRAM depth calculation for WGS, exome, or targeted sequencing";

--- a/pkgs/by-name/mo/mosdns/package.nix
+++ b/pkgs/by-name/mo/mosdns/package.nix
@@ -2,10 +2,9 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  testers,
-  mosdns,
   stdenv,
   installShellFiles,
+  versionCheckHook,
 }:
 
 buildGoModule rec {
@@ -36,12 +35,8 @@ buildGoModule rec {
       --zsh <($out/bin/mosdns completion zsh)
   '';
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = mosdns;
-      command = "${lib.getExe mosdns} version";
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Modular, pluggable DNS forwarder";

--- a/pkgs/by-name/mp/mpack/package.nix
+++ b/pkgs/by-name/mp/mpack/package.nix
@@ -2,8 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  testers,
-  mpack,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -38,15 +37,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  passthru.tests = {
-    version = testers.testVersion {
-      command = ''
-        mpack 2>&1 || echo "mpack exited with error code $?"
-      '';
-      package = mpack;
-      version = "mpack version ${version}";
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "";
 
   meta = with lib; {
     description = "Utilities for encoding and decoding binary files in MIME";

--- a/pkgs/by-name/my/myks/package.nix
+++ b/pkgs/by-name/my/myks/package.nix
@@ -1,10 +1,9 @@
 { lib,
   buildGoModule,
   fetchFromGitHub,
-  testers,
   installShellFiles,
-  myks,
   stdenv,
+  versionCheckHook,
 }:
 
 buildGoModule rec {
@@ -34,8 +33,6 @@ buildGoModule rec {
 
   CGO_ENABLED = 0;
 
-  passthru.tests.version = testers.testVersion { package = myks; };
-
   postInstall =
     lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
       installShellCompletion --cmd myks \
@@ -43,6 +40,9 @@ buildGoModule rec {
         --zsh <($out/bin/myks completion zsh) \
         --fish <($out/bin/myks completion fish)
     '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     changelog = "https://github.com/mykso/myks/blob/v${version}/CHANGELOG.md";

--- a/pkgs/by-name/my/mystmd/package.nix
+++ b/pkgs/by-name/my/mystmd/package.nix
@@ -1,4 +1,4 @@
-{ lib, buildNpmPackage, fetchFromGitHub, mystmd, testers, nix-update-script }:
+{ lib, buildNpmPackage, fetchFromGitHub, nix-update-script, versionCheckHook }:
 
 buildNpmPackage rec {
   pname = "mystmd";
@@ -23,11 +23,12 @@ buildNpmPackage rec {
     runHook postInstall
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "${placeholder "out"}/bin/myst";
+
   passthru = {
-    tests.version = testers.testVersion {
-      package = mystmd;
-      version = "v${version}";
-    };
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/nb/nb-cli/package.nix
+++ b/pkgs/by-name/nb/nb-cli/package.nix
@@ -1,9 +1,8 @@
 {
   fetchPypi,
   lib,
-  nb-cli,
   python3,
-  testers,
+  versionCheckHook,
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -40,14 +39,14 @@ python3.pkgs.buildPythonApplication rec {
     wcwidth
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
   # no test
   doCheck = false;
 
   pythonImportsCheck = [ "nb_cli" ];
 
-  passthru.tests = {
-    version = testers.testVersion { package = nb-cli; };
-  };
+  versionCheckProgram = "nb";
 
   meta = {
     description = "CLI for nonebot2";

--- a/pkgs/by-name/ne/nezha-agent/package.nix
+++ b/pkgs/by-name/ne/nezha-agent/package.nix
@@ -2,8 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  nezha-agent,
-  testers,
+  versionCheckHook,
 }:
 buildGoModule rec {
   pname = "nezha-agent";
@@ -29,12 +28,11 @@ buildGoModule rec {
     rm ./pkg/monitor/myip_test.go
   '';
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = nezha-agent;
-      command = "${nezha-agent}/bin/agent -v";
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "${placeholder "out"}/bin/agent";
+  versionCheckProgramArg = "-v";
 
   meta = {
     description = "Agent of Nezha Monitoring";

--- a/pkgs/by-name/nf/nf-test/package.nix
+++ b/pkgs/by-name/nf/nf-test/package.nix
@@ -2,10 +2,9 @@
 , fetchurl
 , makeWrapper
 , nextflow
-, nf-test
 , openjdk11
 , stdenv
-, testers
+, versionCheckHook
 }:
 stdenv.mkDerivation rec {
 
@@ -41,10 +40,10 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = nf-test;
-    command = "nf-test version";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "version";
 
   meta = with lib; {
     description = "Simple test framework for Nextflow pipelines";

--- a/pkgs/by-name/ni/nimdow/package.nix
+++ b/pkgs/by-name/ni/nimdow/package.nix
@@ -1,4 +1,4 @@
-{ lib, buildNimPackage, fetchFromGitHub, nixosTests, testers }:
+{ lib, buildNimPackage, fetchFromGitHub, nixosTests, versionCheckHook }:
 
 buildNimPackage (finalAttrs: {
   pname = "nimdow";
@@ -27,12 +27,11 @@ buildNimPackage (finalAttrs: {
     substituteInPlace src/nimdowpkg/config/configloader.nim --replace "/usr/share/nimdow" "$out/share/nimdow"
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru.tests = {
     nimdow = nixosTests.nimdow;
-    version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-      version = "v${finalAttrs.version}";
-    };
   };
 
   meta = with lib;

--- a/pkgs/by-name/nu/numbat/package.nix
+++ b/pkgs/by-name/nu/numbat/package.nix
@@ -1,10 +1,9 @@
 { lib
 , stdenv
-, testers
 , fetchFromGitHub
 , rustPlatform
 , darwin
-, numbat
+, versionCheckHook
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -31,9 +30,8 @@ rustPlatform.buildRustPackage rec {
     cp -r $src/${pname}/modules $out/share/${pname}/
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = numbat;
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "High precision scientific calculator with full support for physical units";

--- a/pkgs/by-name/oc/ocsinventory-agent/package.nix
+++ b/pkgs/by-name/oc/ocsinventory-agent/package.nix
@@ -78,6 +78,7 @@ perlPackages.buildPerlPackage rec {
   passthru = {
     tests = {
       inherit (nixosTests) ocsinventory-agent;
+      # TODO: use `versionCheckHook` when the below is resolved
       version = testers.testVersion {
         package = ocsinventory-agent;
         command = "ocsinventory-agent --version";

--- a/pkgs/by-name/of/offpunk/package.nix
+++ b/pkgs/by-name/of/offpunk/package.nix
@@ -3,10 +3,9 @@
 , installShellFiles
 , less
 , lib
-, offpunk
 , python3Packages
-, testers
 , timg
+, versionCheckHook
 , xdg-utils
 , xsel
 }:
@@ -51,7 +50,7 @@ python3Packages.buildPythonApplication rec {
     installManPage man/*.1
   '';
 
-  passthru.tests.version = testers.testVersion { package = offpunk; };
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {
     description = "Command-line and offline-first smolnet browser/feed reader";

--- a/pkgs/by-name/ol/ollama/package.nix
+++ b/pkgs/by-name/ol/ollama/package.nix
@@ -19,7 +19,7 @@
 , autoAddDriverRunpath
 
 , nixosTests
-, testers
+, versionCheckHook
 , ollama
 , ollama-rocm
 , ollama-cuda
@@ -205,13 +205,12 @@ goBuild ((lib.optionalAttrs enableRocm {
     "-X=github.com/ollama/ollama/server.mode=release"
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru.tests = {
     inherit ollama;
     service = nixosTests.ollama;
-    version = testers.testVersion {
-      inherit version;
-      package = ollama;
-    };
   } // lib.optionalAttrs stdenv.isLinux {
     inherit ollama-rocm ollama-cuda;
   };

--- a/pkgs/by-name/oo/oo7/package.nix
+++ b/pkgs/by-name/oo/oo7/package.nix
@@ -3,10 +3,9 @@
   rustPlatform,
   fetchFromGitHub,
   nix-update-script,
-  oo7,
   openssl,
   pkg-config,
-  testers,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -39,9 +38,12 @@ rustPlatform.buildRustPackage rec {
       --replace-fail "@bindir@" "$out/bin"
   '';
 
-  passthru = {
-    tests.testVersion = testers.testVersion { package = oo7; };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
+  versionCheckProgram = "${placeholder "out"}/bin/oo7-cli";
+
+  passthru = {
     # TODO: re-enable this when upstream adds a Cargo.lock
     # updateScript = nix-update-script { };
   };

--- a/pkgs/by-name/op/openpgp-card-tools/package.nix
+++ b/pkgs/by-name/op/openpgp-card-tools/package.nix
@@ -4,8 +4,7 @@
 , fetchFromGitea
 , pkg-config
 , pcsclite
-, testers
-, openpgp-card-tools
+, versionCheckHook
 , darwin
 }:
 
@@ -30,11 +29,8 @@ rustPlatform.buildRustPackage rec {
     darwin.apple_sdk.frameworks.Security
   ];
 
-  passthru = {
-    tests.version = testers.testVersion {
-      package = openpgp-card-tools;
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Tool for inspecting and configuring OpenPGP cards";

--- a/pkgs/by-name/op/opensnitch/package.nix
+++ b/pkgs/by-name/op/opensnitch/package.nix
@@ -9,8 +9,7 @@
 , iptables
 , makeWrapper
 , protoc-gen-go-grpc
-, testers
-, opensnitch
+, versionCheckHook
 , nixosTests
 }:
 
@@ -80,13 +79,11 @@ buildGoModule rec {
       --prefix PATH : ${lib.makeBinPath [ iptables ]}
   '';
 
-  passthru.tests = {
-    inherit (nixosTests) opensnitch;
-    version = testers.testVersion {
-      package = opensnitch;
-      command = "opensnitchd -version";
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "${placeholder "out"}/bin/opensnitchd";
+  versionCheckProgramArg = "-version";
 
   meta = with lib; {
     description = "Application firewall";

--- a/pkgs/by-name/os/osm2pgsql/package.nix
+++ b/pkgs/by-name/os/osm2pgsql/package.nix
@@ -18,7 +18,7 @@
 , opencv
 , potrace
 , protozero
-, testers
+, versionCheckHook
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -57,6 +57,9 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ lib.optional withLuaJIT luajit
     ++ lib.optional (!withLuaJIT) lua;
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   cmakeFlags = [
     (lib.cmakeBool "EXTERNAL_LIBOSMIUM" true)
     (lib.cmakeBool "EXTERNAL_PROTOZERO" true)
@@ -65,10 +68,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   installFlags = [ "install-gen" ];
-
-  passthru.tests.version = testers.testVersion {
-    package = finalAttrs.finalPackage;
-  };
 
   meta = with lib; {
     description = "OpenStreetMap data to PostgreSQL converter";

--- a/pkgs/by-name/ot/otel-desktop-viewer/package.nix
+++ b/pkgs/by-name/ot/otel-desktop-viewer/package.nix
@@ -1,8 +1,7 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
-, testers
-, otel-desktop-viewer
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -25,11 +24,8 @@ buildGoModule rec {
 
   ldflags = [ "-s" "-w" ];
 
-  passthru.tests.version = testers.testVersion {
-    inherit version;
-    package = otel-desktop-viewer;
-    command = "otel-desktop-viewer --version";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     changelog = "https://github.com/CtrlSpice/otel-desktop-viewer/releases/tag/v${version}";

--- a/pkgs/by-name/pa/pack/package.nix
+++ b/pkgs/by-name/pa/pack/package.nix
@@ -3,8 +3,7 @@
   buildGoModule,
   fetchFromGitHub,
   nix-update-script,
-  testers,
-  pack,
+  versionCheckHook,
 }:
 
 buildGoModule rec {
@@ -28,9 +27,11 @@ buildGoModule rec {
     "-X github.com/buildpacks/pack.Version=${version}"
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion { package = pack; };
   };
 
   meta = {

--- a/pkgs/by-name/pa/passt/package.nix
+++ b/pkgs/by-name/pa/passt/package.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchurl
 , gitUpdater
-, testers
+, versionCheckHook
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -19,11 +19,10 @@ stdenv.mkDerivation (finalAttrs: {
     "VERSION=${finalAttrs.version}"
   ];
 
-  passthru = {
-    tests.version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-    };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
+  passthru = {
     updateScript = gitUpdater {
       url = "https://passt.top/passt";
     };

--- a/pkgs/by-name/pa/patch2pr/package.nix
+++ b/pkgs/by-name/pa/patch2pr/package.nix
@@ -1,8 +1,7 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
-, testers
-, patch2pr
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -23,11 +22,8 @@ buildGoModule rec {
     "-X main.commit=${src.rev}"
   ];
 
-  passthru.tests.patch2pr-version = testers.testVersion {
-    package = patch2pr;
-    command = "${patch2pr.meta.mainProgram} --version";
-    version = version;
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Create pull requests from patches without cloning the repository";

--- a/pkgs/by-name/pd/pdk/package.nix
+++ b/pkgs/by-name/pd/pdk/package.nix
@@ -20,6 +20,7 @@ bundlerApp {
   '';
 
   passthru = {
+    # TODO: use `versionCheckHook` when possible
     tests.version = testers.testVersion {
       package = pdk;
       version = (import ./gemset.nix).pdk.version;

--- a/pkgs/by-name/pg/pgcopydb/package.nix
+++ b/pkgs/by-name/pg/pgcopydb/package.nix
@@ -8,7 +8,7 @@
 , postgresql
 , readline
 , sqlite
-, testers
+, versionCheckHook
 , zlib
 }:
 
@@ -48,11 +48,8 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Copy a Postgres database to a target Postgres server (pg_dump | pg_restore on steroids";

--- a/pkgs/by-name/pi/pinact/package.nix
+++ b/pkgs/by-name/pi/pinact/package.nix
@@ -1,8 +1,7 @@
 { lib
 , fetchFromGitHub
 , buildGoModule
-, testers
-, pinact
+, versionCheckHook
 }:
 
 let
@@ -22,11 +21,8 @@ buildGoModule {
 
   doCheck = true;
 
-  passthru.tests.version = testers.testVersion {
-    package = pinact;
-    command = "pinact --version";
-    version = src.rev;
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/pi/pixi/package.nix
+++ b/pkgs/by-name/pi/pixi/package.nix
@@ -7,8 +7,7 @@
 , openssl
 , installShellFiles
 , darwin
-, testers
-, pixi
+, versionCheckHook
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -87,9 +86,8 @@ rustPlatform.buildRustPackage rec {
       --zsh <($out/bin/pixi completion --shell zsh)
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = pixi;
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Package management made easy";

--- a/pkgs/by-name/pl/platformsh/package.nix
+++ b/pkgs/by-name/pl/platformsh/package.nix
@@ -2,9 +2,8 @@
   stdenvNoCC,
   lib,
   fetchurl,
-  testers,
   installShellFiles,
-  platformsh
+  versionCheckHook
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -50,12 +49,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru = {
-    tests.version = testers.testVersion {
-      inherit (finalAttrs) version;
-      package = platformsh;
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "${placeholder "out"}/bin/platform";
 
   meta = {
     description = "Unified tool for managing your Platform.sh services from the command line";

--- a/pkgs/by-name/pl/plow/package.nix
+++ b/pkgs/by-name/pl/plow/package.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, testers, plow }:
+{ lib, buildGoModule, fetchFromGitHub, versionCheckHook }:
 
 buildGoModule rec {
   pname = "plow";
@@ -15,9 +15,8 @@ buildGoModule rec {
 
   ldflags = [ "-s" "-w" ];
 
-  passthru.tests.version = testers.testVersion {
-    package = plow;
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "High-performance HTTP benchmarking tool that includes a real-time web UI and terminal display";

--- a/pkgs/by-name/po/powerpipe/package.nix
+++ b/pkgs/by-name/po/powerpipe/package.nix
@@ -5,8 +5,7 @@
   lib,
   makeWrapper,
   nix-update-script,
-  powerpipe,
-  testers,
+  versionCheckHook,
 }:
 
 buildGoModule rec {
@@ -51,12 +50,10 @@ buildGoModule rec {
       --set-default POWERPIPE_TELEMETRY none
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
-    tests.version = testers.testVersion {
-      command = "${lib.getExe powerpipe} --version";
-      package = powerpipe;
-      version = "v${version}";
-    };
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/pr/presenterm/package.nix
+++ b/pkgs/by-name/pr/presenterm/package.nix
@@ -2,9 +2,8 @@
 , fetchFromGitHub
 , rustPlatform
 , libsixel
-, testers
-, presenterm
 , stdenv
+, versionCheckHook
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -31,10 +30,8 @@ rustPlatform.buildRustPackage rec {
   # Skip test that currently doesn't work
   checkFlags = [ "--skip=execute::test::shell_code_execution" ];
 
-  passthru.tests.version = testers.testVersion {
-    package = presenterm;
-    command = "presenterm --version";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Terminal based slideshow tool";

--- a/pkgs/by-name/pu/puppet-bolt/package.nix
+++ b/pkgs/by-name/pu/puppet-bolt/package.nix
@@ -29,6 +29,7 @@
   '';
 
   passthru = {
+    # TODO: use `versionCheckHook` when possible
     tests.version = testers.testVersion {
       package = puppet-bolt;
       version = (import ./gemset.nix).bolt.version;

--- a/pkgs/by-name/pu/puppet-lint/package.nix
+++ b/pkgs/by-name/pu/puppet-lint/package.nix
@@ -12,6 +12,7 @@ bundlerApp {
   exes = [ "puppet-lint" ];
 
   passthru = {
+    # TODO: use `versionCheckHook` when possible
     tests.version = testers.testVersion {
       package = puppet-lint;
       version = (import ./gemset.nix).puppet-lint.version;

--- a/pkgs/by-name/pu/puppet/package.nix
+++ b/pkgs/by-name/pu/puppet/package.nix
@@ -12,6 +12,7 @@ bundlerApp {
   exes = [ "puppet" ];
 
   passthru = {
+    # TODO: use `versionCheckHook` when possible
     tests.version = testers.testVersion {
       package = puppet;
       command = "HOME=$(mktemp -d) puppet --version";

--- a/pkgs/by-name/pu/purescm/package.nix
+++ b/pkgs/by-name/pu/purescm/package.nix
@@ -1,7 +1,7 @@
 { lib
 , buildNpmPackage
 , fetchNpmDeps
-, testers
+, versionCheckHook
 }:
 
 let
@@ -42,9 +42,8 @@ let
       ln -s $out/share/${pname}/node_modules/.bin $out/bin
     '';
 
-    passthru.tests = {
-      version = testers.testVersion { inherit package; };
-    };
+    nativeInstallCheckInputs = [ versionCheckHook ];
+    doInstallCheck = true;
 
     meta = {
       description = "Chez Scheme back-end for PureScript";

--- a/pkgs/by-name/qu/quickemu/package.nix
+++ b/pkgs/by-name/qu/quickemu/package.nix
@@ -26,8 +26,7 @@
   zsync,
   OVMF,
   OVMFFull,
-  quickemu,
-  testers,
+  versionCheckHook,
   installShellFiles,
 }:
 let
@@ -99,9 +98,8 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.tests = testers.testVersion {
-    package = quickemu;
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Quickly create and run optimised Windows, macOS and Linux virtual machines";

--- a/pkgs/by-name/qu/quickjs-ng/package.nix
+++ b/pkgs/by-name/qu/quickjs-ng/package.nix
@@ -2,8 +2,8 @@
 , stdenv
 , cmake
 , fetchFromGitHub
-, testers
 , texinfo
+, versionCheckHook
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -39,12 +39,10 @@ stdenv.mkDerivation (finalAttrs: {
      install -Dt $info/share/info/ quickjs.info)
   '';
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-      command = "qjs --help || true";
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "qjs";
 
   meta = with lib; {
     description = "Mighty JavaScript engine";

--- a/pkgs/by-name/qu/quicktype/package.nix
+++ b/pkgs/by-name/qu/quicktype/package.nix
@@ -1,4 +1,4 @@
-{ lib, buildNpmPackage, fetchFromGitHub, jq, quicktype, testers }:
+{ lib, buildNpmPackage, fetchFromGitHub, jq, versionCheckHook }:
 
 buildNpmPackage rec {
   pname = "quicktype";
@@ -21,9 +21,8 @@ buildNpmPackage rec {
     mv packages/ $out/lib/node_modules/quicktype/
   '';
 
-  passthru.tests = {
-    version = testers.testVersion { package = quicktype; };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Generate types and converters from JSON, Schema, and GraphQL";

--- a/pkgs/by-name/r1/r10k/package.nix
+++ b/pkgs/by-name/r1/r10k/package.nix
@@ -28,6 +28,7 @@ bundlerApp {
   '';
 
   passthru = {
+    # TODO: use `versionCheckHook` if possible
     tests.version = testers.testVersion {
       command = "${lib.getExe r10k} version";
       package = r10k;

--- a/pkgs/by-name/ra/radicle-node/package.nix
+++ b/pkgs/by-name/ra/radicle-node/package.nix
@@ -12,7 +12,7 @@
 , runCommand
 , rustPlatform
 , stdenv
-, testers
+, versionCheckHook
 , xdg-utils
 }: rustPlatform.buildRustPackage rec {
   pname = "radicle-node";
@@ -64,12 +64,16 @@
     done
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "${placeholder "out"}/bin/rad";
+
   passthru.tests =
     let
       package = radicle-node;
     in
     {
-      version = testers.testVersion { inherit package; };
       basic = runCommand "${package.name}-basic-test"
         {
           nativeBuildInputs = [ jq openssh radicle-node ];

--- a/pkgs/by-name/ra/rav1e/package.nix
+++ b/pkgs/by-name/ra/rav1e/package.nix
@@ -10,9 +10,8 @@
   libgit2,
   libiconv,
   nasm,
-  testers,
+  versionCheckHook,
   zlib,
-  rav1e,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -41,6 +40,9 @@ rustPlatform.buildRustPackage rec {
       darwin.apple_sdk.frameworks.Security
     ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   # Darwin uses `llvm-strip`, which results in link errors when using `-x` to strip the asm library
   # and linking it with cctools ld64.
   postPatch = lib.optionalString (stdenv.isDarwin && stdenv.isx86_64) ''
@@ -56,10 +58,6 @@ rustPlatform.buildRustPackage rec {
   postInstall = ''
     ${rust.envVars.setEnv} cargo cinstall --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
   '';
-
-  passthru = {
-    tests.version = testers.testVersion { package = rav1e; };
-  };
 
   meta = {
     description = "Fastest and safest AV1 encoder";

--- a/pkgs/by-name/rc/rcu/package.nix
+++ b/pkgs/by-name/rc/rcu/package.nix
@@ -2,14 +2,13 @@
 , lib
 , requireFile
 , runCommand
-, rcu
-, testers
 , copyDesktopItems
 , desktopToDarwinBundle
 , libsForQt5
 , makeDesktopItem
 , python3Packages
 , system-config-printer
+, versionCheckHook
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -131,15 +130,8 @@ python3Packages.buildPythonApplication rec {
       --add-flags $out/share/rcu/main.py
   '';
 
-  passthru = {
-    tests.version = testers.testVersion {
-      package = rcu;
-      version = let
-        versionSuffixPos = (lib.strings.stringLength rcu.version) - 1;
-      in
-        "d${lib.strings.substring 0 versionSuffixPos rcu.version}(${lib.strings.substring versionSuffixPos 1 rcu.version})";
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     mainProgram = "rcu";

--- a/pkgs/by-name/re/redocly/package.nix
+++ b/pkgs/by-name/re/redocly/package.nix
@@ -2,8 +2,7 @@
 , buildNpmPackage
 , fetchFromGitHub
 , makeWrapper
-, redocly
-, testers
+, versionCheckHook
 }:
 
 buildNpmPackage rec {
@@ -42,11 +41,8 @@ buildNpmPackage rec {
     ln -s $out/bin/redocly $out/bin/redocly-cli
   '';
 
-  passthru = {
-    tests.version = testers.testVersion {
-      package = redocly;
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     changelog = "https://redocly.com/docs/cli/changelog/";

--- a/pkgs/by-name/re/renovate/package.nix
+++ b/pkgs/by-name/re/renovate/package.nix
@@ -7,11 +7,10 @@
   overrideSDK,
   pnpm_9,
   python3,
-  renovate,
-  testers,
   xcbuild,
   nixosTests,
   nix-update-script,
+  versionCheckHook
 }:
 
 let
@@ -89,9 +88,11 @@ stdenv'.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     tests = {
-      version = testers.testVersion { package = renovate; };
       vm-test = nixosTests.renovate;
     };
     updateScript = nix-update-script { };

--- a/pkgs/by-name/re/revup/package.nix
+++ b/pkgs/by-name/re/revup/package.nix
@@ -3,7 +3,7 @@
   fetchPypi,
   gitUpdater,
   python3Packages,
-  testers,
+  versionCheckHook
 }:
 
 let
@@ -39,11 +39,11 @@ let
       pytest
     ];
 
+    nativeInstallCheckInputs = [ versionCheckHook ];
+    doInstallCheck = true;
+
     passthru = {
       updateScript = gitUpdater { };
-      tests.version = testers.testVersion {
-        package = self;
-      };
     };
 
     meta = {

--- a/pkgs/by-name/ri/ripunzip/package.nix
+++ b/pkgs/by-name/ri/ripunzip/package.nix
@@ -8,6 +8,7 @@
 , testers
 , fetchzip
 , ripunzip
+, versionCheckHook
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -29,13 +30,13 @@ rustPlatform.buildRustPackage rec {
 
   setupHook = ./setup-hook.sh;
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru.tests = {
     fetchzipWithRipunzip = testers.invalidateFetcherByDrvHash (fetchzip.override { unzip = ripunzip; }) {
       url = "https://github.com/google/ripunzip/archive/cb9caa3ba4b0e27a85e165be64c40f1f6dfcc085.zip";
       hash = "sha256-BoErC5VL3Vpvkx6xJq6J+eUJrBnjVEdTuSo7zh98Jy4=";
-    };
-    version = testers.testVersion {
-      package = ripunzip;
     };
   };
 

--- a/pkgs/by-name/ro/roave-backward-compatibility-check/package.nix
+++ b/pkgs/by-name/ro/roave-backward-compatibility-check/package.nix
@@ -2,8 +2,7 @@
   lib,
   fetchFromGitHub,
   php,
-  testers,
-  roave-backward-compatibility-check,
+  versionCheckHook,
 }:
 
 php.buildComposerProject (finalAttrs: {
@@ -19,12 +18,8 @@ php.buildComposerProject (finalAttrs: {
 
   vendorHash = "sha256-I8JZ4CBrrQmZ38QF9SPZtkPirCAxqSCeTUpMg59Mz7U=";
 
-  passthru = {
-    tests.version = testers.testVersion {
-      package = roave-backward-compatibility-check;
-      version = finalAttrs.version;
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     changelog = "https://github.com/Roave/BackwardCompatibilityCheck/releases/tag/${finalAttrs.version}";

--- a/pkgs/by-name/ro/rosa/package.nix
+++ b/pkgs/by-name/ro/rosa/package.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, installShellFiles, testers, rosa, nix-update-script }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles, nix-update-script, versionCheckHook }:
 
 buildGoModule rec {
   pname = "rosa";
@@ -36,11 +36,12 @@ buildGoModule rec {
       --zsh <($out/bin/rosa completion zsh)
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "version --client";
+
   passthru = {
-    tests.version = testers.testVersion {
-      package = rosa;
-      command = "rosa version --client";
-    };
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/ro/roslyn-ls/package.nix
+++ b/pkgs/by-name/ro/roslyn-ls/package.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildDotnetModule, dotnetCorePackages, stdenvNoCC, testers, roslyn-ls, jq }:
+{ lib, fetchFromGitHub, buildDotnetModule, dotnetCorePackages, stdenvNoCC, versionCheckHook, jq }:
 let
   pname = "roslyn-ls";
   # see https://github.com/dotnet/roslyn/blob/main/eng/targets/TargetFrameworks.props
@@ -73,8 +73,12 @@ buildDotnetModule rec {
       runHook postInstall
     '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "Microsoft.CodeAnalysis.LanguageServer";
+
   passthru = {
-    tests.version = testers.testVersion { package = roslyn-ls; };
     updateScript = ./update.sh;
   };
 

--- a/pkgs/by-name/rs/rsmangler/package.nix
+++ b/pkgs/by-name/rs/rsmangler/package.nix
@@ -1,8 +1,8 @@
 { lib
 , stdenvNoCC
 , fetchFromGitHub
-, testers
 , ruby
+, versionCheckHook
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -28,11 +28,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     install -Dm555 rsmangler.rb $out/bin/rsmangler
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = finalAttrs.finalPackage;
-    command = "rsmangler --help";
-    version = "rsmangler v ${lib.versions.majorMinor finalAttrs.version}";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Perform various manipulations on the wordlists";

--- a/pkgs/by-name/sh/shopify-cli/package.nix
+++ b/pkgs/by-name/sh/shopify-cli/package.nix
@@ -1,4 +1,4 @@
-{ buildNpmPackage, lib, makeWrapper, bundlerEnv, testers, shopify-cli }:
+{ buildNpmPackage, lib, makeWrapper, bundlerEnv, versionCheckHook }:
 let
   version = "3.63.2";
 
@@ -27,10 +27,6 @@ buildNpmPackage {
 
   passthru = {
     updateScript = ./update.sh;
-    tests.version = testers.testVersion {
-      package = shopify-cli;
-      command = "shopify version";
-    };
   };
 
   postInstall = ''
@@ -44,6 +40,11 @@ buildNpmPackage {
       --set SHOPIFY_CLI_VERSION ${version} \
       --set SHOPIFY_CLI_BUNDLED_THEME_CLI 0
   '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "version";
 
   meta = {
     platforms = lib.platforms.all;

--- a/pkgs/by-name/sh/shpool/package.nix
+++ b/pkgs/by-name/sh/shpool/package.nix
@@ -3,8 +3,7 @@
   rustPlatform,
   fetchFromGitHub,
   linux-pam,
-  testers,
-  shpool,
+  versionCheckHook
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -41,10 +40,10 @@ rustPlatform.buildRustPackage rec {
     install -Dm444 systemd/shpool.socket -t $out/lib/systemd/user
   '';
 
-  passthru.tests.version = testers.testVersion {
-    command = "shpool version";
-    package = shpool;
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "version";
 
   meta = {
     description = "Persistent session management like tmux, but more lightweight";

--- a/pkgs/by-name/si/sigi/package.nix
+++ b/pkgs/by-name/si/sigi/package.nix
@@ -1,4 +1,4 @@
-{ lib, rustPlatform, fetchCrate, installShellFiles, testers, sigi }:
+{ lib, rustPlatform, fetchCrate, installShellFiles, versionCheckHook }:
 
 rustPlatform.buildRustPackage rec {
   pname = "sigi";
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     installManPage sigi.1
   '';
 
-  passthru.tests.version = testers.testVersion { package = sigi; };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Organizing CLI for people who don't love organizing";

--- a/pkgs/by-name/sk/sketchybar/package.nix
+++ b/pkgs/by-name/sk/sketchybar/package.nix
@@ -4,8 +4,8 @@
   stdenv,
   darwin,
   fetchFromGitHub,
-  testers,
   nix-update-script,
+  versionCheckHook,
 }:
 
 let
@@ -65,12 +65,10 @@ stdenv'.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru = {
-    tests.version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-      version = "sketchybar-v${finalAttrs.version}";
-    };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
+  passthru = {
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/sk/skhd/package.nix
+++ b/pkgs/by-name/sk/skhd/package.nix
@@ -4,8 +4,8 @@
   stdenv,
   darwin,
   fetchFromGitHub,
-  testers,
   nix-update-script,
+  versionCheckHook,
 }:
 let
   inherit (darwin.apple_sdk_11_0.frameworks) Carbon Cocoa;
@@ -38,12 +38,10 @@ stdenv'.mkDerivation (finalAttrs: {
     substituteInPlace $out/Library/LaunchDaemons/org.nixos.skhd.plist --subst-var out
   '';
 
-  passthru = {
-    tests.version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-      version = "skhd-v${finalAttrs.version}";
-    };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
+  passthru = {
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/sm/smassh/package.nix
+++ b/pkgs/by-name/sm/smassh/package.nix
@@ -1,8 +1,7 @@
 { lib
 , fetchFromGitHub
-, smassh
 , python3
-, testers
+, versionCheckHook
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -32,13 +31,14 @@ python3.pkgs.buildPythonApplication rec {
     requests
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
   # No tests available
   doCheck = false;
 
-  passthru.tests.version = testers.testVersion {
-    package = smassh;
-    command = "HOME=$(mktemp -d) smassh --version";
-  };
+  preVersionCheck = ''
+    export HOME=$(mktemp -d)
+  '';
 
   meta = with lib; {
     description = "TUI based typing test application inspired by MonkeyType";

--- a/pkgs/by-name/so/soupault/package.nix
+++ b/pkgs/by-name/so/soupault/package.nix
@@ -2,9 +2,8 @@
 , darwin
 , fetchzip
 , ocamlPackages
-, soupault
 , stdenv
-, testers
+, versionCheckHook
 }:
 
 ocamlPackages.buildDunePackage rec {
@@ -45,10 +44,10 @@ ocamlPackages.buildDunePackage rec {
     yaml
   ];
 
-  passthru.tests.version = testers.testVersion {
-    package = soupault;
-    command = "soupault --version-number";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "--version-number";
 
   meta = {
     description = "Tool that helps you create and manage static websites";

--- a/pkgs/by-name/sp/spicetify-cli/package.nix
+++ b/pkgs/by-name/sp/spicetify-cli/package.nix
@@ -2,8 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  testers,
-  spicetify-cli,
+  versionCheckHook
 }:
 
 buildGoModule rec {
@@ -34,12 +33,10 @@ buildGoModule rec {
     cp -r ${src}/Themes $out/bin/Themes
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
-  installCheckPhase = ''
-    $out/bin/spicetify --help > /dev/null
-  '';
 
-  passthru.tests.version = testers.testVersion { package = spicetify-cli; };
+  versionCheckProgram = "${placeholder "out"}/bin/spicetify";
 
   meta = with lib; {
     description = "Command-line tool to customize Spotify client";

--- a/pkgs/by-name/st/stackit-cli/package.nix
+++ b/pkgs/by-name/st/stackit-cli/package.nix
@@ -5,9 +5,7 @@
 , makeWrapper
 , less
 , xdg-utils
-, testers
-, runCommand
-, stackit-cli
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -53,12 +51,10 @@ buildGoModule rec {
 
   nativeCheckInputs = [ less ];
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = stackit-cli;
-      command = "stackit --version";
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "stackit";
 
   meta = with lib; {
     description = "CLI to manage STACKIT cloud services";

--- a/pkgs/by-name/st/stackql/package.nix
+++ b/pkgs/by-name/st/stackql/package.nix
@@ -2,8 +2,7 @@
   lib,
   fetchFromGitHub,
   buildGoModule,
-  testers,
-  stackql,
+  versionCheckHook
 }:
 
 buildGoModule rec {
@@ -33,10 +32,8 @@ buildGoModule rec {
 
   checkFlags = [ "--tags json1,sqleanal" ];
 
-  passthru.tests.version = testers.testVersion {
-    package = stackql;
-    version = "v${version}";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     homepage = "https://github.com/stackql/stackql";

--- a/pkgs/by-name/st/static-server/package.nix
+++ b/pkgs/by-name/st/static-server/package.nix
@@ -3,9 +3,8 @@
 , fetchFromGitHub
 , curl
 , stdenv
-, testers
-, static-server
 , substituteAll
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -38,11 +37,8 @@ buildGoModule rec {
   # tests sometimes fail with SIGQUIT on darwin
   doCheck = !stdenv.isDarwin;
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = static-server;
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/by-name/st/steampipe/package.nix
+++ b/pkgs/by-name/st/steampipe/package.nix
@@ -5,8 +5,7 @@
   lib,
   makeWrapper,
   nix-update-script,
-  steampipe,
-  testers,
+  versionCheckHook
 }:
 
 buildGoModule rec {
@@ -65,12 +64,10 @@ buildGoModule rec {
       --zsh <($out/bin/steampipe --install-dir $INSTALL_DIR completion zsh)
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
-    tests.version = testers.testVersion {
-      command = "${lib.getExe steampipe} --version";
-      package = steampipe;
-      version = "v${version}";
-    };
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/st/storcli/package.nix
+++ b/pkgs/by-name/st/storcli/package.nix
@@ -2,7 +2,7 @@
 , stdenvNoCC
 , fetchzip
 , rpmextract
-, testers
+, versionCheckHook
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -40,11 +40,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   # Not needed because the binary is statically linked
   dontFixup = true;
 
-  passthru.tests = testers.testVersion {
-    package = finalAttrs.finalPackage;
-    command = "${finalAttrs.meta.mainProgram} -v";
-    version = "00${finalAttrs.version}00.0000";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     # Unfortunately there is no better page for this.

--- a/pkgs/by-name/st/stu/package.nix
+++ b/pkgs/by-name/st/stu/package.nix
@@ -4,8 +4,7 @@
   rustPlatform,
   stdenv,
   darwin,
-  stu,
-  testers,
+  versionCheckHook,
 }:
 let
   version = "0.5.0";
@@ -28,7 +27,8 @@ rustPlatform.buildRustPackage {
     darwin.apple_sdk.frameworks.CoreGraphics
   ];
 
-  passthru.tests.version = testers.testVersion { package = stu; };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Terminal file explorer for S3 buckets";

--- a/pkgs/by-name/su/surrealdb/package.nix
+++ b/pkgs/by-name/su/surrealdb/package.nix
@@ -5,10 +5,9 @@
 , pkg-config
 , openssl
 , rocksdb_8_3
-, testers
-, surrealdb
 , darwin
 , protobuf
+, versionCheckHook
 }:
 
 let
@@ -59,10 +58,11 @@ rustPlatform.buildRustPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  passthru.tests.version = testers.testVersion {
-    package = surrealdb;
-    command = "surreal version";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "surreal";
+  versionCheckProgramArg = "version";
 
   meta = with lib; {
     description = "Scalable, distributed, collaborative, document-graph database, for the realtime web";

--- a/pkgs/by-name/sw/swayfx-unwrapped/package.nix
+++ b/pkgs/by-name/sw/swayfx-unwrapped/package.nix
@@ -23,10 +23,10 @@
   libevdev,
   scdoc,
   scenefx,
+  versionCheckHook,
   wayland-scanner,
   xcbutilwm,
   wlroots,
-  testers,
   nixosTests,
   # Used by the NixOS module:
   isNixOS ? false,
@@ -120,14 +120,12 @@ stdenv.mkDerivation (finalAttrs: {
       (mesonEnable "tray" finalAttrs.trayEnabled)
     ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     tests = {
       basic = nixosTests.swayfx;
-      version = testers.testVersion {
-        package = finalAttrs.finalPackage;
-        command = "sway --version";
-        version = "swayfx version ${finalAttrs.version}";
-      };
     };
   };
 

--- a/pkgs/by-name/sw/swayimg/package.nix
+++ b/pkgs/by-name/sw/swayimg/package.nix
@@ -22,7 +22,7 @@
 , libavif
 , openexr_3
 , bash-completion
-, testers
+, versionCheckHook
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "swayimg";
@@ -67,9 +67,8 @@ stdenv.mkDerivation (finalAttrs: {
     openexr_3
   ];
 
-  passthru.tests.version = testers.testVersion {
-    package = finalAttrs.finalPackage;
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     homepage = "https://github.com/artemsen/swayimg";

--- a/pkgs/by-name/sy/symfony-cli/package.nix
+++ b/pkgs/by-name/sy/symfony-cli/package.nix
@@ -2,10 +2,9 @@
 , fetchFromGitHub
 , lib
 , nix-update-script
-, testers
-, symfony-cli
 , nssTools
 , makeBinaryWrapper
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -49,13 +48,14 @@ buildGoModule rec {
   # Tests requires network access
   doCheck = false;
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "${placeholder "out"}/bin/symfony";
+  versionCheckProgramArg = "version --no-ansi";
+
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion {
-      inherit version;
-      package = symfony-cli;
-      command = "symfony version --no-ansi";
-    };
   };
 
   meta = {

--- a/pkgs/by-name/te/tenv/package.nix
+++ b/pkgs/by-name/te/tenv/package.nix
@@ -1,4 +1,4 @@
-{ buildGoModule, fetchFromGitHub, installShellFiles, lib, tenv, testers }:
+{ buildGoModule, fetchFromGitHub, installShellFiles, lib, versionCheckHook }:
 
 buildGoModule rec {
   pname = "tenv";
@@ -30,11 +30,12 @@ buildGoModule rec {
       --fish <($out/bin/tenv completion fish)
   '';
 
-  passthru.tests.version = testers.testVersion {
-    command = "HOME=$TMPDIR tenv --version";
-    package = tenv;
-    version = "v${version}";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  preVersionCheck = ''
+    export HOME=$(mktemp -d)
+  '';
 
   meta = {
     changelog = "https://github.com/tofuutils/tenv/releases/tag/v${version}";

--- a/pkgs/by-name/te/terraform-plugin-docs/package.nix
+++ b/pkgs/by-name/te/terraform-plugin-docs/package.nix
@@ -3,8 +3,7 @@
 , fetchFromGitHub
 , makeWrapper
 , go
-, testers
-, terraform-plugin-docs
+, versionCheckHook
 , nix-update-script
 }:
 
@@ -42,11 +41,12 @@ buildGoModule rec {
     wrapProgram $out/bin/tfplugindocs --prefix PATH : ${lib.makeBinPath [ go ]}
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "tfplugindocs";
+
   passthru = {
-    tests.version = testers.testVersion {
-      command = "tfplugindocs --version";
-      package = terraform-plugin-docs;
-    };
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/ti/tigerbeetle/package.nix
+++ b/pkgs/by-name/ti/tigerbeetle/package.nix
@@ -2,9 +2,8 @@
 , stdenv
 , fetchFromGitHub
 , zig_0_11
-, testers
-, tigerbeetle
 , nix-update-script
+, versionCheckHook
 }:
 let
   # Read [these comments](pkgs/development/compilers/zig/hook.nix#L12-L30) on the default Zig flags, and the associated links. tigerbeetle stopped exposing the `-Doptimize` build flag, so we can't use the default Nixpkgs zig hook as-is. tigerbeetle only exposes a boolean `-Drelease` flag which we'll add in the tigerbeetle derivation in this file.
@@ -32,11 +31,10 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dgit-commit=0000000000000000000000000000000000000000"
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
-    tests.version = testers.testVersion {
-      package = tigerbeetle;
-      command = "tigerbeetle version";
-    };
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/ti/tilemaker/package.nix
+++ b/pkgs/by-name/ti/tilemaker/package.nix
@@ -10,8 +10,8 @@
 , rapidjson
 , shapelib
 , sqlite
+, versionCheckHook
 , zlib
-, testers
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -48,10 +48,8 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r ../server/static $out/share/tilemaker
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = finalAttrs.finalPackage;
-    command = "tilemaker --help";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Make OpenStreetMap vector tiles without the stack";

--- a/pkgs/by-name/ti/tinymist/package.nix
+++ b/pkgs/by-name/ti/tinymist/package.nix
@@ -8,8 +8,7 @@
 , stdenv
 , darwin
 , nix-update-script
-, testers
-, tinymist
+, versionCheckHook
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -53,12 +52,13 @@ rustPlatform.buildRustPackage rec {
     "--skip=e2e"
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "-V";
+
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion {
-      command = "${meta.mainProgram} -V";
-      package = tinymist;
-    };
   };
 
   meta = {

--- a/pkgs/by-name/ti/tippecanoe/package.nix
+++ b/pkgs/by-name/ti/tippecanoe/package.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, sqlite, zlib, perl, testers }:
+{ lib, stdenv, fetchFromGitHub, sqlite, zlib, perl, versionCheckHook }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tippecanoe";
@@ -21,10 +21,8 @@ stdenv.mkDerivation (finalAttrs: {
   # https://github.com/felt/tippecanoe/issues/148
   doCheck = false;
 
-  passthru.tests.version = testers.testVersion {
-    package = finalAttrs.finalPackage;
-    version = "v${finalAttrs.version}";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Build vector tilesets from large collections of GeoJSON features";

--- a/pkgs/by-name/to/toml-cli/package.nix
+++ b/pkgs/by-name/to/toml-cli/package.nix
@@ -1,4 +1,4 @@
-{ lib, fetchCrate, rustPlatform, testers, toml-cli }:
+{ lib, fetchCrate, rustPlatform, versionCheckHook }:
 
 rustPlatform.buildRustPackage rec {
   pname = "toml-cli";
@@ -19,9 +19,8 @@ rustPlatform.buildRustPackage rec {
     # "--test=integration"
   ];
 
-  passthru.tests = {
-    version = testers.testVersion { package = toml-cli; };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Simple CLI for editing and querying TOML files";

--- a/pkgs/by-name/tp/tpnote/package.nix
+++ b/pkgs/by-name/tp/tpnote/package.nix
@@ -7,8 +7,7 @@
 , oniguruma
 , darwin
 , installShellFiles
-, tpnote
-, testers
+, versionCheckHook
 }:
 
 
@@ -45,7 +44,8 @@ rustPlatform.buildRustPackage rec {
 
   RUSTONIG_SYSTEM_LIBONIG = true;
 
-  passthru.tests.version = testers.testVersion { package = tpnote; };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   # The `tpnote` crate has no unit tests. All tests are in `tpnote-lib`.
   checkType = "debug";

--- a/pkgs/by-name/tr/trealla/package.nix
+++ b/pkgs/by-name/tr/trealla/package.nix
@@ -5,8 +5,8 @@
   openssl,
   readline,
   stdenv,
-  testers,
   valgrind,
+  versionCheckHook,
   xxd,
   # Boolean flags
   checkLeaks ? false,
@@ -69,14 +69,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   checkFlags = [ "test" ] ++ lib.optionals checkLeaks [ "leaks" ];
 
-  passthru = {
-    tests = {
-      version = testers.testVersion {
-        package = finalAttrs.finalPackage;
-        version = "v${finalAttrs.version}";
-      };
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "${placeholder "out"}/bin/tpl";
 
   meta = {
     homepage = "https://trealla-prolog.github.io/trealla/";

--- a/pkgs/by-name/tt/ttop/package.nix
+++ b/pkgs/by-name/tt/ttop/package.nix
@@ -1,4 +1,4 @@
-{ lib, buildNimPackage, fetchFromGitHub, testers }:
+{ lib, buildNimPackage, fetchFromGitHub, versionCheckHook }:
 
 buildNimPackage (finalAttrs: {
   pname = "ttop";
@@ -17,11 +17,8 @@ buildNimPackage (finalAttrs: {
     "-d:NimblePkgVersion=${finalAttrs.version}"
   ];
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Top-like system monitoring tool";

--- a/pkgs/by-name/ty/typescript-language-server/package.nix
+++ b/pkgs/by-name/ty/typescript-language-server/package.nix
@@ -6,8 +6,8 @@
 , makeWrapper
 , nodejs
 , prefetch-yarn-deps
+, versionCheckHook
 , yarn
-, testers
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -68,11 +68,8 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     changelog = "https://github.com/typescript-language-server/typescript-language-server/releases/tag/v${finalAttrs.version}";

--- a/pkgs/by-name/ty/typstyle/package.nix
+++ b/pkgs/by-name/ty/typstyle/package.nix
@@ -7,8 +7,7 @@
 , stdenv
 , darwin
 , nix-update-script
-, testers
-, typstyle
+, versionCheckHook
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -43,9 +42,11 @@ rustPlatform.buildRustPackage rec {
     "--skip=e2e"
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion { package = typstyle; };
   };
 
   meta = {

--- a/pkgs/by-name/ug/uglify-js/package.nix
+++ b/pkgs/by-name/ug/uglify-js/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   testers,
   runCommand,
+  versionCheckHook,
   writeText,
   uglify-js,
 }:
@@ -27,11 +28,14 @@ buildNpmPackage rec {
 
   dontNpmBuild = true;
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "${placeholder "out"}/bin/uglifyjs";
+
   passthru = {
     updateScript = ./update.sh;
     tests = {
-      version = testers.testVersion { package = uglify-js; };
-
       simple = testers.testEqualContents {
         assertion = "uglify-js minifies a basic js file";
         expected = writeText "expected" ''

--- a/pkgs/by-name/up/updatecli/package.nix
+++ b/pkgs/by-name/up/updatecli/package.nix
@@ -5,8 +5,7 @@
   fetchFromGitHub,
   nix-update-script,
   installShellFiles,
-  testers,
-  updatecli,
+  versionCheckHook,
 }:
 
 buildGoModule rec {
@@ -37,10 +36,6 @@ buildGoModule rec {
 
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion {
-      package = updatecli;
-      command = "updatecli version";
-    };
   };
 
   nativeBuildInputs = [ installShellFiles ];
@@ -54,6 +49,11 @@ buildGoModule rec {
     $out/bin/updatecli man > updatecli.1
     installManPage updatecli.1
   '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "version";
 
   meta = with lib; {
     description = "Declarative Dependency Management tool";

--- a/pkgs/by-name/up/upsun/package.nix
+++ b/pkgs/by-name/up/upsun/package.nix
@@ -2,8 +2,7 @@
   stdenvNoCC,
   lib,
   fetchurl,
-  testers,
-  upsun
+  versionCheckHook,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -44,12 +43,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru = {
-    tests.version = testers.testVersion {
-      inherit (finalAttrs) version;
-      package = upsun;
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Unified tool for managing your Upsun services from the command line";

--- a/pkgs/by-name/us/usql/package.nix
+++ b/pkgs/by-name/us/usql/package.nix
@@ -4,8 +4,7 @@
 , unixODBC
 , icu
 , nix-update-script
-, testers
-, usql
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -54,13 +53,11 @@ buildGoModule rec {
   # All the checks currently require docker instances to run the databases.
   doCheck = false;
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion {
-      inherit version;
-      package = usql;
-      command = "usql --version";
-    };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/uv/uv/package.nix
+++ b/pkgs/by-name/uv/uv/package.nix
@@ -8,9 +8,8 @@
 , python3Packages
 , rustPlatform
 , stdenv
-, testers
-, uv
 , nix-update-script
+, versionCheckHook
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -48,6 +47,8 @@ python3Packages.buildPythonApplication rec {
     darwin.apple_sdk.frameworks.SystemConfiguration
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
   dontUseCmakeConfigure = true;
 
   cargoBuildFlags = [ "--package" "uv" ];
@@ -65,9 +66,6 @@ python3Packages.buildPythonApplication rec {
   ];
 
   passthru = {
-    tests.version = testers.testVersion {
-      package = uv;
-    };
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/va/vacuum-go/package.nix
+++ b/pkgs/by-name/va/vacuum-go/package.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, testers, vacuum-go }:
+{ lib, buildGoModule, fetchFromGitHub, versionCheckHook }:
 
 buildGoModule rec {
   pname = "vacuum-go";
@@ -23,13 +23,11 @@ buildGoModule rec {
 
   subPackages = [ "./vacuum.go" ];
 
-  passthru = {
-    tests.version = testers.testVersion {
-      package = vacuum-go;
-      command = "vacuum version";
-      version = "v${version}";
-    };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "${placeholder "out"}/bin/vacuum";
+  versionCheckProgramArg = "version";
 
   meta = {
     description = "The world's fastest OpenAPI & Swagger linter";

--- a/pkgs/by-name/vi/violet/package.nix
+++ b/pkgs/by-name/vi/violet/package.nix
@@ -4,8 +4,7 @@
   fetchFromGitHub,
   nix-update-script,
   stdenv,
-  violet,
-  testers,
+  versionCheckHook
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -22,9 +21,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
     updateScript = nix-update-script { };
-    tests = testers.testVersion { package = violet; };
   };
 
   meta = {

--- a/pkgs/by-name/wa/wakatime-cli/package.nix
+++ b/pkgs/by-name/wa/wakatime-cli/package.nix
@@ -2,8 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  testers,
-  wakatime-cli,
+  versionCheckHook,
 }:
 
 buildGoModule rec {
@@ -47,10 +46,12 @@ buildGoModule rec {
     in
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
-  passthru.tests.version = testers.testVersion {
-    package = wakatime-cli;
-    command = "HOME=$(mktemp -d) wakatime-cli --version";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  preVersionCheck = ''
+    export HOME=$(mktemp -d)
+  '';
 
   meta = with lib; {
     homepage = "https://wakatime.com/";

--- a/pkgs/by-name/we/werf/package.nix
+++ b/pkgs/by-name/we/werf/package.nix
@@ -5,8 +5,7 @@
   fetchFromGitHub,
   installShellFiles,
   btrfs-progs,
-  testers,
-  werf,
+  versionCheckHook,
 }:
 
 buildGoModule rec {
@@ -84,11 +83,10 @@ buildGoModule rec {
       --zsh <($out/bin/werf completion --shell=zsh)
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = werf;
-    command = "werf version";
-    version = src.rev;
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "version";
 
   meta = with lib; {
     description = "GitOps delivery tool";

--- a/pkgs/by-name/wi/wiremock/package.nix
+++ b/pkgs/by-name/wi/wiremock/package.nix
@@ -5,7 +5,7 @@
   lib,
   makeWrapper,
   stdenvNoCC,
-  testers,
+  versionCheckHook
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -29,11 +29,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       --add-flags "-jar $out/share/wiremock/wiremock.jar"
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
-    tests.version = testers.testVersion {
-      command = "${lib.getExe finalAttrs.finalPackage} --version";
-      package = finalAttrs.finalPackage;
-    };
     updateScript = gitUpdater {
       url = "https://github.com/wiremock/wiremock.git";
       ignoredVersions = "(alpha|beta|rc).*";

--- a/pkgs/by-name/wi/wireproxy/package.nix
+++ b/pkgs/by-name/wi/wireproxy/package.nix
@@ -1,8 +1,7 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
-, testers
-, wireproxy
+, versionCheckHook
 }:
 
 buildGoModule rec {
@@ -24,11 +23,8 @@ buildGoModule rec {
 
   vendorHash = "sha256-DNTPzZSxcjkcv7RygTpOIgdYEQ8wBPkuJqfzZGt8ExI=";
 
-  passthru.tests.version = testers.testVersion {
-    package = wireproxy;
-    command = "wireproxy --version";
-    version = src.rev;
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Wireguard client that exposes itself as a socks5 proxy";

--- a/pkgs/by-name/wi/wizer/package.nix
+++ b/pkgs/by-name/wi/wizer/package.nix
@@ -1,8 +1,7 @@
 { lib
 , rustPlatform
 , fetchFromGitHub
-, testers
-, wizer
+, versionCheckHook
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -30,9 +29,8 @@ rustPlatform.buildRustPackage rec {
     export HOME=$(mktemp -d)
   '';
 
-  passthru.tests = {
-    version = testers.testVersion { package = wizer; };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "WebAssembly pre-initializer";

--- a/pkgs/by-name/wl/wlx-overlay-s/package.nix
+++ b/pkgs/by-name/wl/wlx-overlay-s/package.nix
@@ -14,7 +14,7 @@
 , pkg-config
 , pulseaudio
 , shaderc
-, testers
+, versionCheckHook
 , wayland
 , wlx-overlay-s
 , xorg
@@ -74,8 +74,10 @@ rustPlatform.buildRustPackage rec {
       --add-needed ${lib.getLib libxkbcommon}/lib/libxkbcommon.so.0
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
-    tests.testVersion = testers.testVersion { package = wlx-overlay-s; };
 
     updateScript = nix-update-script { };
   };

--- a/pkgs/by-name/ws/wstunnel/package.nix
+++ b/pkgs/by-name/ws/wstunnel/package.nix
@@ -1,8 +1,7 @@
 { lib
 , fetchFromGitHub
 , rustPlatform
-, testers
-, wstunnel
+, versionCheckHook
 , nixosTests
 }:
 
@@ -28,8 +27,10 @@ rustPlatform.buildRustPackage {
     "--skip=tcp::tests::test_proxy_connection"
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru.tests = {
-    version = testers.testVersion { package = wstunnel; };
     nixosTest = nixosTests.wstunnel;
   };
 

--- a/pkgs/by-name/xu/xunit-viewer/package.nix
+++ b/pkgs/by-name/xu/xunit-viewer/package.nix
@@ -25,6 +25,7 @@ buildNpmPackage {
   passthru.updateScript = nix-update-script { };
 
   passthru.tests = {
+    # TODO: maybe use `versionCheckHook`?
     version = testers.testVersion {
       package = xunit-viewer;
       version = "unknown"; # broken, but at least it runs

--- a/pkgs/by-name/ya/yabai/package.nix
+++ b/pkgs/by-name/ya/yabai/package.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
   fetchzip,
   installShellFiles,
-  testers,
+  versionCheckHook,
   writeShellScript,
   common-updater-scripts,
   curl,
@@ -13,7 +13,6 @@
   jq,
   xcodebuild,
   xxd,
-  yabai,
 }:
 let
   inherit (darwin.apple_sdk_11_0.frameworks)
@@ -85,12 +84,10 @@ stdenv'.mkDerivation (finalAttrs: {
         --replace 'return screen.safeAreaInsets.top;' 'return 0;'
       '';
 
-  passthru = {
-    tests.version = testers.testVersion {
-      package = yabai;
-      version = "yabai-v${finalAttrs.version}";
-    };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
+  passthru = {
     sources = {
       # Unfortunately compiling yabai from source on aarch64-darwin is a bit complicated. We use the precompiled binary instead for now.
       # See the comments on https://github.com/NixOS/nixpkgs/pull/188322 for more information.

--- a/pkgs/by-name/ya/yara-x/package.nix
+++ b/pkgs/by-name/ya/yara-x/package.nix
@@ -4,8 +4,7 @@
 , rustPlatform
 , cmake
 , installShellFiles
-, testers
-, yara-x
+, versionCheckHook
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -30,9 +29,10 @@ rustPlatform.buildRustPackage rec {
       --zsh <($out/bin/yr completion zsh)
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = yara-x;
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  versionCheckProgram = "${placeholder "out"}/bin/yr";
 
   meta = {
     description = "Tool to do pattern matching for malware research";

--- a/pkgs/by-name/zo/zola/package.nix
+++ b/pkgs/by-name/zo/zola/package.nix
@@ -6,8 +6,7 @@
 , oniguruma
 , darwin
 , installShellFiles
-, zola
-, testers
+, versionCheckHook
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -43,7 +42,8 @@ rustPlatform.buildRustPackage rec {
       --zsh <($out/bin/zola completion zsh)
   '';
 
-  passthru.tests.version = testers.testVersion { package = zola; };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Fast static site generator with everything built-in";


### PR DESCRIPTION
## Description of changes

Follow up on #320266

This should help

- Simplify expressions
- Reduce (some) repition/workarounds
- Improve automated testing by making these checks a requirement to
  build
- Maintain consistency between which of these version check
  implementations are used across pkgs/by-name
- Provide more real-world examples of this newly added hook
- Avoid https://github.com/NixOS/nixpkgs/issues/312345 in many places

CC @doronbehar

---

I believe all occurrences of `testVersion` have been either replaced or given a TODO comment, with the exception of
```
clang-tidy-sarif
clippy-sarif
hadolint-sarif
hello
sarif-fmt
shellcheck-sarif
```

The sarif packages have been taken care of in #327451, #327452, #327454, #327455, and #327456 earlier today. `hello` will retain it's use of `testVersion` to serve as an example (as I believe this was the intention, given it was already there)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
