### PR TITLE
add unrar license and use

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -1223,6 +1223,13 @@ in mkLicense lset) ({
     fullName = "The Unlicense";
   };
 
+  unrar = {
+    fullName = "UnRAR - free utility for RAR archives: License for use and distribution of FREEWARE version";
+    url = "https://www.rarlab.com/rar/unrarsrc-7.0.9.tar.gz";
+    free = false;
+    redistributable = true;
+  };
+
   upl = {
     spdxId = "UPL-1.0";
     fullName = "Universal Permissive License";

--- a/pkgs/applications/kde/ark/default.nix
+++ b/pkgs/applications/kde/ark/default.nix
@@ -32,7 +32,7 @@ mkDerivation {
     homepage = "https://apps.kde.org/ark/";
     description = "Graphical file compression/decompression utility";
     mainProgram = "ark";
-    license = with licenses; [ gpl2 lgpl3 ] ++ optional unfreeEnableUnrar unfree;
+    license = with licenses; [ gpl2 lgpl3 ] ++ optional unfreeEnableUnrar unrar;
     maintainers = [ maintainers.ttuegel ];
   };
 }

--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -197,7 +197,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     changelog = "https://github.com/kovidgoyal/calibre/releases/tag/v${finalAttrs.version}";
     license = if unrarSupport
-              then lib.licenses.unfreeRedistributable
+              then lib.licenses.unrar
               else lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ pSub ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/un/unrar/package.nix
+++ b/pkgs/by-name/un/unrar/package.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     description = "Utility for RAR archives";
     homepage = "https://www.rarlab.com/";
-    license = licenses.unfreeRedistributable;
+    license = licenses.unrar;
     mainProgram = "unrar";
     maintainers = with maintainers; [ wegank ];
     platforms = platforms.all;

--- a/pkgs/tools/archivers/7zz/default.nix
+++ b/pkgs/tools/archivers/7zz/default.nix
@@ -118,8 +118,7 @@ stdenv.mkDerivation (finalAttrs: {
       # CPP/7zip/Compress/LzfseDecoder.cpp is bsd3
       [ lgpl2Plus /* and */ bsd3 ] ++
       # and CPP/7zip/Compress/Rar* are unfree with the unRAR license restriction
-      # the unRAR compression code is disabled by default
-      lib.optionals enableUnfree [ unfree ];
+      lib.optionals enableUnfree [ unrar ];
     maintainers = with lib.maintainers; [ anna328p eclairevoyant jk peterhoeg ];
     platforms = with lib.platforms; unix ++ windows;
     mainProgram = "7zz";

--- a/pkgs/tools/archivers/p7zip/default.nix
+++ b/pkgs/tools/archivers/p7zip/default.nix
@@ -67,8 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
       # CPP/7zip/Compress/LzfseDecoder.cpp is bsd3
       [ lgpl2Plus /* and */ bsd3 ] ++
       # and CPP/7zip/Compress/Rar* are unfree with the unRAR license restriction
-      # the unRAR compression code is disabled by default
-      lib.optionals enableUnfree [ unfree ];
+      lib.optionals enableUnfree [ unrar ];
     maintainers = with maintainers; [ raskin jk ];
     platforms = platforms.unix;
     mainProgram = "7z";


### PR DESCRIPTION

## Description of changes

License is under the "UnRAR source" link on https://www.rarlab.com/rar_add.htm, not sure if it's better to link to the tarfile or to the webpage.

- **lib/licenses: add unrar**
- **treewide: use unrar license where applicable**
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
