### PR TITLE
udev-block-notify: init at 0.7.11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4352,6 +4352,12 @@
     githubId = 743057;
     name = "Danylo Hlynskyi";
   };
+  danbulant = {
+    name = "Daniel Bulant";
+    email = "danbulant@gmail.com";
+    github = "danbulant";
+    githubId = 30036876;
+  };
   danc86 = {
     name = "Dan Callaghan";
     email = "djc@djc.id.au";

--- a/pkgs/by-name/ud/udev-block-notify/package.nix
+++ b/pkgs/by-name/ud/udev-block-notify/package.nix
@@ -1,0 +1,54 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  multimarkdown,
+  libnotify,
+  udev,
+  systemdLibs,
+  glib,
+  pkg-config,
+  lib,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "udev-block-notify";
+  version = "0.7.11";
+
+  src = fetchFromGitHub {
+    owner = "eworm-de";
+    repo = "udev-block-notify";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-A0uhfb2mEAAJgxRkv+MWTk/9oFiz3r7deAlu1Kpk+CI=";
+  };
+
+  nativeBuildInputs = [
+    multimarkdown
+    pkg-config
+  ];
+  buildInputs = [
+    libnotify
+    udev
+    systemdLibs
+    glib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    substituteInPlace systemd/udev-block-notify.service \
+      --replace-fail '/usr/bin/udev-block-notify' "$out/bin/udev-block-notify"
+
+    install -D -m0755 udev-block-notify $out/bin/udev-block-notify
+    install -D -m0644 systemd/udev-block-notify.service $out/lib/systemd/user/udev-block-notify.service
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/eworm-de/udev-block-notify";
+    description = "Notify about udev block events";
+    mainProgram = "udev-block-notify";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ danbulant ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds [udev-block-notify](https://github.com/eworm-de/udev-block-notify), a user daemon that sends a notification about block device changes.

I am new to NixOS and Nix, just porting software I used to use before.  
Also added myself as a maintainer for that package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md). Hopefully?

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

As a sort of closing question, does it make sense to try and make it a service here in nixpkgs, in home-manager or should I not do that at all? The current package creates a user systemd service that will simply start the program in background, but doesn't enable it.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
