### PR TITLE
python3Packages.pytest-cov-stub: init at 1.0.0

### DIFF
--- a/pkgs/applications/office/todoman/default.nix
+++ b/pkgs/applications/office/todoman/default.nix
@@ -45,7 +45,7 @@ python3.pkgs.buildPythonApplication rec {
     hypothesis
     pytestCheckHook
     glibcLocales
-    pytest-cov
+    pytest-cov-stub
   ];
 
   LC_ALL = "en_US.UTF-8";

--- a/pkgs/development/python-modules/pytest-cov-stub/default.nix
+++ b/pkgs/development/python-modules/pytest-cov-stub/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  buildPythonPackage,
+  python,
+  hatchling,
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-cov-stub";
+  version = (lib.importTOML ./src/pyproject.toml).project.version;
+  pyproject = true;
+
+  src = ./src;
+
+  build-system = [ hatchling ];
+
+  meta = with lib; {
+    description = "Nixpkgs checkPhase stub for pytest-cov";
+    license = licenses.mit;
+    maintainers = [ lib.maintainers.pbsds ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-cov-stub/src/pyproject.toml
+++ b/pkgs/development/python-modules/pytest-cov-stub/src/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pytest-cov-nixpkgs-stub"
+version = "1.0.0"
+
+[tool.hatch.build.targets.wheel]
+packages = ["pytest_cov"]
+
+[project.entry-points.pytest11]
+pytest_cov = "pytest_cov.plugin"

--- a/pkgs/development/python-modules/pytest-cov-stub/src/pytest_cov/plugin.py
+++ b/pkgs/development/python-modules/pytest-cov-stub/src/pytest_cov/plugin.py
@@ -1,0 +1,93 @@
+import argparse
+import pytest
+
+class CoverageError(Exception):
+    pass
+
+class PytestCovWarning(pytest.PytestWarning):
+    pass
+
+class CovDisabledWarning(PytestCovWarning):
+    pass
+
+class CovReportWarning(PytestCovWarning):
+    pass
+
+class StoreReport(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        report_type, file = values
+        namespace.cov_report[report_type] = file
+
+def pytest_addoption(parser):
+    group = parser.getgroup('cov', 'coverage reporting')
+    group.addoption(
+        '--cov',
+        action='append',
+        default=[],
+        metavar='SOURCE',
+        nargs='?',
+        const=True,
+        dest='cov_source',
+    )
+    group.addoption(
+        '--cov-reset',
+        action='store_const',
+        const=[],
+        dest='cov_source',
+    )
+    group.addoption(
+        '--cov-report',
+        action=StoreReport,
+        default={},
+        metavar='TYPE',
+        type=lambda x: x.split(":", 1) if ":" in x else (x, None),
+    )
+    group.addoption(
+        '--cov-config',
+        action='store',
+        default='.coveragerc',
+        metavar='PATH',
+    )
+    group.addoption(
+        '--no-cov-on-fail',
+        action='store_true',
+        default=False,
+    )
+    group.addoption(
+        '--no-cov',
+        action='store_true',
+        default=False,
+    )
+    group.addoption(
+        '--cov-fail-under',
+        action='store',
+        metavar='MIN',
+        type=str,
+    )
+    group.addoption(
+        '--cov-append',
+        action='store_true',
+        default=False,
+    )
+    group.addoption(
+        '--cov-branch',
+        action='store_true',
+        default=None,
+    )
+    group.addoption(
+        '--cov-context',
+        action='store',
+        metavar='CONTEXT',
+        type=str,
+    )
+
+def pytest_configure(config):
+    config.addinivalue_line('markers', 'no_cover: disable coverage for this test.')
+
+@pytest.fixture
+def no_cover():
+    pass
+
+@pytest.fixture
+def cov():
+    pass

--- a/pkgs/development/python-modules/strct/default.nix
+++ b/pkgs/development/python-modules/strct/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   setuptools,
   pytestCheckHook,
+  pytest-cov-stub,
   sortedcontainers,
 }:
 
@@ -19,13 +20,6 @@ buildPythonPackage rec {
     hash = "sha256-uPM2U+emZUCGqEhIeTBmaOu8eSfK4arqvv9bItBWpUs=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail  \
-        '"--cov' \
-        '#"--cov'
-  '';
-
   # don't append .dev0 to version
   env.RELEASING_PROCESS = "1";
 
@@ -33,6 +27,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+    pytest-cov-stub
     sortedcontainers
   ];
 

--- a/pkgs/tools/misc/remote-exec/default.nix
+++ b/pkgs/tools/misc/remote-exec/default.nix
@@ -8,6 +8,7 @@
 , toml
 , watchdog
 , pytestCheckHook
+, pytest-cov-stub
 , rsync
 }:
 
@@ -44,11 +45,6 @@ buildPythonApplication rec {
     watchdog
   ];
 
-  # disable pytest --cov
-  preCheck = ''
-    rm setup.cfg
-  '';
-
   doCheck = true;
 
   nativeCheckInputs = [
@@ -57,6 +53,7 @@ buildPythonApplication rec {
 
   checkInputs = [
     pytestCheckHook
+    pytest-cov-stub
   ];
 
   disabledTestPaths = lib.optionals stdenv.isDarwin [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12343,6 +12343,8 @@ self: super: with self; {
 
   pytest-cov = callPackage ../development/python-modules/pytest-cov { };
 
+  pytest-cov-stub = callPackage ../development/python-modules/pytest-cov-stub { };
+
   pytest-cram = callPackage ../development/python-modules/pytest-cram { };
 
   pytest-datadir = callPackage ../development/python-modules/pytest-datadir { };


### PR DESCRIPTION
## Description of changes

https://github.com/NixOS/nixpkgs/pull/327220#issuecomment-2227544515 finally inspired me to implement this idea I've been brewing for quite a while: a `pytest-cov` stub that does nothing but accept the command line options and provide empty no-op fixtures.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

follow-up candidates for stubbing: 

* pytest-pylint
* pytest-pycodestyle

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
