### PR TITLE
streamLayeredImage: add dynamic tagging of docker image

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -1111,6 +1111,8 @@ rec {
             preferLocalBuild = true;
             passthru = passthru // {
               inherit (conf) imageTag;
+              inherit conf;
+              inherit streamScript;
 
               # Distinguish tarballs and exes at the Nix level so functions that
               # take images can know in advance how the image is supposed to be used.

--- a/pkgs/build-support/docker/stream_layered_image.py
+++ b/pkgs/build-support/docker/stream_layered_image.py
@@ -32,7 +32,6 @@ function does all this.
 [2]: https://github.com/moby/moby/blob/4fb59c20a4fb54f944fe170d0ff1d00eb4a24d6f/image/spec/v1.2.md#image-json-field-descriptions
 """  # noqa: E501
 
-
 import argparse
 import io
 import os
@@ -226,16 +225,13 @@ def add_layer_dir(tar, paths, store_dir, mtime, uid, gid, uname, gname):
     """
 
     invalid_paths = [i for i in paths if not i.startswith(store_dir)]
-    assert len(invalid_paths) == 0, \
-        f"Expecting absolute paths from {store_dir}, but got: {invalid_paths}"
+    assert (
+        len(invalid_paths) == 0
+    ), f"Expecting absolute paths from {store_dir}, but got: {invalid_paths}"
 
     # First, calculate the tarball checksum and the size.
     extract_checksum = ExtractChecksum()
-    archive_paths_to(
-        extract_checksum,
-        paths,
-        mtime, uid, gid, uname, gname
-    )
+    archive_paths_to(extract_checksum, paths, mtime, uid, gid, uname, gname)
     (checksum, size) = extract_checksum.extract()
 
     path = f"{checksum}/layer.tar"
@@ -246,12 +242,9 @@ def add_layer_dir(tar, paths, store_dir, mtime, uid, gid, uname, gname):
     # Then actually stream the contents to the outer tarball.
     read_fd, write_fd = os.pipe()
     with open(read_fd, "rb") as read, open(write_fd, "wb") as write:
+
         def producer():
-            archive_paths_to(
-                write,
-                paths,
-                mtime, uid, gid, uname, gname
-            )
+            archive_paths_to(write, paths, mtime, uid, gid, uname, gname)
             write.close()
 
         # Closing the write end of the fifo also closes the read end,
@@ -293,10 +286,7 @@ def add_customisation_layer(target_tar, customisation_layer, mtime):
         target_tar.addfile(tarinfo, f)
 
     return LayerInfo(
-      size=None,
-      checksum=checksum,
-      path=path,
-      paths=[customisation_layer]
+        size=None, checksum=checksum, path=path, paths=[customisation_layer]
     )
 
 
@@ -318,7 +308,8 @@ def add_bytes(tar, path, content, mtime):
 
 
 def main():
-    arg_parser = argparse.ArgumentParser(description="""
+    arg_parser = argparse.ArgumentParser(
+        description="""
 This script generates a Docker image from a set of store paths. Uses
 Docker Image Specification v1.2 as reference [1].
 
@@ -343,7 +334,7 @@ Docker Image Specification v1.2 as reference [1].
     """,
     )
     arg_parser.add_argument(
-        '--tag', '-t', type=str, help="Override the tag from the configuration"
+        "--tag", "-t", type=str, help="Override the tag from the configuration"
     )
 
     args = arg_parser.parse_args()
@@ -351,9 +342,9 @@ Docker Image Specification v1.2 as reference [1].
         conf = json.load(f)
 
     created = (
-      datetime.now(tz=timezone.utc)
-      if conf["created"] == "now"
-      else datetime.fromisoformat(conf["created"])
+        datetime.now(tz=timezone.utc)
+        if conf["created"] == "now"
+        else datetime.fromisoformat(conf["created"])
     )
     mtime = int(created.timestamp())
     uid = int(conf["uid"])
@@ -370,20 +361,28 @@ Docker Image Specification v1.2 as reference [1].
 
         start = len(layers) + 1
         for num, store_layer in enumerate(conf["store_layers"], start=start):
-            print("Creating layer", num, "from paths:", store_layer,
-                  file=sys.stderr)
-            info = add_layer_dir(tar, store_layer, store_dir,
-                                 mtime, uid, gid, uname, gname)
+            print(
+                "Creating layer",
+                num,
+                "from paths:",
+                store_layer,
+                file=sys.stderr,
+            )
+            info = add_layer_dir(
+                tar, store_layer, store_dir, mtime, uid, gid, uname, gname
+            )
             layers.append(info)
 
-        print("Creating layer", len(layers) + 1, "with customisation...",
-              file=sys.stderr)
+        print(
+            "Creating layer",
+            len(layers) + 1,
+            "with customisation...",
+            file=sys.stderr,
+        )
         layers.append(
-          add_customisation_layer(
-            tar,
-            conf["customisation_layer"],
-            mtime=mtime
-          )
+            add_customisation_layer(
+                tar, conf["customisation_layer"], mtime=mtime
+            )
         )
 
         print("Adding manifests...", file=sys.stderr)
@@ -399,8 +398,8 @@ Docker Image Specification v1.2 as reference [1].
             },
             "history": [
                 {
-                  "created": datetime.isoformat(created),
-                  "comment": f"store paths: {layer.paths}"
+                    "created": datetime.isoformat(created),
+                    "comment": f"store paths: {layer.paths}",
                 }
                 for layer in layers
             ],

--- a/pkgs/build-support/docker/stream_layered_image.py
+++ b/pkgs/build-support/docker/stream_layered_image.py
@@ -334,7 +334,8 @@ Docker Image Specification v1.2 as reference [1].
     """,
     )
     arg_parser.add_argument(
-        "--tag", "-t", type=str, help="Override the tag from the configuration"
+        "--repo_tag", "-t", type=str,
+        help="Override the RepoTags from the configuration"
     )
 
     args = arg_parser.parse_args()
@@ -413,7 +414,7 @@ Docker Image Specification v1.2 as reference [1].
         manifest_json = [
             {
                 "Config": image_json_path,
-                "RepoTags": [args.tag or conf["repo_tag"]],
+                "RepoTags": [args.repo_tag or conf["repo_tag"]],
                 "Layers": [layer.path for layer in layers],
             }
         ]


### PR DESCRIPTION
'podman load' doesn't let me override the name/tag from the image. This name and tag is dynamic and in a CI environment so I would like to be able to adjust the tag dynamically.
Since the image is streamed by stream_layered_image.py, there is no need to stick with the nix-hardcoded image name/tag: the python script can accept another name

I've added argparse to expose the feature. It has the added benefit of adding `--help` support to the script, which makes its usage self-explanatory.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
