### PR TITLE
[24.05] maxima: add patch for CVE-2024-34490

### DIFF
--- a/pkgs/applications/science/math/maxima/5.47.0-CVE-2024-34490.patch
+++ b/pkgs/applications/science/math/maxima/5.47.0-CVE-2024-34490.patch
@@ -1,0 +1,86 @@
+Based on upstream https://sourceforge.net/p/maxima/code/ci/51704ccb090f6f971b641e4e0b7c1c22c4828bf7/
+adjusted to apply to 5.47.0
+
+diff --git a/src/gnuplot_def.lisp b/src/gnuplot_def.lisp
+index 80c174bd5..6fdc8da6d 100644
+--- a/src/gnuplot_def.lisp
++++ b/src/gnuplot_def.lisp
+@@ -286,7 +286,7 @@
+                (format nil "set term postscript eps color solid lw 2 size 16.4 cm, 12.3 cm font \",24\" ~a" gstrings)))
+      (if (getf plot-options :gnuplot_out_file)
+          (setq out-file (getf plot-options :gnuplot_out_file))
+-         (setq out-file "maxplot.ps")))
++         (setq out-file (format nil "~a.ps" (random-name 16)))))
+     ((eq (getf plot-options :gnuplot_term) '$dumb)
+      (if (getf plot-options :gnuplot_dumb_term_command)
+          (setq terminal-command
+@@ -294,7 +294,7 @@
+          (setq terminal-command "set term dumb 79 22"))
+      (if (getf plot-options :gnuplot_out_file)
+          (setq out-file (getf plot-options :gnuplot_out_file))
+-         (setq out-file "maxplot.txt")))
++         (setq out-file (format nil "~a.txt" (random-name 16)))))
+     ((eq (getf plot-options :gnuplot_term) '$default)
+      (if (getf plot-options :gnuplot_default_term_command)
+          (setq terminal-command
+diff --git a/src/plot.lisp b/src/plot.lisp
+index fb2b3136b..8877f7025 100644
+--- a/src/plot.lisp
++++ b/src/plot.lisp
+@@ -1755,16 +1755,24 @@ plot3d([cos(y)*(10.0+6*cos(x)), sin(y)*(10.0+6*cos(x)),-6*sin(x)],
+ 
+ (defvar $xmaxima_plot_command "xmaxima")
+ 
++;; random-file-name
++;; Creates a random word of 'count' alphanumeric characters
++(defun random-name (count)
++  (let ((chars "0123456789abcdefghijklmnopqrstuvwxyz") (name ""))
++    (setf *random-state* (make-random-state t))
++    (dotimes (i count)
++      (setq name (format nil "~a~a" name (aref chars (random 36)))))
++    name))
++
+ (defun plot-set-gnuplot-script-file-name (options)
+   (let ((gnuplot-term (getf options :gnuplot_term))
+ 	(gnuplot-out-file (getf options :gnuplot_out_file)))
+     (if (and (find (getf options :plot_format) '($gnuplot_pipes $gnuplot))
+              (eq gnuplot-term '$default) gnuplot-out-file)
+ 	(plot-file-path gnuplot-out-file t options)
+-      (plot-file-path
+-       (format nil "maxout~d.~(~a~)"
+-	       (getpid)
+-               (ensure-string (getf options :plot_format))) nil options))))
++      (plot-file-path (format nil "~a.~a" (random-name 16)
++                              (ensure-string (getf options :plot_format)))
++                      nil options))))
+ 
+ (defun plot-temp-file0 (file &optional (preserve-file nil))
+   (let ((filename 
+@@ -2577,9 +2585,13 @@ plot2d ( x^2+y^2 = 1, [x, -2, 2], [y, -2 ,2]);
+        (format dest "}~%"))
+   (format dest "}~%"))
+ 
++; TODO: Check whether this function is still being used (villate 20240325)
+ (defun show-open-plot (ans file)
+   (cond ($show_openplot
+-         (with-open-file (st1 (plot-temp-file (format nil "maxout~d.xmaxima" (getpid))) :direction :output :if-exists :supersede)
++         (with-open-file
++          (st1 (plot-temp-file
++                (format nil "~a.xmaxima" (random-name 16)))
++               :direction :output :if-exists :supersede)
+            (princ  ans st1))
+          ($system (concatenate 'string *maxima-prefix* 
+                                (if (string= *autoconf-windows* "true") "\\bin\\" "/bin/") 
+diff --git a/src/xmaxima_def.lisp b/src/xmaxima_def.lisp
+index b6513b564..5a13b6141 100644
+--- a/src/xmaxima_def.lisp
++++ b/src/xmaxima_def.lisp
+@@ -431,7 +431,7 @@
+         (format $pstream "}~%"))))))
+ 
+ (defmethod plot-shipout ((plot xmaxima-plot) options &optional output-file)
+-  (let ((file (plot-file-path (format nil "maxout~d.xmaxima" (getpid)))))
++  (let ((file (plot-file-path (format nil "~a.xmaxima" (random-name 16)))))
+     (cond ($show_openplot
+            (with-open-file (fl
+                             #+sbcl (sb-ext:native-namestring file)

--- a/pkgs/applications/science/math/maxima/default.nix
+++ b/pkgs/applications/science/math/maxima/default.nix
@@ -79,6 +79,8 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://raw.githubusercontent.com/sagemath/sage/07d6c37d18811e2b377a9689790a7c5e24da16ba/build/pkgs/maxima/patches/undoing_true_false_printing_patch.patch";
       sha256 = "0fvi3rcjv6743sqsbgdzazy9jb6r1p1yq63zyj9fx42wd1hgf7yx";
     })
+
+    ./5.47.0-CVE-2024-34490.patch
   ];
 
   # The test suite is disabled since 5.42.2 because of the following issues:


### PR DESCRIPTION
## Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2024-34490

Partial backport of #329007

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
