### PR TITLE
metrics job: schedule on any machine, for now

### DIFF
--- a/pkgs/top-level/metrics.nix
+++ b/pkgs/top-level/metrics.nix
@@ -4,7 +4,8 @@ with pkgs;
 
 runCommand "nixpkgs-metrics"
   { nativeBuildInputs = with pkgs.lib; map getBin [ nix time jq ];
-    requiredSystemFeatures = [ "benchmark" ]; # dedicated `t2a` machine, by @vcunat
+    # see https://github.com/NixOS/nixpkgs/issues/52436
+    #requiredSystemFeatures = [ "benchmark" ]; # dedicated `t2a` machine, by @vcunat
   }
   ''
     export NIX_STORE_DIR=$TMPDIR/store


### PR DESCRIPTION
For non-time metrics it doesn't matter,
and those seem more important anyway.
So better this than nothing, for now.

_The usual checklist doesn't really apply._
