### PR TITLE
python312Packages.msmart-ng: init at 2024.9.0, home-assistant-custom-components.midea_ac: init at 2024.9.2

### DIFF
--- a/pkgs/development/python-modules/msmart-ng/default.nix
+++ b/pkgs/development/python-modules/msmart-ng/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  httpx,
+  pycryptodome,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "msmart-ng";
+  version = "2024.9.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mill1000";
+    repo = "midea-msmart";
+    rev = version;
+    hash = "sha256-djo+sINurnrt0GO8045bgNstjh+yl+CE2GJ1vWivAqY=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    httpx
+    pycryptodome
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTestPaths = [
+    # network access
+    "msmart/tests/test_cloud.py"
+  ];
+
+  pythonImportsCheck = [ "msmart" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/mill1000/midea-msmart/releases/tag/${version}";
+    description = "Python library for local control of Midea (and associated brands) smart air conditioners";
+    homepage = "https://github.com/mill1000/midea-msmart";
+    license = licenses.mit;
+    mainProgram = "msmart-ng";
+    maintainers = with maintainers; [
+      hexa
+      emilylange
+    ];
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -34,6 +34,8 @@
 
   mass = callPackage ./mass { };
 
+  midea_ac = callPackage ./midea_ac { };
+
   midea_ac_lan = callPackage ./midea_ac_lan {};
 
   midea-air-appliances-lan = callPackage ./midea-air-appliances-lan {};

--- a/pkgs/servers/home-assistant/custom-components/midea_ac/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/midea_ac/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  msmart-ng,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "mill1000";
+  domain = "midea_ac";
+  version = "2024.9.2";
+
+  src = fetchFromGitHub {
+    owner = "mill1000";
+    repo = "midea-ac-py";
+    rev = version;
+    hash = "sha256-PVR3yuyWMilmyOS341pS73c9ocOrFfJ9dwiKEYqCtM4=";
+  };
+
+  dependencies = [ msmart-ng ];
+
+  meta = with lib; {
+    description = "Home Assistant custom integration to control Midea (and associated brands) air conditioners via LAN";
+    homepage = "https://github.com/mill1000/midea-ac-py";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      hexa
+      emilylange
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7969,6 +7969,8 @@ self: super: with self; {
 
   msldap = callPackage ../development/python-modules/msldap { };
 
+  msmart-ng = callPackage ../development/python-modules/msmart-ng { };
+
   msoffcrypto-tool = callPackage ../development/python-modules/msoffcrypto-tool { };
 
   msprime = callPackage ../development/python-modules/msprime { };


### PR DESCRIPTION
Python library for local control of Midea (and associated brands) smart air conditioners.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
