### PR TITLE
major-mono-display: init at 2.000

### DIFF
--- a/pkgs/by-name/ma/major-mono-display/package.nix
+++ b/pkgs/by-name/ma/major-mono-display/package.nix
@@ -1,0 +1,39 @@
+{ lib, stdenvNoCC, fetchFromGitHub }:
+
+stdenvNoCC.mkDerivation {
+  pname = "major-mono-display";
+  version = "2.000";
+
+  src = fetchFromGitHub {
+    owner = "googlefonts";
+    repo = "majormono";
+    rev = "fae0bb9c728fe082097baedaf23604e290ddac16";
+    hash = "sha256-ishGGr8bY6UjEG/Hn5We8hOO5mcDq/41+DMn+dQGGUA=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 -t $out/share/fonts/truetype fonts/*.ttf
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Monospaced geometric sans serif all-uppercase typeface";
+    longDescription = ''
+      Majör is a monospaced geometric sans serif all-uppercase typeface
+      which also has a complete set of constructivist display characters
+      with a playful attitude. It has many Opentype features but the basic
+      variation between serious/playful faces can be implemented on web use
+      where Opentype features can be hard to apply, thanks to the fact that
+      the sans serif and the display versions of the letterforms can be
+      reached via lowercase and uppercase options. This makes Majör a great
+      choice for web typography, especially at large point-sizes.
+    '';
+    homepage = "https://github.com/googlefonts/majormono";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ mimvoid ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Add [Major Mono Display](https://github.com/googlefonts/majormono), a monospaced geometric sans serif all-uppercase typeface with a playful attitude.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
