### PR TITLE
Add function to generate a config file with out of band values 

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -6,12 +6,15 @@
 let
   inherit (builtins) head length;
   inherit (lib.trivial) isInOldestRelease mergeAttrs warn warnIf;
-  inherit (lib.strings) concatStringsSep concatMapStringsSep escapeNixIdentifier sanitizeDerivationName;
-  inherit (lib.lists) foldr foldl' concatMap elemAt all partition groupBy take foldl;
+  inherit (lib.strings) concatMapStrings concatStringsSep concatMapStringsSep escapeNixIdentifier sanitizeDerivationName toUpper;
+  inherit (lib.lists) foldr foldl' concatMap elemAt all partition groupBy take foldl imap0;
+
+  placeholderName = path:
+      "%SECRET${toUpper (concatMapStrings (s: "_" + s) path)}%";
 in
 
 rec {
-  inherit (builtins) attrNames listToAttrs hasAttr isAttrs getAttr removeAttrs intersectAttrs;
+  inherit (builtins) attrNames listToAttrs hasAttr isAttrs isList getAttr removeAttrs intersectAttrs;
 
 
   /**
@@ -869,6 +872,19 @@ rec {
       [ attrs ]
     else if isAttrs attrs then
       concatMap (collect pred) (attrValues attrs)
+   else
+      [];
+
+  # Like collect but also recurses on lists.
+  collect' =
+  pred:
+  attrs:
+    if pred attrs then
+      [ attrs ]
+    else if isAttrs attrs then
+      concatMap (collect' pred) (attrValues attrs)
+    else if isList attrs then
+      concatMap (collect' pred) attrs
     else
       [];
 
@@ -1208,6 +1224,21 @@ rec {
             else f (path ++ [ name ]) value);
     in
     recurse [ ] set;
+
+  # Like `mapAttrsRecursiveCond` but also recurse over lists.
+  mapAttrsRecursiveCond' =
+    cond:
+    f:
+    set:
+    let
+      recurse = path: val:
+        if isAttrs val && cond val
+        then mapAttrs (n: v: recurse (path ++ [n]) v) val
+        else if isList val && cond val
+        then imap0 (i: v: recurse (path ++ [(toString i)]) v) val
+        else f path val;
+    in
+      recurse [] set;
 
 
   /**
@@ -2127,6 +2158,64 @@ rec {
         intersection;
     in
       (x // y) // mask;
+
+  /**
+    `replaceWithPlaceholder` is used to replace secrets with a unique placeholder value in a possibly nested configuration represented as a nix object.
+
+    It should probably not be used as-is. Prefer to use the `utils.genConfigOutOfBand` function when writing a NixOS module.
+
+    This function descends recursively in the given attrset (`attrs`) until it finds an attrset that has a field named `sourceField`.
+    When such an attrset is found, it is replaced by a unique placeholder value computed by `placeholderName`.
+
+    It recurses on all fields of an attrset and also in all items of a list.
+  */
+  replaceWithPlaceholder = sourceField: attrs:
+    let
+      hasPlaceholderField = v: isAttrs v && hasAttr sourceField v;
+
+      valueOrPlaceholder = path: value:
+        if ! (hasPlaceholderField value)
+        then value
+        else placeholderName path;
+    in
+      mapAttrsRecursiveCond' (v: ! (hasPlaceholderField v)) valueOrPlaceholder attrs;
+
+  /**
+    `getPlaceholderReplacements` extracts secrets from a possibly nested configuration represented as a nix object.
+
+    It should probably not be used as-is. Prefer to use the `utils.genConfigOutOfBand` function when writing a NixOS module.
+
+    This function descends recursively in the given attrset (`attrs`) until it finds an attrset that has a field named `sourceField`.
+    It then returns an attrset of all those matching ones as value and with the key computed from calling `placeholderName`.
+
+    It recurses on all fields of an attrset and also in all items of a list.
+  */
+  getPlaceholderReplacements = sourceField: attrs:
+    let
+      hasPlaceholderField = v: isAttrs v && hasAttr sourceField v;
+
+      addPathField = path: value:
+        if ! (hasPlaceholderField value)
+        then value
+        else value // { inherit path; };
+
+      secretsWithPath = mapAttrsRecursiveCond' (v: ! (hasPlaceholderField v)) addPathField attrs;
+
+      allSecrets = collect' (v: hasPlaceholderField v) secretsWithPath;
+
+      genReplacement = secret:
+        let
+          secretConfig = {
+            ${sourceField} = getAttr sourceField secret;
+            prefix = secret.prefix or "";
+            suffix = secret.suffix or "";
+            prefixIfNotPresent = secret.prefixIfNotPresent or "";
+            suffixIfNotPresent = secret.suffixIfNotPresent or "";
+          };
+        in
+          nameValuePair (placeholderName secret.path) secretConfig;
+    in
+      listToAttrs (map genReplacement allSecrets);
 
   # DEPRECATED
   zipWithNames = warn

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -90,7 +90,7 @@ let
       getBin getLib getStatic getDev getInclude getMan chooseDevOutputs zipWithNames zip
       recurseIntoAttrs dontRecurseIntoAttrs cartesianProduct cartesianProductOfSets
       mapCartesianProduct updateManyAttrsByPath listToAttrs hasAttr getAttr isAttrs intersectAttrs removeAttrs
-      replaceWithPlaceholder getPlaceholderReplacements;
+      replaceWithPlaceholder getPlaceholderReplacements getLoadCredentials updateToLoadCredentials;
     inherit (self.lists) singleton forEach map foldr fold foldl foldl' imap0 imap1
       filter ifilter0 concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range replicate partition zipListsWith zipLists

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -82,14 +82,15 @@ let
       composeManyExtensions makeExtensible makeExtensibleWithCustomName;
     inherit (self.attrsets) attrByPath hasAttrByPath setAttrByPath
       getAttrFromPath attrVals attrNames attrValues getAttrs catAttrs filterAttrs
-      filterAttrsRecursive foldlAttrs foldAttrs collect nameValuePair mapAttrs
+      filterAttrsRecursive foldlAttrs foldAttrs collect collect' nameValuePair mapAttrs
       mapAttrs' mapAttrsToList attrsToList concatMapAttrs mapAttrsRecursive
-      mapAttrsRecursiveCond genAttrs isDerivation toDerivation optionalAttrs
+      mapAttrsRecursiveCond mapAttrsRecursiveCond' genAttrs isDerivation toDerivation optionalAttrs
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
       recursiveUpdate matchAttrs mergeAttrsList overrideExisting showAttrPath getOutput getFirstOutput
       getBin getLib getStatic getDev getInclude getMan chooseDevOutputs zipWithNames zip
       recurseIntoAttrs dontRecurseIntoAttrs cartesianProduct cartesianProductOfSets
-      mapCartesianProduct updateManyAttrsByPath listToAttrs hasAttr getAttr isAttrs intersectAttrs removeAttrs;
+      mapCartesianProduct updateManyAttrsByPath listToAttrs hasAttr getAttr isAttrs intersectAttrs removeAttrs
+      replaceWithPlaceholder getPlaceholderReplacements;
     inherit (self.lists) singleton forEach map foldr fold foldl foldl' imap0 imap1
       filter ifilter0 concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range replicate partition zipListsWith zipLists

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -59,6 +59,7 @@ let
     getExe
     getExe'
     getLicenseFromSpdxIdOr
+    getLoadCredentials
     getPlaceholderReplacements
     groupBy
     groupBy'
@@ -112,6 +113,7 @@ let
     toShellVars
     types
     updateManyAttrsByPath
+    updateToLoadCredentials
     versions
     xor
     ;
@@ -2629,5 +2631,34 @@ runTests {
             doubleNestedList = [ { n = item; } ];
           }
         );
+  };
+
+  testGetLoadCredentials = {
+    expected = [
+      "a_a:/my/secret/location-a.txt"
+      "c:/my/secret/location-c.txt"
+    ];
+
+    expr = getLoadCredentials "_secret" {
+      a.a._secret = "/my/secret/location-a.txt";
+      b = "/something/else";
+      c._secret = "/my/secret/location-c.txt";
+    };
+  };
+
+  testUpdateToLoadCredentials = {
+    expected = {
+      a.a._secret = "$rootDir/a_a";
+      a.a.other = "other";
+      b = "/something/else";
+      c._secret = "$rootDir/c";
+    };
+
+    expr = updateToLoadCredentials "_secret" "$rootDir" {
+      a.a._secret = "/my/secret/location-a.txt";
+      a.a.other = "other";
+      b = "/something/else";
+      c._secret = "/my/secret/location-c.txt";
+    };
   };
 }

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -59,6 +59,7 @@ let
     getExe
     getExe'
     getLicenseFromSpdxIdOr
+    getPlaceholderReplacements
     groupBy
     groupBy'
     hasAttrByPath
@@ -74,6 +75,7 @@ let
     makeIncludePath
     makeOverridable
     mapAttrs
+    mapAttrsRecursiveCond'
     mapCartesianProduct
     matchAttrs
     mergeAttrs
@@ -88,6 +90,7 @@ let
     range
     recursiveUpdateUntil
     removePrefix
+    replaceWithPlaceholder
     replicate
     runTests
     setFunctionArgs
@@ -2460,5 +2463,171 @@ runTests {
       directory = ./packages-from-directory/c;
     };
     expected = "c";
+  };
+
+  testMapAttrRecursiveCond'TraverseAll = {
+    expr =
+      let
+        attr = {
+          a = 0;
+          b = 1;
+          c = [ 0 1 ];
+          d = [ { a = 0; } ];
+          e = { a = 0; };
+        };
+      in
+        mapAttrsRecursiveCond' (x: true) (path: x: path) (
+          attr
+          // { nestedAttr = attr; }
+          // { nestedList = [ attr attr ]; }
+        );
+    expected = {
+      a = [ "a" ];
+      b = [ "b" ];
+      c = [ [ "c" "0" ] [ "c" "1" ] ];
+      d = [ { a = [ "d" "0" "a" ]; } ];
+      e = { a = [ "e" "a" ]; };
+      nestedAttr = {
+        a = [ "nestedAttr" "a" ];
+        b = [ "nestedAttr" "b" ];
+        c = [ [ "nestedAttr" "c" "0" ] [ "nestedAttr" "c" "1" ] ];
+        d = [ { a = [ "nestedAttr" "d" "0" "a" ]; } ];
+        e = { a = [ "nestedAttr" "e" "a" ]; };
+      };
+      nestedList = [
+        {
+          a = [ "nestedList" "0" "a" ];
+          b = [ "nestedList" "0" "b" ];
+          c = [ [ "nestedList" "0" "c" "0" ] [ "nestedList" "0" "c" "1" ] ];
+          d = [ { a = [ "nestedList" "0" "d" "0" "a" ]; } ];
+          e = { a = [ "nestedList" "0" "e" "a" ]; };
+        }
+        {
+          a = [ "nestedList" "1" "a" ];
+          b = [ "nestedList" "1" "b" ];
+          c = [ [ "nestedList" "1" "c" "0" ] [ "nestedList" "1" "c" "1" ] ];
+          d = [ { a = [ "nestedList" "1" "d" "0" "a" ]; } ];
+          e = { a = [ "nestedList" "1" "e" "a" ]; };
+        }
+      ];
+    };
+  };
+
+  # Tests that withReplacements can:
+  # - recurse in attrs and lists
+  # - ._secret attribute is understood
+  # - .prefix and .suffix attributes are understood
+  # - if ._secret attribute is found, ignores other fields
+  testReplaceWithPlaceholder = {
+    expected =
+      let
+        item = root: {
+          a = "A";
+          b = "%SECRET_${root}B%";
+          c = "%SECRET_${root}C%";
+        };
+      in
+        (item "") // {
+          nestedAttr = item "NESTEDATTR_";
+          nestedList = [ (item "NESTEDLIST_0_") ];
+          doubleNestedList = [ { n = (item "DOUBLENESTEDLIST_0_N_"); } ];
+        };
+    expr =
+      let
+        item = {
+          a = "A";
+          b._secret = "/path/B";
+          b.transform = null;
+          c._secret = "/path/C";
+          c.transform = v: "prefix-${v}-suffix";
+          c.other = "other";
+        };
+      in
+        replaceWithPlaceholder "_secret" (
+          item // {
+            nestedAttr = item;
+            nestedList = [ item ];
+            doubleNestedList = [ { n = item; } ];
+          }
+        );
+  };
+
+  testReplaceWithPlaceholderRootList = {
+    expected =
+      let
+        item = root: {
+          a = "A";
+          b = "%SECRET_${root}B%";
+          c = "%SECRET_${root}C%";
+        };
+      in
+        [
+          (item "0_")
+          (item "1_")
+          [ (item "2_0_") ]
+          [ { n = (item "3_0_N_"); } ]
+        ];
+    expr =
+      let
+        item = {
+          a = "A";
+          b._secret = "/path/B";
+          b.transform = null;
+          c._secret = "/path/C";
+          c.transform = v: "prefix-${v}-suffix";
+          c.other = "other";
+        };
+      in
+        replaceWithPlaceholder "_secret" [
+          item
+          item
+          [ item ]
+          [ { n = item; } ]
+        ];
+  };
+
+  testGetPlaceholderReplacements = {
+    expected =
+      let
+        secrets = root: {
+          "%SECRET_${root}B%" = {
+            _secret = "/path/B";
+            prefix = null;
+            suffix = "";
+            prefixIfNotPresent = "";
+            suffixIfNotPresent = "";
+          };
+          "%SECRET_${root}C%" = {
+            _secret = "/path/C";
+            prefix = "prefix-";
+            suffix = "-suffix";
+            prefixIfNotPresent = "";
+            suffixIfNotPresent = "";
+          };
+        };
+      in
+        (secrets "") //
+        (secrets "NESTEDATTR_") //
+        (secrets "NESTEDLIST_0_") //
+        (secrets "DOUBLENESTEDLIST_0_N_");
+    expr =
+      let
+        item = {
+          a = "A";
+          b._secret = "/path/B";
+          b.prefix = null;
+          c._secret = "/path/C";
+          c.prefix = "prefix-";
+          c.suffix = "-suffix";
+          c.other = "other";
+        };
+      in
+        getPlaceholderReplacements "_secret" (
+          item // {
+            nestedAttr = item;
+            nestedList = [ item ];
+            doubleNestedList = [ { n = item; } ];
+          }
+        );
   };
 }

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -770,6 +770,45 @@ rec {
       nestedTypes.elemType = elemType;
     };
 
+    outOfBand = outOfBand' "_secret";
+
+    outOfBand' = field: lib.types.submodule {
+      options = {
+        ${field} = lib.mkOption {
+          type = path;
+          description = "File that contains the value to be injected in the configuration file.";
+        };
+
+        prefix = lib.mkOption {
+          type = str;
+          description = "Prefix to add to the value that will be injected in the configuration file.";
+          default = "";
+          example = "base64:";
+        };
+
+        prefixIfNotPresent = lib.mkOption {
+          type = str;
+          description = "Like prefix option but only added if the value does not contain the prefix already.";
+          default = "";
+          example = "base64:";
+        };
+
+        suffix = lib.mkOption {
+          type = str;
+          description = "An optional suffix to add to the value that will be injected in the configuration file.";
+          default = "";
+          example = ":sha256";
+        };
+
+        suffixIfNotPresent = lib.mkOption {
+          type = str;
+          description = "Like suffix option but only added if the value does not contain the suffix already.";
+          default = "";
+          example = "base64:";
+        };
+      };
+    };
+
     # A submodule (like typed attribute set). See NixOS manual.
     submodule = modules: submoduleWith {
       shorthandOnlyDefinesConfig = true;

--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -365,7 +365,7 @@ in rec {
 
   makeJobScript = name: text:
     let
-      scriptName = replaceStrings [ "\\" "@" ] [ "-" "_" ] (shellEscape name);
+      scriptName = replaceStrings [ "\\" "@" " " ] [ "-" "_" "_" ] (shellEscape name);
       out = (pkgs.writeShellScriptBin scriptName ''
         set -e
         ${text}

--- a/nixos/lib/test-driver/test_driver/machine.py
+++ b/nixos/lib/test-driver/test_driver/machine.py
@@ -740,7 +740,7 @@ class Machine:
         """
 
         def check_file(_: Any) -> bool:
-            status, _ = self.execute(f"test -e {filename}")
+            status, _ = self.execute(f'test -e "{filename}"')
             return status == 0
 
         with self.nested(f"waiting for file '{filename}'"):

--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -4,22 +4,17 @@ let
   inherit (lib)
     any
     attrNames
-    collect'
     concatMapStringsSep
     concatStringsSep
     elem
-    escapeShellArg
     filter
     flatten
-    forEach
     getExe
     getName
     getPlaceholderReplacements
-    hasAttr
     hasPrefix
     hasSuffix
     imap0
-    imap1
     isAttrs
     isDerivation
     isFloat
@@ -29,7 +24,6 @@ let
     isString
     listToAttrs
     mapAttrs
-    mapAttrsRecursiveCond'
     mapAttrsToList
     nameValuePair
     optionalString

--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -4,13 +4,18 @@ let
   inherit (lib)
     any
     attrNames
+    collect'
     concatMapStringsSep
     concatStringsSep
     elem
     escapeShellArg
     filter
     flatten
+    forEach
+    getExe
     getName
+    getPlaceholderReplacements
+    hasAttr
     hasPrefix
     hasSuffix
     imap0
@@ -24,10 +29,13 @@ let
     isString
     listToAttrs
     mapAttrs
+    mapAttrsRecursiveCond'
+    mapAttrsToList
     nameValuePair
     optionalString
     removePrefix
     removeSuffix
+    replaceWithPlaceholder
     replaceStrings
     stringToCharacters
     types
@@ -289,43 +297,12 @@ utils = rec {
   # Like genJqSecretsReplacementSnippet, but allows the name of the
   # attr which identifies the secret to be changed.
   genJqSecretsReplacementSnippet' = attr: set: output:
-    let
-      secretsRaw = recursiveGetAttrsetWithJqPrefix set attr;
-      # Set default option values
-      secrets = mapAttrs (_name: set: {
-        quote = true;
-      } // set) secretsRaw;
-      stringOrDefault = str: def: if str == "" then def else str;
-    in ''
-      if [[ -h '${output}' ]]; then
-        rm '${output}'
-      fi
-
-      inherit_errexit_enabled=0
-      shopt -pq inherit_errexit && inherit_errexit_enabled=1
-      shopt -s inherit_errexit
-    ''
-    + concatStringsSep
-        "\n"
-        (imap1 (index: name: ''
-                  secret${toString index}=$(<'${secrets.${name}.${attr}}')
-                  export secret${toString index}
-                '')
-               (attrNames secrets))
-    + "\n"
-    + "${pkgs.jq}/bin/jq >'${output}' "
-    + escapeShellArg (stringOrDefault
-          (concatStringsSep
-            " | "
-            (imap1 (index: name: ''${name} = ($ENV.secret${toString index}${optionalString (!secrets.${name}.quote) " | fromjson"})'')
-                   (attrNames secrets)))
-          ".")
-    + ''
-       <<'EOF'
-      ${toJSON set}
-      EOF
-      (( ! $inherit_errexit_enabled )) && shopt -u inherit_errexit
-    '';
+    genConfigOutOfBand {
+      config = set;
+      configLocation = output;
+      sourceField = attr;
+      generator = utils.genConfigOutOfBandFormatAdapter (pkgs.formats.json {});
+    };
 
   /* Remove packages of packagesToRemove from packages, based on their names.
      Relies on package names and has quadratic complexity so use with caution!
@@ -351,5 +328,130 @@ utils = rec {
       units = import ./systemd-network-units.nix { inherit lib systemdUtils; };
     };
   };
+
+  /**
+    Generate a configuration file from an attrset which can have some values coming out of band, replaced in the configuration file on the target system, usually in the `preStart` phase of a Systemd service or in the system activation script. This function returns the replacement script.
+
+
+    # Inputs
+
+    `config`
+
+    : Any combination of AttrSet and List. By default, all values will be stored verbatim in the nix store.
+    : For a value to be given out of band instead, the value must be replaced by an AttrSet with a `_secret` attribute. In this case, the `_secret` field must be a path to a file on the target filesystem that will contain the value to be inserted in the configuration file.
+    : If given, the `prefix` field will be prefixed to the out of band value before being replaced in the configuration file.
+    : If given, the `suffix` field will be suffixed to the out of band value before being replaced in the configuration file.
+
+    `configLocation`
+
+    : Location of the configuration file on the target filesystem, with all the values replaced.
+
+    `generator`
+
+    : Function to generate the configuration file from the first argument `config`.
+    : The format can be anything like JSON, YAML, INI or others.
+    : This function must create a file in the nix store and return the path to the file.
+    : This generated file will not have secrets embedded yet.
+    :
+    : For convenience and maintainability, adapter functions are provided to accommodate two use cases.
+    : When combining with a generator from `pkgs.formats`:
+
+    ```nix
+    genConfigOutOfBandFormatAdapter (pkgs.formats.yaml {});
+    ```
+
+    : When combining with a generator from `lib.generators`:
+
+    ```nix
+    genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON {});
+    ```
+
+    `sourceField`
+
+    : The name of field used to determine if a value is given out of band or not can be changed. By default, the field is `_secret`. Only change this default for backwards compatibility.
+
+    # Type
+
+    ```
+    genConfigOutOfBand :: Any -> String -> (Any -> Path) -> Path
+    ```
+
+    # Examples
+    :::{.example}
+    ## `utils.genConfigOutOfBand` generating JSON file.
+
+    ```nix
+    aSecret = pkgs.writeText "a-secret.txt" "Secret of A";
+    bSecret = pkgs.writeText "b-secret.txt" "Secret of B";
+
+    config = {
+      a.a._secret = aSecret;
+      b = [{
+        _secret = bSecret;
+        prefix = "prefix-";
+        suffix = "-suffix";
+      }];
+      c = "not secret C";
+      d.d = "not secret D";
+    };
+
+    configLocation = "/var/lib/config.json";
+
+    generator = replaceSecretsFormatAdapter (pkgs.formats.json {});
+
+    systemd.service."myservice".preStart = genConfigOutOfBand {
+      inherit config configLocation generator;
+    };
+    ```
+
+    The resulting file will be:
+
+    ```json
+    {
+      "a": { "a": "Secret of A" },
+      "b": [ "prefix-Secret of B-suffix" ],
+      "c": "not a secret",
+      "d": { "d": "not a secret" }
+    }
+    ```
+  */
+  genConfigOutOfBand = { config, configLocation, generator, sourceField ? "_secret" }:
+    let
+      configWithPlaceholders = replaceWithPlaceholder sourceField config;
+
+      fileWithPlaceholders = generator "template" configWithPlaceholders;
+
+      replacements = getPlaceholderReplacements sourceField config;
+    in
+      replacePlaceholdersScript {
+        inherit sourceField fileWithPlaceholders configLocation replacements;
+      };
+
+  genConfigOutOfBandFormatAdapter = format:
+    format.generate;
+
+  genConfigOutOfBandGeneratorAdapter = generator: name: value:
+    pkgs.writeText "generator " (generator value);
+
+  replacePlaceholdersScript = { sourceField, fileWithPlaceholders, configLocation, replacements }:
+    let
+      replaceSecret = pattern: args:
+        ''
+          ${getExe pkgs.replace-secret} \
+            ${pattern} ${args.${sourceField}} ${configLocation} \
+            --prefix="${args.prefix}" \
+            --suffix="${args.suffix}" \
+            --prefix-if-not-present="${args.prefixIfNotPresent}" \
+            --suffix-if-not-present="${args.suffixIfNotPresent}"
+        '';
+    in
+      ''
+      set -euo pipefail
+
+      mkdir -p $(dirname ${configLocation})
+      rm -f ${configLocation}
+      install -Dm600 ${fileWithPlaceholders} ${configLocation}
+      ''
+      + concatStringsSep "\n" (mapAttrsToList replaceSecret replacements);
 };
 in utils

--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -438,7 +438,7 @@ utils = rec {
       replaceSecret = pattern: args:
         ''
           ${getExe pkgs.replace-secret} \
-            ${pattern} ${args.${sourceField}} ${configLocation} \
+            ${pattern} "${args.${sourceField}}" "${configLocation}" \
             --prefix="${args.prefix}" \
             --suffix="${args.suffix}" \
             --prefix-if-not-present="${args.prefixIfNotPresent}" \
@@ -448,9 +448,9 @@ utils = rec {
       ''
       set -euo pipefail
 
-      mkdir -p $(dirname ${configLocation})
-      rm -f ${configLocation}
-      install -Dm600 ${fileWithPlaceholders} ${configLocation}
+      test -d "$(dirname "${configLocation}")" || mkdir -p "$(dirname "${configLocation}")"
+      rm -f "${configLocation}"
+      install -Dm600 "${fileWithPlaceholders}" "${configLocation}"
       ''
       + concatStringsSep "\n" (mapAttrsToList replaceSecret replacements);
 };

--- a/nixos/modules/services/logging/filebeat.nix
+++ b/nixos/modules/services/logging/filebeat.nix
@@ -229,10 +229,11 @@ in
 
           umask u=rwx,g=,o=
 
-          ${utils.genJqSecretsReplacementSnippet
-              cfg.settings
-              "/var/lib/filebeat/filebeat.yml"
-           }
+          ${utils.genConfigOutOfBand {
+              config = cfg.settings;
+              configLocation = "/var/lib/filebeat/filebeat.yml";
+              generator = utils.genConfigOutOfBandFormatAdapter json;
+          }}
         '';
         ExecStart = ''
           ${cfg.package}/bin/filebeat -e \

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -361,6 +361,7 @@ in {
   mimir = handleTest ./mimir.nix {};
   garage = handleTest ./garage {};
   gemstash = handleTest ./gemstash.nix {};
+  genConfigOutOfBand-test = handleTest ./genconfigoutofband-test.nix {};
   geoserver = runTest ./geoserver.nix;
   gerrit = handleTest ./gerrit.nix {};
   geth = handleTest ./geth.nix {};

--- a/nixos/tests/genconfigoutofband-test.nix
+++ b/nixos/tests/genconfigoutofband-test.nix
@@ -42,7 +42,9 @@ let
   tests = {
     replacePlaceholdersScriptJSON = {
       # Path with space on purpose!
-      configs = { "/var/lib/my config.json" = wantedConfig; };
+      configs = {
+        "/var/lib/my config.json" = wantedConfig;
+      };
 
       nodeConfig = {
         system.activationScripts.genOutOfBand =
@@ -70,7 +72,9 @@ let
     };
 
     jsonFormat = {
-      configs = { "/var/lib/config.json" = wantedConfig; };
+      configs = {
+        "/var/lib/config.json" = wantedConfig;
+      };
 
       nodeConfig = {
         system.activationScripts.genOutOfBand =
@@ -95,7 +99,9 @@ let
     };
 
     jsonGen = {
-      configs = { "/var/lib/config.json" = wantedConfig; };
+      configs = {
+        "/var/lib/config.json" = wantedConfig;
+      };
 
       nodeConfig = {
         system.activationScripts.genOutOfBand =
@@ -119,83 +125,93 @@ let
       '';
     };
 
-    otherUserGroupTmpFiles = let
-      configLocation = "/var/lib/outOfBandConfig/config.json";
+    otherUserGroupTmpFiles =
+      let
+        configLocation = "/var/lib/outOfBandConfig/config.json";
 
-      config = utils.genConfigOutOfBandSystemd {
-        config = userConfig;
-        inherit configLocation;
-        generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON { });
-      };
-    in {
-      configs = { ${configLocation} = wantedConfig; };
-
-      waitForUnit = "outOfBand.service";
-
-      nodeConfig = {
-        systemd.tmpfiles.rules = [ "d /var/lib/outOfBandConfig 0770 nobody nobody" ];
-        systemd.services.outOfBand = {
-          wantedBy = [ "sysinit.target" ];
-          after = [ "sysinit.target" ];
-          unitConfig.DefaultDependencies = false;
-          serviceConfig.Type = "oneshot";
-          serviceConfig.RemainAfterExit = true;
-
-          serviceConfig.User = "nobody";
-          serviceConfig.Group = "nobody";
-          serviceConfig.LoadCredential = config.loadCredentials;
-          preStart = config.preStart;
-          script = "cat ${configLocation}";
+        config = utils.genConfigOutOfBandSystemd {
+          config = userConfig;
+          inherit configLocation;
+          generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON { });
         };
-      };
-
-      pythonParseFile = ''
-        gotConfig = json.loads(gotConfig)
-      '';
-    };
-
-    otherUserGroupStateDirectoryManual = let
-      config = utils.genConfigOutOfBandSystemd {
-        config = userConfig;
-        configLocation = "$STATE_DIRECTORY/my config.json";
-        generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON { });
-      };
-    in {
-      # Path with space on purpose!.
-      # StateDirectory can't contain spaces.
-      configs = { "/var/lib/outOfBandConfig/my config.json" = wantedConfig; };
-
-      waitForUnit = "outOfBand.service";
-
-      nodeConfig = {
-        systemd.services.outOfBand = {
-          wantedBy = [ "sysinit.target" ];
-          after = [ "sysinit.target" ];
-          unitConfig.DefaultDependencies = false;
-          serviceConfig.Type = "oneshot";
-          serviceConfig.RemainAfterExit = true;
-
-          serviceConfig.User = "nobody";
-          serviceConfig.Group = "nobody";
-          serviceConfig.StateDirectory = "outOfBandConfig";
-          serviceConfig.LoadCredential = config.loadCredentials;
-          preStart = config.preStart;
-          script = ''
-            echo "$STATE_DIRECTORY/my config.json"
-            cat "$STATE_DIRECTORY/my config.json"
-          '';
+      in
+      {
+        configs = {
+          ${configLocation} = wantedConfig;
         };
+
+        waitForUnit = "outOfBand.service";
+
+        nodeConfig = {
+          systemd.tmpfiles.rules = [ "d /var/lib/outOfBandConfig 0770 nobody nobody" ];
+          systemd.services.outOfBand = {
+            wantedBy = [ "sysinit.target" ];
+            after = [ "sysinit.target" ];
+            unitConfig.DefaultDependencies = false;
+            serviceConfig.Type = "oneshot";
+            serviceConfig.RemainAfterExit = true;
+
+            serviceConfig.User = "nobody";
+            serviceConfig.Group = "nobody";
+            serviceConfig.LoadCredential = config.loadCredentials;
+            preStart = config.preStart;
+            script = "cat ${configLocation}";
+          };
+        };
+
+        pythonParseFile = ''
+          gotConfig = json.loads(gotConfig)
+        '';
       };
 
-      pythonParseFile = ''
-        gotConfig = json.loads(gotConfig)
-      '';
-    };
+    otherUserGroupStateDirectoryManual =
+      let
+        config = utils.genConfigOutOfBandSystemd {
+          config = userConfig;
+          configLocation = "$STATE_DIRECTORY/my config.json";
+          generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON { });
+        };
+      in
+      {
+        # Path with space on purpose!.
+        # StateDirectory can't contain spaces.
+        configs = {
+          "/var/lib/outOfBandConfig/my config.json" = wantedConfig;
+        };
+
+        waitForUnit = "outOfBand.service";
+
+        nodeConfig = {
+          systemd.services.outOfBand = {
+            wantedBy = [ "sysinit.target" ];
+            after = [ "sysinit.target" ];
+            unitConfig.DefaultDependencies = false;
+            serviceConfig.Type = "oneshot";
+            serviceConfig.RemainAfterExit = true;
+
+            serviceConfig.User = "nobody";
+            serviceConfig.Group = "nobody";
+            serviceConfig.StateDirectory = "outOfBandConfig";
+            serviceConfig.LoadCredential = config.loadCredentials;
+            preStart = config.preStart;
+            script = ''
+              echo "$STATE_DIRECTORY/my config.json"
+              cat "$STATE_DIRECTORY/my config.json"
+            '';
+          };
+        };
+
+        pythonParseFile = ''
+          gotConfig = json.loads(gotConfig)
+        '';
+      };
 
     otherUserGroupStateDirectoryModule = {
       # Path with space on purpose!.
       # StateDirectory can't contain spaces.
-      configs = { "/var/lib/outOfBandConfig/my config.json" = wantedConfig; };
+      configs = {
+        "/var/lib/outOfBandConfig/my config.json" = wantedConfig;
+      };
 
       waitForUnit = "outOfBand.service";
 
@@ -210,11 +226,13 @@ let
           serviceConfig.User = "nobody";
           serviceConfig.Group = "nobody";
           serviceConfig.StateDirectory = "outOfBandConfig";
-          outOfBandConfig = [{
-            name = "my config.json";
-            config = userConfig;
-            generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON { });
-          }];
+          outOfBandConfig = [
+            {
+              name = "my config.json";
+              config = userConfig;
+              generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON { });
+            }
+          ];
           script = ''
             echo "$STATE_DIRECTORY/my config.json"
             cat "$STATE_DIRECTORY/my config.json"
@@ -227,43 +245,49 @@ let
       '';
     };
 
-    dynamicUserManual = let
-      config = utils.genConfigOutOfBandSystemd {
-        config = userConfig;
-        configLocation = "$STATE_DIRECTORY/config.json";
-        generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON { });
-      };
-    in {
-      configs = { "/var/lib/private/outOfBandConfig/config.json" = wantedConfig; };
-
-      waitForUnit = "outOfBand.service";
-
-      nodeConfig = {
-        systemd.services.outOfBand = {
-          wantedBy = [ "sysinit.target" ];
-          after = [ "sysinit.target" ];
-          unitConfig.DefaultDependencies = false;
-          serviceConfig.Type = "oneshot";
-          serviceConfig.RemainAfterExit = true; # Allows wait_for_unit to work.
-
-          serviceConfig.DynamicUser = true;
-          serviceConfig.StateDirectory = "outOfBandConfig";
-          serviceConfig.LoadCredential = config.loadCredentials;
-          preStart = config.preStart;
-          script = ''
-            echo $STATE_DIRECTORY/config.json
-            cat $STATE_DIRECTORY/config.json
-          '';
+    dynamicUserManual =
+      let
+        config = utils.genConfigOutOfBandSystemd {
+          config = userConfig;
+          configLocation = "$STATE_DIRECTORY/config.json";
+          generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON { });
         };
-      };
+      in
+      {
+        configs = {
+          "/var/lib/private/outOfBandConfig/config.json" = wantedConfig;
+        };
 
-      pythonParseFile = ''
-        gotConfig = json.loads(gotConfig)
-      '';
-    };
+        waitForUnit = "outOfBand.service";
+
+        nodeConfig = {
+          systemd.services.outOfBand = {
+            wantedBy = [ "sysinit.target" ];
+            after = [ "sysinit.target" ];
+            unitConfig.DefaultDependencies = false;
+            serviceConfig.Type = "oneshot";
+            serviceConfig.RemainAfterExit = true; # Allows wait_for_unit to work.
+
+            serviceConfig.DynamicUser = true;
+            serviceConfig.StateDirectory = "outOfBandConfig";
+            serviceConfig.LoadCredential = config.loadCredentials;
+            preStart = config.preStart;
+            script = ''
+              echo $STATE_DIRECTORY/config.json
+              cat $STATE_DIRECTORY/config.json
+            '';
+          };
+        };
+
+        pythonParseFile = ''
+          gotConfig = json.loads(gotConfig)
+        '';
+      };
 
     dynamicUserModule = {
-      configs = { "/var/lib/outOfBandConfig/config.json" = wantedConfig; };
+      configs = {
+        "/var/lib/outOfBandConfig/config.json" = wantedConfig;
+      };
 
       waitForUnit = "outOfBand.service";
 
@@ -276,11 +300,13 @@ let
           serviceConfig.RemainAfterExit = true; # Allows wait_for_unit to work.
 
           serviceConfig.StateDirectory = "outOfBandConfig";
-          outOfBandConfig = [{
-            name = "config.json";
-            config = userConfig;
-            generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON { });
-          }];
+          outOfBandConfig = [
+            {
+              name = "config.json";
+              config = userConfig;
+              generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON { });
+            }
+          ];
           serviceConfig.DynamicUser = true;
           script = ''
             echo $STATE_DIRECTORY/config.json
@@ -313,17 +339,20 @@ let
           serviceConfig.RemainAfterExit = true; # Allows wait_for_unit to work.
 
           serviceConfig.StateDirectory = "outOfBandConfig";
-          outOfBandConfig = [{
-            name = "config1.json";
-            config = userConfig;
-            generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON { });
-          } {
-            name = "config2.json";
-            config = {
-              config2._secret = "/run/secrets/a-secret.txt";
-            };
-            generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON { });
-          }];
+          outOfBandConfig = [
+            {
+              name = "config1.json";
+              config = userConfig;
+              generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON { });
+            }
+            {
+              name = "config2.json";
+              config = {
+                config2._secret = "/run/secrets/a-secret.txt";
+              };
+              generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON { });
+            }
+          ];
           script = ''
             echo $STATE_DIRECTORY/config1.json
             cat $STATE_DIRECTORY/config1.json
@@ -368,9 +397,11 @@ let
             start_all()
 
           ''
-          + (lib.concatStringsSep "\n" (lib.mapAttrsToList (c: _: ''
-            machine.wait_for_file("${c}")
-          '') configs))
+          + (lib.concatStringsSep "\n" (
+            lib.mapAttrsToList (c: _: ''
+              machine.wait_for_file("${c}")
+            '') configs
+          ))
           + (
             if waitForUnit == null then
               ""
@@ -380,17 +411,19 @@ let
                 print(machine.succeed("systemctl cat ${waitForUnit}"))
               ''
           )
-          + (lib.concatStringsSep "\n" (lib.mapAttrsToList (c: wantedConfig: ''
-            print(machine.succeed("ls -l '${c}'"))
-            gotConfig = machine.succeed("cat '${c}'")
-            print(gotConfig)
-            ${pythonParseFile}
+          + (lib.concatStringsSep "\n" (
+            lib.mapAttrsToList (c: wantedConfig: ''
+              print(machine.succeed("ls -l '${c}'"))
+              gotConfig = machine.succeed("cat '${c}'")
+              print(gotConfig)
+              ${pythonParseFile}
 
-            wantedConfig = json.loads('${lib.generators.toJSON { } wantedConfig}')
+              wantedConfig = json.loads('${lib.generators.toJSON { } wantedConfig}')
 
-            if wantedConfig != gotConfig:
-              raise Exception("\nwantedConfig: {}\n!= gotConfig: {}".format(wantedConfig, gotConfig))
-          '') configs));
+              if wantedConfig != gotConfig:
+                raise Exception("\nwantedConfig: {}\n!= gotConfig: {}".format(wantedConfig, gotConfig))
+            '') configs
+          ));
       }
     );
 in

--- a/nixos/tests/genconfigoutofband-test.nix
+++ b/nixos/tests/genconfigoutofband-test.nix
@@ -1,0 +1,117 @@
+{ system ? builtins.currentSystem
+, config ? {}
+, pkgs ? import ../.. { inherit system config; }
+, lib ? pkgs.lib
+, testing ? import ../lib/testing-python.nix { inherit system pkgs; }
+}:
+
+let
+  inherit (import ../lib/testing-python.nix { inherit system pkgs; }) makeTest;
+  utils = import ../lib/utils.nix { inherit lib config pkgs; };
+
+  aSecret = pkgs.writeText "a-secret.txt" "Secret of A";
+  bSecret = pkgs.writeText "b-secret.txt" "Secret of B";
+  eSecret = pkgs.writeText "e-secret.txt" "prefix-abc";
+
+  userConfig = {
+    a.a._secret = aSecret;
+    b._secret = bSecret;
+    b.prefix = "prefix-";
+    b.suffix = "-suffix";
+    c = "not secret C";
+    d.d = "not secret D";
+    e._secret = eSecret;
+    e.prefixIfNotPresent = "prefix-";
+    e.suffixIfNotPresent = "-suffix";
+  };
+
+  wantedConfig = {
+    a.a = "Secret of A";
+    b = "prefix-Secret of B-suffix";
+    c = "not secret C";
+    d.d = "not secret D";
+    e = "prefix-abc-suffix";
+  };
+
+  tests = {
+    replacePlaceholdersScriptJSONTest = rec {
+      configLocation = "/var/lib/config.json";
+
+      inherit wantedConfig;
+
+      script = utils.replacePlaceholdersScript {
+        sourceField = "_secret";
+        fileWithPlaceholders = pkgs.writeText "config.yaml.template"
+          (lib.generators.toJSON {} (lib.replaceWithPlaceholder "_secret" userConfig));
+        inherit configLocation;
+        replacements = lib.getPlaceholderReplacements "_secret" userConfig;
+      };
+
+      pythonParseFile = ''
+        gotConfig = json.loads(gotConfig)
+      '';
+    };
+
+    genConfigOutOfBandJSONFormat = rec {
+      configLocation = "/var/lib/config.json";
+
+      inherit wantedConfig;
+
+      script = utils.genConfigOutOfBand {
+        config = userConfig;
+        inherit configLocation;
+        generator = utils.genConfigOutOfBandFormatAdapter (pkgs.formats.json {});
+      };
+
+      pythonParseFile = ''
+        gotConfig = json.loads(gotConfig)
+      '';
+    };
+
+    genConfigOutOfBandJSONGen = rec {
+      configLocation = "/var/lib/config.json";
+
+      inherit wantedConfig;
+
+      script = utils.genConfigOutOfBand {
+        config = userConfig;
+        inherit configLocation;
+        generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON {});
+      };
+
+      pythonParseFile = ''
+        gotConfig = json.loads(gotConfig)
+      '';
+    };
+  };
+
+  mkTest = name: { configLocation, wantedConfig, script, pythonParseFile }:
+    import ./make-test-python.nix ({ pkgs, ... }: {
+      inherit name;
+      meta.maintainers = with pkgs.lib.maintainers; [ ibizaman ];
+      nodes.machine = {
+        system.activationScripts.genOutOfBand = script;
+      };
+
+      testScript = ''
+        import json
+
+        start_all()
+
+        wantedConfig = json.loads('${lib.generators.toJSON {} wantedConfig}')
+
+        machine.wait_for_file("${configLocation}")
+        print(machine.succeed("cat ${pkgs.writeText "replaceInTemplate" script}"))
+
+        gotConfig = machine.succeed("cat ${configLocation}")
+        print(gotConfig)
+        ${pythonParseFile}
+
+        if wantedConfig != gotConfig:
+          raise Exception("\nwantedConfig: {}\n!= gotConfig: {}".format(wantedConfig, gotConfig))
+
+      '';
+    });
+in
+
+builtins.mapAttrs (k: v: mkTest k v) tests

--- a/nixos/tests/genconfigoutofband-test.nix
+++ b/nixos/tests/genconfigoutofband-test.nix
@@ -2,25 +2,30 @@
 , config ? {}
 , pkgs ? import ../.. { inherit system config; }
 , lib ? pkgs.lib
-, testing ? import ../lib/testing-python.nix { inherit system pkgs; }
 }:
 
 let
-  inherit (import ../lib/testing-python.nix { inherit system pkgs; }) makeTest;
   utils = import ../lib/utils.nix { inherit lib config pkgs; };
 
-  aSecret = pkgs.writeText "a-secret.txt" "Secret of A";
-  bSecret = pkgs.writeText "b-secret.txt" "Secret of B";
-  eSecret = pkgs.writeText "e-secret.txt" "prefix-abc";
+  writeSecretScript = name: value: ''
+    mkdir -p /run/secrets
+    touch /run/secrets/${name}
+    chmod 700 /run/secrets/${name}
+    echo "${value}" > /run/secrets/${name}
+  '';
+
+  aSecret = writeSecretScript "a-secret.txt" "Secret of A";
+  bSecret = writeSecretScript "b-secret.txt" "Secret of B";
+  eSecret = writeSecretScript "e-secret.txt" "prefix-abc";
 
   userConfig = {
-    a.a._secret = aSecret;
-    b._secret = bSecret;
+    a.a._secret = "/run/secrets/a-secret.txt";
+    b._secret = "/run/secrets/b-secret.txt";
     b.prefix = "prefix-";
     b.suffix = "-suffix";
     c = "not secret C";
     d.d = "not secret D";
-    e._secret = eSecret;
+    e._secret = "/run/secrets/e-secret.txt";
     e.prefixIfNotPresent = "prefix-";
     e.suffixIfNotPresent = "-suffix";
   };
@@ -34,17 +39,20 @@ let
   };
 
   tests = {
-    replacePlaceholdersScriptJSONTest = rec {
-      configLocation = "/var/lib/config.json";
+    replacePlaceholdersScriptJSON = rec {
+      # Path with space on purpose!
+      configLocation = "/var/lib/my config.json";
 
       inherit wantedConfig;
 
-      script = utils.replacePlaceholdersScript {
-        sourceField = "_secret";
-        fileWithPlaceholders = pkgs.writeText "config.yaml.template"
-          (lib.generators.toJSON {} (lib.replaceWithPlaceholder "_secret" userConfig));
-        inherit configLocation;
-        replacements = lib.getPlaceholderReplacements "_secret" userConfig;
+      nodeConfig = {
+        system.activationScripts.genOutOfBand = pkgs.stringsWithDeps.stringAfter [ "aSecret" "bSecret" "eSecret" ] (utils.replacePlaceholdersScript {
+          sourceField = "_secret";
+          fileWithPlaceholders = pkgs.writeText "config.yaml.template"
+            (lib.generators.toJSON {} (lib.replaceWithPlaceholder "_secret" userConfig));
+          inherit configLocation;
+          replacements = lib.getPlaceholderReplacements "_secret" userConfig;
+        });
       };
 
       pythonParseFile = ''
@@ -52,15 +60,17 @@ let
       '';
     };
 
-    genConfigOutOfBandJSONFormat = rec {
+    jsonFormat = rec {
       configLocation = "/var/lib/config.json";
 
       inherit wantedConfig;
 
-      script = utils.genConfigOutOfBand {
-        config = userConfig;
-        inherit configLocation;
-        generator = utils.genConfigOutOfBandFormatAdapter (pkgs.formats.json {});
+      nodeConfig = {
+        system.activationScripts.genOutOfBand = pkgs.stringsWithDeps.stringAfter [ "aSecret" "bSecret" "eSecret" ] (utils.genConfigOutOfBand {
+          config = userConfig;
+          inherit configLocation;
+          generator = utils.genConfigOutOfBandFormatAdapter (pkgs.formats.json {});
+        });
       };
 
       pythonParseFile = ''
@@ -68,30 +78,191 @@ let
       '';
     };
 
-    genConfigOutOfBandJSONGen = rec {
+    jsonGen = rec {
       configLocation = "/var/lib/config.json";
 
       inherit wantedConfig;
 
-      script = utils.genConfigOutOfBand {
-        config = userConfig;
-        inherit configLocation;
-        generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON {});
+      nodeConfig = {
+        system.activationScripts.genOutOfBand = pkgs.stringsWithDeps.stringAfter [ "aSecret" "bSecret" "eSecret" ] (utils.genConfigOutOfBand {
+          config = userConfig;
+          inherit configLocation;
+          generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON {});
+        });
       };
 
       pythonParseFile = ''
         gotConfig = json.loads(gotConfig)
       '';
     };
+
+    otherUserGroupTmpFiles = rec {
+      configLocation = "/var/lib/outOfBandConfig/config.json";
+
+      inherit wantedConfig;
+
+      waitForUnit = "outOfBand.service";
+
+      nodeConfig = {
+        systemd.tmpfiles.rules = [ "d /var/lib/outOfBandConfig 0770 nobody nobody" ];
+        systemd.services.outOfBand = {
+          wantedBy = [ "sysinit.target" ];
+          after = [ "sysinit.target" ];
+          unitConfig.DefaultDependencies = false;
+          serviceConfig.Type = "oneshot";
+          serviceConfig.RemainAfterExit = true;
+
+          serviceConfig.User = "nobody";
+          serviceConfig.Group = "nobody";
+          serviceConfig.LoadCredential = [
+            "a-secret.txt:/run/secrets/a-secret.txt"
+            "b-secret.txt:/run/secrets/b-secret.txt"
+            "e-secret.txt:/run/secrets/e-secret.txt"
+          ];
+          preStart = utils.genConfigOutOfBand {
+            config = lib.attrsets.updateManyAttrsByPath [
+              {
+                path = [ "a" "a" "_secret" ];
+                update = old: "$CREDENTIALS_DIRECTORY/a-secret.txt"; 
+              }
+              {
+                path = [ "b" "_secret" ];
+                update = old: "$CREDENTIALS_DIRECTORY/b-secret.txt"; 
+              }
+              {
+                path = [ "e" "_secret" ];
+                update = old: "$CREDENTIALS_DIRECTORY/e-secret.txt"; 
+              }
+            ] userConfig;
+            inherit configLocation;
+            generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON {});
+          };
+          script = "cat ${configLocation}";
+        };
+      };
+
+      pythonParseFile = ''
+        gotConfig = json.loads(gotConfig)
+      '';
+    };
+
+    otherUserGroupStateDirectory = {
+      # Path with space on purpose!.
+      # StateDirectory can't contain spaces.
+      configLocation = "/var/lib/outOfBandConfig/my config.json";
+
+      inherit wantedConfig;
+
+      waitForUnit = "outOfBand.service";
+
+      nodeConfig = {
+        systemd.services.outOfBand = {
+          wantedBy = [ "sysinit.target" ];
+          after = [ "sysinit.target" ];
+          unitConfig.DefaultDependencies = false;
+          serviceConfig.Type = "oneshot";
+          serviceConfig.RemainAfterExit = true;
+
+          serviceConfig.User = "nobody";
+          serviceConfig.Group = "nobody";
+          serviceConfig.StateDirectory = "outOfBandConfig";
+          serviceConfig.LoadCredential = [
+            "a-secret.txt:/run/secrets/a-secret.txt"
+            "b-secret.txt:/run/secrets/b-secret.txt"
+            "e-secret.txt:/run/secrets/e-secret.txt"
+          ];
+          preStart = utils.genConfigOutOfBand {
+            config = lib.attrsets.updateManyAttrsByPath [
+              {
+                path = [ "a" "a" "_secret" ];
+                update = old: "$CREDENTIALS_DIRECTORY/a-secret.txt"; 
+              }
+              {
+                path = [ "b" "_secret" ];
+                update = old: "$CREDENTIALS_DIRECTORY/b-secret.txt"; 
+              }
+              {
+                path = [ "e" "_secret" ];
+                update = old: "$CREDENTIALS_DIRECTORY/e-secret.txt"; 
+              }
+            ] userConfig;
+            configLocation = "$STATE_DIRECTORY/my config.json";
+            generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON {});
+          };
+          script = "cat \"$STATE_DIRECTORY/my config.json\"";
+        };
+      };
+
+      pythonParseFile = ''
+        gotConfig = json.loads(gotConfig)
+      '';
+    };
+
+
+    dynamicUser = {
+      configLocation = "/var/lib/private/outOfBandConfig/config.json";
+
+      inherit wantedConfig;
+
+      waitForUnit = "outOfBand.service";
+
+      nodeConfig = {
+        # # Needed so that the testScript can fine the config file.
+        # systemd.tmpfiles.rules = [ "d /var/lib/outOfBandConfig 0770 nobody nobody" ];
+
+        systemd.services.outOfBand = {
+          wantedBy = [ "sysinit.target" ];
+          after = [ "sysinit.target" ];
+          unitConfig.DefaultDependencies = false;
+          serviceConfig.Type = "oneshot";
+          serviceConfig.RemainAfterExit = true; # Allows wait_for_unit to work.
+
+          serviceConfig.DynamicUser = true;
+          serviceConfig.StateDirectory = "outOfBandConfig";
+          serviceConfig.LoadCredential = [
+            "a-secret.txt:/run/secrets/a-secret.txt"
+            "b-secret.txt:/run/secrets/b-secret.txt"
+            "e-secret.txt:/run/secrets/e-secret.txt"
+          ];
+          preStart = utils.genConfigOutOfBand {
+            config = lib.attrsets.updateManyAttrsByPath [
+              {
+                path = [ "a" "a" "_secret" ];
+                update = old: "$CREDENTIALS_DIRECTORY/a-secret.txt"; 
+              }
+              {
+                path = [ "b" "_secret" ];
+                update = old: "$CREDENTIALS_DIRECTORY/b-secret.txt"; 
+              }
+              {
+                path = [ "e" "_secret" ];
+                update = old: "$CREDENTIALS_DIRECTORY/e-secret.txt"; 
+              }
+            ] userConfig;
+            configLocation = "$STATE_DIRECTORY/config.json";
+            generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON {});
+          };
+          script = "cat $STATE_DIRECTORY/config.json";
+        };
+      };
+
+      pythonParseFile = ''
+        gotConfig = json.loads(gotConfig)
+      '';
+    };
+
+
   };
 
-  mkTest = name: { configLocation, wantedConfig, script, pythonParseFile }:
+  mkTest = name: { configLocation, wantedConfig, nodeConfig, pythonParseFile, waitForUnit ? null }:
     import ./make-test-python.nix ({ pkgs, ... }: {
       inherit name;
       meta.maintainers = with pkgs.lib.maintainers; [ ibizaman ];
-      nodes.machine = {
-        system.activationScripts.genOutOfBand = script;
-      };
+      nodes.machine = lib.mkMerge [{
+        system.activationScripts.aSecret = aSecret;
+        system.activationScripts.bSecret = bSecret;
+        system.activationScripts.eSecret = eSecret;
+      } nodeConfig];
 
       testScript = ''
         import json
@@ -101,9 +272,10 @@ let
         wantedConfig = json.loads('${lib.generators.toJSON {} wantedConfig}')
 
         machine.wait_for_file("${configLocation}")
-        print(machine.succeed("cat ${pkgs.writeText "replaceInTemplate" script}"))
-
-        gotConfig = machine.succeed("cat ${configLocation}")
+      '' + (if waitForUnit == null then "" else ''
+        machine.wait_for_unit("${waitForUnit}")
+      '') + ''
+        gotConfig = machine.succeed("cat '${configLocation}'")
         print(gotConfig)
         ${pythonParseFile}
 
@@ -114,4 +286,4 @@ let
     });
 in
 
-builtins.mapAttrs (k: v: mkTest k v) tests
+builtins.mapAttrs mkTest tests

--- a/nixos/tests/genconfigoutofband-test.nix
+++ b/nixos/tests/genconfigoutofband-test.nix
@@ -1,7 +1,8 @@
-{ system ? builtins.currentSystem
-, config ? {}
-, pkgs ? import ../.. { inherit system config; }
-, lib ? pkgs.lib
+{
+  system ? builtins.currentSystem,
+  config ? { },
+  pkgs ? import ../.. { inherit system config; },
+  lib ? pkgs.lib,
 }:
 
 let
@@ -46,13 +47,23 @@ let
       inherit wantedConfig;
 
       nodeConfig = {
-        system.activationScripts.genOutOfBand = pkgs.stringsWithDeps.stringAfter [ "aSecret" "bSecret" "eSecret" ] (utils.replacePlaceholdersScript {
-          sourceField = "_secret";
-          fileWithPlaceholders = pkgs.writeText "config.yaml.template"
-            (lib.generators.toJSON {} (lib.replaceWithPlaceholder "_secret" userConfig));
-          inherit configLocation;
-          replacements = lib.getPlaceholderReplacements "_secret" userConfig;
-        });
+        system.activationScripts.genOutOfBand =
+          pkgs.stringsWithDeps.stringAfter
+            [
+              "aSecret"
+              "bSecret"
+              "eSecret"
+            ]
+            (
+              utils.replacePlaceholdersScript {
+                sourceField = "_secret";
+                fileWithPlaceholders = pkgs.writeText "config.yaml.template" (
+                  lib.generators.toJSON { } (lib.replaceWithPlaceholder "_secret" userConfig)
+                );
+                inherit configLocation;
+                replacements = lib.getPlaceholderReplacements "_secret" userConfig;
+              }
+            );
       };
 
       pythonParseFile = ''
@@ -66,11 +77,20 @@ let
       inherit wantedConfig;
 
       nodeConfig = {
-        system.activationScripts.genOutOfBand = pkgs.stringsWithDeps.stringAfter [ "aSecret" "bSecret" "eSecret" ] (utils.genConfigOutOfBand {
-          config = userConfig;
-          inherit configLocation;
-          generator = utils.genConfigOutOfBandFormatAdapter (pkgs.formats.json {});
-        });
+        system.activationScripts.genOutOfBand =
+          pkgs.stringsWithDeps.stringAfter
+            [
+              "aSecret"
+              "bSecret"
+              "eSecret"
+            ]
+            (
+              utils.genConfigOutOfBand {
+                config = userConfig;
+                inherit configLocation;
+                generator = utils.genConfigOutOfBandFormatAdapter (pkgs.formats.json { });
+              }
+            );
       };
 
       pythonParseFile = ''
@@ -84,11 +104,20 @@ let
       inherit wantedConfig;
 
       nodeConfig = {
-        system.activationScripts.genOutOfBand = pkgs.stringsWithDeps.stringAfter [ "aSecret" "bSecret" "eSecret" ] (utils.genConfigOutOfBand {
-          config = userConfig;
-          inherit configLocation;
-          generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON {});
-        });
+        system.activationScripts.genOutOfBand =
+          pkgs.stringsWithDeps.stringAfter
+            [
+              "aSecret"
+              "bSecret"
+              "eSecret"
+            ]
+            (
+              utils.genConfigOutOfBand {
+                config = userConfig;
+                inherit configLocation;
+                generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON { });
+              }
+            );
       };
 
       pythonParseFile = ''
@@ -122,20 +151,30 @@ let
           preStart = utils.genConfigOutOfBand {
             config = lib.attrsets.updateManyAttrsByPath [
               {
-                path = [ "a" "a" "_secret" ];
-                update = old: "$CREDENTIALS_DIRECTORY/a-secret.txt"; 
+                path = [
+                  "a"
+                  "a"
+                  "_secret"
+                ];
+                update = old: "$CREDENTIALS_DIRECTORY/a-secret.txt";
               }
               {
-                path = [ "b" "_secret" ];
-                update = old: "$CREDENTIALS_DIRECTORY/b-secret.txt"; 
+                path = [
+                  "b"
+                  "_secret"
+                ];
+                update = old: "$CREDENTIALS_DIRECTORY/b-secret.txt";
               }
               {
-                path = [ "e" "_secret" ];
-                update = old: "$CREDENTIALS_DIRECTORY/e-secret.txt"; 
+                path = [
+                  "e"
+                  "_secret"
+                ];
+                update = old: "$CREDENTIALS_DIRECTORY/e-secret.txt";
               }
             ] userConfig;
             inherit configLocation;
-            generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON {});
+            generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON { });
           };
           script = "cat ${configLocation}";
         };
@@ -174,20 +213,30 @@ let
           preStart = utils.genConfigOutOfBand {
             config = lib.attrsets.updateManyAttrsByPath [
               {
-                path = [ "a" "a" "_secret" ];
-                update = old: "$CREDENTIALS_DIRECTORY/a-secret.txt"; 
+                path = [
+                  "a"
+                  "a"
+                  "_secret"
+                ];
+                update = old: "$CREDENTIALS_DIRECTORY/a-secret.txt";
               }
               {
-                path = [ "b" "_secret" ];
-                update = old: "$CREDENTIALS_DIRECTORY/b-secret.txt"; 
+                path = [
+                  "b"
+                  "_secret"
+                ];
+                update = old: "$CREDENTIALS_DIRECTORY/b-secret.txt";
               }
               {
-                path = [ "e" "_secret" ];
-                update = old: "$CREDENTIALS_DIRECTORY/e-secret.txt"; 
+                path = [
+                  "e"
+                  "_secret"
+                ];
+                update = old: "$CREDENTIALS_DIRECTORY/e-secret.txt";
               }
             ] userConfig;
             configLocation = "$STATE_DIRECTORY/my config.json";
-            generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON {});
+            generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON { });
           };
           script = "cat \"$STATE_DIRECTORY/my config.json\"";
         };
@@ -197,7 +246,6 @@ let
         gotConfig = json.loads(gotConfig)
       '';
     };
-
 
     dynamicUser = {
       configLocation = "/var/lib/private/outOfBandConfig/config.json";
@@ -227,20 +275,30 @@ let
           preStart = utils.genConfigOutOfBand {
             config = lib.attrsets.updateManyAttrsByPath [
               {
-                path = [ "a" "a" "_secret" ];
-                update = old: "$CREDENTIALS_DIRECTORY/a-secret.txt"; 
+                path = [
+                  "a"
+                  "a"
+                  "_secret"
+                ];
+                update = old: "$CREDENTIALS_DIRECTORY/a-secret.txt";
               }
               {
-                path = [ "b" "_secret" ];
-                update = old: "$CREDENTIALS_DIRECTORY/b-secret.txt"; 
+                path = [
+                  "b"
+                  "_secret"
+                ];
+                update = old: "$CREDENTIALS_DIRECTORY/b-secret.txt";
               }
               {
-                path = [ "e" "_secret" ];
-                update = old: "$CREDENTIALS_DIRECTORY/e-secret.txt"; 
+                path = [
+                  "e"
+                  "_secret"
+                ];
+                update = old: "$CREDENTIALS_DIRECTORY/e-secret.txt";
               }
             ] userConfig;
             configLocation = "$STATE_DIRECTORY/config.json";
-            generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON {});
+            generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON { });
           };
           script = "cat $STATE_DIRECTORY/config.json";
         };
@@ -251,39 +309,60 @@ let
       '';
     };
 
-
   };
 
-  mkTest = name: { configLocation, wantedConfig, nodeConfig, pythonParseFile, waitForUnit ? null }:
-    import ./make-test-python.nix ({ pkgs, ... }: {
-      inherit name;
-      meta.maintainers = with pkgs.lib.maintainers; [ ibizaman ];
-      nodes.machine = lib.mkMerge [{
-        system.activationScripts.aSecret = aSecret;
-        system.activationScripts.bSecret = bSecret;
-        system.activationScripts.eSecret = eSecret;
-      } nodeConfig];
+  mkTest =
+    name:
+    {
+      configLocation,
+      wantedConfig,
+      nodeConfig,
+      pythonParseFile,
+      waitForUnit ? null,
+    }:
+    import ./make-test-python.nix (
+      { pkgs, ... }:
+      {
+        inherit name;
+        meta.maintainers = with pkgs.lib.maintainers; [ ibizaman ];
+        nodes.machine = lib.mkMerge [
+          {
+            system.activationScripts.aSecret = aSecret;
+            system.activationScripts.bSecret = bSecret;
+            system.activationScripts.eSecret = eSecret;
+          }
+          nodeConfig
+        ];
 
-      testScript = ''
-        import json
+        testScript =
+          ''
+            import json
 
-        start_all()
+            start_all()
 
-        wantedConfig = json.loads('${lib.generators.toJSON {} wantedConfig}')
+            wantedConfig = json.loads('${lib.generators.toJSON { } wantedConfig}')
 
-        machine.wait_for_file("${configLocation}")
-      '' + (if waitForUnit == null then "" else ''
-        machine.wait_for_unit("${waitForUnit}")
-      '') + ''
-        gotConfig = machine.succeed("cat '${configLocation}'")
-        print(gotConfig)
-        ${pythonParseFile}
+            machine.wait_for_file("${configLocation}")
+          ''
+          + (
+            if waitForUnit == null then
+              ""
+            else
+              ''
+                machine.wait_for_unit("${waitForUnit}")
+              ''
+          )
+          + ''
+            gotConfig = machine.succeed("cat '${configLocation}'")
+            print(gotConfig)
+            ${pythonParseFile}
 
-        if wantedConfig != gotConfig:
-          raise Exception("\nwantedConfig: {}\n!= gotConfig: {}".format(wantedConfig, gotConfig))
+            if wantedConfig != gotConfig:
+              raise Exception("\nwantedConfig: {}\n!= gotConfig: {}".format(wantedConfig, gotConfig))
 
-      '';
-    });
+          '';
+      }
+    );
 in
 
 builtins.mapAttrs mkTest tests

--- a/nixos/tests/jackett.nix
+++ b/nixos/tests/jackett.nix
@@ -1,8 +1,13 @@
 import ./make-test-python.nix ({ lib, ... }:
 
 let
-  jackettPort = 9117;
-in {
+  # Change port to make sure the variable is used correctly.
+  jackettPort = 9000;
+  # Needs to be >=20 characters.
+  apiKey = "01234567890123456789";
+in
+
+{
   name = "jackett";
   meta.maintainers = with lib.maintainers; [ etu ];
 
@@ -10,12 +15,33 @@ in {
     { pkgs, ... }: {
       services.jackett.enable = true;
       services.jackett.port = jackettPort;
+      services.jackett.settings.APIKey._secret = pkgs.writeText "APIKey" apiKey;
     };
 
-  testScript = ''
-    machine.start()
-    machine.wait_for_unit("jackett.service")
-    machine.wait_for_open_port(${toString jackettPort})
-    machine.succeed("curl --fail http://localhost:${toString jackettPort}/")
-  '';
+  testScript = { nodes, ... }:
+    let
+      cfg = nodes.machine.services.jackett;
+      settings = cfg.settings;
+
+      endpoint = "http://localhost:${toString jackettPort}";
+    in
+      ''
+        machine.start()
+        machine.wait_for_unit("jackett.service")
+        machine.wait_for_open_port(${toString jackettPort})
+
+        with subtest("can reach root endpoint"):
+            machine.succeed("curl --fail ${endpoint}")
+
+        with subtest("can reach health endpoint"):
+            machine.succeed("curl --fail ${endpoint}/health")
+
+        with subtest("can reach login endpoint"):
+            machine.succeed("curl --fail ${endpoint}/UI/Login")
+
+        with subtest("API key in config"):
+            config = machine.succeed("cat ${cfg.dataDir}/ServerConfig.json")
+            if "${apiKey}" not in config:
+                raise Exception(f"Unexpected API Key. Want '${apiKey}', got '{config}'")
+      '';
 })

--- a/nixos/tests/web-apps/snipe-it.nix
+++ b/nixos/tests/web-apps/snipe-it.nix
@@ -31,7 +31,7 @@ in {
           from.address = "snipe-it@localhost";
           replyTo.address = "snipe-it@localhost";
           user = "snipe-it@localhost";
-          passwordFile = toString (pkgs.writeText "snipe-it-mail-pass" "a-secure-mail-password");
+          passwordFile = pkgs.writeText "snipe-it-mail-pass" "a-secure-mail-password";
         };
       };
     };

--- a/pkgs/build-support/replace-secret/replace-secret.py
+++ b/pkgs/build-support/replace-secret/replace-secret.py
@@ -17,12 +17,22 @@ parser = argparse.ArgumentParser(
 parser.add_argument("string_to_replace", help="the string to replace")
 parser.add_argument("secret_file", help="the file containing the secret")
 parser.add_argument("file", help="the file to perform the replacement on")
+parser.add_argument("--prefix", help="add a fixed prefix to the secret", default="")
+parser.add_argument("--suffix", help="add a fixed suffix to the secret", default="")
+parser.add_argument("--prefix-if-not-present", help="add a prefix to the secret if the secret does not include it already", default="")
+parser.add_argument("--suffix-if-not-present", help="add a suffix to the secret if the secret does not include it already", default="")
 args = parser.parse_args()
 
 with open(args.secret_file) as sf, open(args.file, 'r+') as f:
     old = f.read()
+
     secret = sf.read().strip("\n")
-    new_content = old.replace(args.string_to_replace, secret)
+    if not secret.startswith(args.prefix_if_not_present):
+        secret = args.prefix_if_not_present + secret
+    if not secret.endswith(args.suffix_if_not_present):
+        secret = secret + args.suffix_if_not_present
+
+    new_content = old.replace(args.string_to_replace, args.prefix + secret + args.suffix)
     f.seek(0)
     f.write(new_content)
     f.truncate()


### PR DESCRIPTION
## Description of changes

The goal is to provide one official function, that is tested, that supports the majority of use cases. Those use cases are `replace-secret`, `genJqSecretsReplacementSnippet` and any module using a `_secret` field.

Currently, these use cases all have different implementations. They all work of course, but having a central function that is tested and works for all cases would be better for maintainability and re-usability. Indeed, other modules that currently do not support secrets will be easily able to.

This function has one additional feature compared to existing ones, it is generic in the config generator function, allowing one to generate a JSON, YAML, INI or whatever configuration file.

### Concrete example

The following service definition:

```nix
systemd.services.outOfBand = {
  wantedBy = [ "sysinit.target" ];
  after = [ "sysinit.target" ];
  unitConfig.DefaultDependencies = false;
  serviceConfig.Type = "oneshot";
  serviceConfig.RemainAfterExit = true; # Allows wait_for_unit to work.
  serviceConfig.StateDirectory = "outOfBandConfig";

  outOfBandConfig = [{
    name = "myconfig.json";
    config = {
      a.a._secret = "/run/secrets/a-secret.txt";
      b._secret = "/run/secrets/b-secret.txt";
      b.prefix = "prefix-";
      b.suffix = "-suffix";
      c = "not secret C";
      d.d = "not secret D";
      e._secret = "/run/secrets/e-secret.txt";
      e.prefixIfNotPresent = "prefix-";
      e.suffixIfNotPresent = "-suffix";
    };
    generator = utils.genConfigOutOfBandGeneratorAdapter (lib.generators.toJSON { });
  }];
  serviceConfig.DynamicUser = true;
  script = ''
    echo $STATE_DIRECTORY/myconfig.json
    cat $STATE_DIRECTORY/myconfig.json
  '';
};
```

With the content of the secret files being:
```nix
aSecret -> "Secret of A";
bSecret -> "Secret of B";
eSecret -> "prefix-abc";
```

Produces the service:

```
[Unit]
After=sysinit.target
DefaultDependencies=false
[Service]
DynamicUser=true
ExecStart=/nix/store/2l8qay4wfjd3f35lk5npz2jrx0r3wgl5-unit-script-outOfBand-start/bin/outOfBand-start
ExecStartPre=/nix/store/myfrvbz29xa0vz1q785ivp23k6z6r4ir-unit-script-outOfBand-outOfBandConfig/bin/outOfBand-outOfBandConfig
LoadCredential=a_a:/run/secrets/a-secret.txt
LoadCredential=b:/run/secrets/b-secret.txt
LoadCredential=e:/run/secrets/e-secret.txt
RemainAfterExit=true
StateDirectory=outOfBandConfig
Type=oneshot
[Install]
WantedBy=sysinit.target;
```
(I removed the `Environment=` to avoid cluttering the output)

And `cat /nix/store/myfrvbz29xa0vz1q785ivp23k6z6r4ir-unit-script-outOfBand-outOfBandConfig/bin/outOfBand-outOfBandConfig` is:

```
#!/nix/store/i1x9sidnvhhbbha2zhgpxkhpysw6ajmr-bash-5.2p26/bin/bash
set -e
set -euo pipefail

test -d "$(dirname "$STATE_DIRECTORY/myconfig.json")" || mkdir -p "$(dirname "$STATE_DIRECTORY/myconfig.json")"
rm -f "$STATE_DIRECTORY/myconfig.json"
install -Dm600 "/nix/store/14445vijz8cbcja8lmdsm7w208amfll3-generator-template" "$STATE_DIRECTORY/myconfig.json"
/nix/store/sprys974vsv08pi82wa5sr93s7xpfzc8-replace-secret/bin/replace-secret \
  %SECRET_A_A% "$CREDENTIALS_DIRECTORY/a_a" "$STATE_DIRECTORY/myconfig.json" \
  --prefix="" \
  --suffix="" \
  --prefix-if-not-present="" \
  --suffix-if-not-present=""

/nix/store/sprys974vsv08pi82wa5sr93s7xpfzc8-replace-secret/bin/replace-secret \
  %SECRET_B% "$CREDENTIALS_DIRECTORY/b" "$STATE_DIRECTORY/myconfig.json" \
  --prefix="prefix-" \
  --suffix="-suffix" \
  --prefix-if-not-present="" \
  --suffix-if-not-present=""

/nix/store/sprys974vsv08pi82wa5sr93s7xpfzc8-replace-secret/bin/replace-secret \
  %SECRET_E% "$CREDENTIALS_DIRECTORY/e" "$STATE_DIRECTORY/myconfig.json" \
  --prefix="" \
  --suffix="" \
  --prefix-if-not-present="prefix-" \
  --suffix-if-not-present="-suffix"
```

With `cat /nix/store/14445vijz8cbcja8lmdsm7w208amfll3-generator-template` being:

```json
{"a":{"a":"%SECRET_A_A%"},"b":"%SECRET_B%","c":"not secret C","d":{"d":"not secret D"},"e":"%SECRET_E%"}
```

The final configuration file is:

```bash
$ ls -l /var/lib/outOfBandConfig/myconfig.json
-rw------- 1 outOfBand outOfBand 125 Jul 30 20:40 /var/lib/outOfBandConfig/myconfig.json

$ cat /var/lib/outOfBandConfig/myconfig.json
{"a":{"a":"Secret of A"},"b":"prefix-Secret of B-suffix","c":"not secret C","d":{"d":"not secret D"},"e":"prefix-abc-suffix"}
```

### Update existing code

I did a grep for `replace-secret`, `genJqSecretsReplacementSnippet` and `_secret` and compiled a list of modules that should/could be updated to use this instead. I already made some replacements - only for modules including tests - to prove that this implementation works in those cases. Hereunder is the compiled list of modules I found:

<details><summary>Modules using secrets</summary>

| module                                                                  | test-file                                            | replace-secret | genJqSecretsReplacementSnippet | _secret | updated |
|-------------------------------------------------------------------------|------------------------------------------------------|----------------|--------------------------------|---------|---------|
| ./nixos/modules/services/audio/mpd.nix                                  | ∄                                                    |                |                                |         |         |
| ./nixos/modules/services/audio/mpdscribble.nix                          | ∄                                                    |                |                                |         |         |
| ./nixos/modules/services/continuous-integration/jenkins/job-builder.nix | ∄                                                    |                |                                |         |         |
| ./nixos/modules/services/games/archisteamfarm.nix                       | ∄                                                    |                |                                |         |         |
| ./nixos/modules/services/logging/filebeat.nix                           | ./nixos/tests/elk.nix                                |                | ✓                               | ✓        | ✓       |
| ./nixos/modules/services/mail/mailman.nix                               | ./nixos/tests/mailman.nix                            | ✓               |                                |         |         |
| ./nixos/modules/services/matrix/mjolnir.nix                             | ./nixos/tests/matrix/mjolnir.nix                     | ✓               |                                |         |         |
| ./nixos/modules/services/misc/forgejo.nix                               | ./nixos/tests/forgejo.nix ./nixos/tests/renovate.nix | ✓               |                                |         |         |
| ./nixos/modules/services/misc/geoipupdate.nix                           | ∄                                                    |                |                                |         |         |
| ./nixos/modules/services/misc/gitea.nix                                 | ./nixos/tests/gitea.nix                              | ✓               |                                |         |         |
| ./nixos/modules/services/misc/gitlab.nix                                | ./nixos/tests/gitlab.nix                             | ✓               |                                | ✓        | ✓       |
| ./nixos/modules/services/monitoring/parsedmarc.nix                      | ./nixos/tests/parsedmarc/default.nix                 | ✓               |                                | ✓        |         |
| ./nixos/modules/services/monitoring/ups.nix                             | ∄                                                    |                |                                |         |         |
| ./nixos/modules/services/networking/coturn.nix                          | ./nixos/tests/coturn.nix                             | ✓               |                                |         |         |
| ./nixos/modules/services/networking/ddclient.nix                        | ∄                                                    |                |                                |         |         |
| ./nixos/modules/services/networking/gns3-server.nix                     | ./nixos/tests/gns3-server.nix                        | ✓               |                                |         |         |
| ./nixos/modules/services/networking/netbird/coturn.nix                  | ./nixos/tests/coturn.nix                             | ✓               |                                |         |         |
| ./nixos/modules/services/networking/netbird/management.nix              | ./nixos/tests/netbird.nix                            |                | ✓                               | ✓        |         |
| ./nixos/modules/services/networking/sing-box.nix                        | ./nixos/tests/sing-box.nix                           |                | ✓                               | ✓        |         |
| ./nixos/modules/services/web-apps/akkoma.nix                            | ./nixos/tests/akkoma.nix                             | ✓               |                                |         | ✓        |
| ./nixos/modules/services/web-apps/artalk.nix                            | ./nixos/tests/artalk.nix                             |                | ✓                               | ✓        |         |
| ./nixos/modules/services/web-apps/atlassian/confluence.nix              | ∄                                                    |                |                                |         |         |
| ./nixos/modules/services/web-apps/atlassian/crowd.nix                   | ∄                                                    |                |                                |         |         |
| ./nixos/modules/services/web-apps/atlassian/jira.nix                    | ∄                                                    |                |                                |         |         |
| ./nixos/modules/services/web-apps/bookstack.nix                         | ∄                                                    |                |                                |         |         |
| ./nixos/modules/services/web-apps/davis.nix                             | ./nixos/tests/davis.nix                              | ✓               |                                | ✓        |         |
| ./nixos/modules/services/web-apps/dex.nix                               | ./nixos/tests/dex-oidc.nix                           | ✓               |                                |         |         |
| ./nixos/modules/services/web-apps/discourse.nix                         | ./nixos/tests/discourse.nix                          | ✓               | ✓                               | ✓        |         |
| ./nixos/modules/services/web-apps/discourse.nix                         | ./nixos/tests/discourse.nix                          |                | ✓                               |         |         |
| ./nixos/modules/services/web-apps/engelsystem.nix                       | ./nixos/tests/engelsystem.nix                        |                | ✓                               | ✓        |         |
| ./nixos/modules/services/web-apps/kavita.nix                            | ./nixos/tests/kavita.nix                             | ✓               |                                |         |  ✓      |
| ./nixos/modules/services/web-apps/keycloak.nix                          | ./nixos/tests/keycloak.nix                           | ✓               |                                | ✓        |         |
| ./nixos/modules/services/web-apps/lemmy.nix                             | ./nixos/tests/lemmy.nix                              |                | ✓                               | ✓        |         |
| ./nixos/modules/services/web-apps/monica.nix                            | ./nixos/tests/web-apps/monica.nix                    | ✓               |                                | ✓        | ✓        |
| ./nixos/modules/services/web-apps/ocis.nix                              | ./nixos/tests/ocis.nix                               |                |                                | ✓        |         |
| ./nixos/modules/services/web-apps/snipe-it.nix                          | ./nixos/tests/web-apps/snipe-it.nix                  | ✓               |                                | ✓        | ✓        |

</details>

Btw I have no idea how to best structure such a PR. Should I split it? Should I squash all commits? Something else?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
