### PR TITLE
komac: 2.2.1 -> 2.5.0 + add HeitorAugustoLN as a maintainer

### DIFF
--- a/pkgs/by-name/ko/komac/package.nix
+++ b/pkgs/by-name/ko/komac/package.nix
@@ -7,15 +7,17 @@
 , darwin
 , testers
 , komac
+, dbus
+, zstd
 }:
 
 let
-  version = "2.2.1";
+  version = "2.5.0";
   src = fetchFromGitHub {
     owner = "russellbanks";
     repo = "Komac";
     rev = "v${version}";
-    hash = "sha256-dPX8/JUQ+vugd+M/jIjBf4/sNbac0FVQ0obhyAAGI84=";
+    hash = "sha256-X+LZ6D7MTt/0k4hLvk7TVKiL174QDdxwPKu01MyREYw=";
   };
 in
 rustPlatform.buildRustPackage {
@@ -23,15 +25,24 @@ rustPlatform.buildRustPackage {
 
   pname = "komac";
 
-  cargoHash = "sha256-CDPN90X3m/9FRLolAVCIcAuajZbB5OAgLcFXq2ICS8g=";
+  cargoHash = "sha256-VBfXD1IF6D1z28dzXfKRz3/Hh2KRxcsYRRDV8e/Akww=";
 
-  nativeBuildInputs = lib.optionals stdenv.isLinux [ pkg-config ];
+  nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = lib.optionals stdenv.isLinux [
+  buildInputs = [
+    dbus
     openssl
+    zstd
   ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
     darwin.apple_sdk.frameworks.SystemConfiguration
   ];
+
+  env = {
+    OPENSSL_NO_VENDOR = true;
+    YRX_REGENERATE_MODULES_RS = "no";
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+  };
 
   passthru.tests.version = testers.testVersion {
     inherit version;

--- a/pkgs/by-name/ko/komac/package.nix
+++ b/pkgs/by-name/ko/komac/package.nix
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage {
     homepage = "https://github.com/russellbanks/Komac";
     changelog = "https://github.com/russellbanks/Komac/releases/tag/${src.rev}";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ kachick ];
+    maintainers = with maintainers; [ kachick HeitorAugustoLN ];
     mainProgram = "komac";
   };
 }


### PR DESCRIPTION
## Description of changes

- Update komac from 2.2.1 to 2.5.0
- Add myself as one of the maintainers of the package
- Add `zstd` to `buildInputs` as it could be need for `reqwest` crate: russellbanks/Komac#578
- Add `OPENSSL_NO_VENDOR = true` to environment variables, as if not it would cause this error:
![openssl error](https://github.com/user-attachments/assets/4ceb9862-57ca-44c4-bcdb-d06852791fb4)
- Add `ZSTD_SYS_USE_PKG_CONFIG = true` to environment variables
- Add `dbus` to `buildInputs`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
