### PR TITLE
python3Packages.aplpy: fix build

### DIFF
--- a/pkgs/development/python-modules/aplpy/default.nix
+++ b/pkgs/development/python-modules/aplpy/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     hash = "sha256-KCdmBwQWt7IfHsjq7pWlbSISEpfQZDyt+SQSTDaUCV4=";
   };
 
-  # Fix build with Astropy 6 and Python 3.12.
+  # Fix build with Astropy 6.1, Python 3.12 and matplotlib 3.9
   patches = [
     # https://github.com/aplpy/aplpy/pull/496
     (fetchpatch {
@@ -44,6 +44,16 @@ buildPythonPackage rec {
     (fetchpatch {
       url = "https://github.com/aplpy/aplpy/commit/468be394970b39f1aaa6debef51eb674e2dd86d8.patch";
       hash = "sha256-/ovLrFOKb3RQ8TZSviuOV6EYNgz0gtrhVWZLFJBrzFg=";
+    })
+    # https://github.com/aplpy/aplpy/pull/500
+    (fetchpatch {
+      url = "https://github.com/aplpy/aplpy/commit/c9049261b3724821f4d309d85fe73cabcc04d890.patch";
+      hash = "sha256-ivdXLh1Z+WG3EL5u1wO+lqz6X1AP6WpyoZix5YiqW0w=";
+    })
+    # https://github.com/aplpy/aplpy/pull/503
+    (fetchpatch {
+      url = "https://github.com/aplpy/aplpy/commit/edc2aa9770b72bd3ac42db95a6e027b276be9c31.patch";
+      hash = "sha256-QUZenY3XQ/T2tl5apxZUqjf4ACjOzJWb+1AUp5limi4=";
     })
   ];
 
@@ -81,9 +91,5 @@ buildPythonPackage rec {
     homepage = "http://aplpy.github.io";
     license = licenses.mit;
     maintainers = with maintainers; [ smaret ];
-    # Tests fail due to expired matplotlib deprecations:
-    #
-    # > (`matplotlib.cm' has no attribute 'get_cmap'`)
-    broken = true;
   };
 }


### PR DESCRIPTION
## Description of changes

Fixes #328622

Add patch to fix build with `python3Packages.matplotlib` 3.9 from upstream PR:
https://github.com/aplpy/aplpy/pull/500

Add patch to fix build with `python3Packages.astropy` 6.1 from upstream PR:
https://github.com/aplpy/aplpy/pull/503

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
