### PR TITLE
python312Packages.brother-ql: switch to maintained fork

### DIFF
--- a/pkgs/development/python-modules/brother-ql/default.nix
+++ b/pkgs/development/python-modules/brother-ql/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
       (QL-500, QL-550, QL-570, QL-700, QL-710W, QL-720NW, QL-800, QL-820NWB, QL-1050 and more)
     '';
     homepage = "https://github.com/LunarEclipse363/brother_ql_next";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ grahamc ];
     mainProgram = "brother_ql";
   };

--- a/pkgs/development/python-modules/brother-ql/default.nix
+++ b/pkgs/development/python-modules/brother-ql/default.nix
@@ -16,13 +16,13 @@
 
 buildPythonPackage rec {
   pname = "brother-ql";
-  version = "0.11.1";
+  version = "0.11.2";
   format = "pyproject";
 
   src = fetchPypi {
     pname = "brother_ql_next";
     inherit version;
-    hash = "sha256-jG8OvzDy2+2OpdVVixNguLsSwRbSIyvVEbVvorcgxfU=";
+    hash = "sha256-3rTf+4W5KK7zSGIE3bBHXHE0hjyvpjB0IiEtbax6mkU=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/brother-ql/default.nix
+++ b/pkgs/development/python-modules/brother-ql/default.nix
@@ -1,7 +1,7 @@
 {
   fetchPypi,
-  fetchpatch,
   buildPythonPackage,
+  setuptools,
   future,
   packbits,
   pillow,
@@ -10,36 +10,30 @@
   mock,
   click,
   attrs,
+  jsons,
   lib,
 }:
 
 buildPythonPackage rec {
   pname = "brother-ql";
-  version = "0.9.4";
-  format = "setuptools";
+  version = "0.11.1";
+  format = "pyproject";
 
   src = fetchPypi {
-    pname = "brother_ql";
+    pname = "brother_ql_next";
     inherit version;
-    hash = "sha256-H1xXoDnwEsnCBDl/RwAB9267dINCHr3phdDLPGFOhmA=";
+    hash = "sha256-jG8OvzDy2+2OpdVVixNguLsSwRbSIyvVEbVvorcgxfU=";
   };
 
   propagatedBuildInputs = [
+    setuptools
     future
     packbits
     pillow
     pyusb
     click
     attrs
-  ];
-
-  patches = [
-    (fetchpatch {
-      # Make compatible with Pillow>=10.0; https://github.com/pklaus/brother_ql/pull/143
-      name = "brother-ql-pillow10-compat.patch";
-      url = "https://github.com/pklaus/brother_ql/commit/a7e1b94b41f3a6e0f8b365598bc34fb47ca95a6d.patch";
-      hash = "sha256-v3YhmsUWBwE/Vli1SbTQO8q1zbtWYI9iMlVFvz5sxmg=";
-    })
+    jsons
   ];
 
   meta = with lib; {
@@ -48,7 +42,7 @@ buildPythonPackage rec {
       Python package for the raster language protocol of the Brother QL series label printers
       (QL-500, QL-550, QL-570, QL-700, QL-710W, QL-720NW, QL-800, QL-820NWB, QL-1050 and more)
     '';
-    homepage = "https://github.com/pklaus/brother_ql";
+    homepage = "https://github.com/LunarEclipse363/brother_ql_next";
     license = licenses.gpl3;
     maintainers = with maintainers; [ grahamc ];
     mainProgram = "brother_ql";

--- a/pkgs/development/python-modules/brother-ql/default.nix
+++ b/pkgs/development/python-modules/brother-ql/default.nix
@@ -17,7 +17,7 @@
 buildPythonPackage rec {
   pname = "brother-ql";
   version = "0.11.2";
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "brother_ql_next";


### PR DESCRIPTION
## Description of changes

Switches upstream to https://github.com/LunarEclipse363/brother_ql_next, and makes the appropriate changes to version, format, and dependencies to follow upstream's changes.

This fork incorporates the pillow patch that was previously required, so it has been removed.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
