### PR TITLE
darwin.ICU: clean up and fix staging-next

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/ICU/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/ICU/default.nix
@@ -19,25 +19,25 @@ appleDerivation {
 
   postPatch = ''
     substituteInPlace makefile \
-      --replace "/usr/bin/" "" \
-      --replace "xcrun --sdk macosx --find" "echo -n" \
-      --replace "xcrun --sdk macosx.internal --show-sdk-path" "echo -n /dev/null" \
-      --replace "-install_name " "-install_name $out"
+      --replace-fail "/usr/bin/" "" \
+      --replace-fail "xcrun --sdk macosx --find" "echo -n" \
+      --replace-fail "xcrun --sdk macosx.internal --show-sdk-path" "echo -n /dev/null" \
+      --replace-fail "-install_name " "-install_name $out"
 
     substituteInPlace icuSources/config/mh-darwin \
-      --replace "-install_name " "-install_name $out/"
+      --replace-fail "-install_name " "-install_name $out/"
 
     # drop using impure /var/db/timezone/icutz
     substituteInPlace makefile \
-      --replace '-DU_TIMEZONE_FILES_DIR=\"\\\"$(TZDATA_LOOKUP_DIR)\\\"\" -DU_TIMEZONE_PACKAGE=\"\\\"$(TZDATA_PACKAGE)\\\"\"' ""
+      --replace-fail '-DU_TIMEZONE_FILES_DIR=\"\\\"$(TZDATA_LOOKUP_DIR)\\\"\" -DU_TIMEZONE_PACKAGE=\"\\\"$(TZDATA_PACKAGE)\\\"\"' ""
 
     # FIXME: This will cause `ld: warning: OS version (12.0) too small, changing to 13.0.0`, APPLE should fix it.
     substituteInPlace makefile \
-      --replace "ZIPPERING_LDFLAGS=-Wl,-iosmac_version_min,12.0" "ZIPPERING_LDFLAGS="
+      --replace-fail "ZIPPERING_LDFLAGS=-Wl,-iosmac_version_min,12.0" "ZIPPERING_LDFLAGS="
 
     # skip test for missing encodingSamples data
     substituteInPlace icuSources/test/cintltst/ucsdetst.c \
-      --replace "&TestMailFilterCSS" "NULL"
+      --replace-fail "&TestMailFilterCSS" "NULL"
 
     patchShebangs icuSources
   '' + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
@@ -46,7 +46,7 @@ appleDerivation {
     # propagate the correct value of CC, CXX, etc, but has the following double
     # expansion that results in the empty string.
     substituteInPlace makefile \
-      --replace '$($(ENV_BUILDHOST))' '$(ENV_BUILDHOST)'
+      --replace-fail '$($(ENV_BUILDHOST))' '$(ENV_BUILDHOST)'
   '';
 
   # APPLE is using makefile to save its default configuration and call ./configure, so we hack makeFlags

--- a/pkgs/os-specific/darwin/apple-source-releases/ICU/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/ICU/default.nix
@@ -22,7 +22,8 @@ appleDerivation {
       --replace-fail "/usr/bin/" "" \
       --replace-fail "xcrun --sdk macosx --find" "echo -n" \
       --replace-fail "xcrun --sdk macosx.internal --show-sdk-path" "echo -n /dev/null" \
-      --replace-fail "-install_name " "-install_name $out"
+      --replace-fail "-install_name " "-install_name $out" \
+      --replace-fail '-x -u -r -S' '-x --keep-undefined -S'
 
     substituteInPlace icuSources/config/mh-darwin \
       --replace-fail "-install_name " "-install_name $out/"

--- a/pkgs/os-specific/darwin/apple-source-releases/ICU/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/ICU/default.nix
@@ -11,6 +11,8 @@ let
 in
 
 appleDerivation {
+  patches = [ ./suppress-icu-check-crash.patch ];
+
   nativeBuildInputs = [ python3 ];
 
   depsBuildBuild = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [ buildPackages.stdenv.cc ];

--- a/pkgs/os-specific/darwin/apple-source-releases/ICU/suppress-icu-check-crash.patch
+++ b/pkgs/os-specific/darwin/apple-source-releases/ICU/suppress-icu-check-crash.patch
@@ -1,0 +1,13 @@
+diff --git a/icuSources/test/cintltst/cmsgtst.c b/icuSources/test/cintltst/cmsgtst.c
+index cb328707..1073e6c1 100644
+--- a/icuSources/test/cintltst/cmsgtst.c
++++ b/icuSources/test/cintltst/cmsgtst.c
+@@ -231,7 +231,7 @@ static void MessageFormatTest( void )
+                         austrdup(result), austrdup(testResultStrings[i]) );
+                 }
+ 
+-#if (U_PLATFORM == U_PF_LINUX) /* add platforms here .. */
++#if (U_PLATFORM == U_PF_LINUX || U_PLATFORM == U_PF_DARWIN) /* add platforms here .. */
+                 log_verbose("Skipping potentially crashing test for mismatched varargs.\n");
+ #else
+                 log_verbose("Note: the next is a platform dependent test. If it crashes, add an exclusion for your platform near %s:%d\n", __FILE__, __LINE__); 

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -1323,7 +1323,7 @@ in
 
         darwin = super.darwin.overrideScope (_: superDarwin: {
           inherit (prevStage.darwin)
-            CF ICU Libsystem darwin-stubs dyld locale libobjc rewrite-tbd xnu;
+            CF Libsystem darwin-stubs dyld locale libobjc rewrite-tbd xnu;
 
           apple_sdk = superDarwin.apple_sdk // {
             inherit (prevStage.darwin.apple_sdk) sdkRoot;


### PR DESCRIPTION
## Description of changes

Fix darwin.ICU crashes on staging-next https://github.com/NixOS/nixpkgs/pull/328673 and clean up the derivation a bit.

- https://hydra.nixos.org/build/267053979

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
