### PR TITLE
kdePackages.kirigami: hack to propagate qqc2-desktop-style

### DIFF
--- a/pkgs/kde/frameworks/kirigami/default.nix
+++ b/pkgs/kde/frameworks/kirigami/default.nix
@@ -1,14 +1,34 @@
 {
+  stdenv,
   mkKdeDerivation,
   qtsvg,
   qttools,
   qtdeclarative,
   qt5compat,
+  qqc2-desktop-style,
 }:
-mkKdeDerivation {
-  pname = "kirigami";
+# Kirigami has a runtime dependency on qqc2-desktop-style,
+# which has a build time dependency on Kirigami.
+# So, build qqc2-desktop-style against unwrapped Kirigami,
+# and replace all the other Kirigami with a wrapper that
+# propagates both Kirigami and qqc2-desktop-style.
+# This is a hack, but what can you do.
+let
+  unwrapped = mkKdeDerivation {
+    pname = "kirigami";
 
-  extraNativeBuildInputs = [qtsvg qttools];
-  extraBuildInputs = [qtdeclarative];
-  extraPropagatedBuildInputs = [qt5compat];
+    extraNativeBuildInputs = [qtsvg qttools];
+    extraBuildInputs = [qtdeclarative];
+    extraPropagatedBuildInputs = [qt5compat];
+  };
+in stdenv.mkDerivation {
+  pname = "kirigami-wrapped";
+  inherit (unwrapped) version;
+
+  propagatedBuildInputs = [ unwrapped qqc2-desktop-style ];
+
+  dontUnpack = true;
+  dontWrapQtApps = true;
+
+  passthru = { inherit unwrapped; };
 }

--- a/pkgs/kde/frameworks/qqc2-desktop-style/default.nix
+++ b/pkgs/kde/frameworks/qqc2-desktop-style/default.nix
@@ -2,10 +2,13 @@
   mkKdeDerivation,
   qtdeclarative,
   qttools,
+  kirigami,
 }:
 mkKdeDerivation {
   pname = "qqc2-desktop-style";
 
   extraNativeBuildInputs = [qttools];
-  extraBuildInputs = [qtdeclarative];
+  extraBuildInputs = [qtdeclarative kirigami.unwrapped];
+
+  excludeDependencies = ["kirigami"];
 }

--- a/pkgs/kde/gear/filelight/default.nix
+++ b/pkgs/kde/gear/filelight/default.nix
@@ -2,7 +2,6 @@
   mkKdeDerivation,
   kirigami,
   kquickcharts,
-  qqc2-desktop-style,
 }:
 mkKdeDerivation {
   pname = "filelight";
@@ -10,7 +9,6 @@ mkKdeDerivation {
   extraBuildInputs = [
     kirigami
     kquickcharts
-    qqc2-desktop-style
   ];
   meta.mainProgram = "filelight";
 }

--- a/pkgs/kde/gear/kalk/default.nix
+++ b/pkgs/kde/gear/kalk/default.nix
@@ -1,7 +1,6 @@
 {
   mkKdeDerivation,
   qtdeclarative,
-  qqc2-desktop-style,
   kirigami-addons,
   pkg-config,
   bison,
@@ -16,7 +15,6 @@ mkKdeDerivation {
   extraNativeBuildInputs = [pkg-config bison flex];
   extraBuildInputs = [
     qtdeclarative
-    qqc2-desktop-style
     kirigami-addons
     gmp
     mpfr

--- a/pkgs/kde/gear/kweather/default.nix
+++ b/pkgs/kde/gear/kweather/default.nix
@@ -2,12 +2,11 @@
   mkKdeDerivation,
   qtsvg,
   qtcharts,
-  qqc2-desktop-style,
   kholidays,
 }:
 mkKdeDerivation {
   pname = "kweather";
 
-  extraBuildInputs = [qtsvg qtcharts qqc2-desktop-style kholidays];
+  extraBuildInputs = [qtsvg qtcharts kholidays];
   meta.mainProgram = "kweather";
 }

--- a/pkgs/kde/gear/kwordquiz/default.nix
+++ b/pkgs/kde/gear/kwordquiz/default.nix
@@ -2,7 +2,6 @@
   mkKdeDerivation,
   qtsvg,
   qtmultimedia,
-  qqc2-desktop-style,
 }:
 mkKdeDerivation {
   pname = "kwordquiz";
@@ -10,7 +9,6 @@ mkKdeDerivation {
   extraBuildInputs = [
     qtsvg
     qtmultimedia
-    qqc2-desktop-style
   ];
   meta.mainProgram = "kwordquiz";
 }

--- a/pkgs/kde/misc/marknote/default.nix
+++ b/pkgs/kde/misc/marknote/default.nix
@@ -5,7 +5,6 @@
   qtdeclarative,
   qtsvg,
   qtwayland,
-  qqc2-desktop-style
 }:
 mkKdeDerivation rec {
   pname = "marknote";
@@ -20,7 +19,6 @@ mkKdeDerivation rec {
     qtdeclarative
     qtsvg
     qtwayland
-    qqc2-desktop-style
   ];
 
   meta.license = [ lib.licenses.gpl2Plus ];


### PR DESCRIPTION
## Description of changes

This is very unfortunate, but oh well.

CC @raboof who initially led me to notice this.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
