### PR TITLE
lib/deprecated: alias mapAttrsFlatten to mapAttrsToList

### DIFF
--- a/lib/deprecated/misc.nix
+++ b/lib/deprecated/misc.nix
@@ -29,6 +29,7 @@ let
     nameValuePair
     tail
     toList
+    warn
     ;
 
   inherit (lib.attrsets) removeAttrs mapAttrsToList;
@@ -212,8 +213,7 @@ let
     else closePropagationSlow;
 
   # calls a function (f attr value ) for each record item. returns a list
-  # Renamed to lib.attrsets.mapAttrsToList.
-  mapAttrsFlatten = mapAttrsToList;
+  mapAttrsFlatten = warn "lib.misc.mapAttrsFlatten is deprecated, please use lib.attrsets.mapAttrsToList instead." mapAttrsToList;
 
   # attribute set containing one attribute
   nvs = name: value: listToAttrs [ (nameValuePair name value) ];

--- a/lib/deprecated/misc.nix
+++ b/lib/deprecated/misc.nix
@@ -31,7 +31,7 @@ let
     toList
     ;
 
-  inherit (lib.attrsets) removeAttrs;
+  inherit (lib.attrsets) removeAttrs mapAttrsToList;
 
   # returns default if env var is not set
   maybeEnv = name: default:
@@ -212,7 +212,8 @@ let
     else closePropagationSlow;
 
   # calls a function (f attr value ) for each record item. returns a list
-  mapAttrsFlatten = f: r: map (attr: f attr r.${attr}) (attrNames r);
+  # Renamed to lib.attrsets.mapAttrsToList.
+  mapAttrsFlatten = mapAttrsToList;
 
   # attribute set containing one attribute
   nvs = name: value: listToAttrs [ (nameValuePair name value) ];

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -240,6 +240,8 @@
 
 - [`lib.options.mkPackageOptionMD`](https://nixos.org/manual/nixpkgs/unstable#function-library-lib.options.mkPackageOptionMD) is now obsolete; use the identical [`lib.options.mkPackageOption`](https://nixos.org/manual/nixpkgs/unstable#function-library-lib.options.mkPackageOption) instead.
 
+- `lib.misc.mapAttrsFlatten` is now formally deprecated and will be removed in future releases; use the identical [`lib.attrsets.mapAttrsToList`](https://nixos.org/manual/nixpkgs/unstable#function-library-lib.attrsets.mapAttrsToList) instead.
+
 - `nixosTests` now provide a working IPv6 setup for VLAN 1 by default.
 
 - To facilitate dependency injection, the `imgui` package now builds a static archive using vcpkg' CMake rules.

--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -10,7 +10,7 @@ let
   cfg = config.programs.bash;
 
   bashAliases = builtins.concatStringsSep "\n" (
-    lib.mapAttrsFlatten (k: v: "alias -- ${k}=${lib.escapeShellArg v}")
+    lib.mapAttrsToList (k: v: "alias -- ${k}=${lib.escapeShellArg v}")
       (lib.filterAttrs (k: v: v != null) cfg.shellAliases)
   );
 

--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -7,12 +7,12 @@ let
   cfg = config.programs.fish;
 
   fishAbbrs = lib.concatStringsSep "\n" (
-    lib.mapAttrsFlatten (k: v: "abbr -ag ${k} ${lib.escapeShellArg v}")
+    lib.mapAttrsToList (k: v: "abbr -ag ${k} ${lib.escapeShellArg v}")
       cfg.shellAbbrs
   );
 
   fishAliases = lib.concatStringsSep "\n" (
-    lib.mapAttrsFlatten (k: v: "alias ${k} ${lib.escapeShellArg v}")
+    lib.mapAttrsToList (k: v: "alias ${k} ${lib.escapeShellArg v}")
       (lib.filterAttrs (k: v: v != null) cfg.shellAliases)
   );
 

--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -10,7 +10,7 @@ let
   opt = options.programs.zsh;
 
   zshAliases = builtins.concatStringsSep "\n" (
-    lib.mapAttrsFlatten (k: v: "alias -- ${k}=${lib.escapeShellArg v}")
+    lib.mapAttrsToList (k: v: "alias -- ${k}=${lib.escapeShellArg v}")
       (lib.filterAttrs (k: v: v != null) cfg.shellAliases)
   );
 

--- a/nixos/modules/services/networking/openvpn.nix
+++ b/nixos/modules/services/networking/openvpn.nix
@@ -223,7 +223,7 @@ in
 
   config = mkIf (cfg.servers != { }) {
 
-    systemd.services = (listToAttrs (mapAttrsFlatten (name: value: nameValuePair "openvpn-${name}" (makeOpenVPNJob value name)) cfg.servers))
+    systemd.services = (listToAttrs (mapAttrsToList (name: value: nameValuePair "openvpn-${name}" (makeOpenVPNJob value name)) cfg.servers))
       // restartService;
 
     environment.systemPackages = [ openvpn ];


### PR DESCRIPTION
## Description of changes

These functions have identical implementation except for argument names.

This PR also updates usage in Nixpkgs.

__mapAttrsFlatten__: https://github.com/NixOS/nixpkgs/blob/b281753417d9604bc2f9c747bdb826e8f82e04eb/lib/deprecated/misc.nix#L214-L215

__mapAttrsToList__: https://github.com/NixOS/nixpkgs/blob/b281753417d9604bc2f9c747bdb826e8f82e04eb/lib/attrsets.nix#L1093-L1096

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
