### PR TITLE
python312Packages.langchain-core: disable flaky test

### DIFF
--- a/pkgs/development/python-modules/langchain-core/default.nix
+++ b/pkgs/development/python-modules/langchain-core/default.nix
@@ -86,7 +86,11 @@ buildPythonPackage rec {
     '';
   };
 
-  disabledTests = lib.optionals stdenv.isDarwin [
+  disabledTests = [
+    # flaky, sometimes fail to strip uuid from AIMessageChunk before comparing to test value
+    "test_map_stream"
+  ]
+  ++ lib.optionals stdenv.isDarwin [
     # Langchain-core the following tests due to the test comparing execution time with magic values.
     "test_queue_for_streaming_via_sync_call"
     "test_same_event_loop"


### PR DESCRIPTION
## Description of changes

fixes this flaky error:
```
langchain-core> _______________________________ test_map_stream ________________________________
langchain-core> [gw2] linux -- Python 3.12.4 /nix/store/z7xxy35k7620hs6fn6la5fg2lgklv72l-python3-3.12.4/bin/python3.12
langchain-core> 
langchain-core>     def test_map_stream() -> None:
langchain-core>         prompt = (
langchain-core>             SystemMessagePromptTemplate.from_template("You are a nice assistant.")
langchain-core>             + "{question}"
langchain-core>         )
langchain-core>     
langchain-core>         chat_res = "i'm a chatbot"
langchain-core>         # sleep to better simulate a real stream
langchain-core>         chat = FakeListChatModel(responses=[chat_res], sleep=0.01)
langchain-core>     
langchain-core>         llm_res = "i'm a textbot"
langchain-core>         # sleep to better simulate a real stream
langchain-core>         llm = FakeStreamingListLLM(responses=[llm_res], sleep=0.01)
langchain-core>     
langchain-core>         chain: Runnable = prompt | {
langchain-core>             "chat": chat.bind(stop=["Thought:"]),
langchain-core>             "llm": llm,
langchain-core>             "passthrough": RunnablePassthrough(),
langchain-core>         }
langchain-core>     
langchain-core>         stream = chain.stream({"question": "What is your name?"})
langchain-core>     
langchain-core>         final_value = None
langchain-core>         streamed_chunks = []
langchain-core>         for chunk in stream:
langchain-core>             streamed_chunks.append(chunk)
langchain-core>             if final_value is None:
langchain-core>                 final_value = chunk
langchain-core>             else:
langchain-core>                 final_value += chunk
langchain-core>     
langchain-core> >       assert streamed_chunks[0] in [
langchain-core>             {"passthrough": prompt.invoke({"question": "What is your name?"})},
langchain-core>             {"llm": "i"},
langchain-core>             {"chat": AIMessageChunk(content="i")},
langchain-core>         ]
langchain-core> E       AssertionError: assert {'chat': AIMessageChunk(content='i', id='run-28027ac6-d665-40e1-b3a5-3adbdba091ab')} in [{'passthrough': ChatPromptValue(messages=[SystemMessage(content='You are a nice assistant.'), HumanMessage(content='What is your name?')])}, {'llm': 'i'}, {'chat': AIMessageChunk(content='i')}]
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
