### PR TITLE
keepmenu: 1.4.0 -> 1.4.2

### DIFF
--- a/pkgs/by-name/ke/keepmenu/package.nix
+++ b/pkgs/by-name/ke/keepmenu/package.nix
@@ -1,15 +1,22 @@
-{ lib, python3Packages, fetchFromGitHub, xvfb-run, xdotool, dmenu }:
+{ dmenu
+, fetchFromGitHub
+, lib
+, python3Packages
+, xdotool
+, xsel
+, xvfb-run
+}:
 
 python3Packages.buildPythonApplication rec {
   pname = "keepmenu";
-  version = "1.4.0";
+  version = "1.4.2";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "firecat53";
     repo = "keepmenu";
     rev = version;
-    hash = "sha256-3vFg+9Nw+NhuPJbrmBahXwa13wXlBg5IMYwJ+unn88k=";
+    hash = "sha256-Kzt2RqyYvOWnbkflwTHzlnpUaruVQvdGys57DDpH9o8=";
   };
 
   nativeBuildInputs = with python3Packages; [
@@ -22,7 +29,7 @@ python3Packages.buildPythonApplication rec {
     pynput
   ];
 
-  nativeCheckInputs = [ xvfb-run xdotool dmenu ];
+  nativeCheckInputs = [ dmenu xdotool xsel xvfb-run ];
 
   postPatch = ''
     substituteInPlace tests/keepmenu-config.ini tests/tests.py \


### PR DESCRIPTION
## Description of changes

Adds support tofi launcher.

I can run the tests locally for the project but through nixpkgs it hangs on the `installCheckPhase` (while running `xvfb-run python tests/tests.py`). I'm no python expert (just a user trying to update the version) so I'm not really sure how to fix this.

I'll also link to this related PR https://github.com/NixOS/nixpkgs/pull/328675 but that change is not dependent on the version of keepmenu (in other words, the current version of keepmenu is failing due to that issue)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable: 
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
