### PR TITLE
jool: 4.1.11 -> 4.1.12

### DIFF
--- a/pkgs/os-specific/linux/jool/cli.nix
+++ b/pkgs/os-specific/linux/jool/cli.nix
@@ -1,5 +1,12 @@
-{ lib, stdenv, fetchFromGitHub, nixosTests
-, autoreconfHook, pkg-config, libnl, iptables
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nixosTests,
+  autoreconfHook,
+  pkg-config,
+  libnl,
+  iptables,
 }:
 
 let
@@ -12,31 +19,40 @@ stdenv.mkDerivation {
 
   src = sourceAttrs.src;
 
-  patches = [
-    ./validate-config.patch
-  ];
+  patches = [ ./validate-config.patch ];
 
   outputs = [
     "out"
     "man"
   ];
 
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
-  buildInputs = [ libnl iptables ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+  buildInputs = [
+    libnl
+    iptables
+  ];
 
-  makeFlags = [ "-C" "src/usr" ];
+  makeFlags = [
+    "-C"
+    "src/usr"
+  ];
 
   prePatch = ''
     sed -e 's%^XTABLES_SO_DIR = .*%XTABLES_SO_DIR = '"$out"'/lib/xtables%g' -i src/usr/iptables/Makefile
   '';
 
-  passthru.tests = { inherit (nixosTests) jool; };
+  passthru.tests = {
+    inherit (nixosTests) jool;
+  };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://www.jool.mx/";
     description = "Fairly compliant SIIT and Stateful NAT64 for Linux - CLI tools";
-    platforms = platforms.linux;
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ fpletz ];
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ fpletz ];
   };
 }

--- a/pkgs/os-specific/linux/jool/default.nix
+++ b/pkgs/os-specific/linux/jool/default.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, fetchFromGitHub, kernel, nixosTests }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  kernel,
+  nixosTests,
+}:
 
 let
   sourceAttrs = (import ./source.nix) { inherit fetchFromGitHub; };
@@ -23,13 +29,15 @@ stdenv.mkDerivation {
 
   installTargets = "modules_install";
 
-  passthru.tests = { inherit (nixosTests) jool; };
+  passthru.tests = {
+    inherit (nixosTests) jool;
+  };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://www.jool.mx/";
     description = "Fairly compliant SIIT and Stateful NAT64 for Linux - kernel modules";
-    platforms = platforms.linux;
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ fpletz ];
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ fpletz ];
   };
 }

--- a/pkgs/os-specific/linux/jool/source.nix
+++ b/pkgs/os-specific/linux/jool/source.nix
@@ -1,11 +1,11 @@
 { fetchFromGitHub }:
 
 rec {
-  version = "4.1.11";
+  version = "4.1.12";
   src = fetchFromGitHub {
     owner = "NICMx";
     repo = "Jool";
     rev = "refs/tags/v${version}";
-    hash = "sha256-fTYUdtU51/zOBbd568QtfUYnqWl+ZN9uSbE29tJC6UM=";
+    hash = "sha256-NJitXmWWEEglg4jag0mRZlmbf5+0sT08/pCssry5zD0=";
   };
 }


### PR DESCRIPTION
## Description of changes

https://github.com/NICMx/Jool/releases/tag/v4.1.12

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
