### PR TITLE
testers.testEqualContents: use diffoscope instead of diffing find output

### DIFF
--- a/pkgs/build-support/testers/test/default.nix
+++ b/pkgs/build-support/testers/test/default.nix
@@ -99,19 +99,35 @@ lib.recurseIntoAttrs {
   };
 
   testEqualContents = lib.recurseIntoAttrs {
-    happy = testers.testEqualContents {
+    equalDir = testers.testEqualContents {
       assertion = "The same directory contents at different paths are recognized as equal";
       expected = runCommand "expected" {} ''
         mkdir -p $out/c
         echo a >$out/a
         echo b >$out/b
         echo d >$out/c/d
+        echo e >$out/e
+        chmod a+x $out/e
       '';
       actual = runCommand "actual" {} ''
         mkdir -p $out/c
         echo a >$out/a
         echo b >$out/b
         echo d >$out/c/d
+        echo e >$out/e
+        chmod a+x $out/e
+      '';
+    };
+
+    equalExe = testers.testEqualContents {
+      assertion = "The same executable file contents at different paths are recognized as equal";
+      expected = runCommand "expected" { } ''
+        echo test >$out
+        chmod a+x $out
+      '';
+      actual = runCommand "actual" { } ''
+        echo test >$out
+        chmod a+x $out
       '';
     };
 

--- a/pkgs/build-support/testers/test/default.nix
+++ b/pkgs/build-support/testers/test/default.nix
@@ -1,4 +1,4 @@
-{ testers, lib, pkgs, hello, runCommand, ... }:
+{ testers, lib, pkgs, hello, runCommand, emptyFile, emptyDirectory, ... }:
 let
   pkgs-with-overlay = pkgs.extend(final: prev: {
     proof-of-overlay-hello = prev.hello;
@@ -101,131 +101,133 @@ lib.recurseIntoAttrs {
   testEqualContents = lib.recurseIntoAttrs {
     equalDir = testers.testEqualContents {
       assertion = "The same directory contents at different paths are recognized as equal";
-      expected = runCommand "expected" {} ''
-        mkdir -p $out/c
-        echo a >$out/a
-        echo b >$out/b
-        echo d >$out/c/d
-        echo e >$out/e
-        chmod a+x $out/e
+      expected = runCommand "expected" { } ''
+        mkdir -p -- "$out/c"
+        echo a >"$out/a"
+        echo b >"$out/b"
+        echo d >"$out/c/d"
+        echo e >"$out/e"
+        chmod a+x -- "$out/e"
       '';
-      actual = runCommand "actual" {} ''
-        mkdir -p $out/c
-        echo a >$out/a
-        echo b >$out/b
-        echo d >$out/c/d
-        echo e >$out/e
-        chmod a+x $out/e
+      actual = runCommand "actual" { } ''
+        mkdir -p -- "$out/c"
+        echo a >"$out/a"
+        echo b >"$out/b"
+        echo d >"$out/c/d"
+        echo e >"$out/e"
+        chmod a+x -- "$out/e"
       '';
     };
+
+    fileMissing = testers.testBuildFailure (
+      testers.testEqualContents {
+        assertion = "Directories with different file list are not recognized as equal";
+        expected = runCommand "expected" { } ''
+          mkdir -p -- "$out/c"
+          echo a >"$out/a"
+          echo b >"$out/b"
+          echo d >"$out/c/d"
+        '';
+        actual = runCommand "actual" { } ''
+          mkdir -p -- "$out/c"
+          echo a >"$out/a"
+          echo d >"$out/c/d"
+        '';
+      }
+    );
 
     equalExe = testers.testEqualContents {
       assertion = "The same executable file contents at different paths are recognized as equal";
       expected = runCommand "expected" { } ''
-        echo test >$out
-        chmod a+x $out
+        echo test >"$out"
+        chmod a+x -- "$out"
       '';
       actual = runCommand "actual" { } ''
-        echo test >$out
-        chmod a+x $out
+        echo test >"$out"
+        chmod a+x -- "$out"
       '';
     };
 
-    unequalExe =
-      runCommand "testEqualContents-unequalExe" {
-        log = testers.testBuildFailure (testers.testEqualContents {
-          assertion = "The same directory contents at different paths are recognized as equal";
-          expected = runCommand "expected" {} ''
-            mkdir -p $out/c
-            echo a >$out/a
-            chmod a+x $out/a
-            echo b >$out/b
-            echo d >$out/c/d
-          '';
-          actual = runCommand "actual" {} ''
-            mkdir -p $out/c
-            echo a >$out/a
-            echo b >$out/b
-            chmod a+x $out/b
-            echo d >$out/c/d
-          '';
-        });
-      } ''
-        (
-          set -x
-          grep -F -- "executable bits don't match" $log/testBuildFailure.log
-          grep -E -- '+.*-actual/a' $log/testBuildFailure.log
-          grep -E -- '-.*-actual/b' $log/testBuildFailure.log
-          grep -F -- "--- actual-executables" $log/testBuildFailure.log
-          grep -F -- "+++ expected-executables" $log/testBuildFailure.log
-        ) || {
-          echo "Test failed: could not find pattern in build log $log"
-          exit 1
-        }
-        echo 'All good.'
-        touch $out
-      '';
+    unequalExe = testers.testBuildFailure (
+      testers.testEqualContents {
+        assertion = "Different file mode bits are not recognized as equal";
+        expected = runCommand "expected" { } ''
+          touch -- "$out"
+          chmod a+x -- "$out"
+        '';
+        actual = runCommand "actual" { } ''
+          touch -- "$out"
+        '';
+      }
+    );
+
+    unequalExeInDir = testers.testBuildFailure (
+      testers.testEqualContents {
+        assertion = "Different file mode bits are not recognized as equal in directory";
+        expected = runCommand "expected" { } ''
+          mkdir -p -- "$out/a"
+          echo b >"$out/b"
+          chmod a+x -- "$out/b"
+        '';
+        actual = runCommand "actual" { } ''
+          mkdir -p -- "$out/a"
+          echo b >"$out/b"
+        '';
+      }
+    );
+
+    nonExistentPath = testers.testBuildFailure (
+      testers.testEqualContents {
+        assertion = "Non existent paths are not recognized as equal";
+        expected = "${emptyDirectory}/foo";
+        actual = "${emptyDirectory}/bar";
+      }
+    );
+
+    emptyFileAndDir = testers.testBuildFailure (
+      testers.testEqualContents {
+        assertion = "Empty file and directory are not recognized as equal";
+        expected = emptyFile;
+        actual = emptyDirectory;
+      }
+    );
 
     fileDiff =
-      runCommand "testEqualContents-fileDiff" {
-        log = testers.testBuildFailure (testers.testEqualContents {
-          assertion = "The same directory contents at different paths are recognized as equal";
-          expected = runCommand "expected" {} ''
-            mkdir -p $out/c
-            echo a >$out/a
-            echo b >$out/b
-            echo d >$out/c/d
-          '';
-          actual = runCommand "actual" {} ''
-            mkdir -p $out/c
-            echo a >$out/a
-            echo B >$out/b
-            echo d >$out/c/d
-          '';
-        });
-      } ''
+      let
+        log = testers.testBuildFailure (
+          testers.testEqualContents {
+            assertion = "Different files are not recognized as equal in subdirectories";
+            expected = runCommand "expected" { } ''
+              mkdir -p -- "$out/b"
+              echo a >"$out/a"
+              echo EXPECTED >"$out/b/c"
+            '';
+            actual = runCommand "actual" { } ''
+              mkdir -p "$out/b"
+              echo a >"$out/a"
+              echo ACTUAL >"$out/b/c"
+            '';
+          }
+        );
+      in
+      runCommand "testEqualContents-fileDiff" { inherit log; } ''
         (
           set -x
-          grep -F -- "Contents must be equal but were not" $log/testBuildFailure.log
-          grep -E -- '+++ .*-actual/b' $log/testBuildFailure.log
-          grep -E -- '--- .*-actual/b' $log/testBuildFailure.log
-          grep -F -- "-B" $log/testBuildFailure.log
-          grep -F -- "+b" $log/testBuildFailure.log
+          # Note: use `&&` operator to chain commands because errexit (set -e)
+          # does not work in this context (even when set explicitly and with
+          # inherit_errexit), otherwise the subshell exits with the status of
+          # the last run command and ignores preceding failures.
+          grep -F -- 'Contents must be equal, but were not!' "$log/testBuildFailure.log" &&
+          grep -E -- '\+\+\+ .*-expected/b/c' "$log/testBuildFailure.log" &&
+          grep -E -- '--- .*-actual/b/c' "$log/testBuildFailure.log" &&
+          grep -F -- -ACTUAL "$log/testBuildFailure.log" &&
+          grep -F -- +EXPECTED "$log/testBuildFailure.log"
         ) || {
           echo "Test failed: could not find pattern in build log $log"
-          exit 1
+          false
         }
         echo 'All good.'
-        touch $out
-      '';
-
-    fileMissing =
-      runCommand "testEqualContents-fileMissing" {
-        log = testers.testBuildFailure (testers.testEqualContents {
-          assertion = "The same directory contents at different paths are recognized as equal";
-          expected = runCommand "expected" {} ''
-            mkdir -p $out/c
-            echo a >$out/a
-            echo b >$out/b
-            echo d >$out/c/d
-          '';
-          actual = runCommand "actual" {} ''
-            mkdir -p $out/c
-            echo a >$out/a
-            echo d >$out/c/d
-          '';
-        });
-      } ''
-        (
-          set -x
-          grep -F -- "Contents must be equal but were not" $log/testBuildFailure.log
-          grep -E -- 'Only in .*-expected: b' $log/testBuildFailure.log
-        ) || {
-          echo "Test failed: could not find pattern in build log $log"
-          exit 1
-        }
-        echo 'All good.'
-        touch $out
+        touch -- "$out"
       '';
   };
 }


### PR DESCRIPTION
## Description of changes

Current implementation of `testers.testEqualContents` is borked in some cases (e.g. see 7671505abc42a02bc4821007119a6c29172e838e). This PR changes it to use [diffoscope](https://diffoscope.org) instead of diff‘ing find output to compare file mode 🫠

Tested with `nix build --file . tests.testers.testEqualContents`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
