### PR TITLE
arrow-glib: fix build

### DIFF
--- a/pkgs/by-name/ar/arrow-glib/package.nix
+++ b/pkgs/by-name/ar/arrow-glib/package.nix
@@ -1,21 +1,26 @@
-{ stdenv
-, arrow-cpp
-, glib
-, gobject-introspection
-, lib
-, meson
-, ninja
-, pkg-config
+{
+  arrow-cpp,
+  glib,
+  gobject-introspection,
+  lib,
+  meson,
+  ninja,
+  pkg-config,
+  python3,
+  stdenv,
 }:
 
 stdenv.mkDerivation rec {
   pname = "arrow-glib";
   inherit (arrow-cpp) src version;
-  sourceRoot = "apache-arrow-${version}/c_glib";
+  sourceRoot = "source/c_glib";
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     meson
     ninja
+    python3
     pkg-config
     gobject-introspection
   ];
@@ -25,10 +30,10 @@ stdenv.mkDerivation rec {
     glib
   ];
 
-  meta = with lib; {
+  meta = {
     inherit (arrow-cpp.meta) license platforms;
     description = "GLib bindings for Apache Arrow";
     homepage = "https://arrow.apache.org/docs/c_glib/";
-    maintainers = with maintainers; [ amarshall ];
+    maintainers = with lib.maintainers; [ amarshall ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19772,8 +19772,6 @@ with pkgs;
     cudaPackages = cudaPackages_12;
   };
 
-  arrow-glib = callPackage ../development/libraries/arrow-glib { };
-
   arsenal = callPackage ../tools/security/arsenal { };
 
   assimp = callPackage ../development/libraries/assimp { };


### PR DESCRIPTION
arrow-glib: fix build

- migrate to by-name
- remove nested with
- order by alphabetical order items
- nixfmt

Failing build logs:
- x86_64-linux: https://hydra.nixos.org/build/267078977 | [logs](https://hydra.nixos.org/build/267078977/nixlog/1)
- aarch64-darwin: https://hydra.nixos.org/build/267078091