### PR TITLE
dehashed: init at unstable-2024-07-20

### DIFF
--- a/pkgs/by-name/de/dehashed/package.nix
+++ b/pkgs/by-name/de/dehashed/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  python,
+  python3Packages,
+  ...
+}:
+
+python3Packages.buildPythonPackage rec {
+  pname = "dehashed";
+  version = "0-unstable-20-07-2024";
+  format = "other";
+
+  # This is a fork with the shebang
+  src = fetchFromGitHub {
+    owner = "akechishiro";
+    repo = "dehashed";
+    rev = "ad984ea960c533b6a74b077c3849b4fe3606e703";
+    hash = "sha256-JphkugkjgsLzw56udWGwWEe99iZK/X5fW9lcknyqxQU=";
+  };
+
+  doCheck = false;
+
+  propagatedBuildInputs = with python3Packages; [
+    beautifulsoup4
+    certifi
+    charset-normalizer
+    idna
+    fake-useragent
+    requests
+    soupsieve
+    urllib3
+  ];
+
+  installPhase = ''
+    install -Dm755 dehashed.py $out/bin/dehashed.py
+  '';
+
+  meta = with lib; {
+    description = "Python script to query dehashed API for leaked password/hashes";
+    mainProgram = "dehashed.py";
+    homepage = "https://github.com/akechishiro/dehashed";
+    changelog = "https://github.com/akechishiro/dehashed/${src.rev}";
+    license = licenses.unfree; # no license in original package
+    maintainers = with maintainers; [ akechishiro ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Package a Python script that allows to query the dehashed API for leaked passwords.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

>[!NOTE]
 I'm not sure if it's proper to use a fork to add the shebang, but without it the package is unusable, another solution would be to use a patch.

I've opened up upstream : 
- [X] a PR to add the shebang : https://github.com/sm00v/Dehashed/pull/5 
- [X] an issue to ask for the code to be licensed : https://github.com/sm00v/Dehashed/issues/6

If these changes are accepted, I will correct the package and make it point upstream.

EDIT : The two PRs were addressed upstream, the license is Apache2 and the shebang was added by upstream, this PR needs to be updated.