### PR TITLE
typescript-language-server: fix requires typescript

### DIFF
--- a/pkgs/by-name/ty/typescript-language-server/default-fallbackTsserverPath.diff
+++ b/pkgs/by-name/ty/typescript-language-server/default-fallbackTsserverPath.diff
@@ -1,0 +1,15 @@
+diff --git a/src/lsp-server.ts b/src/lsp-server.ts
+index ef5907d..9494430 100644
+--- a/src/lsp-server.ts
++++ b/src/lsp-server.ts
+@@ -323,6 +323,10 @@ export class LspServer {
+             }
+         }
+
++        if (!fallbackTsserverPath) {
++            fallbackTsserverPath = "@typescript@";
++        }
++
+         const fallbackVersionProvider = new TypeScriptVersionProvider(fallbackTsserverPath, this.logger);
+         const fallbackSettingVersion = fallbackVersionProvider.getUserSettingVersion();
+         if (fallbackSettingVersion) {

--- a/pkgs/by-name/ty/typescript-language-server/package.nix
+++ b/pkgs/by-name/ty/typescript-language-server/package.nix
@@ -6,8 +6,10 @@
 , makeWrapper
 , nodejs
 , prefetch-yarn-deps
+, substituteAll
 , yarn
 , testers
+, typescript
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -20,6 +22,13 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-FCv0+tA7AuCdGeG6FEiMyRAHcl0WbezhNYLL7xp5FWU=";
   };
+
+  patches = [
+    (substituteAll {
+      src = ./default-fallbackTsserverPath.diff;
+      typescript = "${typescript}/lib/node_modules/typescript/lib/tsserver.js";
+    })
+  ];
 
   offlineCache = fetchYarnDeps {
     yarnLock = "${finalAttrs.src}/yarn.lock";


### PR DESCRIPTION
typescript-language-server had an [override in node packages](https://github.com/NixOS/nixpkgs/blob/63d37ccd2d178d54e7fb691d7ec76000740ea24a/pkgs/development/node-packages/overrides.nix#L376-L381) that used lndir to provide the typescript dependency. When typescript-language-server was moved, this was not included. Thus, neovim fails to load typescript-language-server unless you add it back yourself with overrideAttrs like this

```nix
          (typescript-language-server.overrideAttrs (prev: {
            postInstall = ''
              ${prev.postInstall or ""}
              ${pkgs.xorg.lndir}/bin/lndir ${pkgs.typescript} $out
            '';
          }))
```

This change adds it back to upstream like it was before the move. Setting tsserver.path in config or installing typescript dependency some other way does not seem to work (outside of using the actual npm command with --cache to install it to a user directory and then setting tsserver.path to that user directory which is.... not ideal), so this is the only way to do it.

@MarcelCoding 