### PR TITLE
lemminx: use jdk headless

### DIFF
--- a/pkgs/by-name/le/lemminx/package.nix
+++ b/pkgs/by-name/le/lemminx/package.nix
@@ -1,7 +1,7 @@
 { lib
 , fetchFromGitHub
 , makeWrapper
-, jre_headless
+, jdk_headless
 , jre_minimal
 , maven
 , writeScript
@@ -15,7 +15,7 @@ let
       "java.logging"
       "java.xml"
     ];
-    jdk = jre_headless;
+    jdk = jdk_headless;
   };
 in
 maven.buildMavenPackage rec {


### PR DESCRIPTION
## Description of changes

This is a continuation of https://github.com/NixOS/nixpkgs/pull/327915.

With https://github.com/NixOS/nixpkgs/pull/327497 we switched to a custom minimal jre to reduce the lemminx closure size. The pr, however, introduced a confusing jdk = jre_headless; assignment because in general you always need a jdk to build a custom jre, e.g. you cannot build a jre with just a jre.

This only works right now because the jre_headless is equal to the jdk_headless: https://github.com/NixOS/nixpkgs/blob/7edc243443b44444eba596557de03ee52beca2eb/pkgs/top-level/all-packages.nix#L15911-L15919

I think this is important because right now the code suggests that you could use a jre to build a jre. E.g. another user might adapt the code to use another jre like this:

E.g. 

```nix
jdk = temurin-jre-bin-21;
```

But this will fail with `jlink: command not found` because the jre does usually not contains jlink. That is what I mean by building a custom jre with another jre and this is what I want to clean up with this pr.

This might look like a small change/nitpick but as a maitainer I care about my API of my package.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
