### PR TITLE
Sysusers only for sysusers

### DIFF
--- a/nixos/modules/system/boot/systemd/sysusers.nix
+++ b/nixos/modules/system/boot/systemd/sysusers.nix
@@ -72,12 +72,19 @@ in
         assertion = config.users.mutableUsers -> config.system.etc.overlay.enable;
         message = "config.users.mutableUsers requires config.system.etc.overlay.enable.";
       }
-    ] ++ lib.mapAttrsToList
-      (username: opts: {
+    ] ++ (lib.mapAttrsToList
+      (_username: opts: {
         assertion = !opts.isNormalUser;
         message = "systemd-sysusers doesn't create normal users. You can currently only use it to create system users.";
       })
-      userCfg.users;
+      userCfg.users)
+    ++ lib.mapAttrsToList
+      (username: opts: {
+        assertion = (opts.password == opts.initialPassword || opts.password == null) &&
+          (opts.hashedPassword == opts.initialHashedPassword || opts.hashedPassword == null);
+        message = "${username} uses password or hashedPassword. systemd-sysupdate only supports initial passwords. It'll never update your passwords.";
+      })
+      systemUsers;
 
     systemd = {
 

--- a/nixos/tests/activation/etc-overlay-immutable.nix
+++ b/nixos/tests/activation/etc-overlay-immutable.nix
@@ -32,6 +32,18 @@
     with subtest("direct symlinks point to the target without indirection"):
       assert machine.succeed("readlink -n /etc/localtime") == "/etc/zoneinfo/Utc"
 
+    with subtest("Correct mode on the source password files"):
+      assert machine.succeed("stat -c '%a' /var/lib/nixos/etc/passwd") == "644\n"
+      assert machine.succeed("stat -c '%a' /var/lib/nixos/etc/group") == "644\n"
+      assert machine.succeed("stat -c '%a' /var/lib/nixos/etc/shadow") == "0\n"
+      assert machine.succeed("stat -c '%a' /var/lib/nixos/etc/gshadow") == "0\n"
+
+    with subtest("Password files are symlinks to /var/lib/nixos/etc"):
+      assert machine.succeed("readlink -f /etc/passwd") == "/var/lib/nixos/etc/passwd\n"
+      assert machine.succeed("readlink -f /etc/group") == "/var/lib/nixos/etc/group\n"
+      assert machine.succeed("readlink -f /etc/shadow") == "/var/lib/nixos/etc/shadow\n"
+      assert machine.succeed("readlink -f /etc/gshadow") == "/var/lib/nixos/etc/gshadow\n"
+
     with subtest("switching to the same generation"):
       machine.succeed("/run/current-system/bin/switch-to-configuration test")
 

--- a/nixos/tests/systemd-sysusers-immutable.nix
+++ b/nixos/tests/systemd-sysusers-immutable.nix
@@ -2,8 +2,8 @@
 
 let
   rootPassword = "$y$j9T$p6OI0WN7.rSfZBOijjRdR.$xUOA2MTcB48ac.9Oc5fz8cxwLv1mMqabnn333iOzSA6";
-  normaloPassword = "$y$j9T$3aiOV/8CADAK22OK2QT3/0$67OKd50Z4qTaZ8c/eRWHLIM.o3ujtC1.n9ysmJfv639";
-  newNormaloPassword = "mellow";
+  sysuserPassword = "$y$j9T$3aiOV/8CADAK22OK2QT3/0$67OKd50Z4qTaZ8c/eRWHLIM.o3ujtC1.n9ysmJfv639";
+  newSysuserPassword = "mellow";
 in
 
 {
@@ -19,15 +19,19 @@ in
     # Override the empty root password set by the test instrumentation
     users.users.root.hashedPasswordFile = lib.mkForce null;
     users.users.root.initialHashedPassword = rootPassword;
-    users.users.normalo = {
-      isNormalUser = true;
-      initialHashedPassword = normaloPassword;
+    users.users.sysuser = {
+      isSystemUser = true;
+      group = "wheel";
+      home = "/sysuser";
+      initialHashedPassword = sysuserPassword;
     };
 
     specialisation.new-generation.configuration = {
-      users.users.new-normalo = {
-        isNormalUser = true;
-        initialPassword = newNormaloPassword;
+      users.users.new-sysuser = {
+        isSystemUser = true;
+        group = "wheel";
+        home = "/new-sysuser";
+        initialPassword = newSysuserPassword;
       };
     };
   };
@@ -47,18 +51,18 @@ in
       print(machine.succeed("getent passwd root"))
       assert "${rootPassword}" in machine.succeed("getent shadow root"), "root user password is not correct"
 
-    with subtest("normalo user is created"):
-      print(machine.succeed("getent passwd normalo"))
-      assert machine.succeed("stat -c '%U' /home/normalo") == "normalo\n"
-      assert "${normaloPassword}" in machine.succeed("getent shadow normalo"), "normalo user password is not correct"
+    with subtest("sysuser user is created"):
+      print(machine.succeed("getent passwd sysuser"))
+      assert machine.succeed("stat -c '%U' /sysuser") == "sysuser\n"
+      assert "${sysuserPassword}" in machine.succeed("getent shadow sysuser"), "sysuser user password is not correct"
 
 
     machine.succeed("/run/current-system/specialisation/new-generation/bin/switch-to-configuration switch")
 
 
-    with subtest("new-normalo user is created after switching to new generation"):
-      print(machine.succeed("getent passwd new-normalo"))
-      print(machine.succeed("getent shadow new-normalo"))
-      assert machine.succeed("stat -c '%U' /home/new-normalo") == "new-normalo\n"
+    with subtest("new-sysuser user is created after switching to new generation"):
+      print(machine.succeed("getent passwd new-sysuser"))
+      print(machine.succeed("getent shadow new-sysuser"))
+      assert machine.succeed("stat -c '%U' /new-sysuser") == "new-sysuser\n"
   '';
 }

--- a/nixos/tests/systemd-sysusers-mutable.nix
+++ b/nixos/tests/systemd-sysusers-mutable.nix
@@ -2,8 +2,8 @@
 
 let
   rootPassword = "$y$j9T$p6OI0WN7.rSfZBOijjRdR.$xUOA2MTcB48ac.9Oc5fz8cxwLv1mMqabnn333iOzSA6";
-  normaloPassword = "hello";
-  newNormaloPassword = "$y$j9T$p6OI0WN7.rSfZBOijjRdR.$xUOA2MTcB48ac.9Oc5fz8cxwLv1mMqabnn333iOzSA6";
+  sysuserPassword = "hello";
+  newSysuserPassword = "$y$j9T$p6OI0WN7.rSfZBOijjRdR.$xUOA2MTcB48ac.9Oc5fz8cxwLv1mMqabnn333iOzSA6";
 in
 
 {
@@ -24,15 +24,19 @@ in
     # Override the empty root password set by the test instrumentation
     users.users.root.hashedPasswordFile = lib.mkForce null;
     users.users.root.initialHashedPassword = rootPassword;
-    users.users.normalo = {
-      isNormalUser = true;
-      initialPassword = normaloPassword;
+    users.users.sysuser = {
+      isSystemUser = true;
+      group = "wheel";
+      home = "/sysuser";
+      initialPassword = sysuserPassword;
     };
 
     specialisation.new-generation.configuration = {
-      users.users.new-normalo = {
-        isNormalUser = true;
-        initialHashedPassword = newNormaloPassword;
+      users.users.new-sysuser = {
+        isSystemUser = true;
+        group = "wheel";
+        home = "/new-sysuser";
+        initialHashedPassword = newSysuserPassword;
       };
     };
   };
@@ -43,7 +47,7 @@ in
     with subtest("systemd-sysusers.service contains the credentials"):
       sysusers_service = machine.succeed("systemctl cat systemd-sysusers.service")
       print(sysusers_service)
-      assert "SetCredential=passwd.plaintext-password.normalo:${normaloPassword}" in sysusers_service
+      assert "SetCredential=passwd.plaintext-password.sysuser:${sysuserPassword}" in sysusers_service
 
     with subtest("Correct mode on the password files"):
       assert machine.succeed("stat -c '%a' /etc/passwd") == "644\n"
@@ -55,17 +59,17 @@ in
       print(machine.succeed("getent passwd root"))
       assert "${rootPassword}" in machine.succeed("getent shadow root"), "root user password is not correct"
 
-    with subtest("normalo user is created"):
-      print(machine.succeed("getent passwd normalo"))
-      assert machine.succeed("stat -c '%U' /home/normalo") == "normalo\n"
+    with subtest("sysuser user is created"):
+      print(machine.succeed("getent passwd sysuser"))
+      assert machine.succeed("stat -c '%U' /sysuser") == "sysuser\n"
 
 
     machine.succeed("/run/current-system/specialisation/new-generation/bin/switch-to-configuration switch")
 
 
-    with subtest("new-normalo user is created after switching to new generation"):
-      print(machine.succeed("getent passwd new-normalo"))
-      assert machine.succeed("stat -c '%U' /home/new-normalo") == "new-normalo\n"
-      assert "${newNormaloPassword}" in machine.succeed("getent shadow new-normalo"), "new-normalo user password is not correct"
+    with subtest("new-sysuser user is created after switching to new generation"):
+      print(machine.succeed("getent passwd new-sysuser"))
+      assert machine.succeed("stat -c '%U' /new-sysuser") == "new-sysuser\n"
+      assert "${newSysuserPassword}" in machine.succeed("getent shadow new-sysuser"), "new-sysuser user password is not correct"
   '';
 }

--- a/nixos/tests/systemd-sysusers-mutable.nix
+++ b/nixos/tests/systemd-sysusers-mutable.nix
@@ -63,6 +63,9 @@ in
       print(machine.succeed("getent passwd sysuser"))
       assert machine.succeed("stat -c '%U' /sysuser") == "sysuser\n"
 
+    with subtest("Manually add new user"):
+      machine.succeed("useradd manual-sysuser")
+
 
     machine.succeed("/run/current-system/specialisation/new-generation/bin/switch-to-configuration switch")
 


### PR DESCRIPTION
d43e323b4aa9ddace802bd12f3fcc34b7701f53e fixes https://github.com/NixOS/nixpkgs/issues/325052
2710a49adb11016f2e1bb4f3786dc099b99cd315 fixes https://github.com/NixOS/nixpkgs/issues/318365
2ca04530c92866b1868f4963c2cb0c97c6a2e4cc fixes https://github.com/NixOS/nixpkgs/issues/307159

The most important change is that sysusers now will only create system users. You cannot use this when you have normal users! I plan to add a perlless mode to add normal users via systemd-homed in the future.

Also, sysusers is now always executed at runtime even when /etc is immutable and when `mutableUsers = false`.

closes #328727

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
