### PR TITLE
doc: fixup doc/build-helpers references

### DIFF
--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -1,12 +1,12 @@
 { pkgs, pkgsLinux, buildPackages, lib, callPackage, runCommand, stdenv, substituteAll, testers }:
-# Documentation is in doc/builders/testers.chapter.md
+# Documentation is in doc/build-helpers/testers.chapter.md
 {
   # See https://nixos.org/manual/nixpkgs/unstable/#tester-lycheeLinkCheck
-  # or doc/builders/testers.chapter.md
+  # or doc/build-helpers/testers.chapter.md
   inherit (callPackage ./lychee.nix {}) lycheeLinkCheck;
 
   # See https://nixos.org/manual/nixpkgs/unstable/#tester-testBuildFailure
-  # or doc/builders/testers.chapter.md
+  # or doc/build-helpers/testers.chapter.md
   testBuildFailure = drv: drv.overrideAttrs (orig: {
     builder = buildPackages.bash;
     args = [
@@ -16,11 +16,11 @@
   });
 
   # See https://nixos.org/manual/nixpkgs/unstable/#tester-testEqualDerivation
-  # or doc/builders/testers.chapter.md
+  # or doc/build-helpers/testers.chapter.md
   testEqualDerivation = callPackage ./test-equal-derivation.nix { };
 
   # See https://nixos.org/manual/nixpkgs/unstable/#tester-testEqualContents
-  # or doc/builders/testers.chapter.md
+  # or doc/build-helpers/testers.chapter.md
   testEqualContents = {
     assertion,
     actual,
@@ -58,7 +58,7 @@
   '';
 
   # See https://nixos.org/manual/nixpkgs/unstable/#tester-testVersion
-  # or doc/builders/testers.chapter.md
+  # or doc/build-helpers/testers.chapter.md
   testVersion =
     { package,
       command ? "${package.meta.mainProgram or package.pname or package.name} --version",
@@ -81,8 +81,8 @@
       fi
     '';
 
-  # See doc/builders/testers.chapter.md or
-  # https://nixos.org/manual/nixpkgs/unstable/#tester-invalidateFetcherByDrvHash
+  # See https://nixos.org/manual/nixpkgs/unstable/#tester-invalidateFetcherByDrvHash
+  # or doc/build-helpers/testers.chapter.md
   invalidateFetcherByDrvHash = f: args:
     let
       drvPath = (f args).drvPath;
@@ -98,8 +98,8 @@
         else salted;
     in checked;
 
-  # See doc/builders/testers.chapter.md or
-  # https://nixos.org/manual/nixpkgs/unstable/#tester-runNixOSTest
+  # See https://nixos.org/manual/nixpkgs/unstable/#tester-runNixOSTest
+  # or doc/build-helpers/testers.chapter.md
   runNixOSTest =
     let nixos = import ../../../nixos/lib {
       inherit lib;
@@ -114,8 +114,8 @@
           node.pkgs = pkgsLinux;
         };
 
-  # See doc/builders/testers.chapter.md or
-  # https://nixos.org/manual/nixpkgs/unstable/#tester-invalidateFetcherByDrvHash
+  # See https://nixos.org/manual/nixpkgs/unstable/#tester-invalidateFetcherByDrvHash
+  # or doc/build-helpers/testers.chapter.md
   nixosTest =
     let
       /* The nixos/lib/testing-python.nix module, preapplied with arguments that

--- a/pkgs/build-support/testers/lychee.nix
+++ b/pkgs/build-support/testers/lychee.nix
@@ -19,7 +19,7 @@ let
     '';
 
   # See https://nixos.org/manual/nixpkgs/unstable/#tester-lycheeLinkCheck
-  # or doc/builders/testers.chapter.md
+  # or doc/build-helpers/testers.chapter.md
   lycheeLinkCheck = {
     site,
     remap ? { },

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -586,7 +586,7 @@ rec {
   '';
 
 
-  # Docs in doc/builders/special/makesetuphook.section.md
+  # Docs in doc/build-helpers/special/makesetuphook.section.md
   # See https://nixos.org/manual/nixpkgs/unstable/#sec-pkgs.makeSetupHook
   makeSetupHook =
     { name ? lib.warn "calling makeSetupHook without passing a name is deprecated." "hook"


### PR DESCRIPTION
## Description of changes

This change updates comments referencing the actual documentation after #262648.

Also makes the format of these comments consistent in `pkgs/build-support/testers/default.nix`.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
