### PR TITLE
ghc-9.8.x: drop obsolete patch for libmpd

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -134,15 +134,6 @@ self: super: {
   #   A factor of 100 is insufficent, 200 seems seems to work.
   hip = appendConfigureFlag "--ghc-options=-fsimpl-tick-factor=200" super.hip;
 
-  # Fix build with text-2.x.
-  libmpd = appendPatch
-    (pkgs.fetchpatch {
-        name = "138.patch"; # https://github.com/vimus/libmpd-haskell/pull/138
-        url = "https://github.com/vimus/libmpd-haskell/compare/95d3b3bab5858d6d1f0e079d0ab7c2d182336acb...f1cbf247261641565a3937b90721f7955d254c5e.patch";
-        sha256 = "Q4fA2J/Tq+WernBo+UIMdj604ILOMlIYkG4Pr046DfM=";
-      })
-    super.libmpd;
-
   # Loosen bounds
   patch = appendPatch (pkgs.fetchpatch {
     url = "https://github.com/reflex-frp/patch/commit/91fed138483a7bf2b098d45b9e5cc36191776320.patch";


### PR DESCRIPTION
The build fix is now a part of the official release.