### PR TITLE
schemamap: init at 0.3.0

### DIFF
--- a/pkgs/by-name/sc/schemamap/package.nix
+++ b/pkgs/by-name/sc/schemamap/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  darwin,
+}:
+
+let
+  version = "0.3.0";
+in
+rustPlatform.buildRustPackage rec {
+  pname = "schemamap";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "schemamap";
+    repo = "schemamap";
+    rev = "v${version}";
+    hash = "sha256-49i2zyOy/yngSgvKd66RsOhF6OlYfgDnEtPEbmhEcIo=";
+  };
+
+  sourceRoot = "${src.name}/rust";
+
+  cargoHash = "sha256-ILgvS96D6yF4Teaa5on6jHZlVoxRLSk8A523PzH1b5Y=";
+
+  buildInputs =
+    [ openssl ]
+    ++ lib.optionals stdenv.isDarwin (
+      with darwin.apple_sdk;
+      [
+        frameworks.Security
+        frameworks.CoreFoundation
+        frameworks.CoreServices
+        frameworks.SystemConfiguration
+      ]
+    );
+
+  nativeBuildInputs = [ pkg-config ];
+
+  meta = {
+    changelog = "https://github.com/schemamap/schemamap/releases/tag/v${version}";
+    description = "Instant batch data import for Postgres";
+    homepage = "https://schemamap.io";
+    license = lib.licenses.mit;
+    mainProgram = "schemamap";
+    maintainers = with lib.maintainers; [ thenonameguy ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This is my [projects](https://schemamap.io/) Rust CLI tool.

It helps people set up their Postgres DB so my SaaS platform can connect to it and create data migrations automatically with it, including

- Postgres -> Postgres sync, with subsetting/PII filtering of data, without DDL changes.
- Spreadsheet <-> Postgres import/export

For now the CLI only includes the SDK setup + NAT traversing networking to test these features locally.

I've tested the x86_64-linux/aarch64-linux builds of the equivalent https://github.com/schemamap/schemamap Flake package output in my own stack extensively.

Adding to nixpkgs mainly for binary caching.

![image](https://github.com/user-attachments/assets/f9e5f41b-d18b-4b68-a5fa-de8707acc9c5)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
