### PR TITLE
mopsa: init at 1.0

### DIFF
--- a/pkgs/development/ocaml-modules/mopsa/default.nix
+++ b/pkgs/development/ocaml-modules/mopsa/default.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitLab,
+  clang,
+  libclang,
+  libllvm,
+  flint,
+  mpfr,
+  pplite,
+  ocaml,
+  menhir,
+  apron,
+  camlidl,
+  yojson,
+  zarith,
+}:
+
+buildDunePackage rec {
+  pname = "mopsa";
+  version = "1.0";
+
+  minimalOCamlVersion = "4.12";
+
+  src = fetchFromGitLab {
+    owner = "mopsa";
+    repo = "mopsa-analyzer";
+    rev = "v${version}";
+    hash = "sha256-nGnWwV7g3SYgShbXGUMooyOdFwXFrQHnQvlc8x9TAS4=";
+  };
+
+  nativeBuildInputs = [
+    clang
+    libllvm
+    menhir
+  ];
+
+  buildInputs = [
+    camlidl
+    flint
+    libclang
+    mpfr
+    pplite
+  ];
+
+  propagatedBuildInputs = [
+    apron
+    yojson
+    zarith
+  ];
+
+  postPatch = ''
+    patchShebangs bin
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    dune build --profile release -p mopsa
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    dune install --profile release --prefix=$bin --libdir=$out/lib/ocaml/${ocaml.version}/site-lib
+    runHook postInstall
+  '';
+
+  outputs = [
+    "bin"
+    "out"
+  ];
+
+  meta = {
+    license = lib.licenses.lgpl3Plus;
+    homepage = "https://mopsa.lip6.fr/";
+    description = "A Modular and Open Platform for Static Analysis using Abstract Interpretation";
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18858,6 +18858,8 @@ with pkgs;
 
   moon = callPackage ../development/tools/build-managers/moon/default.nix { };
 
+  mopsa = ocamlPackages.mopsa.bin;
+
   msgpack-tools = callPackage ../development/tools/msgpack-tools { };
 
   msgpuck = callPackage ../development/libraries/msgpuck { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1181,6 +1181,8 @@ let
 
     mmap =  callPackage ../development/ocaml-modules/mmap { };
 
+    mopsa = callPackage ../development/ocaml-modules/mopsa { };
+
     morbig = callPackage ../development/ocaml-modules/morbig { };
 
     mparser =  callPackage ../development/ocaml-modules/mparser { };


### PR DESCRIPTION
## Description of changes

https://discuss.ocaml.org/t/ann-mopsa-1-0-modular-open-platform-for-static-analysis/15013

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
