### PR TITLE
nextcloudPackages.hmr_enabler: init at 0-unstable-2024-08-24

### DIFF
--- a/pkgs/servers/nextcloud/packages/apps/hmr_enabler.nix
+++ b/pkgs/servers/nextcloud/packages/apps/hmr_enabler.nix
@@ -1,0 +1,38 @@
+{
+  php,
+  fetchFromGitHub,
+  lib,
+}:
+
+php.buildComposerProject (finalAttrs: {
+  pname = "hmr_enabler";
+  # composer doesn't support our unstable version format
+  # version = "0-unstable-2024-08-24";
+  version = "0";
+
+  src = fetchFromGitHub {
+    owner = "nextcloud";
+    repo = "hmr_enabler";
+    rev = "d5d9d330d405ac4aa0de1a87d1133784560462ed";
+    hash = "sha256-uLCpwvMVQ20z9vlO5q/GVPnaaQZ7ZjE8+V/zuqaB9Yo=";
+  };
+
+  composerNoDev = false;
+
+  vendorHash = "sha256-ZuEEcFT+q49CCooEwdiu2Co345s0ZCC7jeEksi6A99A=";
+
+  postInstall = ''
+    chmod -R u+w $out/share
+    mv $out/share/php/hmr_enabler/* $out/
+    rm -r $out/share $out/composer.* $out/Makefile $out/psalm.xml $out/tests
+  '';
+
+  meta = {
+    description = " Development Nextcloud app to enable apps to use hot module reloading";
+    homepage = "https://github.com/nextcloud/hmr_enabler";
+    changelog = "https://github.com/nextcloud/hmr_enabler/blob/master/CHANGELOG.md";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ onny ];
+  };
+
+})

--- a/pkgs/servers/nextcloud/packages/default.nix
+++ b/pkgs/servers/nextcloud/packages/default.nix
@@ -2,28 +2,58 @@
 # Licensed under: MIT
 # Slightly modified
 
-{ lib, pkgs, newScope, apps }:
+{
+  lib,
+  pkgs,
+  newScope,
+  apps,
+  callPackage,
+}:
 
-let packages = self:
-  let
-    generatedJson = {
-      inherit apps;
-    };
-    appBaseDefs = builtins.fromJSON (builtins.readFile ./nextcloud-apps.json);
+let
+  packages =
+    self:
+    let
+      generatedJson = {
+        inherit apps;
+      };
+      appBaseDefs = builtins.fromJSON (builtins.readFile ./nextcloud-apps.json);
 
-  in {
-    # Create a derivation from the official Nextcloud apps.
-    # This takes the data generated from the go tool.
-    mkNextcloudDerivation = self.callPackage ({ }: { pname, data }:
-      pkgs.fetchNextcloudApp {
-        appName = pname;
-        appVersion = data.version;
-        license = appBaseDefs.${pname};
-        inherit (data) url hash description homepage;
-      }) {};
+    in
+    {
+      # Create a derivation from the official Nextcloud apps.
+      # This takes the data generated from the go tool.
+      mkNextcloudDerivation = self.callPackage (
+        { }:
+        { pname, data }:
+        pkgs.fetchNextcloudApp {
+          appName = pname;
+          appVersion = data.version;
+          license = appBaseDefs.${pname};
+          inherit (data)
+            url
+            hash
+            description
+            homepage
+            ;
+        }
+      ) { };
 
-  } // lib.mapAttrs (type: pkgs:
-    lib.makeExtensible (_: lib.mapAttrs (pname: data: self.mkNextcloudDerivation { inherit pname; inherit data; }) pkgs))
-    generatedJson;
+    }
+    // lib.mapAttrs (
+      type: pkgs:
+      lib.makeExtensible (
+        _:
+        lib.mapAttrs (
+          pname: data:
+          self.mkNextcloudDerivation {
+            inherit pname data;
+          }
+        ) pkgs
+      )
+    ) generatedJson;
 
-in (lib.makeExtensible (_: (lib.makeScope newScope packages))).extend (selfNC: superNC: {})
+in
+(lib.makeExtensible (_: (lib.makeScope newScope packages))).extend (
+  import ./thirdparty.nix
+)

--- a/pkgs/servers/nextcloud/packages/thirdparty.nix
+++ b/pkgs/servers/nextcloud/packages/thirdparty.nix
@@ -1,0 +1,12 @@
+_:
+{ apps, callPackage, ... }:
+{
+
+  apps = apps.extend (
+    self: super: {
+
+      hmr_enabler = callPackage ./apps/hmr_enabler.nix { };
+
+    }
+  );
+}


### PR DESCRIPTION
## Description of changes

Packaging app https://github.com/nextcloud/hmr_enabler which is required for Nextcloud development

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
