### PR TITLE
androidndkPkgs: Fix unsupported hardening flags & rename `androidndkPkgs_23b`

### DIFF
--- a/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
+++ b/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, makeWrapper
 , runCommand, wrapBintoolsWith, wrapCCWith, autoPatchelfHook
-, buildAndroidndk, androidndk, targetAndroidndkPkgs
+, llvmPackages, buildAndroidndk, androidndk, targetAndroidndkPkgs
 }:
 
 let
@@ -63,6 +63,7 @@ rec {
     passthru = {
       inherit targetPrefix;
       isClang = true; # clang based cc, but bintools ld
+      inherit (llvmPackages.clang.cc) hardeningUnsupportedFlagsByTargetPlatform;
     };
     dontUnpack = true;
     dontBuild = true;

--- a/pkgs/development/androidndk-pkgs/default.nix
+++ b/pkgs/development/androidndk-pkgs/default.nix
@@ -2,7 +2,7 @@
 }:
 
 let
-  makeNdkPkgs = ndkVersion:
+  makeNdkPkgs = ndkVersion: llvmPackages:
     let
       buildAndroidComposition = buildPackages.buildPackages.androidenv.composeAndroidPackages {
         includeNDK = true;
@@ -22,6 +22,10 @@ let
       inherit (pkgs)
         stdenv
         runCommand wrapBintoolsWith wrapCCWith;
+
+      # For hardeningUnsupportedFlagsByTargetPlatform
+      inherit llvmPackages;
+
       # buildPackages.foo rather than buildPackages.buildPackages.foo would work,
       # but for splicing messing up on infinite recursion for the variants we
       # *dont't* use. Using this workaround, but also making a test to ensure
@@ -33,9 +37,10 @@ let
 in
 
 {
-  "21" = makeNdkPkgs "21.0.6113669";
-  "23b" = makeNdkPkgs "23.1.7779620";
-  "24" = makeNdkPkgs "24.0.8215888";
-  "25" = makeNdkPkgs "25.2.9519653";
-  "26" = makeNdkPkgs "26.3.11579264";
+  "21" = makeNdkPkgs "21.0.6113669" pkgs.llvmPackages_14; # "9"
+  "23b" = makeNdkPkgs "23.1.7779620" pkgs.llvmPackages_14; # "12"
+  # Versions below 24 use a version not available in nixpkgs/old version which could be removed in the near future so use 14 for them as this is only used to get the hardening flags.
+  "24" = makeNdkPkgs "24.0.8215888" pkgs.llvmPackages_14;
+  "25" = makeNdkPkgs "25.2.9519653" pkgs.llvmPackages_14;
+  "26" = makeNdkPkgs "26.3.11579264" pkgs.llvmPackages_17;
 }

--- a/pkgs/development/androidndk-pkgs/default.nix
+++ b/pkgs/development/androidndk-pkgs/default.nix
@@ -1,4 +1,4 @@
-{ lib, androidenv, buildPackages, pkgs, targetPackages
+{ lib, androidenv, buildPackages, pkgs, targetPackages, androidndkPkgs_23, config
 }:
 
 let
@@ -38,7 +38,7 @@ in
 
 {
   "21" = makeNdkPkgs "21.0.6113669" pkgs.llvmPackages_14; # "9"
-  "23b" = makeNdkPkgs "23.1.7779620" pkgs.llvmPackages_14; # "12"
+  "23" = makeNdkPkgs "23.1.7779620" pkgs.llvmPackages_14; # "12"
   # Versions below 24 use a version not available in nixpkgs/old version which could be removed in the near future so use 14 for them as this is only used to get the hardening flags.
   "24" = makeNdkPkgs "24.0.8215888" pkgs.llvmPackages_14;
   "25" = makeNdkPkgs "25.2.9519653" pkgs.llvmPackages_14;

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -88,6 +88,7 @@ mapAliases ({
   ansible_2_12 = throw "Ansible 2.12 goes end of life in 2023/05 and can't be supported throughout the 23.05 release cycle"; # Added 2023-05-16
   ansible_2_13 = throw "Ansible 2.13 goes end of life in 2023/11"; # Added 2023-12-30
   ansible_2_14 = throw "Ansible 2.14 goes end of life in 2024/05 and can't be supported throughout the 24.05 release cycle"; # Added 2024-04-11
+  androidndkPkgs_23b = lib.warn "The package set `androidndkPkgs_23b` has been renamed to `androidndkPkgs_23`." androidndkPkgs_23; # Added 2024-07-21
   apacheAnt_1_9 = throw "Ant 1.9 has been removed since it's not used in nixpkgs anymore"; # Added 2023-11-12
   apacheKafka_2_8 = throw "apacheKafka_2_8 through _3_5 have been removed from nixpkgs as outdated"; # Added 2024-02-12
   apacheKafka_3_0 = throw "apacheKafka_2_8 through _3_5 have been removed from nixpkgs as outdated"; # Added 2024-02-12

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4039,7 +4039,7 @@ with pkgs;
 
   androidndkPkgs = androidndkPkgs_26;
   androidndkPkgs_21 = (callPackage ../development/androidndk-pkgs {})."21";
-  androidndkPkgs_23b = (callPackage ../development/androidndk-pkgs {})."23b";
+  androidndkPkgs_23 = (callPackage ../development/androidndk-pkgs {})."23";
   androidndkPkgs_24 = (callPackage ../development/androidndk-pkgs {})."24";
   androidndkPkgs_25 = (callPackage ../development/androidndk-pkgs {})."25";
   androidndkPkgs_26 = (callPackage ../development/androidndk-pkgs {})."26";


### PR DESCRIPTION
Got this error
`clang-17: error: unsupported option '-fzero-call-used-regs=used-gpr' for target 'armv7-unknown-linux-android'`

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
