### PR TITLE
treewide: make shell.nix files not use top-level `with` statement

### DIFF
--- a/maintainers/scripts/convert-to-import-cargo-lock/shell.nix
+++ b/maintainers/scripts/convert-to-import-cargo-lock/shell.nix
@@ -1,5 +1,17 @@
-with import ../../../. { };
-
+{
+  pkgs ? import ../../.. { },
+}:
+let
+  inherit (pkgs) lib stdenv mkShell;
+in
 mkShell {
-  packages = [ rustc cargo clippy rustfmt ] ++ lib.optional stdenv.isDarwin libiconv;
+  packages =
+    with pkgs;
+    [
+      rustc
+      cargo
+      clippy
+      rustfmt
+    ]
+    ++ lib.optional stdenv.isDarwin pkgs.libiconv;
 }

--- a/nixos/lib/test-driver/shell.nix
+++ b/nixos/lib/test-driver/shell.nix
@@ -1,2 +1,4 @@
-with import ../../.. {};
-pkgs.callPackage ./default.nix {}
+{
+  pkgs ? import ../../.. { },
+}:
+pkgs.callPackage ./default.nix { }

--- a/nixos/maintainers/scripts/azure-new/shell.nix
+++ b/nixos/maintainers/scripts/azure-new/shell.nix
@@ -1,13 +1,16 @@
-with (import ../../../../default.nix {});
-stdenv.mkDerivation {
+{
+  pkgs ? import ../../../../default.nix { },
+}:
+
+pkgs.stdenv.mkDerivation {
   name = "nixcfg-azure-devenv";
 
-  nativeBuildInputs = [
+  nativeBuildInputs = with pkgs; [
     azure-cli
     bash
     cacert
     azure-storage-azcopy
   ];
 
-  AZURE_CONFIG_DIR="/tmp/azure-cli/.azure";
+  AZURE_CONFIG_DIR = "/tmp/azure-cli/.azure";
 }

--- a/pkgs/development/tools/misc/travis/shell.nix
+++ b/pkgs/development/tools/misc/travis/shell.nix
@@ -1,9 +1,10 @@
 # Env to update Gemfile.lock / gemset.nix
-
-with import <nixpkgs> {};
-stdenv.mkDerivation {
+{
+  pkgs ? import ../../../../.. { },
+}:
+pkgs.stdenv.mkDerivation {
   name = "env";
-  buildInputs = [
+  buildInputs = with pkgs; [
     ruby.devEnv
     gnumake
     bundix

--- a/pkgs/tools/security/metasploit/shell.nix
+++ b/pkgs/tools/security/metasploit/shell.nix
@@ -1,9 +1,11 @@
 # Env to update Gemfile.lock / gemset.nix
-with import <nixpkgs> {};
-stdenv.mkDerivation {
+{
+  pkgs ? import ../../../.. { },
+}:
+pkgs.stdenv.mkDerivation {
   name = "env";
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [
+  nativeBuildInputs = [ pkgs.pkg-config ];
+  buildInputs = with pkgs; [
     bundix
     git
     libiconv


### PR DESCRIPTION
- #208242
## Description of changes

This is a very boring PR.

- [x] Make all `shell.nix` instances that used a with at the top level not do that.

## Things done

- [x] Ran `nix-shell` in the following directories on `x86_64-linux`:
  - [x] `maintainers/scripts/convert-to-import-cargo-lock` (@winterqt)
  - [x] `pkgs/tools/security/metasploit` (@Mic92, @zowoq)
  - [x] `pkgs/development/tools/misc/travis` (@Mic92)
  - [x] `nixos/maintainers/scripts/azure-new` (@colemickens)
  - [x] `nixos/lib/test-driver` (@Mic92)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).