### PR TITLE
stdenv: warn about duplicate programs in PATH

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -375,6 +375,13 @@ _addRpathPrefix() {
     fi
 }
 
+# Return success if the specified file has executable file mode bit set.
+# Tested in pkgs/tests/stdenv-functions/default.nix
+isExecutable() {
+    local fn=$1
+    [[ -x $fn && ! -d $fn ]]
+}
+
 # Return success if the specified file is an ELF object.
 isELF() {
     local fn="$1"
@@ -856,6 +863,107 @@ fi
 unset _PATH
 unset _HOST_PATH
 unset _XDG_DATA_DIRS
+
+
+# Check PATH for duplicate programs. Output example (with NIX_DEBUG):
+#
+#   WARNING: final PATH contains 2 instances of foo executable
+#     foo ⇒
+#       /nix/store/.../foo
+#       /nix/store/.../foo
+#
+# Without NIX_DEBUG:
+#
+#   WARNING: final PATH contains 2 instances of foo executable (the first is /nix/store/.../foo)
+#
+# Tested in pkgs/tests/stdenv-functions/default.nix
+_checkDuplicateProgramsInUnixPATH() {
+    local -A executableCounters=()
+    local -A executablePaths=()
+    local -a executableDuplicates=()
+
+    local OLDIFS=$IFS
+    local IFS=:
+    local -a splitPath=($PATH)
+    IFS=$OLDIFS
+
+    local dir filePath fileName
+
+    # Reduce PATH elements (e.g. foo:bar:foo to foo:bar). Note that this does
+    # not handle some cases (it does not perform any lexical path processing).
+    local -a pathArray=()
+    local -A pathElements=()
+    for dir in "${splitPath[@]}"; do
+        if [[ -z $dir ]]; then
+            # PATH element "" means "."
+            dir=.
+        fi
+        if [[ -n ${pathElements[$dir]-} ]]; then
+            continue
+        fi
+        pathElements[$dir]=${#pathArray[@]}
+        pathArray+=("$dir")
+    done
+    unset pathElements splitPath
+
+    # Traverse PATH elements and record duplicate executables.
+    for dir in "${pathArray[@]}"; do
+        for filePath in "$dir"/*; do
+            if ! isExecutable "$filePath"; then
+                continue
+            fi
+            fileName=${filePath##*/}
+            ((executableCounters[$fileName] += 1))
+            if [[ -z ${executablePaths[$fileName]-} ]]; then
+                executablePaths[$fileName]=$filePath
+            fi
+            if ((executableCounters[$fileName] == 2)); then
+                # Bash globs expansions are guaranteed to be in alphabetical
+                # order. Use that instead of an undefined associative arrays
+                # order.
+                executableDuplicates+=("$fileName")
+            fi
+        done
+    done
+
+    # Clean up bookkeeping for non-duplicate executables.
+    for fileName in "${!executableCounters[@]}"; do
+        if ((${executableCounters[$fileName]} > 1)); then
+            continue
+        fi
+        unset 'executableCounters[$fileName]' 'executablePaths[$fileName]'
+    done
+
+    # Print a warning for each duplicate executable (and optionally all
+    # locations if NIX_DEBUG is non-zero).
+    for fileName in "${executableDuplicates[@]}"; do
+        printf 'WARNING: final PATH contains %d instances of %q executable' \
+            ${executableCounters[$fileName]} "$fileName"
+        if ((${NIX_DEBUG:-0} >= 1)); then
+            printf '\n  %q ⇒\n' "$fileName"
+            # We want to print all locations for this file name, but we can’t
+            # have map[string][]string in Bash without dirty workarounds. So
+            # perform a search again.
+            local -i count=${executableCounters[$fileName]}
+            for dir in "${pathArray[@]}"; do
+                filePath=$dir/$fileName
+                if ! isExecutable "$filePath"; then
+                    continue
+                fi
+                printf '    %q\n' "$filePath"
+                if ! ((count -= 1)); then
+                    break
+                fi
+            done
+        else
+            printf ' (the first is %q)\n' \
+                "${executablePaths[$fileName]}"
+        fi
+    done
+}
+if [[ -z ${dontCheckDuplicatePrograms-} && -n ${NIX_LOG_FD-} ]]; then
+    _checkDuplicateProgramsInUnixPATH >&"$NIX_LOG_FD"
+fi
 
 
 # Normalize the NIX_BUILD_CORES variable. The value might be 0, which

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -87,6 +87,7 @@ with pkgs;
 
   stdenv-inputs = callPackage ./stdenv-inputs { };
   stdenv = callPackage ./stdenv { };
+  stdenv-functions = callPackage ./stdenv-functions { };
 
   hardeningFlags = recurseIntoAttrs (callPackage ./cc-wrapper/hardening.nix {});
   hardeningFlags-gcc = recurseIntoAttrs (callPackage ./cc-wrapper/hardening.nix {

--- a/pkgs/test/stdenv-functions/default.nix
+++ b/pkgs/test/stdenv-functions/default.nix
@@ -1,0 +1,153 @@
+# To run these tests:
+# $ nix build --file . tests.stdenv-functions
+# or
+# $ nix-build -A tests.stdenv-functions
+
+{
+  lib,
+  testers,
+  runCommand,
+  emptyFile,
+}:
+{
+  isExecutable = lib.recurseIntoAttrs {
+    happy = runCommand "isExecutable-happy" { } ''
+      touch f
+      chmod a+x f
+      isExecutable f
+      touch -- "$out"
+    '';
+    emptyFile = runCommand "isExecutable-emptyFile" { } ''
+      touch emptyFile
+      isExecutable emptyFile && {
+        echo 'isExecutable must fail for non-executable files'
+        false
+      }
+      touch -- "$out"
+    '';
+    emptyDirectory = runCommand "isExecutable-emptyDirectory" { } ''
+      mkdir emptyDirectory
+      isExecutable emptyDirectory && {
+        echo 'isExecutable must fail for directories'
+        false
+      }
+      touch -- "$out"
+    '';
+  };
+
+  checkDuplicateProgramsInUnixPATH = lib.recurseIntoAttrs {
+    happy = testers.testEqualContents {
+      assertion = "PATH does not have duplicate programs";
+      expected = emptyFile;
+      actual = runCommand "checkDuplicateProgramsInUnixPATH-happy" { } ''
+        mkdir foo bar
+        touch foo/foo bar/bar
+        chmod a+x foo/foo bar/bar
+        PATH=$PWD/foo:$PWD/bar _checkDuplicateProgramsInUnixPATH >"$out"
+      '';
+    };
+
+    emptyPath = testers.testEqualContents {
+      assertion = "Empty PATH does not have duplicate programs";
+      expected = emptyFile;
+      actual = runCommand "checkDuplicateProgramsInUnixPATH-emptyPath" { } ''
+        PATH= _checkDuplicateProgramsInUnixPATH >"$out"
+      '';
+    };
+
+    emptyPathElement = testers.testEqualContents {
+      assertion = "Empty path element is current working directory";
+      expected = builtins.toFile "checkDuplicateProgramsInUnixPATH-emptyPathElement-golden" ''
+        WARNING: final PATH contains 2 instances of foo executable (the first is ./foo)
+      '';
+      actual = runCommand "checkDuplicateProgramsInUnixPATH-emptyPathElement" { } ''
+        touch foo
+        chmod a+x foo
+        mkdir bar
+        touch bar/foo
+        chmod a+x bar/foo
+        PATH=:$PWD/bar _checkDuplicateProgramsInUnixPATH >"$out"
+      '';
+    };
+
+    nonConsecutiveRepetitionInPathElements = testers.testEqualContents {
+      assertion = "Handles non-consecutive repetition in PATH elements";
+      expected = builtins.toFile "checkDuplicateProgramsInUnixPATH-nonConsecutiveRepetitionInPathElements-golden" ''
+        WARNING: final PATH contains 2 instances of a executable (the first is a1/a)
+      '';
+      actual = runCommand "checkDuplicateProgramsInUnixPATH-nonConsecutiveRepetitionInPathElements" { } ''
+        mkdir a1 && touch a1/a && chmod +x a1/a
+        mkdir a2 && touch a2/a && chmod +x a2/a
+        PATH=a1:a2:a1:a2:a1 _checkDuplicateProgramsInUnixPATH >"$out"
+      '';
+    };
+
+    nonExecutable = testers.testEqualContents {
+      assertion = "Ignores files without executable file mode bit set";
+      expected = emptyFile;
+      actual = runCommand "checkDuplicateProgramsInUnixPATH-nonExecutable" { } ''
+        mkdir upper lower
+        touch {upper,lower}/{foo,bar}
+        chmod a+x upper/foo lower/bar
+        PATH=upper:lower _checkDuplicateProgramsInUnixPATH >"$out"
+      '';
+    };
+
+    pathWithSpaces = testers.testEqualContents {
+      assertion = "Handles PATH and executables with spaces";
+      expected = builtins.toFile "checkDuplicateProgramsInUnixPATH-pathWithSpaces-golden" ''
+        WARNING: final PATH contains 3 instances of c executable (the first is a\ b/c)
+      '';
+      actual = runCommand "checkDuplicateProgramsInUnixPATH-pathWithSpaces" { } ''
+        mkdir 'a b' a b
+        touch 'a b/a b' 'a b/c' a/a a/c b/b b/c
+        chmod a+x 'a b/a b' 'a b/c' a/a a/c b/b b/c
+        PATH='a b':a:b _checkDuplicateProgramsInUnixPATH >"$out"
+      '';
+    };
+
+    debugOutput =
+      let
+        foo = runCommand "foo" { } ''
+          mkdir -p -- "$out/bin"
+          touch -- "$out/bin/foo"
+          chmod a+x -- "$out/bin/foo"
+        '';
+        bar = runCommand "bar" { } ''
+          mkdir -p -- "$out/bin"
+          touch -- "$out/bin/bar"
+          chmod a+x -- "$out/bin/bar"
+        '';
+        foobar = runCommand "foobar" { } ''
+          mkdir -p -- "$out"/bin
+          touch -- "$out"/bin/{foo,bar}
+          chmod a+x -- "$out"/bin/{foo,bar}
+        '';
+      in
+      testers.testEqualContents {
+        assertion = "Empty path element is current working directory";
+        expected =
+          runCommand "checkDuplicateProgramsInUnixPATH-debugOutput-golden" { inherit foobar foo bar; }
+            ''
+              for f in foo bar; do
+                printf "WARNING: final PATH contains 2 instances of $f executable\n"
+                printf "  $f ⇒\n"
+                printf "    %q/bin/$f\n" "$foobar"
+                printf "    %q/bin/$f\n" "''${!f}"
+              done >"$out"
+            '';
+        actual =
+          runCommand "checkDuplicateProgramsInUnixPATH-debugOutput"
+            {
+              testPath = lib.makeBinPath [
+                foobar
+                foo
+                bar
+              ];
+            }
+            ''
+              PATH=$testPath NIX_DEBUG=1 _checkDuplicateProgramsInUnixPATH >"$out"
+            '';
+      };
+  };
+}


### PR DESCRIPTION
## Description of changes

When adding packages to build inputs, multiple packages may provide the same program. This is not always intentional, e.g. for Darwin, adding cctools package partially overrides tools from stdenv’s cc attribute (that is provided to derivations as a default native build input and hence is lower on the search path). Note that we don’t currently set CC/AR/etc to absolute paths.

This change adds checks right after the PATH is constructed in stdenv’s setup.sh to warn about duplicate programs on the PATH search path.

<details>
<summary>Example output</summary>

```console
$ PATH= $(type -P nix) develop --file . gcc

$ _checkDuplicateProgramsInUnixPATH
WARNING: final PATH contains 2 instances of patchelf executable (the first is /nix/store/3928df2h57zwvm6gxin5iswwdhdfmxal-patchelf-0.15.0/bin/patchelf)
WARNING: final PATH contains 2 instances of xz executable (the first is /nix/store/d1ycvz1j109k5i62kdpp9d8w38nq2fhj-xz-5.6.2-bin/bin/xz)

$ NIX_DEBUG=1 _checkDuplicateProgramsInUnixPATH
WARNING: final PATH contains 2 instances of patchelf executable
  patchelf ⇒
    /nix/store/3928df2h57zwvm6gxin5iswwdhdfmxal-patchelf-0.15.0/bin/patchelf
    /nix/store/jkh2cpc9h2pyaayi0pyxb1sw641wk7l8-bootstrap-tools/bin/patchelf
WARNING: final PATH contains 2 instances of xz executable
  xz ⇒
    /nix/store/d1ycvz1j109k5i62kdpp9d8w38nq2fhj-xz-5.6.2-bin/bin/xz
    /nix/store/jkh2cpc9h2pyaayi0pyxb1sw641wk7l8-bootstrap-tools/bin/xz
```
</details>

The implementation currently focuses on Unix-like PATH. Windows has a bit more rules for PATH lookups, but we don’t support Windows as a build platform. If Nix and Nixpkgs eventually get ported to Windows, the name of the function should hopefully hint that it should be updated to match the platform semantics.

For convenience, this change also adds isExecutable function to the stdenv that checks whether a file has executable file mode bit set.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
