### PR TITLE
python3Packages.pytest-asyncio_0_21: 0.21.1 -> 0.21.2

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12273,12 +12273,12 @@ self: super: with self; {
   pytest-asyncio = callPackage ../development/python-modules/pytest-asyncio { };
 
   pytest-asyncio_0_21 = pytest-asyncio.overridePythonAttrs (old: rec {
-    version = "0.21.1";
+    version = "0.21.2";
     src = pkgs.fetchFromGitHub {
       owner = "pytest-dev";
       repo = "pytest-asyncio";
       rev = "refs/tags/v${version}";
-      hash = "sha256-Wpo8MpCPGiXrckT2x5/yBYtGlzso/L2urG7yGc7SPkA=";
+      hash = "sha256-AVVvdo/CDF9IU6l779sLc7wKz5h3kzMttdDNTPLYxtQ=";
     };
   });
 


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/pytest-dev/pytest-asyncio/releases/tag/v0.21.2
Changes: https://github.com/pytest-dev/pytest-asyncio/compare/v0.21.1...v0.21.2

Includes a backport for pytest >= 8.2.0 compatibility.

Tests for Python package `asyncua` currently [fail for Python 3.11](https://hydra.nixos.org/build/264340299) since the update of pytest 8.1.1 -> 8.2.2 (b9976c7c5447). The backport provided by pytest-asyncio 0.21.2 fixes the issue.

Note: asyncua still fails for Python 3.12, but it is an upstream issue. Also it is currently [incompatible](https://github.com/pytest-dev/pytest-asyncio/issues/706#issuecomment-1859260562) with pytest-asyncio 0.23.x, so for the moment it must continue to use the pinned 0.21.x branch of pytest-asyncio.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages marked as broken and skipped:</summary>
  <ul>
    <li>python312Packages.magic-wormhole-mailbox-server</li>
    <li>python312Packages.magic-wormhole-mailbox-server.dist</li>
    <li>python312Packages.magic-wormhole-transit-relay</li>
    <li>python312Packages.magic-wormhole-transit-relay.dist</li>
  </ul>
</details>
<details>
  <summary>6 packages failed to build:</summary>
  <ul>
    <li>opcua-client-gui</li>
    <li>opcua-client-gui.dist</li>
    <li>python312Packages.asyncua</li>
    <li>python312Packages.asyncua.dist</li>
    <li>python312Packages.opcua-widgets</li>
    <li>python312Packages.opcua-widgets.dist</li>
  </ul>
</details>
<details>
  <summary>61 packages built:</summary>
  <ul>
    <li>authentik</li>
    <li>buildbot</li>
    <li>buildbot-full</li>
    <li>buildbot-ui</li>
    <li>buildbot-worker</li>
    <li>buildbot-worker.dist</li>
    <li>buildbot.dist</li>
    <li>gnome-keysign</li>
    <li>gnome-keysign.dist</li>
    <li>home-assistant-component-tests.knx</li>
    <li>magic-wormhole (python312Packages.magic-wormhole)</li>
    <li>magic-wormhole.dist (python312Packages.magic-wormhole.dist)</li>
    <li>paperless-ngx</li>
    <li>python311Packages.asyncua</li>
    <li>python311Packages.asyncua.dist</li>
    <li>python311Packages.autobahn</li>
    <li>python311Packages.autobahn.dist</li>
    <li>python311Packages.channels</li>
    <li>python311Packages.channels-redis</li>
    <li>python311Packages.channels-redis.dist</li>
    <li>python311Packages.channels.dist</li>
    <li>python311Packages.daphne</li>
    <li>python311Packages.daphne.dist</li>
    <li>python311Packages.labgrid</li>
    <li>python311Packages.labgrid.dist</li>
    <li>python311Packages.magic-wormhole</li>
    <li>python311Packages.magic-wormhole-mailbox-server</li>
    <li>python311Packages.magic-wormhole-mailbox-server.dist</li>
    <li>python311Packages.magic-wormhole-transit-relay</li>
    <li>python311Packages.magic-wormhole-transit-relay.dist</li>
    <li>python311Packages.magic-wormhole.dist</li>
    <li>python311Packages.opcua-widgets</li>
    <li>python311Packages.opcua-widgets.dist</li>
    <li>python311Packages.pytest-asyncio_0_21</li>
    <li>python311Packages.pytest-asyncio_0_21.dist</li>
    <li>python311Packages.pytest-asyncio_0_21.testout</li>
    <li>python311Packages.strawberry-graphql</li>
    <li>python311Packages.strawberry-graphql.dist</li>
    <li>python311Packages.xknx</li>
    <li>python311Packages.xknx.dist</li>
    <li>python312Packages.autobahn</li>
    <li>python312Packages.autobahn.dist</li>
    <li>python312Packages.channels</li>
    <li>python312Packages.channels-redis</li>
    <li>python312Packages.channels-redis.dist</li>
    <li>python312Packages.channels.dist</li>
    <li>python312Packages.daphne</li>
    <li>python312Packages.daphne.dist</li>
    <li>python312Packages.labgrid</li>
    <li>python312Packages.labgrid.dist</li>
    <li>python312Packages.pytest-asyncio_0_21</li>
    <li>python312Packages.pytest-asyncio_0_21.dist</li>
    <li>python312Packages.pytest-asyncio_0_21.testout</li>
    <li>python312Packages.strawberry-graphql</li>
    <li>python312Packages.strawberry-graphql.dist</li>
    <li>python312Packages.xknx</li>
    <li>python312Packages.xknx.dist</li>
    <li>tahoe-lafs</li>
    <li>tahoe-lafs.dist</li>
    <li>tahoe-lafs.doc</li>
    <li>tahoe-lafs.info</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
