### PR TITLE
nixos/systemd: let systemd setup /etc/machine-id

### DIFF
--- a/nixos/modules/system/boot/stage-2-init.sh
+++ b/nixos/modules/system/boot/stage-2-init.sh
@@ -125,14 +125,6 @@ ln -sfn "$systemConfig" /run/booted-system
 @shell@ @postBootCommands@
 
 
-# Ensure systemd doesn't try to populate /etc, by forcing its first-boot
-# heuristic off. It doesn't matter what's in /etc/machine-id for this purpose,
-# and systemd will immediately fill in the file when it starts, so just
-# creating it is enough. This `: >>` pattern avoids forking and avoids changing
-# the mtime if the file already exists.
-: >> /etc/machine-id
-
-
 # No need to restore the stdout/stderr streams we never redirected and
 # especially no need to start systemd
 if [ "${IN_NIXOS_SYSTEMD_STAGE1:-}" != true ]; then

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -33,6 +33,7 @@ let
       "nss-lookup.target"
       "nss-user-lookup.target"
       "time-sync.target"
+      "first-boot-complete.target"
     ] ++ optionals cfg.package.withCryptsetup [
       "cryptsetup.target"
       "cryptsetup-pre.target"

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -566,6 +566,15 @@ in
       "systemd/user-generators" = { source = hooks "user-generators" cfg.user.generators; };
       "systemd/system-generators" = { source = hooks "system-generators" cfg.generators; };
       "systemd/system-shutdown" = { source = hooks "system-shutdown" cfg.shutdown; };
+
+      # Ignore all other preset files so systemd doesn't try to enable/disable
+      # units during runtime.
+      "systemd/system-preset/00-nixos.preset".text = ''
+        ignore *
+      '';
+      "systemd/user-preset/00-nixos.preset".text = ''
+        ignore *
+      '';
     });
 
     services.dbus.enable = true;

--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -81,6 +81,9 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     import re
     import subprocess
 
+    # Will not succeed unless ConditionFirstBoot=yes
+    machine.wait_for_unit("first-boot-complete.target")
+
     machine.wait_for_x()
     # wait for user services
     machine.wait_for_unit("default.target", "alice")

--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -75,9 +75,13 @@ import ./make-test-python.nix ({ pkgs, ... }: {
       rebootTime = "10min";
       kexecTime = "5min";
     };
+
+    environment.etc."systemd/system-preset/10-testservice.preset".text = ''
+      disable ${config.systemd.services.testservice1.name}
+    '';
   };
 
-  testScript = ''
+  testScript = { nodes, ... }: ''
     import re
     import subprocess
 
@@ -213,5 +217,9 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     with subtest("systemd environment is properly set"):
         machine.systemctl("daemon-reexec")  # Rewrites /proc/1/environ
         machine.succeed("grep -q TZDIR=/etc/zoneinfo /proc/1/environ")
+
+    with subtest("systemd presets are ignored"):
+        machine.succeed("systemctl preset ${nodes.machine.systemd.services.testservice1.name}")
+        machine.succeed("test -e /etc/systemd/system/${nodes.machine.systemd.services.testservice1.name}")
   '';
 })


### PR DESCRIPTION
## Description of changes

If we let systemd setup /etc/machine-id, we get to use ConditionFirstBoot in systemd units and any other integrations related to systemd's detection of first boot. See machine-id(5).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
