### PR TITLE
bootstrap-tools-cross: add s390x to make-bootstrap-tools-cross.nix

### DIFF
--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -28,6 +28,7 @@ in lib.mapAttrs (n: make) (with lib.systems.examples; {
   powerpc64-unknown-linux-gnuabielfv2 = ppc64;
   powerpc64le-unknown-linux-gnu = powernv;
   riscv64-unknown-linux-gnu = riscv64;
+  s390x-unknown-linux-gnu = s390x;
 
   # musl
   aarch64-unknown-linux-musl = aarch64-multiplatform-musl;


### PR DESCRIPTION
## Description of changes

adding s390x to make-bootstrap-tools-cross.nix 