### PR TITLE
nodejs: use ninja for build

### DIFF
--- a/pkgs/development/web/nodejs/bypass-darwin-xcrun-node16.patch
+++ b/pkgs/development/web/nodejs/bypass-darwin-xcrun-node16.patch
@@ -1,7 +1,42 @@
 Avoids needing xcrun or xcodebuild in PATH for native package builds
 
-diff --git a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/xcode_emulation.py b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/xcode_emulation.py
-index a75d8ee..476440d 100644
+--- a/tools/gyp/pylib/gyp/xcode_emulation.py
++++ b/tools/gyp/pylib/gyp/xcode_emulation.py
+@@ -522,7 +522,13 @@ class XcodeSettings:
+         # Since the CLT has no SDK paths anyway, returning None is the
+         # most sensible route and should still do the right thing.
+         try:
+-            return GetStdoutQuiet(["xcrun", "--sdk", sdk, infoitem])
++            #return GetStdoutQuiet(["xcrun", "--sdk", sdk, infoitem])
++            return {
++                "--show-sdk-platform-path": "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform",
++                "--show-sdk-path": "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
++                "--show-sdk-build-version": "19A547",
++                "--show-sdk-version": "10.15"
++            }[infoitem]
+         except GypError:
+             pass
+ 
+@@ -1499,7 +1505,8 @@ def XcodeVersion():
+     version = ""
+     build = ""
+     try:
+-        version_list = GetStdoutQuiet(["xcodebuild", "-version"]).splitlines()
++        #version_list = GetStdoutQuiet(["xcodebuild", "-version"]).splitlines()
++        version_list = []
+         # In some circumstances xcodebuild exits 0 but doesn't return
+         # the right results; for example, a user on 10.7 or 10.8 with
+         # a bogus path set via xcode-select
+@@ -1510,7 +1517,8 @@ def XcodeVersion():
+         version = version_list[0].split()[-1]  # Last word on first line
+         build = version_list[-1].split()[-1]  # Last word on last line
+     except GypError:  # Xcode not installed so look for XCode Command Line Tools
+-        version = CLTVersion()  # macOS Catalina returns 11.0.0.0.1.1567737322
++        #version = CLTVersion()  # macOS Catalina returns 11.0.0.0.1.1567737322
++        version = "11.0.0.0.1.1567737322"
+         if not version:
+             raise GypError("No Xcode or CLT version detected!")
+     # Be careful to convert "4.2.3" to "0423" and "11.0.0" to "1100":
 --- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/xcode_emulation.py
 +++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/xcode_emulation.py
 @@ -522,7 +522,13 @@ class XcodeSettings:

--- a/pkgs/development/web/nodejs/configure-armv6-vfpv2.patch
+++ b/pkgs/development/web/nodejs/configure-armv6-vfpv2.patch
@@ -1,0 +1,15 @@
+Allows ARM FPU to be set to vfpv2, e.g. for Raspberry Pi.
+
+See https://github.com/nodejs/node/issues/44357#issuecomment-1235821878
+
+--- a/configure.py
++++ b/configure.py
+@@ -50,7 +50,7 @@
+ valid_arch = ('arm', 'arm64', 'ia32', 'mips', 'mipsel', 'mips64el', 'ppc',
+               'ppc64', 'x64', 'x86', 'x86_64', 's390x', 'riscv64', 'loong64')
+ valid_arm_float_abi = ('soft', 'softfp', 'hard')
+-valid_arm_fpu = ('vfp', 'vfpv3', 'vfpv3-d16', 'neon')
++valid_arm_fpu = ('vfp', 'vfpv2', 'vfpv3', 'vfpv3-d16', 'neon')
+ valid_mips_arch = ('loongson', 'r1', 'r2', 'r6', 'rx')
+ valid_mips_fpu = ('fp32', 'fp64', 'fpxx')
+ valid_mips_float_abi = ('soft', 'hard')

--- a/pkgs/development/web/nodejs/configure-emulator-node18.patch
+++ b/pkgs/development/web/nodejs/configure-emulator-node18.patch
@@ -1,0 +1,138 @@
+From 4b83f714c821d6d4d2306673ee3a87907cfec80e Mon Sep 17 00:00:00 2001
+From: Ivan Trubach <mr.trubach@icloud.com>
+Date: Fri, 19 Jul 2024 10:45:13 +0300
+Subject: [PATCH] build: support setting an emulator from configure script
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+V8’s JIT infrastructure requires binaries such as mksnapshot to be run
+during the build. However, these binaries must have the same bit-width
+as the host platform (e.g. a x86_64 build platform targeting ARMv6 needs
+to produce a 32-bit binary).
+
+To work around this issue, allow building the binaries for the host
+platform and running them on the build platform with an emulator.
+
+Based on Buildroot’s nodejs-src 0001-add-qemu-wrapper-support.patch.
+https://gitlab.com/buildroot.org/buildroot/-/blob/c1d5eada4d4db9eeaa1c44dd1dea95a67c8a70ca/package/nodejs/nodejs-src/0001-add-qemu-wrapper-support.patch
+
+Upstream: https://github.com/nodejs/node/pull/53899
+---
+ common.gypi              |  1 +
+ configure.py             | 14 ++++++++++++++
+ node.gyp                 |  3 +++
+ tools/v8_gypfiles/v8.gyp |  4 ++++
+ 4 files changed, 22 insertions(+)
+
+diff --git a/common.gypi b/common.gypi
+index ec92c9df4c..6474495ab6 100644
+--- a/common.gypi
++++ b/common.gypi
+@@ -13,6 +13,7 @@
+     'enable_pgo_generate%': '0',
+     'enable_pgo_use%': '0',
+     'python%': 'python',
++    'emulator%': [],
+ 
+     'node_shared%': 'false',
+     'force_dynamic_crt%': 0,
+diff --git a/configure.py b/configure.py
+index 82916748fd..10dc0becbb 100755
+--- a/configure.py
++++ b/configure.py
+@@ -112,6 +112,12 @@ parser.add_argument('--dest-cpu',
+     choices=valid_arch,
+     help=f"CPU architecture to build for ({', '.join(valid_arch)})")
+ 
++parser.add_argument('--emulator',
++    action='store',
++    dest='emulator',
++    default=None,
++    help='emulator command that can run executables built for the target system')
++
+ parser.add_argument('--cross-compiling',
+     action='store_true',
+     dest='cross_compiling',
+@@ -2160,6 +2166,14 @@ write('config.mk', do_not_edit + config_str)
+ gyp_args = ['--no-parallel', '-Dconfiguring_node=1']
+ gyp_args += ['-Dbuild_type=' + config['BUILDTYPE']]
+ 
++if options.emulator is not None:
++  if not options.cross_compiling:
++    # Note that emulator is a list so we have to quote the variable.
++    gyp_args += ['-Demulator=' + shlex.quote(options.emulator)]
++  else:
++    # TODO: perhaps use emulator for tests?
++    warn('The `--emulator` option has no effect when cross-compiling.')
++
+ if options.use_ninja:
+   gyp_args += ['-f', 'ninja-' + flavor]
+ elif flavor == 'win' and sys.platform != 'msys':
+diff --git a/node.gyp b/node.gyp
+index 08cb3f38e8..515b305933 100644
+--- a/node.gyp
++++ b/node.gyp
+@@ -332,6 +332,7 @@
+                     '<(SHARED_INTERMEDIATE_DIR)/node_snapshot.cc',
+                   ],
+                   'action': [
++                    '<@(emulator)',
+                     '<(node_mksnapshot_exec)',
+                     '--build-snapshot',
+                     '<(node_snapshot_main)',
+@@ -351,6 +352,7 @@
+                     '<(SHARED_INTERMEDIATE_DIR)/node_snapshot.cc',
+                   ],
+                   'action': [
++                    '<@(emulator)',
+                     '<@(_inputs)',
+                     '<@(_outputs)',
+                   ],
+@@ -1520,6 +1522,7 @@
+                '<(PRODUCT_DIR)/<(node_core_target_name).def',
+              ],
+              'action': [
++               '<@(emulator)',
+                '<(PRODUCT_DIR)/gen_node_def.exe',
+                '<@(_inputs)',
+                '<@(_outputs)',
+diff --git a/tools/v8_gypfiles/v8.gyp b/tools/v8_gypfiles/v8.gyp
+index ba8b161f0f..d5c90dad50 100644
+--- a/tools/v8_gypfiles/v8.gyp
++++ b/tools/v8_gypfiles/v8.gyp
+@@ -99,6 +99,7 @@
+             '<@(torque_outputs_inc)',
+           ],
+           'action': [
++            '<@(emulator)',
+             '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)torque<(EXECUTABLE_SUFFIX)',
+             '-o', '<(SHARED_INTERMEDIATE_DIR)/torque-generated',
+             '-v8-root', '<(V8_ROOT)',
+@@ -219,6 +220,7 @@
+           'action': [
+             '<(python)',
+             '<(V8_ROOT)/tools/run.py',
++            '<@(emulator)',
+             '<@(_inputs)',
+             '<@(_outputs)',
+           ],
+@@ -442,6 +444,7 @@
+              }],
+           ],
+           'action': [
++            '<@(emulator)',
+             '>@(_inputs)',
+             '>@(mksnapshot_flags)',
+           ],
+@@ -1577,6 +1580,7 @@
+           'action': [
+             '<(python)',
+             '<(V8_ROOT)/tools/run.py',
++            '<@(emulator)',
+             '<@(_inputs)',
+             '<@(_outputs)',
+           ],
+-- 
+2.44.1
+

--- a/pkgs/development/web/nodejs/configure-emulator.patch
+++ b/pkgs/development/web/nodejs/configure-emulator.patch
@@ -1,0 +1,146 @@
+From 999d918bc8fefec1752243743a47c0ce5380bcec Mon Sep 17 00:00:00 2001
+From: Ivan Trubach <mr.trubach@icloud.com>
+Date: Wed, 17 Jul 2024 10:16:02 +0300
+Subject: [PATCH] build: support setting an emulator from configure script
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+V8’s JIT infrastructure requires binaries such as mksnapshot to be run
+during the build. However, these binaries must have the same bit-width
+as the host platform (e.g. a x86_64 build platform targeting ARMv6 needs
+to produce a 32-bit binary).
+
+To work around this issue, allow building the binaries for the host
+platform and running them on the build platform with an emulator.
+
+Based on Buildroot’s nodejs-src 0001-add-qemu-wrapper-support.patch.
+https://gitlab.com/buildroot.org/buildroot/-/blob/c1d5eada4d4db9eeaa1c44dd1dea95a67c8a70ca/package/nodejs/nodejs-src/0001-add-qemu-wrapper-support.patch
+
+Upstream: https://github.com/nodejs/node/pull/53899
+---
+ common.gypi              |  1 +
+ configure.py             | 14 ++++++++++++++
+ node.gyp                 |  4 ++++
+ tools/v8_gypfiles/v8.gyp |  4 ++++
+ 4 files changed, 23 insertions(+)
+
+diff --git a/common.gypi b/common.gypi
+index 154bbf2a0d..54d2afe3b3 100644
+--- a/common.gypi
++++ b/common.gypi
+@@ -13,6 +13,7 @@
+     'enable_pgo_generate%': '0',
+     'enable_pgo_use%': '0',
+     'python%': 'python',
++    'emulator%': [],
+ 
+     'node_shared%': 'false',
+     'force_dynamic_crt%': 0,
+diff --git a/configure.py b/configure.py
+index f7e3310723..f7c7acdf4f 100755
+--- a/configure.py
++++ b/configure.py
+@@ -112,6 +112,12 @@ parser.add_argument('--dest-cpu',
+     choices=valid_arch,
+     help=f"CPU architecture to build for ({', '.join(valid_arch)})")
+ 
++parser.add_argument('--emulator',
++    action='store',
++    dest='emulator',
++    default=None,
++    help='emulator command that can run executables built for the target system')
++
+ parser.add_argument('--cross-compiling',
+     action='store_true',
+     dest='cross_compiling',
+@@ -2276,6 +2282,14 @@ if flavor == 'win' and python.lower().endswith('.exe'):
+ # will fail to run python scripts.
+ gyp_args += ['-Dpython=' + python]
+ 
++if options.emulator is not None:
++  if not options.cross_compiling:
++    # Note that emulator is a list so we have to quote the variable.
++    gyp_args += ['-Demulator=' + shlex.quote(options.emulator)]
++  else:
++    # TODO: perhaps use emulator for tests?
++    warn('The `--emulator` option has no effect when cross-compiling.')
++
+ if options.use_ninja:
+   gyp_args += ['-f', 'ninja-' + flavor]
+ elif flavor == 'win' and sys.platform != 'msys':
+diff --git a/node.gyp b/node.gyp
+index 9617596760..439c76aca6 100644
+--- a/node.gyp
++++ b/node.gyp
+@@ -703,6 +703,7 @@
+                     '<(SHARED_INTERMEDIATE_DIR)/node_snapshot.cc',
+                   ],
+                   'action': [
++                    '<@(emulator)',
+                     '<(node_mksnapshot_exec)',
+                     '--build-snapshot',
+                     '<(node_snapshot_main)',
+@@ -722,6 +723,7 @@
+                     '<(SHARED_INTERMEDIATE_DIR)/node_snapshot.cc',
+                   ],
+                   'action': [
++                    '<@(emulator)',
+                     '<@(_inputs)',
+                     '<@(_outputs)',
+                   ],
+@@ -1010,6 +1012,7 @@
+             '<(SHARED_INTERMEDIATE_DIR)/node_javascript.cc',
+           ],
+           'action': [
++            '<@(emulator)',
+             '<(node_js2c_exec)',
+             '<@(_outputs)',
+             'lib',
+@@ -1477,6 +1480,7 @@
+                '<(PRODUCT_DIR)/<(node_core_target_name).def',
+              ],
+              'action': [
++               '<@(emulator)',
+                '<(PRODUCT_DIR)/gen_node_def.exe',
+                '<@(_inputs)',
+                '<@(_outputs)',
+diff --git a/tools/v8_gypfiles/v8.gyp b/tools/v8_gypfiles/v8.gyp
+index d65a5c268e..5cd6c36b86 100644
+--- a/tools/v8_gypfiles/v8.gyp
++++ b/tools/v8_gypfiles/v8.gyp
+@@ -112,6 +112,7 @@
+             '<@(torque_outputs_inc)',
+           ],
+           'action': [
++            '<@(emulator)',
+             '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)torque<(EXECUTABLE_SUFFIX)',
+             '-o', '<(SHARED_INTERMEDIATE_DIR)/torque-generated',
+             '-v8-root', '<(V8_ROOT)',
+@@ -232,6 +233,7 @@
+           'action': [
+             '<(python)',
+             '<(V8_ROOT)/tools/run.py',
++            '<@(emulator)',
+             '<@(_inputs)',
+             '<@(_outputs)',
+           ],
+@@ -453,6 +455,7 @@
+              }],
+           ],
+           'action': [
++            '<@(emulator)',
+             '>@(_inputs)',
+             '>@(mksnapshot_flags)',
+           ],
+@@ -1842,6 +1845,7 @@
+           'action': [
+             '<(python)',
+             '<(V8_ROOT)/tools/run.py',
++            '<@(emulator)',
+             '<@(_inputs)',
+             '<@(_outputs)',
+           ],
+-- 
+2.44.1
+

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -75,6 +75,7 @@ let
     if platform.isAarch32 && platform ? gcc.fpu then
       lib.throwIfNot (builtins.elem platform.gcc.fpu [
         "vfp"
+        "vfpv2"
         "vfpv3"
         "vfpv3-d16"
         "neon"

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -96,7 +96,7 @@ let
       null;
   # TODO: also handle MIPS flags (mips_arch, mips_fpu, mips_float_abi).
 
-  useSharedHttpParser = !stdenv.isDarwin && lib.versionOlder "${majorVersion}.${minorVersion}" "11.4";
+  useSharedHttpParser = !stdenv.hostPlatform.isDarwin && lib.versionOlder "${majorVersion}.${minorVersion}" "11.4";
 
   sharedLibDeps = { inherit openssl zlib libuv; } // (lib.optionalAttrs useSharedHttpParser { inherit http-parser; });
 
@@ -141,10 +141,10 @@ let
       # Note: do not set TERM=dumb environment variable globally, it is used in
       # test-ci-js test suite to skip tests that otherwise run fine.
       NINJA = "TERM=dumb ninja";
-    } // lib.optionalAttrs (stdenv.isDarwin && stdenv.isx86_64) {
+    } // lib.optionalAttrs (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) {
       # Make sure libc++ uses `posix_memalign` instead of `aligned_alloc` on x86_64-darwin.
       # Otherwise, nodejs would require the 11.0 SDK and macOS 10.15+.
-      NIX_CFLAGS_COMPILE = "-D__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__=101300";
+      NIX_CFLAGS_COMPILE = "-D__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__=101300 -Wno-macro-redefined";
     };
 
     # NB: technically, we do not need bash in build inputs since all scripts are
@@ -286,7 +286,7 @@ let
         "test-tls-cli-max-version-1.3"
         "test-tls-client-auth"
         "test-tls-sni-option"
-      ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      ] ++ lib.optionals stdenv.buildPlatform.isDarwin [
         # Disable tests that don’t work under macOS sandbox.
         "test-macos-app-sandbox"
         "test-os"
@@ -311,6 +311,11 @@ let
         "test-runner-run"
         "test-runner-watch-mode"
         "test-watch-mode-files_watcher"
+      ] ++ lib.optionals (stdenv.buildPlatform.isDarwin && stdenv.buildPlatform.isx86_64) [
+        # These tests fail on x86_64-darwin (even without sandbox).
+        # TODO: revisit at a later date.
+        "test-fs-readv"
+        "test-fs-readv-sync"
       ])}"
     ];
 

--- a/pkgs/development/web/nodejs/v18.nix
+++ b/pkgs/development/web/nodejs/v18.nix
@@ -27,6 +27,7 @@ buildNodejs {
   sha256 = "sha256-p2x+oblq62ljoViAYmDICUtiRNZKaWUp0CBUe5qVyio=";
   patches = [
     ./configure-emulator-node18.patch
+    ./configure-armv6-vfpv2.patch
     ./disable-darwin-v8-system-instrumentation.patch
     ./bypass-darwin-xcrun-node16.patch
     ./revert-arm64-pointer-auth.patch

--- a/pkgs/development/web/nodejs/v18.nix
+++ b/pkgs/development/web/nodejs/v18.nix
@@ -26,6 +26,7 @@ buildNodejs {
   version = "18.20.4";
   sha256 = "sha256-p2x+oblq62ljoViAYmDICUtiRNZKaWUp0CBUe5qVyio=";
   patches = [
+    ./configure-emulator-node18.patch
     ./disable-darwin-v8-system-instrumentation.patch
     ./bypass-darwin-xcrun-node16.patch
     ./revert-arm64-pointer-auth.patch

--- a/pkgs/development/web/nodejs/v20.nix
+++ b/pkgs/development/web/nodejs/v20.nix
@@ -16,6 +16,7 @@ buildNodejs {
   sha256 = "sha256-/dU6VynZNmkaKhFRBG+0iXchy4sPyir5V4I6m0D+DDQ=";
   patches = [
     ./configure-emulator.patch
+    ./configure-armv6-vfpv2.patch
     ./disable-darwin-v8-system-instrumentation-node19.patch
     ./bypass-darwin-xcrun-node16.patch
     ./node-npm-build-npm-package-logic.patch

--- a/pkgs/development/web/nodejs/v20.nix
+++ b/pkgs/development/web/nodejs/v20.nix
@@ -15,6 +15,7 @@ buildNodejs {
   version = "20.15.1";
   sha256 = "sha256-/dU6VynZNmkaKhFRBG+0iXchy4sPyir5V4I6m0D+DDQ=";
   patches = [
+    ./configure-emulator.patch
     ./disable-darwin-v8-system-instrumentation-node19.patch
     ./bypass-darwin-xcrun-node16.patch
     ./node-npm-build-npm-package-logic.patch

--- a/pkgs/development/web/nodejs/v22.nix
+++ b/pkgs/development/web/nodejs/v22.nix
@@ -15,6 +15,7 @@ buildNodejs {
   version = "22.4.1";
   sha256 = "sha256-ZfyFf1qoJWqvyQCzRMARXJrq4loCVB/Vzg29Tf0cX7k=";
   patches = [
+    ./configure-emulator.patch
     ./disable-darwin-v8-system-instrumentation-node19.patch
     ./bypass-darwin-xcrun-node16.patch
     ./node-npm-build-npm-package-logic.patch

--- a/pkgs/development/web/nodejs/v22.nix
+++ b/pkgs/development/web/nodejs/v22.nix
@@ -16,6 +16,7 @@ buildNodejs {
   sha256 = "sha256-ZfyFf1qoJWqvyQCzRMARXJrq4loCVB/Vzg29Tf0cX7k=";
   patches = [
     ./configure-emulator.patch
+    ./configure-armv6-vfpv2.patch
     ./disable-darwin-v8-system-instrumentation-node19.patch
     ./bypass-darwin-xcrun-node16.patch
     ./node-npm-build-npm-package-logic.patch


### PR DESCRIPTION
## Description of changes

This PR contains changes to build Node.js without cross-compilation (see https://github.com/NixOS/nixpkgs/pull/220204#issuecomment-2229544988) and use ninja for build.

Note that we can’t use `--cross-compiling` with Ninja without https://github.com/nodejs/gyp-next/pull/185, but we don’t have to because we use an emulator instead. This is based on Buildroot’s [0001-add-qemu-wrapper-support.patch](https://gitlab.com/buildroot.org/buildroot/-/blob/c1d5eada4d4db9eeaa1c44dd1dea95a67c8a70ca/package/nodejs/nodejs-src/0001-add-qemu-wrapper-support.patch) patch, but re-implemented in a manner that hopefully can be upstreamed (see also https://github.com/nodejs/node/pull/53899).

__Supersedes__
- #220204 (thanks @Cynerd for working on this!)
- #317109

__Fixes__
- #321847
- #319036
- #326150

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-linux → i686-linux (pkgsCross.gnu32)
  - [x] aarch64-linux → armv6l-linux (pkgsCross.raspberryPi but
    `gcc.arch = "armv6kz"` and `gcc.fpu = "vfpv2"`)
  - [x] aarch64-linux → armv7l-linux (pkgsCross.armv7l-hf-multiplatform)
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
