### PR TITLE
nixos/geoclue2: add compass and static sources

### DIFF
--- a/nixos/modules/services/desktops/geoclue2.nix
+++ b/nixos/modules/services/desktops/geoclue2.nix
@@ -233,6 +233,14 @@ in
         '';
       };
 
+      enableCompass = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Whether to enable Compass source.
+        '';
+      };
+
       staticSource = {
         enable = lib.mkEnableOption "Geoclue fixed location source";
         location = lib.mkOption {
@@ -365,6 +373,9 @@ in
             submission-url = cfg.submissionUrl;
             submission-nick = cfg.submissionNick;
           };
+          compass = {
+            enable = cfg.enableCompass;
+          };
         }
         // lib.mapAttrs' appConfigToINICompatible cfg.appConfig
       );
@@ -376,6 +387,7 @@ in
         enableCDMA = lib.mkDefault false;
         enableModemGPS = lib.mkDefault false;
         enableWifi = lib.mkDefault false;
+        enableCompass = lib.mkDefault false;
       };
 
       environment.etc."geoclue/conf.d/static.conf".text = ''

--- a/nixos/modules/services/desktops/geoclue2.nix
+++ b/nixos/modules/services/desktops/geoclue2.nix
@@ -68,6 +68,56 @@ let
       };
     };
 
+  locationConfigModule = lib.types.submodule {
+    options = {
+      latitude = lib.mkOption {
+        type = lib.types.float;
+        default = config.location.latitude;
+        defaultText = lib.literalExpression "config.location.latitude";
+        description = ''
+          Latitude in decimal degrees.
+          Positive values are north of the equator; negative values
+          are south.
+        '';
+      };
+
+      longitude = lib.mkOption {
+        type = lib.types.float;
+        default = config.location.longitude;
+        defaultText = lib.literalExpression "config.location.longitude";
+        description = ''
+          Longitude in decimal degrees.
+          Positive values are north of the equator; negative values
+          are south.
+        '';
+      };
+
+      altitude = lib.mkOption {
+        type = lib.types.number;
+        description = ''
+          Elevation of this location, in metres above sea level.
+        '';
+      };
+
+      accuracyRadius = lib.mkOption {
+        type = lib.types.numbers.nonnegative;
+        description = ''
+          Reported accuracy level, in metres. This value denotes
+          a radius around the given location.
+        '';
+      };
+
+      comment = lib.mkOption {
+        type = lib.types.lines;
+        description = ''
+          A free-form textual description of this location.
+          The value is only used as a comment in the configuration
+          file -- it is not parsed by Geoclue.
+        '';
+        default = "Geoclue static-source configuration";
+      };
+    };
+  };
 in
 {
 
@@ -183,6 +233,29 @@ in
         '';
       };
 
+      staticSource = {
+        enable = lib.mkEnableOption "Geoclue fixed location source";
+        location = lib.mkOption {
+          description = ''
+            A fixed location, which will be stored in the text file
+            {file}`/etc/geolocation`.
+            The map projection and co-ordinate system are not specified,
+            so assume they are whatever Geoclue is using.
+          '';
+          type = locationConfigModule;
+          example = {
+            comment = ''
+              Example location of a machine inside the torch of
+              the Statue of Liberty.
+            '';
+            latitude = 40.6893129;
+            longitude = -74.0445531;
+            altitude = 96;
+            accuracyRadius = 1.83;
+          };
+        };
+      };
+
       appConfig = lib.mkOption {
         type = lib.types.attrsOf appConfigModule;
         default = { };
@@ -203,98 +276,148 @@ in
   };
 
   ###### implementation
-  config = lib.mkIf cfg.enable {
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
 
-    environment.systemPackages = [ cfg.package ];
+      environment.systemPackages = [ cfg.package ];
 
-    services.dbus.packages = [ cfg.package ];
+      services.dbus.packages = [ cfg.package ];
 
-    systemd.packages = [ cfg.package ];
+      systemd.packages = [ cfg.package ];
 
-    # we cannot use DynamicUser as we need the the geoclue user to exist for the
-    # dbus policy to work
-    users = {
-      users.geoclue = {
-        isSystemUser = true;
-        home = "/var/lib/geoclue";
-        group = "geoclue";
-        description = "Geoinformation service";
+      # we cannot use DynamicUser as we need the the geoclue user to exist for the
+      # dbus policy to work
+      users = {
+        users.geoclue = {
+          isSystemUser = true;
+          home = "/var/lib/geoclue";
+          group = "geoclue";
+          description = "Geoinformation service";
+        };
+
+        groups.geoclue = { };
       };
 
-      groups.geoclue = { };
-    };
-
-    systemd.services.geoclue = {
-      wants = lib.optionals cfg.enableWifi [ "network-online.target" ];
-      after = lib.optionals cfg.enableWifi [ "network-online.target" ];
-      # restart geoclue service when the configuration changes
-      restartTriggers = [
-        config.environment.etc."geoclue/geoclue.conf".source
-      ];
-      serviceConfig.StateDirectory = "geoclue";
-    };
-
-    # this needs to run as a user service, since it's associated with the
-    # user who is making the requests
-    systemd.user.services = lib.mkIf cfg.enableDemoAgent {
-      geoclue-agent = {
-        description = "Geoclue agent";
-        # this should really be `partOf = [ "geoclue.service" ]`, but
-        # we can't be part of a system service, and the agent should
-        # be okay with the main service coming and going
-        wantedBy = [ "default.target" ];
+      systemd.services.geoclue = {
         wants = lib.optionals cfg.enableWifi [ "network-online.target" ];
         after = lib.optionals cfg.enableWifi [ "network-online.target" ];
-        unitConfig.ConditionUser = "!@system";
-        serviceConfig = {
-          Type = "exec";
-          ExecStart = "${cfg.package}/libexec/geoclue-2.0/demos/agent";
-          Restart = "on-failure";
-          PrivateTmp = true;
+        # restart geoclue service when the configuration changes
+        restartTriggers = [
+          config.environment.etc."geoclue/geoclue.conf".source
+        ];
+        serviceConfig.StateDirectory = "geoclue";
+      };
+
+      # this needs to run as a user service, since it's associated with the
+      # user who is making the requests
+      systemd.user.services = lib.mkIf cfg.enableDemoAgent {
+        geoclue-agent = {
+          description = "Geoclue agent";
+          # this should really be `partOf = [ "geoclue.service" ]`, but
+          # we can't be part of a system service, and the agent should
+          # be okay with the main service coming and going
+          wantedBy = [ "default.target" ];
+          wants = lib.optionals cfg.enableWifi [ "network-online.target" ];
+          after = lib.optionals cfg.enableWifi [ "network-online.target" ];
+          unitConfig.ConditionUser = "!@system";
+          serviceConfig = {
+            Type = "exec";
+            ExecStart = "${cfg.package}/libexec/geoclue-2.0/demos/agent";
+            Restart = "on-failure";
+            PrivateTmp = true;
+          };
         };
       };
-    };
 
-    services.geoclue2.appConfig.epiphany = {
-      isAllowed = true;
-      isSystem = false;
-    };
+      services.geoclue2.appConfig.epiphany = {
+        isAllowed = true;
+        isSystem = false;
+      };
 
-    services.geoclue2.appConfig.firefox = {
-      isAllowed = true;
-      isSystem = false;
-    };
+      services.geoclue2.appConfig.firefox = {
+        isAllowed = true;
+        isSystem = false;
+      };
 
-    environment.etc."geoclue/geoclue.conf".text = lib.generators.toINI { } (
-      {
-        agent = {
-          whitelist = lib.concatStringsSep ";" (
-            lib.optional cfg.enableDemoAgent "geoclue-demo-agent" ++ defaultWhitelist
-          );
-        };
-        network-nmea = {
-          enable = cfg.enableNmea;
-        };
-        "3g" = {
-          enable = cfg.enable3G;
-        };
-        cdma = {
-          enable = cfg.enableCDMA;
-        };
-        modem-gps = {
-          enable = cfg.enableModemGPS;
-        };
-        wifi = {
-          enable = cfg.enableWifi;
-          url = cfg.geoProviderUrl;
-          submit-data = lib.boolToString cfg.submitData;
-          submission-url = cfg.submissionUrl;
-          submission-nick = cfg.submissionNick;
-        };
-      }
-      // lib.mapAttrs' appConfigToINICompatible cfg.appConfig
-    );
-  };
+      environment.etc."geoclue/geoclue.conf".text = lib.generators.toINI { } (
+        {
+          agent = {
+            whitelist = lib.concatStringsSep ";" (
+              lib.optional cfg.enableDemoAgent "geoclue-demo-agent" ++ defaultWhitelist
+            );
+          };
+          network-nmea = {
+            enable = cfg.enableNmea;
+          };
+          "3g" = {
+            enable = cfg.enable3G;
+          };
+          cdma = {
+            enable = cfg.enableCDMA;
+          };
+          modem-gps = {
+            enable = cfg.enableModemGPS;
+          };
+          wifi = {
+            enable = cfg.enableWifi;
+            url = cfg.geoProviderUrl;
+            submit-data = lib.boolToString cfg.submitData;
+            submission-url = cfg.submissionUrl;
+            submission-nick = cfg.submissionNick;
+          };
+        }
+        // lib.mapAttrs' appConfigToINICompatible cfg.appConfig
+      );
+    })
+    (lib.mkIf cfg.staticSource.enable {
+      services.geoclue2 = {
+        enableNmea = lib.mkDefault false;
+        enable3G = lib.mkDefault false;
+        enableCDMA = lib.mkDefault false;
+        enableModemGPS = lib.mkDefault false;
+        enableWifi = lib.mkDefault false;
+      };
+
+      environment.etc."geoclue/conf.d/static.conf".text = ''
+        # Position is configured in /etc/geolocation
+        [static-source]
+        enable=true
+      '';
+
+      environment.etc.geolocation = {
+        user = lib.mkDefault "geoclue";
+        group = lib.mkDefault "geoclue";
+        mode = lib.mkDefault "0600";
+        text =
+          let
+            header = lib.optionals (cfg.staticSource.location.comment != "") (
+              map (line: "# ${line}\n") (lib.splitString "\n" cfg.staticSource.location.comment)
+            );
+            attrLine =
+              attr:
+              let
+                value = toString cfg.staticSource.location.${attr};
+                padding = lib.max 1 (20 - lib.stringLength value);
+                pad = lib.strings.replicate padding " ";
+                comment = "# ${attr}";
+              in
+              lib.concatStrings [
+                value
+                pad
+                comment
+                "\n"
+              ];
+            data = map attrLine [
+              "latitude"
+              "longitude"
+              "altitude"
+              "accuracyRadius"
+            ];
+          in
+          lib.concatStrings (header ++ data);
+      };
+    })
+  ];
 
   meta = with lib; {
     maintainers = with maintainers; [ ] ++ teams.pantheon.members;

--- a/nixos/modules/services/desktops/geoclue2.nix
+++ b/nixos/modules/services/desktops/geoclue2.nix
@@ -376,6 +376,9 @@ in
           compass = {
             enable = cfg.enableCompass;
           };
+          static-source = {
+            inherit (cfg.staticSource) enable;
+          };
         }
         // lib.mapAttrs' appConfigToINICompatible cfg.appConfig
       );
@@ -389,12 +392,6 @@ in
         enableWifi = lib.mkDefault false;
         enableCompass = lib.mkDefault false;
       };
-
-      environment.etc."geoclue/conf.d/static.conf".text = ''
-        # Position is configured in /etc/geolocation
-        [static-source]
-        enable=true
-      '';
 
       environment.etc.geolocation = {
         user = lib.mkDefault "geoclue";


### PR DESCRIPTION
## Description of changes

Adds the missing compass and static-source options as `enableCompass` and `staticSource` respectively (see the [geoclue man page](https://man.archlinux.org/man/extra/geoclue/geoclue.5.en)). In addition, the option `staticSource.location` configures the contents of [`/etc/geolocation`](https://man.archlinux.org/man/extra/geoclue/geoclue.5.en#STATIC_LOCATION_FILE).

Like the other providers, `enableCompass` defaults to true. When `staticSource.enable = true`, all other providers are disabled as the man page suggests.

> **enable=true**
> Enable the static source.
> If you make use of this source, you probably should
> disable other location sources in geoclue.conf so
> they won't override the configured static location.

The `user` and `group` are set to `geoclue` and the `mode` to `0600` for [extra security](https://man.archlinux.org/man/extra/geoclue/geoclue.5.en#Notes:) as the man page suggests.

> For extra security, the static location file
> can be made readable just by the geoclue user:
> 
> ```bash
> # chown geoclue /etc/geolocation
> # chmod 600 /etc/geolocation
> ```

Fixes https://github.com/NixOS/nixpkgs/issues/311595.

cc @davidak @bobby285271

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
