### PR TITLE
Revert "glew: default enableEGL to true"

### DIFF
--- a/pkgs/development/libraries/glew/default.nix
+++ b/pkgs/development/libraries/glew/default.nix
@@ -1,14 +1,6 @@
-{ lib
-, stdenv
-, fetchurl
-, fetchpatch
-, cmake
-, libGLU
-, libXmu
-, libXi
-, libXext
+{ lib, stdenv, fetchurl, fetchpatch, cmake, libGLU, libXmu, libXi, libXext
 , OpenGL
-, enableEGL ? (!stdenv.isDarwin)
+, enableEGL ? false
 , testers
 }:
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#328907

Broke mangohud, and possibly all of X11 in general? Needs more investigation either way.