### PR TITLE
markdown-oxide: 0.0.21 → 0.23.1

### DIFF
--- a/pkgs/by-name/ma/markdown-oxide/Cargo.lock
+++ b/pkgs/by-name/ma/markdown-oxide/Cargo.lock
@@ -434,6 +434,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzydate"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7265f35cc1f40c655aad829323a1daef5f21fd38904f6ed9bd5ec3df3cbd851c"
+dependencies = [
+ "chrono",
+ "lazy_static",
+ "thiserror",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,11 +636,12 @@ dependencies = [
 
 [[package]]
 name = "markdown-oxide"
-version = "0.1.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "chrono",
  "config",
+ "fuzzydate",
  "indexmap",
  "itertools",
  "nanoid",

--- a/pkgs/by-name/ma/markdown-oxide/package.nix
+++ b/pkgs/by-name/ma/markdown-oxide/package.nix
@@ -1,17 +1,18 @@
-{ lib
-, rustPlatform
-, fetchFromGitHub
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "markdown-oxide";
-  version = "0.0.21";
+  version = "0.23.1";
 
   src = fetchFromGitHub {
     owner = "Feel-ix-343";
     repo = "markdown-oxide";
     rev = "v${version}";
-    hash = "sha256-PrsTHAlFFeqyZTsoKvoe19P2ed7xDtOlBgoKftFytVw=";
+    hash = "sha256-5qH8iYrOcOQNhH/ll5o8EM7NtAUzLD1cv2laOSqKy84=";
   };
 
   cargoLock = {
@@ -24,7 +25,7 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "Markdown LSP server inspired by Obsidian";
     homepage = "https://github.com/Feel-ix-343/markdown-oxide";
-    license = with licenses; [ cc0 ];
+    license = with licenses; [ gpl3Only ];
     maintainers = with maintainers; [ linsui ];
     mainProgram = "markdown-oxide";
   };


### PR DESCRIPTION
## Description of changes

@linsui Tried to implement #328893 but it doesn't compile. 

```
error[E0554]: `#![feature]` may not be used on the stable release channel
 --> src/main.rs:1:1
  |
1 | #![feature(async_closure)]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: use of deprecated field `tower_lsp::lsp_types::SymbolInformation::deprecated`: Use tags instead
  --> src/symbol.rs:46:17
   |
46 |                 deprecated: None,
   |                 ^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: use of deprecated field `tower_lsp::lsp_types::DocumentSymbol::deprecated`: Use tags instead
   --> src/symbol.rs:119:13
    |
119 |             deprecated: None,
    |             ^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0554`.
warning: `markdown-oxide` (bin "markdown-oxide") generated 2 warnings
error: could not compile `markdown-oxide` (bin "markdown-oxide") due to 1 previous error; 2 warnings emitted
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
