### PR TITLE
haskell-modules/generic-builder.nix: work around useSystemCoreFoundationFramework hook

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -150,6 +150,35 @@ assert stdenv.hostPlatform.isWasm -> enableStaticLibraries == false;
 
 let
 
+  # This is a workaround for the 2024-07-20 staging-next cycle to avoid causing mass rebuilds.
+  # todo(@reckenrode) Remove this workaround and remove `NIX_COREFOUNDATION_RPATH`, the related hooks, and ld-wrapper support.
+  nixCoreFoundationRpathWorkaround = stdenv.mkDerivation {
+    name = "nix-corefoundation-rpath-workaround";
+    buildCommand = ''
+      mkdir -p "$out/nix-support"
+      cat <<-EOF > "$out/nix-support/setup-hook"
+      removeUseSystemCoreFoundationFrameworkHook() {
+        unset NIX_COREFOUNDATION_RPATH
+        local _hook
+        for _hook in envBuildBuildHooks envBuildHostHooks envBuildTargetHooks envHostHostHooks envHostTargetHooks envTargetTargetHooks; do
+          local _index=0
+          local _var="\$_hook[@]"
+          for _var in "\''${!_var}"; do
+            if [ "\$_var" = "useSystemCoreFoundationFramework" ]; then
+              unset "\$_hook[\$_index]"
+            fi
+            ((++_index))
+          done
+          unset _index
+          unset _var
+        done
+        unset _hook
+      }
+      addEnvHooks "\$hostOffset" removeUseSystemCoreFoundationFrameworkHook
+      EOF
+    '';
+  };
+
   inherit (lib) optional optionals optionalString versionAtLeast
                        concatStringsSep enableFeature optionalAttrs;
 
@@ -430,7 +459,8 @@ stdenv.mkDerivation ({
   inherit depsBuildBuild nativeBuildInputs;
   buildInputs = otherBuildInputs ++ optionals (!isLibrary) propagatedBuildInputs
     # For patchShebangsAuto in fixupPhase
-    ++ optionals stdenv.hostPlatform.isGhcjs [ nodejs ];
+    ++ optionals stdenv.hostPlatform.isGhcjs [ nodejs ]
+    ++ optionals (stdenv.isDarwin && stdenv.isx86_64) [ nixCoreFoundationRpathWorkaround ];
   propagatedBuildInputs = optionals isLibrary propagatedBuildInputs;
 
   LANG = "en_US.UTF-8";         # GHC needs the locale configured during the Haddock phase.


### PR DESCRIPTION
Fixes some Haskell build failures on x86_64-darwin on staging-next https://github.com/NixOS/nixpkgs/pull/328673.

- https://hydra.nixos.org/build/267100183
- https://hydra.nixos.org/build/267123905
- https://hydra.nixos.org/build/267108483

In 23.11, Darwin was changes to use the system CoreFoundation both aarch64-darwin and x86_64-darwin. The ability to change between implementations was removed, but the hook was left in place because at the time it was harmless. Unfortunately, that is no longer the case.

After the upgrade of ld64 to 951.9, it is no longer as permissive about when `-rpath` may be used. It no longer allows the flag to be used when targeting macOS 10.5, and it no longer allows it when merging objects. The former was an issue for certain versions of GCC (now fixed). The latter is an issue for Haskell.

When a Haskell project uses Darwin frameworks and Cabal to build, they will fail to build without this workaround, giving the following error.

    ld: -rpath can only be used when creating a dynamic final linked image

This is due to an optimization Cabal [performs][1]. If the linker supports creating relocatable objects or merging them, it will do so eagerly. This causes packages such as OpenGLRaw to fail to build due using Cabal and frameworks (OpenGL), which pull in the hook.

This workaround is ugly, but it will be reverted as soon as it hits staging and replaced with the real solution, which is removing the hook. The hook is only used with the 10.12 SDK. The 11.0 and 12.3 SDKs do not support the hook, and being able to switch CoreFoundation implementations is not anticipated to be restored in the future (due to problems it causes).

[1]: https://github.com/haskell/cabal/blob/705b6ebcaed649ed1a30b138b4348d24722d610a/Cabal/src/Distribution/Simple/Program/Builtin.hs#L341-L380

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
