### PR TITLE
ingen: unstable-2019-12-09 -> 0-unstable-2024-07-13, fix build

### DIFF
--- a/pkgs/applications/audio/ingen/default.nix
+++ b/pkgs/applications/audio/ingen/default.nix
@@ -1,28 +1,59 @@
-{ lib, stdenv, fetchgit, boost, ganv, glibmm, gtkmm2, libjack2, lilv
-, lv2, pkg-config, python3, raul, serd, sord, sratom
-, wafHook
-, suil
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  portaudio,
+  boost,
+  ganv,
+  gtkmm2,
+  libjack2,
+  lilv,
+  pkg-config,
+  python3,
+  raul,
+  sord,
+  sratom,
+  suil,
+  meson,
+  ninja,
 }:
 
-stdenv.mkDerivation  rec {
+stdenv.mkDerivation {
   pname = "ingen";
-  version = "unstable-2019-12-09";
-  name = "${pname}-${version}";
+  version = "0-unstable-2024-07-13";
 
-  src = fetchgit {
-    url = "https://gitlab.com/drobilla/ingen.git";
-    rev = "e32f32a360f2bf8f017ea347b6d1e568c0beaf68";
-    sha256 = "0wjn2i3j7jb0bmxymg079xpk4iplb91q0xqqnvnpvyldrr7gawlb";
-    deepClone = true;
+  src = fetchFromGitLab {
+    owner = "drobilla";
+    repo = "ingen";
+    rev = "bbdab98ed282291b6e29a944359c360c9cca127e";
+    hash = "sha256-BllWeVmEkHQaZD9Ba7H0JMRlxVROJ8pkIiC2VXYiweA=";
   };
 
-  nativeBuildInputs = [ pkg-config wafHook python3 python3.pkgs.wrapPython ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    python3
+    python3.pkgs.wrapPython
+  ];
+
   buildInputs = [
-    boost ganv glibmm gtkmm2 libjack2 lilv lv2
-    python3 raul serd sord sratom suil
+    boost
+    ganv
+    gtkmm2
+    libjack2
+    lilv
+    portaudio
+    raul
+    sord
+    sratom
+    suil
   ];
 
   strictDeps = true;
+
+  # lv2specgen.py is not packaged in lv2 but required to build docs
+  mesonFlags = [ "-Ddocs=disabled" ];
 
   pythonPath = [
     python3
@@ -31,13 +62,17 @@ stdenv.mkDerivation  rec {
 
   postInstall = ''
     wrapPythonProgramsIn "$out/bin" "$out $pythonPath"
+    wrapProgram "$out/bin/ingen" --set INGEN_UI_PATH "$out/share/ingen/ingen_gui.ui"
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Modular audio processing system using JACK and LV2 or LADSPA plugins";
     homepage = "http://drobilla.net/software/ingen";
-    license = licenses.agpl3Plus;
-    maintainers = [ maintainers.goibhniu ];
-    platforms = platforms.linux;
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [
+      goibhniu
+      t4ccer
+    ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/libraries/audio/raul/default.nix
+++ b/pkgs/development/libraries/audio/raul/default.nix
@@ -1,27 +1,37 @@
-{ lib, stdenv, fetchgit, boost, gtk2, pkg-config, python3, wafHook }:
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  meson,
+  ninja,
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "raul";
-  version = "unstable-2019-12-09";
-  name = "${pname}-${version}";
+  version = "2.0.0-unstable-2024-07-04";
 
-  src = fetchgit {
-    url = "https://gitlab.com/drobilla/raul.git";
-    fetchSubmodules = true;
-    rev = "e87bb398f025912fb989a09f1450b838b251aea1";
-    sha256 = "1z37jb6ghc13b8nv8a8hcg669gl8vh4ni9djvfgga9vcz8rmcg8l";
+  src = fetchFromGitLab {
+    owner = "drobilla";
+    repo = "raul";
+    rev = "9097952a918f8330a5db9039ad390fc2457f841d";
+    hash = "sha256-k+EU3ROVJyjJPAtNxPmRXp9DALpUHzohCLL6Xe3NUxk=";
   };
 
-  nativeBuildInputs = [ pkg-config wafHook python3 ];
-  buildInputs = [ boost gtk2 ];
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
 
   strictDeps = true;
 
-  meta = with lib; {
+  meta = {
     description = "C++ utility library primarily aimed at audio/musical applications";
     homepage = "http://drobilla.net/software/raul";
-    license = licenses.gpl3;
-    maintainers = [ maintainers.goibhniu ];
-    platforms = platforms.unix;
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [
+      goibhniu
+      t4ccer
+    ];
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/ganv/default.nix
+++ b/pkgs/development/libraries/ganv/default.nix
@@ -1,27 +1,54 @@
-{ lib, stdenv, fetchgit, graphviz, gtk2, gtkmm2, pkg-config, python3, wafHook }:
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  graphviz,
+  gtk2,
+  gtkmm2,
+  meson,
+  ninja,
+  cmake,
+  pkg-config,
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "ganv";
-  version = "unstable-2019-12-30";
+  version = "1.8.2-unstable-2024-07-04";
 
-  src = fetchgit {
-    url = "https://gitlab.com/drobilla/${pname}.git";
-    fetchSubmodules = true;
-    rev = "90bd022f8909f92cc5290fdcfc76c626749e1186";
-    sha256 = "01znnalirbqxpz62fbw2c14c8xn117jc92xv6dhb3hln92k9x37f";
+  src = fetchFromGitLab {
+    owner = "drobilla";
+    repo = "ganv";
+    rev = "4d2e04dbcabd0b5d715ea7eeeb909f4088055763";
+    hash = "sha256-DzODtYI8uwP65ck8Q90QEnjQbvPobepeQVgNZZjF+jk=";
   };
 
-  nativeBuildInputs = [ pkg-config wafHook python3 gtk2 ];
-  buildInputs = [ graphviz gtkmm2 ];
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+    cmake
+  ];
+
+  buildInputs = [
+    gtk2
+    gtkmm2
+    graphviz
+  ];
 
   strictDeps = true;
 
-  meta = with lib; {
+  # libintl detection does not work even if provided
+  mesonAutoFeatures = "disabled";
+
+  meta = {
     description = "Interactive Gtk canvas widget for graph-based interfaces";
     mainProgram = "ganv_bench";
     homepage = "http://drobilla.net";
-    license = licenses.gpl3;
-    maintainers = [ maintainers.goibhniu ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [
+      goibhniu
+      t4ccer
+    ];
+    platforms = lib.platforms.linux;
   };
-  }
+}


### PR DESCRIPTION
## Description of changes

Unbreaks the build of `ingen` and its dependencies, bump to latest `master` to remove dependency on `waf` build system (doesn't work well with new python, new versions use meson)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
