### PR TITLE
dep-tree: 0.20.3 -> 0.23.0

### DIFF
--- a/pkgs/by-name/de/dep-tree/package.nix
+++ b/pkgs/by-name/de/dep-tree/package.nix
@@ -32,7 +32,7 @@ let
     };
   };
   pname = "dep-tree";
-  version = "0.20.3";
+  version = "0.23.0";
 in
 buildGoModule {
   inherit pname version;
@@ -41,14 +41,29 @@ buildGoModule {
     owner = "gabotechs";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-w0t6SF0Kqr+XAKPNJpDJGDTm2Tc6J9OzbXtRUNkqp2k=";
+    hash = "sha256-Vd6g9UE3XEFGjCK8tFfOphYcNx+zeBS9rBVz0MDLe1I=";
   };
 
-  vendorHash = "sha256-ZDADo1takCemPGYySLwPAODUF+mEJXsaxZn4WWmaUR8=";
+  vendorHash = "sha256-KoVOjZq+RrJ2gzLnANHPPtbEY1ztC0rIXWD9AXAxqMg=";
 
   preCheck = ''
     substituteInPlace internal/tui/tui_test.go \
       --replace-fail /tmp/dep-tree-tests ${linkFarm "dep-tree_testDeps-farm" testDeps}
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    # We do not set trimpath for tests, in case they reference test assets
+    export GOFLAGS=''${GOFLAGS//-trimpath/}
+
+    # checkFlags is not able to skip tests via pattern.
+    # possibly requires fixing in buildGoModule.
+    # For now, this is the new checkPhase
+    go test ./... -skip='TestRoot.*|TestFilesFromArgs.*'
+    # these tests were not feasibly fixable.
+    # a LARGE portion of the original source would need to be edited via patch for this to work.
+
+    runHook postCheck
   '';
 
   meta = {


### PR DESCRIPTION
## Description of changes

Updated from 0.20.3 -> 0.23.0

Unfortunately, I also discovered 2 things.

First, in the update, new tests were added in the cmd directory, and some of these tests are not feasibly patched with nix. A large portion of that test file must be completely rewritten to accomodate. So instead they should be skipped.

Second, that checkFlags cannot be used to skip tests by pattern.

In fact, echoing $checkFlags (which is the variable that is read to get these flags within the source of buildGoModule) shows some odd things.

```nix
  checkFlags = ''-skip=\"TestRoot.*|TestFilesFromArgs.*\"'';
```
When checkFlags is the above, echo $checkFlags prints nothing

```nix
  checkFlags = ''./... -skip=\"TestRoot.*|TestFilesFromArgs.*\"'';
```
When checkFlags is the above, echo $checkFlags prints ./...

```nix
  checkFlags = [ ''-skip "TestRoot.*|TestFilesFromArgs.*"'' ];
```
When checkFlags is the above, echo $checkFlags prints -skip

```nix
  checkFlags = ''-skip="TestRoot.*|TestFilesFromArgs.*" -v'';
```
When checkFlags is the above, echo $checkFlags prints -v

```nix
  checkFlags = ''-skip "TestRoot.*|TestFilesFromArgs.*" -v'';
```
When checkFlags is the above, echo $checkFlags prints -skip -v

```nix
  checkFlags = [ ''-skip=\"TestRoot.*|TestFilesFromArgs.*\"'' ''-v'' ];
```
When checkFlags is the above, echo $checkFlags prints -v

```nix
  checkFlags = ''-skip 'TestRoot.*|TestFilesFromArgs.*' -v'';
```
When checkFlags is the above, echo $checkFlags prints -skip -v

I do not know why.

I had to override checkPhase of buildGoModule.

So, if anyone has a better way, please let me know.