### PR TITLE
linuxPackages.nvidiaPackages.beta: 555.52.04 -> 560.28.03

### DIFF
--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -253,7 +253,9 @@ in
 
       open = lib.mkEnableOption ''
         the open source NVIDIA kernel module
-      '';
+      '' // {
+        defaultText = lib.literalExpression ''lib.versionAtLeast config.hardware.nvidia.package.version "560"'';
+      };
     };
   };
 
@@ -302,6 +304,8 @@ in
             extraPackages32 = [ nvidia_x11.lib32 ];
           };
           environment.systemPackages = [ nvidia_x11.bin ];
+
+          hardware.nvidia.open = lib.mkDefault (lib.versionAtLeast nvidia_x11.version "560");
         })
 
         # X11

--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -112,16 +112,17 @@ installPhase() {
 
         # EGL
         if [ "$useGLVND" = "1" ]; then
-            sed -E "s#(libEGL_nvidia)#$i/lib/\\1#" 10_nvidia.json > 10_nvidia.json.fixed
-            sed -E "s#(libnvidia-egl-wayland)#$i/lib/\\1#" 10_nvidia_wayland.json > 10_nvidia_wayland.json.fixed
+            mkdir -p "$i/share/egl/egl_external_platform.d"
+            for icdname in $(find . -name '*_nvidia*.json')
+            do
+                cat "$icdname" | jq ".ICD.library_path |= \"$i/lib/\(.)\"" | tee "$i/share/egl/egl_external_platform.d/$icdname"
+            done
 
-            install -Dm644 10_nvidia.json.fixed $i/share/glvnd/egl_vendor.d/10_nvidia.json
-            install -Dm644 10_nvidia_wayland.json.fixed $i/share/egl/egl_external_platform.d/10_nvidia_wayland.json
+            # glvnd icd
+            mkdir -p "$i/share/glvnd/egl_vendor.d"
+            mv "$i/share/egl/egl_external_platform.d/10_nvidia.json" "$i/share/glvnd/egl_vendor.d/10_nvidia.json"
 
-            if [[ -f "15_nvidia_gbm.json" ]]; then
-              sed -E "s#(libnvidia-egl-gbm)#$i/lib/\\1#" 15_nvidia_gbm.json > 15_nvidia_gbm.json.fixed
-              install -Dm644 15_nvidia_gbm.json.fixed $i/share/egl/egl_external_platform.d/15_nvidia_gbm.json
-
+            if [[ -f "$i/share/egl/egl_external_platform.d/15_nvidia_gbm.json" ]]; then
               mkdir -p $i/lib/gbm
               ln -s $i/lib/libnvidia-allocator.so $i/lib/gbm/nvidia-drm_gbm.so
             fi

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -51,12 +51,12 @@ rec {
   });
 
   beta = selectHighestVersion latest (generic {
-    version = "555.52.04";
-    sha256_64bit = "sha256-nVOubb7zKulXhux9AruUTVBQwccFFuYGWrU1ZiakRAI=";
-    sha256_aarch64 = "sha256-Kt60kTTO3mli66De2d1CAoE3wr0yUbBe7eqCIrYHcWk=";
-    openSha256 = "sha256-wDimW8/rJlmwr1zQz8+b1uvxxxbOf3Bpk060lfLKuy0=";
-    settingsSha256 = "sha256-PMh5efbSEq7iqEMBr2+VGQYkBG73TGUh6FuDHZhmwHk=";
-    persistencedSha256 = "sha256-KAYIvPjUVilQQcD04h163MHmKcQrn2a8oaXujL2Bxro=";
+    version = "560.28.03";
+    sha256_64bit = "sha256-martv18vngYBJw1IFUCAaYr+uc65KtlHAMdLMdtQJ+Y=";
+    sha256_aarch64 = "sha256-+u0ZolZcZoej4nqPGmZn5qpyynLvu2QSm9Rd3wLdDmM=";
+    openSha256 = "sha256-asGpqOpU0tIO9QqceA8XRn5L27OiBFuI9RZ1NjSVwaM=";
+    settingsSha256 = "sha256-b4nhUMCzZc3VANnNb0rmcEH6H7SK2D5eZIplgPV59c8=";
+    persistencedSha256 = "sha256-MhITuC8tH/IPhCOUm60SrPOldOpitk78mH0rg+egkTE=";
   });
 
   # Vulkan developer beta driver

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -41,6 +41,7 @@
 , nukeReferences
 , which
 , libarchive
+, jq
 , # Whether to build the libraries only (i.e. not the kernel module or
   # nvidia-settings).  Used to support 32-bit binaries on 64-bit
   # Linux.
@@ -175,7 +176,7 @@ let
     libPath = libPathFor pkgs;
     libPath32 = optionalString i686bundled (libPathFor pkgsi686Linux);
 
-    nativeBuildInputs = [ perl nukeReferences which libarchive ]
+    nativeBuildInputs = [ perl nukeReferences which libarchive jq ]
       ++ optionals (!libsOnly) kernel.moduleBuildDependencies;
 
     disallowedReferences = optionals (!libsOnly) [ kernel.dev ];

--- a/pkgs/os-specific/linux/nvidia-x11/settings.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/settings.nix
@@ -9,6 +9,7 @@ nvidia_x11: sha256:
 , jansson
 , gtk2
 , dbus
+, vulkan-headers
 , gtk3
 , libXv
 , libXrandr
@@ -117,7 +118,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkg-config m4 addOpenGLRunpath ]
     ++ lib.optionals withGtk3 [ wrapGAppsHook3 ];
 
-  buildInputs = [ jansson libXv libXrandr libXext libXxf86vm libvdpau nvidia_x11 dbus ]
+  buildInputs = [ jansson libXv libXrandr libXext libXxf86vm libvdpau nvidia_x11 dbus vulkan-headers ]
     ++ lib.optionals (withGtk2 || lib.versionOlder nvidia_x11.settingsVersion "525.53") [ gtk2 ]
     ++ lib.optionals withGtk3 [ gtk3 librsvg ];
 


### PR DESCRIPTION
## Description of changes

- Updated nvidia-installer to select the NVIDIA open GPU kernel modules by default on systems with GPUs that support both the proprietary and open kernel modules.
- Fixed a bug that caused GPU driver installation to fail when the system used alternate implementations of the 'tr' utility, such as from the busybox or toybox projects.
- Fixed a bug that could cause the wrong image format to be used for render pass image clears in Vulkan applications when using a VkImage created with VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT. This could lead to rendering corruption, as described in issues such as:
- https://github.com/doitsujin/dxvk/issues/3961
- Fixed multiple issues that could cause crashes or unexpected behaviors when re-creating an NvFBC capture session.
- Added support for EGL_KHR_platform_x11 and EGL_EXT_platform_xcb on Xwayland.
- Fixed a bug that could cause some displays to appear multiple times in the nvidia-settings display layout configuration page on systems with multiple GPUs.
- Added a PipeWire backend to NvFBC that allows it to work on the Wayland compositors that support screencasting via XDG Desktop Portal. This new interface will be available through an upcoming Capture SDK release.
- Added support for multiple concurrent clients to NvFBC direct capture.
- Added reporting of Vulkan information to nvidia-settings control panel.
- Compiling nvidia-settings from source now requires Vulkan header files to be available.
- Support DRM-KMS explicit synchronization via the IN_FENCE_FD mode setting property.
- Support VRR (Variable Refresh Rate) for Wayland on pre-Volta GPUs.
- Added support for Variable Refresh Rate on notebooks with the open kernel modules.
- Updated glXWaitVideoSyncSGI() to be more efficient. This reduces frame stutter in some KDE configurations with GSP offload.
- Fixed a bug that caused OpenGL triple buffering to behave like double buffering.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
