### PR TITLE
simpleitk: 2.3.1 -> 2.4.0

### DIFF
--- a/pkgs/development/libraries/science/biology/elastix/default.nix
+++ b/pkgs/development/libraries/science/biology/elastix/default.nix
@@ -1,26 +1,35 @@
-{ lib, stdenv, fetchFromGitHub, cmake, itk, Cocoa }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  itk,
+  Cocoa,
+}:
 
-stdenv.mkDerivation rec {
-  pname    = "elastix";
-  version = "5.1.0";
+stdenv.mkDerivation (finalAttrs: {
+  pname = "elastix";
+  version = "5.2.0";
 
   src = fetchFromGitHub {
     owner = "SuperElastix";
-    repo = pname;
-    rev = version;
-    hash = "sha256-wFeLU8IwiF43a9TAvecQG+QMw88PQZdJ8sI1Zz3ZeXc=";
+    repo = "elastix";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-edUMj8sjku8EVYaktteIDS+ouaN3kg+CXQCeSWKlLDI=";
   };
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ itk ] ++ lib.optionals stdenv.isDarwin [ Cocoa ];
 
-  doCheck = !stdenv.isDarwin;  # usual dynamic linker issues
+  doCheck = !stdenv.isDarwin; # usual dynamic linker issues
 
   meta = with lib; {
     homepage = "https://elastix.lumc.nl";
     description = "Image registration toolkit based on ITK";
+    changelog = "https://github.com/SuperElastix/elastix/releases/tag/${finalAttrs.version}";
     maintainers = with maintainers; [ bcdarwin ];
-    platforms = platforms.x86_64;  # libitkpng linker issues with ITK 5.1
+    mainProgram = "elastix";
+    platforms = platforms.x86_64; # libitkpng linker issues with ITK 5.1
     license = licenses.asl20;
   };
-}
+})

--- a/pkgs/development/libraries/simpleitk/default.nix
+++ b/pkgs/development/libraries/simpleitk/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "simpleitk";
-  version = "2.3.1";
+  version = "2.4.0";
 
   src = fetchFromGitHub {
     owner = "SimpleITK";
     repo = "SimpleITK";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-JmZUlIdcCQ9yEqxoUwRaxvr/Q7xZm41QA3mtDtoSdyI=";
+    hash = "sha256-/FV5NAM9DJ54Vg6/5yn9DCybry+a8lS3fQ3HWLOeOTA=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
elastix: 5.1.0 -> 5.2.0

## Description of changes

elastix: Routine update and minor improvements (use finalAttrs style, update meta, run nixfmt). [changelog](https://github.com/SuperElastix/elastix/releases/tag/5.2.0)

simpleitk: bump version [changelog](https://github.com/SimpleITK/SimpleITK/releases/tag/v2.4.0)

nixpkgs-review happy (pydicom-seg is broken on master):

```
4 packages failed to build:

python311Packages.pydicom-seg python311Packages.pydicom-seg.dist python312Packages.pydicom-seg python312Packages.pydicom-seg.dist

24 packages built:

elastix python311Packages.intensity-normalization python311Packages.intensity-normalization.dist python311Packages.medpy python311Packages.medpy.dist python311Packages.pymedio python311Packages.pymedio.dist python311Packages.pyradiomics python311Packages.pyradiomics.dist python311Packages.simpleitk python311Packages.simpleitk.dist python311Packages.torchio python311Packages.torchio.dist python312Packages.medpy python312Packages.medpy.dist python312Packages.pymedio python312Packages.pymedio.dist python312Packages.pyradiomics python312Packages.pyradiomics.dist python312Packages.simpleitk python312Packages.simpleitk.dist python312Packages.torchio python312Packages.torchio.dist simpleitk
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
