### PR TITLE
python312Packages.requests: fix ca loading regression in 2.32.3

### DIFF
--- a/pkgs/development/python-modules/requests/ca-load-regression.patch
+++ b/pkgs/development/python-modules/requests/ca-load-regression.patch
@@ -1,0 +1,126 @@
+From 2769cb607d4e696e2fe70802d4246ccc5abd64a8 Mon Sep 17 00:00:00 2001
+From: Nate Prewitt <nate.prewitt@gmail.com>
+Date: Wed, 29 May 2024 12:48:48 -0700
+Subject: [PATCH 1/3] Consider cert settings when using default context
+
+---
+ src/requests/adapters.py | 26 ++++++++++++++++++--------
+ 1 file changed, 18 insertions(+), 8 deletions(-)
+
+diff --git a/src/requests/adapters.py b/src/requests/adapters.py
+index 9a58b16025..991b7e21c9 100644
+--- a/src/requests/adapters.py
++++ b/src/requests/adapters.py
+@@ -87,6 +87,23 @@ def SOCKSProxyManager(*args, **kwargs):
+     _preloaded_ssl_context = None
+ 
+ 
++def _should_use_default_context(
++    verify: "bool | str | None",
++    client_cert: "typing.Tuple[str, str] | str | None",
++    poolmanager_kwargs: typing.Dict[str, typing.Any],
++) -> bool:
++    # Determine if we have and should use our default SSLContext
++    # to optimize performance on standard requests.
++    has_poolmanager_ssl_context = poolmanager_kwargs.get("ssl_context")
++    should_use_default_ssl_context = (
++        verify is True
++        and _preloaded_ssl_context is not None
++        and not has_poolmanager_ssl_context
++        and client_cert is None
++    )
++    return should_use_default_ssl_context
++
++
+ def _urllib3_request_context(
+     request: "PreparedRequest",
+     verify: "bool | str | None",
+@@ -98,19 +115,12 @@ def _urllib3_request_context(
+     parsed_request_url = urlparse(request.url)
+     scheme = parsed_request_url.scheme.lower()
+     port = parsed_request_url.port
+-
+-    # Determine if we have and should use our default SSLContext
+-    # to optimize performance on standard requests.
+     poolmanager_kwargs = getattr(poolmanager, "connection_pool_kw", {})
+-    has_poolmanager_ssl_context = poolmanager_kwargs.get("ssl_context")
+-    should_use_default_ssl_context = (
+-        _preloaded_ssl_context is not None and not has_poolmanager_ssl_context
+-    )
+ 
+     cert_reqs = "CERT_REQUIRED"
+     if verify is False:
+         cert_reqs = "CERT_NONE"
+-    elif verify is True and should_use_default_ssl_context:
++    elif _should_use_default_context(verify, client_cert, poolmanager_kwargs):
+         pool_kwargs["ssl_context"] = _preloaded_ssl_context
+     elif isinstance(verify, str):
+         if not os.path.isdir(verify):
+
+From e341df3efa0323072fab5d16307e2a20295675b9 Mon Sep 17 00:00:00 2001
+From: Nate Prewitt <nate.prewitt@gmail.com>
+Date: Fri, 31 May 2024 11:41:48 -0700
+Subject: [PATCH 2/3] Set default ca_cert bundle if verify is True
+
+---
+ src/requests/adapters.py | 14 +++++++++++---
+ 1 file changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/src/requests/adapters.py b/src/requests/adapters.py
+index 991b7e21c9..ba5a0ec4f0 100644
+--- a/src/requests/adapters.py
++++ b/src/requests/adapters.py
+@@ -118,15 +118,23 @@ def _urllib3_request_context(
+     poolmanager_kwargs = getattr(poolmanager, "connection_pool_kw", {})
+ 
+     cert_reqs = "CERT_REQUIRED"
++    cert_loc = None
+     if verify is False:
+         cert_reqs = "CERT_NONE"
+     elif _should_use_default_context(verify, client_cert, poolmanager_kwargs):
+         pool_kwargs["ssl_context"] = _preloaded_ssl_context
++    elif verify is True:
++        # Set default ca cert location if none provided
++        cert_loc = extract_zipped_paths(DEFAULT_CA_BUNDLE_PATH)
+     elif isinstance(verify, str):
+-        if not os.path.isdir(verify):
+-            pool_kwargs["ca_certs"] = verify
++        cert_loc = verify
++
++    if cert_loc is not None:
++        if not os.path.isdir(cert_loc):
++            pool_kwargs["ca_certs"] = cert_loc
+         else:
+-            pool_kwargs["ca_cert_dir"] = verify
++            pool_kwargs["ca_cert_dir"] = cert_loc
++
+     pool_kwargs["cert_reqs"] = cert_reqs
+     if client_cert is not None:
+         if isinstance(client_cert, tuple) and len(client_cert) == 2:
+
+From da96a92e2eb6dfe7c74704267bcb8f9fd6fb92b0 Mon Sep 17 00:00:00 2001
+From: Nate Prewitt <nate.prewitt@gmail.com>
+Date: Fri, 31 May 2024 12:20:11 -0700
+Subject: [PATCH 3/3] Correct comment to match actual behavior
+
+---
+ src/requests/adapters.py | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/src/requests/adapters.py b/src/requests/adapters.py
+index ba5a0ec4f0..54143f9e6b 100644
+--- a/src/requests/adapters.py
++++ b/src/requests/adapters.py
+@@ -334,10 +334,8 @@ def cert_verify(self, conn, url, verify, cert):
+         if url.lower().startswith("https") and verify:
+             conn.cert_reqs = "CERT_REQUIRED"
+ 
+-            # Only load the CA certificates if 'verify' is a string indicating the CA bundle to use.
+-            # Otherwise, if verify is a boolean, we don't load anything since
+-            # the connection will be using a context with the default certificates already loaded,
+-            # and this avoids a call to the slow load_verify_locations()
++            # Only load the CA certificates if `verify` is a
++            # string indicating the CA bundle to use.
+             if verify is not True:
+                 # `verify` must be a str with a path then
+                 cert_loc = verify

--- a/pkgs/development/python-modules/requests/default.nix
+++ b/pkgs/development/python-modules/requests/default.nix
@@ -30,6 +30,12 @@ buildPythonPackage rec {
     hash = "sha256-VTZUF3NOsYJVWQqf+euX6eHaho1MzWQCOZ6vaK8gp2A=";
   };
 
+  patches = [
+    # https://github.com/psf/requests/issues/6730
+    # https://github.com/psf/requests/pull/6731
+    ./ca-load-regression.patch
+  ];
+
   dependencies = [
     brotlicffi
     certifi


### PR DESCRIPTION
Requests in 2.32.3 caused a regression in the code path that loads the default certificate authorities, breaking downstream consumers like httpie in the process.

The patch series fixing this is currently still a draft, since tests are missing, but it at least fixes the reproducer and httpie.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
