### PR TITLE
phylactery: 0.1.2 -> 0.2.0

### DIFF
--- a/pkgs/servers/web-apps/phylactery/default.nix
+++ b/pkgs/servers/web-apps/phylactery/default.nix
@@ -1,21 +1,15 @@
-{ lib, buildGoModule, fetchFromSourcehut, nixosTests }:
+{ lib, buildGoModule, fetchzip, nixosTests }:
 
 buildGoModule rec {
   pname = "phylactery";
-  version = "0.1.2";
+  version = "0.2.0";
 
-  src = fetchFromSourcehut {
-    owner = "~cnx";
-    repo = pname;
-    rev = version;
-    hash = "sha256-HQN6wJ/4YeuQaDcNgdHj0RgYnn2NxXGRfxybmv60EdQ=";
+  src = fetchzip {
+    url = "https://trong.loang.net/phylactery/snapshot/phylactery-${version}.tar.gz";
+    hash = "sha256-UokK6rVjpzbcKOkZteo5kU7rFMm1meBUM4bkYAYM8rI=";
   };
 
   vendorHash = null;
-
-  preBuild = ''
-    cp ${./go.mod} go.mod
-  '';
 
   ldflags = [ "-s" "-w" ];
 
@@ -24,7 +18,7 @@ buildGoModule rec {
   meta = with lib; {
     description = "Old school comic web server";
     mainProgram = "phylactery";
-    homepage = "https://git.sr.ht/~cnx/phylactery";
+    homepage = "https://trong.loang.net/phylactery/about";
     license = licenses.agpl3Plus;
     maintainers = with maintainers; [ McSinyx ];
     platforms = platforms.all;

--- a/pkgs/servers/web-apps/phylactery/go.mod
+++ b/pkgs/servers/web-apps/phylactery/go.mod
@@ -1,3 +1,0 @@
-module git.sr.ht/~cnx/phylactery
-
-go 1.18


### PR DESCRIPTION
## Description of changes

New version add (hidden) Atom feed support and go.mod.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).