### PR TITLE
jasp-desktop: 0.18.3 -> 0.19.0, format with nixfmt

### DIFF
--- a/pkgs/by-name/ja/jasp-desktop/modules.nix
+++ b/pkgs/by-name/ja/jasp-desktop/modules.nix
@@ -1,8 +1,9 @@
-{ R
-, rPackages
-, fetchFromGitHub
-, jasp-src
-, jasp-version
+{
+  R,
+  rPackages,
+  fetchFromGitHub,
+  jasp-src,
+  jasp-version,
 }:
 
 with rPackages;
@@ -21,7 +22,18 @@ let
     src = jasp-src;
     sourceRoot = "${jasp-src.name}/Engine/jaspGraphs";
 
-    propagatedBuildInputs = [ ggplot2 gridExtra gtable lifecycle jsonlite R6 RColorBrewer rlang scales viridisLite ];
+    propagatedBuildInputs = [
+      ggplot2
+      gridExtra
+      gtable
+      lifecycle
+      jsonlite
+      R6
+      RColorBrewer
+      rlang
+      scales
+      viridisLite
+    ];
   };
 
   jaspBase = buildRPackage {
@@ -41,7 +53,31 @@ let
       cp -r --no-preserve=all ${jaspColumnEncoder-src} inst/include/jaspColumnEncoder
     '';
 
-    propagatedBuildInputs = [ cli codetools ggplot2 gridExtra gridGraphics jaspGraphs jsonlite lifecycle modules officer pkgbuild plyr qgraph ragg R6 Rcpp renv remotes rjson rvg svglite systemfonts withr ];
+    propagatedBuildInputs = [
+      cli
+      codetools
+      ggplot2
+      gridExtra
+      gridGraphics
+      jaspGraphs
+      jsonlite
+      lifecycle
+      modules
+      officer
+      pkgbuild
+      plyr
+      qgraph
+      ragg
+      R6
+      Rcpp
+      renv
+      remotes
+      rjson
+      rvg
+      svglite
+      systemfonts
+      withr
+    ];
   };
 
   stanova = buildRPackage {
@@ -52,7 +88,13 @@ let
       rev = "988ad8e07cda1674b881570a85502be7795fbd4e";
       hash = "sha256-tAeHqTHao2KVRNFBDWmuF++H31aNN6O1ss1Io500QBY=";
     };
-    propagatedBuildInputs = [ emmeans lme4 coda rstan MASS ];
+    propagatedBuildInputs = [
+      emmeans
+      lme4
+      coda
+      rstan
+      MASS
+    ];
   };
 
   bstats = buildRPackage {
@@ -63,7 +105,11 @@ let
       rev = "42d34c18df08d233825bae34fdc0dfa0cd70ce8c";
       hash = "sha256-N2KmbTPbyvzsZTWBRE2x7bteccnzokUWDOB4mOWUdJk=";
     };
-    propagatedBuildInputs = [ hypergeo purrr SuppDists ];
+    propagatedBuildInputs = [
+      hypergeo
+      purrr
+      SuppDists
+    ];
   };
 
   flexplot = buildRPackage {
@@ -74,7 +120,25 @@ let
       rev = "4223ad5fb56028018b964d6f9f5aa5bac8710821";
       hash = "sha256-L+Ed2bIWjq3ZIAGookp8dAjDSeldEbcwynwFVVZ9IcU=";
     };
-    propagatedBuildInputs = [ cowplot MASS tibble withr dplyr magrittr forcats purrr plyr R6 ggplot2 patchwork ggsci lme4 party mgcv rlang ];
+    propagatedBuildInputs = [
+      cowplot
+      MASS
+      tibble
+      withr
+      dplyr
+      magrittr
+      forcats
+      purrr
+      plyr
+      R6
+      ggplot2
+      patchwork
+      ggsci
+      lme4
+      party
+      mgcv
+      rlang
+    ];
   };
 
   # conting has been removed from CRAN
@@ -86,52 +150,443 @@ let
       rev = "03a4eb9a687e015d602022a01d4e638324c110c8";
       hash = "sha256-Sp09YZz1WGyefn31Zy1qGufoKjtuEEZHO+wJvoLArf0=";
     };
-    propagatedBuildInputs = [ mvtnorm gtools tseries coda ];
+    propagatedBuildInputs = [
+      mvtnorm
+      gtools
+      tseries
+      coda
+    ];
   };
 
-  buildJaspModule = name: deps: buildRPackage {
-    name = "${name}-${jasp-version}";
-    version = jasp-version;
-    src = jasp-src;
-    sourceRoot = "${jasp-src.name}/Modules/${name}";
-    propagatedBuildInputs = deps;
-  };
+  buildJaspModule =
+    name: deps:
+    buildRPackage {
+      name = "${name}-${jasp-version}";
+      version = jasp-version;
+      src = jasp-src;
+      sourceRoot = "${jasp-src.name}/Modules/${name}";
+      propagatedBuildInputs = deps;
+    };
 in
 {
-  engine = { inherit jaspBase jaspGraphs; };
+  engine = {
+    inherit jaspBase jaspGraphs;
+  };
+
   modules = rec {
-    jaspAcceptanceSampling = buildJaspModule "jaspAcceptanceSampling" [ abtest BayesFactor conting' ggplot2 jaspBase jaspGraphs plyr stringr vcd vcdExtra AcceptanceSampling ];
-    jaspAnova = buildJaspModule "jaspAnova" [ afex BayesFactor boot car colorspace emmeans ggplot2 jaspBase jaspDescriptives jaspGraphs jaspTTests KernSmooth matrixStats multcomp onewaytests plyr stringi stringr restriktor ];
-    jaspAudit = buildJaspModule "jaspAudit" [ bstats extraDistr ggplot2 ggrepel jaspBase jaspGraphs jfa ];
-    jaspBain = buildJaspModule "jaspBain" [ bain lavaan ggplot2 semPlot stringr jaspBase jaspGraphs jaspSem ];
-    jaspBsts = buildJaspModule "jaspBsts" [ Boom bsts ggplot2 jaspBase jaspGraphs matrixStats reshape2 ];
-    jaspCircular = buildJaspModule "jaspCircular" [ jaspBase jaspGraphs circular ggplot2 ];
-    jaspCochrane = buildJaspModule "jaspCochrane" [ jaspBase jaspGraphs jaspDescriptives jaspMetaAnalysis ];
-    jaspDescriptives = buildJaspModule "jaspDescriptives" [ ggplot2 ggrepel jaspBase jaspGraphs ];
-    jaspDistributions = buildJaspModule "jaspDistributions" [ car fitdistrplus ggplot2 goftest gnorm jaspBase jaspGraphs MASS sgt sn ];
-    jaspEquivalenceTTests = buildJaspModule "jaspEquivalenceTTests" [ BayesFactor ggplot2 jaspBase jaspGraphs metaBMA TOSTER jaspTTests ];
-    jaspFactor = buildJaspModule "jaspFactor" [ ggplot2 jaspBase jaspGraphs jaspSem lavaan psych qgraph reshape2 semPlot GPArotation Rcsdp semTools ];
-    jaspFrequencies = buildJaspModule "jaspFrequencies" [ abtest BayesFactor conting' multibridge ggplot2 jaspBase jaspGraphs plyr stringr vcd vcdExtra ];
-    jaspJags = buildJaspModule "jaspJags" [ coda ggplot2 ggtext hexbin jaspBase jaspGraphs rjags scales stringr ];
-    jaspLearnBayes = buildJaspModule "jaspLearnBayes" [ extraDistr ggplot2 HDInterval jaspBase jaspGraphs MASS MCMCpack MGLM scales ggalluvial ragg runjags ggdist png posterior ];
-    jaspLearnStats = buildJaspModule "jaspLearnStats" [ extraDistr ggplot2 jaspBase jaspGraphs jaspDistributions jaspDescriptives jaspTTests ggforce tidyr igraph ];
-    jaspMachineLearning = buildJaspModule "jaspMachineLearning" [ kknn AUC cluster colorspace DALEX dbscan e1071 fpc gbm Gmedian ggparty ggdendro ggnetwork ggplot2 ggrepel ggridges glmnet jaspBase jaspGraphs MASS mvnormalTest neuralnet network partykit plyr randomForest rpart ROCR Rtsne signal ];
-    jaspMetaAnalysis = buildJaspModule "jaspMetaAnalysis" [ dplyr ggplot2 jaspBase jaspGraphs MASS metaBMA metafor psych purrr rstan stringr tibble tidyr weightr BayesTools RoBMA metamisc ggmcmc pema ];
-    jaspMixedModels = buildJaspModule "jaspMixedModels" [ afex emmeans ggplot2 ggpol jaspBase jaspGraphs lme4 loo mgcv rstan rstanarm stanova withr ];
-    jaspNetwork = buildJaspModule "jaspNetwork" [ bootnet BDgraph corpcor dplyr foreach ggplot2 gtools HDInterval huge IsingSampler jaspBase jaspGraphs mvtnorm qgraph reshape2 snow stringr ];
-    jaspPower = buildJaspModule "jaspPower" [ pwr jaspBase jaspGraphs ];
-    jaspPredictiveAnalytics = buildJaspModule "jaspPredictiveAnalytics" [ jaspBase jaspGraphs bsts bssm precrec reshape2 Boom lubridate prophet BART EBMAforecast imputeTS ];
-    jaspProcess = buildJaspModule "jaspProcess" [ dagitty ggplot2 ggraph jaspBase jaspGraphs ];
-    jaspProphet = buildJaspModule "jaspProphet" [ rstan ggplot2 jaspBase jaspGraphs prophet scales ];
-    jaspQualityControl = buildJaspModule "jaspQualityControl" [ car cowplot daewr desirability DoE_base EnvStats FAdist fitdistrplus FrF2 ggplot2 ggrepel goftest ggpp irr jaspBase jaspDescriptives jaspGraphs mle_tools psych qcc rsm Rspc tidyr tibble vipor weibullness ];
-    jaspRegression = buildJaspModule "jaspRegression" [ BAS boot bstats combinat emmeans ggplot2 ggrepel hmeasure jaspAnova jaspBase jaspDescriptives jaspGraphs jaspTTests lmtest logistf MASS matrixStats mdscore ppcor purrr Rcpp statmod VGAM ];
-    jaspReliability = buildJaspModule "jaspReliability" [ Bayesrel coda ggplot2 ggridges irr jaspBase jaspGraphs LaplacesDemon lme4 MASS psych ];
-    jaspRobustTTests = buildJaspModule "jaspRobustTTests" [ RoBTT ggplot2 jaspBase jaspGraphs ];
-    jaspSem = buildJaspModule "jaspSem" [ forcats ggplot2 jaspBase jaspGraphs lavaan cSEM reshape2 semPlot semTools stringr tibble tidyr ];
-    jaspSummaryStatistics = buildJaspModule "jaspSummaryStatistics" [ BayesFactor bstats jaspBase jaspFrequencies jaspGraphs jaspRegression jaspTTests jaspAnova jaspDescriptives SuppDists bayesplay ];
-    jaspSurvival = buildJaspModule "jaspSurvival" [ survival survminer jaspBase jaspGraphs ];
-    jaspTTests = buildJaspModule "jaspTTests" [ BayesFactor car ggplot2 jaspBase jaspGraphs logspline plotrix plyr ];
-    jaspTimeSeries = buildJaspModule "jaspTimeSeries" [ jaspBase jaspGraphs forecast ];
-    jaspVisualModeling = buildJaspModule "jaspVisualModeling" [ flexplot jaspBase jaspGraphs ];
+    jaspAcceptanceSampling = buildJaspModule "jaspAcceptanceSampling" [
+      abtest
+      BayesFactor
+      conting'
+      ggplot2
+      jaspBase
+      jaspGraphs
+      plyr
+      stringr
+      vcd
+      vcdExtra
+      AcceptanceSampling
+    ];
+    jaspAnova = buildJaspModule "jaspAnova" [
+      afex
+      BayesFactor
+      boot
+      car
+      colorspace
+      emmeans
+      ggplot2
+      jaspBase
+      jaspDescriptives
+      jaspGraphs
+      jaspTTests
+      KernSmooth
+      matrixStats
+      multcomp
+      onewaytests
+      plyr
+      stringi
+      stringr
+      restriktor
+    ];
+    jaspAudit = buildJaspModule "jaspAudit" [
+      bstats
+      extraDistr
+      ggplot2
+      ggrepel
+      jaspBase
+      jaspGraphs
+      jfa
+    ];
+    jaspBain = buildJaspModule "jaspBain" [
+      bain
+      lavaan
+      ggplot2
+      semPlot
+      stringr
+      jaspBase
+      jaspGraphs
+      jaspSem
+    ];
+    jaspBsts = buildJaspModule "jaspBsts" [
+      Boom
+      bsts
+      ggplot2
+      jaspBase
+      jaspGraphs
+      matrixStats
+      reshape2
+    ];
+    jaspCircular = buildJaspModule "jaspCircular" [
+      jaspBase
+      jaspGraphs
+      circular
+      ggplot2
+    ];
+    jaspCochrane = buildJaspModule "jaspCochrane" [
+      jaspBase
+      jaspGraphs
+      jaspDescriptives
+      jaspMetaAnalysis
+    ];
+    jaspDescriptives = buildJaspModule "jaspDescriptives" [
+      ggplot2
+      ggrepel
+      jaspBase
+      jaspGraphs
+    ];
+    jaspDistributions = buildJaspModule "jaspDistributions" [
+      car
+      fitdistrplus
+      ggplot2
+      goftest
+      gnorm
+      jaspBase
+      jaspGraphs
+      MASS
+      sgt
+      sn
+    ];
+    jaspEquivalenceTTests = buildJaspModule "jaspEquivalenceTTests" [
+      BayesFactor
+      ggplot2
+      jaspBase
+      jaspGraphs
+      metaBMA
+      TOSTER
+      jaspTTests
+    ];
+    jaspFactor = buildJaspModule "jaspFactor" [
+      ggplot2
+      jaspBase
+      jaspGraphs
+      jaspSem
+      lavaan
+      psych
+      qgraph
+      reshape2
+      semPlot
+      GPArotation
+      Rcsdp
+      semTools
+    ];
+    jaspFrequencies = buildJaspModule "jaspFrequencies" [
+      abtest
+      BayesFactor
+      conting'
+      multibridge
+      ggplot2
+      jaspBase
+      jaspGraphs
+      plyr
+      stringr
+      vcd
+      vcdExtra
+    ];
+    jaspJags = buildJaspModule "jaspJags" [
+      coda
+      ggplot2
+      ggtext
+      hexbin
+      jaspBase
+      jaspGraphs
+      rjags
+      scales
+      stringr
+    ];
+    jaspLearnBayes = buildJaspModule "jaspLearnBayes" [
+      extraDistr
+      ggplot2
+      HDInterval
+      jaspBase
+      jaspGraphs
+      MASS
+      MCMCpack
+      MGLM
+      scales
+      ggalluvial
+      ragg
+      runjags
+      ggdist
+      png
+      posterior
+    ];
+    jaspLearnStats = buildJaspModule "jaspLearnStats" [
+      extraDistr
+      ggplot2
+      jaspBase
+      jaspGraphs
+      jaspDistributions
+      jaspDescriptives
+      jaspTTests
+      ggforce
+      tidyr
+      igraph
+    ];
+    jaspMachineLearning = buildJaspModule "jaspMachineLearning" [
+      kknn
+      AUC
+      cluster
+      colorspace
+      DALEX
+      dbscan
+      e1071
+      fpc
+      gbm
+      Gmedian
+      ggparty
+      ggdendro
+      ggnetwork
+      ggplot2
+      ggrepel
+      ggridges
+      glmnet
+      jaspBase
+      jaspGraphs
+      MASS
+      mvnormalTest
+      neuralnet
+      network
+      partykit
+      plyr
+      randomForest
+      rpart
+      ROCR
+      Rtsne
+      signal
+    ];
+    jaspMetaAnalysis = buildJaspModule "jaspMetaAnalysis" [
+      dplyr
+      ggplot2
+      jaspBase
+      jaspGraphs
+      MASS
+      metaBMA
+      metafor
+      psych
+      purrr
+      rstan
+      stringr
+      tibble
+      tidyr
+      weightr
+      BayesTools
+      RoBMA
+      metamisc
+      ggmcmc
+      pema
+    ];
+    jaspMixedModels = buildJaspModule "jaspMixedModels" [
+      afex
+      emmeans
+      ggplot2
+      ggpol
+      jaspBase
+      jaspGraphs
+      lme4
+      loo
+      mgcv
+      rstan
+      rstanarm
+      stanova
+      withr
+    ];
+    jaspNetwork = buildJaspModule "jaspNetwork" [
+      bootnet
+      BDgraph
+      corpcor
+      dplyr
+      foreach
+      ggplot2
+      gtools
+      HDInterval
+      huge
+      IsingSampler
+      jaspBase
+      jaspGraphs
+      mvtnorm
+      qgraph
+      reshape2
+      snow
+      stringr
+    ];
+    jaspPower = buildJaspModule "jaspPower" [
+      pwr
+      jaspBase
+      jaspGraphs
+    ];
+    jaspPredictiveAnalytics = buildJaspModule "jaspPredictiveAnalytics" [
+      jaspBase
+      jaspGraphs
+      bsts
+      bssm
+      precrec
+      reshape2
+      Boom
+      lubridate
+      prophet
+      BART
+      EBMAforecast
+      imputeTS
+    ];
+    jaspProcess = buildJaspModule "jaspProcess" [
+      dagitty
+      ggplot2
+      ggraph
+      jaspBase
+      jaspGraphs
+    ];
+    jaspProphet = buildJaspModule "jaspProphet" [
+      rstan
+      ggplot2
+      jaspBase
+      jaspGraphs
+      prophet
+      scales
+    ];
+    jaspQualityControl = buildJaspModule "jaspQualityControl" [
+      car
+      cowplot
+      daewr
+      desirability
+      DoE_base
+      EnvStats
+      FAdist
+      fitdistrplus
+      FrF2
+      ggplot2
+      ggrepel
+      goftest
+      ggpp
+      irr
+      jaspBase
+      jaspDescriptives
+      jaspGraphs
+      mle_tools
+      psych
+      qcc
+      rsm
+      Rspc
+      tidyr
+      tibble
+      vipor
+      weibullness
+    ];
+    jaspRegression = buildJaspModule "jaspRegression" [
+      BAS
+      boot
+      bstats
+      combinat
+      emmeans
+      ggplot2
+      ggrepel
+      hmeasure
+      jaspAnova
+      jaspBase
+      jaspDescriptives
+      jaspGraphs
+      jaspTTests
+      lmtest
+      logistf
+      MASS
+      matrixStats
+      mdscore
+      ppcor
+      purrr
+      Rcpp
+      statmod
+      VGAM
+    ];
+    jaspReliability = buildJaspModule "jaspReliability" [
+      Bayesrel
+      coda
+      ggplot2
+      ggridges
+      irr
+      jaspBase
+      jaspGraphs
+      LaplacesDemon
+      lme4
+      MASS
+      psych
+    ];
+    jaspRobustTTests = buildJaspModule "jaspRobustTTests" [
+      RoBTT
+      ggplot2
+      jaspBase
+      jaspGraphs
+    ];
+    jaspSem = buildJaspModule "jaspSem" [
+      forcats
+      ggplot2
+      jaspBase
+      jaspGraphs
+      lavaan
+      cSEM
+      reshape2
+      semPlot
+      semTools
+      stringr
+      tibble
+      tidyr
+    ];
+    jaspSummaryStatistics = buildJaspModule "jaspSummaryStatistics" [
+      BayesFactor
+      bstats
+      jaspBase
+      jaspFrequencies
+      jaspGraphs
+      jaspRegression
+      jaspTTests
+      jaspAnova
+      jaspDescriptives
+      SuppDists
+      bayesplay
+    ];
+    jaspSurvival = buildJaspModule "jaspSurvival" [
+      survival
+      survminer
+      jaspBase
+      jaspGraphs
+    ];
+    jaspTTests = buildJaspModule "jaspTTests" [
+      BayesFactor
+      car
+      ggplot2
+      jaspBase
+      jaspGraphs
+      logspline
+      plotrix
+      plyr
+    ];
+    jaspTimeSeries = buildJaspModule "jaspTimeSeries" [
+      jaspBase
+      jaspGraphs
+      forecast
+    ];
+    jaspVisualModeling = buildJaspModule "jaspVisualModeling" [
+      flexplot
+      jaspBase
+      jaspGraphs
+    ];
   };
 }

--- a/pkgs/by-name/ja/jasp-desktop/modules.nix
+++ b/pkgs/by-name/ja/jasp-desktop/modules.nix
@@ -1,5 +1,4 @@
 {
-  R,
   rPackages,
   fetchFromGitHub,
   jasp-src,
@@ -117,8 +116,8 @@ let
     src = fetchFromGitHub {
       owner = "dustinfife";
       repo = "flexplot";
-      rev = "4223ad5fb56028018b964d6f9f5aa5bac8710821";
-      hash = "sha256-L+Ed2bIWjq3ZIAGookp8dAjDSeldEbcwynwFVVZ9IcU=";
+      rev = "303a03968f677e71c99a5e22f6352c0811b7b2fb";
+      hash = "sha256-iT5CdtNk0Oi8gga76L6YtyWGACAwpN8A/yTBy7JJERc=";
     };
     propagatedBuildInputs = [
       cowplot
@@ -194,6 +193,7 @@ in
       car
       colorspace
       emmeans
+      effectsize
       ggplot2
       jaspBase
       jaspDescriptives
@@ -202,6 +202,8 @@ in
       KernSmooth
       matrixStats
       multcomp
+      multcompView
+      mvShapiroTest
       onewaytests
       plyr
       stringi
@@ -253,6 +255,13 @@ in
       ggrepel
       jaspBase
       jaspGraphs
+      jaspTTests
+      forecast
+      flexplot
+      ggrain
+      ggpp
+      ggtext
+      dplyr
     ];
     jaspDistributions = buildJaspModule "jaspDistributions" [
       car
@@ -292,6 +301,7 @@ in
     jaspFrequencies = buildJaspModule "jaspFrequencies" [
       abtest
       BayesFactor
+      bridgesampling
       conting'
       multibridge
       ggplot2
@@ -310,6 +320,7 @@ in
       jaspBase
       jaspGraphs
       rjags
+      runjags
       scales
       stringr
     ];
@@ -325,6 +336,7 @@ in
       scales
       ggalluvial
       ragg
+      rjags
       runjags
       ggdist
       png
@@ -449,11 +461,14 @@ in
       imputeTS
     ];
     jaspProcess = buildJaspModule "jaspProcess" [
+      blavaan
       dagitty
       ggplot2
       ggraph
       jaspBase
       jaspGraphs
+      jaspJags
+      runjags
     ];
     jaspProphet = buildJaspModule "jaspProphet" [
       rstan
@@ -581,12 +596,14 @@ in
     jaspTimeSeries = buildJaspModule "jaspTimeSeries" [
       jaspBase
       jaspGraphs
+      jaspDescriptives
       forecast
     ];
     jaspVisualModeling = buildJaspModule "jaspVisualModeling" [
       flexplot
       jaspBase
       jaspGraphs
+      jaspDescriptives
     ];
   };
 }

--- a/pkgs/by-name/ja/jasp-desktop/package.nix
+++ b/pkgs/by-name/ja/jasp-desktop/package.nix
@@ -1,19 +1,20 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, callPackage
-, buildEnv
-, linkFarm
-, substituteAll
-, R
-, rPackages
-, cmake
-, ninja
-, pkg-config
-, boost
-, libarchive
-, readstat
-, qt6
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  callPackage,
+  buildEnv,
+  linkFarm,
+  substituteAll,
+  R,
+  rPackages,
+  cmake,
+  ninja,
+  pkg-config,
+  boost,
+  libarchive,
+  readstat,
+  qt6,
 }:
 
 let
@@ -27,10 +28,14 @@ let
     fetchSubmodules = true;
   };
 
-  inherit (callPackage ./modules.nix {
-    jasp-src = src;
-    jasp-version = version;
-  }) engine modules;
+  inherit
+    (callPackage ./modules.nix {
+      jasp-src = src;
+      jasp-version = version;
+    })
+    engine
+    modules
+    ;
 
   # Merges ${R}/lib/R with all used R packages (even propagated ones)
   customREnv = buildEnv {
@@ -42,8 +47,12 @@ let
     ] ++ lib.attrValues modules;
   };
 
-  modulesDir = linkFarm "jasp-${version}-modules"
-    (lib.mapAttrsToList (name: drv: { name = name; path = "${drv}/library"; }) modules);
+  modulesDir = linkFarm "jasp-${version}-modules" (
+    lib.mapAttrsToList (name: drv: {
+      name = name;
+      path = "${drv}/library";
+    }) modules
+  );
 in
 stdenv.mkDerivation {
   pname = "jasp-desktop";
@@ -76,18 +85,20 @@ stdenv.mkDerivation {
     qt6.wrapQtAppsHook
   ];
 
-  buildInputs = [
-    customREnv
-    boost
-    libarchive
-    readstat
-  ] ++ (with qt6; [
-    qtbase
-    qtdeclarative
-    qtwebengine
-    qtsvg
-    qt5compat
-  ]);
+  buildInputs =
+    [
+      customREnv
+      boost
+      libarchive
+      readstat
+    ]
+    ++ (with qt6; [
+      qtbase
+      qtdeclarative
+      qtwebengine
+      qtsvg
+      qt5compat
+    ]);
 
   env.NIX_LDFLAGS = "-L${rPackages.RInside}/library/RInside/lib";
 
@@ -121,4 +132,3 @@ stdenv.mkDerivation {
     platforms = lib.platforms.linux;
   };
 }
-


### PR DESCRIPTION
## Description of changes

Other than bumping the version and formatting the files I updated the dependencies of the JASP modules.
I also changed specifics of how I'm importing `modules.nix`
I removed `with qt6` in favor of writing out `qt6.` everywhere
I changed `--replace` over to `--replace-fail`
I could also re-enable the `format` hardening option.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
