### PR TITLE
otadump: init at 0.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2304,6 +2304,12 @@
     githubId = 99703210;
     name = "Katherine Jamison";
   };
+  axka = {
+    name = "Axel Karjalainen";
+    email = "axel@axka.fi";
+    github = "axelkar";
+    githubId = 120189068;
+  };
   ayazhafiz = {
     email = "ayaz.hafiz.1@gmail.com";
     github = "hafiz";

--- a/pkgs/by-name/ot/otadump/no-static.patch
+++ b/pkgs/by-name/ot/otadump/no-static.patch
@@ -1,0 +1,13 @@
+diff --git a/Cargo.toml b/Cargo.toml
+index 65be773..3499dee 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -30,7 +30,7 @@ nom = "7.1.3"
+ nom-derive = "0.10.1"
+ prost = "0.11.8"
+ rayon = "1.7.0"
+-rust-lzma = { version = "0.6.0", features = ["static"] }
++rust-lzma = "0.6.0"
+ sha2 = "0.10.6"
+ sync-unsafe-cell = "0.1.0"
+ tempfile = "3.6.0"

--- a/pkgs/by-name/ot/otadump/package.nix
+++ b/pkgs/by-name/ot/otadump/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  protobuf,
+  xz,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "otadump";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "crazystylus";
+    repo = "otadump";
+    rev = version;
+    hash = "sha256-4zPVcTU+0otV4EPQi80uSRkpRo9XzI0V3Kr17ugXX2U=";
+  };
+
+  patches = [ ./no-static.patch ];
+
+  nativeBuildInputs = [
+    pkg-config
+    protobuf
+  ];
+
+  buildInputs = [ xz ];
+
+  doCheck = false; # There are no tests
+
+  cargoHash = "sha256-lTzEgy9mevkmefvTZT9hEBHN5I+kXVqTev5+sy/JoaE=";
+
+  meta = {
+    description = "Command-line tool to extract partitions from Android OTA files";
+    homepage = "https://github.com/crazystylus/otadump";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.axka ];
+    mainProgram = "otadump";
+  };
+}


### PR DESCRIPTION
## Description of changes

It helps to extract partitions from Android OTA files (payload.bin) like payload-dumper-go.

I removed the `static` feature of the rust-lzma crate since the author used it to build universal binaries using musl.

The binary works in `nix-shell --pure -p` too but I'm hoping someone with more experience can tell me if lzma needs to be added to propagatedBuildInputs or something.

<https://github.com/crazystylus/otadump>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
