### PR TITLE
tio: 2.8 -> 3.5; migrate to by-name and modernize

### DIFF
--- a/pkgs/by-name/ti/tio/package.nix
+++ b/pkgs/by-name/ti/tio/package.nix
@@ -1,13 +1,13 @@
 { lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, glib, inih, lua, bash-completion, darwin }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tio";
   version = "3.5";
 
   src = fetchFromGitHub {
     owner = "tio";
     repo = "tio";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-3d3TYHSERIQdw+Iw6qCydGpWRpWrhZwb4SnwV1nVtIk=";
   };
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     homepage = "https://tio.github.io/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ yana ];
-    platforms = platforms.unix;
     mainProgram = "tio";
+    platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/ti/tio/package.nix
+++ b/pkgs/by-name/ti/tio/package.nix
@@ -1,4 +1,16 @@
-{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, glib, inih, lua, bash-completion, darwin }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  glib,
+  inih,
+  lua,
+  bash-completion,
+  darwin,
+}:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tio";
@@ -13,10 +25,18 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  buildInputs = [ inih lua glib ]
-    ++ lib.optionals (stdenv.hostPlatform.isDarwin) [ darwin.apple_sdk.frameworks.IOKit ];
+  buildInputs = [
+    inih
+    lua
+    glib
+  ] ++ lib.optionals (stdenv.hostPlatform.isDarwin) [ darwin.apple_sdk.frameworks.IOKit ];
 
-  nativeBuildInputs = [ meson ninja pkg-config bash-completion ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    bash-completion
+  ];
 
   meta = with lib; {
     description = "Serial console TTY";

--- a/pkgs/tools/misc/tio/default.nix
+++ b/pkgs/tools/misc/tio/default.nix
@@ -1,19 +1,19 @@
-{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, inih, lua, bash-completion, darwin }:
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, glib, inih, lua, bash-completion, darwin }:
 
 stdenv.mkDerivation rec {
   pname = "tio";
-  version = "2.8";
+  version = "3.5";
 
   src = fetchFromGitHub {
     owner = "tio";
     repo = "tio";
     rev = "v${version}";
-    hash = "sha256-BBfLmRhbDeymXXlYp71XTwbAab7h7gJ842fzZJNb6kU=";
+    hash = "sha256-3d3TYHSERIQdw+Iw6qCydGpWRpWrhZwb4SnwV1nVtIk=";
   };
 
   strictDeps = true;
 
-  buildInputs = [ inih lua ]
+  buildInputs = [ inih lua glib ]
     ++ lib.optionals (stdenv.hostPlatform.isDarwin) [ darwin.apple_sdk.frameworks.IOKit ];
 
   nativeBuildInputs = [ meson ninja pkg-config bash-completion ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13411,8 +13411,6 @@ with pkgs;
 
   timer = callPackage ../tools/misc/timer { };
 
-  tio = callPackage ../tools/misc/tio { };
-
   tiv = callPackage ../applications/misc/tiv { };
 
   tkman = callPackage ../tools/misc/tkman { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* Update to [3.5](https://github.com/tio/tio/releases/tag/v3.5)
* Modernize by
  - using `finalAttrs` over `rec`
  - moving to pkgs/by-name
  - formatting using [nixfmt](http://github.com/NixOS/nixfmt)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
