### PR TITLE
nixos/proxmox-lxc: fix getty start and nixos-rebuild

### DIFF
--- a/nixos/modules/virtualisation/proxmox-lxc.nix
+++ b/nixos/modules/virtualisation/proxmox-lxc.nix
@@ -64,6 +64,18 @@ with lib;
         extraCommands = "mkdir -p root etc/systemd/network";
       };
 
+      boot.postBootCommands = ''
+        # After booting, register the contents of the Nix store in the Nix
+        # database.
+        if [ -f /nix-path-registration ]; then
+          ${config.nix.package.out}/bin/nix-store --load-db < /nix-path-registration &&
+          rm /nix-path-registration
+        fi
+
+        # nixos-rebuild also requires a "system" profile
+        ${config.nix.package.out}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system
+      '';
+
       boot = {
         isContainer = true;
         loader.initScript.enable = true;

--- a/nixos/modules/virtualisation/proxmox-lxc.nix
+++ b/nixos/modules/virtualisation/proxmox-lxc.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 
 with lib;
 
@@ -42,15 +47,19 @@ with lib;
     in
     mkIf cfg.enable {
       system.build.tarball = pkgs.callPackage ../../lib/make-system-tarball.nix {
-        storeContents = [{
-          object = config.system.build.toplevel;
-          symlink = "none";
-        }];
+        storeContents = [
+          {
+            object = config.system.build.toplevel;
+            symlink = "none";
+          }
+        ];
 
-        contents = [{
-          source = config.system.build.toplevel + "/init";
-          target = "/sbin/init";
-        }];
+        contents = [
+          {
+            source = config.system.build.toplevel + "/init";
+            target = "/sbin/init";
+          }
+        ];
 
         extraCommands = "mkdir -p root etc/systemd/network";
       };
@@ -84,11 +93,16 @@ with lib;
       };
 
       systemd = {
-        mounts = mkIf (!cfg.privileged) [{
-          enable = false;
-          where = "/sys/kernel/debug";
-        }];
-        services."getty@".unitConfig.ConditionPathExists = [ "" "/dev/%I" ];
+        mounts = mkIf (!cfg.privileged) [
+          {
+            enable = false;
+            where = "/sys/kernel/debug";
+          }
+        ];
+        services."getty@".unitConfig.ConditionPathExists = [
+          ""
+          "/dev/%I"
+        ];
       };
 
     };

--- a/nixos/modules/virtualisation/proxmox-lxc.nix
+++ b/nixos/modules/virtualisation/proxmox-lxc.nix
@@ -99,10 +99,16 @@ with lib;
             where = "/sys/kernel/debug";
           }
         ];
-        services."getty@".unitConfig.ConditionPathExists = [
+
+        # By default only starts getty on tty0 but first on LXC is tty1
+        services."autovt@".unitConfig.ConditionPathExists = [
           ""
           "/dev/%I"
         ];
+
+        # These are disabled by `console.enable` but console via tty is the default in Proxmox
+        services."getty@tty1".enable = lib.mkForce true;
+        services."autovt@".enable = lib.mkForce true;
       };
 
     };


### PR DESCRIPTION
## Description of changes

Before this PR, the console via /dev/console would work but no getty was being started on /dev/tty1 which is the default on Proxmox for new LXC containers.

Furthermore, registering the store paths is important for garbage collection if the store is being changed and the default system profile is need to make nixos-rebuild work. Otherwise switching to a new configuration fails with:

`
'/nix/store/la82b6h2yvrjm5sha9j5kmqks9p8sk5c-system-path/bin/busctl --json=short call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager ListUnitsByPatterns asas 0 0' exited with value 1 at /nix/store/9r6wrz196p8v5kap6mgqr1i95is47nay-nixos-system-unnamed-24.05.83bb0d3-dirty/bin/switch-to-configuration line 145.
`

Fixes https://github.com/nix-community/nixos-generators/issues/319.

cc @smacz42 @hogcycle

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
