### PR TITLE
msecli: init at 10.01.012024.00

### DIFF
--- a/pkgs/by-name/ms/msecli/package.nix
+++ b/pkgs/by-name/ms/msecli/package.nix
@@ -1,0 +1,65 @@
+{
+  autoPatchelfHook,
+  buildFHSEnv,
+  fetchurl,
+  lib,
+  stdenv,
+  zlib,
+}:
+
+let
+  pname = "msecli";
+  version = "10.01.012024.00";
+
+  src = fetchurl {
+    url = "https://web.archive.org/web/20240916144249/https://www.micron.com/content/dam/micron/global/public/products/software/storage-executive-software/msecli/msecli-linux.run";
+    hash = "sha256-IszdD/9fAh+JA26bSR1roXSo8LDU/rf4CuRI3HjU1xc=";
+  };
+
+  buildEnv = buildFHSEnv { name = "msecli-buildEnv"; };
+in
+stdenv.mkDerivation {
+  inherit pname version src;
+
+  buildInputs = [ zlib ];
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    cp "$src" ${src.name}
+    chmod +x ${src.name}
+
+    runHook postUnpack
+  '';
+
+  buildPhase = ''
+    runHook prebuild
+
+    # ignore the exit code as the installer
+    # fails at optional steps due to read only FHS
+    ${buildEnv}/bin/${buildEnv.name} -c "./${src.name} --mode unattended --prefix bin || true"
+
+    runHook postbuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -v bin/msecli $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Micron Storage Executive CLI";
+    homepage = "https://www.micron.com/sales-support/downloads/software-drivers/storage-executive-software";
+    license = lib.licenses.unfree;
+    mainProgram = "msecli";
+    maintainers = with lib.maintainers; [ diadatp ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Micron's Storage Executive CLI (msecli), is a command-line tool for managing and monitoring Micron (and Crucial) SSDs. It is useful for applying firmware updates, over-provisioning management and SMART data reporting.

[Download Page](https://www.micron.com/sales-support/downloads/software-drivers/storage-executive-software)

Also added myself to maintainer-list.nix

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
