### PR TITLE
python311Packages.arviz: 0.18.0 -> 0.19.0

### DIFF
--- a/pkgs/development/python-modules/arviz/default.nix
+++ b/pkgs/development/python-modules/arviz/default.nix
@@ -1,40 +1,45 @@
 {
   lib,
   buildPythonPackage,
-  dm-tree,
+  pythonOlder,
   fetchFromGitHub,
-  emcee,
+
+  # build-system
+  packaging,
+  setuptools,
+
+  # dependencies
+  dm-tree,
   h5netcdf,
   matplotlib,
-  netcdf4,
-  numba,
   numpy,
   pandas,
-  setuptools,
-  cloudpickle,
-  pytestCheckHook,
   scipy,
-  packaging,
-  pythonOlder,
   typing-extensions,
   xarray,
   xarray-einstats,
-  zarr,
+
+  # checks
+  bokeh,
+  cloudpickle,
+  emcee,
   ffmpeg,
   h5py,
-  jaxlib,
-  torchvision,
   jax,
-  # , pymc3 (circular dependency)
+  jaxlib,
+  numba,
+  numpyro,
+  #, pymc3 (circular dependency)
   pyro-ppl,
   #, pystan (not packaged)
-  numpyro,
-  bokeh,
+  pytestCheckHook,
+  torchvision,
+  zarr,
 }:
 
 buildPythonPackage rec {
   pname = "arviz";
-  version = "0.18.0";
+  version = "0.19.0";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -43,7 +48,7 @@ buildPythonPackage rec {
     owner = "arviz-devs";
     repo = "arviz";
     rev = "refs/tags/v${version}";
-    hash = "sha256-SZRqSqChQBSA9/jBXN2ds9hh6TI3qZksHai1j2oVsq0=";
+    hash = "sha256-fwDCl1KWClIOBWIL/ETw3hJUyHdpVpLnRmZoZXL3QXI=";
   };
 
   build-system = [
@@ -55,7 +60,6 @@ buildPythonPackage rec {
     dm-tree
     h5netcdf
     matplotlib
-    netcdf4
     numpy
     pandas
     scipy
@@ -65,6 +69,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
+    bokeh
     cloudpickle
     emcee
     ffmpeg
@@ -79,7 +84,6 @@ buildPythonPackage rec {
     pytestCheckHook
     torchvision
     zarr
-    bokeh
   ];
 
   preCheck = ''
@@ -98,24 +102,15 @@ buildPythonPackage rec {
     "test_plot_kde"
     "test_plot_kde_2d"
     "test_plot_pair"
-    # Array mismatch
-    "test_plot_ts"
-    # The following two tests fail in a common venv-based setup.
-    # An issue has been opened upstream: https://github.com/arviz-devs/arviz/issues/2282
-    "test_plot_ppc_discrete"
-    "test_plot_ppc_discrete_save_animation"
-    # Assertion error
-    "test_data_zarr"
-    "test_plot_forest"
   ];
 
   pythonImportsCheck = [ "arviz" ];
 
-  meta = with lib; {
+  meta = {
     description = "Library for exploratory analysis of Bayesian models";
     homepage = "https://arviz-devs.github.io/arviz/";
     changelog = "https://github.com/arviz-devs/arviz/blob/v${version}/CHANGELOG.md";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ omnipotententity ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ omnipotententity ];
   };
 }


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/arviz-devs/arviz/blob/v0.19.0/CHANGELOG.md

cc @OmnipotentEntity 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
