### PR TITLE
datalad-gooey:  init at unstable-2024-02-20 

### DIFF
--- a/pkgs/by-name/da/datalad-gooey/package.nix
+++ b/pkgs/by-name/da/datalad-gooey/package.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  datalad,
   git,
   python3,
   fetchFromGitHub,

--- a/pkgs/by-name/da/datalad-gooey/package.nix
+++ b/pkgs/by-name/da/datalad-gooey/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  datalad,
+  git,
+  python3,
+  fetchFromGitHub,
+  fetchpatch,
+  darwin,
+  stdenv,
+  git-annex,
+}:
+
+python3.pkgs.buildPythonApplication {
+  pname = "datalad-gooey";
+  # many bug fixes on `master` but no new release
+  version = "unstable-2024-02-20";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "datalad";
+    repo = "datalad-gooey";
+    rev = "5bd6b9257ff1569439d2a77663271f5d665e61b6";
+    hash = "sha256-8779SLcV4wwJ3124lteGzvimDxgijyxa818ZrumPMs4=";
+  };
+
+  build-system = with python3.pkgs; [ setuptools ];
+
+  dependencies = with python3.pkgs; [
+    pyside6
+    pyqtdarktheme
+    datalad-next
+    outdated
+    datalad
+  ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.AppleScriptKit ];
+
+  pythonRemoveDeps = [ "applescript" ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  nativeCheckInputs = [
+    python3.pkgs.pytestCheckHook
+    python3.pkgs.pytest-qt
+    git
+    git-annex
+  ];
+
+  pythonImportsCheck = [ "datalad_gooey" ];
+
+  meta = {
+    description = "Graphical user interface (GUI) for DataLad";
+    homepage = "https://github.com/datalad/datalad-gooey";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gador ];
+    mainProgram = "datalad-gooey";
+  };
+}

--- a/pkgs/development/python-modules/datalad-gooey/default.nix
+++ b/pkgs/development/python-modules/datalad-gooey/default.nix
@@ -1,15 +1,22 @@
 {
+  buildPythonPackage,
   lib,
   git,
-  python3,
   fetchFromGitHub,
-  fetchpatch,
   darwin,
+  setuptools,
   stdenv,
   git-annex,
+  pyside6,
+  pyqtdarktheme,
+  datalad-next,
+  outdated,
+  datalad,
+  pytestCheckHook,
+  pytest-qt,
 }:
 
-python3.pkgs.buildPythonApplication {
+buildPythonPackage {
   pname = "datalad-gooey";
   # many bug fixes on `master` but no new release
   version = "unstable-2024-02-20";
@@ -22,9 +29,9 @@ python3.pkgs.buildPythonApplication {
     hash = "sha256-8779SLcV4wwJ3124lteGzvimDxgijyxa818ZrumPMs4=";
   };
 
-  build-system = with python3.pkgs; [ setuptools ];
+  build-system = [ setuptools ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = [
     pyside6
     pyqtdarktheme
     datalad-next
@@ -39,8 +46,8 @@ python3.pkgs.buildPythonApplication {
   '';
 
   nativeCheckInputs = [
-    python3.pkgs.pytestCheckHook
-    python3.pkgs.pytest-qt
+    pytestCheckHook
+    pytest-qt
     git
     git-annex
   ];

--- a/pkgs/development/python-modules/datalad-next/default.nix
+++ b/pkgs/development/python-modules/datalad-next/default.nix
@@ -14,6 +14,7 @@
   setuptools,
   openssh,
   unzip,
+  versioneer,
   webdavclient3,
 }:
 
@@ -29,9 +30,17 @@ buildPythonPackage rec {
     hash = "sha256-fqP6nG2ncDRg48kvlsmPjNBOzfQp9+7wTcGvsYVrRzA=";
   };
 
+  postPatch = ''
+    # Remove vendorized versioneer.py
+    rm versioneer.py
+  '';
+
   nativeBuildInputs = [ git ];
 
-  build-system = [ setuptools ];
+  build-system = [
+    setuptools
+    versioneer
+  ];
 
   dependencies = [
     annexremote

--- a/pkgs/development/python-modules/datalad-next/default.nix
+++ b/pkgs/development/python-modules/datalad-next/default.nix
@@ -1,0 +1,106 @@
+{
+  annexremote,
+  buildPythonPackage,
+  datalad,
+  datasalad,
+  fetchFromGitHub,
+  git,
+  git-annex,
+  humanize,
+  lib,
+  more-itertools,
+  psutil,
+  pytestCheckHook,
+  setuptools,
+  openssh,
+  unzip,
+  webdavclient3,
+}:
+
+buildPythonPackage rec {
+  pname = "datalad-next";
+  version = "1.5.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "datalad";
+    repo = "datalad-next";
+    rev = "refs/tags/${version}";
+    hash = "sha256-fqP6nG2ncDRg48kvlsmPjNBOzfQp9+7wTcGvsYVrRzA=";
+  };
+
+  nativeBuildInputs = [ git ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    annexremote
+    datasalad
+    datalad
+    humanize
+    more-itertools
+  ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    webdavclient3
+    psutil
+    git-annex
+    datalad
+    openssh
+    unzip
+  ];
+
+  disabledTests = [
+    # remotes available after datalad-next install (through `console_scripts`), but not yet in $PATH during test
+    "test_uncurl_addurl_unredirected"
+    "test_uncurl"
+    "test_uncurl_ria_access"
+    "test_uncurl_store"
+    "test_uncurl_remove"
+    "test_uncurl_testremote"
+    "test_replace_add_archive_content"
+    "test_annex_remote"
+    "test_export_remote"
+    "test_annex_remote_autorepush"
+    "test_export_remote_autorepush"
+    "test_typeweb_annex"
+    "test_typeweb_annex_uncompressed"
+    "test_typeweb_export"
+    "test_submodule_url"
+    "test_uncurl_progress_reporting_to_annex"
+    "test_archivist_retrieval"
+    "test_archivist_retrieval_legacy"
+
+    # hardcoded /bin path
+    "test_auto_if_wanted_data_transfer_path_restriction"
+
+    # requires internet access
+    "test_push_wanted"
+    "test_auto_data_transfer"
+    "test_http_url_operations"
+    "test_transparent_decompression"
+    "test_compressed_file_stay_compressed"
+    "test_ls_file_collection_tarfile"
+    "test_iter_tar"
+  ];
+
+  disabledTestPaths = [
+    # requires internet access
+    "datalad_next/commands/tests/test_download.py"
+    "datalad_next/archive_operations/tests/test_tarfile.py"
+  ];
+  pythonImportsCheck = [ "datalad_next" ];
+
+  meta = {
+    description = "DataLad extension with a staging area for additional functionality, or for improved performance and user experience";
+    changelog = "https://github.com/datalad/datalad-next/blob/main/CHANGELOG.md";
+    homepage = "https://github.com/datalad/datalad-next";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gador ];
+  };
+}

--- a/pkgs/development/python-modules/datalad/default.nix
+++ b/pkgs/development/python-modules/datalad/default.nix
@@ -1,17 +1,55 @@
 {
+  buildPythonPackage,
   lib,
+  setuptools,
   stdenv,
   fetchFromGitHub,
   installShellFiles,
-  python3,
   git,
+  coreutils,
+  # core
+  platformdirs,
+  chardet,
+  iso8601,
+  humanize,
+  fasteners,
+  packaging,
+  patool,
+  tqdm,
+  annexremote,
+  looseversion,
   git-annex,
+  # downloaders
+  boto3,
+  keyrings-alt,
+  keyring,
+  msgpack,
+  requests,
+  # publish
+  python-gitlab,
+  # misc
+  argcomplete,
+  pyperclip,
+  python-dateutil,
+  # duecredit
+  duecredit,
+  # python>=3.8
+  distro,
+  # win
+  colorama,
+  # python-version-dependent
+  pythonOlder,
+  importlib-resources,
+  importlib-metadata,
+  typing-extensions,
+  # tests
+  pytestCheckHook,
   p7zip,
   curl,
-  coreutils,
+  httpretty,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+buildPythonPackage rec {
   pname = "datalad";
   version = "1.1.1";
 
@@ -32,10 +70,9 @@ python3.pkgs.buildPythonApplication rec {
     git
   ];
 
-  build-system = [ python3.pkgs.setuptools ];
+  build-system = [ setuptools ];
 
   dependencies =
-    with python3.pkgs;
     [
       # core
       platformdirs
@@ -68,15 +105,17 @@ python3.pkgs.buildPythonApplication rec {
       argcomplete
       pyperclip
       python-dateutil
+
       # duecredit
       duecredit
+
       # python>=3.8
       distro
     ]
     ++ lib.optionals stdenv.hostPlatform.isWindows [ colorama ]
-    ++ lib.optionals (python3.pythonOlder "3.9") [ importlib-resources ]
-    ++ lib.optionals (python3.pythonOlder "3.10") [ importlib-metadata ]
-    ++ lib.optionals (python3.pythonOlder "3.11") [ typing_extensions ];
+    ++ lib.optionals (pythonOlder "3.9") [ importlib-resources ]
+    ++ lib.optionals (pythonOlder "3.10") [ importlib-metadata ]
+    ++ lib.optionals (pythonOlder "3.11") [ typing-extensions ];
 
   postInstall = ''
     installShellCompletion --cmd datalad \
@@ -180,10 +219,10 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeCheckInputs = [
     p7zip
-    python3.pkgs.pytestCheckHook
+    pytestCheckHook
     git-annex
     curl
-    python3.pkgs.httpretty
+    httpretty
   ];
 
   pythonImportsCheck = [ "datalad" ];

--- a/pkgs/development/python-modules/datalad/default.nix
+++ b/pkgs/development/python-modules/datalad/default.nix
@@ -7,6 +7,7 @@
   installShellFiles,
   git,
   coreutils,
+  versioneer,
   # core
   platformdirs,
   chardet,
@@ -63,6 +64,8 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace datalad/distribution/create_sibling.py \
       --replace-fail "/bin/ls" "${coreutils}/bin/ls"
+    # Remove vendorized versioneer.py
+    rm versioneer.py
   '';
 
   nativeBuildInputs = [
@@ -70,7 +73,10 @@ buildPythonPackage rec {
     git
   ];
 
-  build-system = [ setuptools ];
+  build-system = [
+    setuptools
+    versioneer
+  ];
 
   dependencies =
     [

--- a/pkgs/development/python-modules/datasalad/default.nix
+++ b/pkgs/development/python-modules/datasalad/default.nix
@@ -1,0 +1,46 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  hatch-vcs,
+  lib,
+  more-itertools,
+  psutil,
+  pytestCheckHook,
+  unzip,
+}:
+
+buildPythonPackage rec {
+  pname = "datasalad";
+  version = "0.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "datalad";
+    repo = "datasalad";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-qgHWTokNBzJcBbEPCA/YfklzqyX1lM2yro7ElqBfrig=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    more-itertools
+    psutil
+    unzip
+  ];
+
+  pythonImportsCheck = [ "datasalad" ];
+
+  meta = {
+    description = "Pure-Python library with a collection of utilities for working with Git and git-annex";
+    changelog = "https://github.com/datalad/datasalad/blob/main/CHANGELOG.md";
+    homepage = "https://github.com/datalad/datasalad";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gador ];
+  };
+}

--- a/pkgs/development/python-modules/outdated/default.nix
+++ b/pkgs/development/python-modules/outdated/default.nix
@@ -1,0 +1,40 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  littleutils,
+  requests,
+  setuptools-scm,
+}:
+
+buildPythonPackage rec {
+  pname = "outdated";
+  version = "0.2.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "alexmojaki";
+    repo = "outdated";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-5VpPmgIcVtY97F0Hb0m9MuSW0zjaUJ18ATA4GBRw+jc=";
+  };
+
+  build-system = [ setuptools-scm ];
+
+  dependencies = [
+    littleutils
+    requests
+  ];
+
+  # checks rely on internet connection
+  doCheck = false;
+
+  pythonImportsCheck = [ "outdated" ];
+
+  meta = {
+    description = "Mini-library which, given a package name and a version, checks if it's the latest version available on PyPI";
+    homepage = "https://github.com/alexmojaki/outdated";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gador ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2185,6 +2185,8 @@ with pkgs;
 
   datalad = with python3Packages; toPythonApplication datalad;
 
+  datalad-gooey = with python3Packages; toPythonApplication datalad-gooey;
+
   darcs-to-git = callPackage ../applications/version-management/darcs-to-git { };
 
   degit = callPackage ../applications/version-management/degit { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2183,7 +2183,7 @@ with pkgs;
 
   conform = callPackage ../applications/version-management/conform { };
 
-  datalad = callPackage ../applications/version-management/datalad { };
+  datalad = with python3Packages; toPythonApplication datalad;
 
   darcs-to-git = callPackage ../applications/version-management/darcs-to-git { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2837,6 +2837,8 @@ self: super: with self; {
 
   datalad = callPackage ../development/python-modules/datalad { };
 
+  datalad-gooey = callPackage ../development/python-modules/datalad-gooey { };
+
   datalad-next = callPackage ../development/python-modules/datalad-next { };
 
   datamodeldict = callPackage ../development/python-modules/datamodeldict { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9629,6 +9629,8 @@ self: super: with self; {
 
   outcome = callPackage ../development/python-modules/outcome { };
 
+  outdated = callPackage ../development/python-modules/outdated { };
+
   outspin = callPackage ../development/python-modules/outspin { };
 
   ovh = callPackage ../development/python-modules/ovh { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2843,6 +2843,8 @@ self: super: with self; {
 
   dataproperty = callPackage ../development/python-modules/dataproperty { };
 
+  datasalad = callPackage ../development/python-modules/datasalad { };
+
   dataset = callPackage ../development/python-modules/dataset { };
 
   datasets = callPackage ../development/python-modules/datasets { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2835,6 +2835,8 @@ self: super: with self; {
     inherit (pkgs.darwin.apple_sdk.frameworks) Security SystemConfiguration;
   };
 
+  datalad = callPackage ../development/python-modules/datalad { };
+
   datalad-next = callPackage ../development/python-modules/datalad-next { };
 
   datamodeldict = callPackage ../development/python-modules/datamodeldict { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2835,6 +2835,8 @@ self: super: with self; {
     inherit (pkgs.darwin.apple_sdk.frameworks) Security SystemConfiguration;
   };
 
+  datalad-next = callPackage ../development/python-modules/datalad-next { };
+
   datamodeldict = callPackage ../development/python-modules/datamodeldict { };
 
   datapoint = callPackage ../development/python-modules/datapoint { };


### PR DESCRIPTION
## Description of changes

This adds the GUI component `datalad-gooey` for `datalad`.

Due to dependencies, this PR also includes:

-  python312Packages.outdated: init at 0.2.2 [homepage](https://github.com/alexmojaki/outdated)
-  python312Packages.datasalad: init at 0.2.1  collection of utilities for datalad [homepage](https://github.com/datalad/datasalad)
-  datalad: 1.0.2 -> 1.1.1 (fix build, see also #329398)
-  python312Packages.datalad-next: init at 1.5.0 Datalad extension [homepage](https://github.com/datalad/datalad-next)

Note: For `datalad-gooey` to work under darwin, #329238 needs to be merged first (introduction of `QtUiTools` in `Pyside6`).

Ping @gebner @renesat

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
