### PR TITLE
ci: update tooling

### DIFF
--- a/ci/pinned-nixpkgs.json
+++ b/ci/pinned-nixpkgs.json
@@ -1,4 +1,4 @@
 {
-  "rev": "cfb89a95f19bea461fc37228dc4d07b22fe617c2",
-  "sha256": "1yhsacvry6j8r02lk70p9dphjpi8lpzgq2qay8hiy4nqlys0mrch"
+  "rev": "521d48afa9ae596930a95325529df27fa7135ff5",
+  "sha256": "0a1pa5azw990narsfipdli1wng4nc3vhvrp00hb8v1qfchcq7dc9"
 }

--- a/ci/update-pinned-nixpkgs.sh
+++ b/ci/update-pinned-nixpkgs.sh
@@ -10,7 +10,8 @@ repo=https://github.com/nixos/nixpkgs
 branch=nixpkgs-unstable
 file=$SCRIPT_DIR/pinned-nixpkgs.json
 
-rev=$(git ls-remote "$repo" refs/heads/"$branch" | cut -f1)
+defaultRev=$(git ls-remote "$repo" refs/heads/"$branch" | cut -f1)
+rev=${1:-$defaultRev}
 sha256=$(nix-prefetch-url --unpack "$repo/archive/$rev.tar.gz" --name source)
 
 jq -n --arg rev "$rev" --arg sha256 "$sha256" '$ARGS.named' | tee /dev/stderr > $file


### PR DESCRIPTION
## Description of changes
Update the CI tooling to https://hydra.nixos.org/eval/1807730#tabs-inputs, which
notably contains some fixes for nixfmt: https://github.com/NixOS/nixfmt/pull/215

This is necessary for https://github.com/NixOS/nixpkgs/pull/322537, ping @NixOS/nix-formatting 

## Things done

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
