### PR TITLE
nixos/journald-gateway: remove assertion making system and user args truly optional

### DIFF
--- a/nixos/modules/system/boot/systemd/journald-gateway.nix
+++ b/nixos/modules/system/boot/systemd/journald-gateway.nix
@@ -108,18 +108,6 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    assertions = [
-      {
-        # This prevents the weird case were disabling "system" and "user"
-        # actually enables both because the cli flags are not present.
-        assertion = cfg.system || cfg.user;
-        message = ''
-          systemd-journal-gatewayd cannot serve neither "system" nor "user"
-          journals.
-        '';
-      }
-    ];
-
     systemd.additionalUpstreamSystemUnits = [
       "systemd-journal-gatewayd.socket"
       "systemd-journal-gatewayd.service"


### PR DESCRIPTION
## Description of changes

I would like to remove this assertion to support disabling the `system` and `user` flags at the same time.

The systemd-journal-gatewayd [documentation](https://www.freedesktop.org/software/systemd/man/latest/systemd-journal-gatewayd.service.html#--system) describes the `--system` and `--user` parameters and clarifies that "If neither is specified, all accessible entries are served." So disabling both is a use case which should be supported and not prevented by the nix module.

Example why this is an issue: I have a setup using `systemd-journal-gatewayd` and `systemd-journal-remote`. Using the [`--merge`](https://www.freedesktop.org/software/systemd/man/latest/systemd-journal-gatewayd.service.html#-m) flag would be the way to go to get all journals (including remote ones).

What I want to achieve is: `"${pkgs.systemd}/lib/systemd/systemd-journal-gatewayd --merge"`
But because of the assertion, if have to enable either `system` or `user` which limits the journals again.

So my suggestion would be to remove this assertion.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
