### PR TITLE
checkbashisms: 2.22.1 -> 2.23.7

### DIFF
--- a/pkgs/development/tools/misc/checkbashisms/default.nix
+++ b/pkgs/development/tools/misc/checkbashisms/default.nix
@@ -1,11 +1,19 @@
-{ lib, stdenv, fetchurl, perl, installShellFiles }:
-stdenv.mkDerivation rec {
-  version = "2.22.1";
+{
+  lib,
+  stdenv,
+  fetchurl,
+  installShellFiles,
+  perl,
+  testers,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  version = "2.23.7";
   pname = "checkbashisms";
 
   src = fetchurl {
-    url = "mirror://debian/pool/main/d/devscripts/devscripts_${version}.tar.xz";
-    hash = "sha256-Nd1eYCnSe+NblujG44uKpvunkaITcdrC3g+M3uX+M9U=";
+    url = "mirror://debian/pool/main/d/devscripts/devscripts_${finalAttrs.version}.tar.xz";
+    hash = "sha256-nOnlE1Ry2GR+L/tWZV4AOR6Omap6SormBc8OH/2fNgk=";
   };
 
   nativeBuildInputs = [ installShellFiles ];
@@ -29,12 +37,17 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  passthru.tests = {
+    version = testers.testVersion { package = finalAttrs.finalPackage; };
+  };
+
   meta = {
     homepage = "https://sourceforge.net/projects/checkbaskisms/";
+    changelog = "https://salsa.debian.org/debian/devscripts/-/blob/v${finalAttrs.version}/debian/changelog";
     description = "Check shell scripts for non-portable syntax";
     mainProgram = "checkbashisms";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ kaction ];
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
## Description of changes
Changelog: https://salsa.debian.org/debian/devscripts/-/blob/v2.23.7/debian/changelog



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
