### PR TITLE
kakounePlugins.hop-kak: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15043,6 +15043,12 @@
     githubId = 848535;
     name = "Oleg Lebedev";
   };
+  oleina = {
+    email = "antholeinik@gmail.com";
+    github = "antholeole";
+    githubId = 48811365;
+    name = "Anthony Oleinik";
+  };
   olejorgenb = {
     email = "olejorgenb@yahoo.no";
     github = "olejorgenb";

--- a/pkgs/applications/editors/kakoune/plugins/overrides.nix
+++ b/pkgs/applications/editors/kakoune/plugins/overrides.nix
@@ -2,6 +2,7 @@
 , buildKakounePluginFrom2Nix
 , kakoune-lsp, parinfer-rust, rep
 , fzf, git, guile, kakoune-unwrapped, lua5_3, plan9port
+, rustPlatform
 }:
 
 self: super: {
@@ -130,6 +131,41 @@ declare-option -hidden str ansi_filter %{'"$out"'/bin/kak-ansi-filter}
         --replace ' git ' ' ${git}/bin/git '
     '';
   });
+
+  hop-kak = rustPlatform.buildRustPackage rec {
+    pname = "hop-kak";
+    version = "0.2.0";
+
+    src = fetchgit {
+      url = "https://git.sr.ht/~hadronized/hop.kak";
+      rev = "7314ec64809a69e0044ba7ec57a18b43e3b5f005";
+      sha256 = "stmGZQU0tp+5xxrexKMzwSwHj5F/F4HzDO9BorNWC3w=";
+
+      # this package uses git to put the commit hash in the
+      # help dialog, so leave the .git folder so the command
+      # succeeds.
+      leaveDotGit = true;
+    };
+
+    nativeBuildInputs = [
+      git
+    ];
+
+    cargoHash = "sha256-EjSj/+BysGwJBxK6Ccg2+pXHdB2Lg3dxIURRsSVTHVY=";
+
+    postInstall = ''
+      mkdir -p $out/share/kak/bin
+      mv $out/bin/hop-kak $out/share/kak/bin/
+    '';
+
+    meta = with lib; {
+      description = "hinting brought to Kakoune selections";
+      homepage = "https://git.sr.ht/~hadronized/hop.kak/";
+      license = licenses.bsd3;
+      maintainers = with maintainers; [ oleina ];
+      platforms = platforms.all;
+    };
+  };
 
   quickscope-kak = buildKakounePluginFrom2Nix rec {
     pname = "quickscope-kak";

--- a/pkgs/applications/editors/kakoune/wrapper.nix
+++ b/pkgs/applications/editors/kakoune/wrapper.nix
@@ -14,10 +14,17 @@ in
     paths = [ kakoune ] ++ requestedPlugins;
 
     postBuild = ''
+      # create a directory for bins that kakoune needs
+      # access to, without polluting the users path by adding
+      # that binary nested with this symlinkJoin.
+      mkdir -p $out/share/kak/bin
+
       # location of kak binary is used to find ../share/kak/autoload,
       # unless explicitly overriden with KAKOUNE_RUNTIME
       rm "$out/bin/kak"
-      makeWrapper "${kakoune}/bin/kak" "$out/bin/kak" --set KAKOUNE_RUNTIME "$out/share/kak"
+      makeWrapper "${kakoune}/bin/kak" "$out/bin/kak" \
+        --set KAKOUNE_RUNTIME "$out/share/kak" \
+        --set PATH "$PATH:$out/share/kak/bin"
 
       # currently kakoune ignores doc files if they are symlinks, so workaround by
       # copying doc files over, so they become regular files...


### PR DESCRIPTION
## Description of changes

added `hop.kak`, a binary for jumping around a kakoune buffer, similar to leap.nvim. source: https://git.sr.ht/~hadronized/hop.kak

## Things done

this package does not ship with a module, as most of the other kakoune plugins do; instead, it is a rust binary that you are supposed to invoke in your kakrc. I added a bin directory to kakoune's path; there's no reason to use this package outside of kakoune configuration, so it doesn't make sense to expose it anywhere outside of kakoune.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
