### PR TITLE
percona-toolkit: init at 3.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13130,6 +13130,13 @@
     github = "michaeldonovan";
     githubId = 14077230;
   };
+  michaelglass = {
+    email = "nixpkgs@mike.is";
+    name = "Michael Glass";
+    github = "michaelglass";
+    githubId = 60136;
+    keys = [ { fingerprint = "46AF 8625 D92A 219B 8E6D  B7F8 9CDD 3769 1649 1385"; } ];
+  };
   michaelgrahamevans = {
     email = "michaelgrahamevans@gmail.com";
     name = "Michael Evans";

--- a/pkgs/by-name/pe/percona-toolkit/package.nix
+++ b/pkgs/by-name/pe/percona-toolkit/package.nix
@@ -1,0 +1,51 @@
+{
+  stdenv,
+  lib,
+  perlPackages,
+  makeWrapper,
+}:
+
+let
+  perconaToolkit = perlPackages.PerconaToolkit;
+in
+
+stdenv.mkDerivation {
+  pname = perconaToolkit.name;
+  version = perconaToolkit.version;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  src = perconaToolkit;
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    # make sure dest already exists before symlink
+    # this prevents installing a broken link into the path
+    ln -s ${perconaToolkit}/lib $out/lib
+    ln -s ${perconaToolkit}/share $out/share
+
+    for cmd in ${perconaToolkit}/bin/*; do
+        ln -s $cmd $out/bin
+    done
+  '';
+
+  dontStrip = true;
+  postFixup = ''
+    for cmd in $out/bin/*; do
+        wrapProgram $cmd --prefix PERL5LIB
+    done
+  '';
+
+  meta = {
+    inherit (perconaToolkit.meta)
+      description
+      homepage
+      license
+      platforms
+      changelog
+      ;
+
+    maintainers = with lib.maintainers; [ michaelglass ];
+  };
+}

--- a/pkgs/development/perl-modules/Percona-Toolkit/default.nix
+++ b/pkgs/development/perl-modules/Percona-Toolkit/default.nix
@@ -1,5 +1,12 @@
-{ lib, fetchFromGitHub, buildPerlPackage, shortenPerlShebang
-, DBDmysql, DBI, IOSocketSSL, TermReadKey
+{
+  lib,
+  fetchFromGitHub,
+  buildPerlPackage,
+  shortenPerlShebang,
+  DBDmysql,
+  DBI,
+  IOSocketSSL,
+  TermReadKey,
 }:
 
 buildPerlPackage rec {
@@ -17,7 +24,12 @@ buildPerlPackage rec {
 
   nativeBuildInputs = [ shortenPerlShebang ];
 
-  buildInputs = [ DBDmysql DBI IOSocketSSL TermReadKey ];
+  buildInputs = [
+    DBDmysql
+    DBI
+    IOSocketSSL
+    TermReadKey
+  ];
 
   postInstall = ''
     shortenPerlShebang $(grep -l "/bin/env perl" $out/bin/*)
@@ -26,6 +38,7 @@ buildPerlPackage rec {
   meta = {
     description = "Collection of advanced command-line tools to perform a variety of MySQL and system tasks";
     homepage = "https://www.percona.com/software/database-tools/percona-toolkit";
+    changelog = "https://docs.percona.com/percona-toolkit/release_notes.html";
     license = with lib.licenses; [ gpl2Only ];
     maintainers = with lib.maintainers; [ izorkin ];
   };


### PR DESCRIPTION
## Description of changes

the perl module `percona-toolkit` isn't executable out of the box. This wraps the package to ensure you can install it and use it directly, without installing `perl` alongside.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
