### PR TITLE
{stdenv,ninja}: add support for `NIX_LOAD_LIMIT`

### DIFF
--- a/pkgs/by-name/ni/ninja/setup-hook.sh
+++ b/pkgs/by-name/ni/ninja/setup-hook.sh
@@ -10,6 +10,7 @@ ninjaBuildPhase() {
 
     local flagsArray=(
         -j$buildCores
+        ${NIX_LOAD_LIMIT:+-l${NIX_LOAD_LIMIT}}
         $ninjaFlags "${ninjaFlagsArray[@]}"
     )
 
@@ -39,6 +40,7 @@ ninjaCheckPhase() {
 
         local flagsArray=(
             -j$buildCores
+            ${NIX_LOAD_LIMIT:+-l${NIX_LOAD_LIMIT}}
             $ninjaFlags "${ninjaFlagsArray[@]}"
             $checkTarget
         )
@@ -63,6 +65,7 @@ ninjaInstallPhase() {
     # shellcheck disable=SC2086
     local flagsArray=(
         -j$buildCores
+        ${NIX_LOAD_LIMIT:+-l${NIX_LOAD_LIMIT}}
         $ninjaFlags "${ninjaFlagsArray[@]}"
         ${installTargets:-install}
     )


### PR DESCRIPTION
## Description of changes

See: https://github.com/NixOS/nix/pull/11143

Untested draft, do not merge, warning warning warning.

Copious previous discussion and events: https://github.com/NixOS/nixpkgs/pull/174473, https://github.com/NixOS/nixpkgs/pull/184886, https://github.com/NixOS/nixpkgs/pull/192447, https://github.com/NixOS/nixpkgs/pull/192799.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
