### PR TITLE
scarlett2: init at 0-unstable-2024-04-06

### DIFF
--- a/pkgs/by-name/sc/scarlett2/package.nix
+++ b/pkgs/by-name/sc/scarlett2/package.nix
@@ -1,0 +1,63 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  alsa-lib,
+  openssl,
+  pkg-config,
+  lib,
+  unstableGitUpdater,
+}:
+
+let
+
+  firmwareSrc = fetchFromGitHub {
+    owner = "geoffreybennett";
+    repo = "scarlett2-firmware";
+    rev = "f628dfb4d2e874b2078dbb43e8c1d59dd6553dd1";
+    hash = "sha256-s61eyS47SuIbK9KR59XxHpybvl9tHFWPLkpHmdqwO24=";
+  };
+
+in
+stdenv.mkDerivation {
+
+  pname = "scarlett2";
+
+  version = "0-unstable-2024-04-06";
+
+  src = fetchFromGitHub {
+    owner = "geoffreybennett";
+    repo = "scarlett2";
+    rev = "1c262bcac11bceb6da8334b8f5b56d3c9331bfc8";
+    hash = "sha256-yhmXVfys300NwZ8UJ7WvOyNkGP3OkIVoRaToF+SenQA=";
+  };
+
+  buildInputs = [
+    alsa-lib
+    openssl
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  preBuild = ''
+    makeFlagsArray+=( PREFIX=$out )
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  # the program expects to find firmware files in a directory called "firmware" relative to the resolved path of the binary
+  postInstall = ''
+    mkdir -p $out/share
+    mv $out/bin/scarlett2 $out/share
+    ln -s $out/share/scarlett2 $out/bin/scarlett2
+    ln -s ${firmwareSrc}/firmware $out/share/firmware
+  '';
+
+  meta = {
+    description = "Scarlett2 Firmware Management Utility for Scarlett 2nd, 3rd, and 4th Gen, Clarett USB, and Clarett+ interfaces";
+    homepage = "https://github.com/geoffreybennett/scarlett2";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ squalus ];
+    mainProgram = "scarlett2";
+  };
+
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Scarlett2 Firmware Management Utility for Scarlett 2nd, 3rd, and 4th Gen, Clarett USB, and Clarett+ interfaces

This command-line tool provides firmware management for Focusrite audio interfaces using the Scarlett2 USB protocol.

Tested a firmware update on a real device on NixOS x86_64-linux.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
