### PR TITLE
python3Packages.commitizen: Add library along with binary

### DIFF
--- a/pkgs/development/python-modules/commitizen/default.nix
+++ b/pkgs/development/python-modules/commitizen/default.nix
@@ -1,20 +1,39 @@
 { lib
 , commitizen
 , fetchFromGitHub
+, buildPythonPackage
 , git
-, python3
+, pythonOlder
 , stdenv
 , installShellFiles
+, poetry-core
 , nix-update-script
 , testers
+, argcomplete
+, charset-normalizer
+, colorama
+, decli
+, importlib-metadata
+, jinja2
+, packaging
+, pyyaml
+, questionary
+, termcolor
+, tomlkit
+, py
+, pytest-freezer
+, pytest-mock
+, pytest-regressions
+, pytest7CheckHook
+, deprecated
 }:
 
-python3.pkgs.buildPythonApplication rec {
+buildPythonPackage rec {
   pname = "commitizen";
   version = "3.28.0";
   format = "pyproject";
 
-  disabled = python3.pythonOlder "3.8";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "commitizen-tools";
@@ -28,12 +47,12 @@ python3.pkgs.buildPythonApplication rec {
     "decli"
   ];
 
-  nativeBuildInputs = with python3.pkgs; [
+  nativeBuildInputs = [
     poetry-core
     installShellFiles
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = [
     argcomplete
     charset-normalizer
     colorama
@@ -47,7 +66,7 @@ python3.pkgs.buildPythonApplication rec {
     tomlkit
   ];
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = [
     argcomplete
     deprecated
     git
@@ -59,6 +78,8 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   doCheck = true;
+
+  pythonImportsCheck = [ "commitizen" ];
 
   # The tests require a functional git installation
   # which requires a valid HOME directory.
@@ -85,14 +106,14 @@ python3.pkgs.buildPythonApplication rec {
 
   postInstall =
     let
-      argcomplete = lib.getExe' python3.pkgs.argcomplete "register-python-argcomplete";
+      register-python-argcomplete = lib.getExe' argcomplete "register-python-argcomplete";
     in
     lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform)
       ''
         installShellCompletion --cmd cz \
-          --bash <(${argcomplete} --shell bash $out/bin/cz) \
-          --zsh <(${argcomplete} --shell zsh $out/bin/cz) \
-          --fish <(${argcomplete} --shell fish $out/bin/cz)
+          --bash <(${register-python-argcomplete} --shell bash $out/bin/cz) \
+          --zsh <(${register-python-argcomplete} --shell zsh $out/bin/cz) \
+          --fish <(${register-python-argcomplete} --shell fish $out/bin/cz)
       '';
 
   passthru = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4544,7 +4544,7 @@ with pkgs;
 
   comma = callPackage ../tools/package-management/comma { };
 
-  commitizen = callPackage ../applications/version-management/commitizen { };
+  commitizen = with python3Packages; toPythonApplication commitizen;
 
   common-licenses = callPackage ../data/misc/common-licenses { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2053,6 +2053,8 @@ self: super: with self; {
 
   command-runner = callPackage ../development/python-modules/command-runner { };
 
+  commitizen = callPackage ../development/python-modules/commitizen { };
+
   connect-box = callPackage ../development/python-modules/connect-box { };
 
   connection-pool = callPackage ../development/python-modules/connection-pool { };


### PR DESCRIPTION
custom commit rules require the library, see:
https://commitizen-tools.github.io/commitizen/customization/#2-customize-through-customizing-a-class

cc: @lovesegfault @anthonyroussel 
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
