### PR TITLE
edk2: 202402 -> 202408

### DIFF
--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -189,6 +189,9 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
   in {
     firmware  = "${prefix}_CODE.fd";
     variables = "${prefix}_VARS.fd";
+    variablesMs =
+      assert msVarsTemplate;
+      "${prefix}_VARS.ms.fd";
     # This will test the EFI firmware for the host platform as part of the NixOS Tests setup.
     tests.basic-systemd-boot = nixosTests.systemd-boot.basic;
     tests.secureBoot-systemd-boot = nixosTests.systemd-boot.secureBoot;

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -191,6 +191,6 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
     license = lib.licenses.bsd2;
     platforms = metaPlatforms;
     maintainers = with lib.maintainers; [ adamcstephens raitobezarius mjoerg ];
-    broken = stdenv.isDarwin;
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 })

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -76,8 +76,8 @@ let
       "debian/python"
       "debian/PkKek-1-*.pem"
     ];
-    rev = "refs/tags/debian/2023.11-5";
-    hash = "sha256-4vDOoZbWQg7yKXiQprK8CRzKGkbKQYlAgQzTqmNxxjU=";
+    rev = "refs/tags/debian/2024.05-1";
+    hash = "sha256-uAjXJaHOVh944ZxcA2IgCsrsncxuhc0JKlsXs0E03s0=";
   };
 
   buildPrefix = "Build/*/*";

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -190,7 +190,7 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
     homepage = "https://github.com/tianocore/tianocore.github.io/wiki/OVMF";
     license = lib.licenses.bsd2;
     platforms = metaPlatforms;
-    maintainers = with lib.maintainers; [ adamcstephens raitobezarius ];
+    maintainers = with lib.maintainers; [ adamcstephens raitobezarius mjoerg ];
     broken = stdenv.isDarwin;
   };
 })

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -138,7 +138,8 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
   '' + lib.optionalString msVarsTemplate ''
     (
     cd ${buildPrefix}
-    python3 $NIX_BUILD_TOP/debian/edk2-vars-generator.py \
+    # locale must be set on Darwin for invocations of mtools to work correctly
+    LC_ALL=C python3 $NIX_BUILD_TOP/debian/edk2-vars-generator.py \
       --flavor ${msVarsArgs.flavor} \
       --enrolldefaultkeys ${msVarsArgs.archDir}/EnrollDefaultKeys.efi \
       --shell ${msVarsArgs.archDir}/Shell.efi \

--- a/pkgs/by-name/ed/edk2/package.nix
+++ b/pkgs/by-name/ed/edk2/package.nix
@@ -69,11 +69,6 @@ edk2 = stdenv.mkDerivation {
       cd CryptoPkg/Library/OpensslLib/openssl
       tar --strip-components=1 -xf ${buildPackages.openssl.src}
 
-      # Fix missing INT64_MAX include that edk2 explicitly does not provide
-      # via it's own <stdint.h>. Let's pull in openssl's definition instead:
-      sed -i crypto/property/property_parse.c \
-          -e '1i #include "internal/numbers.h"'
-
       # Apply OpenSSL patches.
       ${lib.pipe buildPackages.openssl.patches [
         (builtins.filter (

--- a/pkgs/by-name/ed/edk2/package.nix
+++ b/pkgs/by-name/ed/edk2/package.nix
@@ -92,6 +92,12 @@ edk2 = stdenv.mkDerivation {
         lib.concatStrings
       ]}
       )
+
+      # enable compilation using Clang
+      # https://bugzilla.tianocore.org/show_bug.cgi?id=4620
+      substituteInPlace BaseTools/Conf/tools_def.template --replace-fail \
+        'DEFINE CLANGPDB_WARNING_OVERRIDES    = ' \
+        'DEFINE CLANGPDB_WARNING_OVERRIDES    = -Wno-unneeded-internal-declaration '
     '';
   };
 

--- a/pkgs/by-name/ed/edk2/package.nix
+++ b/pkgs/by-name/ed/edk2/package.nix
@@ -100,12 +100,13 @@ edk2 = stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  meta = {
     description = "Intel EFI development kit";
     homepage = "https://github.com/tianocore/tianocore.github.io/wiki/EDK-II/";
     changelog = "https://github.com/tianocore/edk2/releases/tag/edk2-stable${edk2.version}";
-    license = licenses.bsd2;
-    platforms = with platforms; aarch64 ++ arm ++ i686 ++ x86_64 ++ riscv64;
+    license = lib.licenses.bsd2;
+    platforms = with lib.platforms; aarch64 ++ arm ++ i686 ++ x86_64 ++ riscv64;
+    maintainers = [ lib.maintainers.mjoerg ];
   };
 
   passthru = {

--- a/pkgs/by-name/ed/edk2/package.nix
+++ b/pkgs/by-name/ed/edk2/package.nix
@@ -33,14 +33,14 @@ buildType = if stdenv.isDarwin then
 
 edk2 = stdenv.mkDerivation {
   pname = "edk2";
-  version = "202405";
+  version = "202408";
 
   srcWithVendoring = fetchFromGitHub {
     owner = "tianocore";
     repo = "edk2";
     rev = "edk2-stable${edk2.version}";
     fetchSubmodules = true;
-    hash = "sha256-+phKAr3xc4T8tg6YAoGgRWCmxZiFzhazEAai48ICnKM=";
+    hash = "sha256-2odaTqiAZD5xduT0dwIYWj3gY/aFPVsTFbblIsEhBiA=";
   };
 
   src = applyPatches {
@@ -58,13 +58,6 @@ edk2 = stdenv.mkDerivation {
         name = "fix-cross-compilation-antlr-dlg.patch";
         url = "https://github.com/tianocore/edk2/commit/a34ff4a8f69a7b8a52b9b299153a8fac702c7df1.patch";
         hash = "sha256-u+niqwjuLV5tNPykW4xhb7PW2XvUmXhx5uvftG1UIbU=";
-      })
-      # TODO: remove on next version of edk2
-      # https://github.com/tianocore/edk2/pull/5690
-      (fetchpatch {
-        name = "fix-stuck-system.patch";
-        url = "https://github.com/tianocore/edk2/commit/ced13b93afea87a8a1fe6ddbb67240a84cb2e3d3.patch";
-        hash = "sha256-RHfJ9OcMGs3jDg2jQyzcjbYkJcmc/SZyrdXBsUw9vDA=";
       })
     ];
 

--- a/pkgs/by-name/ed/edk2/package.nix
+++ b/pkgs/by-name/ed/edk2/package.nix
@@ -33,14 +33,14 @@ buildType = if stdenv.isDarwin then
 
 edk2 = stdenv.mkDerivation {
   pname = "edk2";
-  version = "202402";
+  version = "202405";
 
   srcWithVendoring = fetchFromGitHub {
     owner = "tianocore";
     repo = "edk2";
     rev = "edk2-stable${edk2.version}";
     fetchSubmodules = true;
-    hash = "sha256-Nurm6QNKCyV6wvbj0ELdYAL7mbZ0yg/tTwnEJ+N18ng=";
+    hash = "sha256-+phKAr3xc4T8tg6YAoGgRWCmxZiFzhazEAai48ICnKM=";
   };
 
   src = applyPatches {
@@ -58,6 +58,13 @@ edk2 = stdenv.mkDerivation {
         name = "fix-cross-compilation-antlr-dlg.patch";
         url = "https://github.com/tianocore/edk2/commit/a34ff4a8f69a7b8a52b9b299153a8fac702c7df1.patch";
         hash = "sha256-u+niqwjuLV5tNPykW4xhb7PW2XvUmXhx5uvftG1UIbU=";
+      })
+      # TODO: remove on next version of edk2
+      # https://github.com/tianocore/edk2/pull/5690
+      (fetchpatch {
+        name = "fix-stuck-system.patch";
+        url = "https://github.com/tianocore/edk2/commit/ced13b93afea87a8a1fe6ddbb67240a84cb2e3d3.patch";
+        hash = "sha256-RHfJ9OcMGs3jDg2jQyzcjbYkJcmc/SZyrdXBsUw9vDA=";
       })
     ];
 

--- a/pkgs/tools/misc/edk2-uefi-shell/default.nix
+++ b/pkgs/tools/misc/edk2-uefi-shell/default.nix
@@ -38,5 +38,6 @@ edk2.mkDerivation "ShellPkg/ShellPkg.dsc" (finalAttrs: {
     description = "UEFI Shell from Tianocore EFI development kit";
     homepage = "https://github.com/tianocore/tianocore.github.io/wiki/ShellPkg";
     maintainers = with lib.maintainers; [ LunNova mjoerg ];
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 })

--- a/pkgs/tools/misc/edk2-uefi-shell/default.nix
+++ b/pkgs/tools/misc/edk2-uefi-shell/default.nix
@@ -37,6 +37,6 @@ edk2.mkDerivation "ShellPkg/ShellPkg.dsc" (finalAttrs: {
     inherit (edk2.meta) license platforms;
     description = "UEFI Shell from Tianocore EFI development kit";
     homepage = "https://github.com/tianocore/tianocore.github.io/wiki/ShellPkg";
-    maintainers = with lib.maintainers; [ LunNova ];
+    maintainers = with lib.maintainers; [ LunNova mjoerg ];
   };
 })


### PR DESCRIPTION
## Description of changes

edk2:
+ remove obsoleted patch
+ ensure patches to EDK II and OpenSSL are propagated to edk2.mkDerivation
+ update to 202405 with patch to avoid stuck system (#325403)
+ update to 202408

edk2-uefi-shell:
+ mark as broken on Darwin aarch64

OVMF:
+ fix build on Darwin x86-64
+ update Debian source used for building NVRAM variable templates with MSFT keys
+ expose NVRAM variable templates through passthru

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>47 packages built:</summary>
  <ul>
    <li>OVMF</li>
    <li>OVMF-cloud-hypervisor</li>
    <li>OVMF-cloud-hypervisor.fd</li>
    <li>OVMF.fd</li>
    <li>OVMFFull</li>
    <li>OVMFFull.fd</li>
    <li>edk2</li>
    <li>edk2-uefi-shell</li>
    <li>lxd-lts</li>
    <li>multipass</li>
    <li>qemu_xen (qemu_xen_4_19)</li>
    <li>qemu_xen.debug (qemu_xen_4_19.debug)</li>
    <li>qemu_xen.ga (qemu_xen_4_19.ga)</li>
    <li>qemu_xen_4_16</li>
    <li>qemu_xen_4_16.debug</li>
    <li>qemu_xen_4_16.ga</li>
    <li>qemu_xen_4_17</li>
    <li>qemu_xen_4_17.debug</li>
    <li>qemu_xen_4_17.ga</li>
    <li>qemu_xen_4_18</li>
    <li>qemu_xen_4_18.debug</li>
    <li>qemu_xen_4_18.ga</li>
    <li>quickemu</li>
    <li>quickgui</li>
    <li>quickgui.debug</li>
    <li>quickgui.pubcache</li>
    <li>xen-guest-agent</li>
    <li>xen-slim</li>
    <li>xen-slim.boot</li>
    <li>xen-slim.dev</li>
    <li>xen-slim.doc</li>
    <li>xen-slim.man</li>
    <li>xenPackages.xen_4_16-slim</li>
    <li>xenPackages.xen_4_16-slim.boot</li>
    <li>xenPackages.xen_4_16-slim.dev</li>
    <li>xenPackages.xen_4_16-slim.doc</li>
    <li>xenPackages.xen_4_16-slim.man</li>
    <li>xenPackages.xen_4_17-slim</li>
    <li>xenPackages.xen_4_17-slim.boot</li>
    <li>xenPackages.xen_4_17-slim.dev</li>
    <li>xenPackages.xen_4_17-slim.doc</li>
    <li>xenPackages.xen_4_17-slim.man</li>
    <li>xenPackages.xen_4_18-slim</li>
    <li>xenPackages.xen_4_18-slim.boot</li>
    <li>xenPackages.xen_4_18-slim.dev</li>
    <li>xenPackages.xen_4_18-slim.doc</li>
    <li>xenPackages.xen_4_18-slim.man</li>
  </ul>
</details>

## Result of `nixpkgs-review` run on x86_64-darwin [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>9 packages built:</summary>
  <ul>
    <li>OVMF</li>
    <li>OVMF-cloud-hypervisor</li>
    <li>OVMF-cloud-hypervisor.fd</li>
    <li>OVMF.fd</li>
    <li>OVMFFull</li>
    <li>OVMFFull.fd</li>
    <li>edk2</li>
    <li>edk2-uefi-shell</li>
    <li>quickemu</li>
  </ul>
</details>

## Result of `nixpkgs-review` run on aarch64-darwin [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>6 packages marked as broken and skipped:</summary>
  <ul>
    <li>OVMF</li>
    <li>OVMF.fd</li>
    <li>OVMFFull</li>
    <li>OVMFFull.fd</li>
    <li>edk2-uefi-shell</li>
    <li>quickemu</li>
  </ul>
</details>
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>edk2</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc