### PR TITLE
quirc: Use dylib with absolute install name on Darwin

### DIFF
--- a/pkgs/tools/graphics/quirc/0001-Don-t-build-demos.patch
+++ b/pkgs/tools/graphics/quirc/0001-Don-t-build-demos.patch
@@ -1,8 +1,17 @@
+From 7435b2e12c2004cb0c497ff313288902f2a6f39a Mon Sep 17 00:00:00 2001
+From: toonn <toonn@toonn.io>
+Date: Fri, 19 Jul 2024 21:53:58 +0200
+Subject: [PATCH] Don't build demos
+
+---
+ Makefile | 7 ++-----
+ 1 file changed, 2 insertions(+), 5 deletions(-)
+
 diff --git a/Makefile b/Makefile
-index 2d5b745..ecef988 100644
+index 8327b4e..7901cc5 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -37,7 +37,7 @@ DEMO_UTIL_OBJ = \
+@@ -45,7 +45,7 @@ DEMO_UTIL_OBJ = \
  
  OPENCV_CFLAGS := $(shell pkg-config --cflags opencv4 2>&1)
  OPENCV_LIBS = $(shell pkg-config --libs opencv4)
@@ -11,19 +20,23 @@ index 2d5b745..ecef988 100644
  
  .PHONY: all v4l sdl opencv install uninstall clean
  
-@@ -85,14 +85,11 @@ libquirc.so.$(LIB_VERSION): $(LIB_OBJ)
+@@ -93,15 +93,12 @@ libquirc.$(VERSIONED_LIB_SUFFIX): $(LIB_OBJ)
  .cxx.o:
  	$(CXX) $(QUIRC_CXXFLAGS) -o $@ -c $<
  
--install: libquirc.a libquirc.so.$(LIB_VERSION) quirc-demo quirc-scanner
-+install: libquirc.a libquirc.so.$(LIB_VERSION)
+-install: libquirc.a libquirc.$(LIB_SUFFIX) quirc-demo quirc-scanner
++install: libquirc.a libquirc.$(LIB_SUFFIX)
  	install -o root -g root -m 0644 lib/quirc.h $(DESTDIR)$(PREFIX)/include
  	install -o root -g root -m 0644 libquirc.a $(DESTDIR)$(PREFIX)/lib
- 	install -o root -g root -m 0755 libquirc.so.$(LIB_VERSION) \
+ 	install -o root -g root -m 0755 libquirc.$(VERSIONED_LIB_SUFFIX) \
  		$(DESTDIR)$(PREFIX)/lib
+ 	cp -d libquirc.$(LIB_SUFFIX) $(DESTDIR)$(PREFIX)/lib
 -	install -o root -g root -m 0755 quirc-demo $(DESTDIR)$(PREFIX)/bin
 -	# install -o root -g root -m 0755 quirc-demo-opencv $(DESTDIR)$(PREFIX)/bin
 -	install -o root -g root -m 0755 quirc-scanner $(DESTDIR)$(PREFIX)/bin
  
  uninstall:
  	rm -f $(DESTDIR)$(PREFIX)/include/quirc.h
+-- 
+2.42.2
+

--- a/pkgs/tools/graphics/quirc/default.nix
+++ b/pkgs/tools/graphics/quirc/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchFromGitHub, SDL_gfx, SDL, libjpeg, libpng, opencv
-, pkg-config }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch2, SDL_gfx, SDL, libjpeg, libpng
+, opencv, pkg-config }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "quirc";
@@ -25,29 +25,38 @@ stdenv.mkDerivation (finalAttrs: {
   makeFlags = [ "PREFIX=$(out)" ];
   env.NIX_CFLAGS_COMPILE = "-I${lib.getDev SDL}/include/SDL -I${SDL_gfx}/include/SDL";
 
-  # Disable building of linux-only demos on darwin systems
-  patches = lib.optionals stdenv.isDarwin [ ./0001-dont-build-demos.patch ];
-
-  buildPhase = lib.optionalString stdenv.isDarwin ''
-    runHook preBuild
-    make libquirc.so
-    make qrtest
-    runHook postBuild
-  '';
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/dlbeer/quirc/commit/2c350d8aaf37246e538a2c93b2cce8c78600d2fc.patch?full_index=1";
+      hash = "sha256-ZTcy/EoOBoyOjtXjmT+J/JcbX8lxGKmbWer23lymbWo=";
+    })
+    (fetchpatch2 {
+      url = "https://github.com/dlbeer/quirc/commit/257c6c94d99960819ecabf72199e5822f60a3bc5.patch?full_index=1";
+      hash = "sha256-WLQK7vy34VmgJzppTnRjAcZoSGWVaXQSaGq9An8W0rw=";
+    })
+  ] ++ lib.optionals stdenv.isDarwin [
+    # Disable building of linux-only demos on darwin systems
+    ./0001-Don-t-build-demos.patch
+  ];
 
   preInstall = ''
     mkdir -p "$out"/{bin,lib,include}
 
     # install all binaries
-    find -maxdepth 1 -type f -executable ! -name '*.so.*' | xargs cp -t "$out"/bin
+    find -maxdepth 1 -type f -executable ! -name '*.so.*' ! -name '*.dylib' \
+      | xargs cp -t "$out"/bin
   '';
 
   postInstall = ''
     # don't install static library
     rm $out/lib/libquirc.a
-
+  '' + (if stdenv.isDarwin then ''
+    # Set absolute install name to avoid the need for DYLD_LIBRARY_PATH
+    dylib=$out/lib/libquirc.${finalAttrs.version}.dylib
+    ${stdenv.cc.targetPrefix}install_name_tool -id "$dylib" "$dylib"
+  '' else ''
     ln -s $out/lib/libquirc.so.* $out/lib/libquirc.so
-  '';
+  '');
 
   meta = {
     description = "Small QR code decoding library";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is a prerequisite for fixing ffmpeg_7-full on Darwin. It's a common pattern in Nixpkgs to use an absolute install name.

I upstreamed the dylib renaming in dlbeer/quirc#144 but the patch needs to be vendored because upstream changes mean it doesn't apply to the packaged release.
The patch is not strictly necessary but means the next version bump will be easier as dropping the patch will be sufficient, rather than remembering to make the other extension related changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
