### PR TITLE
nixos/system.autoUpgrade: escape `system.autoUpgrade.flags`

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -234,6 +234,8 @@
 - The `services.mxisd` module has been removed as both [mxisd](https://github.com/kamax-matrix/mxisd) and [ma1sd](https://github.com/ma1uta/ma1sd) are not maintained any longer.
   Consequently the package `pkgs.ma1sd` has also been removed.
 
+- `system.autoUpgrade.flags` is now trated as a list of separate CLI arguments that are individually escaped, instead of being concatenated with spaces.
+
 ## Other Notable Changes {#sec-release-24.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/tasks/auto-upgrade.nix
+++ b/nixos/modules/tasks/auto-upgrade.nix
@@ -181,7 +181,7 @@ in {
           "nixpkgs=${cfg.channel}/nixexprs.tar.xz"
         ]
       else
-        [ "--flake ${cfg.flake}" ]);
+        [ "--flake" "${cfg.flake}" ]);
 
     systemd.services.nixos-upgrade = {
       description = "NixOS Upgrade";
@@ -213,7 +213,7 @@ in {
         shutdown = "${config.systemd.package}/bin/shutdown";
         upgradeFlag = optional (cfg.channel == null) "--upgrade";
       in if cfg.allowReboot then ''
-        ${nixos-rebuild} boot ${toString (cfg.flags ++ upgradeFlag)}
+        ${nixos-rebuild} boot ${escapeShellArgs (cfg.flags ++ upgradeFlag)}
         booted="$(${readlink} /run/booted-system/{initrd,kernel,kernel-modules})"
         built="$(${readlink} /nix/var/nix/profiles/system/{initrd,kernel,kernel-modules})"
 
@@ -243,7 +243,7 @@ in {
         ''}
 
         if [ "''${booted}" = "''${built}" ]; then
-          ${nixos-rebuild} ${cfg.operation} ${toString cfg.flags}
+          ${nixos-rebuild} ${cfg.operation} ${escapeShellArgs cfg.flags}
         ${optionalString (cfg.rebootWindow != null) ''
           elif [ "''${do_reboot}" != true ]; then
             echo "Outside of configured reboot window, skipping."
@@ -252,7 +252,7 @@ in {
           ${shutdown} -r +1
         fi
       '' else ''
-        ${nixos-rebuild} ${cfg.operation} ${toString (cfg.flags ++ upgradeFlag)}
+        ${nixos-rebuild} ${cfg.operation} ${escapeShellArgs (cfg.flags ++ upgradeFlag)}
       '';
 
       startAt = cfg.dates;


### PR DESCRIPTION
`system.autoUpgrade.flags` is a list of separate CLI arguments. It should be escaped and internally used as such.

I made the changes in `auto-upgrade.nix`, realized it broke my own upgrade-hackery, then added the changelog entry, reduced my hackery, and it works.

So, this will break dubious usage of those flags, but I believe that the expected thing is that the flags are escaped properly.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
