### PR TITLE
plex-desktop: enable updateScript & inherit meta

### DIFF
--- a/pkgs/by-name/pl/plex-desktop/package.nix
+++ b/pkgs/by-name/pl/plex-desktop/package.nix
@@ -121,6 +121,7 @@ let
   };
 in
 buildFHSEnv {
+  inherit meta;
   name = "${pname}-${version}";
   targetPkgs = pkgs: [ xkeyboard_config ];
 
@@ -148,4 +149,5 @@ buildFHSEnv {
     ${lib.toShellVars extraEnv}
     exec ${plex-desktop}/Plex.sh
   '';
+  passthru.updateScript = ./update.sh;
 }

--- a/pkgs/by-name/pl/plex-desktop/package.nix
+++ b/pkgs/by-name/pl/plex-desktop/package.nix
@@ -1,34 +1,35 @@
-{ alsa-lib
-, autoPatchelfHook
-, buildFHSEnv
-, dbus
-, elfutils
-, expat
-, extraEnv ? { }
-, fetchFromGitLab
-, fetchurl
-, glib
-, glibc
-, lib
-, libGL
-, libapparmor
-, libbsd
-, libedit
-, libffi_3_3
-, libgcrypt
-, libglvnd
-, makeShellWrapper
-, sqlite
-, squashfsTools
-, stdenv
-, tcp_wrappers
-, udev
-, waylandpp
-, writeShellScript
-, xkeyboard_config
-, xorg
-, xz
-, zstd
+{
+  alsa-lib,
+  autoPatchelfHook,
+  buildFHSEnv,
+  dbus,
+  elfutils,
+  expat,
+  extraEnv ? { },
+  fetchFromGitLab,
+  fetchurl,
+  glib,
+  glibc,
+  lib,
+  libGL,
+  libapparmor,
+  libbsd,
+  libedit,
+  libffi_3_3,
+  libgcrypt,
+  libglvnd,
+  makeShellWrapper,
+  sqlite,
+  squashfsTools,
+  stdenv,
+  tcp_wrappers,
+  udev,
+  waylandpp,
+  writeShellScript,
+  xkeyboard_config,
+  xorg,
+  xz,
+  zstd,
 }:
 let
   pname = "plex-desktop";
@@ -104,48 +105,47 @@ let
 
     dontWrapQtApps = true;
 
-    installPhase =
-      ''
-        runHook preInstall
+    installPhase = ''
+      runHook preInstall
 
-        cp -r . $out
+      cp -r . $out
 
-        ln -s ${libedit}/lib/libedit.so.0 $out/lib/libedit.so.2
-        rm $out/usr/lib/x86_64-linux-gnu/libasound.so.2
-        ln -s ${alsa-lib}/lib/libasound.so.2 $out/usr/lib/x86_64-linux-gnu/libasound.so.2
-        rm $out/usr/lib/x86_64-linux-gnu/libasound.so.2.0.0
-        ln -s ${alsa-lib}/lib/libasound.so.2.0.0 $out/usr/lib/x86_64-linux-gnu/libasound.so.2.0.0
+      ln -s ${libedit}/lib/libedit.so.0 $out/lib/libedit.so.2
+      rm $out/usr/lib/x86_64-linux-gnu/libasound.so.2
+      ln -s ${alsa-lib}/lib/libasound.so.2 $out/usr/lib/x86_64-linux-gnu/libasound.so.2
+      rm $out/usr/lib/x86_64-linux-gnu/libasound.so.2.0.0
+      ln -s ${alsa-lib}/lib/libasound.so.2.0.0 $out/usr/lib/x86_64-linux-gnu/libasound.so.2.0.0
 
-        runHook postInstall
-      '';
+      runHook postInstall
+    '';
   };
 in
 buildFHSEnv {
-    name = "${pname}-${version}";
-    targetPkgs = pkgs: [ xkeyboard_config ];
+  name = "${pname}-${version}";
+  targetPkgs = pkgs: [ xkeyboard_config ];
 
-    extraInstallCommands = ''
-      mkdir -p $out/share/applications $out/share/icons/hicolor/scalable/apps
-      install -m 444 -D ${plex-desktop}/meta/gui/plex-desktop.desktop $out/share/applications/plex-desktop.desktop
-      substituteInPlace $out/share/applications/plex-desktop.desktop \
-        --replace-fail \
-        'Icon=''${SNAP}/meta/gui/icon.png' \
-        'Icon=${plex-desktop}/meta/gui/icon.png' \
-        --replace-fail \
-        'Exec=plex-desktop' \
-        'Exec=plex-desktop-${version}'
-    '';
+  extraInstallCommands = ''
+    mkdir -p $out/share/applications $out/share/icons/hicolor/scalable/apps
+    install -m 444 -D ${plex-desktop}/meta/gui/plex-desktop.desktop $out/share/applications/plex-desktop.desktop
+    substituteInPlace $out/share/applications/plex-desktop.desktop \
+      --replace-fail 'Icon=''${SNAP}/meta/gui/icon.png' 'Icon=${plex-desktop}/meta/gui/icon.png' \
+      --replace-fail 'Exec=plex-desktop' 'Exec=plex-desktop-${version}'
+  '';
 
-    runScript = writeShellScript "plex-desktop.sh" ''
-      # Widevine won't download unless this directory exists.
-      mkdir -p $HOME/.cache/plex/
-      PLEX_USR_PATH=${lib.makeSearchPath "usr/lib/x86_64-linux-gnu"  [ plex-desktop ]}
+  runScript = writeShellScript "plex-desktop.sh" ''
+    # Widevine won't download unless this directory exists.
+    mkdir -p $HOME/.cache/plex/
+    PLEX_USR_PATH=${lib.makeSearchPath "usr/lib/x86_64-linux-gnu" [ plex-desktop ]}
 
-      set -o allexport
-      LD_LIBRARY_PATH=${lib.makeLibraryPath [ plex-desktop libglvnd-1_4_0 ]}:$PLEX_USR_PATH
-      LIBGL_DRIVERS_PATH=$PLEX_USR_PATH/dri
-      ${lib.toShellVars extraEnv}
-      exec ${plex-desktop}/Plex.sh
+    set -o allexport
+    LD_LIBRARY_PATH=${
+      lib.makeLibraryPath [
+        plex-desktop
+        libglvnd-1_4_0
+      ]
+    }:$PLEX_USR_PATH
+    LIBGL_DRIVERS_PATH=$PLEX_USR_PATH/dri
+    ${lib.toShellVars extraEnv}
+    exec ${plex-desktop}/Plex.sh
   '';
 }
-


### PR DESCRIPTION
## Description of changes

Enable automatic updates by setting  passthru.updateScript.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Tested with

```
nix-shell maintainers/scripts/update.nix --argstr package plex-desktop
```

And, we get the commit: `plex-desktop: 1.96.0 -> 1.97.2`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
