### PR TITLE
emacsPackages.copilot: fix dependencies

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/copilot/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/copilot/default.nix
@@ -7,7 +7,7 @@
   s,
   melpaBuild,
 }:
-melpaBuild {
+melpaBuild rec {
   pname = "copilot";
   version = "0-unstable-2023-12-26";
 
@@ -26,7 +26,7 @@ melpaBuild {
     s
   ];
 
-  propagatedUserEnvPkgs = [ nodejs ];
+  propagatedUserEnvPkgs = packageRequires ++ [ nodejs ];
 
   meta = {
     description = "Unofficial copilot plugin for Emacs";


### PR DESCRIPTION
## Description of changes

Since https://github.com/NixOS/nixpkgs/pull/327952, copilot fails to load:

    nix-build -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/f5380ca553a9f988fe47b99e28ed6b9975a375fa.tar.gz --expr "(import <nixpkgs> {}).emacsPackages.emacsWithPackages (epkgs: [epkgs.copilot])" && result/bin/emacs -q --eval "(use-package copilot)"
    [...]
     ■  Error (use-package): copilot/:catch: Cannot open load file: No such file or directory, s

The required packages are not needed for building, only for running. Move them all to propagatedUserEnvPkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
