### PR TITLE
appimageupdate: init at 2.0.0-alpha-1-20230526; zsync2: init at 2.0.0-alpha-1-20230304

### DIFF
--- a/pkgs/by-name/ap/appimageupdate/package.nix
+++ b/pkgs/by-name/ap/appimageupdate/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  qt5,
+  zsync2,
+  libcpr,
+  libgcrypt,
+  libappimage,
+  argagg,
+  nlohmann_json,
+  gpgme,
+  appimageupdate-qt,
+  withQtUI ? false,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "appimageupdate";
+  version = "2.0.0-alpha-1-20230526";
+
+  src = fetchFromGitHub {
+    owner = "AppImageCommunity";
+    repo = "AppImageUpdate";
+    rev = finalAttrs.version;
+    hash = "sha256-b2RqSw0Ksn9OLxQV9+3reBiqrty+Kx9OwV93jlvuPnY=";
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'VERSION 1-alpha' 'VERSION ${finalAttrs.version}' \
+      --replace-fail 'env LC_ALL=C date -u "+%Y-%m-%d %H:%M:%S %Z"' 'bash -c "echo 1970-01-01 00:00:01 UTC"' \
+      --replace-fail 'git rev-parse --short HEAD' 'bash -c "echo unknown"' \
+      --replace-fail '<local dev build>' '<nixpkgs build>'
+  '';
+
+  nativeBuildInputs =
+    [
+      cmake
+      pkg-config
+    ]
+    ++ lib.optionals withQtUI [
+      qt5.wrapQtAppsHook
+    ];
+
+  buildInputs =
+    [
+      zsync2
+      libcpr
+      libgcrypt
+      libappimage
+      argagg
+      nlohmann_json
+      gpgme
+    ]
+    ++ lib.optionals withQtUI [
+      qt5.qtbase
+    ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "USE_SYSTEM_ZSYNC2" true)
+    (lib.cmakeBool "USE_SYSTEM_LIBAPPIMAGE" true)
+    (lib.cmakeBool "BUILD_QT_UI" withQtUI)
+  ];
+
+  dontWrapQtApps = true;
+
+  preFixup = lib.optionalString withQtUI ''
+    wrapQtApp "$out/bin/AppImageUpdate"
+  '';
+
+  passthru.tests = {
+    inherit appimageupdate-qt;
+  };
+
+  meta = {
+    description = "Update AppImages using information embedded in the AppImage itself";
+    homepage = "https://github.com/AppImageCommunity/AppImageUpdate";
+    license = lib.licenses.mit;
+    mainProgram = if withQtUI then "AppImageUpdate" else "appimageupdatetool";
+    maintainers = with lib.maintainers; [ aleksana ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/zs/zsync2/package.nix
+++ b/pkgs/by-name/zs/zsync2/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  pkg-config,
+  libgcrypt,
+  libcpr,
+  libargs,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zsync2";
+  version = "2.0.0-alpha-1-20230304";
+
+  src = fetchFromGitHub {
+    owner = "AppImageCommunity";
+    repo = "zsync2";
+    rev = finalAttrs.version;
+    hash = "sha256-OCeMEXQmbc34MZ1NyOfAASdrUyeSQqqfvWqAszJN4x0=";
+  };
+
+  patches = [
+    # Add missing cstdint includes
+    (fetchpatch {
+      url = "https://github.com/AppImageCommunity/zsync2/commit/e57e1fce68194fa920542fd334488de5123e4832.patch";
+      hash = "sha256-iLXxD6v+pSwFKmwAEyzbYUJ3DmtpvV/DYr8kcD+t5Cg=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'VERSION "2.0.0-alpha-1"' 'VERSION "${finalAttrs.version}"' \
+      --replace-fail 'git rev-parse --short HEAD' 'bash -c "echo unknown"' \
+      --replace-fail '<local dev build>' '<nixpkgs build>' \
+      --replace-fail 'env LC_ALL=C date -u "+%Y-%m-%d %H:%M:%S %Z"' 'bash -c "echo 1970-01-01 00:00:01 UTC"'
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libgcrypt
+    libcpr
+    libargs
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "USE_SYSTEM_CPR" true)
+    (lib.cmakeBool "USE_SYSTEM_ARGS" true)
+  ];
+
+  meta = {
+    description = "Rewrite of the advanced file download/sync tool zsync";
+    homepage = "https://github.com/AppImageCommunity/zsync2";
+    license = lib.licenses.artistic2;
+    mainProgram = "zsync2";
+    maintainers = with lib.maintainers; [ aleksana ];
+    # macro only supports linux as of now
+    # src/zsclient.cpp#L460
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -196,6 +196,8 @@ with pkgs;
 
   appimageTools = callPackage ../build-support/appimage { };
 
+  appimageupdate-qt = appimageupdate.override { withQtUI = true; };
+
   appindicator-sharp = callPackage ../development/libraries/appindicator-sharp { };
 
   bindle = callPackage ../servers/bindle {


### PR DESCRIPTION
## Description of changes

Haven't figured out how to build multilib appimagelauncher, adding these two first

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
