### PR TITLE
treewide: remove maintainer goibhniu

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7541,12 +7541,6 @@
     githubId = 605072;
     name = "Daniel Goertzen";
   };
-  goibhniu = {
-    email = "cillian.deroiste@gmail.com";
-    github = "cillianderoiste";
-    githubId = 643494;
-    name = "Cillian de Róiste";
-  };
   GoldsteinE = {
     email = "root@goldstein.rs";
     github = "GoldsteinE";

--- a/pkgs/applications/audio/a2jmidid/default.nix
+++ b/pkgs/applications/audio/a2jmidid/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     description = "Daemon for exposing legacy ALSA sequencer applications in JACK MIDI system";
     homepage = "https://a2jmidid.ladish.org/";
     license = licenses.gpl2Only;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" ];
   };
 }

--- a/pkgs/applications/audio/ams-lv2/default.nix
+++ b/pkgs/applications/audio/ams-lv2/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation  rec {
     description = "LV2 port of the internal modules found in Alsa Modular Synth";
     homepage = "https://github.com/blablack/ams-lv2";
     license = licenses.gpl3;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux;
     # Build uses `-msse` and `-mfpmath=sse`
     badPlatforms = [ "aarch64-linux" ];

--- a/pkgs/applications/audio/ardour/7.nix
+++ b/pkgs/applications/audio/ardour/7.nix
@@ -207,6 +207,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     mainProgram = "ardour7";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ goibhniu magnetophon mitchmindtree ];
+    maintainers = with maintainers; [ magnetophon mitchmindtree ];
   };
 }

--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -214,6 +214,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     mainProgram = "ardour8";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ goibhniu magnetophon mitchmindtree ];
+    maintainers = with maintainers; [ magnetophon mitchmindtree ];
   };
 }

--- a/pkgs/applications/audio/bristol/default.nix
+++ b/pkgs/applications/audio/bristol/default.nix
@@ -55,6 +55,6 @@ stdenv.mkDerivation rec {
     homepage = "https://bristol.sourceforge.net";
     license = licenses.gpl3;
     platforms = [ "x86_64-linux" "i686-linux" ];
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/audio/calf/default.nix
+++ b/pkgs/applications/audio/calf/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     homepage = "https://calf-studio-gear.org";
     description = "Set of high quality open source audio plugins for musicians";
     license = licenses.lgpl2;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux;
     mainProgram = "calfjackhost";
   };

--- a/pkgs/applications/audio/distrho/default.nix
+++ b/pkgs/applications/audio/distrho/default.nix
@@ -92,7 +92,7 @@ stdenv.mkDerivation rec {
         wolpertinger
     '';
     license = with licenses; [ gpl2Only gpl3Only gpl2Plus lgpl2Plus lgpl3Only mit ];
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/audio/drumgizmo/default.nix
+++ b/pkgs/applications/audio/drumgizmo/default.nix
@@ -35,6 +35,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.drumgizmo.org";
     license = licenses.lgpl3Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.goibhniu maintainers.nico202 ];
+    maintainers = [ maintainers.nico202 ];
   };
 }

--- a/pkgs/applications/audio/drumkv1/default.nix
+++ b/pkgs/applications/audio/drumkv1/default.nix
@@ -19,6 +19,6 @@ mkDerivation rec {
     homepage = "http://drumkv1.sourceforge.net/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/audio/fluidsynth/default.nix
+++ b/pkgs/applications/audio/fluidsynth/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     description = "Real-time software synthesizer based on the SoundFont 2 specifications";
     homepage    = "https://www.fluidsynth.org";
     license     = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ goibhniu lovek323 ];
+    maintainers = with maintainers; [ lovek323 ];
     platforms   = platforms.unix;
     mainProgram = "fluidsynth";
   };

--- a/pkgs/applications/audio/gigedit/default.nix
+++ b/pkgs/applications/audio/gigedit/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.linuxsampler.org";
     description = "Gigasampler file access library";
     license = licenses.gpl2;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux;
     mainProgram = "gigedit";
   };

--- a/pkgs/applications/audio/guitarix/default.nix
+++ b/pkgs/applications/audio/guitarix/default.nix
@@ -131,7 +131,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://github.com/brummer10/guitarix";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ astsmtl goibhniu lord-valen ];
+    maintainers = with maintainers; [ astsmtl lord-valen ];
     platforms = platforms.linux;
   };
 })

--- a/pkgs/applications/audio/hydrogen/default.nix
+++ b/pkgs/applications/audio/hydrogen/default.nix
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     homepage = "http://www.hydrogen-music.org";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ goibhniu orivej ];
+    maintainers = with maintainers; [ orivej ];
   };
 }

--- a/pkgs/applications/audio/ingen/default.nix
+++ b/pkgs/applications/audio/ingen/default.nix
@@ -69,10 +69,7 @@ stdenv.mkDerivation {
     description = "Modular audio processing system using JACK and LV2 or LADSPA plugins";
     homepage = "http://drobilla.net/software/ingen";
     license = lib.licenses.agpl3Plus;
-    maintainers = with lib.maintainers; [
-      goibhniu
-      t4ccer
-    ];
+    maintainers = with lib.maintainers; [ t4ccer ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/audio/jack-capture/default.nix
+++ b/pkgs/applications/audio/jack-capture/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     mainProgram = "jack_capture";
     homepage = "https://github.com/kmatheussen/jack_capture/";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ goibhniu orivej ];
+    maintainers = with maintainers; [ orivej ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/audio/jack-oscrolloscope/default.nix
+++ b/pkgs/applications/audio/jack-oscrolloscope/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     mainProgram = "jack_oscrolloscope";
     homepage = "http://das.nasophon.de/jack_oscrolloscope";
     license = licenses.gpl2;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/audio/jalv/default.nix
+++ b/pkgs/applications/audio/jalv/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation  rec {
     description = "Simple but fully featured LV2 host for Jack";
     homepage = "http://drobilla.net/software/jalv";
     license = licenses.isc;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/audio/lash/default.nix
+++ b/pkgs/applications/audio/lash/default.nix
@@ -34,6 +34,6 @@ stdenv.mkDerivation  rec {
     homepage = "https://www.nongnu.org/lash";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/audio/linuxsampler/default.nix
+++ b/pkgs/applications/audio/linuxsampler/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
       FAQ, please contact us.
     '';
     license = licenses.unfree;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/audio/lmms/default.nix
+++ b/pkgs/applications/audio/lmms/default.nix
@@ -52,6 +52,6 @@ mkDerivation rec {
     homepage = "https://lmms.io";
     license = licenses.gpl2Plus;
     platforms = [ "x86_64-linux" "i686-linux" ];
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/audio/mda-lv2/default.nix
+++ b/pkgs/applications/audio/mda-lv2/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     homepage = "http://drobilla.net/software/mda-lv2.html";
     description = "LV2 port of the MDA plugins by Paul Kellett";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/audio/mhwaveedit/default.nix
+++ b/pkgs/applications/audio/mhwaveedit/default.nix
@@ -35,6 +35,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/magnush/mhwaveedit";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/audio/mid2key/default.nix
+++ b/pkgs/applications/audio/mid2key/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     homepage = "http://code.google.com/p/mid2key/";
     description = "Simple tool which maps midi notes to simulated keystrokes";
     license = licenses.gpl3;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux;
     mainProgram = "mid2key";
   };

--- a/pkgs/applications/audio/mixxx/default.nix
+++ b/pkgs/applications/audio/mixxx/default.nix
@@ -147,7 +147,7 @@ mkDerivation rec {
     description = "Digital DJ mixing software";
     mainProgram = "mixxx";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ goibhniu bfortz benley ];
+    maintainers = with maintainers; [ bfortz benley ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/audio/petrifoo/default.nix
+++ b/pkgs/applications/audio/petrifoo/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation  rec {
     homepage = "https://petri-foo.sourceforge.net";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     mainProgram = "petri-foo";
   };
 }

--- a/pkgs/applications/audio/pianobooster/default.nix
+++ b/pkgs/applications/audio/pianobooster/default.nix
@@ -67,6 +67,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/pianobooster/PianoBooster";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ goibhniu orivej ];
+    maintainers = with maintainers; [ orivej ];
   };
 }

--- a/pkgs/applications/audio/puredata/default.nix
+++ b/pkgs/applications/audio/puredata/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     homepage = "http://puredata.info";
     license = licenses.bsd3;
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ goibhniu carlthome ];
+    maintainers = with maintainers; [ carlthome ];
     mainProgram = "pd";
     changelog = "https://msp.puredata.info/Pd_documentation/x5.htm#s1";
   };

--- a/pkgs/applications/audio/qjackctl/default.nix
+++ b/pkgs/applications/audio/qjackctl/default.nix
@@ -41,7 +41,7 @@ mkDerivation rec {
     mainProgram = "qjackctl";
     homepage = "https://github.com/rncbc/qjackctl";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/audio/qsampler/default.nix
+++ b/pkgs/applications/audio/qsampler/default.nix
@@ -22,7 +22,7 @@ mkDerivation rec {
     description = "Graphical frontend to LinuxSampler";
     mainProgram = "qsampler";
     license = licenses.gpl2;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/audio/qsynth/default.nix
+++ b/pkgs/applications/audio/qsynth/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     mainProgram = "qsynth";
     homepage = "https://sourceforge.net/projects/qsynth";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/audio/rakarrack/default.nix
+++ b/pkgs/applications/audio/rakarrack/default.nix
@@ -26,6 +26,6 @@ stdenv.mkDerivation  rec {
     homepage = "https://rakarrack.sourceforge.net";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/audio/samplv1/default.nix
+++ b/pkgs/applications/audio/samplv1/default.nix
@@ -22,6 +22,6 @@ mkDerivation rec {
     homepage = "http://samplv1.sourceforge.net/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/audio/seq24/default.nix
+++ b/pkgs/applications/audio/seq24/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation  rec {
     homepage = "http://www.filter24.org/seq24";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
     mainProgram = "seq24";
   };
 }

--- a/pkgs/applications/audio/setbfree/default.nix
+++ b/pkgs/applications/audio/setbfree/default.nix
@@ -48,6 +48,6 @@ stdenv.mkDerivation  rec {
     homepage = "https://setbfree.org";
     license = licenses.gpl2;
     platforms = [ "x86_64-linux" "i686-linux" ]; # fails on ARM and Darwin
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/audio/sonic-visualiser/default.nix
+++ b/pkgs/applications/audio/sonic-visualiser/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     description = "View and analyse contents of music audio files";
     homepage = "https://www.sonicvisualiser.org/";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.goibhniu maintainers.marcweber ];
+    maintainers = [ maintainers.marcweber ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/audio/swh-lv2/default.nix
+++ b/pkgs/applications/audio/swh-lv2/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
       generators, surround encoders and more.
     '';
     license = licenses.gpl3;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/audio/synthv1/default.nix
+++ b/pkgs/applications/audio/synthv1/default.nix
@@ -19,6 +19,6 @@ mkDerivation rec {
     homepage = "https://synthv1.sourceforge.io/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/audio/vkeybd/default.nix
+++ b/pkgs/applications/audio/vkeybd/default.nix
@@ -24,6 +24,6 @@ stdenv.mkDerivation  rec {
     homepage = "https://www.alsa-project.org/~tiwai/alsa.html";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/audio/xsynth-dssi/default.nix
+++ b/pkgs/applications/audio/xsynth-dssi/default.nix
@@ -34,6 +34,6 @@ stdenv.mkDerivation  rec {
     homepage = "https://dssi.sourceforge.net/download.html#Xsynth-DSSI";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/audio/yoshimi/default.nix
+++ b/pkgs/applications/audio/yoshimi/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
     homepage = "https://yoshimi.github.io/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     mainProgram = "yoshimi";
   };
 }

--- a/pkgs/applications/audio/zynaddsubfx/default.nix
+++ b/pkgs/applications/audio/zynaddsubfx/default.nix
@@ -148,7 +148,7 @@ in stdenv.mkDerivation rec {
       else "https://zynaddsubfx.sourceforge.io";
 
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ goibhniu kira-bruneau ];
+    maintainers = with maintainers; [ kira-bruneau ];
     platforms = platforms.all;
 
     # On macOS:

--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -145,6 +145,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.darktable.org";
     license = licenses.gpl3Plus;
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ goibhniu flosse mrVanDalo paperdigits freyacodes ];
+    maintainers = with maintainers; [ flosse mrVanDalo paperdigits freyacodes ];
   };
 }

--- a/pkgs/applications/graphics/mypaint/default.nix
+++ b/pkgs/applications/graphics/mypaint/default.nix
@@ -136,6 +136,6 @@ in buildPythonApplication rec {
     homepage = "http://mypaint.org/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ goibhniu jtojnar ];
+    maintainers = with maintainers; [ jtojnar ];
   };
 }

--- a/pkgs/applications/graphics/synfigstudio/default.nix
+++ b/pkgs/applications/graphics/synfigstudio/default.nix
@@ -160,7 +160,7 @@ stdenv.mkDerivation {
     description = "2D animation program";
     homepage = "http://www.synfig.org";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/applications/misc/artha/default.nix
+++ b/pkgs/applications/misc/artha/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     description = "Offline thesaurus based on WordNet";
     homepage = "https://artha.sourceforge.net";
     license = licenses.gpl2;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux;
     mainProgram = "artha";
   };

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -427,10 +427,7 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     # the current apple sdk is too old (currently 11_0) and fails to build "metal" on x86_64-darwin
     broken = stdenv.hostPlatform.system == "x86_64-darwin";
-    maintainers = with lib.maintainers; [
-      goibhniu
-      veprbl
-    ];
+    maintainers = with lib.maintainers; [ veprbl ];
     mainProgram = "blender";
   };
 })

--- a/pkgs/applications/misc/hovercraft/default.nix
+++ b/pkgs/applications/misc/hovercraft/default.nix
@@ -39,6 +39,6 @@ buildPythonApplication rec {
     mainProgram = "hovercraft";
     homepage = "https://github.com/regebro/hovercraft";
     license = licenses.mit;
-    maintainers = with maintainers; [ goibhniu makefu ];
+    maintainers = with maintainers; [ makefu ];
   };
 }

--- a/pkgs/applications/video/shotcut/default.nix
+++ b/pkgs/applications/video/shotcut/default.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://shotcut.org";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ goibhniu woffs peti ];
+    maintainers = with maintainers; [ woffs peti ];
     platforms = platforms.unix;
     mainProgram = "shotcut";
   };

--- a/pkgs/applications/video/simplescreenrecorder/default.nix
+++ b/pkgs/applications/video/simplescreenrecorder/default.nix
@@ -40,6 +40,6 @@ mkDerivation rec {
     homepage = "https://www.maartenbaert.be/simplescreenrecorder";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/qt/qtractor/package.nix
+++ b/pkgs/by-name/qt/qtractor/package.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
     in "https://github.com/rncbc/qtractor/blob/qtractor_${version'}/ChangeLog";
     license = licenses.gpl2Plus;
     mainProgram = "qtractor";
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/aqbanking/default.nix
+++ b/pkgs/development/libraries/aqbanking/default.nix
@@ -32,7 +32,7 @@ in stdenv.mkDerivation rec {
     homepage = "https://www.aquamaniac.de/rdm/";
     hydraPlatforms = [];
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/aqbanking/gwenhywfar.nix
+++ b/pkgs/development/libraries/aqbanking/gwenhywfar.nix
@@ -63,7 +63,7 @@ in stdenv.mkDerivation rec {
     description = "OS abstraction functions used by aqbanking and related tools";
     homepage = "https://www.aquamaniac.de/rdm/projects/gwenhywfar";
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/aubio/default.nix
+++ b/pkgs/development/libraries/aubio/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     description = "Library for audio labelling";
     homepage = "https://aubio.org/";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ goibhniu marcweber fpletz ];
+    maintainers = with maintainers; [ marcweber fpletz ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/audio/libsmf/default.nix
+++ b/pkgs/development/libraries/audio/libsmf/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     description = "C library for reading and writing Standard MIDI Files";
     homepage = "https://github.com/stump/libsmf";
     license = licenses.bsd2;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     mainProgram = "smfsh";
     platforms = platforms.unix;
   };

--- a/pkgs/development/libraries/audio/lilv/default.nix
+++ b/pkgs/development/libraries/audio/lilv/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     homepage = "http://drobilla.net/software/lilv";
     description = "C library to make the use of LV2 plugins";
     license = licenses.mit;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/audio/lv2/default.nix
+++ b/pkgs/development/libraries/audio/lv2/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     description = "Plugin standard for audio systems";
     mainProgram = "lv2_validate";
     license = licenses.mit;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/audio/lvtk/default.nix
+++ b/pkgs/development/libraries/audio/lvtk/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     mainProgram = "ttl2c";
     homepage = "https://lvtk.org/";
     license = licenses.gpl3;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/audio/qm-dsp/default.nix
+++ b/pkgs/development/libraries/audio/qm-dsp/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     description = "C++ library of functions for DSP and Music Informatics purposes";
     homepage = "https://code.soundsoftware.ac.uk/projects/qm-dsp";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/audio/raul/default.nix
+++ b/pkgs/development/libraries/audio/raul/default.nix
@@ -28,10 +28,7 @@ stdenv.mkDerivation {
     description = "C++ utility library primarily aimed at audio/musical applications";
     homepage = "http://drobilla.net/software/raul";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [
-      goibhniu
-      t4ccer
-    ];
+    maintainers = with lib.maintainers; [ t4ccer ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/audio/sratom/default.nix
+++ b/pkgs/development/libraries/audio/sratom/default.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
     homepage = "https://drobilla.net/software/sratom";
     description = "Library for serialising LV2 atoms to/from RDF";
     license = licenses.mit;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/audio/suil/default.nix
+++ b/pkgs/development/libraries/audio/suil/default.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
     homepage = "http://drobilla.net/software/suil";
     description = "Lightweight C library for loading and wrapping LV2 plugin UIs";
     license = licenses.mit;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/audio/vamp-plugin-sdk/default.nix
+++ b/pkgs/development/libraries/audio/vamp-plugin-sdk/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     description = "Audio processing plugin system for plugins that extract descriptive information from audio data";
     homepage = "https://vamp-plugins.org/";
     license = licenses.bsd3;
-    maintainers = [ maintainers.goibhniu maintainers.marcweber ];
+    maintainers = [ maintainers.marcweber ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/dbus-cplusplus/default.nix
+++ b/pkgs/development/libraries/dbus-cplusplus/default.nix
@@ -64,6 +64,6 @@ stdenv.mkDerivation rec {
     description = "C++ API for D-BUS";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/frei0r/default.nix
+++ b/pkgs/development/libraries/frei0r/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     homepage = "https://frei0r.dyne.org";
     description = "Minimalist, cross-platform, shared video plugins";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/ganv/default.nix
+++ b/pkgs/development/libraries/ganv/default.nix
@@ -45,10 +45,7 @@ stdenv.mkDerivation {
     mainProgram = "ganv_bench";
     homepage = "http://drobilla.net";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [
-      goibhniu
-      t4ccer
-    ];
+    maintainers = with lib.maintainers; [ t4ccer ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/libraries/kissfft/default.nix
+++ b/pkgs/development/libraries/kissfft/default.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
     description = "Mixed-radix Fast Fourier Transform based up on the KISS principle";
     homepage = "https://github.com/mborgerding/kissfft";
     license = licenses.bsd3;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/libconfig/default.nix
+++ b/pkgs/development/libraries/libconfig/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.hyperrealm.com/libconfig";
     description = "Simple library for processing structured configuration files";
     license = licenses.lgpl3;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/libepoxy/default.nix
+++ b/pkgs/development/libraries/libepoxy/default.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Library for handling OpenGL function pointer management";
     homepage = "https://github.com/anholt/libepoxy";
     license = licenses.mit;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
     platforms = platforms.unix;
     pkgConfigModules = [ "epoxy" ];
   };

--- a/pkgs/development/libraries/libfakekey/default.nix
+++ b/pkgs/development/libraries/libfakekey/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     description = "X virtual keyboard library";
     homepage = "https://www.yoctoproject.org/tools-resources/projects/matchbox";
     license = licenses.gpl2;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libgig/default.nix
+++ b/pkgs/development/libraries/libgig/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.linuxsampler.org";
     description = "Gigasampler file access library";
     license = licenses.gpl2;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/liblscp/default.nix
+++ b/pkgs/development/libraries/liblscp/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.linuxsampler.org";
     description = "LinuxSampler Control Protocol (LSCP) wrapper library";
     license = licenses.gpl2;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libmypaint/default.nix
+++ b/pkgs/development/libraries/libmypaint/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     homepage = "http://mypaint.org/";
     description = "Library for making brushstrokes which is used by MyPaint and other projects";
     license = licenses.isc;
-    maintainers = with maintainers; [ goibhniu jtojnar ];
+    maintainers = with maintainers; [ jtojnar ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/minixml/default.nix
+++ b/pkgs/development/libraries/minixml/default.nix
@@ -23,6 +23,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.msweet.org/mxml/";
     license = licenses.asl20;
     platforms = platforms.all;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/mlt/default.nix
+++ b/pkgs/development/libraries/mlt/default.nix
@@ -140,7 +140,7 @@ stdenv.mkDerivation rec {
     description = "Open source multimedia framework, designed for television broadcasting";
     homepage = "https://www.mltframework.org/";
     license = with licenses; [ lgpl21Plus gpl2Plus ];
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/movit/default.nix
+++ b/pkgs/development/libraries/movit/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     description = "High-performance, high-quality video filters for the GPU";
     homepage = "https://movit.sesse.net";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/opencolorio/1.x.nix
+++ b/pkgs/development/libraries/opencolorio/1.x.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     homepage = "https://opencolorio.org";
     description = "Color management framework for visual effects and animation";
     license = licenses.bsd3;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/openimageio/default.nix
+++ b/pkgs/development/libraries/openimageio/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
     homepage = "https://openimageio.org";
     description = "Library and tools for reading and writing images";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/robin-map/default.nix
+++ b/pkgs/development/libraries/robin-map/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/Tessil/robin-map";
     changelog = "https://github.com/Tessil/robin-map/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/rubberband/default.nix
+++ b/pkgs/development/libraries/rubberband/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     homepage = "https://breakfastquay.com/rubberband/";
     # commercial license available as well, see homepage. You'll get some more optimized routines
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.goibhniu maintainers.marcweber ];
+    maintainers = [ maintainers.marcweber ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/serd/default.nix
+++ b/pkgs/development/libraries/serd/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     description = "Lightweight C library for RDF syntax which supports reading and writing Turtle and NTriples";
     homepage = "https://drobilla.net/software/serd";
     license = licenses.mit;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     mainProgram = "serdi";
     platforms = platforms.unix;
   };

--- a/pkgs/development/libraries/sord/default.nix
+++ b/pkgs/development/libraries/sord/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     homepage = "http://drobilla.net/software/sord";
     description = "Lightweight C library for storing RDF data in memory";
     license = with licenses; [ bsd0 isc ];
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/evdev/default.nix
+++ b/pkgs/development/python-modules/evdev/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     homepage = "https://python-evdev.readthedocs.io/";
     changelog = "https://github.com/gvalkov/python-evdev/blob/v${version}/docs/changelog.rst";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/limnoria/default.nix
+++ b/pkgs/development/python-modules/limnoria/default.nix
@@ -59,6 +59,6 @@ buildPythonPackage rec {
     description = "Modified version of Supybot, an IRC bot";
     homepage = "https://github.com/ProgVal/Limnoria";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pathtools/default.nix
+++ b/pkgs/development/python-modules/pathtools/default.nix
@@ -22,6 +22,6 @@ buildPythonPackage rec {
     description = "Pattern matching and various utilities for file systems paths";
     homepage = "https://github.com/gorakhargosh/pathtools";
     license = licenses.mit;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -67,10 +67,7 @@ import ./generic.nix (
         processing and graphics capabilities.
       '';
       license = licenses.hpnd;
-      maintainers = with maintainers; [
-        goibhniu
-        prikhi
-      ];
+      maintainers = with maintainers; [ prikhi ];
     };
   }
   // args

--- a/pkgs/development/python-modules/rope/default.nix
+++ b/pkgs/development/python-modules/rope/default.nix
@@ -45,6 +45,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/python-rope/rope";
     changelog = "https://github.com/python-rope/rope/blob/${version}/CHANGELOG.md";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/svg-path/default.nix
+++ b/pkgs/development/python-modules/svg-path/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     description = "SVG path objects and parser";
     homepage = "https://github.com/regebro/svg.path";
     license = licenses.mit;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/virtualenv/default.nix
+++ b/pkgs/development/python-modules/virtualenv/default.nix
@@ -88,6 +88,6 @@ buildPythonPackage rec {
     homepage = "http://www.virtualenv.org";
     changelog = "https://github.com/pypa/virtualenv/blob/${version}/docs/changelog.rst";
     license = licenses.mit;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/watchdog/default.nix
+++ b/pkgs/development/python-modules/watchdog/default.nix
@@ -104,6 +104,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/gorakhargosh/watchdog";
     changelog = "https://github.com/gorakhargosh/watchdog/blob/v${version}/changelog.rst";
     license = licenses.asl20;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zbaemon/default.nix
+++ b/pkgs/development/python-modules/zbaemon/default.nix
@@ -23,6 +23,6 @@ buildPythonPackage rec {
     description = "Daemon process control library and tools for Unix-based systems";
     homepage = "https://pypi.python.org/pypi/zdaemon";
     license = licenses.zpl20;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zc-lockfile/default.nix
+++ b/pkgs/development/python-modules/zc-lockfile/default.nix
@@ -23,6 +23,6 @@ buildPythonPackage rec {
     description = "Inter-process locks";
     homepage = "https://www.python.org/pypi/zc.lockfile";
     license = licenses.zpl20;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zconfig/default.nix
+++ b/pkgs/development/python-modules/zconfig/default.nix
@@ -49,6 +49,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/zopefoundation/ZConfig";
     changelog = "https://github.com/zopefoundation/ZConfig/blob/${version}/CHANGES.rst";
     license = licenses.zpl20;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zdaemon/default.nix
+++ b/pkgs/development/python-modules/zdaemon/default.nix
@@ -31,6 +31,6 @@ buildPythonPackage rec {
     homepage = "https://pypi.python.org/pypi/zdaemon";
     changelog = "https://github.com/zopefoundation/zdaemon/blob/${version}/CHANGES.rst";
     license = licenses.zpl21;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zodb/default.nix
+++ b/pkgs/development/python-modules/zodb/default.nix
@@ -55,6 +55,6 @@ buildPythonPackage rec {
     homepage = "https://zodb-docs.readthedocs.io/";
     changelog = "https://github.com/zopefoundation/ZODB/blob/${version}/CHANGES.rst";
     license = licenses.zpl21;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zope-component/default.nix
+++ b/pkgs/development/python-modules/zope-component/default.nix
@@ -42,6 +42,6 @@ buildPythonPackage rec {
     description = "Zope Component Architecture";
     changelog = "https://github.com/zopefoundation/zope.component/blob/${version}/CHANGES.rst";
     license = licenses.zpl20;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zope-configuration/default.nix
+++ b/pkgs/development/python-modules/zope-configuration/default.nix
@@ -53,6 +53,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/zopefoundation/zope.configuration";
     changelog = "https://github.com/zopefoundation/zope.configuration/blob/${version}/CHANGES.rst";
     license = licenses.zpl21;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zope-contenttype/default.nix
+++ b/pkgs/development/python-modules/zope-contenttype/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     description = "Utility module for content-type (MIME type) handling";
     changelog = "https://github.com/zopefoundation/zope.contenttype/blob/${version}/CHANGES.rst";
     license = licenses.zpl21;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zope-dottedname/default.nix
+++ b/pkgs/development/python-modules/zope-dottedname/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     description = "Resolver for Python dotted names";
     changelog = "https://github.com/zopefoundation/zope.dottedname/blob/${version}/CHANGES.rst";
     license = licenses.zpl21;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zope-event/default.nix
+++ b/pkgs/development/python-modules/zope-event/default.nix
@@ -17,6 +17,6 @@ buildPythonPackage rec {
     description = "Event publishing system";
     homepage = "https://pypi.org/project/zope.event/";
     license = licenses.zpl20;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zope-exceptions/default.nix
+++ b/pkgs/development/python-modules/zope-exceptions/default.nix
@@ -34,6 +34,6 @@ buildPythonPackage rec {
     homepage = "https://pypi.python.org/pypi/zope.exceptions";
     changelog = "https://github.com/zopefoundation/zope.exceptions/blob/${version}/CHANGES.rst";
     license = licenses.zpl21;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zope-filerepresentation/default.nix
+++ b/pkgs/development/python-modules/zope-filerepresentation/default.nix
@@ -28,6 +28,6 @@ buildPythonPackage rec {
     homepage = "https://zopefilerepresentation.readthedocs.io/";
     description = "File-system Representation Interfaces";
     license = licenses.zpl20;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zope-i18nmessageid/default.nix
+++ b/pkgs/development/python-modules/zope-i18nmessageid/default.nix
@@ -31,6 +31,6 @@ buildPythonPackage rec {
     description = "Message Identifiers for internationalization";
     changelog = "https://github.com/zopefoundation/zope.i18nmessageid/blob/${version}/CHANGES.rst";
     license = licenses.zpl20;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zope-interface/default.nix
+++ b/pkgs/development/python-modules/zope-interface/default.nix
@@ -27,6 +27,6 @@ buildPythonPackage rec {
     description = "Zope.Interface";
     homepage = "https://github.com/zopefoundation/zope.interface";
     license = licenses.zpl20;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zope-lifecycleevent/default.nix
+++ b/pkgs/development/python-modules/zope-lifecycleevent/default.nix
@@ -41,6 +41,6 @@ buildPythonPackage rec {
     description = "Object life-cycle events";
     changelog = "https://github.com/zopefoundation/zope.lifecycleevent/blob/${version}/CHANGES.rst";
     license = licenses.zpl21;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zope-location/default.nix
+++ b/pkgs/development/python-modules/zope-location/default.nix
@@ -27,6 +27,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/zopefoundation/zope.location/";
     description = "Zope Location";
     license = licenses.zpl20;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zope-proxy/default.nix
+++ b/pkgs/development/python-modules/zope-proxy/default.nix
@@ -34,6 +34,6 @@ buildPythonPackage rec {
     description = "Generic Transparent Proxies";
     changelog = "https://github.com/zopefoundation/zope.proxy/blob/${version}/CHANGES.rst";
     license = licenses.zpl21;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zope-schema/default.nix
+++ b/pkgs/development/python-modules/zope-schema/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/zopefoundation/zope.schema";
     description = "zope.interface extension for defining data schemas";
     license = licenses.zpl20;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zope-size/default.nix
+++ b/pkgs/development/python-modules/zope-size/default.nix
@@ -24,6 +24,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/zopefoundation/zope.size";
     description = "Interfaces and simple adapter that give the size of an object";
     license = licenses.zpl20;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zope-testing/default.nix
+++ b/pkgs/development/python-modules/zope-testing/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/zopefoundation/zope.testing";
     changelog = "https://github.com/zopefoundation/zope.testing/blob/${version}/CHANGES.rst";
     license = licenses.zpl21;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zope-testrunner/default.nix
+++ b/pkgs/development/python-modules/zope-testrunner/default.nix
@@ -31,6 +31,6 @@ buildPythonPackage rec {
     mainProgram = "zope-testrunner";
     homepage = "https://pypi.python.org/pypi/zope.testrunner";
     license = licenses.zpl20;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/tools/selenium/chromedriver/binary.nix
+++ b/pkgs/development/tools/selenium/chromedriver/binary.nix
@@ -55,7 +55,7 @@ in stdenv.mkDerivation rec {
     '';
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.bsd3;
-    maintainers = with maintainers; [ goibhniu primeos ];
+    maintainers = with maintainers; [ primeos ];
     # Note from primeos: By updating Chromium I also update Google Chrome and
     # ChromeDriver.
     platforms = attrNames allSpecs;

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -220,7 +220,7 @@ let
       homepage = "https://nodejs.org";
       changelog = "https://github.com/nodejs/node/releases/tag/v${version}";
       license = licenses.mit;
-      maintainers = with maintainers; [ goibhniu aduh95 ];
+      maintainers = with maintainers; [ aduh95 ];
       platforms = platforms.linux ++ platforms.darwin;
       mainProgram = "node";
       knownVulnerabilities = optional (versionOlder version "18") "This NodeJS release has reached its end of life. See https://nodejs.org/en/about/releases/.";

--- a/pkgs/misc/jackaudio/default.nix
+++ b/pkgs/misc/jackaudio/default.nix
@@ -86,6 +86,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.gpl2Plus;
     pkgConfigModules = [ "jack" ];
     platforms = platforms.unix;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/os-specific/linux/ffado/default.nix
+++ b/pkgs/os-specific/linux/ffado/default.nix
@@ -125,7 +125,6 @@ mkDerivation rec {
     description = "FireWire audio drivers";
     license = licenses.gpl3;
     maintainers = with maintainers; [
-      goibhniu
       michojel
     ];
     platforms = platforms.linux;

--- a/pkgs/os-specific/linux/plymouth/default.nix
+++ b/pkgs/os-specific/linux/plymouth/default.nix
@@ -121,7 +121,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.freedesktop.org/wiki/Software/Plymouth/";
     description = "Boot splash and boot logger";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.goibhniu ] ++ teams.gnome.members;
+    maintainers = teams.gnome.members;
     platforms = platforms.linux;
   };
 })

--- a/pkgs/os-specific/linux/xf86-input-wacom/default.nix
+++ b/pkgs/os-specific/linux/xf86-input-wacom/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    maintainers = with maintainers; [ goibhniu moni ];
+    maintainers = with maintainers; [ moni ];
     description = "Wacom digitizer driver for X11";
     homepage = "https://linuxwacom.sourceforge.net";
     license = licenses.gpl2Only;

--- a/pkgs/os-specific/linux/xf86-video-nested/default.nix
+++ b/pkgs/os-specific/linux/xf86-video-nested/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     homepage = "https://cgit.freedesktop.org/xorg/driver/xf86-video-nested";
     description = "Driver to run Xorg on top of Xorg or something else";
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.linux;
     license = licenses.mit;
   };

--- a/pkgs/servers/http/yaws/default.nix
+++ b/pkgs/servers/http/yaws/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/erlyaws/yaws";
     license = licenses.bsd2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
   };
 
 }

--- a/pkgs/tools/misc/rockbox-utility/default.nix
+++ b/pkgs/tools/misc/rockbox-utility/default.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation  rec {
     homepage = "https://www.rockbox.org";
     description = "Open source firmware for digital music players";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ AndersonTorres goibhniu ];
+    maintainers = with maintainers; [ AndersonTorres ];
     mainProgram = "RockboxUtility";
     platforms = platforms.linux;
   };

--- a/pkgs/tools/misc/ttfautohint/default.nix
+++ b/pkgs/tools/misc/ttfautohint/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://www.freetype.org/ttfautohint";
     license = licenses.gpl2Plus; # or the FreeType License (BSD + advertising clause)
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 

--- a/pkgs/tools/security/aespipe/default.nix
+++ b/pkgs/tools/security/aespipe/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     description = "AES encrypting or decrypting pipe";
     homepage = "https://loop-aes.sourceforge.net/aespipe.README";
     license = licenses.gpl2Only;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/system/symlinks/default.nix
+++ b/pkgs/tools/system/symlinks/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     description = "Find and remedy problematic symbolic links on a system";
     homepage = "https://github.com/brandt/symlinks";
     license = licenses.mit;
-    maintainers = with maintainers; [ goibhniu ckauhaus ];
+    maintainers = with maintainers; [ ckauhaus ];
     platforms = platforms.unix;
     mainProgram = "symlinks";
   };

--- a/pkgs/tools/text/podiff/default.nix
+++ b/pkgs/tools/text/podiff/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
     mainProgram = "podiff";
     homepage = "http://puszcza.gnu.org.ua/software/podiff";
     license = licenses.gpl3Plus;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/text/uni2ascii/default.nix
+++ b/pkgs/tools/text/uni2ascii/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     It also provides ways of converting non-ASCII characters to
     similar ASCII characters, e.g. by stripping diacritics.
     '';
-    maintainers = with lib.maintainers; [ goibhniu ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 }


### PR DESCRIPTION
## Description of changes

Inactive in Nixpkgs since 2018 (and a single PR in 2022).
https://github.com/NixOS/nixpkgs/issues?q=author%3Acillianderoiste

Pinging @cillianderoiste (aka `goibhniu` in `maintainer-list.nix`).

See https://github.com/NixOS/nixpkgs/issues/290642

According to `grep` from #327779, this change leaves 91 packages without maintainer.

<details>
<summary>List of orphaned packages after this change</summary>

```
pkgs/applications/audio/a2jmidid/default.nix
pkgs/applications/audio/ams-lv2/default.nix
pkgs/applications/audio/bristol/default.nix
pkgs/applications/audio/calf/default.nix
pkgs/applications/audio/distrho/default.nix
pkgs/applications/audio/drumkv1/default.nix
pkgs/applications/audio/gigedit/default.nix
pkgs/applications/audio/jack-oscrolloscope/default.nix
pkgs/applications/audio/jalv/default.nix
pkgs/applications/audio/lash/default.nix
pkgs/applications/audio/linuxsampler/default.nix
pkgs/applications/audio/mda-lv2/default.nix
pkgs/applications/audio/mhwaveedit/default.nix
pkgs/applications/audio/mid2key/default.nix
pkgs/applications/audio/petrifoo/default.nix
pkgs/applications/audio/qjackctl/default.nix
pkgs/applications/audio/qsampler/default.nix
pkgs/applications/audio/qsynth/default.nix
pkgs/applications/audio/rakarrack/default.nix
pkgs/applications/audio/samplv1/default.nix
pkgs/applications/audio/seq24/default.nix
pkgs/applications/audio/setbfree/default.nix
pkgs/applications/audio/swh-lv2/default.nix
pkgs/applications/audio/synthv1/default.nix
pkgs/applications/audio/vkeybd/default.nix
pkgs/applications/audio/xsynth-dssi/default.nix
pkgs/applications/audio/yoshimi/default.nix
pkgs/applications/graphics/synfigstudio/default.nix
pkgs/applications/misc/artha/default.nix
pkgs/applications/video/simplescreenrecorder/default.nix
pkgs/by-name/qt/qtractor/package.nix
pkgs/development/libraries/aqbanking/default.nix
pkgs/development/libraries/aqbanking/gwenhywfar.nix
pkgs/development/libraries/audio/libsmf/default.nix
pkgs/development/libraries/audio/lilv/default.nix
pkgs/development/libraries/audio/lv2/default.nix
pkgs/development/libraries/audio/lvtk/default.nix
pkgs/development/libraries/audio/qm-dsp/default.nix
pkgs/development/libraries/audio/sratom/default.nix
pkgs/development/libraries/audio/suil/default.nix
pkgs/development/libraries/dbus-cplusplus/default.nix
pkgs/development/libraries/frei0r/default.nix
pkgs/development/libraries/kissfft/default.nix
pkgs/development/libraries/libconfig/default.nix
pkgs/development/libraries/libepoxy/default.nix
pkgs/development/libraries/libfakekey/default.nix
pkgs/development/libraries/libgig/default.nix
pkgs/development/libraries/liblscp/default.nix
pkgs/development/libraries/minixml/default.nix
pkgs/development/libraries/mlt/default.nix
pkgs/development/libraries/movit/default.nix
pkgs/development/libraries/opencolorio/1.x.nix
pkgs/development/libraries/openimageio/default.nix
pkgs/development/libraries/robin-map/default.nix
pkgs/development/libraries/serd/default.nix
pkgs/development/libraries/sord/default.nix
pkgs/development/python-modules/evdev/default.nix
pkgs/development/python-modules/limnoria/default.nix
pkgs/development/python-modules/pathtools/default.nix
pkgs/development/python-modules/rope/default.nix
pkgs/development/python-modules/svg-path/default.nix
pkgs/development/python-modules/virtualenv/default.nix
pkgs/development/python-modules/watchdog/default.nix
pkgs/development/python-modules/zbaemon/default.nix
pkgs/development/python-modules/zc-lockfile/default.nix
pkgs/development/python-modules/zconfig/default.nix
pkgs/development/python-modules/zdaemon/default.nix
pkgs/development/python-modules/zodb/default.nix
pkgs/development/python-modules/zope-component/default.nix
pkgs/development/python-modules/zope-configuration/default.nix
pkgs/development/python-modules/zope-contenttype/default.nix
pkgs/development/python-modules/zope-dottedname/default.nix
pkgs/development/python-modules/zope-event/default.nix
pkgs/development/python-modules/zope-exceptions/default.nix
pkgs/development/python-modules/zope-filerepresentation/default.nix
pkgs/development/python-modules/zope-i18nmessageid/default.nix
pkgs/development/python-modules/zope-interface/default.nix
pkgs/development/python-modules/zope-lifecycleevent/default.nix
pkgs/development/python-modules/zope-location/default.nix
pkgs/development/python-modules/zope-proxy/default.nix
pkgs/development/python-modules/zope-schema/default.nix
pkgs/development/python-modules/zope-size/default.nix
pkgs/development/python-modules/zope-testing/default.nix
pkgs/development/python-modules/zope-testrunner/default.nix
pkgs/misc/jackaudio/default.nix
pkgs/os-specific/linux/xf86-video-nested/default.nix
pkgs/servers/http/yaws/default.nix
pkgs/tools/misc/ttfautohint/default.nix
pkgs/tools/security/aespipe/default.nix
pkgs/tools/text/podiff/default.nix
pkgs/tools/text/uni2ascii/default.nix
```
</details>

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
