### PR TITLE
nixos/lemurs: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -62,6 +62,8 @@
 
 - [SuiteNumérique Meet](https://github.com/suitenumerique/meet) is an open source alternative to Google Meet and Zoom powered by LiveKit: HD video calls, screen sharing, and chat features. Built with Django and React. Available as [services.lasuite-meet](#opt-services.lasuite-meet.enable).
 
+- [lemurs](https://github.com/coastalwhite/lemurs), a customizable TUI display/login manager. Available at [services.displayManager.lemurs](#opt-services.displayManager.lemurs.enable).
+
 - [paisa](https://github.com/ananthakumaran/paisa), a personal finance tracker and dashboard. Available as [services.paisa](#opt-services.paisa.enable).
 
 ## Backward Incompatibilities {#sec-release-25.11-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -597,6 +597,7 @@
   ./services/display-managers/default.nix
   ./services/display-managers/gdm.nix
   ./services/display-managers/greetd.nix
+  ./services/display-managers/lemurs.nix
   ./services/display-managers/ly.nix
   ./services/display-managers/sddm.nix
   ./services/editors/emacs.nix

--- a/nixos/modules/services/display-managers/default.nix
+++ b/nixos/modules/services/display-managers/default.nix
@@ -257,7 +257,12 @@ in
         dmConf = config.services.xserver.displayManager;
         noDmUsed =
           !(
-            cfg.gdm.enable || cfg.sddm.enable || dmConf.xpra.enable || dmConf.lightdm.enable || cfg.ly.enable
+            cfg.gdm.enable
+            || cfg.sddm.enable
+            || dmConf.xpra.enable
+            || dmConf.lightdm.enable
+            || cfg.ly.enable
+            || cfg.lemurs.enable
           );
       in
       lib.mkIf noDmUsed (lib.mkDefault false);

--- a/nixos/modules/services/display-managers/lemurs.nix
+++ b/nixos/modules/services/display-managers/lemurs.nix
@@ -1,0 +1,127 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.displayManager.lemurs;
+  settingsFormat = pkgs.formats.toml { };
+in
+{
+  options.services.displayManager.lemurs = {
+    enable = lib.mkEnableOption "" // {
+      description = ''
+        Whether to enable lemurs, a customizable TUI display/login manager.
+
+        ::: {.note}
+        For Wayland compositors, your user must be in the "seat" group.
+        :::
+      '';
+    };
+
+    package = lib.mkPackageOption pkgs "lemurs" { };
+
+    settings = lib.mkOption {
+      type = settingsFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          do_log = true;
+        }
+      '';
+      description = ''
+        Configuration for lemurs, provided as a Nix attribute set and automatically
+        serialized to TOML.
+        See [lemurs configuration documentation](https://github.com/coastalwhite/lemurs/blob/main/extra/config.toml) for available options.
+      '';
+    };
+
+    vt = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 2;
+      description = ''
+        The virtual console (tty) that lemurs should use.
+      '';
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !config.services.displayManager.autoLogin.enable;
+        message = ''
+          lemurs doesn't support auto login.
+        '';
+      }
+    ];
+
+    security.pam.services.lemurs = {
+      unixAuth = true;
+      startSession = true;
+      # See https://github.com/coastalwhite/lemurs/issues/166
+      setLoginUid = false;
+      enableGnomeKeyring = lib.mkDefault config.services.gnome.gnome-keyring.enable;
+    };
+
+    environment.systemPackages = [ cfg.package ];
+
+    services = {
+      dbus.packages = [ cfg.package ];
+      # Required for wayland with setLoginUid = false;
+      seatd.enable = true;
+      xserver = {
+        # To enable user switching, allow lemurs to allocate TTYs/displays dynamically.
+        tty = null;
+        display = null;
+      };
+      displayManager = {
+        enable = true;
+        execCmd = "exec ${lib.getExe cfg.package} --config ${settingsFormat.generate "config.toml" cfg.settings}";
+        # set default settings
+        lemurs.settings =
+          let
+            desktops = config.services.displayManager.sessionData.desktops;
+          in
+          {
+            tty = lib.mkDefault cfg.vt;
+            system_shell = lib.mkDefault "${pkgs.bash}/bin/bash";
+            initial_path = lib.mkDefault "/run/current-system/sw/bin";
+            x11 = {
+              xauth_path = lib.mkDefault "${pkgs.xorg.xauth}/bin/xauth";
+              xserver_path = lib.mkDefault "${pkgs.xorg.xorgserver}/bin/X";
+              xsessions_path = lib.mkDefault "${desktops}/share/xsessions";
+              xsetup_path = lib.mkDefault config.services.displayManager.sessionData.wrapper;
+            };
+            wayland.wayland_sessions_path = lib.mkDefault "${desktops}/share/wayland-sessions";
+          };
+      };
+    };
+
+    systemd.services.display-manager = {
+      unitConfig = {
+        Wants = [ "systemd-user-sessions.service" ];
+        After = [
+          "systemd-user-sessions.service"
+          "getty@tty${toString cfg.vt}.service"
+          "plymouth-quit-wait.service"
+        ];
+        Conflicts = [ "getty@tty${toString cfg.vt}.service" ];
+      };
+      serviceConfig = {
+        Type = "idle";
+        # Defaults from lemurs upstream configuration
+        StandardInput = "tty";
+        TTYPath = "/dev/tty${toString cfg.vt}";
+        TTYReset = "yes";
+        TTYVHangup = "yes";
+      };
+      # Don't kill a user session when using nixos-rebuild
+      restartIfChanged = false;
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    nullcube
+    stunkymonkey
+  ];
+}

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -768,6 +768,7 @@ in
             || dmConf.startx.enable
             || config.services.greetd.enable
             || config.services.displayManager.ly.enable
+            || config.services.displayManager.lemurs.enable
           );
       in
       mkIf (default) (mkDefault true);

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -790,6 +790,11 @@ in
   leaps = runTest ./leaps.nix;
   lemmy = runTest ./lemmy.nix;
   libinput = runTest ./libinput.nix;
+  lemurs = runTest ./lemurs/lemurs.nix;
+  lemurs-wayland = runTest ./lemurs/lemurs-wayland.nix;
+  lemurs-wayland-script = runTest ./lemurs/lemurs-wayland-script.nix;
+  lemurs-xorg = runTest ./lemurs/lemurs-xorg.nix;
+  lemurs-xorg-script = runTest ./lemurs/lemurs-xorg-script.nix;
   librenms = runTest ./librenms.nix;
   libresprite = runTest ./libresprite.nix;
   libreswan = runTest ./libreswan.nix;

--- a/nixos/tests/lemurs/lemurs-wayland-script.nix
+++ b/nixos/tests/lemurs/lemurs-wayland-script.nix
@@ -1,0 +1,50 @@
+{ lib, ... }:
+{
+  name = "lemurs-wayland-script";
+  meta = with lib.maintainers; {
+    maintainers = [
+      nullcube
+      stunkymonkey
+    ];
+  };
+
+  nodes.machine =
+    { lib, config, ... }:
+    {
+      imports = [ ../common/user-account.nix ];
+
+      # Required for wayland to work with Lemurs
+      services.seatd.enable = true;
+      users.users.alice.extraGroups = [ "seat" ];
+
+      services.displayManager.lemurs.enable = true;
+
+      programs.sway.enable = true;
+      environment.etc."lemurs/wayland/sway" = {
+        mode = "755";
+        text = ''
+          #! /bin/sh
+          exec ${lib.getExe config.programs.sway.package}
+        '';
+      };
+    };
+
+  testScript = ''
+    machine.start()
+
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_until_succeeds("pgrep -f 'lemurs.*tty1'")
+    machine.screenshot("postboot")
+
+    with subtest("Log in as alice to Sway"):
+      machine.send_chars("\n")
+      machine.send_chars("alice\n")
+      machine.sleep(1)
+      machine.send_chars("foobar\n")
+      machine.sleep(1)
+      machine.wait_until_succeeds("pgrep -u alice sway")
+      machine.sleep(10)
+      machine.succeed("pgrep -u alice sway")
+      machine.screenshot("postlogin")
+  '';
+}

--- a/nixos/tests/lemurs/lemurs-wayland.nix
+++ b/nixos/tests/lemurs/lemurs-wayland.nix
@@ -1,0 +1,43 @@
+{ lib, ... }:
+{
+  name = "lemurs-wayland";
+  meta = with lib.maintainers; {
+    maintainers = [
+      nullcube
+      stunkymonkey
+    ];
+  };
+
+  nodes.machine =
+    { ... }:
+    {
+      imports = [ ../common/user-account.nix ];
+
+      # Required for wayland to work with Lemurs
+      services.seatd.enable = true;
+      users.users.alice.extraGroups = [ "seat" ];
+
+      services.displayManager.lemurs.enable = true;
+
+      programs.river.enable = true;
+    };
+
+  testScript = ''
+    machine.start()
+
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_until_succeeds("pgrep -f 'lemurs.*tty1'")
+    machine.screenshot("postboot")
+
+    with subtest("Log in as alice to river"):
+      machine.send_chars("\n")
+      machine.send_chars("alice\n")
+      machine.sleep(1)
+      machine.send_chars("foobar\n")
+      machine.sleep(1)
+      machine.wait_until_succeeds("pgrep -u alice river")
+      machine.sleep(10)
+      machine.succeed("pgrep -u alice river")
+      machine.screenshot("postlogin")
+  '';
+}

--- a/nixos/tests/lemurs/lemurs-xorg-script.nix
+++ b/nixos/tests/lemurs/lemurs-xorg-script.nix
@@ -1,0 +1,46 @@
+{ lib, ... }:
+{
+  name = "lemurs-xorg-script";
+  meta = with lib.maintainers; {
+    maintainers = [
+      nullcube
+      stunkymonkey
+    ];
+  };
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ ../common/user-account.nix ];
+
+      services.displayManager.lemurs.enable = true;
+
+      services.xserver.enable = true;
+
+      environment.etc."lemurs/wms/icewm" = {
+        mode = "755";
+        text = ''
+          #! /bin/sh
+          exec ${pkgs.icewm}/bin/icewm-session
+        '';
+      };
+    };
+
+  testScript = ''
+    machine.start()
+
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_until_succeeds("pgrep -f 'lemurs.*tty1'")
+    machine.screenshot("postboot")
+
+    with subtest("Log in as alice to icewm"):
+      machine.send_chars("\n")
+      machine.send_chars("alice\n")
+      machine.sleep(1)
+      machine.send_chars("foobar\n")
+      machine.wait_until_succeeds("pgrep -u alice icewm")
+      machine.sleep(10)
+      machine.succeed("pgrep -u alice icewm")
+      machine.screenshot("postlogin")
+  '';
+}

--- a/nixos/tests/lemurs/lemurs-xorg.nix
+++ b/nixos/tests/lemurs/lemurs-xorg.nix
@@ -1,0 +1,40 @@
+{ lib, ... }:
+{
+  name = "lemurs-xorg";
+  meta = with lib.maintainers; {
+    maintainers = [
+      nullcube
+      stunkymonkey
+    ];
+  };
+
+  nodes.machine =
+    { ... }:
+    {
+      imports = [ ../common/user-account.nix ];
+
+      services.displayManager.lemurs.enable = true;
+
+      services.xserver.enable = true;
+
+      services.xserver.windowManager.icewm.enable = true;
+    };
+
+  testScript = ''
+    machine.start()
+
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_until_succeeds("pgrep -f 'lemurs.*tty1'")
+    machine.screenshot("postboot")
+
+    with subtest("Log in as alice to icewm"):
+      machine.send_chars("\n")
+      machine.send_chars("alice\n")
+      machine.sleep(1)
+      machine.send_chars("foobar\n")
+      machine.wait_until_succeeds("pgrep -u alice icewm")
+      machine.sleep(10)
+      machine.succeed("pgrep -u alice icewm")
+      machine.screenshot("postlogin")
+  '';
+}

--- a/nixos/tests/lemurs/lemurs.nix
+++ b/nixos/tests/lemurs/lemurs.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  ...
+}:
+{
+  name = "lemurs";
+  meta = with lib.maintainers; {
+    maintainers = [
+      nullcube
+      stunkymonkey
+    ];
+  };
+
+  nodes.machine = _: {
+    imports = [ ../common/user-account.nix ];
+    services.displayManager.lemurs.enable = true;
+  };
+
+  testScript = ''
+    machine.start()
+
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_until_succeeds("pgrep -f 'lemurs.*tty1'")
+    machine.screenshot("postboot")
+
+    with subtest("Log in as alice on a virtual console"):
+      machine.send_chars("\n")
+      machine.send_chars("alice\n")
+      machine.sleep(1)
+      machine.send_chars("foobar\n")
+      machine.sleep(1)
+      machine.wait_until_succeeds("pgrep -u alice bash")
+      machine.screenshot("postlogin")
+      machine.send_chars("touch done\n")
+      machine.wait_for_file("/home/alice/done")
+  '';
+}

--- a/pkgs/by-name/le/lemurs/package.nix
+++ b/pkgs/by-name/le/lemurs/package.nix
@@ -6,6 +6,7 @@
   rustPlatform,
   systemdMinimal,
   versionCheckHook,
+  nixosTests,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "lemurs";
@@ -29,6 +30,16 @@ rustPlatform.buildRustPackage rec {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.tests = {
+    inherit (nixosTests)
+      lemurs
+      lemurs-wayland
+      lemurs-wayland-script
+      lemurs-xorg
+      lemurs-xorg-script
+      ;
+  };
 
   meta = {
     description = "Customizable TUI display/login manager written in Rust";


### PR DESCRIPTION
## Description of changes

add https://github.com/coastalwhite/lemurs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
