### PR TITLE
nixos/k3s: add options for graceful node shutdown and kubelet config

### DIFF
--- a/nixos/tests/k3s/default.nix
+++ b/nixos/tests/k3s/default.nix
@@ -15,6 +15,9 @@ in
       inherit (pkgs) etcd;
     }
   ) allK3s;
-  single-node = lib.mapAttrs (_: k3s: import ./single-node.nix { inherit system pkgs k3s; }) allK3s;
+  kubelet-config = lib.mapAttrs (
+    _: k3s: import ./kubelet-config.nix { inherit system pkgs k3s; }
+  ) allK3s;
   multi-node = lib.mapAttrs (_: k3s: import ./multi-node.nix { inherit system pkgs k3s; }) allK3s;
+  single-node = lib.mapAttrs (_: k3s: import ./single-node.nix { inherit system pkgs k3s; }) allK3s;
 }

--- a/nixos/tests/k3s/kubelet-config.nix
+++ b/nixos/tests/k3s/kubelet-config.nix
@@ -1,0 +1,80 @@
+# A test that sets extra kubelet configuration and enables graceful node shutdown
+import ../make-test-python.nix (
+  {
+    pkgs,
+    lib,
+    k3s,
+    ...
+  }:
+  let
+    nodeName = "test";
+    shutdownGracePeriod = "1m13s";
+    shutdownGracePeriodCriticalPods = "13s";
+    podsPerCore = 3;
+    memoryThrottlingFactor = 0.69;
+    containerLogMaxSize = "5Mi";
+  in
+  {
+    name = "${k3s.name}-kubelet-config";
+    nodes.machine =
+      { pkgs, ... }:
+      {
+        environment.systemPackages = [ pkgs.jq ];
+
+        # k3s uses enough resources the default vm fails.
+        virtualisation.memorySize = 1536;
+        virtualisation.diskSize = 4096;
+
+        services.k3s = {
+          enable = true;
+          package = k3s;
+          # Slightly reduce resource usage
+          extraFlags = [
+            "--disable coredns"
+            "--disable local-storage"
+            "--disable metrics-server"
+            "--disable servicelb"
+            "--disable traefik"
+            "--node-name ${nodeName}"
+          ];
+          gracefulNodeShutdown = {
+            enable = true;
+            inherit shutdownGracePeriod shutdownGracePeriodCriticalPods;
+          };
+          extraKubeletConfig = {
+            inherit podsPerCore memoryThrottlingFactor containerLogMaxSize;
+          };
+        };
+      };
+
+    testScript = ''
+      import json
+
+      start_all()
+      machine.wait_for_unit("k3s")
+      # wait until the node is ready
+      machine.wait_until_succeeds(r"""kubectl wait --for='jsonpath={.status.conditions[?(@.type=="Ready")].status}=True' nodes/${nodeName}""")
+      # test whether the kubelet registered an inhibitor lock
+      machine.succeed("systemd-inhibit --list --no-legend | grep \"kubelet.*k3s-server.*shutdown\"")
+      # run kubectl proxy in the background, close stdout through redirection to not wait for the command to finish
+      machine.execute("kubectl proxy --address 127.0.0.1 --port=8001 >&2 &")
+      machine.wait_until_succeeds("nc -z 127.0.0.1 8001")
+      # get the kubeletconfig
+      kubelet_config=json.loads(machine.succeed("curl http://127.0.0.1:8001/api/v1/nodes/${nodeName}/proxy/configz | jq '.kubeletconfig'"))
+
+      with subtest("Kubelet config values are set correctly"):
+        assert kubelet_config["shutdownGracePeriod"] == "${shutdownGracePeriod}", \
+          f"unexpected value for shutdownGracePeriod: {kubelet_config["shutdownGracePeriod"]}"
+        assert kubelet_config["shutdownGracePeriodCriticalPods"] == "${shutdownGracePeriodCriticalPods}", \
+          f"unexpected value for shutdownGracePeriodCriticalPods: {kubelet_config["shutdownGracePeriodCriticalPods"]}"
+        assert kubelet_config["podsPerCore"] == ${toString podsPerCore}, \
+          f"unexpected value for podsPerCore: {kubelet_config["podsPerCore"]}"
+        assert kubelet_config["memoryThrottlingFactor"] == ${toString memoryThrottlingFactor}, \
+          f"unexpected value for memoryThrottlingFactor: {kubelet_config["memoryThrottlingFactor"]}"
+        assert kubelet_config["containerLogMaxSize"] == "${containerLogMaxSize}", \
+          f"unexpected value for containerLogMaxSize: {kubelet_config["containerLogMaxSize"]}"
+    '';
+
+    meta.maintainers = lib.teams.k3s.members;
+  }
+)


### PR DESCRIPTION
## Description of changes

Allow to set kubelet configuration parameters
via an option. Additionally, expose the
respective options for graceful node
shutdown directly, as it is anticipated to
be used frequently.

This was mentioned in https://github.com/NixOS/nixpkgs/issues/255783#issuecomment-2235950967. However, I think we shouldn't enable graceful node shutdown by default as it deviates from default k3s behavior without addressing a Nix/NixOS specific problem. Additionally, it will kill anything that doesn't shut down fast enough.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

CC @NixOS/k3s
