### PR TITLE
Added parameter address to nixos/journald-gateway and nixos/journald-remote

### DIFF
--- a/nixos/modules/system/boot/systemd/journald-gateway.nix
+++ b/nixos/modules/system/boot/systemd/journald-gateway.nix
@@ -13,6 +13,14 @@ in
   options.services.journald.gateway = {
     enable = lib.mkEnableOption "the HTTP gateway to the journal";
 
+    address = lib.mkOption {
+      default = "[::]";
+      type = lib.types.str;
+      description = ''
+        The address to listen to.
+      '';
+    };
+
     port = lib.mkOption {
       default = 19531;
       type = lib.types.port;
@@ -126,9 +134,9 @@ in
     systemd.sockets.systemd-journal-gatewayd = {
       wantedBy = [ "sockets.target" ];
       listenStreams = [
-        # Clear the default port
+        # Clear the default address and port
         ""
-        (toString cfg.port)
+        "${cfg.address}:${toString cfg.port}"
       ];
     };
   };

--- a/nixos/modules/system/boot/systemd/journald-remote.nix
+++ b/nixos/modules/system/boot/systemd/journald-remote.nix
@@ -37,6 +37,14 @@ in
       '';
     };
 
+    address = lib.mkOption {
+      default = "[::]";
+      type = lib.types.str;
+      description = ''
+        The address to listen to.
+      '';
+    };
+
     port = lib.mkOption {
       default = 19532;
       type = lib.types.port;
@@ -144,9 +152,9 @@ in
     systemd.sockets.systemd-journal-remote = {
       wantedBy = [ "sockets.target" ];
       listenStreams = [
-        # Clear the default port
+        # Clear the default address and port
         ""
-        (toString cfg.port)
+        "${cfg.address}:${toString cfg.port}"
       ];
     };
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Currently, the modules `nixos/journald-remote` and `nixos/journald-gateway` support to configure the port but not the address, the services should listen to. This PR introduces a new parameter `address` to both modules.

An alternative would be a new parameter `listenAddress` (or some other name) combing address and port, example `[::]:19531`. But then the currently used parameter `port` would be redundant. So imho this solution may be better, but I am open for other suggestions. 

Goal is the same: I would like to specify on which address these services should listen to.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
