### PR TITLE
gradle: 8.8 → 8.10

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -161,9 +161,9 @@ rec {
   # https://docs.gradle.org/current/userguide/compatibility.html
 
   gradle_8 = gen {
-    version = "8.8";
+    version = "8.10";
     nativeVersion = "0.22-milestone-26";
-    hash = "sha256-pLQVhgH4Y2ze6rCb12r7ZAAwu1sUSq/iYaXorwJ9xhI=";
+    hash = "sha256-W5xes/n8LJSrrqV9kL14dHyhF927+WyFnTdBGBoSvyo=";
     defaultJava = jdk21;
   };
 


### PR DESCRIPTION
## Description of changes

https://docs.gradle.org/8.9/release-notes.html

https://docs.gradle.org/8.10/release-notes.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages failed to build:</summary>
  <ul>
    <li>diffoscope</li>
    <li>diffoscope.dist</li>
    <li>diffoscope.man</li>
  </ul>
</details>
<details>
  <summary>37 packages built:</summary>
  <ul>
    <li>apkleaks</li>
    <li>apkleaks.dist</li>
    <li>apksigcopier</li>
    <li>apksigcopier.dist</li>
    <li>apksigner</li>
    <li>cie-middleware-linux</li>
    <li>cryptomator</li>
    <li>experienced-pixel-dungeon</li>
    <li>fdroidserver</li>
    <li>fdroidserver.dist</li>
    <li>ghidra-extensions.gnudisassembler</li>
    <li>ghidra-extensions.machinelearning</li>
    <li>ghidra-extensions.sleighdevtools</li>
    <li>gradle (gradle_8)</li>
    <li>gradle-unwrapped</li>
    <li>gscan2pdf</li>
    <li>gscan2pdf.man</li>
    <li>jabref</li>
    <li>jadx</li>
    <li>javaPackages.openjfx22</li>
    <li>jextract</li>
    <li>jextract-21</li>
    <li>kotlin-language-server</li>
    <li>mindustry</li>
    <li>mindustry-server</li>
    <li>mindustry-wayland</li>
    <li>moneydance</li>
    <li>pdf-sign</li>
    <li>pdfchain</li>
    <li>pdftk</li>
    <li>pidginPackages.purple-signald</li>
    <li>rat-king-adventure</li>
    <li>rkpd2</li>
    <li>shattered-pixel-dungeon</li>
    <li>shorter-pixel-dungeon</li>
    <li>signald</li>
    <li>signaturepdf</li>
  </ul>
</details>

Failure to build diffoscope seems to be unrelated.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
