### PR TITLE
nixos/pgadmin: don't assume creation of user

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -141,3 +141,6 @@ acd0e3898feb321cb9a71a0fd376f1157d0f4553
 
 # poptracker: format with nixfmt-rfc-style (#326697)
 ff5c8f6cc3d1f2e017e86d50965c14b71f00567b
+
+# nixos/pgadmin: format with nixfmt-rfc-style
+478ee172d3818fc36dce47a8f94d61742e6bd87c

--- a/nixos/modules/services/admin/pgadmin.nix
+++ b/nixos/modules/services/admin/pgadmin.nix
@@ -1,12 +1,17 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   cfg = config.services.pgadmin;
+  inherit (lib.types) int bool str oneOf listOf attrsOf port path nullOr;
+  inherit (lib) mkEnableOption mkOption mkPackageOption mkDefault mkForce mkIf mapAttrsToList concatStringsSep optional optionalAttrs optionalString escapeShellArg;
 
-  _base = with types; [ int bool str ];
-  base = with types; oneOf ([ (listOf (oneOf _base)) (attrsOf (oneOf _base)) ] ++ _base);
+  _base = [ int bool str ];
+  base = oneOf ([ (listOf (oneOf _base)) (attrsOf (oneOf _base)) ] ++ _base);
 
   formatAttrset = attr:
     "{${concatStringsSep "\n" (mapAttrsToList (key: value: "${builtins.toJSON key}: ${formatPyValue value},") attr)}}";
@@ -23,7 +28,7 @@ let
   formatPy = attrs:
     concatStringsSep "\n" (mapAttrsToList (key: value: "${key} = ${formatPyValue value}") attrs);
 
-  pyType = with types; attrsOf (oneOf [ (attrsOf base) (listOf base) base ]);
+  pyType = attrsOf (oneOf [ (attrsOf base) (listOf base) base ]);
 in
 {
   options.services.pgadmin = {
@@ -31,7 +36,7 @@ in
 
     port = mkOption {
       description = "Port for pgadmin4 to run on";
-      type = types.port;
+      type = port;
       default = 5050;
     };
 
@@ -39,7 +44,7 @@ in
 
     initialEmail = mkOption {
       description = "Initial email for the pgAdmin account";
-      type = types.str;
+      type = str;
     };
 
     initialPasswordFile = mkOption {
@@ -48,12 +53,12 @@ in
         Please see `services.pgadmin.minimumPasswordLength`.
         NOTE: Should be string not a store path, to prevent the password from being world readable
       '';
-      type = types.path;
+      type = path;
     };
 
     minimumPasswordLength = mkOption {
       description = "Minimum length of the password";
-      type = types.int;
+      type = int;
       default = 6;
     };
 
@@ -62,39 +67,39 @@ in
         description = ''
           Enable SMTP email server. This is necessary, if you want to use password recovery or change your own password
         '';
-        type = types.bool;
+        type = bool;
         default = false;
       };
       address = mkOption {
         description = "SMTP server for email delivery";
-        type = types.str;
+        type = str;
         default = "localhost";
       };
       port = mkOption {
         description = "SMTP server port for email delivery";
-        type = types.port;
+        type = port;
         default = 25;
       };
       useSSL = mkOption {
         description = "SMTP server should use SSL";
-        type = types.bool;
+        type = bool;
         default = false;
       };
       useTLS = mkOption {
         description = "SMTP server should use TLS";
-        type = types.bool;
+        type = bool;
         default = false;
       };
       username = mkOption {
         description = "SMTP server username for email delivery";
-        type = types.nullOr types.str;
+        type = nullOr str;
         default = null;
       };
       sender = mkOption {
         description = ''
           SMTP server sender email for email delivery. Some servers require this to be a valid email address from that server
         '';
-        type = types.str;
+        type = str;
         example = "noreply@example.com";
       };
       passwordFile = mkOption {
@@ -102,7 +107,7 @@ in
           Password for SMTP email account.
           NOTE: Should be string not a store path, to prevent the password from being world readable
         '';
-        type = types.path;
+        type = path;
       };
     };
 
@@ -195,7 +200,7 @@ in
     users.groups.pgadmin = { };
 
     environment.etc."pgadmin/config_system.py" = {
-      text = lib.optionalString cfg.emailServer.enable ''
+      text = optionalString cfg.emailServer.enable ''
         import os
         with open(os.path.join(os.environ['CREDENTIALS_DIRECTORY'], 'email_password')) as f:
           pw = f.read()

--- a/nixos/modules/services/admin/pgadmin.nix
+++ b/nixos/modules/services/admin/pgadmin.nix
@@ -7,28 +7,78 @@
 
 let
   cfg = config.services.pgadmin;
-  inherit (lib.types) int bool str oneOf listOf attrsOf port path nullOr;
-  inherit (lib) mkEnableOption mkOption mkPackageOption mkDefault mkForce mkIf mapAttrsToList concatStringsSep optional optionalAttrs optionalString escapeShellArg;
+  inherit (lib.types)
+    int
+    bool
+    str
+    oneOf
+    listOf
+    attrsOf
+    port
+    path
+    nullOr
+    ;
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    mkPackageOption
+    mkDefault
+    mkForce
+    mkIf
+    mapAttrsToList
+    concatStringsSep
+    optional
+    optionalAttrs
+    optionalString
+    escapeShellArg
+    ;
 
-  _base = [ int bool str ];
-  base = oneOf ([ (listOf (oneOf _base)) (attrsOf (oneOf _base)) ] ++ _base);
+  _base = [
+    int
+    bool
+    str
+  ];
+  base = oneOf (
+    [
+      (listOf (oneOf _base))
+      (attrsOf (oneOf _base))
+    ]
+    ++ _base
+  );
 
-  formatAttrset = attr:
-    "{${concatStringsSep "\n" (mapAttrsToList (key: value: "${builtins.toJSON key}: ${formatPyValue value},") attr)}}";
+  formatAttrset =
+    attr:
+    "{${
+      concatStringsSep "\n" (
+        mapAttrsToList (key: value: "${builtins.toJSON key}: ${formatPyValue value},") attr
+      )
+    }}";
 
-  formatPyValue = value:
-    if builtins.isString value then builtins.toJSON value
-    else if value ? _expr then value._expr
-    else if builtins.isInt value then toString value
-    else if builtins.isBool value then (if value then "True" else "False")
-    else if builtins.isAttrs value then (formatAttrset value)
-    else if builtins.isList value then "[${concatStringsSep "\n" (map (v: "${formatPyValue v},") value)}]"
-    else throw "Unrecognized type";
+  formatPyValue =
+    value:
+    if builtins.isString value then
+      builtins.toJSON value
+    else if value ? _expr then
+      value._expr
+    else if builtins.isInt value then
+      toString value
+    else if builtins.isBool value then
+      (if value then "True" else "False")
+    else if builtins.isAttrs value then
+      (formatAttrset value)
+    else if builtins.isList value then
+      "[${concatStringsSep "\n" (map (v: "${formatPyValue v},") value)}]"
+    else
+      throw "Unrecognized type";
 
-  formatPy = attrs:
-    concatStringsSep "\n" (mapAttrsToList (key: value: "${key} = ${formatPyValue value}") attrs);
+  formatPy =
+    attrs: concatStringsSep "\n" (mapAttrsToList (key: value: "${key} = ${formatPyValue value}") attrs);
 
-  pyType = attrsOf (oneOf [ (attrsOf base) (listOf base) base ]);
+  pyType = attrsOf (oneOf [
+    (attrsOf base)
+    (listOf base)
+    base
+  ]);
 in
 {
   options.services.pgadmin = {
@@ -153,21 +203,22 @@ in
   config = mkIf (cfg.enable) {
     networking.firewall.allowedTCPPorts = mkIf (cfg.openFirewall) [ cfg.port ];
 
-    services.pgadmin.settings = {
-      DEFAULT_SERVER_PORT = cfg.port;
-      PASSWORD_LENGTH_MIN = cfg.minimumPasswordLength;
-      SERVER_MODE = true;
-      UPGRADE_CHECK_ENABLED = false;
-    } // (optionalAttrs cfg.openFirewall {
-      DEFAULT_SERVER = mkDefault "::";
-    }) // (optionalAttrs cfg.emailServer.enable {
-      MAIL_SERVER = cfg.emailServer.address;
-      MAIL_PORT = cfg.emailServer.port;
-      MAIL_USE_SSL = cfg.emailServer.useSSL;
-      MAIL_USE_TLS = cfg.emailServer.useTLS;
-      MAIL_USERNAME = cfg.emailServer.username;
-      SECURITY_EMAIL_SENDER = cfg.emailServer.sender;
-    });
+    services.pgadmin.settings =
+      {
+        DEFAULT_SERVER_PORT = cfg.port;
+        PASSWORD_LENGTH_MIN = cfg.minimumPasswordLength;
+        SERVER_MODE = true;
+        UPGRADE_CHECK_ENABLED = false;
+      }
+      // (optionalAttrs cfg.openFirewall { DEFAULT_SERVER = mkDefault "::"; })
+      // (optionalAttrs cfg.emailServer.enable {
+        MAIL_SERVER = cfg.emailServer.address;
+        MAIL_PORT = cfg.emailServer.port;
+        MAIL_USE_SSL = cfg.emailServer.useSSL;
+        MAIL_USE_TLS = cfg.emailServer.useTLS;
+        MAIL_USERNAME = cfg.emailServer.username;
+        SECURITY_EMAIL_SENDER = cfg.emailServer.sender;
+      });
 
     systemd.services.pgadmin = {
       wantedBy = [ "multi-user.target" ];
@@ -177,7 +228,11 @@ in
       # in case postgres doesn't start, pgadmin will just start normally
       wants = [ "postgresql.service" ];
 
-      path = [ config.services.postgresql.package pkgs.coreutils pkgs.bash ];
+      path = [
+        config.services.postgresql.package
+        pkgs.coreutils
+        pkgs.bash
+      ];
 
       preStart = ''
         # NOTE: this is idempotent (aka running it twice has no effect)
@@ -204,9 +259,7 @@ in
         ) | ${cfg.package}/bin/pgadmin4-cli setup-db
       '';
 
-      restartTriggers = [
-        "/etc/pgadmin/config_system.py"
-      ];
+      restartTriggers = [ "/etc/pgadmin/config_system.py" ];
 
       serviceConfig = {
         User = cfg.user;
@@ -215,8 +268,9 @@ in
         LogsDirectory = "pgadmin";
         StateDirectory = "pgadmin";
         ExecStart = "${cfg.package}/bin/pgadmin4";
-        LoadCredential = [ "initial_password:${cfg.initialPasswordFile}" ]
-          ++ optional cfg.emailServer.enable "email_password:${cfg.emailServer.passwordFile}";
+        LoadCredential = [
+          "initial_password:${cfg.initialPasswordFile}"
+        ] ++ optional cfg.emailServer.enable "email_password:${cfg.emailServer.passwordFile}";
       };
     };
 
@@ -229,12 +283,14 @@ in
     users.groups = mkIf (cfg.group == "pgadmin") { pgadmin = { }; };
 
     environment.etc."pgadmin/config_system.py" = {
-      text = optionalString cfg.emailServer.enable ''
-        import os
-        with open(os.path.join(os.environ['CREDENTIALS_DIRECTORY'], 'email_password')) as f:
-          pw = f.read()
-        MAIL_PASSWORD = pw
-      '' + formatPy cfg.settings;
+      text =
+        optionalString cfg.emailServer.enable ''
+          import os
+          with open(os.path.join(os.environ['CREDENTIALS_DIRECTORY'], 'email_password')) as f:
+            pw = f.read()
+          MAIL_PASSWORD = pw
+        ''
+        + formatPy cfg.settings;
       mode = "0600";
       user = cfg.user;
       group = cfg.group;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- Updated the PGAdmin module to be in line with e.g. [Caddy](https://github.com/NixOS/nixpkgs/blob/839825739c9d7a654f425a345deacfd597a816d8/nixos/modules/services/web-servers/caddy/default.nix), which does not assume that the service user is created with `users.users`.
- `with lib` was replaced with `inherit (lib)`
- Ran `nixfmt`

Using an external user was tested and found to be working ([1](https://github.com/TheRealGramdalf/nixos/blob/e47fbef5ffb6d790debe3a75940a5ebddab67c6d/mods/nixos/pogadmin.nix), [2](https://github.com/TheRealGramdalf/nixos/blob/e47fbef5ffb6d790debe3a75940a5ebddab67c6d/config/hosts/aer/services/postgres.nix)) with Kanidm's POSIX account functionality. WebUI is confirmed to be accessible while running as said user.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
