### PR TITLE
uwsm: init at 0.17.0

### DIFF
--- a/pkgs/by-name/uw/uwsm/package.nix
+++ b/pkgs/by-name/uw/uwsm/package.nix
@@ -1,0 +1,71 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  scdoc,
+  pkg-config,
+  nix-update-script,
+  dmenu,
+  libnotify,
+  python3Packages,
+  util-linux,
+  fumonSupport ? true,
+  uuctlSupport ? true,
+  uwsmAppSupport ? true,
+}:
+let
+  python = python3Packages.python.withPackages (ps: [
+    ps.pydbus
+    ps.dbus-python
+    ps.pyxdg
+  ]);
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "uwsm";
+  version = "0.17.0";
+
+  src = fetchFromGitHub {
+    owner = "Vladimir-csp";
+    repo = "uwsm";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-M2j7l5XTSS2IzaJofAHct1tuAO2A9Ps9mCgAWKEvzoE=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    scdoc
+  ];
+
+  buildInputs = [
+    libnotify
+    util-linux
+  ] ++ (lib.optionals uuctlSupport [ dmenu ]);
+
+  propagatedBuildInputs = [ python ];
+
+  mesonFlags = [
+    "--prefix=${placeholder "out"}"
+    (lib.mapAttrsToList lib.mesonEnable {
+      "uwsm-app" = uwsmAppSupport;
+      "fumon" = fumonSupport;
+      "uuctl" = uuctlSupport;
+      "man-pages" = true;
+    })
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Universal wayland session manager";
+    homepage = "https://github.com/Vladimir-csp/uwsm";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ johnrtitor ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Homepage:- https://github.com/Vladimir-csp/uwsm
Description:-  Wraps standalone Wayland compositors into a set of Systemd units on the fly. This provides robust session management including environment, XDG autostart support, bi-directional binding with login session, and clean shutdown.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
