### PR TITLE
terraspace: 2.2.8 -> 2.2.17

### DIFF
--- a/pkgs/applications/networking/cluster/terraspace/Gemfile
+++ b/pkgs/applications/networking/cluster/terraspace/Gemfile
@@ -1,2 +1,2 @@
 source "https://rubygems.org"
-gem "terraspace", '~> 2.2.8'
+gem "terraspace"

--- a/pkgs/applications/networking/cluster/terraspace/Gemfile.lock
+++ b/pkgs/applications/networking/cluster/terraspace/Gemfile.lock
@@ -1,36 +1,45 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.6)
+    activesupport (7.1.3.4)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
-    aws-eventstream (1.2.0)
-    aws-partitions (1.785.0)
-    aws-sdk-core (3.177.0)
-      aws-eventstream (~> 1, >= 1.0.2)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.956.0)
+    aws-sdk-core (3.201.1)
+      aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
-      aws-sigv4 (~> 1.5)
+      aws-sigv4 (~> 1.8)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.70.0)
-      aws-sdk-core (~> 3, >= 3.177.0)
-      aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.128.0)
-      aws-sdk-core (~> 3, >= 3.177.0)
+    aws-sdk-kms (1.88.0)
+      aws-sdk-core (~> 3, >= 3.201.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.156.0)
+      aws-sdk-core (~> 3, >= 3.201.0)
       aws-sdk-kms (~> 1)
-      aws-sigv4 (~> 1.6)
-    aws-sigv4 (1.6.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.8.0)
       aws-eventstream (~> 1, >= 1.0.2)
-    cli-format (0.2.2)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
+    cli-format (0.6.1)
       activesupport
       text-table
       zeitwerk
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.3.3)
+    connection_pool (2.4.1)
     deep_merge (1.2.2)
-    diff-lcs (1.5.0)
-    dotenv (2.8.1)
-    dsl_evaluator (0.3.1)
+    diff-lcs (1.5.1)
+    dotenv (3.1.2)
+    drb (2.2.1)
+    dsl_evaluator (0.3.2)
       activesupport
       memoist
       rainbow
@@ -38,40 +47,42 @@ GEM
     eventmachine (1.2.7)
     eventmachine-tail (0.6.5)
       eventmachine
-    graph (2.11.0)
+    graph (2.11.1)
     hcl_parser (0.2.2)
       rhcl
-    i18n (1.14.1)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     jmespath (1.6.2)
     memoist (0.16.2)
-    minitest (5.18.1)
-    nokogiri (1.15.3)
-      racc (~> 1.4)
+    mini_portile2 (2.8.7)
+    minitest (5.24.1)
+    mutex_m (0.2.0)
+    nokogiri (1.16.6)
       mini_portile2 (~> 2.8.2)
-    racc (1.7.1)
-    mini_portile2 (2.8.2)
+      racc (~> 1.4)
+    racc (1.8.0)
     rainbow (3.1.1)
     render_me_pretty (0.9.0)
       activesupport
       rainbow
       tilt
-    rexml (3.2.5)
+    rexml (3.3.2)
+      strscan
     rhcl (0.1.0)
       deep_merge
-    rspec (3.12.0)
-      rspec-core (~> 3.12.0)
-      rspec-expectations (~> 3.12.0)
-      rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.2)
-      rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.3)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.5)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-support (3.12.1)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
     rspec-terraspace (0.3.3)
       activesupport
       memoist
@@ -79,7 +90,8 @@ GEM
       rspec
       zeitwerk
     rubyzip (2.3.2)
-    terraspace (2.2.8)
+    strscan (3.1.0)
+    terraspace (2.2.17)
       activesupport
       bundler
       cli-format
@@ -110,20 +122,20 @@ GEM
       thor
       zeitwerk
     text-table (1.2.4)
-    thor (1.2.2)
-    tilt (2.2.0)
+    thor (1.3.1)
+    tilt (2.4.0)
     tty-tree (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.6.8)
+    zeitwerk (2.6.16)
     zip_folder (0.1.0)
       rubyzip
 
 PLATFORMS
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
-  terraspace (~> 2.2.8)
+  terraspace
 
 BUNDLED WITH
-   2.3.26
+   2.5.11

--- a/pkgs/applications/networking/cluster/terraspace/gemset.nix
+++ b/pkgs/applications/networking/cluster/terraspace/gemset.nix
@@ -1,34 +1,34 @@
 {
   activesupport = {
-    dependencies = ["concurrent-ruby" "i18n" "minitest" "tzinfo"];
+    dependencies = ["base64" "bigdecimal" "concurrent-ruby" "connection_pool" "drb" "i18n" "minitest" "mutex_m" "tzinfo"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1cjsf26656996hv48wgv2mkwxf0fy1qc68ikgzq7mzfq2mmvmayk";
+      sha256 = "0283wk1zxb76lg79dk501kcf5xy9h25qiw15m86s4nrfv11vqns5";
       type = "gem";
     };
-    version = "7.0.6";
+    version = "7.1.3.4";
   };
   aws-eventstream = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1pyis1nvnbjxk12a43xvgj2gv0mvp4cnkc1gzw0v1018r61399gz";
+      sha256 = "0gvdg4yx4p9av2glmp7vsxhs0n8fj1ga9kq2xdb8f95j7b04qhzi";
       type = "gem";
     };
-    version = "1.2.0";
+    version = "1.3.0";
   };
   aws-partitions = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "05m0c3h1z0jhaqiciil55fshrjvc725cf1lc0g933pf98vqflb0r";
+      sha256 = "03zb6x4x68y91gywsyi4a6hxy4pdyng8mnxwd858bhjfymml8kkf";
       type = "gem";
     };
-    version = "1.785.0";
+    version = "1.956.0";
   };
   aws-sdk-core = {
     dependencies = ["aws-eventstream" "aws-partitions" "aws-sigv4" "jmespath"];
@@ -36,10 +36,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "09firi4bin3ay4pd59qgxspq2f1isfi1li8rabpw6lvvbhnar168";
+      sha256 = "1ihl7iwndl3jjy89sh427wf8mdb7ii76bsjf6fkxq9ha30nz4f3g";
       type = "gem";
     };
-    version = "3.177.0";
+    version = "3.201.1";
   };
   aws-sdk-kms = {
     dependencies = ["aws-sdk-core" "aws-sigv4"];
@@ -47,10 +47,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1x73qj2c39ap926by14x56cjmp2cd5jpq5gv33xynypy1idyb0fj";
+      sha256 = "02g3l3lcyddqncrwjxgawxl33p2p715k1gbrdlgyiv0yvy88sn0k";
       type = "gem";
     };
-    version = "1.70.0";
+    version = "1.88.0";
   };
   aws-sdk-s3 = {
     dependencies = ["aws-sdk-core" "aws-sdk-kms" "aws-sigv4"];
@@ -58,10 +58,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "11cxk6b3p1bsl1gg3pi93qx2ynbjrrsrsc68nnqsjm4npvaj052v";
+      sha256 = "0ika0xmmrkc7jiwdi5gqia5wywkcbw1nal2dhl436dkh38fxl0lk";
       type = "gem";
     };
-    version = "1.128.0";
+    version = "1.156.0";
   };
   aws-sigv4 = {
     dependencies = ["aws-eventstream"];
@@ -69,10 +69,30 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0z889c4c1w7wsjm3szg64ay5j51kjl4pdf94nlr1yks2rlanm7na";
+      sha256 = "1g3w27wzjy4si6kp49w10as6ml6g6zl3xrfqs5ikpfciidv9kpc4";
       type = "gem";
     };
-    version = "1.6.0";
+    version = "1.8.0";
+  };
+  base64 = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "01qml0yilb9basf7is2614skjp8384h2pycfx86cr8023arfj98g";
+      type = "gem";
+    };
+    version = "0.2.0";
+  };
+  bigdecimal = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1gi7zqgmqwi5lizggs1jhc3zlwaqayy9rx2ah80sxy24bbnng558";
+      type = "gem";
+    };
+    version = "3.1.8";
   };
   cli-format = {
     dependencies = ["activesupport" "text-table" "zeitwerk"];
@@ -80,20 +100,30 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1mr8vkw5zwb3flhhf8s923mi7r85g1ky0lmjz4q5xhwb48ji55qf";
+      sha256 = "0rrjck5r25dlcg1gwz6pb5f4rllx77lg6a514a5l3lajfd95shm3";
       type = "gem";
     };
-    version = "0.2.2";
+    version = "0.6.1";
   };
   concurrent-ruby = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0krcwb6mn0iklajwngwsg850nk8k9b35dhmc2qkbdqvmifdi2y9q";
+      sha256 = "0skwdasxq7mnlcccn6aqabl7n9r3jd7k19ryzlzzip64cn4x572g";
       type = "gem";
     };
-    version = "1.2.2";
+    version = "1.3.3";
+  };
+  connection_pool = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1x32mcpm2cl5492kd6lbjbaf17qsssmpx9kdyr7z1wcif2cwyh0g";
+      type = "gem";
+    };
+    version = "2.4.1";
   };
   deep_merge = {
     groups = ["default"];
@@ -110,20 +140,30 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0rwvjahnp7cpmracd8x732rjgnilqv2sx7d1gfrysslc3h039fa9";
+      sha256 = "1znxccz83m4xgpd239nyqxlifdb7m8rlfayk6s259186nkgj6ci7";
       type = "gem";
     };
-    version = "1.5.0";
+    version = "1.5.1";
   };
   dotenv = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1n0pi8x8ql5h1mijvm8lgn6bhq4xjb5a500p5r1krq4s6j9lg565";
+      sha256 = "0y24jabiz4cf9ni9vi4j8sab8b5phpf2mpw3981r0r94l4m6q0q8";
       type = "gem";
     };
-    version = "2.8.1";
+    version = "3.1.2";
+  };
+  drb = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0h5kbj9hvg5hb3c7l425zpds0vb42phvln2knab8nmazg2zp5m79";
+      type = "gem";
+    };
+    version = "2.2.1";
   };
   dsl_evaluator = {
     dependencies = ["activesupport" "memoist" "rainbow" "zeitwerk"];
@@ -131,10 +171,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0mck2j0gr851kj9l7pix97jmmwwazfjq83ryamx5rpdbgv5mrh51";
+      sha256 = "0hd079baa5pfyyc2wc9p5h82qjp7fnx0s0shn2i19ig186cizh2x";
       type = "gem";
     };
-    version = "0.3.1";
+    version = "0.3.2";
   };
   eventmachine = {
     groups = ["default"];
@@ -162,10 +202,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "10l1bdqc9yzdk6kqwh9vw918lyw846gpqw2z8kfcwl53zdjdzcl9";
+      sha256 = "1bwssjgl9nfq9jhn9bfc7pqfl2c2xi0wnpng66l029m03kmdq8k4";
       type = "gem";
     };
-    version = "2.11.0";
+    version = "2.11.1";
   };
   hcl_parser = {
     dependencies = ["rhcl"];
@@ -184,10 +224,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0qaamqsh5f3szhcakkak8ikxlzxqnv49n2p7504hcz2l0f4nj0wx";
+      sha256 = "1ffix518y7976qih9k1lgnc17i3v6yrlh0a3mckpxdb4wc2vrp16";
       type = "gem";
     };
-    version = "1.14.1";
+    version = "1.14.5";
   };
   jmespath = {
     groups = ["default"];
@@ -214,20 +254,30 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0z7f38iq37h376n9xbl4gajdrnwzq284c9v1py4imw3gri2d5cj6";
+      sha256 = "1q1f2sdw3y3y9mnym9dhjgsjr72sq975cfg5c4yx7gwv8nmzbvhk";
       type = "gem";
     };
-    version = "2.8.2";
+    version = "2.8.7";
   };
   minitest = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1kg9wh7jlc9zsr3hkhpzkbn0ynf4np5ap9m2d8xdrb8shy0y6pmb";
+      sha256 = "0jj629q3vw5yn90q4di4dyb87pil4a8qfm2srhgy5nc8j2n33v1i";
       type = "gem";
     };
-    version = "5.18.1";
+    version = "5.24.1";
+  };
+  mutex_m = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1ma093ayps1m92q845hmpk0dmadicvifkbf05rpq9pifhin0rvxn";
+      type = "gem";
+    };
+    version = "0.2.0";
   };
   nokogiri = {
     dependencies = ["mini_portile2" "racc"];
@@ -235,20 +285,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1jw8a20a9k05fpz3q24im19b97idss3179z76yn5scc5b8lk2rl7";
+      sha256 = "1vz1ychq2fhfqjgqdrx8bqkaxg5dzcgwnah00m57ydylczfy8pwk";
       type = "gem";
     };
-    version = "1.15.3";
+    version = "1.16.6";
   };
   racc = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "11v3l46mwnlzlc371wr3x6yylpgafgwdf0q7hc7c1lzx6r414r5g";
+      sha256 = "021s7maw0c4d9a6s07vbmllrzqsj2sgmrwimlh8ffkvwqdjrld09";
       type = "gem";
     };
-    version = "1.7.1";
+    version = "1.8.0";
   };
   rainbow = {
     groups = ["default"];
@@ -272,14 +322,15 @@
     version = "0.9.0";
   };
   rexml = {
+    dependencies = ["strscan"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "08ximcyfjy94pm1rhcx04ny1vx2sk0x4y185gzn86yfsbzwkng53";
+      sha256 = "0zr5qpa8lampaqzhdcjcvyqnrqcjl7439mqjlkjz43wdhmpnh4s5";
       type = "gem";
     };
-    version = "3.2.5";
+    version = "3.3.2";
   };
   rhcl = {
     dependencies = ["deep_merge"];
@@ -298,10 +349,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "171rc90vcgjl8p1bdrqa92ymrj8a87qf6w20x05xq29mljcigi6c";
+      sha256 = "14xrp8vq6i9zx37vh0yp4h9m0anx9paw200l1r5ad9fmq559346l";
       type = "gem";
     };
-    version = "3.12.0";
+    version = "3.13.0";
   };
   rspec-core = {
     dependencies = ["rspec-support"];
@@ -309,10 +360,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0l95bnjxdabrn79hwdhn2q1n7mn26pj7y1w5660v5qi81x458nqm";
+      sha256 = "0k252n7s80bvjvpskgfm285a3djjjqyjcarlh3aq7a4dx2s94xsm";
       type = "gem";
     };
-    version = "3.12.2";
+    version = "3.13.0";
   };
   rspec-expectations = {
     dependencies = ["diff-lcs" "rspec-support"];
@@ -320,10 +371,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "05j44jfqlv7j2rpxb5vqzf9hfv7w8ba46wwgxwcwd8p0wzi1hg89";
+      sha256 = "0022nxs9gqfhx35n4klibig770n0j31pnkd8anz00yvrvkdghk41";
       type = "gem";
     };
-    version = "3.12.3";
+    version = "3.13.1";
   };
   rspec-mocks = {
     dependencies = ["diff-lcs" "rspec-support"];
@@ -331,20 +382,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1hfm17xakfvwya236graj6c2arr4sb9zasp35q5fykhyz8mhs0w2";
+      sha256 = "0f3vgp43hajw716vmgjv6f4ar6f97zf50snny6y3fy9kkj4qjw88";
       type = "gem";
     };
-    version = "3.12.5";
+    version = "3.13.1";
   };
   rspec-support = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1ky86j3ksi26ng9ybd7j0qsdf1lpr8mzrmn98yy9gzv801fvhsgr";
+      sha256 = "03z7gpqz5xkw9rf53835pa8a9vgj4lic54rnix9vfwmp2m7pv1s8";
       type = "gem";
     };
-    version = "3.12.1";
+    version = "3.13.1";
   };
   rspec-terraspace = {
     dependencies = ["activesupport" "memoist" "rainbow" "rspec" "zeitwerk"];
@@ -367,16 +418,26 @@
     };
     version = "2.3.2";
   };
+  strscan = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0mamrl7pxacbc79ny5hzmakc9grbjysm3yy6119ppgsg44fsif01";
+      type = "gem";
+    };
+    version = "3.1.0";
+  };
   terraspace = {
     dependencies = ["activesupport" "cli-format" "deep_merge" "dotenv" "dsl_evaluator" "eventmachine-tail" "graph" "hcl_parser" "memoist" "rainbow" "render_me_pretty" "rexml" "rspec-terraspace" "terraspace-bundler" "thor" "tty-tree" "zeitwerk" "zip_folder"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1zhcdaiq0sgk2gcy4krkzm4qrvcaibkf5n755qgqgcp1f1b0w6gl";
+      sha256 = "1zmnp71fwcj453cafmb8iicbk93flk98wh0wdk0q9xd3mgm3qh6x";
       type = "gem";
     };
-    version = "2.2.8";
+    version = "2.2.17";
   };
   terraspace-bundler = {
     dependencies = ["activesupport" "aws-sdk-s3" "dsl_evaluator" "memoist" "nokogiri" "rainbow" "rubyzip" "thor" "zeitwerk"];
@@ -404,20 +465,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0k7j2wn14h1pl4smibasw0bp66kg626drxb59z7rzflch99cd4rg";
+      sha256 = "1vq1fjp45az9hfp6fxljhdrkv75cvbab1jfrwcw738pnsiqk8zps";
       type = "gem";
     };
-    version = "1.2.2";
+    version = "1.3.1";
   };
   tilt = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0bmjgbv8158klwp2r3klxjwaj93nh1sbl4xvj9wsha0ic478avz7";
+      sha256 = "0kds7wkxmb038cwp6ravnwn8k65ixc68wpm8j5jx5bhx8ndg4x6z";
       type = "gem";
     };
-    version = "2.2.0";
+    version = "2.4.0";
   };
   tty-tree = {
     groups = ["default"];
@@ -445,10 +506,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0ck6bj7wa73dkdh13735jl06k6cfny98glxjkas82aivlmyzqqbk";
+      sha256 = "08cfb35232p9s1r4jqv8wacv38vxh699mgbr9y03ga89gx9lipqp";
       type = "gem";
     };
-    version = "2.6.8";
+    version = "2.6.16";
   };
   zip_folder = {
     dependencies = ["rubyzip"];


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`terraspace` pkg is currently broken for `aarch64-darwin` on `master`(ca15aff5f428ae9d6cd76f741068864d9e962e47) and `nixos-24.05`(53e81e790209e41f0c1efa9ff26ff2fd7ab35e27). It hasnt been updated in about a year.

Bumping to the latest release fixes the pkg. 

I also had to bump the package using the following method due to some existing issues with `bundle lock` including
architecture specific pre-built ruby packages (`nokogiri` specifically). Relates to https://github.com/nix-community/bundix/issues/88:

```
$ rm pkgs/applications/networking/cluster/terraspace/Gemfile.lock
$ export BUNDLE_FORCE_RUBY_PLATFORM="true"
$ nix-shell maintainers/scripts/update.nix --argstr package terraspace
```

Reproducing the build failure on `aarch64-darwin`:

```
nix-repl> :lf .
warning: Git tree '/Users/robert.hernandez/workspace/cloudinfra' is dirty
Added 20 variables.

nix-repl> :b inputs.nixpkgs.legacyPackages.aarch64-darwin.terraspace
warning: Nix search path entry '/nix/var/nix/profiles/per-user/root/channels' does not exist, ignoring
error: builder for '/nix/store/0jr1749dk5ddar9x2n69ysagdj068245-ruby3.1-nokogiri-1.15.3.drv' failed with exit code 1;
       last 10 log lines:
       > /nix/store/h7xrhgdyy68lxxgybxjcnjg71r2xwqv9-libxml2-2.12.7-dev/include/libxml2/libxml/xmlerror.h:898:29: note: passing argument to parameter 'handler' here
       >                                  xmlStructuredErrorFunc handler);
       >                                                         ^
       > 2 errors generated.
       > make: *** [Makefile:247: html4_document.o] Error 1
       >
       > make failed, exit code 2
       >
       > Gem files will remain installed in /nix/store/p69v1hf4ykqvaf92h1mb1jhxazv7cs70-ruby3.1-nokogiri-1.15.3/lib/ruby/gems/3.1.0/gems/nokogiri-1.15.3 for inspection.
       > Results logged to /nix/store/p69v1hf4ykqvaf92h1mb1jhxazv7cs70-ruby3.1-nokogiri-1.15.3/lib/ruby/gems/3.1.0/extensions/arm64-darwin-23/3.1.0/nokogiri-1.15.3/gem_make.out
       For full logs, run 'nix log /nix/store/0jr1749dk5ddar9x2n69ysagdj068245-ruby3.1-nokogiri-1.15.3.drv'.
error: 1 dependencies of derivation '/nix/store/kigmgvma1gic7jvngv1klim9g9jcl9p7-terraspace.drv' failed to build
error: 1 dependencies of derivation '/nix/store/c77q25lil7cm9pf3bvf1g1yc97gbgmq3-terraspace-2.2.8.drv' failed to build
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
