### PR TITLE
mbrola-voices: extract from mbrola, allow language selection

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
@@ -66,4 +66,13 @@ with lib;
     glxinfo
   ];
 
+  nixpkgs.overlays = [
+    (self: super: {
+      mbrola-voices = super.mbrola-voices.override {
+        # only ship with one voice per language
+        languages = [ "*1" ];
+      };
+    })
+  ];
+
 }

--- a/pkgs/applications/audio/mbrola/default.nix
+++ b/pkgs/applications/audio/mbrola/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, runCommandLocal }:
+{ stdenv, lib, fetchFromGitHub, runCommandLocal, mbrola-voices }:
 
 let
   pname = "mbrola";
@@ -10,20 +10,6 @@ let
     platforms = platforms.all;
     description = "Speech synthesizer based on the concatenation of diphones";
     homepage = "https://github.com/numediart/MBROLA";
-  };
-
-  # Very big (0.65 G) so kept as a fixed-output derivation to limit "duplicates".
-  voices = fetchFromGitHub {
-    owner = "numediart";
-    repo = "MBROLA-voices";
-    rev = "fe05a0ccef6a941207fd6aaad0b31294a1f93a51";  # using latest commit
-    sha256 = "1w0y2xjp9rndwdjagp2wxh656mdm3d6w9cs411g27rjyfy1205a0";
-
-    name = "${pname}-voices-${version}";
-    meta = meta // {
-      description = "Speech synthesizer based on the concatenation of diphones (voice files)";
-      homepage = "https://github.com/numediart/MBROLA-voices";
-    };
   };
 
   bin = stdenv.mkDerivation {
@@ -60,7 +46,7 @@ in
     }
     ''
       mkdir -p "$out/share/mbrola"
-      ln -s '${voices}/data' "$out/share/mbrola/voices"
+      ln -s '${mbrola-voices}/data' "$out/share/mbrola/voices"
       ln -s '${bin}/bin' "$out/"
     ''
 

--- a/pkgs/applications/audio/mbrola/voices.nix
+++ b/pkgs/applications/audio/mbrola/voices.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  unstableGitUpdater,
+  mbrola,
+  languages ? [ ],
+}:
+
+let
+  src = fetchFromGitHub {
+    owner = "numediart";
+    repo = "MBROLA-voices";
+    rev = "fe05a0ccef6a941207fd6aaad0b31294a1f93a51";
+    hash = "sha256-QBUggnde5iNeCESzxE0btVVTDOxc3Kdk483mdGUXHvA=";
+  };
+
+  meta = {
+    description = "Speech synthesizer based on the concatenation of diphones (voice files)";
+    homepage = "https://github.com/numediart/MBROLA-voices";
+    license = mbrola.meta.license;
+  };
+in
+
+if (languages == [ ]) then
+  src // { inherit meta; }
+else
+  stdenv.mkDerivation {
+    pname = "mbrola-voices";
+    version = "0-unstable-2020-03-30";
+
+    inherit src;
+
+    postPatch = ''
+      shopt -s extglob
+      pushd data
+      rm -rfv !(${lib.concatStringsSep "|" languages})
+      popd
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir $out
+      cp -R data $out/
+
+      runHook postInstall
+    '';
+
+    inherit meta;
+  }

--- a/pkgs/applications/audio/mbrola/voices.nix
+++ b/pkgs/applications/audio/mbrola/voices.nix
@@ -9,7 +9,7 @@
 
 let
   pname = "mbrola-voices";
-  version = "0-unstable-2020-03-30";
+  version = "3.3"; # FIXME: revert this line on staging*
 
   src = fetchFromGitHub {
     owner = "numediart";

--- a/pkgs/applications/audio/mbrola/voices.nix
+++ b/pkgs/applications/audio/mbrola/voices.nix
@@ -8,11 +8,15 @@
 }:
 
 let
+  pname = "mbrola-voices";
+  version = "0-unstable-2020-03-30";
+
   src = fetchFromGitHub {
     owner = "numediart";
     repo = "MBROLA-voices";
     rev = "fe05a0ccef6a941207fd6aaad0b31294a1f93a51";
     hash = "sha256-QBUggnde5iNeCESzxE0btVVTDOxc3Kdk483mdGUXHvA=";
+    name = "${pname}-${version}";
   };
 
   meta = {
@@ -26,10 +30,7 @@ if (languages == [ ]) then
   src // { inherit meta; }
 else
   stdenv.mkDerivation {
-    pname = "mbrola-voices";
-    version = "0-unstable-2020-03-30";
-
-    inherit src;
+    inherit pname version src;
 
     postPatch = ''
       shopt -s extglob

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32208,6 +32208,8 @@ with pkgs;
 
   mbrola = callPackage ../applications/audio/mbrola { };
 
+  mbrola-voices = callPackage ../applications/audio/mbrola/voices.nix { };
+
   mcpp = callPackage ../development/compilers/mcpp { };
 
   mda_lv2 = callPackage ../applications/audio/mda-lv2 { };


### PR DESCRIPTION
Allow filtering voices based on any number of extglob patterns.

## Description of changes

Restricting mbrola-voices to only one voice per language saves 387M, and is what I recommend we should do on the ISO, because it likely doesn't compromise accessbility too much.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
