### PR TITLE
bcc: fix bashreadline

### DIFF
--- a/pkgs/by-name/bc/bcc/bashreadline.py-remove-dependency-on-elftools.patch
+++ b/pkgs/by-name/bc/bcc/bashreadline.py-remove-dependency-on-elftools.patch
@@ -1,0 +1,48 @@
+From 25c77bff079c331ae12d9e4499c82fdabf301610 Mon Sep 17 00:00:00 2001
+From: Dominique Martinet <asmadeus@codewreck.org>
+Date: Sun, 21 Jul 2024 20:59:51 +0900
+Subject: [PATCH] bashreadline.py: remove dependency on elftools
+
+This helper is only here to differentiate between very old bash
+versions or semi-recent ones; since we'll only catter to newer
+bash versions we don't need to bother with elftools here:
+just hardcode the newer symbol.
+---
+ tools/bashreadline.py | 14 +-------------
+ 1 file changed, 1 insertion(+), 13 deletions(-)
+
+diff --git a/tools/bashreadline.py b/tools/bashreadline.py
+index 7e8324a2c0ea..e4b20aeb2371 100755
+--- a/tools/bashreadline.py
++++ b/tools/bashreadline.py
+@@ -17,7 +17,6 @@
+ # 12-Feb-2016    Allan McAleavy migrated to BPF_PERF_OUTPUT
+ 
+ from __future__ import print_function
+-from elftools.elf.elffile import ELFFile
+ from bcc import BPF
+ from time import strftime
+ import argparse
+@@ -33,18 +32,7 @@ args = parser.parse_args()
+ 
+ name = args.shared if args.shared else "/bin/bash"
+ 
+-
+-def get_sym(filename):
+-    with open(filename, 'rb') as f:
+-        elf = ELFFile(f)
+-        symbol_table = elf.get_section_by_name(".dynsym")
+-        for symbol in symbol_table.iter_symbols():
+-            if symbol.name == "readline_internal_teardown":
+-                return "readline_internal_teardown"
+-    return "readline"
+-
+-
+-sym = get_sym(name)
++sym = "readline_internal_teardown"
+ 
+ # load BPF program
+ bpf_text = """
+-- 
+2.45.2
+

--- a/pkgs/by-name/bc/bcc/package.nix
+++ b/pkgs/by-name/bc/bcc/package.nix
@@ -15,6 +15,7 @@
   netperf,
   nixosTests,
   python3Packages,
+  readline,
   stdenv,
   zip,
 }:
@@ -50,6 +51,9 @@ python3Packages.buildPythonApplication rec {
     # This is needed until we fix
     # https://github.com/NixOS/nixpkgs/issues/40427
     ./fix-deadlock-detector-import.patch
+    # Quick & dirty fix for bashreadline
+    # https://github.com/NixOS/nixpkgs/issues/328743
+    ./bashreadline.py-remove-dependency-on-elftools.patch
   ];
 
   propagatedBuildInputs = [ python3Packages.netaddr ];
@@ -85,7 +89,10 @@ python3Packages.buildPythonApplication rec {
 
     # https://github.com/iovisor/bcc/issues/3996
     substituteInPlace src/cc/libbcc.pc.in \
-      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
+      --replace-fail '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
+
+    substituteInPlace tools/bashreadline.py \
+      --replace-fail '/bin/bash' '${readline}/lib/libreadline.so'
   '';
 
   preInstall = ''


### PR DESCRIPTION
## Description of changes

- we didn't provide the newly required elfutils python dependency, but we're only dealing with newer bashes so just use the new symbol
- while here also default to using our libreadline as bash is configured to use it on nixos; this can still be overriden

Fixes: #328743

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] tested the new result/bin/bashreadline works
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
