### PR TITLE
xev{d,e}: Fix darwin build

### DIFF
--- a/pkgs/by-name/xe/xevd/package.nix
+++ b/pkgs/by-name/xe/xevd/package.nix
@@ -19,18 +19,64 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Dc2V77t+DrZo9252FAL0eczrmikrseU02ob2RLBdVvU=";
   };
 
-  patches = lib.optionals (!lib.versionOlder "0.5.0" finalAttrs.version) [
-    (fetchpatch2 {
-      url = "https://github.com/mpeg5/xevd/commit/7eda92a6ebb622189450f7b63cfd4dcd32fd6dff.patch?full_index=1";
-      hash = "sha256-Ru7jGk1b+Id5x1zaiGb7YKZGTNaTcArZGYyHbJURfgs=";
-    })
-  ];
+  patches = lib.optionals (!lib.versionOlder "0.5.0" finalAttrs.version) (
+    builtins.map fetchpatch2 [
+      # Upstream accepted patches, should be dropped on next version bump.
+      {
+        url = "https://github.com/mpeg5/xevd/commit/7eda92a6ebb622189450f7b63cfd4dcd32fd6dff.patch?full_index=1";
+        hash = "sha256-Ru7jGk1b+Id5x1zaiGb7YKZGTNaTcArZGYyHbJURfgs=";
+      }
+      {
+        url = "https://github.com/mpeg5/xevd/commit/499bc0153a99f8c8fd00143dd81fc0d858a5b509.patch?full_index=1";
+        hash = "sha256-3ExBNTeBhj/IBweYkgWZ2ZgUypFua4oSC24XXFmjxXA=";
+      }
+      {
+        url = "https://github.com/mpeg5/xevd/commit/b099623a09c09cddfe7f732fb795b2af8a020620.patch?full_index=1";
+        hash = "sha256-Ee/PQmsGpUCU7KUMbdGEXEEKOc8BHYcGF4mq+mmWb/w=";
+      }
+      {
+        url = "https://github.com/mpeg5/xevd/commit/2e6b24bf1f946c30d789b114dfd56e91b99039fe.patch?full_index=1";
+        hash = "sha256-thT0kVSKwWruyhIjDFBulyUNeyG9zQ8rQtpZVmRvYxI=";
+      }
+      {
+        url = "https://github.com/mpeg5/xevd/commit/c1f23a41b8def84ab006a8ce4e9221b2fff84a1a.patch?full_index=1";
+        hash = "sha256-MOJ9mU5txk6ISzJsQdK+TTb2dlWD8ofGZI0nfq9rsPo=";
+      }
+      {
+        url = "https://github.com/mpeg5/xevd/commit/adf1c45d6edb0d235997a40261689d7454b711c5.patch?full_index=1";
+        hash = "sha256-tGIPaswx9S1Oy8QF928RzV/AHr710kYxXfMRYg6SLR4=";
+      }
+    ]
+  );
 
   postPatch = ''
     echo v$version > version.txt
   '';
 
   nativeBuildInputs = [ cmake ];
+
+  cmakeFlags =
+    let
+      inherit (lib) cmakeBool cmakeFeature optional;
+      inherit (stdenv.hostPlatform) isAarch64 isDarwin;
+    in
+    optional isAarch64 (cmakeBool "ARM" true)
+    ++ optional isDarwin (cmakeFeature "CMAKE_SYSTEM_NAME" "Darwin");
+
+  env.NIX_CFLAGS_COMPILE = builtins.toString (
+    builtins.map (w: "-Wno-" + w) (
+      [
+        # Evaluate on version bump whether still necessary.
+        "sometimes-uninitialized"
+        "unknown-warning-option"
+      ]
+      ++ (
+        # Fixed upstream in 325fd9f94f3fdf0231fa931a31ebb72e63dc3498 but might
+        # change behavior, therefore opted to leave it out for now.
+        lib.optional (!lib.versionOlder "0.5.0" finalAttrs.version) "for-loop-analysis"
+      )
+    )
+  );
 
   postInstall = ''
     ln $dev/include/xevd/* $dev/include/
@@ -53,7 +99,6 @@ stdenv.mkDerivation (finalAttrs: {
     pkgConfigModules = [ "xevd" ];
     maintainers = with lib.maintainers; [ jopejoe1 ];
     platforms = lib.platforms.all;
-    # Currently only supports gcc and msvc as compiler, the limitation for clang gets removed in the next release, but that does not fix building on darwin.
-    broken = !stdenv.hostPlatform.isx86 || !stdenv.cc.isGNU;
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 })

--- a/pkgs/by-name/xe/xeve/0001-CMakeLists.txt-Disable-static-linking-on-Darwin.patch
+++ b/pkgs/by-name/xe/xeve/0001-CMakeLists.txt-Disable-static-linking-on-Darwin.patch
@@ -1,0 +1,27 @@
+From f3927c3cb05ffc77f62026bafd7cea1d25de1e72 Mon Sep 17 00:00:00 2001
+From: toonn <toonn@toonn.io>
+Date: Tue, 2 Jul 2024 19:23:11 +0200
+Subject: [PATCH 1/2] CMakeLists.txt: Disable static linking on Darwin
+
+---
+ CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e0873d5..1d639c4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -64,7 +64,9 @@ if(NOT ARM)
+ else()
+   add_definitions(-DARM=1)
+   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -flax-vector-conversions")
+-  set(CMAKE_EXE_LINKER_FLAGS "-static")
++  if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
++    set(CMAKE_EXE_LINKER_FLAGS "-static")
++  endif()
+ endif()
+ message("ARM=${ARM}")
+ 
+-- 
+2.44.1
+

--- a/pkgs/by-name/xe/xeve/0002-sse2neon-Cast-to-variable-type.patch
+++ b/pkgs/by-name/xe/xeve/0002-sse2neon-Cast-to-variable-type.patch
@@ -1,0 +1,27 @@
+From d1a480867c0778ee46ff0213e2b1e494afcb67fc Mon Sep 17 00:00:00 2001
+From: toonn <toonn@toonn.io>
+Date: Mon, 1 Jul 2024 15:19:37 +0200
+Subject: [PATCH 2/2] sse2neon: Cast to variable type
+
+The `__m128d` type corresponds to `float32x4_t` or `float64x2_t`
+depending on the platform. The cast cannot explicitly use either type.
+---
+ src_base/neon/sse2neon.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src_base/neon/sse2neon.h b/src_base/neon/sse2neon.h
+index 490c0a4..3290fa3 100644
+--- a/src_base/neon/sse2neon.h
++++ b/src_base/neon/sse2neon.h
+@@ -6003,7 +6003,7 @@ FORCE_INLINE void _mm_storeu_si32(void *p, __m128i a)
+ FORCE_INLINE void _mm_stream_pd(double *p, __m128d a)
+ {
+ #if __has_builtin(__builtin_nontemporal_store)
+-    __builtin_nontemporal_store(a, (float32x4_t *) p);
++    __builtin_nontemporal_store(a, (__m128d *) p);
+ #elif defined(__aarch64__)
+     vst1q_f64(p, vreinterpretq_f64_m128d(a));
+ #else
+-- 
+2.44.1
+

--- a/pkgs/by-name/xe/xeve/package.nix
+++ b/pkgs/by-name/xe/xeve/package.nix
@@ -18,18 +18,70 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-8jXntm/yFme9ZPImdW54jAr11hEsU1K+N5/7RLmITPs=";
   };
 
-  patches = lib.optionals (!lib.versionOlder "0.5.0" finalAttrs.version) [
-    (fetchpatch2 {
-      url = "https://github.com/mpeg5/xeve/commit/954ed6e0494cd2438fd15c717c0146e88e582b33.patch?full_index=1";
-      hash = "sha256-//NtOUm1fqPFvOM955N6gF+QgmOdmuVunwx/3s/G/J8=";
-    })
-  ];
+  patches =
+    lib.optionals (!lib.versionOlder "0.5.0" finalAttrs.version) (
+      builtins.map fetchpatch2 [
+        {
+          url = "https://github.com/mpeg5/xeve/commit/954ed6e0494cd2438fd15c717c0146e88e582b33.patch?full_index=1";
+          hash = "sha256-//NtOUm1fqPFvOM955N6gF+QgmOdmuVunwx/3s/G/J8=";
+        }
+        {
+          url = "https://github.com/mpeg5/xeve/commit/07a6f2a6d13dfaa0f73c3752f8cd802c251d8252.patch?full_index=1";
+          hash = "sha256-P9J7Y9O/lb/MSa5oCfft7z764AbLBLZnMmrmPEZPcws=";
+        }
+        {
+          url = "https://github.com/mpeg5/xeve/commit/0a0f3bd397161253b606bdbeaa518fbe019d24e1.patch?full_index=1";
+          hash = "sha256-PoZpE64gWkTUS4Q+SK+DH1I1Ac0UEzwwnlvpYN16hsI=";
+        }
+        {
+          url = "https://github.com/mpeg5/xeve/commit/e029f1619ecedbda152b8680641fa10eea9eeace.patch?full_index=1";
+          hash = "sha256-ooIBzNtGSjDgYvTzA8T0KB+QzsUiy14mPpoRqrHF3Pg=";
+        }
+      ]
+      ++ [
+        # Backport to 0.5.0 of upstream patch c564ac77c103dbba472df3e13f4733691fd499ed
+        ./0001-CMakeLists.txt-Disable-static-linking-on-Darwin.patch
+      ]
+    )
+    ++ [
+      # Rejected upstream, can be dropped when a fix for
+      # https://github.com/mpeg5/xeve/pull/123 is in a version bump.
+      ./0002-sse2neon-Cast-to-variable-type.patch
+    ];
 
   postPatch = ''
     echo v$version > version.txt
   '';
 
   nativeBuildInputs = [ cmake ];
+
+  cmakeFlags =
+    let
+      inherit (lib) cmakeBool cmakeFeature optional;
+      inherit (stdenv.hostPlatform) isAarch64 isDarwin;
+    in
+    optional isAarch64 (cmakeBool "ARM" true)
+    ++ optional isDarwin (cmakeFeature "CMAKE_SYSTEM_NAME" "Darwin");
+
+  env.NIX_CFLAGS_COMPILE = builtins.toString (
+    builtins.map (w: "-Wno-" + w) (
+      [
+        # Patch addressing an if without a body was rejected upstream, third
+        # line-based comment in this thread, https://github.com/mpeg5/xeve/pull/122#pullrequestreview-2187744305
+        # Evaluate on version bump whether still necessary.
+        "empty-body"
+
+        # Evaluate on version bump whether still necessary.
+        "parentheses-equality"
+        "unknown-warning-option"
+      ]
+      ++ (
+        # Fixed upstream in 325fd9f94f3fdf0231fa931a31ebb72e63dc3498 but might
+        # change behavior, therefore opted to leave it out for now.
+        lib.optional (!lib.versionOlder "0.5.0" finalAttrs.version) "for-loop-analysis"
+      )
+    )
+  );
 
   postInstall = ''
     ln $dev/include/xeve/* $dev/include/
@@ -50,7 +102,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "xeve_app";
     maintainers = with lib.maintainers; [ jopejoe1 ];
     platforms = lib.platforms.all;
-    # Currently only supports gcc and msvc as compiler, the limitation for clang gets removed in the next release, but that does not fix building on darwin.
-    broken = !stdenv.hostPlatform.isx86 || !stdenv.cc.isGNU;
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 })


### PR DESCRIPTION
## Description of changes

I'm bundling the changes for xevd and xeve because they are so similar. If preferable I can split them into two separate PRs.

This is a prerequisite to fixing ffmpeg_7-full on Darwin.
I'm still in the process of upstreaming this work so it's quite a number of patches to vendor, some of which might technically be possible to fetchpatch after upstreaming.
The patches are likely to change before being accepted upstream. So it mostly depends on how quickly we want ffmpeg_7-full working on Darwin (and potentially aarch64-linux, couldn't test).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
