### PR TITLE
python3Packages.{pyqt3d, pychart}: 5.15.6 -> 5.15.7, python3Packages.pyqtdatavisualization: 5.15.5 -> 5.15.6

### DIFF
--- a/pkgs/development/python-modules/pyqt3d/default.nix
+++ b/pkgs/development/python-modules/pyqt3d/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "pyqt3d";
-  version = "5.15.6";
+  version = "5.15.7";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "PyQt3D";
     inherit version;
-    hash = "sha256-fWxtVc2PwiGzE8mVwPhymjdxFJJvA3f46QEdRevziBw=";
+    hash = "sha256-6ng+tUbH2tLV6q+C6lBQ3eRSVamELgoddYSIHp4lqVE=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/pyqtchart/default.nix
+++ b/pkgs/development/python-modules/pyqtchart/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "pyqtchart";
-  version = "5.15.6";
+  version = "5.15.7";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "PyQtChart";
     inherit version;
-    hash = "sha256-JpF5b+kqKUphdZKlxcNeeF3JH3dZ3vnrItp532N2Izk=";
+    hash = "sha256-vJ8dJscl6CCw//jbbpBuiyhhKKFLOpjFmgzQw9mSQJU=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/pyqtdatavisualization/default.nix
+++ b/pkgs/development/python-modules/pyqtdatavisualization/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "pyqtdatavisualization";
-  version = "5.15.5";
+  version = "5.15.6";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "PyQtDataVisualization";
     inherit version;
-    hash = "sha256-iSf496pwhX7wDFHj379vg92fOFX0FuDVMVknYcu53H8=";
+    hash = "sha256-ntM7IOdHvGnh1hnxR7sWJcwA1u9ATb8Ha6E6n/b2Bh0=";
   };
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

Patch releases.
* https://pypi.org/project/PyQt3D/#history
* https://pypi.org/project/PyQtChart/#history
* https://pypi.org/project/PyQtDataVisualization/#history

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>22 packages built:</summary>
  <ul>
    <li>python311Packages.pyqt3d</li>
    <li>python311Packages.pyqt3d.dev</li>
    <li>python311Packages.pyqt3d.dist</li>
    <li>python311Packages.pyqt5-stubs</li>
    <li>python311Packages.pyqt5-stubs.dist</li>
    <li>python311Packages.pyqtchart</li>
    <li>python311Packages.pyqtchart.dev</li>
    <li>python311Packages.pyqtchart.dist</li>
    <li>python311Packages.pyqtdatavisualization</li>
    <li>python311Packages.pyqtdatavisualization.dev</li>
    <li>python311Packages.pyqtdatavisualization.dist</li>
    <li>python312Packages.pyqt3d</li>
    <li>python312Packages.pyqt3d.dev</li>
    <li>python312Packages.pyqt3d.dist</li>
    <li>python312Packages.pyqt5-stubs</li>
    <li>python312Packages.pyqt5-stubs.dist</li>
    <li>python312Packages.pyqtchart</li>
    <li>python312Packages.pyqtchart.dev</li>
    <li>python312Packages.pyqtchart.dist</li>
    <li>python312Packages.pyqtdatavisualization</li>
    <li>python312Packages.pyqtdatavisualization.dev</li>
    <li>python312Packages.pyqtdatavisualization.dist</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
