### PR TITLE
{ghc,haskellPackages}: first pass at working on FreeBSD

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.7-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.7-binary.nix
@@ -7,6 +7,7 @@
 , coreutils
 , rcodesign
 , targetPackages
+, updateAutotoolsGnuConfigScriptsHook
 
   # minimal = true; will remove files that aren't strictly necessary for
   # regular builds and GHC bootstrapping.
@@ -204,7 +205,9 @@ stdenv.mkDerivation rec {
   #           https://gitlab.haskell.org/ghc/ghc/-/issues/20059
   #       and update this comment accordingly.
 
-  nativeBuildInputs = [ perl ]
+  # updateAutotoolsGnuConfigScriptsHook is necessary to build on native FreeBSD pending inclusion of
+  # https://git.savannah.gnu.org/cgit/config.git/commit/?id=e4786449e1c26716e3f9ea182caf472e4dbc96e0
+  nativeBuildInputs = [ perl updateAutotoolsGnuConfigScriptsHook ]
     # Upstream binaries may not be linker-signed, which invalidates their signatures
     # because `install_name_tool` will only replace a signature if it is both
     # an ad hoc signature and the signature is flagged as linker-signed.

--- a/pkgs/development/compilers/ghc/8.10.7-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.7-binary.nix
@@ -301,7 +301,7 @@ stdenv.mkDerivation rec {
           -exec sed -i "s@FFI_LIB_DIR@FFI_LIB_DIR ${numactl.out}/lib@g" {} \;
     '' +
     # Rename needed libraries and binaries, fix interpreter
-    lib.optionalString (stdenv.isLinux || stdenv.isFreeBSD) ''
+    lib.optionalString stdenv.hostPlatform.isElf ''
       find . -type f -executable -exec patchelf \
           --interpreter ${stdenv.cc.bintools.dynamicLinker} {} \;
     '' +
@@ -363,9 +363,9 @@ stdenv.mkDerivation rec {
   # This is extremely bogus and should be investigated.
   dontStrip = if stdenv.hostPlatform.isMusl then true else false; # `if` for explicitness
 
-  # On Linux/FreeBSD, use patchelf to modify the executables so that they can
+  # Use patchelf to modify ELF executables so that they can
   # find editline/gmp.
-  postFixup = lib.optionalString (stdenv.isLinux || stdenv.isFreeBSD)
+  postFixup = lib.optionalString stdenv.hostPlatform.isElf
     (if stdenv.hostPlatform.isAarch64 then
       # Keep rpath as small as possible on aarch64 for patchelf#244.  All Elfs
       # are 2 directories deep from $out/lib, so pooling symlinks there makes

--- a/pkgs/development/compilers/ghc/8.6.5-binary.nix
+++ b/pkgs/development/compilers/ghc/8.6.5-binary.nix
@@ -4,6 +4,7 @@
 , llvmPackages
 , coreutils
 , targetPackages
+, updateAutotoolsGnuConfigScriptsHook
 }:
 
 # Prebuilt only does native
@@ -79,7 +80,9 @@ stdenv.mkDerivation rec {
   }.${stdenv.hostPlatform.system}
     or (throw "cannot bootstrap GHC on this platform"));
 
-  nativeBuildInputs = [ perl ];
+  # updateAutotoolsGnuConfigScriptsHook is necessary to build on native FreeBSD pending inclusion of
+  # https://git.savannah.gnu.org/cgit/config.git/commit/?id=e4786449e1c26716e3f9ea182caf472e4dbc96e0
+  nativeBuildInputs = [ perl updateAutotoolsGnuConfigScriptsHook ];
 
   # Cannot patchelf beforehand due to relative RPATHs that anticipate
   # the final install location/

--- a/pkgs/development/compilers/ghc/9.2.4-binary.nix
+++ b/pkgs/development/compilers/ghc/9.2.4-binary.nix
@@ -282,7 +282,7 @@ stdenv.mkDerivation rec {
           -exec sed -i "s@FFI_LIB_DIR@FFI_LIB_DIR ${numactl.out}/lib@g" {} \;
     '' +
     # Rename needed libraries and binaries, fix interpreter
-    lib.optionalString (stdenv.isLinux || stdenv.isFreeBSD) ''
+    lib.optionalString stdenv.hostPlatform.isElf ''
       find . -type f -executable -exec patchelf \
           --interpreter ${stdenv.cc.bintools.dynamicLinker} {} \;
     '';
@@ -330,9 +330,9 @@ stdenv.mkDerivation rec {
   # This is extremely bogus and should be investigated.
   dontStrip = if stdenv.hostPlatform.isMusl then true else false; # `if` for explicitness
 
-  # On Linux/FreeBSD, use patchelf to modify the executables so that they can
+  # Use patchelf to modify ELF executables so that they can
   # find editline/gmp.
-  postFixup = lib.optionalString ((stdenv.isLinux || stdenv.isFreeBSD) && !(binDistUsed.isStatic or false))
+  postFixup = lib.optionalString (stdenv.hostPlatform.isElf && !(binDistUsed.isStatic or false))
     (if stdenv.hostPlatform.isAarch64 then
       # Keep rpath as small as possible on aarch64 for patchelf#244.  All Elfs
       # are 2 directories deep from $out/lib, so pooling symlinks there makes

--- a/pkgs/development/compilers/ghc/9.2.4-binary.nix
+++ b/pkgs/development/compilers/ghc/9.2.4-binary.nix
@@ -6,6 +6,7 @@
 , llvmPackages
 , coreutils
 , targetPackages
+, updateAutotoolsGnuConfigScriptsHook
 
   # minimal = true; will remove files that aren't strictly necessary for
   # regular builds and GHC bootstrapping.
@@ -189,7 +190,9 @@ stdenv.mkDerivation rec {
 
   src = fetchurl binDistUsed.src;
 
-  nativeBuildInputs = [ perl ];
+  # updateAutotoolsGnuConfigScriptsHook is necessary to build on native FreeBSD pending inclusion of
+  # https://git.savannah.gnu.org/cgit/config.git/commit/?id=e4786449e1c26716e3f9ea182caf472e4dbc96e0
+  nativeBuildInputs = [ perl updateAutotoolsGnuConfigScriptsHook ];
 
   # Set LD_LIBRARY_PATH or equivalent so that the programs running as part
   # of the bindist installer can find the libraries they expect.

--- a/pkgs/development/compilers/ghc/9.6.3-binary.nix
+++ b/pkgs/development/compilers/ghc/9.6.3-binary.nix
@@ -5,6 +5,7 @@
 , llvmPackages
 , coreutils
 , targetPackages
+, updateAutotoolsGnuConfigScriptsHook
 
   # minimal = true; will remove files that aren't strictly necessary for
   # regular builds and GHC bootstrapping.
@@ -172,7 +173,9 @@ stdenv.mkDerivation rec {
 
   src = fetchurl binDistUsed.src;
 
-  nativeBuildInputs = [ perl ];
+  # updateAutotoolsGnuConfigScriptsHook is necessary to build on native FreeBSD pending inclusion of
+  # https://git.savannah.gnu.org/cgit/config.git/commit/?id=e4786449e1c26716e3f9ea182caf472e4dbc96e0
+  nativeBuildInputs = [ perl updateAutotoolsGnuConfigScriptsHook ];
 
   # Set LD_LIBRARY_PATH or equivalent so that the programs running as part
   # of the bindist installer can find the libraries they expect.

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -30,6 +30,7 @@
 , autoSignDarwinBinariesHook
 , bash
 , srcOnly
+, updateAutotoolsGnuConfigScriptsHook
 
 , libiconv ? null, ncurses
 , glibcLocales ? null
@@ -477,6 +478,9 @@ stdenv.mkDerivation ({
   dontAddExtraLibs = true;
 
   nativeBuildInputs = [
+    # updateAutotoolsGnuConfigScriptsHook is necessary to build on native FreeBSD pending inclusion of
+    # https://git.savannah.gnu.org/cgit/config.git/commit/?id=e4786449e1c26716e3f9ea182caf472e4dbc96e0
+    updateAutotoolsGnuConfigScriptsHook
     perl ghc hadrian bootPkgs.alex bootPkgs.happy bootPkgs.hscolour
     # autoconf and friends are necessary for hadrian to create the bindist
     autoconf automake m4

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -572,6 +572,14 @@ self: super: {
   HerbiePlugin = dontCheck super.HerbiePlugin;
   wai-cors = dontCheck super.wai-cors;
 
+  # This fixes the build on FreeBSD. Can be removed when we get a release >0.2.2
+  streamly-core = appendPatch (pkgs.fetchpatch {
+    url = "https://github.com/composewell/streamly/commit/437c6332a19580a1fe085d593f6bb60b3d9608f8.patch";
+    hash = "sha256-z5v3MGLq2ELlTEGxfHcg2igAM2PC7whx6KIv1Uj2ujw=";
+    includes = ["src/*" "streamly-core.cabal"];
+    stripLen = 1;
+  }) (doJailbreak super.streamly-core) ;
+
   # 2024-05-18: Upstream tests against a different pandoc version
   pandoc-crossref = dontCheck super.pandoc-crossref;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1147,6 +1147,14 @@ self: super: {
   digestive-functors-blaze = doJailbreak super.digestive-functors-blaze;
   digestive-functors = doJailbreak super.digestive-functors;
 
+  # https://github.com/TeofilC/digest/pull/13
+  # this patch is nixpkgs specific, since we have no "base system"
+  digest = super.digest.overrideAttrs {
+    postPatch = ''
+      sed -E -i -e 's/ && !os\(freebsd\)//' digest.cabal
+    '';
+  };
+
   # Wrap the generated binaries to include their run-time dependencies in
   # $PATH. Also, cryptol needs a version of sbl that's newer than what we have
   # in LTS-13.x.

--- a/pkgs/development/haskell-modules/configuration-freebsd.nix
+++ b/pkgs/development/haskell-modules/configuration-freebsd.nix
@@ -1,0 +1,15 @@
+# FREEBSD-SPECIFIC OVERRIDES FOR THE HASKELL PACKAGE SET IN NIXPKGS
+
+{ pkgs, haskellLib }:
+
+let
+  inherit (pkgs) lib darwin;
+in
+
+with haskellLib;
+
+self: super: ({
+  # this can be removed when we get time-compat v1.9.7
+  # fix: https://github.com/haskellari/time-compat/commit/cb7ab16ee80e28cd2c611e274305d9173b9a0b33
+  time-compat = dontCheck super.time-compat;
+})

--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -9,6 +9,7 @@
 , configurationNix ? import ./configuration-nix.nix
 , configurationArm ? import ./configuration-arm.nix
 , configurationDarwin ? import ./configuration-darwin.nix
+, configurationFreeBSD ? import ./configuration-freebsd.nix
 , configurationJS ? import ./configuration-ghcjs-9.x.nix
 }:
 
@@ -29,6 +30,8 @@ let
     (configurationArm { inherit pkgs haskellLib; })
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
     (configurationDarwin { inherit pkgs haskellLib; })
+  ] ++ lib.optionals stdenv.hostPlatform.isFreeBSD [
+    (configurationFreeBSD { inherit pkgs haskellLib; })
   ] ++ lib.optionals stdenv.hostPlatform.isGhcjs [
     (configurationJS { inherit pkgs haskellLib; })
   ]


### PR DESCRIPTION
## Description of changes

The goal here was to make `nix-output-monitor` build. These are all its deps.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
