### PR TITLE
dataexplorer: 3.8.5 -> 3.9.0, move to by-name

### DIFF
--- a/pkgs/by-name/da/dataexplorer/package.nix
+++ b/pkgs/by-name/da/dataexplorer/package.nix
@@ -2,23 +2,24 @@
 , stdenv
 , fetchurl
 , ant
-, jdk
+# executable fails to start for jdk > 17
+, jdk17
 , makeWrapper
 , strip-nondeterminism
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dataexplorer";
-  version = "3.8.5";
+  version = "3.9.0";
 
   src = fetchurl {
     url = "mirror://savannah/dataexplorer/dataexplorer-${finalAttrs.version}-src.tar.gz";
-    hash = "sha256-b68xIZNbzHdPyZwLngcnjcoBtI6AeTdrblz/qx/HbGQ=";
+    hash = "sha256-MQAnLCkcs3r8/2j4zYaMC/JM8nBCEvqHKk8lv+7b9KE=";
   };
 
   nativeBuildInputs = [
     ant
-    jdk
+    jdk17
     makeWrapper
     strip-nondeterminism
   ];
@@ -44,11 +45,11 @@ stdenv.mkDerivation (finalAttrs: {
     # but it hardcodes bash shebang and does not pin the java path.
     # So we create our own wrapper, using similar cmdline args as upstream.
     mkdir -p $out/bin
-    makeWrapper ${jdk}/bin/java $out/bin/DataExplorer \
+    makeWrapper ${jdk17}/bin/java $out/bin/DataExplorer \
       --add-flags "-Xms64m -Xmx3092m -jar $out/share/DataExplorer/DataExplorer.jar" \
       --set SWT_GTK3 0
 
-    makeWrapper ${jdk}/bin/java $out/bin/DevicePropertiesEditor \
+    makeWrapper ${jdk17}/bin/java $out/bin/DevicePropertiesEditor \
       --add-flags "-Xms32m -Xmx512m -classpath $out/share/DataExplorer/DataExplorer.jar gde.ui.dialog.edit.DevicePropertiesEditor" \
       --set SWT_GTK3 0 \
       --set LIBOVERLAY_SCROLLBAR 0

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38163,11 +38163,6 @@ with pkgs;
 
   csxcad = callPackage ../applications/science/electronics/csxcad { };
 
-  dataexplorer = callPackage ../applications/science/electronics/dataexplorer {
-    # executable fails at startup for jdk > 17
-    jdk = jdk17;
-  };
-
   degate = libsForQt5.callPackage ../applications/science/electronics/degate { };
 
   diylc = callPackage ../applications/science/electronics/diylc { };


### PR DESCRIPTION
## Description of changes

* Project homepage: https://www.nongnu.org/dataexplorer/index.html
* Changelog v3.8.6: https://savannah.nongnu.org/news/?id=10622
* Changelog v3.9.0: https://savannah.nongnu.org/news/?id=10654

Successfully tested with a battery charger on x86_64-linux.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>dataexplorer</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
