### PR TITLE
python3Packages.objexplore: refactor & adopt as co-maintainer

### DIFF
--- a/pkgs/development/python-modules/objexplore/default.nix
+++ b/pkgs/development/python-modules/objexplore/default.nix
@@ -1,13 +1,13 @@
 {
-  blessed,
-  buildPythonPackage,
-  fetchFromGitHub,
   lib,
-  pandas,
-  pytestCheckHook,
+  buildPythonPackage,
   pythonOlder,
-  rich,
+  fetchFromGitHub,
   setuptools,
+  blessed,
+  rich,
+  pytestCheckHook,
+  pandas
 }:
 
 buildPythonPackage rec {
@@ -20,14 +20,11 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "kylepollina";
     repo = "objexplore";
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     hash = "sha256-FFQIiip7pk9fQhjGLxMSMakwoXbzaUjXcbQgDX52dnI=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail '==' '>='
-  '';
+  pythonRelaxDeps = [ "blessed" "rich" ];
 
   build-system = [ setuptools ];
 
@@ -53,10 +50,10 @@ buildPythonPackage rec {
     "objexplore.utils"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Terminal UI to interactively inspect and explore Python objects";
     homepage = "https://github.com/kylepollina/objexplore";
-    license = licenses.mit;
-    maintainers = with maintainers; [ pbsds ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pbsds ];
   };
 }

--- a/pkgs/development/python-modules/objexplore/default.nix
+++ b/pkgs/development/python-modules/objexplore/default.nix
@@ -54,6 +54,6 @@ buildPythonPackage rec {
     description = "Terminal UI to interactively inspect and explore Python objects";
     homepage = "https://github.com/kylepollina/objexplore";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pbsds ];
+    maintainers = with lib.maintainers; [ pbsds sigmanificient ];
   };
 }


### PR DESCRIPTION
Minor Refactoring (nits):

- Sort inputs
- Replace `substituteInPlace` with `pythonRelaxDeps`
- Change `with lib;` to smaller with statements (license, maintainers)
- Use `refs/tags` for version## Description of changes

Adopt the package (as co-maintainer), as I created a similar version within [osxphotos's draft pr](https://github.com/NixOS/nixpkgs/pull/326978).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
