### PR TITLE
python3Packages.inspect-ai: init at 0.3.17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19976,6 +19976,12 @@
     githubId = 71843723;
     keys = [ { fingerprint = "EEFB CC3A C529 CFD1 943D  A75C BDD5 7BE9 9D55 5965"; } ];
   };
+  theodoreehrenborg = {
+    name = "Theodore Ehrenborg";
+    email = "theodore.ehrenborg@gmail.com";
+    github = "TheodoreEhrenborg";
+    githubId = 46494248;
+  };
   therealansh = {
     email = "tyagiansh23@gmail.com";
     github = "therealansh";

--- a/pkgs/development/python-modules/inspect-ai/default.nix
+++ b/pkgs/development/python-modules/inspect-ai/default.nix
@@ -1,0 +1,80 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, aiofiles
+, beautifulsoup4
+, click
+, debugpy
+, docstring-parser
+, fsspec
+, httpx
+, json-stream
+, jsonlines
+, nest-asyncio
+, numpy
+, platformdirs
+, psutil
+, pydantic
+, python-dotenv
+, pyyaml
+, rich
+, s3fs
+, semver
+, setuptools
+, setuptools_scm
+, shortuuid
+, tenacity
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "inspect_ai";
+  version = "0.3.17";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-lxiUXRyyRq3QtBdMgskCg9Ex3vsNgg7BIH82SRuKrnA=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    setuptools_scm
+  ];
+
+  propagatedBuildInputs = [
+    aiofiles
+    beautifulsoup4
+    click
+    debugpy
+    docstring-parser
+    fsspec
+    httpx
+    json-stream
+    jsonlines
+    nest-asyncio
+    numpy
+    platformdirs
+    psutil
+    pydantic
+    python-dotenv
+    pyyaml
+    rich
+    s3fs
+    semver
+    shortuuid
+    tenacity
+    typing-extensions
+  ];
+
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://inspect.ai-safety-institute.org.uk/";
+    changelog = "https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/CHANGELOG.md";
+    description = "A framework for large language model evaluations";
+    license = licenses.mit;
+    maintainers = with maintainers; [ theodoreehrenborg ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5913,6 +5913,8 @@ self: super: with self; {
 
   insightface = callPackage ../development/python-modules/insightface { };
 
+  inspect-ai = callPackage ../development/python-modules/inspect-ai { };
+
   installer = callPackage ../development/python-modules/installer { };
 
   insteon-frontend-home-assistant = callPackage ../development/python-modules/insteon-frontend-home-assistant { };


### PR DESCRIPTION
## Description of changes

Project homepage: https://inspect.ai-safety-institute.org.uk/, github: https://github.com/UKGovernmentBEIS/inspect_ai/

Many of the tests require Internet access, so I've disabled them

I've checked that `nix-shell -E 'with import ~/projects/nixpkgs {}; mkShell { buildInputs = [ python3Packages.inspect-ai  ]; }'` runs without errors. Within the nix-shell I'm able to run the example scripts from the homepage (`inspect eval arc.py --model openai/gpt-3.5-turbo` and `inspect view`)

I've copied the structure of `more-itertools/default.nix`. Not sure what "This PR does not cleanly list package outputs after merging" means, but I'm happy to fix it

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
