### PR TITLE
tracexec: 0.4.0 -> 0.5.1

### DIFF
--- a/pkgs/by-name/tr/tracexec/package.nix
+++ b/pkgs/by-name/tr/tracexec/package.nix
@@ -8,7 +8,7 @@
 }:
 let
   pname = "tracexec";
-  version = "0.4.0";
+  version = "0.5.1";
 in
 rustPlatform.buildRustPackage {
   inherit pname version;
@@ -17,14 +17,12 @@ rustPlatform.buildRustPackage {
     owner = "kxxt";
     repo = "tracexec";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Rhxg3VmdMSo1xlazvToIdvkBvuFUKTq82U3PnedGHHs=";
+    hash = "sha256-RDOVKcGzSbej8THJGJgdLo/RPoD4Eks6USifXvd5PvY=";
   };
 
-  cargoHash = "sha256-rioZfUJD4ZOpXGCWsBDQkYwW9XtTjFnGgMKl0mPF5XM=";
+  cargoHash = "sha256-ELNksIEwGvcZ5grrmK4Nyvkyw2bkEdNQ2q4RSy4VqdM=";
 
-  nativeBuildInputs = [
-    cargo-about
-  ];
+  nativeBuildInputs = [ cargo-about ];
 
   # Remove RiscV64 specialisation when this is fixed:
   # * https://github.com/NixOS/nixpkgs/pull/310158#pullrequestreview-2046944158
@@ -62,7 +60,10 @@ rustPlatform.buildRustPackage {
     homepage = "https://github.com/kxxt/tracexec";
     license = lib.licenses.gpl2Plus;
     mainProgram = "tracexec";
-    maintainers = with lib.maintainers; [ fpletz nh2 ];
+    maintainers = with lib.maintainers; [
+      fpletz
+      nh2
+    ];
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
## Description of changes

https://github.com/kxxt/tracexec/releases/tag/v0.5.0
https://github.com/kxxt/tracexec/releases/tag/v0.5.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
