### PR TITLE
python3Packages.langgraph: init at 0.1.9  python3Packages.langgraph-sdk: init at 0.1.26 langgraph-cli: init at 0.1.49

### DIFF
--- a/pkgs/by-name/la/langgraph-cli/package.nix
+++ b/pkgs/by-name/la/langgraph-cli/package.nix
@@ -1,0 +1,3 @@
+{ python3Packages }:
+
+python3Packages.toPythonApplication python3Packages.langgraph-cli

--- a/pkgs/development/python-modules/langgraph-cli/default.nix
+++ b/pkgs/development/python-modules/langgraph-cli/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  buildPythonPackage,
+  click,
+  fetchFromGitHub,
+  nix-update-script,
+  poetry-core,
+  pytest-asyncio,
+  pytestCheckHook,
+  pythonOlder,
+}:
+
+buildPythonPackage rec {
+  pname = "langgraph-cli";
+  version = "0.1.49";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "langchain-ai";
+    repo = "langgraph";
+    rev = "refs/tags/cli==${version}";
+    hash = "sha256-yphXboJA/TLGIPggb2Cvsxn1+WUSYMzC0wPHft3TGvo=";
+  };
+
+  sourceRoot = "${src.name}/libs/cli";
+
+  build-system = [ poetry-core ];
+
+  dependencies = [ click ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "tests/unit_tests" ];
+
+  pythonImportsCheck = [ "langgraph_cli" ];
+
+  disabledTests = [
+    # Flaky tests that generate a Docker configuration then compare to exact text
+    "test_config_to_docker_simple"
+    "test_config_to_docker_pipconfig"
+    "test_config_to_compose_env_vars"
+    "test_config_to_compose_env_file"
+    "test_config_to_compose_end_to_end"
+    "test_config_to_compose_simple_config"
+    "test_config_to_compose_watch"
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "cli==(.*)"
+    ];
+  };
+
+  meta = {
+    description = "Official CLI for LangGraph API";
+    homepage = "https://github.com/langchain-ai/langgraph/libs/cli";
+    changelog = "https://github.com/langchain-ai/langgraph/releases/tag/${version}";
+    mainProgram = "langgraph";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sarahec ];
+  };
+}

--- a/pkgs/development/python-modules/langgraph-sdk/default.nix
+++ b/pkgs/development/python-modules/langgraph-sdk/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  httpx,
+  httpx-sse,
+  orjson,
+  poetry-core,
+  pythonOlder,
+  writeScript,
+}:
+
+buildPythonPackage rec {
+  pname = "langgraph-sdk";
+  version = "0.1.26";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "langchain-ai";
+    repo = "langgraph";
+    rev = "refs/tags/sdk==${version}";
+    hash = "sha256-o7JrB2WSWfPm927tDRMcjzx+6Io6Q+Yjp4XPVs2+F4o=";
+  };
+
+  sourceRoot = "${src.name}/libs/sdk-py";
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    httpx
+    httpx-sse
+    orjson
+  ];
+
+  pythonImportsCheck = [ "langgraph_sdk" ];
+
+  passthru = {
+    # python3Packages.langgraph-sdk depends on python3Packages.langgraph. langgraph-cli is independent of both.
+    updateScript = writeScript "update.sh" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p nix-update
+
+      set -eu -o pipefail
+      nix-update --commit --version-regex '(.*)' python3Packages.langgraph
+      nix-update --commit --version-regex 'sdk==(.*)' python3Packages.langgraph-sdk
+    '';
+  };
+
+  meta = {
+    description = "SDK for interacting with the LangGraph Cloud REST API";
+    homepage = "https://github.com/langchain-ai/langgraphtree/main/libs/sdk-py";
+    changelog = "https://github.com/langchain-ai/langgraph/releases/tag/sdk==${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sarahec ];
+  };
+}

--- a/pkgs/development/python-modules/langgraph/default.nix
+++ b/pkgs/development/python-modules/langgraph/default.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  buildPythonPackage,
+  aiosqlite,
+  dataclasses-json,
+  fetchFromGitHub,
+  grandalf,
+  httpx,
+  langchain-core,
+  langgraph-sdk,
+  langsmith,
+  poetry-core,
+  pydantic,
+  pytest-asyncio,
+  pytest-mock,
+  pytest-xdist,
+  pytestCheckHook,
+  pythonOlder,
+  syrupy,
+}:
+
+buildPythonPackage rec {
+  pname = "langgraph";
+  version = "0.1.9";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "langchain-ai";
+    repo = "langgraph";
+    rev = "refs/tags/${version}";
+    hash = "sha256-sBjSfKzcILkHgvo8g/NHC+/yUjQSyZB/8xaSCY3rPDs=";
+  };
+
+  sourceRoot = "${src.name}/libs/langgraph";
+
+  build-system = [ poetry-core ];
+
+  dependencies = [ langchain-core ];
+
+  pythonImportsCheck = [ "langgraph" ];
+
+  nativeCheckInputs = [
+    aiosqlite
+    dataclasses-json
+    grandalf
+    httpx
+    langsmith
+    pydantic
+    pytest-asyncio
+    pytest-mock
+    pytest-xdist
+    pytestCheckHook
+    syrupy
+  ];
+
+  pytestFlagsArray = [ "--snapshot-update" ];
+
+  disabledTests = [
+    "test_doesnt_warn_valid_schema" # test is flaky due to pydantic error on the exception
+  ];
+
+  passthru = {
+    updateScript = langgraph-sdk.updateScript;
+  };
+
+  meta = {
+    description = "Build resilient language agents as graphs";
+    homepage = "https://github.com/langchain-ai/langgraph";
+    changelog = "https://github.com/langchain-ai/langgraph/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sarahec ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6660,6 +6660,12 @@ self: super: with self; {
 
   langfuse = callPackage ../development/python-modules/langfuse { };
 
+  langgraph = callPackage ../development/python-modules/langgraph { };
+
+  langgraph-cli = callPackage ../development/python-modules/langgraph-cli { };
+
+  langgraph-sdk = callPackage ../development/python-modules/langgraph-sdk { };
+
   langid = callPackage ../development/python-modules/langid { };
 
   langsmith = callPackage ../development/python-modules/langsmith { };


### PR DESCRIPTION
## Description of changes

Adds the [langgraph](https://github.com/langchain-ai/langgraph) AI tools:

* [python3Packages.langgraph](https://github.com/langchain-ai/langgraph) is used in building Generative AI clients using agents. 
* [python3Packages.langgraph-sdk](https://github.com/langchain-ai/langgraph/libs/sdk-py) wraps the REST API for LangGraph servers (e.g. the LangGraph Cloud or via `langgraph-cli`).
* [langgraph-cli](https://github.com/langchain-ai/langgraph/libs/cli) manages local instances of the LangGraph server.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
