### PR TITLE
nixos/espanso: fix wayland problems due to missing capabilities

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -189,6 +189,7 @@
   ./programs/ecryptfs.nix
   ./programs/environment.nix
   ./programs/envision.nix
+  ./programs/espanso-capdacoverride
   ./programs/evince.nix
   ./programs/extra-container.nix
   ./programs/fcast-receiver.nix

--- a/nixos/modules/programs/espanso-capdacoverride/default.nix
+++ b/nixos/modules/programs/espanso-capdacoverride/default.nix
@@ -1,0 +1,60 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+{
+  meta = {
+    maintainers = with maintainers; [ pitkling ];
+  };
+
+  options = {
+    programs.espanso.capdacoverride = {
+      enable = (mkEnableOption "espanso-wayland overlay with DAC_OVERRIDE capability") // {
+        default = false;
+        extraDescription = ''
+          Creates an espanso binary with the DAC_OVERRIDE capability (via `security.wrappers`) and overlays `pkgs.espanso-wayland` such that self-forks call the capability-enabled binary.
+          Required for `pkgs.espanso-wayland` to work correctly if not run with root privileges.
+        '';
+      };
+
+      package = mkOption {
+        type = types.package // {
+          check = package: types.package.check package && (builtins.elem "wayland" package.buildFeatures);
+          description =
+            types.package.description
+            + " for espanso with wayland support (`package.builtFeatures` must contain `\"wayland\"`)";
+        };
+        default = pkgs._espanso-wayland-orig;
+        defaultText = "pkgs.espanso-wayland (before applying the overlay)";
+        description = "The espanso-wayland package used as the base to generate the capability-enabled package.";
+      };
+    };
+  };
+
+  config =
+    let
+      cfg = config.programs.espanso.capdacoverride;
+    in
+    mkIf cfg.enable {
+      nixpkgs.overlays = [
+        (final: prev: {
+          _espanso-wayland-orig = prev.espanso-wayland;
+          espanso-wayland = pkgs.callPackage ./espanso-capdacoverride.nix {
+            capDacOverrideWrapperDir = "${config.security.wrapperDir}";
+            espanso = cfg.package;
+          };
+        })
+      ];
+
+      security.wrappers."${pkgs.espanso-wayland.meta.mainProgram}" = {
+        source = "${getExe pkgs.espanso-wayland}";
+        capabilities = "cap_dac_override+p";
+        owner = "root";
+        group = "root";
+      };
+    };
+}

--- a/nixos/modules/programs/espanso-capdacoverride/default.nix
+++ b/nixos/modules/programs/espanso-capdacoverride/default.nix
@@ -48,7 +48,7 @@ in
         })
       ];
 
-      security.wrappers."${pkgs.espanso-wayland.meta.mainProgram}" = {
+      security.wrappers."espanso-wayland" = {
         source = lib.getExe pkgs.espanso-wayland;
         capabilities = "cap_dac_override+p";
         owner = "root";

--- a/nixos/modules/programs/espanso-capdacoverride/default.nix
+++ b/nixos/modules/programs/espanso-capdacoverride/default.nix
@@ -36,23 +36,22 @@ in
     };
   };
 
-  config =
-    lib.mkIf cfg.enable {
-      nixpkgs.overlays = [
-        (final: prev: {
-          _espanso-wayland-orig = prev.espanso-wayland;
-          espanso-wayland = pkgs.callPackage ./espanso-capdacoverride.nix {
-            capDacOverrideWrapperDir = "${config.security.wrapperDir}";
-            espanso = cfg.package;
-          };
-        })
-      ];
+  config = lib.mkIf cfg.enable {
+    nixpkgs.overlays = [
+      (final: prev: {
+        _espanso-wayland-orig = prev.espanso-wayland;
+        espanso-wayland = pkgs.callPackage ./espanso-capdacoverride.nix {
+          capDacOverrideWrapperDir = "${config.security.wrapperDir}";
+          espanso = cfg.package;
+        };
+      })
+    ];
 
-      security.wrappers."espanso-wayland" = {
-        source = lib.getExe pkgs.espanso-wayland;
-        capabilities = "cap_dac_override+p";
-        owner = "root";
-        group = "root";
-      };
+    security.wrappers."espanso-wayland" = {
+      source = lib.getExe pkgs.espanso-wayland;
+      capabilities = "cap_dac_override+p";
+      owner = "root";
+      group = "root";
     };
+  };
 }

--- a/nixos/modules/programs/espanso-capdacoverride/default.nix
+++ b/nixos/modules/programs/espanso-capdacoverride/default.nix
@@ -5,15 +5,14 @@
   ...
 }:
 
-with lib;
 {
   meta = {
-    maintainers = with maintainers; [ pitkling ];
+    maintainers = with lib.maintainers; [ pitkling ];
   };
 
   options = {
     programs.espanso.capdacoverride = {
-      enable = (mkEnableOption "espanso-wayland overlay with DAC_OVERRIDE capability") // {
+      enable = (lib.mkEnableOption "espanso-wayland overlay with DAC_OVERRIDE capability") // {
         default = false;
         extraDescription = ''
           Creates an espanso binary with the DAC_OVERRIDE capability (via `security.wrappers`) and overlays `pkgs.espanso-wayland` such that self-forks call the capability-enabled binary.
@@ -21,11 +20,11 @@ with lib;
         '';
       };
 
-      package = mkOption {
-        type = types.package // {
-          check = package: types.package.check package && (builtins.elem "wayland" package.buildFeatures);
+      package = lib.mkOption {
+        type = lib.types.package // {
+          check = package: lib.types.package.check package && (builtins.elem "wayland" package.buildFeatures);
           description =
-            types.package.description
+            lib.types.package.description
             + " for espanso with wayland support (`package.builtFeatures` must contain `\"wayland\"`)";
         };
         default = pkgs._espanso-wayland-orig;
@@ -39,7 +38,7 @@ with lib;
     let
       cfg = config.programs.espanso.capdacoverride;
     in
-    mkIf cfg.enable {
+    lib.mkIf cfg.enable {
       nixpkgs.overlays = [
         (final: prev: {
           _espanso-wayland-orig = prev.espanso-wayland;
@@ -51,7 +50,7 @@ with lib;
       ];
 
       security.wrappers."${pkgs.espanso-wayland.meta.mainProgram}" = {
-        source = "${getExe pkgs.espanso-wayland}";
+        source = "${lib.getExe pkgs.espanso-wayland}";
         capabilities = "cap_dac_override+p";
         owner = "root";
         group = "root";

--- a/nixos/modules/programs/espanso-capdacoverride/default.nix
+++ b/nixos/modules/programs/espanso-capdacoverride/default.nix
@@ -5,6 +5,9 @@
   ...
 }:
 
+let
+  cfg = config.programs.espanso.capdacoverride;
+in
 {
   meta = {
     maintainers = with lib.maintainers; [ pitkling ];
@@ -13,8 +16,7 @@
   options = {
     programs.espanso.capdacoverride = {
       enable = (lib.mkEnableOption "espanso-wayland overlay with DAC_OVERRIDE capability") // {
-        default = false;
-        extraDescription = ''
+        description = ''
           Creates an espanso binary with the DAC_OVERRIDE capability (via `security.wrappers`) and overlays `pkgs.espanso-wayland` such that self-forks call the capability-enabled binary.
           Required for `pkgs.espanso-wayland` to work correctly if not run with root privileges.
         '';
@@ -35,9 +37,6 @@
   };
 
   config =
-    let
-      cfg = config.programs.espanso.capdacoverride;
-    in
     lib.mkIf cfg.enable {
       nixpkgs.overlays = [
         (final: prev: {
@@ -50,7 +49,7 @@
       ];
 
       security.wrappers."${pkgs.espanso-wayland.meta.mainProgram}" = {
-        source = "${lib.getExe pkgs.espanso-wayland}";
+        source = lib.getExe pkgs.espanso-wayland;
         capabilities = "cap_dac_override+p";
         owner = "root";
         group = "root";

--- a/nixos/modules/programs/espanso-capdacoverride/espanso-capdacoverride.nix
+++ b/nixos/modules/programs/espanso-capdacoverride/espanso-capdacoverride.nix
@@ -1,0 +1,60 @@
+{
+  autoPatchelfHook,
+  capDacOverrideWrapperDir,
+  espanso,
+  patchelfUnstable, # have to use patchelfUnstable to support --rename-dynamic-symbols
+  stdenv,
+}:
+let
+  inherit (espanso) version;
+  pname = "${espanso.pname}-capdacoverride";
+
+  wrapperLibName = "wrapper-lib.so";
+  wrapperLibSource = "wrapper-lib.c";
+
+  # On Wayland, Espanso requires the DAC_OVERRIDE capability. One can create a wrapper binary with this
+  # capability using the `config.security.wrappers.<name>` framework. However, this is not enough: the
+  # capability is required by a worker process of Espanso created by forking `/proc/self/exe`, which points
+  # to the executable **without** the DAC_OVERRIDE capability. Thus, we inject a wrapper library into Espanso
+  # that redirects requests to `/proc/self/exe` to the binary with the proper capabilities.
+  wrapperLib = stdenv.mkDerivation {
+    name = "${pname}-${version}-wrapper-lib";
+
+    src = builtins.path {
+      name = "${pname}-${version}-wrapper-lib-source";
+      path = ./.;
+      filter = path: type: baseNameOf path == wrapperLibSource;
+    };
+
+    postPatch = ''
+      substitute ${wrapperLibSource} lib.c --subst-var-by to "${capDacOverrideWrapperDir}/espanso"
+      cc -fPIC -shared lib.c -o ${wrapperLibName}
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      install -D -t $out/lib ${wrapperLibName}
+      runHook postInstall
+    '';
+  };
+in
+espanso.overrideAttrs (previousAttrs: {
+  inherit pname;
+
+  buildInputs = previousAttrs.buildInputs ++ [ wrapperLib ];
+
+  nativeBuildInputs = previousAttrs.nativeBuildInputs ++ [
+    autoPatchelfHook
+    patchelfUnstable
+  ];
+
+  postInstall =
+    ''
+      echo readlink readlink_wrapper > readlink_name_map
+      patchelf \
+        --rename-dynamic-symbols readlink_name_map \
+        --add-needed ${wrapperLibName} \
+        "$out/bin/espanso"
+    ''
+    + previousAttrs.postInstall;
+})

--- a/nixos/modules/programs/espanso-capdacoverride/espanso-capdacoverride.nix
+++ b/nixos/modules/programs/espanso-capdacoverride/espanso-capdacoverride.nix
@@ -27,7 +27,7 @@ let
     };
 
     postPatch = ''
-      substitute ${wrapperLibSource} lib.c --subst-var-by to "${capDacOverrideWrapperDir}/espanso"
+      substitute ${wrapperLibSource} lib.c --subst-var-by to "${capDacOverrideWrapperDir}/espanso-wayland"
       cc -fPIC -shared lib.c -o ${wrapperLibName}
     '';
 

--- a/nixos/modules/programs/espanso-capdacoverride/espanso-capdacoverride.nix
+++ b/nixos/modules/programs/espanso-capdacoverride/espanso-capdacoverride.nix
@@ -10,7 +10,6 @@ let
   pname = "${espanso.pname}-capdacoverride";
 
   wrapperLibName = "wrapper-lib.so";
-  wrapperLibSource = "wrapper-lib.c";
 
   # On Wayland, Espanso requires the DAC_OVERRIDE capability. One can create a wrapper binary with this
   # capability using the `config.security.wrappers.<name>` framework. However, this is not enough: the
@@ -20,15 +19,16 @@ let
   wrapperLib = stdenv.mkDerivation {
     name = "${pname}-${version}-wrapper-lib";
 
-    src = builtins.path {
-      name = "${pname}-${version}-wrapper-lib-source";
-      path = ./.;
-      filter = path: type: baseNameOf path == wrapperLibSource;
-    };
+    dontUnpack = true;
 
     postPatch = ''
-      substitute ${wrapperLibSource} lib.c --subst-var-by to "${capDacOverrideWrapperDir}/espanso-wayland"
+      substitute ${./wrapper-lib.c} lib.c --subst-var-by to "${capDacOverrideWrapperDir}/espanso-wayland"
+    '';
+
+    buildPhase = ''
+      runHook preBuild
       cc -fPIC -shared lib.c -o ${wrapperLibName}
+      runHook postBuild
     '';
 
     installPhase = ''

--- a/nixos/modules/programs/espanso-capdacoverride/wrapper-lib.c
+++ b/nixos/modules/programs/espanso-capdacoverride/wrapper-lib.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static const char from[] =  "/proc/self/exe";
+static const char to[]   = "@to@";
+
+ssize_t readlink_wrapper(const char *restrict path, char *restrict buf, size_t bufsize) {
+    if (strcmp(path, from) == 0) {
+        printf("readlink_wrapper.c: Resolving readlink call to '%s' to '%s'\n", from, to);
+        size_t to_length = strlen(to);
+        if (to_length > bufsize) {
+            to_length = bufsize;
+        }
+        memcpy(buf, to, to_length);
+        return to_length;
+    } else {
+        return readlink(path, buf, bufsize);
+    }
+}


### PR DESCRIPTION
## Description of changes

This PR fixes #249364 ~(which I assume is actually not only Wayland-specific)~. When enabled via `programs.espanso.capdacoverride.enable = true`, it injects an overlay that overrides `pkgs.espanso-wayland` with a package that has the DAC_OVERRIDE capability.

With this in place, espanso can be used under Wayland (both in NixOS and Home Manager) via the standard way:

```nix
services.espanso = {
  enable = true;
  package = pkgs.espanso-wayland;
};
```

There is also a `programs.espanso.capdacoverride.package` option that allows to set which espanso-wayland is used as a base for the DAC-OVERRIDE-enabled package version. For example, if you pulled in espanso-wayland from nixpkgs-unstable under pkgs.unstable.espanso-wayland), you can set:

```nix
programs.espanso.capdacoverride.package = pkgs.unstable.espanso-wayland
```

If this module is added, one should probably add a note to the `services.espanso` module mentioning that this must be enabled for Wayland (or it won't work). Alternatively, one could detect automatically whether the user wants to use an espanso-wayland package and activate this module automatically.


## Detailed Description

Under Wayland, Espanso requires the DAC_OVERRIDE capability (see the [documentation](https://espanso.org/docs/install/linux/#wayland-compile)). NixOS does not support capabilities in the Nix store but instead provides a framework to create wrapper binaries with suitable capabilities. While the wrapper does some work to maintain those capabilities across forks, this is not enough in the case of Espanso, which drops the extra capabilities early on and relies on **file capabilities** to regain those capabilities when forking a worker process (via `/proc/self/exe`). Unfortunately, the symlink under `/proc/self/exe` does not point to the capability-enabled wrapper but to the original binary in the nix store.

Thus, this PR wraps the original espanso-wayland package definition and injects a wrapper library that intercepts the `readlink`-call and – if it looks up `/proc/self/exe` – returns the capability-enabled wrapper.  Since `espanso-wayland` is broken without those capabilities, the wrapped espanso-wayland package is then overlayed (unless explicitly disabled via `programs.espanso.capdacoverride.enable = false`) over `pkgs.espanso-wayland` (making the original `pkgs.espanso_wayland` available under `pkgs._espanso-wayland-orig`).

Note that the updated package definition **must** be created on-the-fly during evaluation of the system configuration, since the path to the capability-enabled wrapper depends on the `security.wrapperDir`.

This has been working ~~pretty well~~ flawlessly on my system for several ~~weeks~~ months. It seems currently the only workaround for #249364 that keeps all of Espanso's features. For example, there is also #339594, but with it we lose Espanso's self-monitoring (which is used, e.g., for automatically re-loading the configuration when it changes). Happy about any feedback (especially from the corresponding maintainers @kimat @pyrox0 @n8henrie @numkem) to improve this if you think this is a viable way forward.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
