### PR TITLE
libabw: fix build after libxml2 update

### DIFF
--- a/pkgs/development/libraries/libabw/default.nix
+++ b/pkgs/development/libraries/libabw/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, boost, doxygen, gperf, pkg-config, librevenge, libxml2, perl }:
+{ lib, stdenv, fetchurl, boost, doxygen, gperf, pkg-config, librevenge, libxml2, perl, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "libabw";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ boost doxygen gperf librevenge libxml2 perl ];
+  buildInputs = [ boost doxygen gperf librevenge libxml2 perl zlib ];
 
   meta = with lib; {
     homepage = "https://wiki.documentfoundation.org/DLP/Libraries/libabw";


### PR DESCRIPTION
## Description of changes

libabw requires zlib, which was previously but no longer propagated by libxml2. Fixes build failure on staging-next https://github.com/NixOS/nixpkgs/pull/328673

https://hydra.nixos.org/build/266918370/nixlog/1/tail

(see https://github.com/NixOS/nixpkgs/pull/328956 for a _very_ similar PR :slightly_smiling_face: )

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  * NOTE: `libabw` is a dependency of `libreoffice` which is quite chonky..
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
