### PR TITLE
added s390x option type via magic attributes

### DIFF
--- a/nixos/modules/system/boot/binfmt.nix
+++ b/nixos/modules/system/boot/binfmt.nix
@@ -141,6 +141,10 @@ let
       magicOrExtension = ''\x00asm'';
       mask = ''\xff\xff\xff\xff'';
     };
+    s390x-linux = {
+      magicOrExtension = ''\x7fELF\x02\x02\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x16'';
+      mask = ''\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff'';
+    };
     x86_64-windows.magicOrExtension = "MZ";
     i686-windows.magicOrExtension = "MZ";
   };


### PR DESCRIPTION
## Description of changes

added the binfmt magic attributes for s390x so the module option boot.binfmt.emulatedSystems's type would also include s390x-linux. While not part of supported platforms nix is aware of s390x and can cross/compile binaries for s390x or even minimal nixos sytem build.toplevel drv's <with some changes> judging by my efforts regarding bringing nixos to s390x. I think it would make sense to include this option since its a trivial change.


*S390X is the architecture used by IBM mainframes such as the IBM system Z10 in my case.*

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - (assuming this should work for other platforms as well due to the nature of the change)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

### usage/tested behavior:
if binfmt is  setup for s390x using the changes found in this commit. Running the code below (build for s390x) would have the following output:
```bash
$ cat 1.c
```
```C
#include<stdio.h>
int main(int argc, char ** argv) {
    printf("lol %i\n", argc);
    return 0;
 }
```
```bash
# s390x gcc compiler build for x86_64 but any arch should work 
/nix/store/hm6lyzbi70zyv6br3zp3s82pbbks26ak-s390x-unknown-linux-gnu-gcc-wrapper-13.3.0/bin/s390x-unknown-linux-gnu-gcc 1.c
$ ./a.out
lol 1
./a.out test
lol 2
```

if however binfmt isn't setup for the magic elf sequence added in this commit this would trigger a format error instead

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
