### PR TITLE
opam: fixes after #324381

### DIFF
--- a/pkgs/development/ocaml-modules/opam-core/default.nix
+++ b/pkgs/development/ocaml-modules/opam-core/default.nix
@@ -1,15 +1,13 @@
-{ lib, buildDunePackage, unzip
-, opam, ocamlgraph, re, cppo }:
+{ lib, buildDunePackage, opam
+, jsonm, ocamlgraph, re, sha, swhid_core, uutf
+}:
 
 buildDunePackage rec {
   pname = "opam-core";
 
   inherit (opam) src version;
 
-  useDune2 = true;
-
-  nativeBuildInputs = [ unzip cppo ];
-  propagatedBuildInputs = [ ocamlgraph re ];
+  propagatedBuildInputs = [ jsonm ocamlgraph uutf re sha swhid_core ];
 
   # get rid of check for curl at configure time
   # opam-core does not call curl at run time

--- a/pkgs/development/ocaml-modules/opam-format/default.nix
+++ b/pkgs/development/ocaml-modules/opam-format/default.nix
@@ -1,19 +1,14 @@
-{ lib, buildDunePackage, unzip, opam-core, opam-file-format }:
+{ lib, buildDunePackage, opam-core, opam-file-format }:
 
 buildDunePackage rec {
   pname = "opam-format";
 
-  useDune2 = true;
-
   inherit (opam-core) src version;
-
-  minimalOCamlVersion = "4.02.3";
 
   # get rid of check for curl at configure time
   # opam-format does not call curl at run time
   configureFlags = [ "--disable-checks" ];
 
-  nativeBuildInputs = [ unzip ];
   propagatedBuildInputs = [ opam-core opam-file-format ];
 
   meta = opam-core.meta // {

--- a/pkgs/development/ocaml-modules/opam-repository/default.nix
+++ b/pkgs/development/ocaml-modules/opam-repository/default.nix
@@ -1,24 +1,19 @@
-{ lib, buildDunePackage, unzip, opam-format, curl }:
+{ lib, buildDunePackage, opam-format, curl }:
 
 buildDunePackage rec {
   pname = "opam-repository";
-
-  minimalOCamlVersion = "4.02";
-
-  useDune2 = true;
 
   inherit (opam-format) src version;
 
   patches = [ ./download-tool.patch ];
   postPatch = ''
     substituteInPlace src/repository/opamRepositoryConfig.ml \
-      --replace "SUBSTITUTE_NIXOS_CURL_PATH" "\"${curl}/bin/curl\""
+      --replace-fail "SUBSTITUTE_NIXOS_CURL_PATH" "\"${curl}/bin/curl\""
   '';
 
-  strictDeps = true;
-
-  nativeBuildInputs = [ unzip curl ];
   propagatedBuildInputs = [ opam-format ];
+
+  configureFlags = [ "--disable-checks" ];
 
   meta = opam-format.meta // {
     description = "OPAM repository and remote sources handling, including curl/wget, rsync, git, mercurial, darcs backends";

--- a/pkgs/development/ocaml-modules/opam-state/default.nix
+++ b/pkgs/development/ocaml-modules/opam-state/default.nix
@@ -1,18 +1,15 @@
-{ lib, buildDunePackage, unzip, opam, opam-repository }:
+{ lib, buildDunePackage, opam, opam-repository, spdx_licenses }:
 
 buildDunePackage rec {
   pname = "opam-state";
 
   inherit (opam) src version;
 
-  useDune2 = true;
-
   # get rid of check for curl at configure time
   # opam-state does not call curl at run time
   configureFlags = [ "--disable-checks" ];
 
-  nativeBuildInputs = [ unzip ];
-  propagatedBuildInputs = [ opam-repository ];
+  propagatedBuildInputs = [ opam-repository spdx_licenses ];
 
   meta = opam.meta // {
     description = "OPAM development library handling the ~/.opam hierarchy, repository and switch states";

--- a/pkgs/development/ocaml-modules/spdx_licenses/default.nix
+++ b/pkgs/development/ocaml-modules/spdx_licenses/default.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  fetchurl,
+  buildDunePackage,
+}:
+
+buildDunePackage rec {
+  pname = "spdx_licenses";
+  version = "1.2.0";
+
+  minimalOCamlVersion = "4.08";
+
+  src = fetchurl {
+    url = "https://github.com/kit-ty-kate/spdx_licenses/releases/download/v${version}/spdx_licenses-${version}.tar.gz";
+    hash = "sha256-9ViB7PRDz70w3RJczapgn2tJx9wTWgAbdzos6r3J2r4=";
+  };
+
+  meta = {
+    homepage = "https://github.com/kit-ty-kate/spdx_licenses";
+    description = "A library providing a strict SPDX License Expression parser";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/swhid_core/default.nix
+++ b/pkgs/development/ocaml-modules/swhid_core/default.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+}:
+
+buildDunePackage rec {
+  pname = "swhid_core";
+  version = "0.1";
+
+  minimalOCamlVersion = "4.03";
+
+  src = fetchFromGitHub {
+    owner = "OCamlPro";
+    repo = "swhid_core";
+    rev = version;
+    hash = "sha256-uLnVbptCvmBeNbOjGjyAWAKgzkKLDTYVFY6SNH2zf0A=";
+  };
+
+  meta = {
+    description = "OCaml library to work with swhids";
+    homepage = "https://github.com/ocamlpro/swhid_core";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/tools/ocaml/opam-publish/default.nix
+++ b/pkgs/development/tools/ocaml/opam-publish/default.nix
@@ -15,16 +15,14 @@ in
 
 buildDunePackage rec {
   pname = "opam-publish";
-  version = "2.3.0";
+  version = "2.3.1";
 
   src = fetchFromGitHub {
     owner = "ocaml-opam";
     repo = pname;
     rev = version;
-    sha256 = "sha256-CiZOljFBUUC3ExGSzzTATGqmxKjbzjRlL4aaL/fx9zI=";
+    hash = "sha256-ll6G9L7zAw53R7FxvZDBL300b+YElzpBygbiIWB3FUU=";
   };
-
-  duneVersion = "3";
 
   buildInputs = [
     cmdliner

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1379,7 +1379,7 @@ let
     omd = callPackage ../development/ocaml-modules/omd { };
 
     opam-core = callPackage ../development/ocaml-modules/opam-core {
-      inherit (pkgs) opam unzip;
+      inherit (pkgs) opam;
     };
 
     opam-file-format = callPackage ../development/ocaml-modules/opam-file-format { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1388,9 +1388,7 @@ let
       inherit (pkgs) unzip;
     };
 
-    opam-repository = callPackage ../development/ocaml-modules/opam-repository {
-      inherit (pkgs) unzip;
-    };
+    opam-repository = callPackage ../development/ocaml-modules/opam-repository { };
 
     opam-state = callPackage ../development/ocaml-modules/opam-state {
       inherit (pkgs) unzip;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1746,6 +1746,8 @@ let
 
     stringext = callPackage ../development/ocaml-modules/stringext { };
 
+    swhid_core = callPackage ../development/ocaml-modules/swhid_core { };
+
     syslog = callPackage ../development/ocaml-modules/syslog { };
 
     syslog-message = callPackage ../development/ocaml-modules/syslog-message { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1390,9 +1390,7 @@ let
 
     opam-repository = callPackage ../development/ocaml-modules/opam-repository { };
 
-    opam-state = callPackage ../development/ocaml-modules/opam-state {
-      inherit (pkgs) unzip;
-    };
+    opam-state = callPackage ../development/ocaml-modules/opam-state { };
 
     opium = callPackage ../development/ocaml-modules/opium { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1714,6 +1714,8 @@ let
       inherit (pkgs) soundtouch;
     };
 
+    spdx_licenses = callPackage ../development/ocaml-modules/spdx_licenses { };
+
     speex = callPackage ../development/ocaml-modules/speex {
       inherit (pkgs) speex;
     };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1384,9 +1384,7 @@ let
 
     opam-file-format = callPackage ../development/ocaml-modules/opam-file-format { };
 
-    opam-format = callPackage ../development/ocaml-modules/opam-format {
-      inherit (pkgs) unzip;
-    };
+    opam-format = callPackage ../development/ocaml-modules/opam-format { };
 
     opam-repository = callPackage ../development/ocaml-modules/opam-repository { };
 


### PR DESCRIPTION
## Description of changes

A few packages got broken by the update of `opam` to 2.2.0. This fixes it.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
