### PR TITLE
ifm: init at 4.0.2

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -54,6 +54,8 @@
 
 - [Apache Tika](https://github.com/apache/tika), a toolkit that detects and extracts metadata and text from over a thousand different file types. Available as [services.tika](option.html#opt-services.tika).
 
+- [Improved File Manager](https://github.com/misterunknown/ifm), or IFM, a single-file web-based file manager.
+
 ## Backward Incompatibilities {#sec-release-24.11-incompatibilities}
 
 - `transmission` package has been aliased with a `trace` warning to `transmission_3`. Since [Transmission 4 has been released last year](https://github.com/transmission/transmission/releases/tag/4.0.0), and Transmission 3 will eventually go away, it was decided perform this warning alias to make people aware of the new version. The `services.transmission.package` defaults to `transmission_3` as well because the upgrade can cause data loss in certain specific usage patterns (examples: [#5153](https://github.com/transmission/transmission/issues/5153), [#6796](https://github.com/transmission/transmission/issues/6796)). Please make sure to back up to your data directory per your usage:

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1403,6 +1403,7 @@
   ./services/web-apps/honk.nix
   ./services/web-apps/icingaweb2/icingaweb2.nix
   ./services/web-apps/icingaweb2/module-monitoring.nix
+  ./services/web-apps/ifm.nix
   ./services/web-apps/invidious.nix
   ./services/web-apps/invoiceplane.nix
   ./services/web-apps/isso.nix

--- a/nixos/modules/services/web-apps/ifm.nix
+++ b/nixos/modules/services/web-apps/ifm.nix
@@ -1,0 +1,81 @@
+{ config, lib, pkgs, ...}:
+let
+  cfg = config.services.ifm;
+
+  version = "4.0.2";
+  src = pkgs.fetchurl {
+    url = "https://github.com/misterunknown/ifm/releases/download/v${version}/cdn.ifm.php";
+    hash = "sha256-37WbRM6D7JGmd//06zMhxMGIh8ioY8vRUmxX4OHgqBE=";
+  };
+
+  php = pkgs.php83;
+in {
+  options.services.ifm = {
+    enable = lib.mkEnableOption ''
+      Improved file manager, a single-file web-based filemanager
+
+      Lightweight and minimal, served using PHP's built-in server
+  '';
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      description = "Directory to serve throught the file managing service";
+    };
+
+    listenAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = "Address on which the service is listening";
+      example = "0.0.0.0";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 9090;
+      description = "Port on which to serve the IFM service";
+    };
+
+    settings = lib.mkOption {
+      type = with lib.types; attrsOf anything;
+      default = {};
+      description = ''
+        Configuration of the IFM service.
+
+        See [the documentation](https://github.com/misterunknown/ifm/wiki/Configuration)
+        for available options and default values.
+      '';
+      example = {
+        IFM_GUI_SHOWPATH = 0;
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.ifm = {
+      description = "Improved file manager, a single-file web based filemanager";
+
+      after = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      environment = {
+        IFM_ROOT_DIR = "/data";
+      } // (builtins.mapAttrs (_: val: toString val) cfg.settings);
+
+      script = ''
+        mkdir -p /tmp/ifm
+        ln -s ${src} /tmp/ifm/index.php
+        ${lib.getExe php} -S ${cfg.listenAddress}:${builtins.toString cfg.port} -t /tmp/ifm
+      '';
+
+      serviceConfig = {
+        DynamicUser = true;
+        User = "ifm";
+        StandardOutput = "journal";
+        BindPaths = "${cfg.dataDir}:/data";
+        PrivateTmp = true;
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ litchipi ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -439,6 +439,7 @@ in {
   hydra = handleTest ./hydra {};
   i3wm = handleTest ./i3wm.nix {};
   icingaweb2 = handleTest ./icingaweb2.nix {};
+  ifm = handleTest ./ifm.nix {};
   iftop = handleTest ./iftop.nix {};
   incron = handleTest ./incron.nix {};
   incus = pkgs.recurseIntoAttrs (handleTest ./incus { inherit handleTestOn; inherit (pkgs) incus; });

--- a/nixos/tests/ifm.nix
+++ b/nixos/tests/ifm.nix
@@ -1,0 +1,36 @@
+import ./make-test-python.nix ({ pkgs, ...} :
+
+{
+  name = "ifm";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ litchipi ];
+  };
+
+  nodes = {
+    server = rec {
+      services.ifm = {
+        enable = true;
+        port = 9001;
+        dataDir = "/data";
+      };
+
+      system.activationScripts.ifm-setup-dir = ''
+        mkdir -p ${services.ifm.dataDir}
+        chmod u+w,g+w,o+w ${services.ifm.dataDir}
+      '';
+    };
+  };
+
+  testScript = ''
+    start_all()
+    server.wait_for_unit("ifm.service")
+    server.wait_for_open_port(9001)
+    server.succeed("curl --fail http://localhost:9001")
+
+    server.succeed("echo \"testfile\" > testfile && shasum testfile >> checksums")
+    server.succeed("curl --fail http://localhost:9001 -X POST -F \"api=upload\" -F \"dir=\" -F \"file=@testfile\" | grep \"OK\"");
+    server.succeed("rm testfile")
+    server.succeed("curl --fail http://localhost:9001 -X POST -F \"api=download\" -F \"filename=testfile\" -F \"dir=\" --output testfile");
+    server.succeed("shasum testfile >> checksums && shasum --check checksums")
+  '';
+})


### PR DESCRIPTION
## Description of changes

Create a web-app module for a single-file service called IFM for Improved File Manager.

See homepage here: https://github.com/misterunknown/ifm

I thought it wasn't worth a package (as it's just downloading a file), so only the module is done here.

Not really familiar with PHP's web server, so I don't know if that's an acceptable way to serve the PHP file, or if we should set up a nginx / caddy / whatever in the module as a replacement.

For security purposes, the systemd service is isolated, and only has a bind mount access to the `dataDir` provided in the configuration.

Didn't test the advanced configuration as described here: https://github.com/misterunknown/ifm/wiki/Configuration, particularly the authentication, but as it's not very "bound" to the operating system (except ldap), it should not break.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
