### PR TITLE
gdb + deps: fix build on FreeBSD

### DIFF
--- a/pkgs/development/libraries/libipt/default.nix
+++ b/pkgs/development/libraries/libipt/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake }:
+{ lib, stdenv, fetchFromGitHub, cmake, freebsd }:
 
 stdenv.mkDerivation rec {
   pname = "libipt";
@@ -12,6 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
+  buildInputs = lib.optional stdenv.isFreeBSD freebsd.libstdthreads;
 
   meta = with lib; {
     description = "Intel Processor Trace decoder library";

--- a/pkgs/development/libraries/mpfr/default.nix
+++ b/pkgs/development/libraries/mpfr/default.nix
@@ -3,6 +3,7 @@
 , fetchurl
 , gmp
 , writeScript
+, updateAutotoolsGnuConfigScriptsHook
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -25,6 +26,9 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "doc" "info" ];
 
   strictDeps = true;
+  # necessary to build on FreeBSD native pending inclusion of
+  # https://git.savannah.gnu.org/cgit/config.git/commit/?id=e4786449e1c26716e3f9ea182caf472e4dbc96e0
+  nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];
   # mpfr.h requires gmp.h
   propagatedBuildInputs = [ gmp ];
 

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -155,7 +155,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Plus;
 
     # GDB upstream does not support ARM darwin
-    platforms = with platforms; linux ++ cygwin ++ ["x86_64-darwin"];
+    platforms = with platforms; linux ++ cygwin ++ freebsd ++ ["x86_64-darwin"];
     maintainers = with maintainers; [ pierron globin lsix ];
   };
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libstdthreads.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libstdthreads.nix
@@ -1,0 +1,5 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "lib/libstdthreads";
+  extraPaths = [ "lib/libc/Versions.def" ];
+}

--- a/pkgs/tools/text/source-highlight/default.nix
+++ b/pkgs/tools/text/source-highlight/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchpatch, fetchurl, boost }:
+{ lib, stdenv, fetchpatch, fetchurl, boost, updateAutotoolsGnuConfigScriptsHook }:
 
 stdenv.mkDerivation rec {
   pname = "source-highlight";
@@ -43,6 +43,9 @@ stdenv.mkDerivation rec {
   '';
 
   strictDeps = true;
+  # necessary to build on FreeBSD native pending inclusion of
+  # https://git.savannah.gnu.org/cgit/config.git/commit/?id=e4786449e1c26716e3f9ea182caf472e4dbc96e0
+  nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];
   buildInputs = [ boost ];
 
   configureFlags = [


### PR DESCRIPTION
## Description of changes

Fixes several packages such that gdb can compile and run on FreeBSD. These should all be pretty uncontroversial changes, so I bundled them.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x68_64-freebsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
