### PR TITLE
gnu-cobol: 3.1.2 -> 3.2

### DIFF
--- a/pkgs/development/compilers/gnu-cobol/default.nix
+++ b/pkgs/development/compilers/gnu-cobol/default.nix
@@ -4,6 +4,7 @@
 , autoconf269
 , automake
 , libtool
+, pkg-config
 # libs
 , cjson
 , db
@@ -20,14 +21,15 @@
 
 stdenv.mkDerivation rec {
   pname = "gnu-cobol";
-  version = "3.1.2";
+  version = "3.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/gnucobol/${lib.versions.majorMinor version}/gnucobol-${version}.tar.xz";
-    sha256 = "0x15ybfm63g7c9340fc6712h9v59spnbyaz4rf85pmnp3zbhaw2r";
+    hash = "sha256-O7SK9GztR3n6z0H9wu5g5My4bqqZ0BCzZoUxXfOcLuI=";
   };
 
   nativeBuildInputs = [
+    pkg-config
     autoconf269
     automake
     libtool
@@ -51,13 +53,26 @@ stdenv.mkDerivation rec {
   # Skips a broken test
   postPatch = ''
     sed -i '/^AT_CHECK.*crud\.cob/i AT_SKIP_IF([true])' tests/testsuite.src/listings.at
+    # upstream reports the following tests as known failures
+    # test 843:
+    sed -i '14180i\AT_SKIP_IF([true])' tests/testsuite.src/run_misc.at
+    # test 875:
+    sed -i '2894s/^/AT_SKIP_IF([true])/' tests/testsuite.src/run_file.at
   '';
 
   preConfigure = ''
     autoconf
     aclocal
     automake
+  '' + lib.optionalString stdenv.isDarwin ''
+    # when building with nix on darwin, configure will use GNU strip,
+    # which fails due to using --strip-unneeded, which is not supported
+    substituteInPlace configure --replace-fail '"GNU strip"' 'FAKE GNU strip'
   '';
+
+  # error: call to undeclared function 'xmlCleanupParser'
+  # ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
+  env.CFLAGS = lib.optionalString stdenv.isDarwin "-Wno-error=implicit-function-declaration";
 
   enableParallelBuilding = true;
 
@@ -71,7 +86,7 @@ stdenv.mkDerivation rec {
     runHook preInstallCheck
 
     # Run tests
-    make -j$NIX_BUILD_CORES check
+    TESTSUITEFLAGS="--jobs=$NIX_BUILD_CORES" make check
 
     # Sanity check
     message="Hello, COBOL!"

--- a/pkgs/development/compilers/gnu-cobol/default.nix
+++ b/pkgs/development/compilers/gnu-cobol/default.nix
@@ -111,7 +111,7 @@ stdenv.mkDerivation rec {
     description = "Open-source COBOL compiler";
     homepage = "https://sourceforge.net/projects/gnucobol/";
     license = with licenses; [ gpl3Only lgpl3Only ];
-    maintainers = with maintainers; [ ericsagnes lovesegfault ];
+    maintainers = with maintainers; [ ericsagnes lovesegfault techknowlogick ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
## Description of changes

See "NEWS" on this page https://sourceforge.net/projects/gnucobol/files/ for changelog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
