### PR TITLE
Partially revert "build(deps): bump cachix/install-nix-action from 26 to 27"

### DIFF
--- a/.github/workflows/check-by-name.yml
+++ b/.github/workflows/check-by-name.yml
@@ -94,7 +94,7 @@ jobs:
           base=$(mktemp -d)
           git worktree add "$base" "$(git rev-parse HEAD^1)"
           echo "base=$base" >> "$GITHUB_ENV"
-      - uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
+      - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
         if: env.mergedSha
       - name: Fetching the pinned tool
         if: env.mergedSha


### PR DESCRIPTION
## Description of changes

This partially reverts https://github.com/NixOS/nixpkgs/pull/313109 because it's causing failures on master: https://github.com/NixOS/nixpkgs/actions/runs/10061768002/job/27812623186?pr=329433

```
I/O error:  Failed to get the definition info for attribute acl: In /home/runner/work/nixpkgs/nixpkgs/pkgs/stdenv/linux/default.nix, attribute parent node is not an attribute path node: NODE_INHERIT@28432..28603
```

The reason is because the pkgs/by-name check doesn't work for newer Nix versions yet, see https://github.com/NixOS/nixpkgs-check-by-name/issues/78

It's not enough to look at CI when updating GitHub workflows that trigger on `pull_request_target`, because they use the workflow file from the base branch, not the PR branch. Ping @Artturin @mweinelt 

- [x] Tested that this makes it work: https://github.com/infinisil/nixpkgs/pull/2

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
