### PR TITLE
zed-editor: fix darwin

### DIFF
--- a/pkgs/by-name/ze/zed-editor/0002-disable-livekit-darwin.patch
+++ b/pkgs/by-name/ze/zed-editor/0002-disable-livekit-darwin.patch
@@ -1,0 +1,55 @@
+diff --git a/crates/live_kit_client/Cargo.toml b/crates/live_kit_client/Cargo.toml
+index e23c63453e..d0142b83d8 100644
+--- a/crates/live_kit_client/Cargo.toml
++++ b/crates/live_kit_client/Cargo.toml
+@@ -40,10 +40,10 @@ nanoid = { workspace = true, optional = true}
+ parking_lot.workspace = true
+ postage.workspace = true
+ 
+-[target.'cfg(target_os = "macos")'.dependencies]
++[target.'cfg(target_os = "none")'.dependencies]
+ core-foundation.workspace = true
+ 
+-[target.'cfg(all(not(target_os = "macos")))'.dependencies]
++[target.'cfg(all(not(target_os = "none")))'.dependencies]
+ async-trait = { workspace = true }
+ collections = { workspace = true }
+ gpui = { workspace = true }
+diff --git a/crates/live_kit_client/build.rs b/crates/live_kit_client/build.rs
+index 2fdfd982bf..7272614b87 100644
+--- a/crates/live_kit_client/build.rs
++++ b/crates/live_kit_client/build.rs
+@@ -36,7 +36,7 @@ const MACOS_TARGET_VERSION: &str = "10.15.7";
+ 
+ fn main() {
+     if cfg!(all(
+-        target_os = "macos",
++        target_os = "none",
+         not(any(test, feature = "test-support", feature = "no-webrtc")),
+     )) {
+         let swift_target = get_swift_target();
+diff --git a/crates/live_kit_client/src/live_kit_client.rs b/crates/live_kit_client/src/live_kit_client.rs
+index 4820a4eedb..6179e6c55a 100644
+--- a/crates/live_kit_client/src/live_kit_client.rs
++++ b/crates/live_kit_client/src/live_kit_client.rs
+@@ -2,16 +2,16 @@
+ 
+ use std::sync::Arc;
+ 
+-#[cfg(all(target_os = "macos", not(any(test, feature = "test-support"))))]
++#[cfg(all(target_os = "none", not(any(test, feature = "test-support"))))]
+ pub mod prod;
+ 
+-#[cfg(all(target_os = "macos", not(any(test, feature = "test-support"))))]
++#[cfg(all(target_os = "none", not(any(test, feature = "test-support"))))]
+ pub use prod::*;
+ 
+-#[cfg(any(test, feature = "test-support", not(target_os = "macos")))]
++#[cfg(any(test, feature = "test-support", not(target_os = "none")))]
+ pub mod test;
+ 
+-#[cfg(any(test, feature = "test-support", not(target_os = "macos")))]
++#[cfg(any(test, feature = "test-support", not(target_os = "none")))]
+ pub use test::*;
+ 
+ pub type Sid = String;

--- a/pkgs/by-name/ze/zed-editor/package.nix
+++ b/pkgs/by-name/ze/zed-editor/package.nix
@@ -192,7 +192,7 @@ rustPlatform.buildRustPackage rec {
     };
     # Setting this environment variable allows to disable auto-updates
     # https://zed.dev/docs/development/linux#notes-for-packaging-zed
-    ZED_UPDATE_EXPLANATION = "zed has been installed using nix. Auto-updates have thus been disabled.";
+    ZED_UPDATE_EXPLANATION = "Zed has been installed using Nix. Auto-updates have thus been disabled.";
     # Used by `zed --version`
     RELEASE_VERSION = version;
     # Required until `-isysroot` can be used with libclang in nixpkgs on darwin, otherwise


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes #320084.

~~Once https://github.com/zed-industries/zed/pull/13343 lands, building Zed on macOS becomes much easier as we do not have to deal with building a separate Swift library that Zed depends on anymore.~~

As https://github.com/zed-industries/zed/pull/13343 seems to need much longer to implement than I originally anticipated, I updated this PR to disable livekit until this change lands, so we can already go ahead and release darwin support without it, using the same internal fallbacks the Linux version is using.

As this PR is making use of the new pattern for using macOS SDKs, it's targetting staging-next, so merging this PR will have to wait until staging-next has been merged into master (and this PR has been retargetted at master). 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
