### PR TITLE
ulauncher: add pyasyncore for Python 3.12 compat

### DIFF
--- a/pkgs/applications/misc/ulauncher/default.nix
+++ b/pkgs/applications/misc/ulauncher/default.nix
@@ -54,6 +54,7 @@ python3Packages.buildPythonApplication rec {
     pygobject3
     pyinotify
     levenshtein
+    pyasyncore
     pyxdg
     pycairo
     requests


### PR DESCRIPTION
asyncore has been removed from Python 3.12. For applications that still
need it, the pyasyncore dependency can be explicitly added. So that's
what we'll do.

After nixpkgs updated to Python 3.12, I began getting the following
traceback when starting ulauncher.

    Traceback (most recent call last):
      File "/nix/store/rcqlxcr07aylib5sa7v38b4ba92jzxx4-ulauncher-5.15.7/bin/.ulauncher-wrapped", line 28, in <module>
        from ulauncher.main import main
      File "/nix/store/rcqlxcr07aylib5sa7v38b4ba92jzxx4-ulauncher-5.15.7/lib/python3.12/site-packages/ulauncher/main.py", line 25, in <module>
        from ulauncher.ui.windows.UlauncherWindow import UlauncherWindow
      File "/nix/store/rcqlxcr07aylib5sa7v38b4ba92jzxx4-ulauncher-5.15.7/lib/python3.12/site-packages/ulauncher/ui/windows/UlauncherWindow.py", line 37, in <module>
        from ulauncher.search.apps.app_watcher import start as start_app_watcher
      File "/nix/store/rcqlxcr07aylib5sa7v38b4ba92jzxx4-ulauncher-5.15.7/lib/python3.12/site-packages/ulauncher/search/apps/app_watcher.py", line 7, in <module>
        import pyinotify
      File "/nix/store/8bxngdzbnzig8ddw0ypdg1plsmrpqmi2-python3.12-pyinotify-0.9.6/lib/python3.12/site-packages/pyinotify.py", line 71, in <module>
        import asyncore
    ModuleNotFoundError: No module named 'asyncore'

Adding pyasyncore to propagatedBuildInputs solves this and ulauncher
functions normally with no errors logged.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
