### PR TITLE
emacsPackages.agda2-mode: trivialBuild -> melpaBuild

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/agda2-mode/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/agda2-mode/default.nix
@@ -1,29 +1,18 @@
-{ trivialBuild
+{ melpaBuild
 , haskellPackages
 }:
 let
-  Agda = haskellPackages.Agda.bin;
+  Agda = haskellPackages.Agda;
 in
-trivialBuild {
-  pname = "agda-mode";
-  version = Agda.version;
+melpaBuild {
+  pname = "agda2-mode";
+  inherit (Agda) src version;
 
-  dontUnpack = true;
-
-  # already byte-compiled by Agda builder
-  buildPhase = ''
-    agda=`${Agda}/bin/agda-mode locate`
-    cp `dirname $agda`/*.el* .
-  '';
+  files = ''("src/data/emacs-mode/*.el")'';
 
   meta = {
     inherit (Agda.meta) homepage license;
     description = "Agda2-mode for Emacs extracted from Agda package";
-    longDescription = ''
-      Wrapper packages that liberates init.el from `agda-mode locate` magic.
-      Simply add this to user profile or systemPackages and do `(require
-      'agda2)` in init.el.
-    '';
   };
 }
 

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/agda2-mode/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/agda2-mode/default.nix
@@ -1,6 +1,4 @@
-{ melpaBuild
-, haskellPackages
-}:
+{ melpaBuild, haskellPackages }:
 let
   Agda = haskellPackages.Agda;
 in
@@ -15,4 +13,3 @@ melpaBuild {
     description = "Agda2-mode for Emacs extracted from Agda package";
   };
 }
-


### PR DESCRIPTION
## Description of changes

This patch does not increase closure size:

```console
> nix path-info -rSsh result/ | sort -hk3
/nix/store/7v6xff4kcrb696dyzbgywy3myv63fwsj-emacs-funcs.sh                 1.2K    1.2K
/nix/store/bihw7p4zdqwyxmnc8h67c06lnjkvdan8-xgcc-13.3.0-libgcc           155.9K  155.9K
/nix/store/vf553z7mi2vqk8ca6kkfd9x5gy3nnz0p-libunistring-1.1               1.7M    1.7M
/nix/store/pq755f1pxaas9q7666wzdzxidcvf9frg-libidn2-2.3.7                352.7K    2.1M
/nix/store/m71p7f0nymb19yn1dascklyya2i96jfw-glibc-2.39-52                 28.8M   31.0M
/nix/store/v9jyklnpicy1vzwcm41aj14qwsq5p22c-emacs-agda2-mode-2.6.4.3     804.6K   31.8M
```

related: https://github.com/NixOS/nixpkgs/issues/278925

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
