### PR TITLE
python312Packages.pdfminer-six: 20231228 -> 20240706

### DIFF
--- a/pkgs/development/python-modules/commoncode/default.nix
+++ b/pkgs/development/python-modules/commoncode/default.nix
@@ -6,9 +6,9 @@
   buildPythonPackage,
   click,
   fetchFromGitHub,
+  fetchpatch2,
   pytest-xdist,
   pytestCheckHook,
-  pythonAtLeast,
   pythonOlder,
   requests,
   saneyaml,
@@ -19,7 +19,7 @@
 buildPythonPackage rec {
   pname = "commoncode";
   version = "31.2.1";
-  format = "pyproject";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -30,11 +30,19 @@ buildPythonPackage rec {
     hash = "sha256-4ZgyNlMj1i1fRru4wgDOyP3qzbne8D2eH/tFI60kgrE=";
   };
 
+  patches = [
+    # https://github.com/nexB/commoncode/pull/66
+    (fetchpatch2 {
+      url = "https://github.com/nexB/commoncode/commit/4f87b3c9272dcf209b9c4b997e98b58e0edaf570.patch";
+      hash = "sha256-loUtAww+SK7kMt5uqZmLQ8Wg/OqB7LWVA4BiztnwHsA=";
+    })
+  ];
+
   dontConfigure = true;
 
-  nativeBuildInputs = [ setuptools-scm ];
+  build-system = [ setuptools-scm ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     attrs
     beautifulsoup4
     click
@@ -47,11 +55,6 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-xdist
   ];
-
-  preCheck = ''
-    # prevent readout of /etc/os-release during tests
-    sed -i "s/is_on_ubuntu_22()/lambda _: False/" src/commoncode/system.py
-  '';
 
   disabledTests =
     [
@@ -68,11 +71,6 @@ buildPythonPackage rec {
       # CI environment on darwin
       "test_searchable_paths"
     ];
-
-  disabledTestPaths = lib.optionals (pythonAtLeast "3.10") [
-    # https://github.com/nexB/commoncode/issues/36
-    "src/commoncode/fetch.py"
-  ];
 
   pythonImportsCheck = [ "commoncode" ];
 

--- a/pkgs/development/python-modules/debian-inspector/default.nix
+++ b/pkgs/development/python-modules/debian-inspector/default.nix
@@ -13,9 +13,9 @@
 buildPythonPackage rec {
   pname = "debian-inspector";
   version = "31.1.0";
-  format = "setuptools";
+  pyproject = true;
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     pname = "debian_inspector";
@@ -25,15 +25,17 @@ buildPythonPackage rec {
 
   dontConfigure = true;
 
-  nativeBuildInputs = [ setuptools-scm ];
+  build-system = [ setuptools-scm ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     chardet
     attrs
-    commoncode
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    commoncode
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "debian_inspector" ];
 

--- a/pkgs/development/python-modules/pdfminer-six/default.nix
+++ b/pkgs/development/python-modules/pdfminer-six/default.nix
@@ -2,12 +2,9 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  importlib-metadata,
-  isPy3k,
   cryptography,
   charset-normalizer,
   pythonOlder,
-  typing-extensions,
   pytestCheckHook,
   setuptools,
   substituteAll,
@@ -16,16 +13,16 @@
 
 buildPythonPackage rec {
   pname = "pdfminer-six";
-  version = "20231228";
+  version = "20240706";
   pyproject = true;
 
-  disabled = !isPy3k;
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "pdfminer";
     repo = "pdfminer.six";
-    rev = version;
-    hash = "sha256-LXPECQQojD3IY9zRkrDBufy4A8XUuYiRpryqUx/I3qo=";
+    rev = "refs/tags/${version}";
+    hash = "sha256-aY7GQADRxeiclr6/G3RRgrPcl8rGiC85JYEIjIa+vG0=";
   };
 
   patches = [
@@ -35,17 +32,12 @@ buildPythonPackage rec {
     })
   ];
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs =
-    [
-      charset-normalizer
-      cryptography
-    ]
-    ++ lib.optionals (pythonOlder "3.8") [
-      importlib-metadata
-      typing-extensions
-    ];
+  dependencies = [
+    charset-normalizer
+    cryptography
+  ];
 
   postInstall = ''
     for file in $out/bin/*.py; do
@@ -67,6 +59,7 @@ buildPythonPackage rec {
   };
 
   meta = with lib; {
+    changelog = "https://github.com/pdfminer/pdfminer.six/blob/${src.rev}/CHANGELOG.md";
     description = "PDF parser and analyzer";
     homepage = "https://github.com/pdfminer/pdfminer.six";
     license = licenses.mit;

--- a/pkgs/development/python-modules/pdfminer-six/disable-setuptools-git-versioning.patch
+++ b/pkgs/development/python-modules/pdfminer-six/disable-setuptools-git-versioning.patch
@@ -1,13 +1,15 @@
+diff --git a/setup.py b/setup.py
+index 42764e2..e7b93d3 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -7,10 +7,7 @@
+@@ -19,10 +19,7 @@ if sys.version_info < (3, 12):
  
  setup(
      name="pdfminer.six",
 -    setuptools_git_versioning={
 -        "enabled": True,
 -    },
--    setup_requires=["setuptools-git-versioning<2"],
+-    setup_requires=["setuptools-git-versioning<3"],
 +    version="@version@",
      packages=["pdfminer"],
      package_data={"pdfminer": ["cmap/*.pickle.gz", "py.typed"]},


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/pdfminer/pdfminer.six/compare/20231228...20240706

Changelog: https://github.com/pdfminer/pdfminer.six/blob/20240706/CHANGELOG.md



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
