### PR TITLE
spidermonkey_91: Fix compilation by setting the python version

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/common.nix
+++ b/pkgs/development/interpreters/spidermonkey/common.nix
@@ -14,6 +14,7 @@
 , pkg-config
 , python3
 , python39
+, python311
 , rustc
 , which
 , zip
@@ -31,6 +32,11 @@
 , libiconv
 }:
 
+let
+  pythonToUse = if lib.versionOlder version "91" then python39
+    else if lib.versionOlder version "102" then python311
+    else python3;
+in
 stdenv.mkDerivation (finalAttrs: rec {
   pname = "spidermonkey";
   inherit version;
@@ -79,7 +85,7 @@ stdenv.mkDerivation (finalAttrs: rec {
     perl
     pkg-config
     # 78 requires python up to 3.9
-    (if lib.versionOlder version "91" then python39 else python3)
+    pythonToUse
     rustc
     rustc.llvmPackages.llvm # for llvm-objdump
     which
@@ -155,7 +161,7 @@ stdenv.mkDerivation (finalAttrs: rec {
     export CXXFLAGS="-fpermissive"
   '' + ''
     export LIBXUL_DIST=$out
-    export PYTHON="${buildPackages.python3.interpreter}"
+    export PYTHON="${pythonToUse.interpreter}"
   '' + lib.optionalString (lib.versionAtLeast version "91") ''
     export M4=m4
     export AWK=awk


### PR DESCRIPTION
## Description of changes
Fixed compilation of spidermonkey_91, a dependancy of couchdb3

## Things done
Force spidermonkey 91 to use python3.11 instead of the latest. This fix compilation.
Also checked that the hash of other versions of spidermonkey did not change

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
