### PR TITLE
wl-restart: init at 0.2.0

### DIFF
--- a/pkgs/by-name/wl/wl-restart/package.nix
+++ b/pkgs/by-name/wl/wl-restart/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  scdoc,
+  nix-update-script,
+}:
+stdenv.mkDerivation {
+  pname = "wl-restart";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "Ferdi265";
+    repo = "wl-restart";
+    rev = "v0.2.0";
+    hash = "sha256-pMsYLU9pjN2cgz7FxJJwkDHKJt1mIAuagJSBjrPUMAM=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    scdoc
+  ];
+
+  cmakeFlags = [ "-DINSTALL_DOCUMENTATION=ON" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "seamlessly restart your wayland compositor when it crashes";
+    mainProgram = "wl-restart";
+    license = lib.licenses.gpl3;
+    homepage = "https://github.com/Ferdi265/wl-restart";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ _0x5a4 ];
+  };
+}


### PR DESCRIPTION
## Description of changes

https://github.com/Ferdi265/wl-restart/

Restarts your wayland compositor when it crashes and seamlessly reconnect clients that support it, similar to KDEs `kwin_wayland_wrapper`. At the Moment this only really supported by QT6, but KDE is pushing for it to be supported in more toolkits. 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
