### PR TITLE
rr: fix cross-compilation

### DIFF
--- a/pkgs/development/tools/analysis/rr/default.nix
+++ b/pkgs/development/tools/analysis/rr/default.nix
@@ -1,25 +1,33 @@
-{ lib, stdenv, fetchFromGitHub
-, bash, cmake, pkg-config, which, makeWrapper
-, libpfm, zlib, python3, procps, gdb, capnproto
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  bash,
+  capnproto,
+  cmake,
+  gdb,
+  libpfm,
+  makeWrapper,
+  pkg-config,
+  procps,
+  python3,
+  which,
+  zlib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "5.8.0";
   pname = "rr";
 
   src = fetchFromGitHub {
     owner = "mozilla";
     repo = "rr";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-FudAAkWIe6gv4NYFoe9E0hlgTM70lymBE5Fw/vbehps=";
   };
 
-  patches = [ ];
-
   postPatch = ''
     substituteInPlace src/Command.cc --replace '_BSD_SOURCE' '_DEFAULT_SOURCE'
-    sed '7i#include <math.h>' -i src/Scheduler.cc
-    sed '1i#include <ctime>' -i src/test-monitor/test-monitor.cc
     patchShebangs src
   '';
 
@@ -31,19 +39,34 @@ stdenv.mkDerivation rec {
   # collect2: error: ld returned 1 exit status
   #
   # See also https://github.com/NixOS/nixpkgs/pull/110846
-  preConfigure = ''substituteInPlace CMakeLists.txt --replace "-flto" ""'';
+  preConfigure = ''
+    substituteInPlace CMakeLists.txt --replace "-flto" ""
+  '';
 
   strictDeps = true;
 
-  nativeBuildInputs = [ cmake pkg-config which makeWrapper capnproto python3.pythonOnBuildForHost ];
+  nativeBuildInputs = [
+    capnproto
+    cmake
+    makeWrapper
+    pkg-config
+    python3.pythonOnBuildForHost
+    which
+  ];
 
   buildInputs = [
-    libpfm zlib python3 procps gdb capnproto bash
+    bash
+    capnproto
+    gdb
+    libpfm
+    procps
+    python3
+    zlib
   ];
 
   cmakeFlags = [
     (lib.cmakeBool "disable32bit" true)
-    (lib.cmakeBool "BUILD_TESTS" doCheck)
+    (lib.cmakeBool "BUILD_TESTS" finalAttrs.doCheck)
   ];
 
   # we turn on additional warnings due to hardening
@@ -59,9 +82,7 @@ stdenv.mkDerivation rec {
   # needs GDB to replay programs at runtime
   preFixup = ''
     wrapProgram "$out/bin/rr" \
-      --prefix PATH ":" "${lib.makeBinPath [
-        gdb
-      ]}";
+      --prefix PATH ":" "${lib.makeBinPath [ gdb ]}";
   '';
 
   meta = {
@@ -74,8 +95,18 @@ stdenv.mkDerivation rec {
       time the same execution is replayed.
     '';
 
-    license = with lib.licenses; [ mit bsd2 ];
-    maintainers = with lib.maintainers; [ pierron thoughtpolice ];
-    platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" ];
+    license = with lib.licenses; [
+      mit
+      bsd2
+    ];
+    maintainers = with lib.maintainers; [
+      pierron
+      thoughtpolice
+    ];
+    platforms = [
+      "aarch64-linux"
+      "i686-linux"
+      "x86_64-linux"
+    ];
   };
-}
+})


### PR DESCRIPTION
## Description of changes

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
