### PR TITLE
nixos/xdg/*: disable by default 

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -267,6 +267,9 @@
 
 - `bluemap` has changed the format used to store map tiles, and the database layout has been heavily modified. Upstream recommends a clean reinstallation: <https://github.com/BlueMap-Minecraft/BlueMap/releases/tag/v5.2>. Unless you are using an SQL storage backend, this should only entail deleting the contents of `config.services.bluemap.coreSettings.data` (defaults to `/var/lib/bluemap`) and `config.services.bluemap.webRoot` (defaults to `/var/lib/bluemap/web`).
 
+- `xdg.autostart.enable`, `xdg.icons.enable`, `xdg.menues.enable`, `xdg.mime.enable` and `xdg.sounds.enable` default now to false but all desktop managers in nixpkgs itself activate them.
+  If you roll your own desktop, you might need to enable them explicitly.
+
 - `wstunnel` has had a major version upgrade that entailed rewriting the program in Rust.
   The module was updated to accommodate for breaking changes and breaking changes to the
   module options were minimised as much as possible. Nonetheless, some were inevitable due

--- a/nixos/modules/config/xdg/autostart.nix
+++ b/nixos/modules/config/xdg/autostart.nix
@@ -7,7 +7,7 @@
   options = {
     xdg.autostart.enable = lib.mkOption {
       type = lib.types.bool;
-      default = true;
+      default = false;
       description = ''
         Whether to install files to support the
         [XDG Autostart specification](https://specifications.freedesktop.org/autostart-spec/latest).

--- a/nixos/modules/config/xdg/icons.nix
+++ b/nixos/modules/config/xdg/icons.nix
@@ -12,7 +12,7 @@
   options = {
     xdg.icons.enable = lib.mkOption {
       type = lib.types.bool;
-      default = true;
+      default = false;
       description = ''
         Whether to install files to support the
         [XDG Icon Theme specification](https://specifications.freedesktop.org/icon-theme-spec/latest).

--- a/nixos/modules/config/xdg/menus.nix
+++ b/nixos/modules/config/xdg/menus.nix
@@ -7,7 +7,7 @@
   options = {
     xdg.menus.enable = lib.mkOption {
       type = lib.types.bool;
-      default = true;
+      default = false;
       description = ''
         Whether to install files to support the
         [XDG Desktop Menu specification](https://specifications.freedesktop.org/menu-spec/latest).

--- a/nixos/modules/config/xdg/mime.nix
+++ b/nixos/modules/config/xdg/mime.nix
@@ -14,7 +14,7 @@ in
   options = {
     xdg.mime.enable = lib.mkOption {
       type = lib.types.bool;
-      default = true;
+      default = false;
       description = ''
         Whether to install files to support the
         [XDG Shared MIME-info specification](https://specifications.freedesktop.org/shared-mime-info-spec/latest) and the

--- a/nixos/modules/config/xdg/portal.nix
+++ b/nixos/modules/config/xdg/portal.nix
@@ -36,11 +36,7 @@ in
   };
 
   options.xdg.portal = {
-    enable =
-      mkEnableOption ''[xdg desktop integration](https://github.com/flatpak/xdg-desktop-portal)''
-      // {
-        default = false;
-      };
+    enable = mkEnableOption ''[xdg desktop integration](https://github.com/flatpak/xdg-desktop-portal)'';
 
     extraPortals = mkOption {
       type = types.listOf types.package;

--- a/nixos/modules/config/xdg/sounds.nix
+++ b/nixos/modules/config/xdg/sounds.nix
@@ -12,7 +12,7 @@
   options = {
     xdg.sounds.enable = lib.mkOption {
       type = lib.types.bool;
-      default = true;
+      default = false;
       description = ''
         Whether to install files to support the
         [XDG Sound Theme specification](https://www.freedesktop.org/wiki/Specifications/sound-theme-spec/).

--- a/nixos/modules/profiles/minimal.nix
+++ b/nixos/modules/profiles/minimal.nix
@@ -32,9 +32,4 @@ with lib;
   services.logrotate.enable = mkDefault false;
 
   services.udisks2.enable = mkDefault false;
-
-  xdg.autostart.enable = mkDefault false;
-  xdg.icons.enable = mkDefault false;
-  xdg.mime.enable = mkDefault false;
-  xdg.sounds.enable = mkDefault false;
 }

--- a/nixos/modules/programs/miriway.nix
+++ b/nixos/modules/programs/miriway.nix
@@ -79,7 +79,13 @@ in
     # To make the Miriway session available if a display manager like SDDM is enabled:
     services.displayManager.sessionPackages = [ pkgs.miriway ];
 
-    xdg.icons.enable = true;
+    xdg = {
+      autostart.enable = true;
+      icons.enable = true;
+      menus.enable = true;
+      mime.enable = true;
+      sounds.enable = true;
+    };
   };
 
   meta.maintainers = with lib.maintainers; [ OPNA2608 ];

--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -280,7 +280,6 @@ in
     systemd.packages = [ kdePackages.drkonqi ];
     systemd.services."drkonqi-coredump-processor@".wantedBy = [ "systemd-coredump@.service" ];
 
-    xdg.icons.enable = true;
     xdg.icons.fallbackCursorThemes = mkDefault [ "breeze_cursors" ];
 
     xdg.portal.enable = true;

--- a/nixos/modules/services/misc/graphical-desktop.nix
+++ b/nixos/modules/services/misc/graphical-desktop.nix
@@ -68,6 +68,7 @@ in
       menus.enable = true;
       mime.enable = true;
       icons.enable = true;
+      sounds.enable = true;
     };
   };
 }

--- a/nixos/modules/services/x11/desktop-managers/cinnamon.nix
+++ b/nixos/modules/services/x11/desktop-managers/cinnamon.nix
@@ -195,9 +195,6 @@ in
         xapp # provides some xapp-* icons
       ] config.environment.cinnamon.excludePackages);
 
-      xdg.mime.enable = true;
-      xdg.icons.enable = true;
-
       xdg.portal.enable = true;
       xdg.portal.extraPortals = [
         pkgs.xdg-desktop-portal-xapp

--- a/nixos/modules/services/x11/desktop-managers/deepin.nix
+++ b/nixos/modules/services/x11/desktop-managers/deepin.nix
@@ -73,9 +73,6 @@ in
     programs.gnupg.agent.pinentryPackage = mkDefault pkgs.pinentry-qt;
 
     fonts.packages = with pkgs; [ noto-fonts ];
-    xdg.mime.enable = true;
-    xdg.menus.enable = true;
-    xdg.icons.enable = true;
     xdg.portal.enable = mkDefault true;
     xdg.portal.extraPortals = mkDefault [
       pkgs.xdg-desktop-portal-gtk

--- a/nixos/modules/services/x11/desktop-managers/gnome.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome.nix
@@ -298,10 +298,6 @@ in
       services.upower.enable = config.powerManagement.enable;
       services.libinput.enable = mkDefault true; # for controlling touchpad settings via gnome control center
 
-      # Explicitly enabled since GNOME will be severely broken without these.
-      xdg.mime.enable = true;
-      xdg.icons.enable = true;
-
       xdg.portal.enable = true;
       xdg.portal.extraPortals = [
         pkgs.xdg-desktop-portal-gnome

--- a/nixos/modules/services/x11/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.nix
@@ -236,9 +236,6 @@ in
       # Settings from elementary-default-settings
       environment.etc."gtk-3.0/settings.ini".source = "${pkgs.pantheon.elementary-default-settings}/etc/gtk-3.0/settings.ini";
 
-      xdg.mime.enable = true;
-      xdg.icons.enable = true;
-
       xdg.portal.enable = true;
       xdg.portal.extraPortals = [
         pkgs.xdg-desktop-portal-gtk

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -377,8 +377,6 @@ in
         };
       };
 
-      xdg.icons.enable = true;
-
       xdg.portal.enable = true;
       xdg.portal.extraPortals = [ pkgs.plasma5Packages.xdg-desktop-portal-kde ];
       xdg.portal.configPackages = mkDefault [ pkgs.plasma5Packages.xdg-desktop-portal-kde ];


### PR DESCRIPTION
## Description of changes

I don't need hicolor-icon-theme on my headless server.

Requires #335115

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
