### PR TITLE
libsForQt5.libqofono: 0.103 -> 0.123

### DIFF
--- a/pkgs/desktops/lomiri/applications/lomiri-system-settings/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-system-settings/default.nix
@@ -2,6 +2,7 @@
 , lib
 , fetchFromGitLab
 , fetchpatch
+, fetchpatch2
 , gitUpdater
 , testers
 , accountsservice
@@ -80,6 +81,12 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://gitlab.com/ubports/development/core/lomiri-system-settings/-/commit/67d9e28ebab8bdb9473d5bf8da2b7573e6848fa2.patch";
       hash = "sha256-pFWNne2UH3R5Fz9ayHvIpDXDQbXPs0k4b/oRg0fzi+s=";
     })
+
+    (fetchpatch2 {
+      name = "0004-lomiri-system-settings-QOfono-namespace-change.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-system-settings/-/commit/c0b5b007d77993fabdd95be5ccbbba5151f0f165.patch";
+      hash = "sha256-HB7qdlbY0AVG6X3hL3IHf0Z7rm1G0wfdqo5MXtY7bfE=";
+    })
   ] ++ [
 
     ./2000-Support-wrapping-for-Nixpkgs.patch
@@ -94,6 +101,13 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
+    # Part of 0004-lomiri-system-settings-QOfono-namespace-change.patch, fetchpatch2 cannot handle rename-only changes
+    for unmovedThing in tests/mocks/MeeGo/QOfono/*; do
+      mv "$unmovedThing" "tests/mocks/QOfono/$(basename "$unmovedThing")"
+    done
+    rmdir tests/mocks/MeeGo/QOfono
+    rmdir tests/mocks/MeeGo
+
     substituteInPlace CMakeLists.txt \
       --replace-fail "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}" \
 

--- a/pkgs/desktops/lomiri/applications/lomiri-system-settings/plugins/lomiri-system-settings-security-privacy.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-system-settings/plugins/lomiri-system-settings-security-privacy.nix
@@ -33,6 +33,10 @@ stdenv.mkDerivation (finalAttrs: {
       substituteInPlace CMakeLists.txt \
         --replace-fail "pkg_get_variable($pcvarname LomiriSystemSettings $pcvar)" "set($pcvarname $(pkg-config LomiriSystemSettings --define-variable=prefix=$out --define-variable=libdir=$out/lib --variable=$pcvar))"
     done
+
+    # Compatibility with newer libqofono
+    substituteInPlace plugins/security-privacy/{Ofono,PageComponent,SimPin}.qml \
+      --replace-fail 'import MeeGo.QOfono' 'import QOfono'
   '';
 
   strictDeps = true;

--- a/pkgs/desktops/lomiri/applications/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri/default.nix
@@ -116,6 +116,14 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-guq/Ykcq4WcuXxNKO1eA4sJFyGSpZo0gtyFTdeK/GeE=";
     })
 
+    # fetchpatch2 for renames
+    # Remove when version > 0.2.1
+    (fetchpatch2 {
+      name = "1010-lomiri-QOfono-namespace.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri/-/commit/d0397dadb5f05097f916c5b39e6d9b95d4ab9e4d.patch";
+      hash = "sha256-wIkHlz2vYxF9eeH/sYYEdD9f8m4ylHEXXnX/DFG3HXg=";
+    })
+
     ./9901-lomiri-Disable-Wizard.patch
     ./9902-lomiri-Check-NIXOS_XKB_LAYOUTS.patch
   ];
@@ -125,6 +133,13 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace data/lomiri-greeter.desktop.in.in \
       --replace-fail '@CMAKE_INSTALL_FULL_BINDIR@/lomiri-greeter-wrapper @CMAKE_INSTALL_FULL_BINDIR@/lomiri --mode=greeter' '@CMAKE_INSTALL_FULL_BINDIR@/lomiri --mode=greeter' \
       --replace-fail 'X-LightDM-Session-Type=mir' 'X-LightDM-Session-Type=wayland'
+
+    # Part of QOfono namespace patch, fetchpatch2 cannot handle rename-only changes
+    for unmovedThing in tests/mocks/MeeGo/QOfono/*; do
+      mv "$unmovedThing" "tests/mocks/QOfono/$(basename "$unmovedThing")"
+    done
+    rmdir tests/mocks/MeeGo/QOfono
+    rmdir tests/mocks/MeeGo
 
     # Need to replace prefix
     substituteInPlace data/systemd-user/CMakeLists.txt \

--- a/pkgs/development/libraries/libqofono/default.nix
+++ b/pkgs/development/libraries/libqofono/default.nix
@@ -1,7 +1,7 @@
 { lib
 , substituteAll
 , mkDerivation
-, fetchFromGitLab
+, fetchFromGitHub
 , gitUpdater
 , mobile-broadband-provider-info
 , qmake
@@ -11,14 +11,13 @@
 
 mkDerivation rec {
   pname = "libqofono";
-  version = "0.103";
+  version = "0.123";
 
-  src = fetchFromGitLab {
-    domain = "git.sailfishos.org";
-    owner = "mer-core";
+  src = fetchFromGitHub {
+    owner = "sailfishos";
     repo = "libqofono";
     rev = version;
-    sha256 = "1ly5aj412ljcjvhqyry6nhiglbzzhczsy1a6w4i4fja60b2m1z45";
+    hash = "sha256-Ml86wHejSDyR2ibamuzg14GZ5S7zHBgPC9K5G+sgtC0=";
   };
 
   patches = [

--- a/pkgs/development/libraries/libqofono/default.nix
+++ b/pkgs/development/libraries/libqofono/default.nix
@@ -2,6 +2,7 @@
 , substituteAll
 , mkDerivation
 , fetchFromGitLab
+, gitUpdater
 , mobile-broadband-provider-info
 , qmake
 , qtbase
@@ -47,6 +48,8 @@ mkDerivation rec {
     qtbase
     qtdeclarative
   ];
+
+  passthru.updateScript = gitUpdater { };
 
   meta = with lib; {
     description = "Library for accessing the ofono daemon, and declarative plugin for it";


### PR DESCRIPTION
## Description of changes

0.103 is more than 3 years old: https://github.com/sailfishos/libqofono/releases/tag/0.103

Needed for newer `lomiri.lomiri-system-settings`: https://gitlab.com/ubports/development/core/lomiri-system-settings/-/commit/c0b5b007d77993fabdd95be5ccbbba5151f0f165

Not tested impact yet, will throw in patches to other packages as needed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
