### PR TITLE
hextazy: updated to 0.4, and updated github owner

### DIFF
--- a/pkgs/by-name/he/hextazy/package.nix
+++ b/pkgs/by-name/he/hextazy/package.nix
@@ -7,21 +7,21 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "hextazy";
-  version = "0.2";
+  version = "0.4";
 
   src = fetchFromGitHub {
-    owner = "faelian";
+    owner = "0xfalafel";
     repo = "hextazy";
     rev = "${version}";
-    hash = "sha256-e1uoKMejdTz8KH7uFkZ9YCE1WTwaxCZjcxh4g2ermNY=";
+    hash = "sha256-5ZT6oXG3dWJ8vPX0oieWQsYJQYCTwtlb1B8kmGlLv0k=";
   };
 
-  cargoHash = "sha256-5Z+ptr1JmeiP4hK8k+M1d189I0X53/jRUEFwgWGK3xQ=";
+  cargoHash = "sha256-n1HvkWNbHU8UUlqsCnuKESKQznk1WTe6eQiUJjVVXYE=";
 
   meta = {
     description = "TUI hexeditor in Rust with colored bytes";
-    homepage = "https://github.com/faelian/hextazy";
-    changelog = "https://github.com/faelian/hextazy/releases/tags/${src.rev}";
+    homepage = "https://github.com/0xfalafel/hextazy";
+    changelog = "https://github.com/0xfalafel/hextazy/releases/tags/${src.rev}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ akechishiro ];
     mainProgram = "hextazy";


### PR DESCRIPTION
## Description of changes

Author of `hextazy` here, I have changed my Github username from _Faelian_ to _0xfalafel_.
This commit update the _owner_ in `fetchFromGitHub` to my current username.

I have also taken the opportunity to update to version `0.4` which add a number of improvements:

* jump to any address by typing `:0xaddr`, where `addr` is the address in hexadecimal
* Ascii editor (select it with `Tab`)
* Shortcuts like `Ctrl+C` or `Ctrl+Q` to quit
* Improvement of the borders
* `Home` or `End` to go at the start of end of the file
* miscellaneous bug fixes.

Changelog: [https://github.com/0xfalafel/hextazy/releases](https://github.com/0xfalafel/hextazy/releases)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
