### PR TITLE
python3Packages.beaker: replace nose tests with pytest

### DIFF
--- a/pkgs/development/python-modules/beaker/default.nix
+++ b/pkgs/development/python-modules/beaker/default.nix
@@ -1,10 +1,8 @@
 {
-  stdenv,
   lib,
   buildPythonPackage,
   fetchFromGitHub,
   glibcLocales,
-  nose,
   pylibmc,
   python-memcached,
   redis,
@@ -15,7 +13,8 @@
   pycrypto,
   cryptography,
   isPy27,
-  isPy3k,
+  pytestCheckHook,
+  setuptools,
   funcsigs ? null,
   pycryptopp ? null,
 }:
@@ -23,16 +22,19 @@
 buildPythonPackage rec {
   pname = "beaker";
   version = "1.13.0";
+  pyproject = true;
 
   # The pypy release do not contains the tests
   src = fetchFromGitHub {
     owner = "bbangert";
     repo = "beaker";
     rev = "refs/tags/${version}";
-    sha256 = "sha256-HzjhOPXElwKoJLrhGIbVn798tbX/kaS1EpQIX+vXCtE=";
+    hash = "sha256-HzjhOPXElwKoJLrhGIbVn798tbX/kaS1EpQIX+vXCtE=";
   };
 
-  propagatedBuildInputs =
+  build-system = [ setuptools ];
+
+  dependencies =
     [
       sqlalchemy
       pycrypto
@@ -47,29 +49,19 @@ buildPythonPackage rec {
     glibcLocales
     python-memcached
     mock
-    nose
     pylibmc
     pymongo
     redis
     webtest
+    pytestCheckHook
   ];
 
-  # Can not run memcached tests because it immediately tries to connect
-  postPatch = ''
-    rm tests/test_memcached.py
-  '';
-
+  # Can not run memcached tests because it immediately tries to connect.
   # Disable external tests because they need to connect to a live database.
-  # Also disable a test in test_cache.py called "test_upgrade" because
-  # it currently fails on darwin.
-  # Please see issue https://github.com/bbangert/beaker/issues/166
-  checkPhase = ''
-    nosetests \
-      -e ".*test_ext_.*" \
-      -e "test_upgrade" \
-      ${lib.optionalString (!stdenv.isLinux) ''-e "test_cookie_expires_different_locale"''} \
-      -vv tests
-  '';
+  pytestFlagsArray = [
+    "--ignore=tests/test_memcached.py"
+    "--ignore-glob='tests/test_managers/test_ext_*'"
+  ];
 
   meta = {
     description = "Session and Caching library with WSGI Middleware";


### PR DESCRIPTION
## Description of changes

Addresses #326513.
Dependency nose was replaces by pytest in version 1.12.0 (2022-12-07).

- Moved test exclusions from `checkPhase` to `pytestFlagsArray`.
- `pyproject = true` PEP 517 migration

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
