### PR TITLE
python311Packages.llm-claude-3: init at v0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9470,6 +9470,11 @@
     githubId = 9866621;
     name = "Jack";
   };
+  jkachmar = {
+    github = "jkachmar";
+    githubId = 8461423;
+    name = "jkachmar";
+  };
   jkarlson = {
     email = "jekarlson@gmail.com";
     github = "ethorsoe";

--- a/pkgs/development/python-modules/llm-claude-3/default.nix
+++ b/pkgs/development/python-modules/llm-claude-3/default.nix
@@ -43,7 +43,6 @@ buildPythonPackage rec {
     description = "LLM plugin for interacting with the Claude 3 family of models";
     homepage = "https://github.com/simonw/llm-claude-3";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ jkachmar ];
   };
 }
-

--- a/pkgs/development/python-modules/llm-claude-3/default.nix
+++ b/pkgs/development/python-modules/llm-claude-3/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  anthropic,
+  llm,
+  pytestCheckHook,
+  pytest,
+  pytest-recording,
+  nix-update-script,
+}:
+buildPythonPackage rec {
+  pname = "llm-claude-3";
+  version = "0.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "simonw";
+    repo = "llm-claude-3";
+    rev = "refs/tags/${version}";
+    hash = "sha256-5qF5BK319PNzB4XsLdYvtyq/SxBDdHJ9IoKWEnvNRp4=";
+  };
+
+  build-system = [ setuptools ];
+  buildInputs = [ llm ];
+  dependencies = [ anthropic ];
+  optional-dependencies = {
+    test = [
+      pytest
+      pytest-recording
+    ];
+  };
+
+  # Test suite requires network access to talk to Claude (duh).
+  nativeCheckInputs = [ pytestCheckHook ];
+  doCheck = false;
+  pythonImportsCheck = [ "llm_claude_3" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "LLM plugin for interacting with the Claude 3 family of models";
+    homepage = "https://github.com/simonw/llm-claude-3";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7105,6 +7105,7 @@ self: super: with self; {
   };
 
   llm = callPackage ../development/python-modules/llm { };
+  llm-claude-3 = callPackage ../development/python-modules/llm-claude-3 { };
 
   llmx = callPackage ../development/python-modules/llmx { };
 


### PR DESCRIPTION
## Description of changes

add [llm-claude-3](https://github.com/simonw/llm-claude-3), a plugin for `llm` that adds support for Anthropic's Claude 3 model backend.

this is related to https://github.com/NixOS/nixpkgs/issues/255320 & https://github.com/NixOS/nixpkgs/pull/268955.

cc @aldoborrero as the maintainer for `llm` itself.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
