### PR TITLE
linuxKernel.packages.hpuefi-mod: init at 3.05

### DIFF
--- a/pkgs/os-specific/linux/hpuefi-mod/default.nix
+++ b/pkgs/os-specific/linux/hpuefi-mod/default.nix
@@ -1,0 +1,43 @@
+{
+  stdenv,
+  fetchzip,
+  kernel,
+  lib,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hpuefi-mod";
+  version = "3.05";
+
+  src = fetchzip {
+    url = "https://ftp.hp.com/pub/softpaq/sp150501-151000/sp150953.tgz";
+    hash = "sha256-ofzqu5Y2g+QU0myJ4SF39ZJGXH1zXzX1Ys2FhXVTQKE=";
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+  strictDeps = true;
+
+  makeFlags = [
+    "KVERS=${kernel.modDirVersion}"
+    "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "DESTDIR=$(out)"
+  ];
+
+  unpackPhase = ''
+    tar -xzf "$src/non-rpms/hpuefi-mod-${finalAttrs.version}.tgz"
+    cd hpuefi-mod-${finalAttrs.version}
+  '';
+
+  prePatch = ''
+    substituteInPlace "Makefile" \
+      --replace depmod \#
+  '';
+
+  meta = {
+    homepage = "https://ftp.hp.com/pub/caps-softpaq/cmit/linuxtools/HP_LinuxTools.html";
+    description = "Kernel module for managing BIOS settings and updating BIOS firmware on supported HP computers";
+    license = lib.licenses.gpl2Only; # See "License" section in ./non-rpms/hpuefi-mod-*.tgz/README
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ tomodachi94 ];
+  };
+})

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -604,6 +604,8 @@ in {
 
     hid-tmff2 = callPackage ../os-specific/linux/hid-tmff2 { };
 
+    hpuefi-mod = callPackage ../os-specific/linux/hpuefi-mod { };
+
     drbd = callPackage ../os-specific/linux/drbd/driver.nix { };
 
   } // lib.optionalAttrs config.allowAliases {


### PR DESCRIPTION
## Description of changes

Adds the `hpuefi-mod` kernel module, which allows for interacting with the BIOS of certain HP machines:
* 2015 and newer HP Desktop Workstations
* 2018 and newer HP business Notebooks and Desktops.

https://ftp.hp.com/pub/caps-softpaq/cmit/linuxtools/HP_LinuxTools.html
https://ftp.hp.com/pub/caps-softpaq/cmit/linuxtools/HP_Linux_Tools_Users_Guide.pdf

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
