### PR TITLE
python312Packages.pyside6: allow optional dependencies for darwin

### DIFF
--- a/pkgs/development/python-modules/pyside6/default.nix
+++ b/pkgs/development/python-modules/pyside6/default.nix
@@ -64,17 +64,17 @@ stdenv.mkDerivation (finalAttrs: {
   # Also we remove "Designer" from darwin build, due to linking failure
   postPatch =
     ''
-    # Don't ignore optional Qt modules
-    substituteInPlace cmake/PySideHelpers.cmake \
-      --replace-fail \
-        'string(FIND "''${_module_dir}" "''${_core_abs_dir}" found_basepath)' \
-        'set (found_basepath 0)'
-  ''
-  + lib.optionalString stdenv.isDarwin ''
-    substituteInPlace cmake/PySideHelpers.cmake \
-      --replace-fail \
-        "Designer" ""
-  '';
+      # Don't ignore optional Qt modules
+      substituteInPlace cmake/PySideHelpers.cmake \
+        --replace-fail \
+          'string(FIND "''${_module_dir}" "''${_core_abs_dir}" found_basepath)' \
+          'set (found_basepath 0)'
+    ''
+    + lib.optionalString stdenv.isDarwin ''
+      substituteInPlace cmake/PySideHelpers.cmake \
+        --replace-fail \
+          "Designer" ""
+    '';
 
   # "Couldn't find libclang.dylib You will likely need to add it manually to PATH to ensure the build succeeds."
   env = lib.optionalAttrs stdenv.isDarwin { LLVM_INSTALL_DIR = "${llvmPackages.libclang.lib}/lib"; };

--- a/pkgs/development/python-modules/pyside6/default.nix
+++ b/pkgs/development/python-modules/pyside6/default.nix
@@ -5,6 +5,7 @@
   cups,
   ninja,
   python,
+  pythonImportsCheckHook,
   moveBuildTree,
   shiboken6,
   llvmPackages,
@@ -83,6 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     ninja
     python
+    pythonImportsCheckHook
   ] ++ lib.optionals stdenv.isDarwin [ moveBuildTree ];
 
   buildInputs =
@@ -118,6 +120,8 @@ stdenv.mkDerivation (finalAttrs: {
     ${python.pythonOnBuildForHost.interpreter} setup.py egg_info --build-type=pyside6
     cp -r PySide6.egg-info $out/${python.sitePackages}/
   '';
+
+  pythonImportsCheck = [ "PySide6" ];
 
   meta = {
     description = "Python bindings for Qt";

--- a/pkgs/development/python-modules/pyside6/default.nix
+++ b/pkgs/development/python-modules/pyside6/default.nix
@@ -2,11 +2,54 @@
   lib,
   stdenv,
   cmake,
+  cups,
   ninja,
   python,
   moveBuildTree,
   shiboken6,
+  llvmPackages,
+  symlinkJoin,
+  libGL,
+  darwin,
 }:
+let
+  packages = with python.pkgs.qt6; [
+    # required
+    python.pkgs.ninja
+    python.pkgs.packaging
+    python.pkgs.setuptools
+    qtbase
+
+    # optional
+    qt3d
+    qtcharts
+    qtconnectivity
+    qtdatavis3d
+    qtdeclarative
+    qthttpserver
+    qtmultimedia
+    qtnetworkauth
+    qtquick3d
+    qtremoteobjects
+    qtscxml
+    qtsensors
+    qtspeech
+    qtsvg
+    qtwebchannel
+    qtwebsockets
+    qtpositioning
+    qtlocation
+    qtshadertools
+    qtserialport
+    qtserialbus
+    qtgraphs
+    qttools
+  ];
+  qt_linked = symlinkJoin {
+    name = "qt_linked";
+    paths = packages;
+  };
+in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pyside6";
@@ -15,15 +58,26 @@ stdenv.mkDerivation (finalAttrs: {
 
   sourceRoot = "pyside-setup-everywhere-src-${finalAttrs.version}/sources/pyside6";
 
-  # FIXME: cmake/Macros/PySideModules.cmake supposes that all Qt frameworks on macOS
+  # cmake/Macros/PySideModules.cmake supposes that all Qt frameworks on macOS
   # reside in the same directory as QtCore.framework, which is not true for Nix.
-  postPatch = lib.optionalString stdenv.isLinux ''
+  # We therefore symLink all required and optional Qt modules in one directory tree ("qt_linked").
+  # Also we remove "Designer" from darwin build, due to linking failure
+  postPatch =
+    ''
     # Don't ignore optional Qt modules
     substituteInPlace cmake/PySideHelpers.cmake \
       --replace-fail \
         'string(FIND "''${_module_dir}" "''${_core_abs_dir}" found_basepath)' \
         'set (found_basepath 0)'
+  ''
+  + lib.optionalString stdenv.isDarwin ''
+    substituteInPlace cmake/PySideHelpers.cmake \
+      --replace-fail \
+        "Designer" ""
   '';
+
+  # "Couldn't find libclang.dylib You will likely need to add it manually to PATH to ensure the build succeeds."
+  env = lib.optionalAttrs stdenv.isDarwin { LLVM_INSTALL_DIR = "${llvmPackages.libclang.lib}/lib"; };
 
   nativeBuildInputs = [
     cmake
@@ -32,35 +86,26 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ lib.optionals stdenv.isDarwin [ moveBuildTree ];
 
   buildInputs =
-    with python.pkgs.qt6;
-    [
-      # required
-      qtbase
-      python.pkgs.ninja
-      python.pkgs.packaging
-      python.pkgs.setuptools
-    ]
-    ++ lib.optionals stdenv.isLinux [
-      # optional
-      qt3d
-      qtcharts
-      qtconnectivity
-      qtdatavis3d
-      qtdeclarative
-      qthttpserver
-      qtmultimedia
-      qtnetworkauth
-      qtquick3d
-      qtremoteobjects
-      qtscxml
-      qtsensors
-      qtspeech
-      qtsvg
-      qttools
-      qtwebchannel
-      qtwebengine
-      qtwebsockets
-    ];
+    if stdenv.isLinux then
+      # qtwebengine fails under darwin
+      # see https://github.com/NixOS/nixpkgs/pull/312987
+      packages ++ [ python.pkgs.qt6.qtwebengine ]
+    else
+      with darwin.apple_sdk_11_0.frameworks;
+      [
+        qt_linked
+        libGL
+        cups
+        # frameworks
+        IOKit
+        DiskArbitration
+        CoreBluetooth
+        EventKit
+        AVFoundation
+        Contacts
+        AGL
+        AppKit
+      ];
 
   propagatedBuildInputs = [ shiboken6 ];
 


### PR DESCRIPTION
## Description of changes

This PR refactors `pyside6` by:

- adding `LLVM_INSTALL_DIR` environment variable to let `pyside6` find the `libclang` library
- add required darwin frameworks
- use a `symlinkJoin` construct of all qt6 dependencies so `pyside6` finds the dependencies on darwin. This is necessary, because `pyside6` on macos expects all dependencies to be under the same directory
- remove the optional module `Designer` from the darwin python bindings, since it causes linker failures.
- adding a `pythonImportsCheck`

The benefit of this change is that `pyside6` now includes almost all the python bindings for Qt (except Designer and qtwebengine) on darwin.

This also adds the following modules to the `x86_64-linux` binding:

- qtpositioning
- qtlocation
- qtshadertools
- qtserialport
- qtserialbus
- qtgraphs

Ping @gebner 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
