### PR TITLE
tracker-miners: fix store permissions

### DIFF
--- a/pkgs/by-name/tr/tracker-miners/package.nix
+++ b/pkgs/by-name/tr/tracker-miners/package.nix
@@ -54,6 +54,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-50OIFUtcGXtLfuQvDc6MX7vd1NNhCT74jU+zA+M9pf4=";
   };
 
+  patches = [
+    ./tracker-landlock-nix-store-permission.patch
+  ];
+
   nativeBuildInputs = [
     asciidoc
     docbook-xsl-nons

--- a/pkgs/by-name/tr/tracker-miners/tracker-landlock-nix-store-permission.patch
+++ b/pkgs/by-name/tr/tracker-miners/tracker-landlock-nix-store-permission.patch
@@ -1,0 +1,15 @@
+diff --git a/src/libtracker-miners-common/tracker-landlock.c b/src/libtracker-miners-common/tracker-landlock.c
+index 6d4510be1..1de5d5a90 100644
+--- a/src/libtracker-miners-common/tracker-landlock.c
++++ b/src/libtracker-miners-common/tracker-landlock.c
+@@ -184,6 +184,10 @@ gboolean
+ tracker_landlock_init (const gchar * const *indexed_folders)
+ {
+ 	TrackerLandlockRule stock_rules[] = {
++		{ "/nix/store",
++		 (LANDLOCK_ACCESS_FS_EXECUTE |
++		  LANDLOCK_ACCESS_FS_READ_FILE |
++		  LANDLOCK_ACCESS_FS_READ_DIR) },
+ 		/* Allow access to the executable itself */
+ 		{ LIBEXECDIR "/tracker-extract-3",
+ 		 LANDLOCK_ACCESS_FS_READ_FILE |


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/319587
according to  https://gitlab.gnome.org/GNOME/localsearch/-/issues/351

## Description of changes

Add patch `tracker-landlock-nix-store-permission.patch`

## Things done

I've checked that the patch fixes the problem by building a VM with GNOME.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
