### PR TITLE
emacs: add two parameters to genericBuild to control errors

### DIFF
--- a/pkgs/applications/editors/emacs/build-support/generic.nix
+++ b/pkgs/applications/editors/emacs/build-support/generic.nix
@@ -27,6 +27,8 @@ in
 , buildInputs ? []
 , packageRequires ? []
 , meta ? {}
+, turnCompilationWarningToError ? false
+, ignoreCompilationError ? true
 , ...
 }@args:
 
@@ -73,6 +75,8 @@ stdenv.mkDerivation (finalAttrs: ({
 
   addEmacsNativeLoadPath = true;
 
+  inherit turnCompilationWarningToError ignoreCompilationError;
+
   postInstall = ''
     # Besides adding the output directory to the native load path, make sure
     # the current package's elisp files are in the load path, otherwise
@@ -86,8 +90,9 @@ stdenv.mkDerivation (finalAttrs: ({
           "emacs \
              --batch \
              --eval '(setq large-file-warning-threshold nil)' \
+             --eval '(setq byte-compile-error-on-warn ${if finalAttrs.turnCompilationWarningToError then "t" else "nil"})' \
              -f batch-native-compile {} \
-           || true"
+           || exit ${if finalAttrs.ignoreCompilationError then "0" else "\\$?"}"
   '';
 }
 

--- a/pkgs/applications/editors/emacs/build-support/generic.nix
+++ b/pkgs/applications/editors/emacs/build-support/generic.nix
@@ -83,7 +83,11 @@ stdenv.mkDerivation (finalAttrs: ({
 
     find $out/share/emacs -type f -name '*.el' -print0 \
       | xargs -0 -I {} -n 1 -P $NIX_BUILD_CORES sh -c \
-          "emacs --batch --eval '(setq large-file-warning-threshold nil)' -f batch-native-compile {} || true"
+          "emacs \
+             --batch \
+             --eval '(setq large-file-warning-threshold nil)' \
+             -f batch-native-compile {} \
+           || true"
   '';
 }
 

--- a/pkgs/applications/editors/emacs/build-support/generic.nix
+++ b/pkgs/applications/editors/emacs/build-support/generic.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: ({
     addEmacsVars "$out"
 
     find $out/share/emacs -type f -name '*.el' -print0 \
-      | xargs -0 -I {} -n 1 -P $NIX_BUILD_CORES sh -c \
+      | xargs --verbose -0 -I {} -n 1 -P $NIX_BUILD_CORES sh -c \
           "emacs \
              --batch \
              --eval '(setq large-file-warning-threshold nil)' \


### PR DESCRIPTION
## Description of changes

Motivation: `nix build` for elisp packages can fail at errors or warnings now, which can be used in CI to improve code quality.

The patch introduces two parameters, turnCompilationWarningToError and
ignoreCompilationError, to control errors in genericBuild.

Note that this patch keeps the old behavior by default.  Hopefully one
day we set the default value of ignoreCompilationError to false.

Also note that these two parameters can be changed per package using
the overrideAttrs interface.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
