### PR TITLE
zapret: init as 0-unstable-2024-07-16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14537,6 +14537,11 @@
     github = "dev-nis";
     githubId = 132921300;
   };
+  nishimara = {
+    name = "nishimara";
+    github = "Nishimara";
+    githubId = 59232119;
+  };
   nitsky = {
     name = "nitsky";
     github = "nitsky";

--- a/pkgs/by-name/za/zapret/package.nix
+++ b/pkgs/by-name/za/zapret/package.nix
@@ -46,10 +46,8 @@ stdenv.mkDerivation {
     cp $src/init.d/sysv/zapret $out/usr/share/zapret/init.d/sysv/init.d
 
     substituteInPlace $out/usr/share/zapret/init.d/sysv/functions \
-      --replace "ZAPRET_BASE=\$(readlink -f \"\$EXEDIR/../..\")" "ZAPRET_BASE=$out/usr/share/zapret"
-
-    # i think the most of it can be overrided by env
-    cp $src/config $out/usr/share/zapret
+      --replace "ZAPRET_BASE=\$(readlink -f \"\$EXEDIR/../..\")" "ZAPRET_BASE=$out/usr/share/zapret" \
+      --replace ". \"\$ZAPRET_BASE/config\"" ""
 
     cp -r $src/docs/* $out/usr/share/docs
 

--- a/pkgs/by-name/za/zapret/package.nix
+++ b/pkgs/by-name/za/zapret/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  libcap,
+  zlib,
+  libnetfilter_queue,
+  libnfnetlink,
+
+  iptables,
+  nftables,
+  gawk
+}:
+
+stdenv.mkDerivation {
+  pname = "zapret";
+  version = "0-unstable-2024-07-16";
+
+  src = fetchFromGitHub {
+    owner = "bol-van";
+    repo = "zapret";
+    rev = "9fcd8f830ebde2491719a5c698e22d1d5210e0fb";
+    sha256 = "sha256-8cqKCNYLLkZXlwrybKUPG6fLd7gmf8zV9tjWoTxAwIY=";
+  };
+
+  buildInputs = [ libcap zlib libnetfilter_queue libnfnetlink ];
+  nativeBuildInputs = [ iptables nftables gawk ];
+
+  buildPhase = ''
+    mkdir -p $out/bin
+
+    make TGT=$out/bin
+  '';
+
+  installPhase = ''
+    mkdir -p $out/usr/share/zapret/init.d/sysv
+    mkdir -p $out/usr/share/docs
+
+    cp $src/blockcheck.sh $out/bin/blockcheck
+
+    substituteInPlace $out/bin/blockcheck \
+      --replace "ZAPRET_BASE=\"\$EXEDIR\"" "ZAPRET_BASE=$out/usr/share/zapret"
+
+    cp $src/init.d/sysv/functions $out/usr/share/zapret/init.d/sysv/functions
+    cp $src/init.d/sysv/zapret $out/usr/share/zapret/init.d/sysv/init.d
+
+    substituteInPlace $out/usr/share/zapret/init.d/sysv/functions \
+      --replace "ZAPRET_BASE=\$(readlink -f \"\$EXEDIR/../..\")" "ZAPRET_BASE=$out/usr/share/zapret"
+
+    # i think the most of it can be overrided by env
+    cp $src/config $out/usr/share/zapret
+
+    cp -r $src/docs/* $out/usr/share/docs
+
+    mkdir -p $out/usr/share/zapret/{common,ipset}
+
+    cp $src/common/* $out/usr/share/zapret/common
+    cp $src/ipset/* $out/usr/share/zapret/ipset
+
+    mkdir -p $out/usr/share/zapret/nfq
+    ln -s ../../../../bin/nfqws $out/usr/share/zapret/nfq/nfqws
+
+    for i in ip2net mdig tpws
+    do
+      mkdir -p $out/usr/share/zapret/$i
+      ln -s ../../../../bin/$i $out/usr/share/zapret/$i/$i
+    done
+
+    ln -s ../usr/share/zapret/init.d/sysv/init.d $out/bin/zapret
+  '';
+
+  meta = with lib; {
+    description = "DPI bypass multi platform";
+    homepage = "https://github.com/bol-van/zapret";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nishimara ];
+    mainProgram = "zapret";
+
+    # probably gonna work on darwin, but untested
+    broken = stdenv.isDarwin;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Init zapret, DPI bypassing tool
https://github.com/bol-van/zapret/tree/9fcd8f830ebde2491719a5c698e22d1d5210e0fb

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
