### PR TITLE
 Option to allow containers to bind to specific interfaces

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -110,16 +110,6 @@ let
         extraFlags+=" --network-veth"
       fi
 
-      if [ -n "$HOST_PORT" ]; then
-        OIFS=$IFS
-        IFS=","
-        for i in $HOST_PORT
-        do
-            extraFlags+=" --port=$i"
-        done
-        IFS=$OIFS
-      fi
-
       if [ -n "$HOST_BRIDGE" ]; then
         extraFlags+=" --network-bridge=$HOST_BRIDGE"
       fi
@@ -167,7 +157,6 @@ let
         --setenv LOCAL_ADDRESS="$LOCAL_ADDRESS" \
         --setenv HOST_ADDRESS6="$HOST_ADDRESS6" \
         --setenv LOCAL_ADDRESS6="$LOCAL_ADDRESS6" \
-        --setenv HOST_PORT="$HOST_PORT" \
         --setenv PATH="$PATH" \
         ${optionalString cfg.ephemeral "--ephemeral"} \
         ${optionalString (cfg.additionalCapabilities != null && cfg.additionalCapabilities != [])
@@ -247,6 +236,7 @@ let
           fi
         fi
         ${concatStringsSep "\n" (mapAttrsToList renderExtraVeth cfg.extraVeths)}
+
       ''
   );
 
@@ -363,7 +353,7 @@ let
           protocol = mkOption {
             type = types.str;
             default = "tcp";
-            description = "The protocol specifier for port forwarding between host and container";
+            description = "The protocol specifier for port forwarding between host and container. Possible values: tcp, tcp6, udp, udp6";
           };
           hostPort = mkOption {
             type = types.int;
@@ -374,13 +364,18 @@ let
             default = null;
             description = "Target port of container";
           };
+          interfaces = mkOption {
+            type = types.listOf types.str;
+            default = [];
+            description = "List of external interface names on the host to bind the port to. Defaults to all interfaces including lo";
+          };
         };
       });
       default = [];
-      example = [ { protocol = "tcp"; hostPort = 8080; containerPort = 80; } ];
+      example = [ { protocol = "tcp"; hostPort = 8080; containerPort = 80; interfaces = [ "eth0" "lo" ]; } ];
       description = ''
         List of forwarded ports from host to container. Each forwarded port
-        is specified by protocol, hostPort and containerPort. By default,
+        is specified by protocol, hostPort and containerPort and interfaces. By default,
         protocol is tcp and hostPort and containerPort are assumed to be
         the same if containerPort is not explicitly given.
       '';
@@ -805,6 +800,45 @@ in
 
         serviceConfig = serviceDirectives dummyConfig;
       };
+
+      portForwarding = with lib; concatLists (concatLists (forEach (filter (x: x.value.forwardPorts != []) (
+        (mapAttrsToList (name: cfg:  nameValuePair name cfg) config.containers))) (containerConfig:
+          forEach containerConfig.value.forwardPorts (port:
+            if port.interfaces == [] then [{
+              containerName = containerConfig.name;
+              hostPort = port.hostPort;
+              containerPort = port.containerPort;
+              interface = "";
+              protocol = port.protocol;
+            }] else forEach port.interfaces (interface:  {
+              containerName = containerConfig.name;
+              hostPort = port.hostPort;
+              containerPort = port.containerPort;
+              interface = interface;
+              protocol = port.protocol;
+            })
+      ))));
+
+      portForwardIps = portForward:
+        if lib.strings.hasSuffix portForward.protocol "6"
+        then
+          ''
+          HOST_IP=`ip -f inet6 addr show ${portForward.interface} | sed -En -e 's/.*inet6 ([0-9a-f:]+).*/\1/p'`
+          CONTAINER_IP=`machinectl status web | grep Address -A 1 | tail -n 1 | sed -En -e 's/\s+([0-9a-f:]+)\%/\1/p'
+          ''
+        else
+          ''
+          HOST_IP=`ip -f inet addr show ${portForward.interface} | sed -En -e 's/.*inet ([0-9.]+).*/\1/p'`
+          CONTAINER_IP=`machinectl status ${portForward.containerName} | grep Address -A 1 | sed -En -e 's/.*Address:\s+([0-9.]+).*/\1/p'`
+          '';
+
+      portForwardBind = portForward: if (portForward.interface != "") then ",bind=$HOST_IP" else "";
+
+      portForwardScript = portForward:
+        ''
+          ${portForwardIps portForward}
+          ${pkgs.socat}/bin/socat ${portForward.protocol}-listen:${toString portForward.hostPort},fork,reuseaddr${portForwardBind portForward} ${portForward.protocol}:$CONTAINER_IP:${toString portForward.containerPort}
+        '';
     in {
       warnings =
         (optional (config.virtualisation.containers.enable && versionOlder config.system.stateVersion "22.05") ''
@@ -851,15 +885,37 @@ in
                 restartIfChanged = containerConfig.restartIfChanged;
               }
             )
-        )) config.containers)
+          )) config.containers)
+        ++ (forEach portForwarding (portForward: {
+          name = "container@${portForward.containerName}-forward-${portForward.interface}-${toString portForward.hostPort}-${portForward.protocol}";
+          value = {
+            bindsTo = if portForward.interface != "" && portForward.interface != "lo" then ["sys-subsystem-net-devices-${portForward.interface}.device"] else [];
+            partOf = [ "container@${portForward.containerName}.service" ];
+            script = portForwardScript portForward;
+            description = "Port forwarding for container ${portForward.containerName} ${portForward.interface}:${toString portForward.hostPort}";
+            path = [ pkgs.iproute2 ];
+            environment.root = if config.containers.${portForward.containerName}.ephemeral then "/run/nixos-containers/%i" else "${stateDirectory}/%i";
+          } // (
+            optionalAttrs config.containers.${portForward.containerName}.autoStart
+              {
+                wantedBy = [ "machines.target" ];
+                wants = [ "network.target" ];
+                after = [ "network.target" ];
+                restartTriggers = [
+                  config.containers.${portForward.containerName}.path
+                  config.environment.etc."${configurationDirectoryName}/${portForward.containerName}.conf".source
+                ];
+                restartIfChanged = config.containers.${portForward.containerName}.restartIfChanged;
+              }
+            );
+        }))
       ));
 
       # Generate a configuration file in /etc/nixos-containers for each
       # container so that container@.target can get the container
       # configuration.
       environment.etc =
-        let mkPortStr = p: p.protocol + ":" + (toString p.hostPort) + ":" + (if p.containerPort == null then toString p.hostPort else toString p.containerPort);
-        in mapAttrs' (name: cfg: nameValuePair "${configurationDirectoryName}/${name}.conf"
+        mapAttrs' (name: cfg: nameValuePair "${configurationDirectoryName}/${name}.conf"
         { text =
             ''
               SYSTEM_PATH=${cfg.path}
@@ -867,9 +923,6 @@ in
                 PRIVATE_NETWORK=1
                 ${optionalString (cfg.hostBridge != null) ''
                   HOST_BRIDGE=${cfg.hostBridge}
-                ''}
-                ${optionalString (length cfg.forwardPorts > 0) ''
-                  HOST_PORT=${concatStringsSep "," (map mkPortStr cfg.forwardPorts)}
                 ''}
                 ${optionalString (cfg.hostAddress != null) ''
                   HOST_ADDRESS=${cfg.hostAddress}
@@ -884,7 +937,6 @@ in
                   LOCAL_ADDRESS6=${cfg.localAddress6}
                 ''}
               ''}
-              INTERFACES="${toString cfg.interfaces}"
               MACVLANS="${toString cfg.macvlans}"
               ${optionalString cfg.autoStart ''
                 AUTO_START=1
@@ -910,7 +962,7 @@ in
 
       environment.systemPackages = [
         nixos-container
-      ];
+      ] ++ (if portForwarding != [] then [pkgs.socat] else []);
 
       boot.kernelModules = [
         "bridge"

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -224,6 +224,7 @@ in {
   containers-nested = handleTest ./containers-nested.nix {};
   containers-physical_interfaces = handleTest ./containers-physical_interfaces.nix {};
   containers-portforward = handleTest ./containers-portforward.nix {};
+  containers-portforward-interface = handleTest ./containers-portforward-interface.nix {};
   containers-reloadable = handleTest ./containers-reloadable.nix {};
   containers-require-bind-mounts = handleTest ./containers-require-bind-mounts.nix {};
   containers-restart_networking = handleTest ./containers-restart_networking.nix {};

--- a/nixos/tests/containers-portforward-interface.nix
+++ b/nixos/tests/containers-portforward-interface.nix
@@ -1,0 +1,72 @@
+let
+  hostIp = "192.168.0.1";
+  hostPort = 10080;
+  containerIp = "192.168.0.100";
+  containerPort = 80;
+in
+
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "containers-portforward-interface";
+  meta = {
+    maintainers = with lib.maintainers; [ aristid aszlig kampfschlaefer ianwookim ];
+  };
+
+  nodes.machine =
+    { pkgs, ... }:
+    { imports = [ ../modules/installer/cd-dvd/channel.nix ];
+      virtualisation.writableStore = true;
+
+      containers.webserver =
+        { privateNetwork = true;
+          hostAddress = hostIp;
+          localAddress = containerIp;
+          forwardPorts = [ { protocol = "tcp"; hostPort = hostPort; containerPort = containerPort; interfaces = [ "eth0" ]; } ];
+          config =
+            { services.httpd.enable = true;
+              services.httpd.adminAddr = "foo@example.org";
+              networking.firewall.allowedTCPPorts = [ 80 ];
+            };
+        };
+
+
+      networking.interfaces.eth0.ipv4.addresses = [
+        { address = "192.168.0.1"; prefixLength = 24; }
+      ];
+
+      networking.interfaces.eth1.ipv4.addresses = [
+        { address = "192.168.2.1"; prefixLength = 24; }
+      ];
+
+      virtualisation.additionalPaths = [ pkgs.stdenv ];
+    };
+
+  testScript =
+    ''
+      container_list = machine.succeed("nixos-container list")
+      assert "webserver" in container_list
+
+      # Start the webserver container.
+      machine.succeed("nixos-container start webserver")
+
+      # wait two seconds for the container to start and the network to be up
+      machine.sleep(2)
+
+      # Since "start" returns after the container has reached
+      # multi-user.target, we should now be able to access it.
+      # ip = machine.succeed("nixos-container show-ip webserver").strip()
+      machine.succeed("ping -n -c1 ${hostIp}")
+      machine.fail("curl --fail --connect-timeout 2 http://${hostIp}:${toString hostPort}/ > /dev/null")
+
+      # This should pass and works outside tests
+      machine.succeed("curl --fail http://192.168.0.1:${toString hostPort}/ > /dev/null")
+
+      # Stop the container.
+      #machine.succeed("nixos-container stop webserver")
+      #machine.fail("curl --fail --connect-timeout 2 http://${hostIp}:${toString hostPort}/ > /dev/null")
+      #machine.fail("curl --fail --connect-timeout 2 http://127.0.0.1:${toString hostPort}/ > /dev/null")
+
+      # Destroying a declarative container should fail.
+      machine.fail("nixos-container destroy webserver")
+    '';
+
+})


### PR DESCRIPTION
This adds the following option in `containers..forwardPorts`:

```
    forwardPorts = [
      {
        containerPort = 80;
        hostPort = 8080;
        protocol = "tcp";
        interfaces = [
          "lo"
        ];
      }

```

A list of interfaces can be specified so that different services can listen on IP addresses.

In addition, it allows the loopback interface to be bound

## Description of changes

Feedback is welcome, this is my first time doing anything in the nix language that isn't just defining data structures for system configuration so no doubt there are better ways to achieve what I've done here.

The current containers implementation has a few limitations when it comes to port forwarding:

- You cannot bind ports on different interfaces on the host, it's (nearly) all or nothing
- The loopback interface cannot be bound

The last one is a little surprising. Tools like docker make us used to being able to access a container via `127.0.0.1:80` or whatever.

There are quite a few times when I'd like to access a container locally but not expose it to the rest of the network. For example a web development machine. While the firewall can do this, why bind the port only to have the firewall block access to it?

Alternatively, a machine with a public and local interface on the network, I can differentiate between internet facing services and local only services.

## Implementation

There is a new `interfaces` option in `forwardPorts` when declaring a container.

Example:

```
  containers.web = {
    autoStart = true;
    privateNetwork = true;
    config = ./lemp.nix;
    extraFlags = [ "--U ];

    hostAddress = "192.168.100.10";
    localAddress = "192.168.100.11";

    bindMounts = {
      "/app" = {
        hostPath = "/tmp";
        isReadOnly = true;
      };
    };

    forwardPorts = [
      {
        containerPort = 80;
        hostPort = 8080;
        protocol = "tcp";
        interfaces = [
          "lo"
        ];
      }
    ];
  };
```

### Implementation choices

Nspawn's port options are very limited. This implementation skips it and manually configures port forwarding from the host to the container.

Interface names were chosen over IP addresses as IPs can change. For example, running a service on a machine on the local network and accessing it via the hostname is not uncommon. By using interface it doesn't matter if the IP changes `machinename:port` will still work to other machines on the network if the host IP changes.

I'm using `socat` to handle the forwarding. It may be possible to do this with IP tables but regardless what I tried I could not get forwarding to work on the loopback address. Though I'm no iptables expert. Similar issue [described here](https://serverfault.com/questions/665739/forwarding-a-port-on-the-loopback-interface-to-a-remote-ip-port)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
