### PR TITLE
xed-editor: 3.6.4 -> 3.6.5

### DIFF
--- a/pkgs/applications/editors/xed-editor/default.nix
+++ b/pkgs/applications/editors/xed-editor/default.nix
@@ -12,6 +12,7 @@
 , python3
 , meson
 , ninja
+, versionCheckHook
 , wrapGAppsHook3
 , intltool
 , itstool
@@ -19,13 +20,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xed-editor";
-  version = "3.6.4";
+  version = "3.6.5";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "xed";
     rev = version;
-    sha256 = "sha256-EwBcgFHw6Mh+eS5hfTLoywH0dVt/TpNt4y6xQxe/x/Q=";
+    sha256 = "sha256-FG8SlMyhee0W88Pt3oW1tsFyy/KeCOE+QlDbE6hzjcg=";
   };
 
   patches = [
@@ -41,6 +42,7 @@ stdenv.mkDerivation rec {
     itstool
     ninja
     python3
+    versionCheckHook
     wrapGAppsHook3
   ];
 
@@ -55,14 +57,7 @@ stdenv.mkDerivation rec {
   ];
 
   doInstallCheck = true;
-  installCheckPhase = ''
-    if [[ "$($out/bin/xed --version)" == "xed - Version ${version}" ]] ; then
-      echo "${pname} smoke test passed"
-    else
-      echo "${pname} smoke test failed"
-      return 1
-    fi
-  '';
+  versionCheckProgram = "${placeholder "out"}/bin/xed";
 
   meta = with lib; {
     description = "Light weight text editor from Linux Mint";


### PR DESCRIPTION
https://github.com/linuxmint/xed/compare/3.6.4...3.6.5


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

