### PR TITLE
home-assistant.python.pkgs.pytest-homeassistant-custom-component: init at 0.13.147

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/govee-lan/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/govee-lan/default.nix
@@ -1,7 +1,10 @@
 { lib
 , buildHomeAssistantComponent
 , fetchFromGitHub
+, fetchpatch2
 , govee-led-wez
+, pytest-homeassistant-custom-component
+, pytestCheckHook
 }:
 
 buildHomeAssistantComponent {
@@ -16,19 +19,32 @@ buildHomeAssistantComponent {
     hash = "sha256-ZhrxEPBEi+Z+2ZOAQ1amhO0tqvhM6tyFQgoRIVNDtXY=";
   };
 
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/wez/govee-lan-hass/commit/b4cecac5ae00d95c49fcfe3bbfc405cbfc5dd84c.patch";
+      hash = "sha256-+MPO4kxxE1nZ/+sIY7v8WukHMrVowgMMBVfRDw2uv8o=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace-fail "--cov=custom_components" ""
+  '';
+
   dontBuild = true;
 
   propagatedBuildInputs = [
     govee-led-wez
   ];
 
-  # enable when pytest-homeassistant-custom-component is packaged
+  # AttributeError: 'async_generator' object has no attribute 'config'
   doCheck = false;
 
-  # nativeCheckInputs = [
-  #   pytest-homeassistant-custom-component
-  #   pytestCheckHook
-  # ];
+  nativeCheckInputs = [
+    pytest-homeassistant-custom-component
+    pytestCheckHook
+  ];
+
 
   meta = with lib; {
     description = "Control Govee lights via the LAN API from Home Assistant";

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -455,6 +455,8 @@ let
       # internal python packages only consumed by home-assistant itself
       home-assistant-frontend = self.callPackage ./frontend.nix { };
       home-assistant-intents = self.callPackage ./intents.nix { };
+      homeassistant = self.toPythonModule home-assistant;
+      pytest-homeassistant-custom-component = self.callPackage ./pytest-homeassistant-custom-component.nix { };
     })
   ];
 

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  setuptools,
+  aiohttp,
+  bcrypt,
+  freezegun,
+  homeassistant,
+  pytest-asyncio,
+  pytest-socket,
+  requests-mock,
+  syrupy,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-homeassistant-custom-component";
+  version = "0.13.147";
+  pyproject = true;
+
+  disabled = pythonOlder "3.12";
+
+  src = fetchFromGitHub {
+    owner = "MatthewFlamm";
+    repo = "pytest-homeassistant-custom-component";
+    rev = "refs/tags/${version}";
+    hash = "sha256-FivgP0tKmu9QKPSVU9c/3SNduyKoSeAquHysdHSs11E=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonRemoveDeps = true;
+
+  dependencies = [
+    aiohttp
+    bcrypt
+    freezegun
+    homeassistant
+    pytest-asyncio
+    pytest-socket
+    requests-mock
+    syrupy
+  ];
+
+  pythonImportsCheck = [ "pytest_homeassistant_custom_component.plugins" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    changelog = "https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/blob/${src.rev}/CHANGELOG.md";
+    description = "Package to automatically extract testing plugins from Home Assistant for custom component testing";
+    homepage = "https://github.com/MatthewFlamm/pytest-homeassistant-custom-component";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}


### PR DESCRIPTION
We'd need to have Home Assistant be available as `home-assistant.python.pkgs.homeassistant`, similarly to how poetry does it. Should we do that?

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
