### PR TITLE
nixos/etc: handle mountpoints on top of /etc when switching

### DIFF
--- a/nixos/tests/activation/etc-overlay-immutable.nix
+++ b/nixos/tests/activation/etc-overlay-immutable.nix
@@ -15,6 +15,11 @@
     boot.kernelPackages = pkgs.linuxPackages_latest;
     time.timeZone = "Utc";
 
+    environment.etc = {
+      "mountpoint/.keep".text = "keep";
+      "filemount".text = "keep";
+    };
+
     specialisation.new-generation.configuration = {
       environment.etc."newgen".text = "newgen";
     };
@@ -33,8 +38,17 @@
     with subtest("switching to a new generation"):
       machine.fail("stat /etc/newgen")
 
+      machine.succeed("mount -t tmpfs tmpfs /etc/mountpoint")
+      machine.succeed("touch /etc/mountpoint/extra-file")
+      machine.succeed("mount --bind /dev/null /etc/filemount")
+
       machine.succeed("/run/current-system/specialisation/new-generation/bin/switch-to-configuration switch")
 
       assert machine.succeed("cat /etc/newgen") == "newgen"
+
+      print(machine.succeed("findmnt /etc/mountpoint"))
+      print(machine.succeed("ls /etc/mountpoint"))
+      print(machine.succeed("stat /etc/mountpoint/extra-file"))
+      print(machine.succeed("findmnt /etc/filemount"))
   '';
 }

--- a/nixos/tests/activation/etc-overlay-mutable.nix
+++ b/nixos/tests/activation/etc-overlay-mutable.nix
@@ -28,9 +28,22 @@
       machine.fail("stat /etc/newgen")
       machine.succeed("echo -n 'mutable' > /etc/mutable")
 
+      # Directory
+      machine.succeed("mkdir /etc/mountpoint")
+      machine.succeed("mount -t tmpfs tmpfs /etc/mountpoint")
+      machine.succeed("touch /etc/mountpoint/extra-file")
+
+      # File
+      machine.succeed("touch /etc/filemount")
+      machine.succeed("mount --bind /dev/null /etc/filemount")
+
       machine.succeed("/run/current-system/specialisation/new-generation/bin/switch-to-configuration switch")
 
       assert machine.succeed("cat /etc/newgen") == "newgen"
       assert machine.succeed("cat /etc/mutable") == "mutable"
+
+      print(machine.succeed("findmnt /etc/mountpoint"))
+      print(machine.succeed("stat /etc/mountpoint/extra-file"))
+      print(machine.succeed("findmnt /etc/filemount"))
   '';
 }

--- a/pkgs/by-name/mo/move-mount-beneath/package.nix
+++ b/pkgs/by-name/mo/move-mount-beneath/package.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 }:
 
 stdenv.mkDerivation {
@@ -19,6 +20,15 @@ stdenv.mkDerivation {
     install -D move-mount $out/bin/move-mount
     runHook postInstall
   '';
+
+  patches = [
+    # Fix uninitialized variable in flags_attr, https://github.com/brauner/move-mount-beneath/pull/2
+    (fetchpatch {
+      name = "aarch64";
+      url = "https://github.com/brauner/move-mount-beneath/commit/0bd0b863f7b98608514d90d4f2a80a21ce2e6cd3.patch";
+      hash = "sha256-D3TttAT0aFqpYC8LuVnrkLwDcfVFOSeYzUDx6VqPu1Q=";
+    })
+  ];
 
   meta = {
     description = "Toy binary to illustrate adding a mount beneath an existing mount";


### PR DESCRIPTION

## Description of changes

Fixes #303262 #291398

Should also fix the error reported here: https://github.com/NixOS/nixpkgs/issues/303262#issuecomment-2108945906

The activation script that remounts the /etc overlay now handles other mount points on top of /etc by bind mounting them to the new temporary /etc overlay and then atomically revealing it.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
