### PR TITLE
e2fsprogs: build fuse2fs on darwin

### DIFF
--- a/pkgs/tools/filesystems/e2fsprogs/default.nix
+++ b/pkgs/tools/filesystems/e2fsprogs/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, buildPackages, fetchurl, fetchpatch, pkg-config, libuuid, gettext, texinfo
-, withFuse ? stdenv.isLinux, fuse3
+, withFuse ? stdenv.isLinux || stdenv.isDarwin, fuse3, macfuse-stubs
 , shared ? !stdenv.hostPlatform.isStatic
 , e2fsprogs, runCommand
 }:
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ pkg-config texinfo ];
   buildInputs = [ libuuid gettext ]
-    ++ lib.optionals withFuse [ fuse3 ];
+    ++ lib.optional withFuse (if stdenv.isDarwin then macfuse-stubs else fuse3);
 
   patches = [
     # Avoid trouble with older systems like NixOS 23.05.
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
       url = "https://lore.kernel.org/linux-ext4/20240527091542.4121237-2-hi@alyssa.is/raw";
       hash = "sha256-pMoqm2eo5zYaTdU+Ppa4+posCVFb2A9S4uo5oApaaqc=";
     })
-  ];
+  ] ++ lib.optional stdenv.isDarwin ./macfuse.patch;
 
   configureFlags =
     if stdenv.isLinux then [
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
       "--disable-uuidd"
     ] else [
       "--enable-libuuid --disable-e2initrd-helper"
-    ];
+    ] ++ lib.optional stdenv.isDarwin "CFLAGS=-D_FILE_OFFSET_BITS=64";
 
   nativeCheckInputs = [ buildPackages.perl ];
   doCheck = true;

--- a/pkgs/tools/filesystems/e2fsprogs/macfuse.patch
+++ b/pkgs/tools/filesystems/e2fsprogs/macfuse.patch
@@ -1,0 +1,20 @@
+--- a/misc/fuse2fs.c
++++ b/misc/fuse2fs.c
+@@ -2441,7 +2441,7 @@
+ #undef XATTR_TRANSLATOR
+
+ static int op_getxattr(const char *path, const char *key, char *value,
+-		       size_t len)
++		       size_t len, uint32_t position EXT2FS_ATTR((unused)))
+ {
+ 	struct fuse_context *ctxt = fuse_get_context();
+ 	struct fuse2fs *ff = (struct fuse2fs *)ctxt->private_data;
+@@ -2623,7 +2623,7 @@
+
+ static int op_setxattr(const char *path EXT2FS_ATTR((unused)),
+ 		       const char *key, const char *value,
+-		       size_t len, int flags EXT2FS_ATTR((unused)))
++		       size_t len, int flags EXT2FS_ATTR((unused)), uint32_t position EXT2FS_ATTR((unused)))
+ {
+ 	struct fuse_context *ctxt = fuse_get_context();
+ 	struct fuse2fs *ff = (struct fuse2fs *)ctxt->private_data;


### PR DESCRIPTION
## Description of changes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
