### PR TITLE
home-assistant-custom-components.volkswagencarnet: init at 5.0.3

### DIFF
--- a/pkgs/development/python-modules/volkswagencarnet/default.nix
+++ b/pkgs/development/python-modules/volkswagencarnet/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools-scm,
+  aiohttp,
+  beautifulsoup4,
+  lxml,
+  pyjwt,
+  freezegun,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "volkswagencarnet";
+  version = "5.0.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "robinostlund";
+    repo = "volkswagencarnet";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-NpfkhFGxd3VjLjQ8pPpamYgwc5zqWt5CojONe4L1s4s=";
+  };
+
+  postPatch = ''
+    substituteInPlace tests/conftest.py \
+      --replace-fail 'pytest_plugins = ["pytest_cov"]' 'pytest_plugins = []'
+  '';
+
+  build-system = [ setuptools-scm ];
+
+  dependencies = [
+    aiohttp
+    beautifulsoup4
+    lxml
+    pyjwt
+  ];
+
+  pythonImportsCheck = [ "volkswagencarnet" ];
+
+  nativeCheckInputs = [
+    freezegun
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "A python library for volkswagen carnet";
+    homepage = "https://github.com/robinostlund/volkswagencarnet";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/README.md
+++ b/pkgs/servers/home-assistant/custom-components/README.md
@@ -20,7 +20,7 @@ versions into the Python environment.
 
 ```nix
 { lib
-, buildHomeAssistantcomponent
+, buildHomeAssistantComponent
 , fetchFromGitHub
 }:
 

--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -60,6 +60,8 @@
 
   tuya_local = callPackage ./tuya_local {};
 
+  volkswagencarnet = callPackage ./volkswagencarnet { };
+
   waste_collection_schedule = callPackage ./waste_collection_schedule {};
 
   xiaomi_gateway3 = callPackage ./xiaomi_gateway3 {};

--- a/pkgs/servers/home-assistant/custom-components/volkswagencarnet/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/volkswagencarnet/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  volkswagencarnet,
+  pytest-homeassistant-custom-component,
+  pytestCheckHook,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "robinostlund";
+  domain = "volkswagencarnet";
+  version = "5.0.3";
+
+  src = fetchFromGitHub {
+    owner = "robinostlund";
+    repo = "homeassistant-volkswagencarnet";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-3wykS2TYjr9hoQSPc1F3m5aDiLW1tzvQfjfjnr4N2Y0=";
+  };
+
+  dependencies = [ volkswagencarnet ];
+
+  nativeCheckInputs = [
+    pytest-homeassistant-custom-component
+    pytestCheckHook
+  ];
+
+  # https://github.com/robinostlund/homeassistant-volkswagencarnet/issues/651
+  doCheck = false;
+
+  meta = {
+    description = "Volkswagen Connect component for Home Assistant";
+    homepage = "https://github.com/robinostlund/homeassistant-volkswagencarnet";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -455,6 +455,8 @@ let
       # internal python packages only consumed by home-assistant itself
       home-assistant-frontend = self.callPackage ./frontend.nix { };
       home-assistant-intents = self.callPackage ./intents.nix { };
+      homeassistant = self.toPythonModule home-assistant;
+      pytest-homeassistant-custom-component = self.callPackage ./pytest-homeassistant-custom-component.nix { };
     })
   ];
 

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  setuptools,
+  aiohttp,
+  bcrypt,
+  freezegun,
+  homeassistant,
+  pytest-asyncio,
+  pytest-socket,
+  requests-mock,
+  syrupy,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-homeassistant-custom-component";
+  version = "0.13.147";
+  pyproject = true;
+
+  disabled = pythonOlder "3.12";
+
+  src = fetchFromGitHub {
+    owner = "MatthewFlamm";
+    repo = "pytest-homeassistant-custom-component";
+    rev = "refs/tags/${version}";
+    hash = "sha256-FivgP0tKmu9QKPSVU9c/3SNduyKoSeAquHysdHSs11E=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonRemoveDeps = true;
+
+  dependencies = [
+    aiohttp
+    bcrypt
+    freezegun
+    homeassistant
+    pytest-asyncio
+    pytest-socket
+    requests-mock
+    syrupy
+  ];
+
+  pythonImportsCheck = [ "pytest_homeassistant_custom_component.plugins" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    changelog = "https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/blob/${src.rev}/CHANGELOG.md";
+    description = "Package to automatically extract testing plugins from Home Assistant for custom component testing";
+    homepage = "https://github.com/MatthewFlamm/pytest-homeassistant-custom-component";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17040,6 +17040,8 @@ self: super: with self; {
 
   volatile = callPackage ../development/python-modules/volatile { };
 
+  volkswagencarnet = callPackage ../development/python-modules/volkswagencarnet { };
+
   volkszaehler = callPackage ../development/python-modules/volkszaehler { };
 
   voluptuous = callPackage ../development/python-modules/voluptuous { };


### PR DESCRIPTION
depends on https://github.com/NixOS/nixpkgs/pull/329121

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
