### PR TITLE
nixos/postgresql: add `upgrade.*` options

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -774,6 +774,7 @@ in {
   apache_datasketches = handleTest ./apache_datasketches.nix {};
   postgresql = handleTest ./postgresql.nix {};
   postgresql-jit = handleTest ./postgresql-jit.nix {};
+  postgresql-upgrade = handleTest ./postgresql-upgrade.nix {};
   postgresql-wal-receiver = handleTest ./postgresql-wal-receiver.nix {};
   postgresql-tls-client-cert = handleTest ./postgresql-tls-client-cert.nix {};
   powerdns = handleTest ./powerdns.nix {};

--- a/nixos/tests/postgresql-upgrade.nix
+++ b/nixos/tests/postgresql-upgrade.nix
@@ -1,0 +1,141 @@
+{ system ? builtins.currentSystem
+, config ? { }
+, pkgs ? import ../.. { inherit system config; }
+, package ? null
+,
+}:
+
+with import ../lib/testing-python.nix { inherit system pkgs; };
+
+let
+  lib = pkgs.lib;
+
+  insertData = pkgs.writeShellApplication {
+    name = "insert-data";
+    runtimeInputs = [ pkgs.gnugrep ];
+    text = ''
+      run_sql() {
+        su -c 'psql testdb -At -v ON_ERROR_STOP=1' postgres
+      }
+
+      run_sql <<- 'QUERY'
+        CREATE TABLE books (
+          title   text,
+          author  text,
+          year    int
+        );
+
+        INSERT INTO books (title, author, year) VALUES
+        ('Do Androids Dream Of Electric Sheep?', 'Philip K. Dick', 1968),
+        ('Neuromancer', 'William Gibson', 1984),
+        ('Cryptonomicon', 'Neal Stephenson', 1999),
+        ('Accelerando', 'Charles Stross', 2005);
+      QUERY
+    '';
+  };
+
+  verifyData = pkgs.writeShellApplication {
+    name = "verify-data";
+    runtimeInputs = [ pkgs.gnugrep ];
+    text = ''
+      run_sql() {
+        su -c 'psql testdb -At -v ON_ERROR_STOP=1' postgres
+      }
+
+      die() {
+        echo "$1" >&2 && exit 1
+      }
+
+      run_sql <<- 'QUERY' | grep 't' || die 'No author found 1'
+        SELECT exists(SELECT * FROM books WHERE author = 'Philip K. Dick');
+      QUERY
+
+      run_sql <<- 'QUERY' | grep 't' || die 'No title found'
+        SELECT exists(SELECT * FROM books WHERE title = 'Neuromancer');
+      QUERY
+
+      run_sql <<- 'QUERY' | grep 't' || die 'No year found'
+        SELECT exists(SELECT * FROM books WHERE year = 1999);
+      QUERY
+
+      run_sql <<- 'QUERY' | grep 't' || die 'No author found 2'
+        SELECT exists(SELECT * FROM books WHERE author = 'Charles Stross');
+      QUERY
+    '';
+  };
+
+  makePostgresqUpgradeTest = { pkgFrom, pkgTo }:
+    makeTest {
+      name = "postgresql-upgrade-${pkgFrom.psqlSchema}-${pkgTo.psqlSchema}";
+      meta.maintainers = with lib.maintainers; [ tm-drtina ];
+
+      nodes.machine = { ... }: {
+        services.postgresql = {
+          enable = true;
+          package = pkgFrom;
+          ensureDatabases = [ "testdb" ];
+        };
+        specialisation = {
+          upgraded.configuration = {
+            services.postgresql = {
+              package = lib.mkForce pkgTo;
+              upgrade.enable = true;
+            };
+          };
+          upgraded-autodetect.configuration = {
+            services.postgresql = {
+              package = lib.mkForce pkgTo;
+              upgrade.enable = true;
+              # This simulates upgrade from older stateVersion
+              upgrade.enablePreviousInstallationAutodetection = true;
+            };
+          };
+        };
+      };
+
+      testScript = { nodes, ... }:
+        let
+          machine = nodes.machine.system.build.toplevel;
+          databaseDir = nodes.machine.services.postgresql.databaseDir;
+          oldDataDir = nodes.machine.services.postgresql.dataDir;
+          newDataDir = nodes.machine.specialisation.upgraded.configuration.services.postgresql.dataDir;
+        in
+        ''
+          machine.wait_for_unit("postgresql")
+          machine.succeed("${lib.getExe insertData}")
+
+          with subtest("Upgrade while having symlink to previous dataDir"):
+            machine.succeed("${machine}/specialisation/upgraded/bin/switch-to-configuration test 2>&1")
+            machine.wait_for_unit("postgresql")
+            machine.succeed("${lib.getExe verifyData}")
+
+          with subtest("Reset back to old version"):
+            # This will reuse the old dataDir
+            machine.succeed("${machine}/bin/switch-to-configuration test 2>&1")
+            machine.wait_for_unit("postgresql")
+
+            # Now it should be safe to remove "new" dataDir
+            machine.succeed("rm -r '${newDataDir}'")
+
+          with subtest("Upgrade while *NOT* having symlink to previous dataDir"):
+            machine.succeed("rm '${databaseDir}/current' '${oldDataDir}/nix-postgresql-bin'")
+            machine.succeed("${machine}/specialisation/upgraded-autodetect/bin/switch-to-configuration test 2>&1")
+            machine.wait_for_unit("postgresql")
+            machine.succeed("${lib.getExe verifyData}")
+        '';
+    };
+
+  allPackages = map (pkg: pkgs.${pkg}) (builtins.attrNames (import ../../pkgs/servers/sql/postgresql pkgs));
+  olderPackages = pkg: builtins.filter (p: lib.versionOlder p.version pkg.version) allPackages;
+
+  # Creates [{pkgOld: ..., pkgNew: ...}, ...]
+  versionMatrix = pkgs: builtins.concatMap (pkgTo: map (pkgFrom: { inherit pkgTo pkgFrom; }) (olderPackages pkgTo)) pkgs;
+  makeTests = targetPkgs: map makePostgresqUpgradeTest (versionMatrix targetPkgs);
+  asAttrs = tests: builtins.listToAttrs (map (test: { name = test.name; value = test; }) tests);
+in
+if package == null then
+  # all-tests.nix: Maps the generic function over all attributes of PostgreSQL packages
+  asAttrs (makeTests allPackages)
+else
+  # Called directly from <package>.tests
+  asAttrs (makeTests [ package ])

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -238,13 +238,19 @@ let
           package = this;
         };
         pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      } // lib.optionalAttrs jitSupport {
+      } // (lib.optionalAttrs jitSupport {
         postgresql-jit = import ../../../../nixos/tests/postgresql-jit.nix {
           inherit (stdenv) system;
           pkgs = self;
           package = this;
         };
-      };
+      }) // (
+        import ../../../../nixos/tests/postgresql-upgrade.nix {
+          inherit (stdenv) system;
+          pkgs = self;
+          package = this;
+        }
+      );
     };
 
     meta = with lib; {


### PR DESCRIPTION
## Description of changes

This adds an option to automatically upgrade postgresql
Picks up where #237838 ended with most of the feedback integrated.

TODO:
- [ ] Documentation/Release notes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
