### PR TITLE
pcsx2-bin: 1.7.5919 -> 2.1.17, derivation improvements

### DIFF
--- a/pkgs/by-name/pc/pcsx2-bin/package.nix
+++ b/pkgs/by-name/pc/pcsx2-bin/package.nix
@@ -3,12 +3,10 @@
   stdenvNoCC,
   fetchurl,
   makeWrapper,
-  # To grab metadata
-  pcsx2,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
-  pname = "pcsx2";
+  pname = "pcsx2-bin";
   version = "1.7.5919";
 
   src = fetchurl {
@@ -26,9 +24,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/{bin,Applications}
+    mkdir -p $out/Applications
     cp -r "PCSX2-v${finalAttrs.version}.app" $out/Applications/PCSX2.app
-    makeWrapper $out/Applications/PCSX2.app/Contents/MacOS/PCSX2 $out/bin/pcsx2-qt
     runHook postInstall
   '';
 
@@ -37,17 +34,23 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    inherit (pcsx2.meta)
-      homepage
-      longDescription
-      license
-      changelog
-      downloadPage
-      ;
-    description = "Playstation 2 emulator; precompiled binary for MacOS, repacked from official website";
+    homepage = "https://pcsx2.net";
+    description = "Playstation 2 emulator (precompiled binary, repacked from official website)";
+    longDescription = ''
+      PCSX2 is an open-source PlayStation 2 (AKA PS2) emulator. Its purpose is
+      to emulate the PS2 hardware, using a combination of MIPS CPU Interpreters,
+      Recompilers and a Virtual Machine which manages hardware states and PS2
+      system memory. This allows you to play PS2 games on your PC, with many
+      additional features and benefits.
+    '';
+    changelog = "https://github.com/PCSX2/pcsx2/releases/tag/v${finalAttrs.version}";
+    downloadPage = "https://github.com/PCSX2/pcsx2";
+    license = with lib.licenses; [
+      gpl3Plus
+      lgpl3Plus
+    ];
     maintainers = with lib.maintainers; [ matteopacini ];
-    mainProgram = "pcsx2-qt";
-    platforms = lib.systems.inspect.patternLogicalAnd lib.systems.inspect.patterns.isDarwin lib.systems.inspect.patterns.isx86_64;
+    platforms = [ "x86_64-darwin" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 })

--- a/pkgs/by-name/pc/pcsx2-bin/package.nix
+++ b/pkgs/by-name/pc/pcsx2-bin/package.nix
@@ -7,11 +7,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "pcsx2-bin";
-  version = "1.7.5919";
+  version = "2.1.17";
 
   src = fetchurl {
     url = "https://github.com/PCSX2/pcsx2/releases/download/v${finalAttrs.version}/pcsx2-v${finalAttrs.version}-macos-Qt.tar.xz";
-    hash = "sha256-NYgHsYXoIhI2pxqqiMgz5sKBAezEFf4AfEfu5S3diMg=";
+    hash = "sha256-WuxvMcGuCyTAc99JkUjG0qcV7SXWy9fmaZR0+8iGepQ=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
## Description of changes

- Upgraded to latest available version
- @AndersonTorres removed dependency on `pcsx2`, and changed the name to `pcsx2-bin`
    - Update bot and script are failing -  [looks like a platform mismatch between the two derivations](https://r.ryantm.com/log/pcsx2-bin/2024-07-13.log)
    - Because of this change, I've added the missing `meta` bits from the `pcsx2` derivation
- QOL improvements:
    - Made `platforms` more readable
    - Removed `bin/pcsx2-qt` wrapper  for Darwin, as it doesn't make much sense

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
