### PR TITLE
nixos/amazon-image: remove top-level `with lib`

### DIFF
--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -1,8 +1,8 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib) mkOption optionalString types versionAtLeast;
+  inherit (lib.options) literalExpression;
   cfg = config.amazonImage;
   amiBootMode = if config.ec2.efi then "uefi" else "legacy-bios";
 
@@ -15,7 +15,7 @@ in {
   # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html#timeout-nvme-ebs-volumes
   config.boot.kernelParams =
     let timeout =
-      if pkgs.lib.versionAtLeast config.boot.kernelPackages.kernel.version "4.15"
+      if versionAtLeast config.boot.kernelPackages.kernel.version "4.15"
       then "4294967295"
       else  "255";
     in [ "nvme_core.io_timeout=${timeout}" ];
@@ -156,5 +156,5 @@ in {
     };
   in if config.ec2.zfs.enable then zfsBuilder else extBuilder;
 
-  meta.maintainers = with maintainers; [ arianvp ];
+  meta.maintainers = with lib.maintainers; [ arianvp ];
 }

--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -6,9 +6,8 @@
 
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib) mkDefault mkIf;
   cfg = config.ec2;
 in
 
@@ -107,5 +106,5 @@ in
     # (e.g. it depends on GTK).
     services.udisks2.enable = false;
   };
-  meta.maintainers = with maintainers; [ arianvp ];
+  meta.maintainers = with lib.maintainers; [ arianvp ];
 }


### PR DESCRIPTION
- #208242 

## Description of changes

Removed top-level `with lib` and replaced with equivalent code. Pretty boring.

## Things done

- [x] `nix-build nixos/release.nix -A manual.x86_64-linux` (which evaluates these files)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).