### PR TITLE
aquamarine: init at 0.1.1; hyprwayland-scanner: 0.3.10 -> 0.4.0; hyprlock: 0.4.0 -> 0.4.1

### DIFF
--- a/pkgs/by-name/aq/aquamarine/package.nix
+++ b/pkgs/by-name/aq/aquamarine/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  fetchFromGitHub,
+  hwdata,
+  hyprutils,
+  hyprwayland-scanner,
+  libdisplay-info,
+  libdrm,
+  libffi,
+  libGL,
+  libinput,
+  mesa,
+  nix-update-script,
+  pixman,
+  pkg-config,
+  seatd,
+  udev,
+  wayland,
+  wayland-protocols,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "aquamarine";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "hyprwm";
+    repo = "aquamarine";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-rux5XA+ixI0fuiQGSOerLKxsW2D8cfjmP1B7FY24xF8=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    hyprwayland-scanner
+    pkg-config
+  ];
+
+  buildInputs = [
+    hyprutils
+    libdisplay-info
+    libdrm
+    libffi
+    libGL
+    libinput
+    mesa
+    pixman
+    seatd
+    udev
+    wayland
+    wayland-protocols
+  ];
+
+  depsBuildBuild = [ hwdata ];
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  cmakeBuildType = "RelWithDebInfo";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    changelog = "https://github.com/hyprwm/aquamarine/releases/tag/${finalAttrs.version}";
+    description = "A very light linux rendering backend library";
+    homepage = "https://github.com/hyprwm/aquamarine";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
+      fufexan
+      johnrtitor
+    ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/hy/hyprlock/package.nix
+++ b/pkgs/by-name/hy/hyprlock/package.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hyprlock";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "hyprlock";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Dd/DK6FKiwVhr6PygCieEjzn7AFf6xijw6mdhquLnkw=";
+    hash = "sha256-w+AyYuqlZ/uWEimiptlHjtDFECm/JlUOD2ciCw8/+/8=";
   };
 
   strictDeps = true;
@@ -64,9 +64,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ iynaix ];
     mainProgram = "hyprlock";
-    platforms = [
-      "aarch64-linux"
-      "x86_64-linux"
-    ];
+    platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/hy/hyprlock/package.nix
+++ b/pkgs/by-name/hy/hyprlock/package.nix
@@ -62,7 +62,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Hyprland's GPU-accelerated screen locking utility";
     homepage = "https://github.com/hyprwm/hyprlock";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ iynaix ];
+    maintainers = with lib.maintainers; [
+      iynaix
+      johnrtitor
+    ];
     mainProgram = "hyprlock";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/hy/hyprwayland-scanner/package.nix
+++ b/pkgs/by-name/hy/hyprwayland-scanner/package.nix
@@ -9,13 +9,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "hyprwayland-scanner";
-  version = "0.3.10";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "hyprwayland-scanner";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-YxmfxHfWed1fosaa7fC1u7XoKp1anEZU+7Lh/ojRKoM=";
+    hash = "sha256-JPdL+Qul+jEueAn8CARfcWP83eJgwkhMejQYfDvrgvU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/hy/hyprwayland-scanner/package.nix
+++ b/pkgs/by-name/hy/hyprwayland-scanner/package.nix
@@ -36,7 +36,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Hyprland version of wayland-scanner in and for C++";
     changelog = "https://github.com/hyprwm/hyprwayland-scanner/releases/tag/${finalAttrs.version}";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ fufexan ];
+    maintainers = with lib.maintainers; [
+      fufexan
+      johnrtitor
+    ];
     mainProgram = "hyprwayland-scanner";
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
## Description of changes

Aquamarine for the upcoming Hyprland 0.42.0 release.
- Homepage: https://github.com/hyprwm/aquamarine

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
