### PR TITLE
{gradle.fetchDeps,shattered-pixel-dungeon}: fix eval on Nix 2.3.18

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/fetch-deps.nix
+++ b/pkgs/development/tools/build-managers/gradle/fetch-deps.nix
@@ -123,10 +123,9 @@ let
 
             fileList = builtins.filter (x: lib.hasPrefix xmlBase x && x != url) (builtins.attrNames finalData);
             jarPomList = map parseArtifactUrl fileList;
-            sortedJarPomList =
-              lib.sort
-                (a: b: lib.splitVersion a.version < lib.splitVersion b.version)
-                jarPomList;
+
+            sortByVersion = a: b: (builtins.compareVersions a.version b.version) < 0;
+            sortedJarPomList = lib.sort sortByVersion jarPomList;
 
             uniqueVersionFiles =
               builtins.map ({ i, x }: x)

--- a/pkgs/games/shattered-pixel-dungeon/generic.nix
+++ b/pkgs/games/shattered-pixel-dungeon/generic.nix
@@ -53,7 +53,7 @@ let
     keywords = [ "roguelike" "dungeon" "crawler" ];
   };
 
-  depsPath' = if depsPath != null then depsPath else ./${pname}/deps.json;
+  depsPath' = if depsPath != null then depsPath else ./. + "/${pname}/deps.json";
 
 in stdenv.mkDerivation (cleanAttrs // {
   inherit pname version src patches postPatch;


### PR DESCRIPTION
## Motivation

I discovered this problem developing tests for `nixpkgs-check-by-name` in nixos/nixpkgs-check-by-name#79. Nix 2.3.18 is `nixVersions.minimum`.

The changes were introduced in #272380. CC @chayleaf.

## Description of changes

- [x] Use `./. + "relative path"` instead of constructing a path with newer Nix syntax.
- [x] Use `lib.compareLists` instead of comparing lists directly.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [x] Nix 2.3.18 (`nixVersions.minimum`)
  - [x] Nix 2.23.2 (`nixVersions.latest`)
  - [x] Nix 2.18.5 (`nixVersions.stable`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).