### PR TITLE
regreet: add options for controlling theming

### DIFF
--- a/nixos/modules/programs/regreet.nix
+++ b/nixos/modules/programs/regreet.nix
@@ -58,9 +58,96 @@ in
         modifiable properties.
       '';
     };
+
+    theme = {
+      package = lib.mkPackageOption pkgs "gnome-themes-extra" { } // {
+        description = ''
+          The package that provides the theme given in the name option.
+        '';
+      };
+
+      name = lib.mkOption {
+        type = lib.types.str;
+        default = "Adwaita";
+        description = ''
+          Name of the theme to use for regreet.
+        '';
+      };
+    };
+
+    iconTheme = {
+      package = lib.mkPackageOption pkgs "adwaita-icon-theme" { } // {
+        description = ''
+          The package that provides the icon theme given in the name option.
+        '';
+      };
+
+      name = lib.mkOption {
+        type = lib.types.str;
+        default = "Adwaita";
+        description = ''
+          Name of the icon theme to use for regreet.
+        '';
+      };
+    };
+
+    font = {
+      package = lib.mkPackageOption pkgs "cantarell-fonts" { } // {
+        description = ''
+          The package that provides the font given in the name option.
+        '';
+      };
+
+      name = lib.mkOption {
+        type = lib.types.str;
+        default = "Cantarell";
+        description = ''
+          Name of the font to use for regreet.
+        '';
+      };
+
+      size = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 16;
+        description = ''
+          Size of the font to use for regreet.
+        '';
+      };
+    };
+
+    cursorTheme = {
+      package = lib.mkPackageOption pkgs "adwaita-icon-theme" { } // {
+        description = ''
+          The package that provides the cursor theme given in the name option.
+        '';
+      };
+
+      name = lib.mkOption {
+        type = lib.types.str;
+        default = "Adwaita";
+        description = ''
+          Name of the cursor theme to use for regreet.
+        '';
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.theme.package
+      cfg.iconTheme.package
+      cfg.cursorTheme.package
+    ];
+
+    fonts.packages = [ cfg.font.package ];
+
+    programs.regreet.settings = {
+      cursor_theme_name = cfg.cursorTheme.name;
+      font_name = "${cfg.font.name} ${toString cfg.font.size}";
+      icon_theme_name = cfg.iconTheme.name;
+      theme_name = cfg.theme.name;
+    };
+
     services.greetd = {
       enable = lib.mkDefault true;
       settings.default_session.command = lib.mkDefault "${pkgs.dbus}/bin/dbus-run-session ${lib.getExe pkgs.cage} ${lib.escapeShellArgs cfg.cageArgs} -- ${lib.getExe cfg.package}";


### PR DESCRIPTION
## Description of changes

Add options to match LightDM Greeters like `lightdm-gtk-greeter`: https://search.nixos.org/options?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=lightdm.greeters+name

The defaults come from the default regreet configuration: https://github.com/rharish101/ReGreet/blob/main/regreet.sample.toml#L23-L33

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
