### PR TITLE
[staging-next] avoid borg evaluation warning "cargoSha256 is deprecated"

### DIFF
--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -563,7 +563,7 @@
         pname = "cord.nvim-rust";
         inherit version src;
 
-        cargoSha256 = "sha256-6FYf4pHEPxvhKHHPmkjQ40zPxaiypnpDxF8kNH+h+tg=";
+        cargoHash = "sha256-6FYf4pHEPxvhKHHPmkjQ40zPxaiypnpDxF8kNH+h+tg=";
 
         installPhase = let
           cargoTarget = stdenv.hostPlatform.rust.cargoShortTarget;

--- a/pkgs/by-name/te/termsnap/package.nix
+++ b/pkgs/by-name/te/termsnap/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-FTgbbiDlHXGjkv3a2TAxjAqdClWkuteyUrtjQ8fMSIs=";
   };
 
-  cargoSha256 = "sha256-hXlRkqcMHFEAnm883Q8sR8gcEbSNMutoJQsMW2M5wOY=";
+  cargoHash = "sha256-hXlRkqcMHFEAnm883Q8sR8gcEbSNMutoJQsMW2M5wOY=";
 
   meta = with lib; {
     description = "Create SVGs from terminal output";


### PR DESCRIPTION
## Description of changes

Borg currently fails with this error on staging-next (https://github.com/NixOS/nixpkgs/pull/328673):

https://gist.github.com/GrahamcOfBorg/ce67b0d241bb104ef30d11a8a6a58bf0
```
nix-env did not evaluate cleanly:
 ["trace: evaluation warning: cargoSha256 is deprecated. Please use cargoHash with SRI hash instead",
"trace: evaluation warning: cargoSha256 is deprecated. Please use cargoHash with SRI hash instead",
"trace: evaluation warning: cargoSha256 is deprecated. Please use cargoHash with SRI hash instead",
"trace: evaluation warning: cargoSha256 is deprecated. Please use cargoHash with SRI hash instead",
"trace: evaluation warning: cargoSha256 is deprecated. Please use cargoHash with SRI hash instead",
"trace: evaluation warning: cargoSha256 is deprecated. Please use cargoHash with SRI hash instead",
"trace: evaluation warning: cargoSha256 is deprecated. Please use cargoHash with SRI hash instead",
"trace: evaluation warning: cargoSha256 is deprecated. Please use cargoHash with SRI hash instead"]
```

These were the only two occurrences I found, let's see if there's others hiding.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
