### PR TITLE
python312Packages.pytest-flake8: 1.1.1 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/pytest-flake8/default.nix
+++ b/pkgs/development/python-modules/pytest-flake8/default.nix
@@ -1,44 +1,52 @@
 {
   lib,
-  fetchpatch,
   buildPythonPackage,
   pythonOlder,
-  fetchPypi,
+  fetchFromGitHub,
+  setuptools-scm,
   flake8,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "pytest-flake8";
-  version = "1.1.1";
+  version = "1.2.0";
+  pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
-  format = "setuptools";
-
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "ba4f243de3cb4c2486ed9e70752c80dd4b636f7ccb27d4eba763c35ed0cd316e";
+  src = fetchFromGitHub {
+    owner = "coherent-oss";
+    repo = "pytest-flake8";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-VNefGRB++FZFIGOS8Pyxbfe0zAXqwy+p6uERE70+CT4=";
   };
 
-  patches = [
-    # https://github.com/tholo/pytest-flake8/issues/87
-    # https://github.com/tholo/pytest-flake8/pull/88
-    (fetchpatch {
-      url = "https://github.com/tholo/pytest-flake8/commit/976e6180201f7808a3007c8c5903a1637b18c0c8.patch";
-      hash = "sha256-Hbcpz4fTXtXRnIWuKuDhOVpGx9H1sdQRKqxadk2s+uE=";
-    })
-  ];
+  build-system = [ setuptools-scm ];
 
-  propagatedBuildInputs = [ flake8 ];
+  dependencies = [ flake8 ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  disabledTests = [
+    # https://github.com/coherent-oss/pytest-flake8/issues/2
+    "test_version"
+    "test_default_flake8_ignores"
+    "test_ignores_all"
+    "test_w293w292"
+    "test_mtime_caching"
+    "test_ok_verbose"
+    "test_keyword_match"
+    "test_run_on_init_file"
+    "test_unicode_error"
+    "test_junit_classname"
+  ];
+
   meta = {
+    changelog = "https://github.com/coherent-oss/pytest-flake8/blob/${src.rev}/NEWS.rst";
     description = "py.test plugin for efficiently checking PEP8 compliance";
-    homepage = "https://github.com/tholo/pytest-flake8";
+    homepage = "https://github.com/coherent-oss/pytest-flake8";
     maintainers = with lib.maintainers; [ jluttine ];
     license = lib.licenses.bsd2;
-    broken = lib.versionAtLeast flake8.version "6.0.0";
   };
 }


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/coherent-oss/pytest-flake8/compare/refs/tags/v1.1.1...v1.2.0

Changelog: https://github.com/coherent-oss/pytest-flake8/blob/refs/tags/v1.2.0/NEWS.rst



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
