### PR TITLE
zunit: init at 0.8.2

### DIFF
--- a/pkgs/by-name/zu/zunit/package.nix
+++ b/pkgs/by-name/zu/zunit/package.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  zsh,
+  revolver,
+  installShellFiles,
+  testers,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "zunit";
+  version = "0.8.2";
+
+  src = fetchFromGitHub {
+    owner = "zunit-zsh";
+    repo = "zunit";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-GkBewb795piCaniZJZpGEZFhKaNs8p8swV5z34OegPY=";
+    deepClone = true; # Needed in order to get "tests" folder
+  };
+
+  strictDeps = true;
+  doCheck = true;
+  doInstallCheck = true;
+
+  nativeBuildInputs = [
+    zsh
+    installShellFiles
+  ];
+  nativeCheckInputs = [ revolver ];
+  buildInputs = [
+    zsh
+    revolver
+  ];
+
+  postPatch = ''
+    for i in $(find src/ -type f -print); do
+      substituteInPlace $i \
+        --replace-warn " revolver " " ${lib.getExe revolver} "
+    done
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    zsh build.zsh
+
+    runHook postBuild
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    HOME="$TEMPDIR" zsh zunit
+
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 zunit $out/bin/zunit
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    installShellCompletion --cmd zunit --zsh zunit.zsh-completion
+  '';
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    PATH=$PATH:$out/bin zunit --help
+
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Powerful testing framework for ZSH projects";
+    homepage = "https://zunit.xyz/";
+    downloadPage = "https://github.com/zunit-zsh/zunit/releases";
+    license = lib.licenses.mit;
+    mainProgram = "zunit";
+    inherit (zsh.meta) platforms;
+    maintainers = with lib.maintainers; [ d-brasher ];
+  };
+})


### PR DESCRIPTION
## Description of changes

[Zunit](https://zunit.xyz/) is a powerful testing framework for ZSH projects.

Although the last commit is 4 years old, it is useful for testing ZSH plugins (such as [F-Sy-H](https://github.com/z-shell/F-Sy-H), [zsh-autopair](https://github.com/hlissner/zsh-autopair), [zsh-you-should-use](https://github.com/MichaelAquilina/zsh-you-should-use), [fast-syntax-highlighting](https://github.com/zdharma-continuum/fast-syntax-highlighting)), that I'm planning to package next.

Closes https://github.com/NixOS/nixpkgs/issues/262514
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Status:
- [x] Waiting for https://github.com/NixOS/nixpkgs/pull/327424, as `revolver` is a dependency of this package

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
