### PR TITLE
emacsPackages.elisp-ffi: clean

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/elisp-ffi/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/elisp-ffi/default.nix
@@ -3,22 +3,17 @@
 , fetchFromGitHub
 , pkg-config
 , libffi
-, writeText
 }:
 
-let
-  rev = "da37c516a0e59bdce63fb2dc006a231dee62a1d9";
-in melpaBuild {
+melpaBuild {
   pname = "elisp-ffi";
-  version = "20170518.0";
-
-  commit = rev;
+  version = "1.0.0-unstable-2017-05-18";
 
   src = fetchFromGitHub {
     owner = "skeeto";
     repo = "elisp-ffi";
-    inherit rev;
-    sha256 = "sha256-StOezQEnNTjRmjY02ub5FRh59aL6gWfw+qgboz0wF94=";
+    rev = "da37c516a0e59bdce63fb2dc006a231dee62a1d9";
+    hash = "sha256-StOezQEnNTjRmjY02ub5FRh59aL6gWfw+qgboz0wF94=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -30,10 +25,6 @@ in melpaBuild {
     make
  '';
 
-  recipe = writeText "recipe" ''
-   (elisp-ffi :repo "skeeto/elisp-ffi" :fetcher github)
-  '';
-
   meta = {
     description = "Emacs Lisp Foreign Function Interface";
     longDescription = ''
@@ -42,6 +33,6 @@ in melpaBuild {
         driving a subprocess to do the heavy lifting, passing result
         values on to Emacs.
       '';
-    license = lib.licenses.publicDomain;
+    license = lib.licenses.unlicense;
   };
 }

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/elisp-ffi/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/elisp-ffi/default.nix
@@ -1,8 +1,9 @@
-{ lib
-, melpaBuild
-, fetchFromGitHub
-, pkg-config
-, libffi
+{
+  lib,
+  melpaBuild,
+  fetchFromGitHub,
+  pkg-config,
+  libffi,
 }:
 
 melpaBuild {
@@ -23,16 +24,16 @@ melpaBuild {
   preBuild = ''
     mv ffi.el elisp-ffi.el
     make
- '';
+  '';
 
   meta = {
     description = "Emacs Lisp Foreign Function Interface";
     longDescription = ''
-        This library provides an FFI for Emacs Lisp so that Emacs
-        programs can invoke functions in native libraries. It works by
-        driving a subprocess to do the heavy lifting, passing result
-        values on to Emacs.
-      '';
+      This library provides an FFI for Emacs Lisp so that Emacs
+      programs can invoke functions in native libraries. It works by
+      driving a subprocess to do the heavy lifting, passing result
+      values on to Emacs.
+    '';
     license = lib.licenses.unlicense;
   };
 }


### PR DESCRIPTION
## Description of changes
related: https://github.com/NixOS/nixpkgs/issues/278925

This package probably have been broken for a long time because there is no built binary in the result package.  However, fixing that is not in the scope of this PR.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
