### PR TITLE
erlang_27: 27.0.1 -> 27.0

### DIFF
--- a/pkgs/development/interpreters/erlang/27.nix
+++ b/pkgs/development/interpreters/erlang/27.nix
@@ -1,6 +1,6 @@
 { mkDerivation }:
 
 mkDerivation {
-  version = "27.0.1";
-  sha256 = "sha256-Lp6J9eq6RXDi0RRjeVO/CIa4h/m7/fwOp/y0u0sTdFQ=";
+  version = "27.0";
+  sha256 = "sha256-YZWBLcpkm8B4sjoQO7I9ywXcmxXL+Dvq/JYsLsr7TO0=";
 }


### PR DESCRIPTION
Partially reverts NixOS/nixpkgs#326403

The OTP 27.0.1 changes are not building the documentation on Linux. The issue was reported here: https://github.com/NixOS/nixpkgs/pull/326403#issuecomment-2227047895. I wasn't able to reproduce this when building OTP separate from `nix-build -A erlang_27` so I'll need to dig a bit deeper to figure this out.

@happysalada @adamcstephens 