### PR TITLE
gcc{6,7,8,9}: fix Darwin build failures on staging-next

### DIFF
--- a/pkgs/development/compilers/gcc/common/builder.nix
+++ b/pkgs/development/compilers/gcc/common/builder.nix
@@ -7,6 +7,14 @@
 let
   forceLibgccToBuildCrtStuff =
     import ./libgcc-buildstuff.nix { inherit lib stdenv; };
+
+  # todo(@reckenrode) Remove in staging. This is ugly, but it avoid unwanted rebuilds on Darwin and Linux.
+  enableDarwinFixesForStagingNext =
+    version:
+    stdenv.buildPlatform.isDarwin
+    && stdenv.buildPlatform.isx86_64
+    && lib.versionAtLeast version "6"
+    && lib.versionOlder version "10";
 in
 
 originalAttrs: (stdenv.mkDerivation (finalAttrs: originalAttrs // {
@@ -20,9 +28,20 @@ originalAttrs: (stdenv.mkDerivation (finalAttrs: originalAttrs // {
 
     if test "$staticCompiler" = "1"; then
         EXTRA_LDFLAGS="-static"
-    else
-        EXTRA_LDFLAGS="-Wl,-rpath,''${!outputLib}/lib"
-    fi
+    ${
+      if enableDarwinFixesForStagingNext finalAttrs.version then
+        ''
+          elif test "''${NIX_DONT_SET_RPATH-}" != "1"; then
+              EXTRA_LDFLAGS="-Wl,-rpath,''${!outputLib}/lib"
+          else
+              EXTRA_LDFLAGS=""
+        ''
+      else
+        ''
+          else
+              EXTRA_LDFLAGS="-Wl,-rpath,''${!outputLib}/lib"
+        ''
+    }fi
 
     # GCC interprets empty paths as ".", which we don't want.
     if test -z "''${CPATH-}"; then unset CPATH; fi
@@ -56,9 +75,24 @@ originalAttrs: (stdenv.mkDerivation (finalAttrs: originalAttrs // {
                 extraLDFlags=("-L/usr/lib64" "-L/usr/lib")
                 libc_libdir="/usr/lib"
             fi
-            extraLDFlags=("-L$libc_libdir" "-rpath" "$libc_libdir"
-                          "''${extraLDFlags[@]}")
-            for i in "''${extraLDFlags[@]}"; do
+            ${
+              if enableDarwinFixesForStagingNext finalAttrs.version then
+                ''
+                  extraLDFlags=("-L$libc_libdir")
+                          nixDontSetRpathVar=NIX_DONT_SET_RPATH''${post}
+                          if test "''${!nixDontSetRpathVar-}" != "1"; then
+                              extraLDFlags+=("-rpath" "$libc_libdir")
+                          fi
+                          extraLDFlags+=("''${extraLDFlags[@]}")
+                ''
+              else
+                ''
+                  extraLDFlags=("-L$libc_libdir" "-rpath" "$libc_libdir"
+                                        "''${extraLDFlags[@]}")
+                ''
+# The strange indentation with the next line is to ensure the string renders the same when the condition is false,
+# which is necessary to prevent unwanted rebuilds in staging-next.
+}        for i in "''${extraLDFlags[@]}"; do
                 declare -g EXTRA_LDFLAGS''${post}+=" -Wl,$i"
             done
         done

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -450,7 +450,7 @@ pipe ((callFile ./common/builder.nix {}) ({
     badPlatforms =
       # avr-gcc8 is maintained for the `qmk` package
       if (is8 && targetPlatform.isAvr) then []
-      else if !(is48 || is49) then [ "aarch64-darwin" ]
+      else if !(is48 || is49 || is6) then [ "aarch64-darwin" ]
       else platforms.darwin;
   } // optionalAttrs is11 {
     badPlatforms = if targetPlatform != hostPlatform then [ "aarch64-darwin" ] else [ ];

--- a/pkgs/development/compilers/gcc/patches/6/AvailabilityInternal.h-fixincludes.patch
+++ b/pkgs/development/compilers/gcc/patches/6/AvailabilityInternal.h-fixincludes.patch
@@ -1,0 +1,105 @@
+diff --git a/fixincludes/fixincl.x b/fixincludes/fixincl.x
+index 662dc97762c..5140a04f9dd 100644
+--- a/fixincludes/fixincl.x
++++ b/fixincludes/fixincl.x
+@@ -3053,6 +3053,43 @@ static const char* apzDarwin_Stdint_7Patch[] = {
+ #endif",
+     (char*)NULL };
+ 
++/* * * * * * * * * * * * * * * * * * * * * * * * * *
++ *
++ *  Description of Darwin_Nix_Sdk_Availabilityinternal fix
++ */
++tSCC zDarwin_Nix_Sdk_AvailabilityinternalName[] =
++     "darwin_nix_sdk_availabilityinternal";
++
++/*
++ *  File name selection pattern
++ */
++tSCC zDarwin_Nix_Sdk_AvailabilityinternalList[] =
++  "AvailabilityInternal.h\0";
++/*
++ *  Machine/OS name selection pattern
++ */
++tSCC* apzDarwin_Nix_Sdk_AvailabilityinternalMachs[] = {
++        "*-*-darwin*",
++        (const char*)NULL };
++
++/*
++ *  content selection pattern - do fix if pattern found
++ */
++tSCC zDarwin_Nix_Sdk_AvailabilityinternalSelect0[] =
++       "(.*)__has_builtin\\(__is_target_os\\)(.*)";
++
++#define    DARWIN_NIX_SDK_AVAILABILITYINTERNAL_TEST_CT  1
++static tTestDesc aDarwin_Nix_Sdk_AvailabilityinternalTests[] = {
++  { TT_EGREP,    zDarwin_Nix_Sdk_AvailabilityinternalSelect0, (regex_t*)NULL }, };
++
++/*
++ *  Fix Command Arguments for Darwin_Nix_Sdk_Availabilityinternal
++ */
++static const char* apzDarwin_Nix_Sdk_AvailabilityinternalPatch[] = {
++    "format",
++    "%10%2",
++    (char*)NULL };
++
+ /* * * * * * * * * * * * * * * * * * * * * * * * * *
+  *
+  *  Description of Dec_Intern_Asm fix
+@@ -9855,9 +9892,9 @@ static const char* apzX11_SprintfPatch[] = {
+  *
+  *  List of all fixes
+  */
+-#define REGEX_COUNT          277
++#define REGEX_COUNT          278
+ #define MACH_LIST_SIZE_LIMIT 187
+-#define FIX_COUNT            241
++#define FIX_COUNT            242
+ 
+ /*
+  *  Enumerate the fixes
+@@ -9933,6 +9970,7 @@ typedef enum {
+     DARWIN_STDINT_5_FIXIDX,
+     DARWIN_STDINT_6_FIXIDX,
+     DARWIN_STDINT_7_FIXIDX,
++    DARWIN_NIX_SDK_AVAILABILITYINTERNAL_FIXIDX,
+     DEC_INTERN_ASM_FIXIDX,
+     DJGPP_WCHAR_H_FIXIDX,
+     ECD_CURSOR_FIXIDX,
+@@ -10457,6 +10495,11 @@ tFixDesc fixDescList[ FIX_COUNT ] = {
+      DARWIN_STDINT_7_TEST_CT, FD_MACH_ONLY | FD_SUBROUTINE,
+      aDarwin_Stdint_7Tests,   apzDarwin_Stdint_7Patch, 0 },
+ 
++  {  zDarwin_Nix_Sdk_AvailabilityinternalName,    zDarwin_Nix_Sdk_AvailabilityinternalList,
++     apzDarwin_Nix_Sdk_AvailabilityinternalMachs,
++     DARWIN_NIX_SDK_AVAILABILITYINTERNAL_TEST_CT, FD_MACH_ONLY | FD_SUBROUTINE,
++     aDarwin_Nix_Sdk_AvailabilityinternalTests,   apzDarwin_Nix_Sdk_AvailabilityinternalPatch, 0 },
++
+   {  zDec_Intern_AsmName,    zDec_Intern_AsmList,
+      apzDec_Intern_AsmMachs,
+      DEC_INTERN_ASM_TEST_CT, FD_MACH_ONLY,
+diff --git a/fixincludes/inclhack.def b/fixincludes/inclhack.def
+index 98fb5b61649..8aad418dff8 100644
+--- a/fixincludes/inclhack.def
++++ b/fixincludes/inclhack.def
+@@ -1591,6 +1591,20 @@ fix = {
+ 		"#define UINTMAX_C(v) (v ## ULL)";
+ };
+ 
++/*
++ * Newer versions of AvailabilityInternal.h use `__has_builtin`,
++ * which is not implemented in or compatible with GCC.
++ */
++fix = {
++    hackname  = darwin_nix_sdk_availabilityinternal;
++    mach      = "*-*-darwin*";
++    files     = AvailabilityInternal.h;
++    c_fix     = format;
++    c_fix_arg = "%10%2";
++    select    = "(.*)__has_builtin\\(__is_target_os\\)(.*)";
++    test_text = "__has_builtin(__is_target_os)";
++};
++
+ /*
+  *  Fix <c_asm.h> on Digital UNIX V4.0:
+  *  It contains a prototype for a DEC C internal asm() function,

--- a/pkgs/development/compilers/gcc/patches/7/AvailabilityInternal.h-fixincludes.patch
+++ b/pkgs/development/compilers/gcc/patches/7/AvailabilityInternal.h-fixincludes.patch
@@ -1,0 +1,105 @@
+diff --git a/fixincludes/fixincl.x b/fixincludes/fixincl.x
+index d12ba7c3e88..9f31b29c509 100644
+--- a/fixincludes/fixincl.x
++++ b/fixincludes/fixincl.x
+@@ -3468,6 +3468,43 @@ static const char* apzDarwin_Ucred__AtomicPatch[] = {
+ #endif\n",
+     (char*)NULL };
+ 
++/* * * * * * * * * * * * * * * * * * * * * * * * * *
++ *
++ *  Description of Darwin_Nix_Sdk_Availabilityinternal fix
++ */
++tSCC zDarwin_Nix_Sdk_AvailabilityinternalName[] =
++     "darwin_nix_sdk_availabilityinternal";
++
++/*
++ *  File name selection pattern
++ */
++tSCC zDarwin_Nix_Sdk_AvailabilityinternalList[] =
++  "AvailabilityInternal.h\0";
++/*
++ *  Machine/OS name selection pattern
++ */
++tSCC* apzDarwin_Nix_Sdk_AvailabilityinternalMachs[] = {
++        "*-*-darwin*",
++        (const char*)NULL };
++
++/*
++ *  content selection pattern - do fix if pattern found
++ */
++tSCC zDarwin_Nix_Sdk_AvailabilityinternalSelect0[] =
++       "(.*)__has_builtin\\(__is_target_os\\)(.*)";
++
++#define    DARWIN_NIX_SDK_AVAILABILITYINTERNAL_TEST_CT  1
++static tTestDesc aDarwin_Nix_Sdk_AvailabilityinternalTests[] = {
++  { TT_EGREP,    zDarwin_Nix_Sdk_AvailabilityinternalSelect0, (regex_t*)NULL }, };
++
++/*
++ *  Fix Command Arguments for Darwin_Nix_Sdk_Availabilityinternal
++ */
++static const char* apzDarwin_Nix_Sdk_AvailabilityinternalPatch[] = {
++    "format",
++    "%10%2",
++    (char*)NULL };
++
+ /* * * * * * * * * * * * * * * * * * * * * * * * * *
+  *
+  *  Description of Dec_Intern_Asm fix
+@@ -10347,9 +10384,9 @@ static const char* apzX11_SprintfPatch[] = {
+  *
+  *  List of all fixes
+  */
+-#define REGEX_COUNT          291
++#define REGEX_COUNT          292
+ #define MACH_LIST_SIZE_LIMIT 187
+-#define FIX_COUNT            253
++#define FIX_COUNT            254
+ 
+ /*
+  *  Enumerate the fixes
+@@ -10435,6 +10472,7 @@ typedef enum {
+     DARWIN_STDINT_6_FIXIDX,
+     DARWIN_STDINT_7_FIXIDX,
+     DARWIN_UCRED__ATOMIC_FIXIDX,
++    DARWIN_NIX_SDK_AVAILABILITYINTERNAL_FIXIDX,
+     DEC_INTERN_ASM_FIXIDX,
+     DJGPP_WCHAR_H_FIXIDX,
+     ECD_CURSOR_FIXIDX,
+@@ -11011,6 +11049,11 @@ tFixDesc fixDescList[ FIX_COUNT ] = {
+      DARWIN_UCRED__ATOMIC_TEST_CT, FD_MACH_ONLY | FD_SUBROUTINE,
+      aDarwin_Ucred__AtomicTests,   apzDarwin_Ucred__AtomicPatch, 0 },
+ 
++  {  zDarwin_Nix_Sdk_AvailabilityinternalName,    zDarwin_Nix_Sdk_AvailabilityinternalList,
++     apzDarwin_Nix_Sdk_AvailabilityinternalMachs,
++     DARWIN_NIX_SDK_AVAILABILITYINTERNAL_TEST_CT, FD_MACH_ONLY | FD_SUBROUTINE,
++     aDarwin_Nix_Sdk_AvailabilityinternalTests,   apzDarwin_Nix_Sdk_AvailabilityinternalPatch, 0 },
++
+   {  zDec_Intern_AsmName,    zDec_Intern_AsmList,
+      apzDec_Intern_AsmMachs,
+      DEC_INTERN_ASM_TEST_CT, FD_MACH_ONLY,
+diff --git a/fixincludes/inclhack.def b/fixincludes/inclhack.def
+index 179e2f3c98a..70b681f35c8 100644
+--- a/fixincludes/inclhack.def
++++ b/fixincludes/inclhack.def
+@@ -1793,6 +1793,20 @@ fix = {
+     test_text = ""; /* Don't provide this for wrap fixes.  */
+ };
+ 
++/*
++ * Newer versions of AvailabilityInternal.h use `__has_builtin`,
++ * which is not implemented in or compatible with GCC.
++ */
++fix = {
++    hackname  = darwin_nix_sdk_availabilityinternal;
++    mach      = "*-*-darwin*";
++    files     = AvailabilityInternal.h;
++    c_fix     = format;
++    c_fix_arg = "%10%2";
++    select    = "(.*)__has_builtin\\(__is_target_os\\)(.*)";
++    test_text = "__has_builtin(__is_target_os)";
++};
++
+ /*
+  *  Fix <c_asm.h> on Digital UNIX V4.0:
+  *  It contains a prototype for a DEC C internal asm() function,

--- a/pkgs/development/compilers/gcc/patches/8/AvailabilityInternal.h-fixincludes.patch
+++ b/pkgs/development/compilers/gcc/patches/8/AvailabilityInternal.h-fixincludes.patch
@@ -1,0 +1,105 @@
+diff --git a/fixincludes/fixincl.x b/fixincludes/fixincl.x
+index 9578c99ab7b..e0ae73496c6 100644
+--- a/fixincludes/fixincl.x
++++ b/fixincludes/fixincl.x
+@@ -3428,6 +3428,43 @@ static const char* apzDarwin_Ucred__AtomicPatch[] = {
+ #endif\n",
+     (char*)NULL };
+ 
++/* * * * * * * * * * * * * * * * * * * * * * * * * *
++ *
++ *  Description of Darwin_Nix_Sdk_Availabilityinternal fix
++ */
++tSCC zDarwin_Nix_Sdk_AvailabilityinternalName[] =
++     "darwin_nix_sdk_availabilityinternal";
++
++/*
++ *  File name selection pattern
++ */
++tSCC zDarwin_Nix_Sdk_AvailabilityinternalList[] =
++  "AvailabilityInternal.h\0";
++/*
++ *  Machine/OS name selection pattern
++ */
++tSCC* apzDarwin_Nix_Sdk_AvailabilityinternalMachs[] = {
++        "*-*-darwin*",
++        (const char*)NULL };
++
++/*
++ *  content selection pattern - do fix if pattern found
++ */
++tSCC zDarwin_Nix_Sdk_AvailabilityinternalSelect0[] =
++       "(.*)__has_builtin\\(__is_target_os\\)(.*)";
++
++#define    DARWIN_NIX_SDK_AVAILABILITYINTERNAL_TEST_CT  1
++static tTestDesc aDarwin_Nix_Sdk_AvailabilityinternalTests[] = {
++  { TT_EGREP,    zDarwin_Nix_Sdk_AvailabilityinternalSelect0, (regex_t*)NULL }, };
++
++/*
++ *  Fix Command Arguments for Darwin_Nix_Sdk_Availabilityinternal
++ */
++static const char* apzDarwin_Nix_Sdk_AvailabilityinternalPatch[] = {
++    "format",
++    "%10%2",
++    (char*)NULL };
++
+ /* * * * * * * * * * * * * * * * * * * * * * * * * *
+  *
+  *  Description of Dec_Intern_Asm fix
+@@ -10356,9 +10393,9 @@ static const char* apzX11_SprintfPatch[] = {
+  *
+  *  List of all fixes
+  */
+-#define REGEX_COUNT          294
++#define REGEX_COUNT          295
+ #define MACH_LIST_SIZE_LIMIT 187
+-#define FIX_COUNT            255
++#define FIX_COUNT            256
+ 
+ /*
+  *  Enumerate the fixes
+@@ -10445,6 +10482,7 @@ typedef enum {
+     DARWIN_STDINT_6_FIXIDX,
+     DARWIN_STDINT_7_FIXIDX,
+     DARWIN_UCRED__ATOMIC_FIXIDX,
++    DARWIN_NIX_SDK_AVAILABILITYINTERNAL_FIXIDX,
+     DEC_INTERN_ASM_FIXIDX,
+     DJGPP_WCHAR_H_FIXIDX,
+     ECD_CURSOR_FIXIDX,
+@@ -11027,6 +11065,11 @@ tFixDesc fixDescList[ FIX_COUNT ] = {
+      DARWIN_UCRED__ATOMIC_TEST_CT, FD_MACH_ONLY | FD_SUBROUTINE,
+      aDarwin_Ucred__AtomicTests,   apzDarwin_Ucred__AtomicPatch, 0 },
+ 
++  {  zDarwin_Nix_Sdk_AvailabilityinternalName,    zDarwin_Nix_Sdk_AvailabilityinternalList,
++     apzDarwin_Nix_Sdk_AvailabilityinternalMachs,
++     DARWIN_NIX_SDK_AVAILABILITYINTERNAL_TEST_CT, FD_MACH_ONLY | FD_SUBROUTINE,
++     aDarwin_Nix_Sdk_AvailabilityinternalTests,   apzDarwin_Nix_Sdk_AvailabilityinternalPatch, 0 },
++
+   {  zDec_Intern_AsmName,    zDec_Intern_AsmList,
+      apzDec_Intern_AsmMachs,
+      DEC_INTERN_ASM_TEST_CT, FD_MACH_ONLY,
+diff --git a/fixincludes/inclhack.def b/fixincludes/inclhack.def
+index 948ea1d9183..5eb403ac841 100644
+--- a/fixincludes/inclhack.def
++++ b/fixincludes/inclhack.def
+@@ -1697,6 +1697,20 @@ fix = {
+     test_text = ""; /* Don't provide this for wrap fixes.  */
+ };
+ 
++/*
++ * Newer versions of AvailabilityInternal.h use `__has_builtin`,
++ * which is not implemented in or compatible with GCC.
++ */
++fix = {
++    hackname  = darwin_nix_sdk_availabilityinternal;
++    mach      = "*-*-darwin*";
++    files     = AvailabilityInternal.h;
++    c_fix     = format;
++    c_fix_arg = "%10%2";
++    select    = "(.*)__has_builtin\\(__is_target_os\\)(.*)";
++    test_text = "__has_builtin(__is_target_os)";
++};
++
+ /*
+  *  Fix <c_asm.h> on Digital UNIX V4.0:
+  *  It contains a prototype for a DEC C internal asm() function,

--- a/pkgs/development/compilers/gcc/patches/9/AvailabilityInternal.h-fixincludes.patch
+++ b/pkgs/development/compilers/gcc/patches/9/AvailabilityInternal.h-fixincludes.patch
@@ -1,0 +1,105 @@
+diff --git a/fixincludes/fixincl.x b/fixincludes/fixincl.x
+index 47a3578f017..6cf22d19b2a 100644
+--- a/fixincludes/fixincl.x
++++ b/fixincludes/fixincl.x
+@@ -3480,6 +3480,43 @@ static const char* apzDarwin_Ucred__AtomicPatch[] = {
+ #endif\n",
+     (char*)NULL };
+ 
++/* * * * * * * * * * * * * * * * * * * * * * * * * *
++ *
++ *  Description of Darwin_Nix_Sdk_Availabilityinternal fix
++ */
++tSCC zDarwin_Nix_Sdk_AvailabilityinternalName[] =
++     "darwin_nix_sdk_availabilityinternal";
++
++/*
++ *  File name selection pattern
++ */
++tSCC zDarwin_Nix_Sdk_AvailabilityinternalList[] =
++  "AvailabilityInternal.h\0";
++/*
++ *  Machine/OS name selection pattern
++ */
++tSCC* apzDarwin_Nix_Sdk_AvailabilityinternalMachs[] = {
++        "*-*-darwin*",
++        (const char*)NULL };
++
++/*
++ *  content selection pattern - do fix if pattern found
++ */
++tSCC zDarwin_Nix_Sdk_AvailabilityinternalSelect0[] =
++       "(.*)__has_builtin\\(__is_target_os\\)(.*)";
++
++#define    DARWIN_NIX_SDK_AVAILABILITYINTERNAL_TEST_CT  1
++static tTestDesc aDarwin_Nix_Sdk_AvailabilityinternalTests[] = {
++  { TT_EGREP,    zDarwin_Nix_Sdk_AvailabilityinternalSelect0, (regex_t*)NULL }, };
++
++/*
++ *  Fix Command Arguments for Darwin_Nix_Sdk_Availabilityinternal
++ */
++static const char* apzDarwin_Nix_Sdk_AvailabilityinternalPatch[] = {
++    "format",
++    "%10%2",
++    (char*)NULL };
++
+ /* * * * * * * * * * * * * * * * * * * * * * * * * *
+  *
+  *  Description of Dec_Intern_Asm fix
+@@ -10445,9 +10482,9 @@ static const char* apzX11_SprintfPatch[] = {
+  *
+  *  List of all fixes
+  */
+-#define REGEX_COUNT          296
++#define REGEX_COUNT          297
+ #define MACH_LIST_SIZE_LIMIT 187
+-#define FIX_COUNT            257
++#define FIX_COUNT            258
+ 
+ /*
+  *  Enumerate the fixes
+@@ -10535,6 +10572,7 @@ typedef enum {
+     DARWIN_STDINT_6_FIXIDX,
+     DARWIN_STDINT_7_FIXIDX,
+     DARWIN_UCRED__ATOMIC_FIXIDX,
++    DARWIN_NIX_SDK_AVAILABILITYINTERNAL_FIXIDX,
+     DEC_INTERN_ASM_FIXIDX,
+     DJGPP_WCHAR_H_FIXIDX,
+     ECD_CURSOR_FIXIDX,
+@@ -11123,6 +11161,11 @@ tFixDesc fixDescList[ FIX_COUNT ] = {
+      DARWIN_UCRED__ATOMIC_TEST_CT, FD_MACH_ONLY | FD_SUBROUTINE,
+      aDarwin_Ucred__AtomicTests,   apzDarwin_Ucred__AtomicPatch, 0 },
+ 
++  {  zDarwin_Nix_Sdk_AvailabilityinternalName,    zDarwin_Nix_Sdk_AvailabilityinternalList,
++     apzDarwin_Nix_Sdk_AvailabilityinternalMachs,
++     DARWIN_NIX_SDK_AVAILABILITYINTERNAL_TEST_CT, FD_MACH_ONLY | FD_SUBROUTINE,
++     aDarwin_Nix_Sdk_AvailabilityinternalTests,   apzDarwin_Nix_Sdk_AvailabilityinternalPatch, 0 },
++
+   {  zDec_Intern_AsmName,    zDec_Intern_AsmList,
+      apzDec_Intern_AsmMachs,
+      DEC_INTERN_ASM_TEST_CT, FD_MACH_ONLY,
+diff --git a/fixincludes/inclhack.def b/fixincludes/inclhack.def
+index bf136fdaa20..89bceb46c26 100644
+--- a/fixincludes/inclhack.def
++++ b/fixincludes/inclhack.def
+@@ -1727,6 +1727,20 @@ fix = {
+     test_text = ""; /* Don't provide this for wrap fixes.  */
+ };
+ 
++/*
++ * Newer versions of AvailabilityInternal.h use `__has_builtin`,
++ * which is not implemented in or compatible with GCC.
++ */
++fix = {
++    hackname  = darwin_nix_sdk_availabilityinternal;
++    mach      = "*-*-darwin*";
++    files     = AvailabilityInternal.h;
++    c_fix     = format;
++    c_fix_arg = "%10%2";
++    select    = "(.*)__has_builtin\\(__is_target_os\\)(.*)";
++    test_text = "__has_builtin(__is_target_os)";
++};
++
+ /*
+  *  Fix <c_asm.h> on Digital UNIX V4.0:
+  *  It contains a prototype for a DEC C internal asm() function,

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -167,6 +167,14 @@ in
   }) ];
 }.${majorVersion} or [])
 
+# Work around newer AvailabilityInternal.h when building older versions of GCC.
+++ optionals (stdenv.isDarwin) ({
+  "9" = [ ../patches/9/AvailabilityInternal.h-fixincludes.patch ];
+  "8" = [ ../patches/8/AvailabilityInternal.h-fixincludes.patch ];
+  "7" = [ ../patches/7/AvailabilityInternal.h-fixincludes.patch ];
+  "6" = [ ../patches/6/AvailabilityInternal.h-fixincludes.patch ];
+}.${majorVersion} or [])
+
 
 ## Windows
 


### PR DESCRIPTION
## Description of changes

Fix Darwin builds of GCC on staging-next https://github.com/NixOS/nixpkgs/pull/328673.

- https://hydra.nixos.org/build/266906260

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
