### PR TITLE
rofi-emoji: 3.4.0 -> 3.4.1 + 4.0.0; rofi-emoji-wayland: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12349,6 +12349,13 @@
     githubId = 115060;
     name = "Marek Maksimczyk";
   };
+  Mange = {
+    name = "Magnus Bergmark";
+    email = "me@mange.dev";
+    github = "Mange";
+    githubId = 1599;
+    keys = [ { fingerprint = "2EA6 F4AA 110A 1BF2 2275  19A9 0443 C69F 6F02 2CDE"; } ];
+  };
   mangoiv = {
     email = "contact@mangoiv.com";
     github = "mangoiv";

--- a/pkgs/applications/misc/rofi-emoji/default.nix
+++ b/pkgs/applications/misc/rofi-emoji/default.nix
@@ -15,61 +15,58 @@
 , rofi-unwrapped
 , wl-clipboard
 , xclip
-, xsel
 , xdotool
 , wtype
 }:
 
-stdenv.mkDerivation rec {
-  pname = "rofi-emoji";
-  version = "3.4.0";
+import ./versions.nix ({ version, hash, patches}:
+  stdenv.mkDerivation rec {
+    pname = "rofi-emoji";
+    inherit version;
 
-  src = fetchFromGitHub {
-    owner = "Mange";
-    repo = pname;
-    rev = "v${version}";
-    hash = "sha256-tF3yAKRUix+if+45rxg5vq83Pu33TQ6oUKWPIs/l4X0=";
-  };
+    src = fetchFromGitHub {
+      owner = "Mange";
+      repo = "rofi-emoji";
+      rev = "v${version}";
+      inherit hash;
+    };
 
-  patches = [
-    # Look for plugin-related files in $out/lib/rofi
-    ./0001-Patch-plugindir-to-output.patch
-  ];
+    inherit patches;
 
-  postPatch = ''
-    patchShebangs clipboard-adapter.sh
-  '';
+    postPatch = ''
+      patchShebangs clipboard-adapter.sh
+    '';
 
-  postFixup = ''
-    chmod +x $out/share/rofi-emoji/clipboard-adapter.sh
-    wrapProgram $out/share/rofi-emoji/clipboard-adapter.sh \
-     --prefix PATH ":" ${lib.makeBinPath ([ libnotify wl-clipboard xclip xsel ]
-       ++ lib.optionals waylandSupport [ wtype ]
-       ++ lib.optionals x11Support [ xdotool ])}
-  '';
+    postFixup = ''
+      chmod +x $out/share/rofi-emoji/clipboard-adapter.sh
+      wrapProgram $out/share/rofi-emoji/clipboard-adapter.sh \
+       --prefix PATH ":" ${lib.makeBinPath ([ libnotify ]
+         ++ lib.optionals waylandSupport [ wl-clipboard wtype ]
+         ++ lib.optionals x11Support [ xclip xdotool ])}
+    '';
 
 
-  nativeBuildInputs = [
-    autoreconfHook
-    pkg-config
-    makeWrapper
-  ];
+    nativeBuildInputs = [
+      autoreconfHook
+      pkg-config
+      makeWrapper
+    ];
 
-  buildInputs = [
-    cairo
-    glib
-    libnotify
-    rofi-unwrapped
-    wl-clipboard
-    xclip
-    xsel
-  ];
+    buildInputs = [
+      cairo
+      glib
+      libnotify
+      rofi-unwrapped
+    ]
+      ++ lib.optionals waylandSupport [ wl-clipboard wtype ]
+      ++ lib.optionals x11Support [ xclip ];
 
-  meta = with lib; {
-    description = "Emoji selector plugin for Rofi";
-    homepage = "https://github.com/Mange/rofi-emoji";
-    license = licenses.mit;
-    maintainers = with maintainers; [ cole-h ];
-    platforms = platforms.linux;
-  };
-}
+    meta = with lib; {
+      description = "Emoji selector plugin for Rofi (built against ${rofi-unwrapped.pname})";
+      homepage = "https://github.com/Mange/rofi-emoji";
+      license = licenses.mit;
+      maintainers = with maintainers; [ cole-h Mange ];
+      platforms = platforms.linux;
+    };
+  }
+)

--- a/pkgs/applications/misc/rofi-emoji/versions.nix
+++ b/pkgs/applications/misc/rofi-emoji/versions.nix
@@ -1,0 +1,18 @@
+generic: {
+  v4 = generic {
+    version = "4.0.0";
+    hash = "sha256-864Mohxfc3EchBKtSNifxy8g8T8YBUQ/H7+8Ti6TiFo=";
+    patches = [
+      # Look for plugin-related files in $out/lib/rofi
+      ./0001-Patch-plugindir-to-output.patch
+    ];
+  };
+  v3 = generic {
+    version = "3.4.1";
+    hash = "sha256-ZHhgYytPB14zj2MS8kChRD+LTqXzHRrz7YIikuQD6i0=";
+    patches = [
+      # Look for plugin-related files in $out/lib/rofi
+      ./0001-Patch-plugindir-to-output.patch
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32469,7 +32469,12 @@ with pkgs;
 
   rofi-calc = callPackage ../applications/science/math/rofi-calc { };
 
-  rofi-emoji = callPackage ../applications/misc/rofi-emoji { };
+  rofi-emoji = (callPackage ../applications/misc/rofi-emoji { }).v3;
+  rofi-emoji-wayland = (
+    callPackage ../applications/misc/rofi-emoji {
+      rofi-unwrapped = rofi-wayland-unwrapped;
+    }
+  ).v4;
 
   rofi-file-browser = callPackage ../applications/misc/rofi-file-browser { };
 


### PR DESCRIPTION
## Description of changes

Version 4.0.0: https://github.com/Mange/rofi-emoji/releases/tag/v4.0.0
Version 3.4.1: https://github.com/Mange/rofi-emoji/releases/tag/v3.4.1

Provide two versions of `rofi-emoji`:
* Version 3.x for use with current `rofi` pkg.
* Version 4.x for `master` version of `rofi`, `rofi-wayland`, and similar forks.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

## Design discussion

The most popular versions of Rofi seems to be `rofi` and `rofi-wayland`, which is also why the fork has official support here. Sadly, the `rofi-emoji` plugin doesn't work against that one unless you compile against it too. Right now I expose a `-wayland` variant of `rofi-emoji` that is built against `rofi-wayland` and uses the version 4 source of `rofi-emoji`.

Since a user might want to use a completely custom version of Rofi, I think I should expose the plain versions (3 and 4) of the packages too and users can then override them in their own configs and switch out the `rofi-unwrapped` argument. Does that make sense?

Part of this might be solved by having all `plugins` passed into the wrapped `rofi` also override the `rofi-unwrapped` version?

I'll gladly take some advice here. I'm also pretty new to Nix itself, so I'm not used to the conventions and idioms that we want to use here. Please let me know if something I've done is completely bonkers!

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
