### PR TITLE
tree-wide: use top-level cctools

### DIFF
--- a/pkgs/applications/blockchains/clightning/default.nix
+++ b/pkgs/applications/blockchains/clightning/default.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, cctools
 , darwin
 , fetchurl
 , autoconf
@@ -30,11 +31,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-FD7JFM80wrruqBWjYnJHZh2f2GZJ6XDQmUQ0XetnWBg=";
   };
 
-  # when building on darwin we need dawin.cctools to provide the correct libtool
+  # when building on darwin we need cctools to provide the correct libtool
   # as libwally-core detects the host as darwin and tries to add the -static
   # option to libtool, also we have to add the modified gsed package.
   nativeBuildInputs = [ autoconf autogen automake gettext libtool lowdown protobuf py3 unzip which ]
-    ++ lib.optionals stdenv.isDarwin [ darwin.cctools darwin.autoSignDarwinBinariesHook ];
+    ++ lib.optionals stdenv.isDarwin [ cctools darwin.autoSignDarwinBinariesHook ];
 
   buildInputs = [ gmp libsodium sqlite zlib jq ];
 

--- a/pkgs/applications/networking/irc/thelounge/default.nix
+++ b/pkgs/applications/networking/irc/thelounge/default.nix
@@ -7,7 +7,7 @@
 , fixup-yarn-lock
 , python3
 , npmHooks
-, darwin
+, cctools
 , sqlite
 , srcOnly
 , buildPackages
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-MM6SgVT7Pjdu96A4eWRucEzT7uNPxBqUDgHKl8mH2C0=";
   };
 
-  nativeBuildInputs = [ nodejs yarn fixup-yarn-lock python3 npmHooks.npmInstallHook ] ++ lib.optional stdenv.isDarwin darwin.cctools;
+  nativeBuildInputs = [ nodejs yarn fixup-yarn-lock python3 npmHooks.npmInstallHook ] ++ lib.optional stdenv.isDarwin cctools;
   buildInputs = [ sqlite ];
 
   configurePhase = ''

--- a/pkgs/build-support/node/build-npm-package/default.nix
+++ b/pkgs/build-support/node/build-npm-package/default.nix
@@ -3,7 +3,7 @@
 , fetchNpmDeps
 , buildPackages
 , nodejs
-, darwin
+, cctools
 } @ topLevelArgs:
 
 { name ? "${args.pname}-${args.version}"
@@ -76,7 +76,7 @@ stdenv.mkDerivation (args // {
       (if npmInstallHook != null then npmInstallHook else npmHooks.npmInstallHook)
       nodejs.python
     ]
-    ++ lib.optionals stdenv.isDarwin [ darwin.cctools ];
+    ++ lib.optionals stdenv.isDarwin [ cctools ];
   buildInputs = buildInputs ++ [ nodejs ];
 
   strictDeps = true;

--- a/pkgs/by-name/bi/bitwarden-cli/package.nix
+++ b/pkgs/by-name/bi/bitwarden-cli/package.nix
@@ -4,7 +4,7 @@
 , nodejs_20
 , fetchFromGitHub
 , python311
-, darwin
+, cctools
 , nixosTests
 , xcbuild
 }:
@@ -27,7 +27,7 @@ buildNpmPackage rec {
   nativeBuildInputs = [
     python311
   ] ++ lib.optionals stdenv.isDarwin [
-    darwin.cctools
+    cctools
     xcbuild.xcrun
   ];
 

--- a/pkgs/by-name/fr/frankenphp/package.nix
+++ b/pkgs/by-name/fr/frankenphp/package.nix
@@ -6,6 +6,7 @@
 , brotli
 , testers
 , frankenphp
+, cctools
 , darwin
 , libiconv
 , pkg-config
@@ -44,7 +45,7 @@ in buildGoModule rec {
   vendorHash = "sha256-Ir1lwTu3JqIFp9jhJyhTAFm/+XlStkPuCoNAZneeKGc=";
 
   buildInputs = [ phpUnwrapped brotli ] ++ phpUnwrapped.buildInputs;
-  nativeBuildInputs = [ makeBinaryWrapper ] ++ lib.optionals stdenv.isDarwin [ pkg-config darwin.cctools darwin.autoSignDarwinBinariesHook ];
+  nativeBuildInputs = [ makeBinaryWrapper ] ++ lib.optionals stdenv.isDarwin [ pkg-config cctools darwin.autoSignDarwinBinariesHook ];
 
   subPackages = [ "frankenphp" ];
 

--- a/pkgs/by-name/li/live555/package.nix
+++ b/pkgs/by-name/li/live555/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  darwin,
+  cctools,
   fetchpatch,
   fetchurl,
   openssl,
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = lib.optionals stdenv.isDarwin [
-    darwin.cctools
+    cctools
   ];
 
   buildInputs = [

--- a/pkgs/by-name/my/mysql84/package.nix
+++ b/pkgs/by-name/my/mysql84/package.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, bison, cmake, pkg-config
 , icu, libedit, libevent, lz4, ncurses, openssl, protobuf_21, re2, readline, zlib, zstd, libfido2
-, darwin, numactl, libtirpc, rpcsvc-proto, curl
+, cctools, darwin, numactl, libtirpc, rpcsvc-proto, curl
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ lib.optionals stdenv.isLinux [
     numactl libtirpc
   ] ++ lib.optionals stdenv.isDarwin [
-    darwin.cctools darwin.apple_sdk.frameworks.CoreServices darwin.developer_cmds darwin.DarwinTools
+    cctools darwin.apple_sdk.frameworks.CoreServices darwin.developer_cmds darwin.DarwinTools
   ];
 
   outputs = [ "out" "static" ];

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchzip,
-  darwin,
+  cctools,
   gfortran,
   python3,
   blas,
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
 
   prePatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace config/install.py \
-      --replace /usr/bin/install_name_tool ${darwin.cctools}/bin/install_name_tool
+      --replace /usr/bin/install_name_tool ${cctools}/bin/install_name_tool
   '';
 
   # Both OpenMPI and MPICH get confused by the sandbox environment and spew errors like this (both to stdout and stderr):

--- a/pkgs/by-name/pr/protoc-gen-js/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-js/package.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildBazelPackage, bazel_6, fetchFromGitHub, darwin }:
+{ stdenv, lib, buildBazelPackage, bazel_6, fetchFromGitHub, cctools }:
 
 buildBazelPackage rec {
   pname = "protoc-gen-js";
@@ -17,7 +17,7 @@ buildBazelPackage rec {
   removeRulesCC = false;
   removeLocalConfigCC = false;
 
-  LIBTOOL = lib.optionalString stdenv.isDarwin "${darwin.cctools}/bin/libtool";
+  LIBTOOL = lib.optionalString stdenv.isDarwin "${cctools}/bin/libtool";
 
   fetchAttrs.sha256 = "sha256-WOBlZ0XNrl5UxIaSDxZeOfzS2a8ZkrKdTLKHBDC9UNQ=";
 

--- a/pkgs/by-name/ri/ride/package.nix
+++ b/pkgs/by-name/ri/ride/package.nix
@@ -12,7 +12,7 @@
   copyDesktopItems,
   makeDesktopItem,
   electron,
-  darwin,
+  cctools,
 }:
 
 let
@@ -92,7 +92,7 @@ buildNpmPackage rec {
       makeWrapper
     ]
     ++ lib.optionals (!stdenv.isDarwin) [ copyDesktopItems ]
-    ++ lib.optionals stdenv.isDarwin [ darwin.cctools ];
+    ++ lib.optionals stdenv.isDarwin [ cctools ];
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 

--- a/pkgs/data/fonts/iosevka/default.nix
+++ b/pkgs/data/fonts/iosevka/default.nix
@@ -2,7 +2,7 @@
 , lib
 , buildNpmPackage
 , fetchFromGitHub
-, darwin
+, cctools
 , remarshal
 , ttfautohint-nox
   # Custom font set options.
@@ -71,7 +71,7 @@ buildNpmPackage rec {
     ttfautohint-nox
   ] ++ lib.optionals stdenv.isDarwin [
     # libtool
-    darwin.cctools
+    cctools
   ];
 
   buildPlan =

--- a/pkgs/development/compilers/chez-racket/shared.nix
+++ b/pkgs/development/compilers/chez-racket/shared.nix
@@ -1,5 +1,5 @@
 args:
-{ stdenv, lib, fetchFromGitHub, coreutils, darwin
+{ stdenv, lib, fetchFromGitHub, coreutils, cctools, darwin
 , ncurses, libiconv, libX11, zlib, lz4
 }:
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation (args // {
     export LZ4="$(find ${lz4.out}/lib -type f | sort | head -n1)"
   '';
 
-  nativeBuildInputs = lib.optionals stdenv.isDarwin (with darwin; [ cctools autoSignDarwinBinariesHook ]);
+  nativeBuildInputs = lib.optionals stdenv.isDarwin ([ cctools darwin.autoSignDarwinBinariesHook ]);
   buildInputs = [ libiconv libX11 lz4 ncurses zlib ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/compilers/dart/default.nix
+++ b/pkgs/development/compilers/dart/default.nix
@@ -3,6 +3,7 @@
 , fetchurl
 , unzip
 , runCommand
+, cctools
 , darwin
 , sources ? import ./sources.nix {inherit fetchurl;}
 , version ? sources.versionUsed
@@ -41,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
 
       testCompile = runCommand "dart-test-compile" {
         nativeBuildInputs = [ finalAttrs.finalPackage ]
-          ++ lib.optionals stdenv.isDarwin [ darwin.cctools darwin.sigtool ];
+          ++ lib.optionals stdenv.isDarwin [ cctools darwin.sigtool ];
       } ''
         HELLO_MESSAGE="Hello, world!"
         echo "void main() => print('$HELLO_MESSAGE');" > hello.dart

--- a/pkgs/development/compilers/dotnet/sigtool.nix
+++ b/pkgs/development/compilers/dotnet/sigtool.nix
@@ -1,11 +1,10 @@
-{ darwin
+{ cctools
+, darwin
 , fetchFromGitHub
 , makeWrapper
 }:
-let
-  cctools = darwin.cctools;
 
-in darwin.sigtool.overrideAttrs (old: {
+darwin.sigtool.overrideAttrs (old: {
   # this is a fork of sigtool that supports -v and --remove-signature, which are
   # used by the dotnet sdk
   src = fetchFromGitHub {

--- a/pkgs/development/compilers/elm/packages/node/node-composition.nix
+++ b/pkgs/development/compilers/elm/packages/node/node-composition.nix
@@ -8,7 +8,7 @@ let
   nodeEnv = import ../../../../node-packages/node-env.nix {
     inherit (pkgs) stdenv lib python2 runCommand writeTextFile writeShellScript;
     inherit pkgs nodejs;
-    libtool = if pkgs.stdenv.isDarwin then pkgs.darwin.cctools else null;
+    libtool = if pkgs.stdenv.isDarwin then pkgs.cctools or pkgs.darwin.cctools else null;
   };
 in
 import ./node-packages.nix {

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -33,6 +33,7 @@
 , nukeReferences
 , callPackage
 , majorMinorVersion
+, cctools
 , darwin
 
 # only for gcc<=6.x
@@ -457,7 +458,7 @@ pipe ((callFile ./common/builder.nix {}) ({
 } // optionalAttrs (!atLeast10 && stdenv.targetPlatform.isDarwin) {
   # GCC <10 requires default cctools `strip` instead of `llvm-strip` used by Darwin bintools.
   preBuild = ''
-    makeFlagsArray+=('STRIP=${getBin darwin.cctools-port}/bin/${stdenv.cc.targetPrefix}strip')
+    makeFlagsArray+=('STRIP=${getBin cctools}/bin/${stdenv.cc.targetPrefix}strip')
   '';
 } // optionalAttrs (!atLeast8) {
   doCheck = false; # requires a lot of tools, causes a dependency cycle for stdenv

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -273,9 +273,9 @@ in
   ./6/gnat-glibc234.patch
 ]
 
-# The clang-based assembler used in darwin.cctools-llvm (LLVM >11) does not support piping input.
+# The clang-based assembler used in darwin.binutils (LLVM >11) does not support piping input.
 # Fortunately, it does not exhibit the problem GCC has with the cctools assembler.
-# This patch can be dropped should darwin.cctools-llvm ever implement support.
+# This patch can be dropped should darwin.binutils ever implement support.
 ++ optional (!atLeast7 && hostPlatform.isDarwin && lib.versionAtLeast (lib.getVersion stdenv.cc) "12") ./4.9/darwin-clang-as.patch
 
 # Building libstdc++ with flat namespaces results in trying to link CoreFoundation, which

--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -13,6 +13,7 @@
 , substituteAll
 , which
 , z3
+, cctools
 , darwin
 }:
 
@@ -36,7 +37,7 @@ stdenv.mkDerivation (rec {
   };
 
   nativeBuildInputs = [ cmake makeWrapper which python3 ]
-    ++ lib.optionals (stdenv.isDarwin) [ darwin.cctools ];
+    ++ lib.optionals (stdenv.isDarwin) [ cctools ];
   buildInputs = [ libxml2 z3 ];
 
   # Sandbox disallows network access, so disabling problematic networking tests

--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -58,7 +58,7 @@ let
     xcbuild = xcodebuild;
 
     swift-unwrapped = callPackage ./compiler {
-      inherit (darwin) DarwinTools cctools sigtool;
+      inherit (darwin) DarwinTools sigtool;
       inherit (apple_sdk) MacOSX-SDK CLTools_Executables;
       inherit (apple_sdk.frameworks) CoreServices Foundation Combine;
     };
@@ -85,7 +85,7 @@ let
     };
 
     swiftpm = callPackage ./swiftpm {
-      inherit (darwin) DarwinTools cctools;
+      inherit (darwin) DarwinTools;
       inherit (apple_sdk.frameworks) CryptoKit LocalAuthentication;
       swift = swiftNoSwiftDriver;
     };

--- a/pkgs/development/interpreters/cyclone/default.nix
+++ b/pkgs/development/interpreters/cyclone/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, libck, darwin }:
+{ lib, stdenv, fetchFromGitHub, libck, cctools }:
 
 let
   version = "0.34.0";
@@ -15,7 +15,7 @@ let
 
     enableParallelBuilding = true;
 
-    nativeBuildInputs = lib.optionals stdenv.isDarwin [ darwin.cctools ];
+    nativeBuildInputs = lib.optionals stdenv.isDarwin [ cctools ];
 
     buildInputs = [ libck ];
 
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
   enableParallelBuilding = true;
 
   nativeBuildInputs = [ bootstrap ]
-    ++ lib.optionals stdenv.isDarwin [ darwin.cctools ];
+    ++ lib.optionals stdenv.isDarwin [ cctools ];
 
   buildInputs = [ libck ];
 

--- a/pkgs/development/libraries/catboost/default.nix
+++ b/pkgs/development/libraries/catboost/default.nix
@@ -2,7 +2,7 @@
 , config
 , fetchFromGitHub
 , cmake
-, darwin
+, cctools
 , libiconv
 , llvmPackages
 , ninja
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     ragel
     yasm
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.cctools
+    cctools
   ] ++ lib.optionals cudaSupport (with cudaPackages; [
     cuda_nvcc
   ]);

--- a/pkgs/development/libraries/freeimage/default.nix
+++ b/pkgs/development/libraries/freeimage/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchsvn, darwin, libtiff
+{ lib, stdenv, fetchsvn, cctools, libtiff
 , libpng, zlib, libwebp, libraw, openexr, openjpeg
 , libjpeg, jxrlib, pkg-config
 , fixDarwinDylibNames, autoSignDarwinBinariesHook }:
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
   ] ++ lib.optionals stdenv.isDarwin [
-    darwin.cctools
+    cctools
     fixDarwinDylibNames
   ] ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
     autoSignDarwinBinariesHook

--- a/pkgs/development/libraries/libmcrypt/default.nix
+++ b/pkgs/development/libraries/libmcrypt/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, darwin, disablePosixThreads ? false }:
+{ lib, stdenv, fetchurl, cctools, disablePosixThreads ? false }:
 
 stdenv.mkDerivation rec {
   pname = "libmcrypt";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0gipgb939vy9m66d3k8il98rvvwczyaw2ixr8yn6icds9c3nrsz4";
   };
 
-  buildInputs = lib.optional stdenv.isDarwin darwin.cctools;
+  buildInputs = lib.optional stdenv.isDarwin cctools;
 
   configureFlags = lib.optionals disablePosixThreads [ "--disable-posix-threads" ]
     ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [

--- a/pkgs/development/libraries/nss/generic.nix
+++ b/pkgs/development/libraries/nss/generic.nix
@@ -7,7 +7,7 @@
 , zlib
 , sqlite
 , ninja
-, darwin
+, cctools
 , fixDarwinDylibNames
 , buildPackages
 , useP11kit ? true
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   nativeBuildInputs = [ perl ninja (buildPackages.python3.withPackages (ps: with ps; [ gyp ])) ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.cctools fixDarwinDylibNames ];
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ cctools fixDarwinDylibNames ];
 
   buildInputs = [ zlib sqlite ];
 

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -314,7 +314,7 @@ let
           in if stdenv'.isDarwin then overrideSDK stdenv' "11.0" else stdenv';
         inherit (srcs.qtwebengine) version;
         python = python3;
-        inherit (darwin) cctools xnu;
+        inherit (darwin) xnu;
         inherit (darwin.apple_sdk_11_0) libpm libunwind;
         inherit (darwin.apple_sdk_11_0.libs) sandbox;
         inherit (darwin.apple_sdk_11_0.frameworks) ApplicationServices AVFoundation Foundation ForceFeedback GameController AppKit

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -152,7 +152,7 @@ let
       qtwayland = callPackage ./modules/qtwayland.nix { };
       qtwebchannel = callPackage ./modules/qtwebchannel.nix { };
       qtwebengine = callPackage ./modules/qtwebengine.nix {
-        inherit (darwin) autoSignDarwinBinariesHook bootstrap_cmds cctools xnu;
+        inherit (darwin) autoSignDarwinBinariesHook bootstrap_cmds xnu;
         inherit (darwin.apple_sdk_11_0) libpm libunwind;
         inherit (darwin.apple_sdk_11_0.libs) sandbox;
         inherit (darwin.apple_sdk_11_0.frameworks)

--- a/pkgs/development/libraries/science/math/mkl/default.nix
+++ b/pkgs/development/libraries/science/math/mkl/default.nix
@@ -5,7 +5,7 @@
 , fetchurl
 , rpmextract
 , _7zz
-, darwin
+, cctools
 , validatePkgConfig
 , enableStatic ? stdenv.hostPlatform.isStatic
 }:
@@ -72,7 +72,7 @@ in stdenvNoCC.mkDerivation ({
 
   nativeBuildInputs = [ validatePkgConfig ] ++ (if stdenvNoCC.isDarwin
     then
-      [ _7zz darwin.cctools ]
+      [ _7zz cctools ]
     else
       [ rpmextract ]);
 

--- a/pkgs/development/node-packages/composition.nix
+++ b/pkgs/development/node-packages/composition.nix
@@ -8,7 +8,7 @@ let
   nodeEnv = import ./node-env.nix {
     inherit (pkgs) stdenv lib python2 runCommand writeTextFile writeShellScript;
     inherit pkgs nodejs;
-    libtool = if pkgs.stdenv.isDarwin then pkgs.darwin.cctools else null;
+    libtool = if pkgs.stdenv.isDarwin then pkgs.cctools or pkgs.darwin.cctools else null;
   };
 in
 import ./node-packages.nix {

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1256,7 +1256,7 @@ let
     pbdZMQ = old.pbdZMQ.overrideAttrs (attrs: {
       postPatch = lib.optionalString stdenv.isDarwin ''
         for file in R/*.{r,r.in}; do
-            sed -i 's#system("which \(\w\+\)"[^)]*)#"${pkgs.darwin.cctools}/bin/\1"#g' $file
+            sed -i 's#system("which \(\w\+\)"[^)]*)#"${pkgs.cctools}/bin/\1"#g' $file
         done
       '';
     });

--- a/pkgs/development/tools/build-managers/bazel/bazel_7/cpp-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_7/cpp-test.nix
@@ -3,6 +3,7 @@
 , bazel-examples
 , bazelTest
 , callPackage
+, cctools
 , darwin
 , distDir
 , extraBazelArgs ? ""
@@ -37,8 +38,8 @@ let
     #! ${runtimeShell}
 
     export CXX='${stdenv.cc}/bin/clang++'
-    export LD='${darwin.cctools}/bin/ld'
-    export LIBTOOL='${darwin.cctools}/bin/libtool'
+    export LD='${cctools}/bin/ld'
+    export LIBTOOL='${cctools}/bin/libtool'
     export CC='${stdenv.cc}/bin/clang'
 
     # XXX: hack for macosX, this flags disable bazel usage of xcode

--- a/pkgs/development/tools/build-managers/bazel/bazel_7/java-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_7/java-test.nix
@@ -4,7 +4,7 @@
 , stdenv
 , symlinkJoin
 , callPackage
-, darwin
+, cctools
 , extraBazelArgs ? ""
 , lib
 , openjdk8
@@ -38,8 +38,8 @@ let
     #! ${runtimeShell}
 
     export CXX='${stdenv.cc}/bin/clang++'
-    export LD='${darwin.cctools}/bin/ld'
-    export LIBTOOL='${darwin.cctools}/bin/libtool'
+    export LD='${cctools}/bin/ld'
+    export LIBTOOL='${cctools}/bin/libtool'
     export CC='${stdenv.cc}/bin/clang'
 
     # XXX: hack for macosX, this flags disable bazel usage of xcode

--- a/pkgs/development/tools/build-managers/bazel/bazel_7/protobuf-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_7/protobuf-test.nix
@@ -2,6 +2,7 @@
 , Foundation
 , bazelTest
 , callPackage
+, cctools
 , darwin
 , distDir
 , extraBazelArgs ? ""
@@ -97,8 +98,8 @@ let
     #! ${runtimeShell}
 
     export CXX='${stdenv.cc}/bin/clang++'
-    export LD='${darwin.cctools}/bin/ld'
-    export LIBTOOL='${darwin.cctools}/bin/libtool'
+    export LD='${cctools}/bin/ld'
+    export LIBTOOL='${cctools}/bin/libtool'
     export CC='${stdenv.cc}/bin/clang'
 
     # XXX: hack for macosX, this flags disable bazel usage of xcode

--- a/pkgs/development/tools/build-managers/bazel/cpp-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/cpp-test.nix
@@ -3,6 +3,7 @@
 , bazelTest
 , bazel-examples
 , stdenv
+, cctools
 , darwin
 , extraBazelArgs ? ""
 , lib
@@ -20,8 +21,8 @@ let
     #! ${runtimeShell}
 
     export CXX='${stdenv.cc}/bin/clang++'
-    export LD='${darwin.cctools}/bin/ld'
-    export LIBTOOL='${darwin.cctools}/bin/libtool'
+    export LD='${cctools}/bin/ld'
+    export LIBTOOL='${cctools}/bin/libtool'
     export CC='${stdenv.cc}/bin/clang'
 
     # XXX: hack for macosX, this flags disable bazel usage of xcode

--- a/pkgs/development/tools/build-managers/bazel/java-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/java-test.nix
@@ -2,7 +2,7 @@
 , bazelTest
 , bazel-examples
 , stdenv
-, darwin
+, cctools
 , extraBazelArgs ? ""
 , lib
 , openjdk8
@@ -20,8 +20,8 @@ let
     #! ${runtimeShell}
 
     export CXX='${stdenv.cc}/bin/clang++'
-    export LD='${darwin.cctools}/bin/ld'
-    export LIBTOOL='${darwin.cctools}/bin/libtool'
+    export LD='${cctools}/bin/ld'
+    export LIBTOOL='${cctools}/bin/libtool'
     export CC='${stdenv.cc}/bin/clang'
 
     # XXX: hack for macosX, this flags disable bazel usage of xcode

--- a/pkgs/development/tools/build-managers/bazel/protobuf-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/protobuf-test.nix
@@ -4,7 +4,7 @@
 , fetchFromGitHub
 , fetchurl
 , stdenv
-, darwin
+, cctools
 , lib
 , openjdk8
 , jdk11_headless
@@ -134,8 +134,8 @@ let
     #! ${runtimeShell}
 
     export CXX='${stdenv.cc}/bin/clang++'
-    export LD='${darwin.cctools}/bin/ld'
-    export LIBTOOL='${darwin.cctools}/bin/libtool'
+    export LD='${cctools}/bin/ld'
+    export LIBTOOL='${cctools}/bin/libtool'
     export CC='${stdenv.cc}/bin/clang'
 
     # XXX: hack for macosX, this flags disable bazel usage of xcode

--- a/pkgs/development/tools/build-managers/bazel/python-bin-path-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/python-bin-path-test.nix
@@ -2,7 +2,7 @@
   bazel
 , bazelTest
 , stdenv
-, darwin
+, cctools
 , extraBazelArgs ? ""
 , lib
 , runLocal
@@ -17,8 +17,8 @@ let
     #! ${runtimeShell}
 
     export CXX='${stdenv.cc}/bin/clang++'
-    export LD='${darwin.cctools}/bin/ld'
-    export LIBTOOL='${darwin.cctools}/bin/libtool'
+    export LD='${cctools}/bin/ld'
+    export LIBTOOL='${cctools}/bin/libtool'
     export CC='${stdenv.cc}/bin/clang'
 
     # XXX: hack for macosX, this flags disable bazel usage of xcode

--- a/pkgs/development/tools/build-managers/gn/generic.nix
+++ b/pkgs/development/tools/build-managers/gn/generic.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchgit, darwin, writeText
+{ stdenv, lib, fetchgit, cctools, darwin, writeText
 , ninja, python3
 , ...
 }:

--- a/pkgs/development/tools/nodehun/default.nix
+++ b/pkgs/development/tools/nodehun/default.nix
@@ -1,4 +1,5 @@
 { buildNpmPackage
+, cctools
 , darwin
 , fetchFromGitHub
 , lib
@@ -31,7 +32,7 @@ buildNpmPackage {
 
   buildInputs = lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.CoreServices ];
   nativeBuildInputs = [ nodePackages.node-gyp python3 ]
-    ++ lib.optionals stdenv.isDarwin [ darwin.cctools ];
+    ++ lib.optionals stdenv.isDarwin [ cctools ];
 
   postInstall = ''
     # Only keep the necessary parts of build/Release to reduce closure size

--- a/pkgs/development/tools/xcbuild/toolchains.nix
+++ b/pkgs/development/tools/xcbuild/toolchains.nix
@@ -60,7 +60,7 @@ runCommand "Toolchains" {} (''
   ln -s ${buildPackages.indent}/bin/indent $toolchain/bin/indent
   ln -s ${buildPackages.ctags}/bin/ctags $toolchain/bin/ctags
 '' + optionalString stdenv.isDarwin ''
-  for bin in ${getBin buildPackages.darwin.cctools}/bin/*; do
+  for bin in ${getBin buildPackages.cctools}/bin/*; do
     if ! [ -e "$toolchain/bin/$(basename $bin)" ]; then
       ln -s $bin $toolchain/bin
     fi

--- a/pkgs/development/web/netlify-cli/composition.nix
+++ b/pkgs/development/web/netlify-cli/composition.nix
@@ -8,7 +8,7 @@ let
   nodeEnv = import ./node-env.nix {
     inherit (pkgs) stdenv lib python2 runCommand writeTextFile writeShellScript;
     inherit pkgs nodejs;
-    libtool = if pkgs.stdenv.isDarwin then pkgs.darwin.cctools else null;
+    libtool = if pkgs.stdenv.isDarwin then pkgs.cctools or pkgs.darwin.cctools else null;
   };
 in
 import ./node-packages.nix {

--- a/pkgs/development/web/playwright-test/default.nix
+++ b/pkgs/development/web/playwright-test/default.nix
@@ -8,7 +8,7 @@ let
   nodeEnv = import ./node-env.nix {
     inherit (pkgs) stdenv lib python2 runCommand writeTextFile writeShellScript;
     inherit pkgs nodejs;
-    libtool = if pkgs.stdenv.isDarwin then pkgs.darwin.cctools else null;
+    libtool = if pkgs.stdenv.isDarwin then pkgs.darwin or pkgs.darwin.cctools else null;
   };
 in
 import ./node-packages.nix {

--- a/pkgs/misc/base16-builder/node-packages.nix
+++ b/pkgs/misc/base16-builder/node-packages.nix
@@ -12,7 +12,7 @@ let
   nodeEnv = import ../../development/node-packages/node-env.nix {
     inherit (pkgs) stdenv lib python2 runCommand writeTextFile writeShellScript;
     inherit pkgs nodejs;
-    libtool = if pkgs.stdenv.isDarwin then pkgs.darwin.cctools else null;
+    libtool = if pkgs.stdenv.isDarwin then pkgs.cctools or pkgs.darwin.cctools else null;
   };
 in
 import ./node-packages-generated.nix {

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -56,7 +56,6 @@ makeScopeWithSplicing' {
 
       compat = self.callPackage ./pkgs/compat/package.nix {
         inherit (buildPackages) coreutils;
-        inherit (buildPackages.darwin) cctools-port;
         inherit (buildNetbsd) makeMinimal;
         inherit (self) install;
       };

--- a/pkgs/os-specific/bsd/netbsd/pkgs/compat/package.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/compat/package.nix
@@ -5,7 +5,7 @@
   zlib,
   defaultMakeFlags,
   coreutils,
-  cctools-port,
+  cctools,
   install,
   bsdSetupHook,
   netbsdSetupHook,
@@ -72,7 +72,7 @@ mkDerivation (
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
         # GNU objcopy produces broken .a libs which won't link into dependers.
         # Makefiles only invoke `$OBJCOPY -x/-X`, so cctools strip works here.
-        "OBJCOPY=${cctools-port}/bin/strip"
+        "OBJCOPY=${cctools}/bin/strip"
       ];
     RENAME = "-D";
 

--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
@@ -61,7 +61,7 @@ appleDerivation' stdenv {
       (cd $dep/include && find . -name '*.h' | copyHierarchy $out/include)
     done
 
-    (cd ${lib.getDev buildPackages.darwin.cctools}/include/mach-o && find . -name '*.h' | copyHierarchy $out/include/mach-o)
+    (cd ${lib.getDev buildPackages.cctools}/include/mach-o && find . -name '*.h' | copyHierarchy $out/include/mach-o)
 
     for header in pthread.h pthread_impl.h pthread_spis.h sched.h; do
       ln -s "$out/include/pthread/$header" "$out/include/$header"

--- a/pkgs/servers/mx-puppet-discord/node-composition.nix
+++ b/pkgs/servers/mx-puppet-discord/node-composition.nix
@@ -8,7 +8,7 @@ let
   nodeEnv = import ../../development/node-packages/node-env.nix {
     inherit (pkgs) stdenv lib python2 runCommand writeTextFile writeShellScript;
     inherit pkgs nodejs;
-    libtool = if pkgs.stdenv.isDarwin then pkgs.darwin.cctools else null;
+    libtool = if pkgs.stdenv.isDarwin then pkgs.cctools or pkgs.darwin.cctools else null;
   };
 in
 import ./node-packages.nix {

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -247,21 +247,18 @@ in
       # TODO should be removed
       version = "10.5.25";
       hash = "sha256-lhnQ9R6GQ1dGayxjMBo0pT99/ZnxjE/UUvqyK/Obpk4=";
-      inherit (self.darwin) cctools;
       inherit (self.darwin.apple_sdk.frameworks) CoreServices;
     };
     mariadb_106 = self.callPackage generic {
       # Supported until 2026-07-06
       version = "10.6.18";
       hash = "sha256-aJihER9HEwcJ4ouix70aV+S7VxAfbhCeWX1R5tOFzxg=";
-      inherit (self.darwin) cctools;
       inherit (self.darwin.apple_sdk.frameworks) CoreServices;
     };
     mariadb_1011 = self.callPackage generic {
       # Supported until 2028-02-16
       version = "10.11.8";
       hash = "sha256-XwTz4z2fHL7/BeecVNQdMCYwUAyZWu5ysGOOL5383w8=";
-      inherit (self.darwin) cctools;
       inherit (self.darwin.apple_sdk.frameworks) CoreServices;
     };
     mariadb_110 = self.callPackage generic {
@@ -269,7 +266,6 @@ in
       # TODO should be removed
       version = "11.0.6";
       hash = "sha256-AYnWKUbDfG20a/GkaLqVgLy6joDwWVjsSDwzh+zPmgA=";
-      inherit (self.darwin) cctools;
       inherit (self.darwin.apple_sdk.frameworks) CoreServices;
     };
   }

--- a/pkgs/servers/sql/percona-server/default.nix
+++ b/pkgs/servers/sql/percona-server/default.nix
@@ -1,13 +1,13 @@
 pkgs: {
   percona-server_lts = pkgs.callPackage ./lts.nix {
-    inherit (pkgs.darwin) cctools developer_cmds DarwinTools;
+    inherit (pkgs.darwin) developer_cmds DarwinTools;
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreServices;
     boost = pkgs.boost177; # Configure checks for specific version.
     icu = pkgs.icu69;
     protobuf = pkgs.protobuf_21;
   };
   percona-server_innovation = pkgs.callPackage ./innovation.nix {
-    inherit (pkgs.darwin) cctools developer_cmds DarwinTools;
+    inherit (pkgs.darwin) developer_cmds DarwinTools;
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreServices;
     # newer versions cause linking failures against `libabsl_spinlock_wait`
     protobuf = pkgs.protobuf_21;

--- a/pkgs/servers/web-apps/ethercalc/node-packages.nix
+++ b/pkgs/servers/web-apps/ethercalc/node-packages.nix
@@ -8,7 +8,7 @@ let
   nodeEnv = import ../../../development/node-packages/node-env.nix {
     inherit (pkgs) stdenv lib python2 runCommand writeTextFile writeShellScript;
     inherit pkgs nodejs;
-    libtool = if pkgs.stdenv.isDarwin then pkgs.darwin.cctools else null;
+    libtool = if pkgs.stdenv.isDarwin then pkgs.cctools or pkgs.darwin.cctools else null;
   };
 in
 import ./node-packages-generated.nix {

--- a/pkgs/tools/admin/balena-cli/default.nix
+++ b/pkgs/tools/admin/balena-cli/default.nix
@@ -8,6 +8,7 @@
 , nodePackages
 , python3
 , udev
+, cctools
 , darwin
 }:
 
@@ -38,7 +39,7 @@ in buildNpmPackage' rec {
     nodePackages.node-gyp
     python3
   ] ++ lib.optionals stdenv.isDarwin [
-    darwin.cctools
+    cctools
   ];
 
   buildInputs = lib.optionals stdenv.isLinux [

--- a/pkgs/tools/audio/dl-librescore/default.nix
+++ b/pkgs/tools/audio/dl-librescore/default.nix
@@ -3,7 +3,7 @@
 , buildNpmPackage
 , fetchFromGitHub
 , python3
-, darwin
+, cctools
 }:
 
 buildNpmPackage rec {
@@ -31,7 +31,7 @@ buildNpmPackage rec {
   nativeBuildInputs = [
     python3
   ] ++ lib.optionals stdenv.isDarwin [
-    darwin.cctools
+    cctools
   ];
 
   meta = {

--- a/pkgs/tools/misc/hsd/default.nix
+++ b/pkgs/tools/misc/hsd/default.nix
@@ -4,7 +4,7 @@
 , fetchFromGitHub
 , python3
 , unbound
-, darwin
+, cctools
 }:
 
 buildNpmPackage rec {
@@ -23,7 +23,7 @@ buildNpmPackage rec {
   nativeBuildInputs = [
     python3
   ] ++ lib.optionals stdenv.isDarwin [
-    darwin.cctools
+    cctools
   ];
 
   buildInputs = [

--- a/pkgs/tools/misc/moreutils/default.nix
+++ b/pkgs/tools/misc/moreutils/default.nix
@@ -8,7 +8,7 @@
 , perlPackages
 , makeWrapper
 , perl # for pod2man
-, darwin
+, cctools
 , gitUpdater
 }:
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     (perl.withPackages (p: [ p.IPCRun p.TimeDate p.TimeDuration ]))
   ] ++ lib.optionals stdenv.isDarwin [
-    darwin.cctools
+    cctools
   ];
 
   makeFlags = [

--- a/pkgs/tools/networking/curl-impersonate/default.nix
+++ b/pkgs/tools/networking/curl-impersonate/default.nix
@@ -16,7 +16,7 @@
 , autoconf
 , automake
 , libtool
-, darwin
+, cctools
 , cacert
 , unzip
 , go
@@ -63,7 +63,7 @@ let
 
     nativeBuildInputs = lib.optionals stdenv.isDarwin [
       # Must come first so that it shadows the 'libtool' command but leaves 'libtoolize'
-      darwin.cctools
+      cctools
     ] ++ [
       installShellFiles
       cmake

--- a/pkgs/tools/security/onlykey/onlykey.nix
+++ b/pkgs/tools/security/onlykey/onlykey.nix
@@ -8,7 +8,7 @@ let
   nodeEnv = import ../../../development/node-packages/node-env.nix {
     inherit (pkgs) stdenv lib python2 runCommand writeTextFile writeShellScript;
     inherit pkgs nodejs;
-    libtool = if pkgs.stdenv.isDarwin then pkgs.darwin.cctools else null;
+    libtool = if pkgs.stdenv.isDarwin then pkgs.cctools or pkgs.darwin.cctools else null;
   };
 in
 import ./node-packages.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1055,7 +1055,7 @@ with pkgs;
 
   inherit ({
     mysql-shell_8 = callPackage ../development/tools/mysql-shell/8.nix {
-      inherit (darwin) cctools DarwinTools;
+      inherit (darwin) DarwinTools;
       inherit (darwin.apple_sdk.frameworks) CoreServices;
       antlr = antlr4_10;
       icu =  icu73;
@@ -1066,7 +1066,7 @@ with pkgs;
   ;
 
   mysql-shell-innovation = callPackage ../development/tools/mysql-shell/innovation.nix {
-    inherit (darwin) cctools DarwinTools;
+    inherit (darwin) DarwinTools;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
     antlr = antlr4_10;
     icu =  icu73;
@@ -3810,9 +3810,7 @@ with pkgs;
 
   glyr = callPackage ../tools/audio/glyr { };
 
-  google-amber = callPackage ../tools/graphics/amber {
-    inherit (darwin) cctools;
-  };
+  google-amber = callPackage ../tools/graphics/amber { };
 
   hakrawler = callPackage ../tools/security/hakrawler { };
 
@@ -5445,7 +5443,6 @@ with pkgs;
   hocr-tools = with python3Packages; toPythonApplication hocr-tools;
 
   homepage-dashboard = callPackage ../servers/homepage-dashboard {
-    inherit (darwin) cctools;
     inherit (darwin.apple_sdk.frameworks) IOKit;
   };
 
@@ -7912,7 +7909,7 @@ with pkgs;
   lpd8editor = libsForQt5.callPackage ../applications/audio/lpd8editor {};
 
   lp_solve = callPackage ../applications/science/math/lp_solve {
-    inherit (darwin) cctools autoSignDarwinBinariesHook;
+    inherit (darwin) autoSignDarwinBinariesHook;
   };
 
   fabric-installer = callPackage ../tools/games/minecraft/fabric-installer { };
@@ -10324,7 +10321,7 @@ with pkgs;
   bubblemail = callPackage ../applications/networking/mailreaders/bubblemail { };
 
   mailpit = callPackage ../servers/mail/mailpit {
-    libtool = if stdenv.isDarwin then darwin.cctools else libtool;
+    libtool = if stdenv.isDarwin then cctools else libtool;
   };
 
   mailsend = callPackage ../tools/networking/mailsend { };
@@ -12625,9 +12622,7 @@ with pkgs;
 
   selectdefaultapplication = libsForQt5.callPackage ../applications/misc/selectdefaultapplication { };
 
-  semantic-release = callPackage ../development/tools/semantic-release {
-    inherit (darwin) cctools;
-  };
+  semantic-release = callPackage ../development/tools/semantic-release { };
 
   semgrep = python3.pkgs.callPackage ../tools/security/semgrep { };
   semgrep-core = callPackage ../tools/security/semgrep/semgrep-core.nix { };
@@ -14236,7 +14231,6 @@ with pkgs;
 
   unicorn = callPackage ../development/libraries/unicorn {
     inherit (darwin.apple_sdk.frameworks) IOKit;
-    inherit (darwin) cctools;
   };
 
   unittest-cpp = callPackage ../development/libraries/unittest-cpp { };
@@ -15013,9 +15007,7 @@ with pkgs;
     stdenv = gccStdenv;
   };
 
-  chez = callPackage ../development/compilers/chez {
-    inherit (darwin) cctools;
-  };
+  chez = callPackage ../development/compilers/chez { };
 
   chez-racket = callPackage ../development/compilers/chez-racket { };
 
@@ -17308,7 +17300,7 @@ with pkgs;
     inherit (darwin) libobjc;
   };
   defaultGemConfig = callPackage ../development/ruby-modules/gem-config {
-    inherit (darwin) DarwinTools cctools autoSignDarwinBinariesHook;
+    inherit (darwin) DarwinTools autoSignDarwinBinariesHook;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
   bundix = callPackage ../development/ruby-modules/bundix { };
@@ -17804,7 +17796,7 @@ with pkgs;
   bazel = bazel_6;
 
   bazel_5 = callPackage ../development/tools/build-managers/bazel/bazel_5 {
-    inherit (darwin) cctools sigtool;
+    inherit (darwin) sigtool;
     inherit (darwin.apple_sdk.frameworks) CoreFoundation CoreServices Foundation;
     buildJdk = jdk11_headless;
     runJdk = jdk11_headless;
@@ -17815,7 +17807,7 @@ with pkgs;
   };
 
   bazel_6 = darwin.apple_sdk_11_0.callPackage ../development/tools/build-managers/bazel/bazel_6 {
-    inherit (darwin) cctools sigtool;
+    inherit (darwin) sigtool;
     inherit (darwin.apple_sdk_11_0.frameworks) CoreFoundation CoreServices Foundation;
     buildJdk = jdk11_headless;
     runJdk = jdk11_headless;
@@ -17827,7 +17819,7 @@ with pkgs;
   };
 
   bazel_7 = darwin.apple_sdk_11_0.callPackage ../development/tools/build-managers/bazel/bazel_7 {
-    inherit (darwin) cctools sigtool;
+    inherit (darwin) sigtool;
     inherit (darwin.apple_sdk_11_0.frameworks) CoreFoundation CoreServices Foundation IOKit;
     buildJdk = jdk17_headless;
     runJdk = jdk17_headless;
@@ -19547,7 +19539,7 @@ with pkgs;
   jhiccup = callPackage ../development/tools/java/jhiccup { };
 
   valgrind = callPackage ../development/tools/analysis/valgrind {
-    inherit (buildPackages.darwin) xnu bootstrap_cmds cctools;
+    inherit (buildPackages.darwin) xnu bootstrap_cmds;
   };
   valgrind-light = res.valgrind.override { gdb = null; };
 
@@ -20825,7 +20817,6 @@ with pkgs;
 
   gobject-introspection-unwrapped = callPackage ../development/libraries/gobject-introspection {
     nixStoreDir = config.nix.storeDir or builtins.storeDir;
-    inherit (darwin) cctools;
   };
 
   goocanvas = callPackage ../development/libraries/goocanvas { };
@@ -20873,7 +20864,6 @@ with pkgs;
   };
 
   gpac = callPackage ../applications/video/gpac {
-    inherit (darwin) cctools;
     inherit (darwin.apple_sdk.frameworks) Carbon;
   };
 
@@ -22867,7 +22857,7 @@ with pkgs;
   lirc = callPackage ../development/libraries/lirc { };
 
   liquid-dsp = callPackage ../development/libraries/liquid-dsp {
-    inherit (darwin) autoSignDarwinBinariesHook cctools;
+    inherit (darwin) autoSignDarwinBinariesHook;
   };
 
   liquidfun = callPackage ../development/libraries/liquidfun { };
@@ -25832,14 +25822,12 @@ with pkgs;
   mongodb-5_0 = callPackage ../servers/nosql/mongodb/5.0.nix {
     sasl = cyrus_sasl;
     boost = boost179.override { enableShared = false; };
-    inherit (darwin) cctools;
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
 
   mongodb-6_0 = darwin.apple_sdk_11_0.callPackage ../servers/nosql/mongodb/6.0.nix {
     sasl = cyrus_sasl;
     boost = boost178.override { enableShared = false; };
-    inherit (darwin) cctools;
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
     stdenv = if stdenv.isDarwin then
       darwin.apple_sdk_11_0.stdenv.override (old: {
@@ -25863,7 +25851,7 @@ with pkgs;
   influxdb2 = callPackage ../servers/nosql/influxdb2/combined.nix { };
 
   mysql80 = callPackage ../servers/sql/mysql/8.0.x.nix {
-    inherit (darwin) cctools developer_cmds DarwinTools;
+    inherit (darwin) developer_cmds DarwinTools;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
     boost = boost177; # Configure checks for specific version.
     icu = icu69;
@@ -26146,7 +26134,7 @@ with pkgs;
 
   rethinkdb = callPackage ../servers/nosql/rethinkdb {
     stdenv = clangStdenv;
-    libtool = darwin.cctools;
+    libtool = cctools;
     protobuf = protobuf_21;
   };
 
@@ -28729,7 +28717,7 @@ with pkgs;
   session-desktop = callPackage ../applications/networking/instant-messengers/session-desktop { };
 
   shaderc = callPackage ../development/compilers/shaderc {
-    inherit (darwin) autoSignDarwinBinariesHook cctools;
+    inherit (darwin) autoSignDarwinBinariesHook;
   };
 
   shades-of-gray-theme = callPackage ../data/themes/shades-of-gray { };
@@ -32162,7 +32150,7 @@ with pkgs;
 
   mac = callPackage ../development/libraries/mac { };
 
-  macdylibbundler = callPackage ../development/tools/misc/macdylibbundler { inherit (darwin) cctools; };
+  macdylibbundler = callPackage ../development/tools/misc/macdylibbundler { };
 
   magic-wormhole = with python3Packages; toPythonApplication magic-wormhole;
 
@@ -34810,14 +34798,12 @@ with pkgs;
   openvscode-server = callPackage ../servers/openvscode-server {
     nodejs = nodejs_18;
     inherit (darwin.apple_sdk.frameworks) AppKit Cocoa Security;
-    inherit (darwin) cctools;
     inherit (nodePackages) node-gyp;
   };
 
   code-server = callPackage ../servers/code-server {
     nodejs = nodejs_18;
     inherit (darwin.apple_sdk.frameworks) AppKit Cocoa CoreServices Security;
-    inherit (darwin) cctools;
     inherit (nodePackages) node-gyp;
   };
 
@@ -36207,9 +36193,7 @@ with pkgs;
 
   garden-of-coloured-lights = callPackage ../games/garden-of-coloured-lights { allegro = allegro4; };
 
-  gargoyle = callPackage ../games/gargoyle {
-    inherit (darwin) cctools;
-  };
+  gargoyle = callPackage ../games/gargoyle { };
 
   gav = callPackage ../games/gav { };
 
@@ -36675,7 +36659,6 @@ with pkgs;
   scid-vs-pc = callPackage ../games/scid-vs-pc { };
 
   scummvm = callPackage ../games/scummvm {
-    inherit (darwin) cctools;
     inherit (darwin.apple_sdk.frameworks) Cocoa AudioToolbox Carbon CoreMIDI AudioUnit;
   };
 
@@ -40069,7 +40052,7 @@ with pkgs;
 
   check-uptime = callPackage ../servers/monitoring/plugins/uptime.nix { };
 
-  ghc-standalone-archive = callPackage ../os-specific/darwin/ghc-standalone-archive { inherit (darwin) cctools; };
+  ghc-standalone-archive = callPackage ../os-specific/darwin/ghc-standalone-archive { };
 
   vdr = callPackage ../applications/video/vdr { };
   vdrPlugins = recurseIntoAttrs (callPackage ../applications/video/vdr/plugins.nix { });

--- a/pkgs/top-level/darwin-aliases.nix
+++ b/pkgs/top-level/darwin-aliases.nix
@@ -52,8 +52,10 @@ mapAliases ({
   builder = throw "'darwin.builder' has been changed and renamed to 'darwin.linux-builder'. The default ssh port is now 31022. Please update your configuration or override the port back to 22. See https://nixos.org/manual/nixpkgs/unstable/#sec-darwin-builder"; # added 2023-07-06
 
   ### C ###
+  cctools = pkgs.cctools; # added 2024-07-17
   cctools-apple = pkgs.cctools; # added 2024-07-01
   cctools-llvm = pkgs.cctools; # added 2024-07-01
+  cctools-port = pkgs.cctools; # added 2024-07-17
 
   ### I ###
 

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -120,7 +120,7 @@ impure-cmds // appleSourcePackages // chooseLibs // {
     name = "${lib.getName self.binutils-unwrapped}-dualas-${lib.getVersion self.binutils-unwrapped}";
     paths = [
       self.binutils-unwrapped
-      (lib.getOutput "gas" self.cctools)
+      (lib.getOutput "gas" pkgs.cctools)
     ];
   };
 
@@ -132,10 +132,6 @@ impure-cmds // appleSourcePackages // chooseLibs // {
     libc = preLibcCrossHeaders;
     bintools = self.binutils-unwrapped;
   };
-
-  cctools = self.cctools-port;
-
-  cctools-port = pkgs.cctools;
 
   # TODO(@connorbaker): See https://github.com/NixOS/nixpkgs/issues/229389.
   cf-private = self.apple_sdk.frameworks.CoreFoundation;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6159,7 +6159,6 @@ self: super: with self; {
   };
 
   jaxlib-build = callPackage ../development/python-modules/jaxlib rec {
-    inherit (pkgs.darwin) cctools;
     # Some platforms don't have `cudaSupport` defined, hence the need for 'or false'.
     inherit (pkgs.config) cudaSupport;
     IOKit = pkgs.darwin.apple_sdk_11_0.IOKit;
@@ -7660,9 +7659,7 @@ self: super: with self; {
 
   minio = callPackage ../development/python-modules/minio { };
 
-  miniupnpc = callPackage ../development/python-modules/miniupnpc {
-    inherit (pkgs.darwin) cctools;
-  };
+  miniupnpc = callPackage ../development/python-modules/miniupnpc { };
 
   mip = callPackage ../development/python-modules/mip { };
 
@@ -15208,7 +15205,6 @@ self: super: with self; {
     };
   in
   callPackage ../development/python-modules/tensorflow {
-    inherit (pkgs.darwin) cctools;
     inherit (pkgs.config) cudaSupport;
     inherit (pkgs.darwin.apple_sdk.frameworks) Foundation Security;
     flatbuffers-core = pkgs.flatbuffers;
@@ -15235,9 +15231,7 @@ self: super: with self; {
 
   tensorflow-metadata = callPackage ../development/python-modules/tensorflow-metadata { };
 
-  tensorflow-probability = callPackage ../development/python-modules/tensorflow-probability {
-    inherit (pkgs.darwin) cctools;
-  };
+  tensorflow-probability = callPackage ../development/python-modules/tensorflow-probability { };
 
   tensorflow = self.tensorflow-build;
 


### PR DESCRIPTION
## Description of changes

This PR is the first follow-up to https://github.com/NixOS/nixpkgs/pull/307880. It finishes moving darwin.cctools to the top-level by adding darwin.cctools and darwin.cctools-port to darwin-aliases.nix.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
