### PR TITLE
Lomiri module & tests: ubuntu_font_family -> ubuntu-classic

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -63,7 +63,7 @@ in {
 
     fonts.packages = with pkgs; [
       # Applications tend to default to Ubuntu font
-      ubuntu_font_family
+      ubuntu-classic
     ];
 
     # Copy-pasted basic stuff

--- a/nixos/tests/lomiri-calculator-app.nix
+++ b/nixos/tests/lomiri-calculator-app.nix
@@ -24,7 +24,7 @@
 
       fonts.packages = with pkgs; [
         # Intended font & helps with OCR
-        ubuntu_font_family
+        ubuntu-classic
       ];
     };
 

--- a/nixos/tests/lomiri-clock-app.nix
+++ b/nixos/tests/lomiri-clock-app.nix
@@ -24,7 +24,7 @@
 
       fonts.packages = with pkgs; [
         # Intended font & helps with OCR
-        ubuntu_font_family
+        ubuntu-classic
       ];
     };
 

--- a/nixos/tests/lomiri-filemanager-app.nix
+++ b/nixos/tests/lomiri-filemanager-app.nix
@@ -24,7 +24,7 @@
 
       fonts.packages = with pkgs; [
         # Intended font & helps with OCR
-        ubuntu_font_family
+        ubuntu-classic
       ];
     };
 

--- a/nixos/tests/lomiri-system-settings.nix
+++ b/nixos/tests/lomiri-system-settings.nix
@@ -23,7 +23,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
 
     fonts.packages = with pkgs; [
       # Intended font & helps with OCR
-      ubuntu_font_family
+      ubuntu-classic
     ];
 
     services.upower.enable = true;

--- a/nixos/tests/morph-browser.nix
+++ b/nixos/tests/morph-browser.nix
@@ -23,7 +23,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
 
     fonts.packages = with pkgs; [
       # Intended font & helps with OCR
-      ubuntu_font_family
+      ubuntu-classic
     ];
   };
 

--- a/nixos/tests/teleports.nix
+++ b/nixos/tests/teleports.nix
@@ -24,7 +24,7 @@
 
       fonts.packages = with pkgs; [
         # Intended font & helps with OCR
-        ubuntu_font_family
+        ubuntu-classic
       ];
     };
 


### PR DESCRIPTION
## Description of changes

```
       error: undefined variable 'ubuntu_font_family'
       at /home/puna/Development/nixpkgs/nixos/tests/lomiri-clock-app.nix:27:9:
           26|         # Intended font & helps with OCR
           27|         ubuntu_font_family
             |         ^
           28|       ];
```

Borked by #290014 missing the adjustments for all the Lomiri stuff. Haven't checked if the new font might be better, just fixing alias-less evaluation on my end for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
