### PR TITLE
yubikey-touch-detector - Remove opinionated --libnotify in systemd service unit

### DIFF
--- a/pkgs/tools/security/yubikey-touch-detector/default.nix
+++ b/pkgs/tools/security/yubikey-touch-detector/default.nix
@@ -26,7 +26,7 @@ buildGoModule rec {
     install -Dm444 -t $out/lib/systemd/user *.{service,socket}
 
     substituteInPlace $out/lib/systemd/user/*.service \
-      --replace /usr/bin/yubikey-touch-detector "$out/bin/yubikey-touch-detector --libnotify"
+      --replace /usr/bin/yubikey-touch-detector "$out/bin/yubikey-touch-detector"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Including this opinionated argument completely removes the ability to change the behavior in `$XDG_CONFIG_HOME/yubikey-touch-detector/service.conf`.