### PR TITLE
python3Packages.setuptools, thrift: Fix setuptools to give thrift python 3.12 support

### DIFF
--- a/pkgs/development/python-modules/setuptools/default.nix
+++ b/pkgs/development/python-modules/setuptools/default.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   python,
   wheel,
+  fetchpatch,
 }:
 
 buildPythonPackage rec {
@@ -22,6 +23,13 @@ buildPythonPackage rec {
   patches = [
     ./tag-date.patch
     ./setuptools-distutils-C++.patch
+    (fetchpatch {
+      # PR: https://github.com/pypa/setuptools/pull/4484
+      # Fix error, ModuleNotFoundError: No module named 'distutils', for function byte_compile
+      name = "fix-byte-complie.patch";
+      url = "https://patch-diff.githubusercontent.com/raw/pypa/setuptools/pull/4484.patch";
+      sha256 = "sha256-gVE/D/w8cTRh2GMFDs6XeNprtpVitMNNmgo0e0Zz33k=";
+    })
   ];
 
   nativeBuildInputs = [ wheel ];

--- a/pkgs/development/python-modules/thrift/default.nix
+++ b/pkgs/development/python-modules/thrift/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonAtLeast,
   pythonOlder,
   setuptools,
   six,
@@ -13,8 +12,7 @@ buildPythonPackage rec {
   version = "0.20.0";
   pyproject = true;
 
-  # Still uses distutils
-  disabled = pythonOlder "3.7" || pythonAtLeast "3.12";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
## Description of changes
The python package `thrift` is broken for python 3.12. The reason is that `thrift` use `distutils` that was removed in 3.12, to build.

But `setuptools` give backwards compatibility for `distutils`. But it was a bug in `setuptools` that broke the build process for `thrift`. 

See PR in `setuptools`, that we use as a patch in `setuptools` to solve the problem: https://github.com/pypa/setuptools/pull/4484

One concern, since this touches `setuptools` that many python packages depend on, implies big rebuild. 

Is this something we will backport to 24.05 to give python.3.12 support for `thrift`?

This can maybe solve python 3.12 for other packages also. 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
