### PR TITLE
go: support FreeBSD

### DIFF
--- a/pkgs/development/compilers/go/1.21.nix
+++ b/pkgs/development/compilers/go/1.21.nix
@@ -184,7 +184,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://go.dev/";
     license = licenses.bsd3;
     maintainers = teams.golang.members;
-    platforms = platforms.darwin ++ platforms.linux;
+    platforms = platforms.darwin ++ platforms.linux ++ platforms.freebsd;
     mainProgram = "go";
   };
 })

--- a/pkgs/development/compilers/go/1.22.nix
+++ b/pkgs/development/compilers/go/1.22.nix
@@ -186,7 +186,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://go.dev/";
     license = licenses.bsd3;
     maintainers = teams.golang.members;
-    platforms = platforms.darwin ++ platforms.linux ++ platforms.wasi;
+    platforms = platforms.darwin ++ platforms.linux ++ platforms.wasi ++ platforms.freebsd;
     mainProgram = "go";
   };
 })

--- a/pkgs/development/compilers/go/1.23.nix
+++ b/pkgs/development/compilers/go/1.23.nix
@@ -184,7 +184,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://go.dev/";
     license = licenses.bsd3;
     maintainers = teams.golang.members;
-    platforms = platforms.darwin ++ platforms.linux ++ platforms.wasi;
+    platforms = platforms.darwin ++ platforms.linux ++ platforms.wasi ++ platforms.freebsd;
     mainProgram = "go";
   };
 })

--- a/pkgs/development/compilers/go/bootstrap121.nix
+++ b/pkgs/development/compilers/go/bootstrap121.nix
@@ -5,6 +5,11 @@ callPackage ./binary.nix {
     # Use `print-hashes.sh ${version}` to generate the list below
     darwin-amd64 = "b314de9f704ab122c077d2ec8e67e3670affe8865479d1f01991e7ac55d65e70";
     darwin-arm64 = "3aca44de55c5e098de2f406e98aba328898b05d509a2e2a356416faacf2c4566";
+    freebsd-386 = "312a0065714a50862af714e7a5b3fbbd70fe68f905ffb9bcc56d42eadf6bffab";
+    freebsd-amd64 = "b8eaa36654625df799654f77f4af0ea7bd9e5e760ebe86e68fe7c484748ae995";
+    freebsd-arm64 = "bca5be1a9934fc522cb1a2e4849bb9f12ee6b480b48949e36a4dfb8e755a4b25";
+    freebsd-armv6l = "f4c9c91fa9c37d6d6b7644f3f6b67167b2a44bd48c0cba1d2a5ff5fd50ceb364";
+    freebsd-riscv64 = "45b99a9884dcd0dd4c8e4c0f99a4dc2901b8e9628dd8091ae5c0620afd536f0a";
     linux-386 = "0e6f378d9b072fab0a3d9ff4d5e990d98487d47252dba8160015a61e6bd0bcba";
     linux-amd64 = "d0398903a16ba2232b389fb31032ddf57cac34efda306a0eebac34f0965a0742";
     linux-arm64 = "f3d4548edf9b22f26bbd49720350bbfe59d75b7090a1a2bff1afad8214febaf3";

--- a/pkgs/development/compilers/go/print-hashes.sh
+++ b/pkgs/development/compilers/go/print-hashes.sh
@@ -13,4 +13,4 @@ fi
 
 curl -s "${BASEURL}?mode=json&include=all" |
   jq '.[] | select(.version == "go'"${VERSION}"'")' |
-  jq -r '.files[] | select(.kind == "archive" and (.os == "linux" or .os == "darwin")) | (.os + "-" + .arch + " = \"" + .sha256 + "\";")'
+  jq -r '.files[] | select(.kind == "archive" and (.os == "linux" or .os == "darwin" or .os == "freebsd")) | (.os + "-" + .arch + " = \"" + .sha256 + "\";")'


### PR DESCRIPTION
## Description of changes

Simply marking support and re-downloading the hashes is enough to get everything to work. Tests were done by compiling syncthing.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
