### PR TITLE
rPackages.torch: use binary package for installation

### DIFF
--- a/doc/languages-frameworks/r.section.md
+++ b/doc/languages-frameworks/r.section.md
@@ -94,6 +94,54 @@ Executing `nix-shell` will then drop you into an environment equivalent to the
 one above. If you need additional packages just add them to the list and
 re-enter the shell.
 
+## torch with GPU acceleration {#torch-gpu-accel}
+
+The `torch` package included in `nixpkgs` is based on the binary packages by the
+mlverse team. By default, the CPU version of the package is installed. On Linux
+distributions other than NixOS, it is possible to enable GPU acceleration by
+setting `config.cudaSupport` to true when importing `nixpkgs` in a `shell.nix`.
+You will also need to use `nixglhost`. Here is an example of such a shell:
+
+```nix
+{ pkgs ? import <nixpkgs> {config.cudaSupport = true; }, lib ? pkgs.lib }:
+
+let
+ nixglhost-sources = pkgs.fetchFromGitHub {
+   owner = "numtide";
+   repo = "nix-gl-host";
+   rev = "main";
+   # Replace this with the hash Nix will complain about, TOFU style.
+   hash = "";
+ };
+
+ nixglhost = pkgs.callPackage "${nixglhost-sources}/default.nix" { };
+
+ rpkgs = builtins.attrValues {
+   inherit (pkgs.rPackages)
+     torch;
+ };
+
+ wrapped_pkgs = pkgs.rWrapper.override {
+   packages = [ rpkgs ];
+ };
+
+in pkgs.mkShell {
+  buildInputs = [
+    nixglhost
+    wrapped_pkgs
+  ];
+}
+
+```
+
+After executing `nix-shell` to drop in that environment, call `nixglhost R` to
+start a GPU accelerated R session. Test that everything worked well by calling
+`torch::cuda_memory_summary()` which should return a list of summary statistics
+regarding the available GPU memory.
+
+We are looking for contributors that could help us package the darwin binaries
+as well as fix `torch` for NixOS as well.
+
 ## Updating the package set {#updating-the-package-set}
 
 There is a script and associated environment for regenerating the package

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1816,6 +1816,16 @@ let
          "sha256-qUn8Rot6ME7iTvtNd52iw3ebqMnpLz7kwl/9GoPHD+I=";
       in
      old.torch.overrideAttrs (attrs: {
+       nativeBuildInputs = attrs.nativeBuildInputs or [ ] ++ [
+         pkgs.autoPatchelfHook
+         pkgs.autoAddDriverRunpath
+       ];
+      buildInputs = attrs.buildInputs or [ ] ++ [
+        "${lib.getLib R}/lib/R" # libR
+        pkgs.zlib
+      ] ++ lib.optionals pkgs.config.cudaSupport [
+        pkgs.cudaPackages.cuda_cudart
+      ];
       src = pkgs.fetchzip {
        url = "https://torch-cdn.mlverse.org/packages/${accel}/0.13.0/src/contrib/torch_0.13.0_R_x86_64-pc-linux-gnu.tar.gz";
        sha256 = binary_sha;

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1803,10 +1803,23 @@ let
       '';
     });
 
-    torch = old.torch.overrideAttrs (attrs: {
-      preConfigure = ''
-        patchShebangs configure
-      '';
+    torch = let
+      # Sets the correct string to download either the binary for
+      # the cpu version of the torch package, or the
+      # the cuda-enabled version.
+      # To use gpu acceleration, set `config.cudaSupport = true;`
+      # when importing nixpkgs in your shell
+       accel = if pkgs.config.cudaSupport then "cu118" else "cpu";
+
+       binary_sha = if pkgs.config.cudaSupport then
+         "sha256-a80sG89C0svZzkjNRpY0rTR2P1JdvKAbWDGIIghsv2Y=" else
+         "sha256-qUn8Rot6ME7iTvtNd52iw3ebqMnpLz7kwl/9GoPHD+I=";
+      in
+     old.torch.overrideAttrs (attrs: {
+      src = pkgs.fetchzip {
+       url = "https://torch-cdn.mlverse.org/packages/${accel}/0.13.0/src/contrib/torch_0.13.0_R_x86_64-pc-linux-gnu.tar.gz";
+       sha256 = binary_sha;
+      };
     });
 
     pak = old.pak.overrideAttrs (attrs: {


### PR DESCRIPTION
## Description of changes

With this PR, I suggest that we use the prebuild binary supplied by the mlverse team. Currently, the {torch} package installs, but at first run, it wants to download and install the libtorch and liblantern libraries which doesn't work. Instead, we could use the prebuilt binaries of the `{torch}` package which simplifies the whole process, as described in their documentation: https://torch.mlverse.org/docs/articles/installation#pre-built

This  PR  handles both the CPU and GPU versions for Linux. I have also updated the documentation to explain how to use it in a second commit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
