### PR TITLE
emacsPackages.el-easydraw: clean

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/el-easydraw/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/el-easydraw/default.nix
@@ -1,57 +1,31 @@
 { lib
 , melpaBuild
 , fetchFromGitHub
-, writeText
-, writeScript
 , gzip
+, unstableGitUpdater
 }:
 
-let
-  rev = "a6c849619abcdd80dc82ec5417195414ad438fa3";
-in
 melpaBuild {
   pname = "edraw";
-  version = "20240701.444";
+  version = "1.2.0-unstable-2024-07-01";
 
   src = fetchFromGitHub {
     owner = "misohena";
     repo = "el-easydraw";
-    inherit rev;
+    rev = "a6c849619abcdd80dc82ec5417195414ad438fa3";
     hash = "sha256-CbcI1mmghc3HObg80bjScVDcJ1DHx9aX1WP2HlhAshs=";
   };
 
-  commit = rev;
-
   packageRequires = [ gzip ];
 
-  recipe = writeText "recipe" ''
-    (edraw
-      :repo "misohena/el-easydraw"
-      :fetcher github
-      :files
-      ("*.el"
-       "msg"))
-  '';
+  files = ''(:defaults "msg")'';
 
-  passthru.updateScript = writeScript "update.sh" ''
-    #!/usr/bin/env nix-shell
-    #!nix-shell -i bash -p common-updater-scripts coreutils git gnused
-    set -eu -o pipefail
-    tmpdir="$(mktemp -d)"
-    git clone --depth=1 https://github.com/misohena/el-easydraw.git "$tmpdir"
-    pushd "$tmpdir"
-    commit=$(git show -s --pretty='format:%H')
-    # Based on: https://github.com/melpa/melpa/blob/2d8716906a0c9e18d6c979d8450bf1d15dd785eb/package-build/package-build.el#L523-L533
-    version=$(TZ=UTC git show -s --pretty='format:%cd' --date='format-local:%Y%m%d.%H%M' | sed 's|\.0*|.|')
-    popd
-    update-source-version emacsPackages.el-easydraw $version --rev="$commit"
-  '';
+  passthru.updateScript = unstableGitUpdater { tagPrefix = "v"; };
 
   meta = {
     homepage = "https://github.com/misohena/el-easydraw";
     description = "Embedded drawing tool for Emacs";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ brahyerr ];
-    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/el-easydraw/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/el-easydraw/default.nix
@@ -17,7 +17,7 @@ melpaBuild {
     hash = "sha256-CbcI1mmghc3HObg80bjScVDcJ1DHx9aX1WP2HlhAshs=";
   };
 
-  packageRequires = [ gzip ];
+  propagatedUserEnvPkgs = [ gzip ];
 
   files = ''(:defaults "msg")'';
 

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/el-easydraw/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/el-easydraw/default.nix
@@ -1,8 +1,9 @@
-{ lib
-, melpaBuild
-, fetchFromGitHub
-, gzip
-, unstableGitUpdater
+{
+  lib,
+  melpaBuild,
+  fetchFromGitHub,
+  gzip,
+  unstableGitUpdater,
 }:
 
 melpaBuild {


### PR DESCRIPTION
## Description of changes

- emacsPackages.el-easydraw: clean
- emacsPackages.el-easydraw: format using nixfmt-rfc-style
- emacsPackages.el-easydraw: move gzip to propagatedUserEnvPkgs
  gzip is only needed at runtime.  It is not needed at build time.

related: https://github.com/NixOS/nixpkgs/issues/278925

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
