### PR TITLE
lemmy-ui: fix execution

### DIFF
--- a/nixos/tests/lemmy.nix
+++ b/nixos/tests/lemmy.nix
@@ -51,8 +51,8 @@ in
 
     with subtest("the backend starts and responds"):
         server.wait_for_open_port(${toString backendPort})
-        # wait until succeeds, it just needs few seconds for migrations, but lets give it 10s max
-        server.wait_until_succeeds("curl --fail localhost:${toString backendPort}/api/v3/site", 10)
+        # wait until succeeds, it just needs few seconds for migrations, but lets give it 50s max
+        server.wait_until_succeeds("curl --fail localhost:${toString backendPort}/api/v3/site", 50)
 
     with subtest("the UI starts and responds"):
         server.wait_for_unit("lemmy-ui.service")
@@ -77,7 +77,7 @@ in
         server.execute("systemctl stop lemmy-ui.service")
 
         def assert_http_code(url, expected_http_code, extra_curl_args=""):
-            _, http_code = server.execute(f'curl --silent -o /dev/null {extra_curl_args} --fail --write-out "%{{http_code}}" {url}')
+            _, http_code = server.execute(f'curl --location --silent -o /dev/null {extra_curl_args} --fail --write-out "%{{http_code}}" {url}')
             assert http_code == str(expected_http_code), f"expected http code {expected_http_code}, got {http_code}"
 
         # Caddy responds with HTTP code 502 if it cannot handle the requested path

--- a/pkgs/servers/web-apps/lemmy/ui.nix
+++ b/pkgs/servers/web-apps/lemmy/ui.nix
@@ -2,13 +2,10 @@
 , stdenvNoCC
 , libsass
 , nodejs
-, python3
-, pkg-config
 , pnpm_9
 , fetchFromGitHub
 , nixosTests
 , vips
-, nodePackages
 }:
 
 let
@@ -60,10 +57,18 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   #     runHook postInstall
 
   #  '';
-    preInstall = ''
+  preInstall = ''
     mkdir $out
     cp -R ./dist $out
     cp -R ./node_modules $out
+  '';
+
+  preFixup = ''
+    find $out -name libvips-cpp.so.42 -print0 | while read -d $'\0' libvips; do
+      echo replacing libvips at $libvips
+      rm $libvips
+      ln -s ${lib.getLib vips}/lib/libvips-cpp.so.42 $libvips
+    done
   '';
 
 


### PR DESCRIPTION
## Description of changes
https://github.com/NixOS/nixpkgs/issues/327742

My lemmy-ui kept crashing (while the server kept working well). Some core dump analysis showed it came from vips, and so I replaced the libvips vendored in the source with a NixPkgs one. It work now.

Also fixed the test, which failed due to too quick timeout (once) and also a redirect.

Note that the error didn’t happened in the test, only on my production server.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
