### PR TITLE
python312Packages.apptools: 5.2.1 -> 5.3.0

### DIFF
--- a/pkgs/development/python-modules/apptools/default.nix
+++ b/pkgs/development/python-modules/apptools/default.nix
@@ -2,11 +2,13 @@
   lib,
   buildPythonPackage,
   configobj,
-  fetchPypi,
-  importlib-resources,
+  fetchFromGitHub,
+  numpy,
   pandas,
+  pyface,
   pytestCheckHook,
   pythonOlder,
+  setuptools,
   tables,
   traits,
   traitsui,
@@ -14,27 +16,37 @@
 
 buildPythonPackage rec {
   pname = "apptools";
-  version = "5.2.1";
-  format = "setuptools";
+  version = "5.3.0";
+  pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-xiaPXfzzCIvK92oAA+ULd3TQG1JY1xmbQQtIUv8iRuM=";
+  src = fetchFromGitHub {
+    owner = "enthought";
+    repo = "apptools";
+    rev = "refs/tags/${version}";
+    hash = "sha256-qNtDHmvl5HbtdbjnugVM7CKVCW+ysAwRB9e2Ounh808=";
   };
 
-  propagatedBuildInputs = [
-    configobj
-    traits
-    traitsui
-  ] ++ lib.optionals (pythonOlder "3.9") [ importlib-resources ];
+  build-system = [ setuptools ];
 
-  nativeCheckInputs = [
-    tables
-    pandas
-    pytestCheckHook
-  ];
+  dependencies = [ traits ];
+
+  optional-dependencies = {
+    gui = [
+      pyface
+      traitsui
+    ];
+    h5 = [
+      numpy
+      pandas
+      tables
+    ];
+    persistence = [ numpy ];
+    preferences = [ configobj ];
+  };
+
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   preCheck = ''
     export HOME=$TMP

--- a/pkgs/development/python-modules/envisage/default.nix
+++ b/pkgs/development/python-modules/envisage/default.nix
@@ -4,47 +4,42 @@
   buildPythonPackage,
   fetchPypi,
   ipython,
+  pyface,
   pytestCheckHook,
   pythonAtLeast,
   pythonOlder,
   setuptools,
   traits,
+  traitsui,
 }:
 
 buildPythonPackage rec {
   pname = "envisage";
   version = "7.0.3";
-  format = "pyproject";
+  pyproject = true;
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-97GviL86j/8qmsbja7SN6pkp4/YSIEz+lK7WKwMWyeM=";
   };
 
-  # for the optional dependency ipykernel, only versions < 6 are
-  # supported, so it's not included in the tests, and not propagated
-  propagatedBuildInputs = [
-    traits
+  build-system = [ setuptools ];
+
+  dependencies = [
     apptools
+    pyface
     setuptools
-  ];
+    traits
+    traitsui
+  ] ++ apptools.optional-dependencies.preferences;
 
   preCheck = ''
     export HOME=$PWD/HOME
   '';
 
-  nativeCheckInputs = [
-    ipython
-    pytestCheckHook
-  ];
-
-  disabledTestPaths = lib.optionals (pythonAtLeast "3.10") [
-    # https://github.com/enthought/envisage/issues/455
-    "envisage/tests/test_egg_basket_plugin_manager.py"
-    "envisage/tests/test_egg_plugin_manager.py"
-  ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "envisage" ];
 


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/enthought/apptools/compare/refs/tags/5.2.1...5.3.0

Changelog: https://github.com/enthought/apptools/releases/tag/5.3.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->
closes https://github.com/NixOS/nixpkgs/pull/327811

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
