### PR TITLE
aicommit2: init at 2.1.5

### DIFF
--- a/pkgs/by-name/ai/aicommit2/package.nix
+++ b/pkgs/by-name/ai/aicommit2/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  nodejs,
+  pnpm,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "aicommit2";
+  version = "2.1.5";
+
+  src = fetchFromGitHub {
+    owner = "tak-bro";
+    repo = "aicommit2";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-/bl0Qo4y3rDdGXIKTdjC5wtbeW1NUaIMkw5uzSQ+8Dk=";
+  };
+
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-y3IftcRhsDDyMZ2AE07WyY94mp0j6M6UVno7Qp8d/G8=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm.configHook
+  ];
+  buildInputs = [ nodejs ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib/aicommit2}
+    cp -r {dist,node_modules} $out/lib/aicommit2
+
+    ln -s $out/lib/aicommit2/dist/cli.mjs $out/bin/aicommit2
+    ln -s $out/lib/aicommit2/dist/cli.mjs $out/bin/aic2
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Reactive CLI that generates git commit messages with AI";
+    homepage = "https://github.com/tak-bro/aicommit2";
+    changelog = "https://github.com/tak-bro/aicommit2/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ByteSudoer ];
+    mainProgram = "aicommit2";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes
Project description
A Reactive CLI that generates git commit messages with Ollama, ChatGPT, Gemini, Claude, Mistral and other AI.
Conventional Commits and bitmoji.dev aware.

Metadata
- homepage URL: [www.npmjs.com/package/aicommit2](https://www.npmjs.com/package/aicommit2)
- source URL: https://github.com/tak-bro/aicommit2
- license: mit
- platforms: unix, linux, darwin, ...

Closes https://github.com/NixOS/nixpkgs/issues/328908
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
