### PR TITLE
[Backport release-24.05] Backport 328413, 328022 and 325540 to release 24.05

### DIFF
--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -44,13 +44,13 @@ let
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "koboldcpp";
-  version = "1.69.1";
+  version = "1.70.1";
 
   src = fetchFromGitHub {
     owner = "LostRuins";
     repo = "koboldcpp";
     rev = "refs/tags/v${finalAttrs.version}";
-    sha256 = "sha256-808HyqrB9/cFJU7nq7Cm5Fm4OFPML4oQtnv0hystwAg=";
+    sha256 = "sha256-wtSkmjx5mzESMvIflqH+QEavH5oeBgKBz8/JjU+CASo=";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -43,6 +43,12 @@ let
     --prefix LD_LIBRARY_PATH: "${lib.makeLibraryPath [ addDriverRunpath.driverLink ]}"
   '';
 
+  darwinFrameworks =
+    if (stdenv.isDarwin && stdenv.isx86_64) then
+      darwin.apple_sdk.frameworks
+    else
+      darwin.apple_sdk_11_0.frameworks;
+
   effectiveStdenv = if cublasSupport then cudaPackages.backendStdenv else stdenv;
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
@@ -69,15 +75,15 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     [ tk ]
     ++ finalAttrs.pythonInputs
     ++ lib.optionals effectiveStdenv.isDarwin [
-      darwin.apple_sdk_11_0.frameworks.Accelerate
-      darwin.apple_sdk_11_0.frameworks.CoreVideo
-      darwin.apple_sdk_11_0.frameworks.CoreGraphics
-      darwin.apple_sdk_11_0.frameworks.CoreServices
+      darwinFrameworks.Accelerate
+      darwinFrameworks.CoreVideo
+      darwinFrameworks.CoreGraphics
+      darwinFrameworks.CoreServices
     ]
     ++ lib.optionals metalSupport [
-      darwin.apple_sdk_11_0.frameworks.MetalKit
-      darwin.apple_sdk_11_0.frameworks.Foundation
-      darwin.apple_sdk_11_0.frameworks.MetalPerformanceShaders
+      darwinFrameworks.MetalKit
+      darwinFrameworks.Foundation
+      darwinFrameworks.MetalPerformanceShaders
     ]
     ++ lib.optionals openblasSupport [ openblas ]
     ++ lib.optionals cublasSupport [
@@ -95,14 +101,14 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   pythonPath = finalAttrs.pythonInputs;
 
   darwinLdFlags = lib.optionals stdenv.isDarwin [
-    "-F${darwin.apple_sdk_11_0.frameworks.CoreServices}/Library/Frameworks"
-    "-F${darwin.apple_sdk_11_0.frameworks.Accelerate}/Library/Frameworks"
+    "-F${darwinFrameworks.CoreServices}/Library/Frameworks"
+    "-F${darwinFrameworks.Accelerate}/Library/Frameworks"
     "-framework CoreServices"
     "-framework Accelerate"
   ];
   metalLdFlags = lib.optionals metalSupport [
-    "-F${darwin.apple_sdk_11_0.frameworks.Foundation}/Library/Frameworks"
-    "-F${darwin.apple_sdk_11_0.frameworks.Metal}/Library/Frameworks"
+    "-F${darwinFrameworks.Foundation}/Library/Frameworks"
+    "-F${darwinFrameworks.Metal}/Library/Frameworks"
     "-framework Foundation"
     "-framework Metal"
   ];

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -5,6 +5,7 @@
   makeWrapper,
   gitUpdater,
   python3Packages,
+  python311Packages ? null, # Ignored. Kept for compatibility with the release
   tk,
   addDriverRunpath,
 
@@ -31,6 +32,8 @@
   vulkan-loader,
 
   metalSupport ? stdenv.isDarwin && stdenv.isAarch64,
+  march ? "",
+  mtune ? "",
 }:
 
 let
@@ -105,6 +108,14 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   ];
 
   env.NIX_LDFLAGS = lib.concatStringsSep " " (finalAttrs.darwinLdFlags ++ finalAttrs.metalLdFlags);
+
+  env.NIX_CFLAGS_COMPILE =
+    lib.optionalString (march != "") (
+      lib.warn "koboldcpp: the march argument is only kept for compatibility; use overrideAttrs intead" "-march=${march}"
+    )
+    + lib.optionalString (mtune != "") (
+      lib.warn "koboldcpp: the mtune argument is only kept for compatibility; use overrideAttrs intead" "-mtune=${mtune}"
+    );
 
   makeFlags = [
     (makeBool "LLAMA_OPENBLAS" openblasSupport)

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -22,7 +22,7 @@
   cublasSupport ? config.cudaSupport,
   # You can find a full list here: https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
   # For example if you're on an GTX 1080 that means you're using "Pascal" and you need to pass "sm_60"
-  arches ? cudaPackages.cudaFlags.arches or [ ],
+  cudaArches ? cudaPackages.cudaFlags.arches or [ ],
 
   clblastSupport ? stdenv.isLinux,
   clblast,
@@ -129,7 +129,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     (makeBool "LLAMA_CLBLAST" clblastSupport)
     (makeBool "LLAMA_VULKAN" vulkanSupport)
     (makeBool "LLAMA_METAL" metalSupport)
-    (lib.optionalString cublasSupport "CUDA_DOCKER_ARCH=sm_${builtins.head arches}")
+    (lib.optionalString cublasSupport "CUDA_DOCKER_ARCH=sm_${builtins.head cudaArches}")
   ];
 
   installPhase = ''

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -19,6 +19,9 @@
   openblas,
 
   cublasSupport ? config.cudaSupport,
+  # You can find a full list here: https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
+  # For example if you're on an GTX 1080 that means you're using "Pascal" and you need to pass "sm_60"
+  arches ? cudaPackages.cudaFlags.arches or [ ],
 
   clblastSupport ? stdenv.isLinux,
   clblast,
@@ -28,19 +31,6 @@
   vulkan-loader,
 
   metalSupport ? stdenv.isDarwin && stdenv.isAarch64,
-
-  # You can find a full list here: https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
-  # For example if you're on an GTX 1080 that means you're using "Pascal" and you need to pass "sm_60"
-  arches ? cudaPackages.cudaFlags.arches or [ ],
-
-  # You can find list of x86_64 options here: https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
-  # For ARM here: https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html
-  # If you set "march" to "native", specify "mtune" as well; otherwise, it will be set to "generic". (credit to: https://lemire.me/blog/2018/07/25/it-is-more-complicated-than-i-thought-mtune-march-in-gcc/)
-  march ? "",
-  # Apple Silicon Chips (M1, M2, M3 and so on DO NOT use mtune)
-  # For example, if you have an AMD Ryzen CPU, you will set "mtune" to "znver2"
-  mtune ? "",
-  mcpu ? "",
 }:
 
 let
@@ -115,12 +105,6 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   ];
 
   env.NIX_LDFLAGS = lib.concatStringsSep " " (finalAttrs.darwinLdFlags ++ finalAttrs.metalLdFlags);
-
-  env.NIX_CFLAGS_COMPILE = lib.concatStringsSep " " [
-    (lib.optionalString (march != "") "-march=${march}")
-    (lib.optionalString (mtune != "") "-mtune=${mtune}")
-    (lib.optionalString (mcpu != "") "-mcpu=${mcpu}")
-  ];
 
   makeFlags = [
     (makeBool "LLAMA_OPENBLAS" openblasSupport)

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -52,13 +52,13 @@ let
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "koboldcpp";
-  version = "1.68";
+  version = "1.69.1";
 
   src = fetchFromGitHub {
     owner = "LostRuins";
     repo = "koboldcpp";
     rev = "refs/tags/v${finalAttrs.version}";
-    sha256 = "sha256-zqRlQ8HgT4fmGHD6uxxa2duZrx9Vhxd+gm1XQ7w9ay0=";
+    sha256 = "sha256-808HyqrB9/cFJU7nq7Cm5Fm4OFPML4oQtnv0hystwAg=";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -39,7 +39,7 @@
 let
   makeBool = option: bool: (if bool then "${option}=1" else "");
 
-  makeWrapperArgs = lib.optionalString config.cudaSupport ''
+  libraryPathWrapperArgs = lib.optionalString config.cudaSupport ''
     --prefix LD_LIBRARY_PATH: "${lib.makeLibraryPath [ addDriverRunpath.driverLink ]}"
   '';
 
@@ -158,7 +158,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     wrapPythonProgramsIn "$out/bin" "$pythonPath"
     makeWrapper "$out/bin/koboldcpp.unwrapped" "$out/bin/koboldcpp" \
-      --prefix PATH ${lib.makeBinPath [ tk ]} ${makeWrapperArgs}
+      --prefix PATH ${lib.makeBinPath [ tk ]} ${libraryPathWrapperArgs}
   '';
 
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -4,7 +4,7 @@
   stdenv,
   makeWrapper,
   gitUpdater,
-  python311Packages,
+  python3Packages,
   tk,
 
   darwin,
@@ -56,10 +56,10 @@ effectiveStdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     makeWrapper
-    python311Packages.wrapPython
+    python3Packages.wrapPython
   ];
 
-  pythonInputs = builtins.attrValues { inherit (python311Packages) tkinter customtkinter packaging; };
+  pythonInputs = builtins.attrValues { inherit (python3Packages) tkinter customtkinter packaging; };
 
   buildInputs =
     [ tk ]

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -129,7 +129,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     (makeBool "LLAMA_CLBLAST" clblastSupport)
     (makeBool "LLAMA_VULKAN" vulkanSupport)
     (makeBool "LLAMA_METAL" metalSupport)
-    (lib.optionalString cublasSupport "CUDA_DOCKER_ARCH=sm_${builtins.head cudaArches}")
+    (lib.optionals cublasSupport "CUDA_DOCKER_ARCH=sm_${builtins.head cudaArches}")
   ];
 
   installPhase = ''


### PR DESCRIPTION
## Description of changes

Backport https://github.com/NixOS/nixpkgs/pull/328413 https://github.com/NixOS/nixpkgs/pull/328022 and https://github.com/NixOS/nixpkgs/pull/325540 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc