### PR TITLE
Bump fprintd-tod and libfprintd-tod 

### DIFF
--- a/pkgs/development/libraries/libfprint-2-tod1-vfs0090/0003-Update-fpi_ssm_next_state_delayed-calls.patch
+++ b/pkgs/development/libraries/libfprint-2-tod1-vfs0090/0003-Update-fpi_ssm_next_state_delayed-calls.patch
@@ -1,0 +1,34 @@
+From 5c65dd8e47fbb1d9ad0594a1334857e32c5de256 Mon Sep 17 00:00:00 2001
+From: Yurii Matsiuk <24990891+ymatsiuk@users.noreply.github.com>
+Date: Thu, 18 Jul 2024 13:40:38 +0200
+Subject: [PATCH] Update fpi_ssm_next_state_delayed calls
+
+---
+ vfs0090.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/vfs0090.c b/vfs0090.c
+index 8034faf..665c19d 100644
+--- a/vfs0090.c
++++ b/vfs0090.c
+@@ -1629,7 +1629,7 @@ led_blink_callback_with_ssm (FpiUsbTransfer *transfer, FpDevice *dev,
+ 
+   if (!error)
+     {
+-      fpi_ssm_next_state_delayed (ssm, 200, NULL);
++      fpi_ssm_next_state_delayed (ssm, 200);
+     }
+   else
+     {
+@@ -2951,7 +2951,7 @@ reactivate_ssm (FpiSsm *ssm, FpDevice *dev)
+   switch (fpi_ssm_get_cur_state (ssm))
+     {
+     case REACTIVATE_STATE_WAIT:
+-      fpi_ssm_next_state_delayed (ssm, 100, NULL);
++      fpi_ssm_next_state_delayed (ssm, 100);
+       break;
+ 
+     case REACTIVATE_STATE_DEACTIVATE:
+-- 
+2.45.1
+

--- a/pkgs/development/libraries/libfprint-2-tod1-vfs0090/default.nix
+++ b/pkgs/development/libraries/libfprint-2-tod1-vfs0090/default.nix
@@ -1,14 +1,14 @@
 { stdenv, lib, fetchFromGitLab, pkg-config, libfprint, libfprint-tod, gusb, udev, nss, openssl, meson, pixman, ninja, glib }:
-stdenv.mkDerivation {
+stdenv.mkDerivation rec{
   pname = "libfprint-2-tod1-vfs0090";
-  version = "0.8.5";
+  version = "0.96.91";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "3v1n0";
     repo = "libfprint-tod-vfs0090";
-    rev = "6084a1545589beec0c741200b18b0902cca225ba";
-    sha256 = "sha256-tSML/8USd/LuHF/YGLvNgykixF6VYtfE4SXzeV47840=";
+    rev = "${version}";
+    sha256 = "sha256-Qy2GYyx5aG1HfeAMVsiI3wLbfaN0bfjAOG0Jd9OnCdU=";
   };
 
   patches = [
@@ -16,6 +16,7 @@ stdenv.mkDerivation {
     ./0001-vfs0090-add-missing-explicit-dependencies-in-meson.b.patch
     # TODO remove once https://gitlab.freedesktop.org/3v1n0/libfprint-tod-vfs0090/-/merge_requests/2 is merged
     ./0002-vfs0090-add-missing-linux-limits.h-include.patch
+    ./0003-Update-fpi_ssm_next_state_delayed-calls.patch
   ];
 
   nativeBuildInputs = [ pkg-config meson ninja ];

--- a/pkgs/development/libraries/libfprint-2-tod1-vfs0090/default.nix
+++ b/pkgs/development/libraries/libfprint-2-tod1-vfs0090/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec{
     domain = "gitlab.freedesktop.org";
     owner = "3v1n0";
     repo = "libfprint-tod-vfs0090";
-    rev = "${version}";
+    rev = version;
     sha256 = "sha256-Qy2GYyx5aG1HfeAMVsiI3wLbfaN0bfjAOG0Jd9OnCdU=";
   };
 

--- a/pkgs/development/libraries/libfprint-tod/default.nix
+++ b/pkgs/development/libraries/libfprint-tod/default.nix
@@ -5,9 +5,11 @@
 
 # for the curious, "tod" means "Touch OEM Drivers" meaning it can load
 # external .so's.
-libfprint.overrideAttrs ({ postPatch ? "", mesonFlags ? [], ... }: let
-  version = "1.90.7+git20210222+tod1";
-in  {
+libfprint.overrideAttrs ({ postPatch ? "", mesonFlags ? [ ], ... }:
+let
+  version = "1.94.7+tod1";
+in
+{
   pname = "libfprint-tod";
   inherit version;
 
@@ -16,21 +18,14 @@ in  {
     owner = "3v1n0";
     repo = "libfprint";
     rev = "v${version}";
-    sha256 = "0cj7iy5799pchyzqqncpkhibkq012g3bdpn18pfb19nm43svhn4j";
+    sha256 = "sha256-q6m/J5GH86/z/mKnrYoanhKWR7+reKIRHqhDOUkknFA=";
   };
 
-  mesonFlags = [
-    # Include virtual drivers for fprintd tests
-    "-Ddrivers=all"
-    "-Dudev_hwdb_dir=${placeholder "out"}/lib/udev/hwdb.d"
+  patches = [
+    # TODO: try fixing the check
+    # https://gitlab.freedesktop.org/3v1n0/libfprint/-/commit/8e7e5bf7104df691217eda520b727470045cafcd
+    ./revert-8e7e5bf7104df691217eda520b727470045cafcd.patch
   ];
-
-
-  postPatch = ''
-    ${postPatch}
-    patchShebangs ./tests/*.py ./tests/*.sh
-  '';
-
 
   meta = with lib; {
     homepage = "https://gitlab.freedesktop.org/3v1n0/libfprint";

--- a/pkgs/development/libraries/libfprint-tod/revert-8e7e5bf7104df691217eda520b727470045cafcd.patch
+++ b/pkgs/development/libraries/libfprint-tod/revert-8e7e5bf7104df691217eda520b727470045cafcd.patch
@@ -1,0 +1,99 @@
+commit 08c9c9980dd7628d6db4baeed57982ce9bf8212e
+Author: Yurii Matsiuk <24990891+ymatsiuk@users.noreply.github.com>
+Date:   Thu Jul 18 11:49:38 2024 +0200
+
+    Revert "tests: Add tests to ensure that we don't duplicate symbols in libraries"
+    
+    This reverts commit 8e7e5bf7104df691217eda520b727470045cafcd.
+
+diff --git a/libfprint/tod/tests/check-library-symbols.sh b/libfprint/tod/tests/check-library-symbols.sh
+deleted file mode 100755
+index 61f44c3..0000000
+--- a/libfprint/tod/tests/check-library-symbols.sh
++++ /dev/null
+@@ -1,65 +0,0 @@
+-#!/bin/bash
+-
+-library1=$1
+-library2=$2
+-
+-function cleanup_results() {
+-    grep -F -w '.text' | cut -s -f2 | awk '{print $(NF)}'
+-}
+-
+-function dump_exported_symbols() {
+-    objdump -TC "$1" | cleanup_results
+-}
+-
+-function dump_defined_symbols() {
+-    objdump -t "$1" | cleanup_results
+-}
+-
+-function in_array() {
+-  local target=$1
+-  shift
+-
+-  local i;
+-  for i in "$@"; do
+-    if [[ "$i" == "$target" ]]; then
+-        return 0
+-    fi
+-  done
+-
+-  return 1
+-}
+-
+-function is_fatal() {
+-    if [[ "$1" == "fp_"* ]] || [[ "$1" == "fpi_"* ]]; then
+-        return 0
+-    fi
+-    return 1
+-}
+-
+-lib1_exported=($(dump_exported_symbols "$library1"))
+-lib2_exported=($(dump_exported_symbols "$library2"))
+-
+-lib1_defined=("$(dump_defined_symbols "$library1")")
+-lib2_defined=("$(dump_defined_symbols "$library2")")
+-
+-valid=true
+-
+-for f in ${lib1_exported[*]}; do
+-    if in_array "$f" ${lib2_exported[*]}; then
+-        echo "$f function exported in both $library1 and $library2"
+-        if is_fatal "$f"; then
+-            valid=false
+-        fi
+-    fi
+-done
+-
+-for f in ${lib1_defined[*]}; do
+-    if in_array "$f" ${lib2_defined[*]}; then
+-        echo "$f function defined in both $library1 and $library2"
+-        if is_fatal "$f"; then
+-            valid=false
+-        fi
+-    fi
+-done
+-
+-[[ "$valid" == true ]] && exit 0
+diff --git a/tests/meson.build b/tests/meson.build
+index db61c1b..32d993a 100644
+--- a/tests/meson.build
++++ b/tests/meson.build
+@@ -557,15 +557,4 @@ if get_option('tod')
+             )
+         endif
+     endforeach
+-
+-    if find_program('objdump', required: false).found()
+-        check_libs_symbols = find_program(meson.source_root() /
+-            'libfprint/tod/tests/check-library-symbols.sh')
+-        test('check-tod-lib-sybmbols',
+-            check_libs_symbols,
+-            args: [libfprint.full_path(), libfprint_tod.full_path()],
+-            depends: [libfprint, libfprint_tod],
+-            suite: ['abi-check', tod_suites ],
+-        )
+-    endif
+ endif

--- a/pkgs/tools/security/fprintd/tod.nix
+++ b/pkgs/tools/security/fprintd/tod.nix
@@ -1,50 +1,20 @@
 { lib
 , fetchFromGitLab
-, fetchpatch
 , fprintd
 , libfprint-tod
 }:
 
 (fprintd.override { libfprint = libfprint-tod; }).overrideAttrs (oldAttrs: rec {
     pname = "fprintd-tod";
-    version = "1.90.9";
+    version = "1.94.3";
 
     src = fetchFromGitLab {
       domain = "gitlab.freedesktop.org";
       owner = "libfprint";
       repo = "fprintd";
       rev = "v${version}";
-      sha256 = "sha256-rOTVThHOY/Q2IIu2RGiv26UE2V/JFfWWnfKZQfKl5Mg=";
+      sha256 = "sha256-shH+ctQAx4fpTMWTmo3wB45ZS38Jf8RknryPabfZ6QE=";
     };
-
-    patches = oldAttrs.patches or [] ++ [
-      (fetchpatch {
-        name = "use-more-idiomatic-correct-embedded-shell-scripting";
-        url = "https://gitlab.freedesktop.org/libfprint/fprintd/-/commit/f4256533d1ffdc203c3f8c6ee42e8dcde470a93f.patch";
-        sha256 = "sha256-4uPrYEgJyXU4zx2V3gwKKLaD6ty0wylSriHlvKvOhek=";
-      })
-      (fetchpatch {
-        name = "remove-pointless-copying-of-files-into-build-directory";
-        url = "https://gitlab.freedesktop.org/libfprint/fprintd/-/commit/2c34cef5ef2004d8479475db5523c572eb409a6b.patch";
-        sha256 = "sha256-2pZBbMF1xjoDKn/jCAIldbeR2JNEVduXB8bqUrj2Ih4=";
-      })
-      (fetchpatch {
-        name = "build-Do-not-use-positional-arguments-in-i18n.merge_file";
-        url = "https://gitlab.freedesktop.org/libfprint/fprintd/-/commit/50943b1bd4f18d103c35233f0446ce7a31d1817e.patch";
-        sha256 = "sha256-ANkAq6fr0VRjkS0ckvf/ddVB2mH4b2uJRTI4H8vPPes=";
-      })
-      (fetchpatch {
-        name = "tests-Fix-dbusmock-AddDevice-calls-to-include-option";
-        url = "https://gitlab.freedesktop.org/libfprint/fprintd/-/commit/ae04fa989720279e5558c3b8ff9ebe1959b1cf36.patch";
-        sha256 = "sha256-jW5vlzrbZQ1gUDLBf7G50GnZfZxhlnL2Eu+9Bghdwdw=";
-      })
-    ];
-
-    postPatch = oldAttrs.postPatch or "" + ''
-      # part of "remove-pointless-copying-of-files-into-build-directory" but git-apply doesn't handle renaming
-      mv src/device.xml src/net.reactivated.Fprint.Device.xml
-      mv src/manager.xml src/net.reactivated.Fprint.Manager.xml
-    '';
 
     meta = {
       homepage = "https://fprint.freedesktop.org/";


### PR DESCRIPTION
## Description of changes

@hmenke I noticed you were porting changes from upstream `fprintd` to `fprintd-tod`. This PR should bring both fprintd-tod and libfprintd-tod to the latest upstream version. Please help me out with testing.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
