### PR TITLE
linux: add x32 subarchitecture for x86_64-linux

### DIFF
--- a/nixos/modules/security/misc.nix
+++ b/nixos/modules/security/misc.nix
@@ -98,6 +98,17 @@ with lib;
           enters the guest.  May incur significant performance cost.
       '';
     };
+
+    security.enableX32Abi = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to enable the x32 subarchitecture on x86_64 kernels.
+        Enabling the x32 subarchitecture means that programs built for
+        the x32 ABI will run, but at the cost of security as x32 may
+        introduce security risks if enabled.
+      '';
+    };
   };
 
   config = mkMerge [
@@ -135,6 +146,10 @@ with lib;
 
     (mkIf (config.security.virtualisation.flushL1DataCache != null) {
       boot.kernelParams = [ "kvm-intel.vmentry_l1d_flush=${config.security.virtualisation.flushL1DataCache}" ];
+    })
+
+    (mkIf (!config.security.enableX32Abi) {
+      boot.kernelParams = [ "syscall.x32=n" ];
     })
   ];
 }

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -1294,6 +1294,9 @@ let
 
       # Enable Intel Turbo Boost Max 3.0
       INTEL_TURBO_MAX_3 = yes;
+
+      # Enable the x32 subarchitecture for compatible programs
+      X86_X32_ABI = yes;
     };
 
     accel = {


### PR DESCRIPTION
The x32 subarchitecture is basically x86_64, but with ILP32. This option doesn't force all programs to use the x32 ABI, but instead on a per-program basis when the ELF header is set to use both x86_64 AND 32 bits. Debian's kernel already has built-in support for the x32 ABI, but has to be manually enabled via editing the GRUB configuration, last time I tried.

To be honest, I want this to be enabled because I made a set of hand-golfed x86_64 programs, with a port to the x32 ABI to save more bytes. I *do* have it set in my config, but it is annoying to recompile the kernel every time a new kernel version releases, which takes an hour or so.

Fixes #1579, the third oldest issue currently open as of now.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
   - See below
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
   - Ran out of space on my NixOS partition
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
   - x32 is not used by many people, so I wouldn't consider the change to be major.
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
