### PR TITLE
way-shell: init package and module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -49,6 +49,8 @@
 
 - [Eintopf](https://eintopf.info), community event and calendar web application. Available as [services.eintopf](options.html#opt-services.eintopf).
 
+- [way-shell](https://github.com/ldelossa/way-shell/), a GNOME-like shell for Wayland compositors. Available as [programs.way-shell](#opt-programs.way-shell.enable).
+
 - [Radicle](https://radicle.xyz), an open source, peer-to-peer code collaboration stack built on Git. Available as [services.radicle](#opt-services.radicle.enable).
 
 - [ddns-updater](https://github.com/qdm12/ddns-updater), a service to update DNS records periodically with WebUI for many DNS providers. Available as [services.ddns-updater](#opt-services.ddns-updater.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -305,6 +305,7 @@
   ./programs/vim.nix
   ./programs/virt-manager.nix
   ./programs/wavemon.nix
+  ./programs/way-shell.nix
   ./programs/wayland/cardboard.nix
   ./programs/wayland/hyprlock.nix
   ./programs/wayland/hyprland.nix

--- a/nixos/modules/programs/way-shell.nix
+++ b/nixos/modules/programs/way-shell.nix
@@ -1,0 +1,22 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.way-shell;
+in
+{
+  options.programs.way-shell = {
+    enable = lib.mkEnableOption "way-shell, a GNOME-like shell for Wayland compositors";
+
+    package = lib.mkPackageOption pkgs "way-shell" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    services.upower.enable = true;
+  };
+}

--- a/pkgs/by-name/wa/way-shell/link-against-pw.patch
+++ b/pkgs/by-name/wa/way-shell/link-against-pw.patch
@@ -1,0 +1,12 @@
+diff --git a/Makefile b/Makefile
+index ace1b6a..f6f2ecf 100644
+--- a/Makefile
++++ b/Makefile
+@@ -12,6 +12,7 @@ DEPS := libadwaita-1 \
+ 		wireplumber-0.5 \
+ 		json-glib-1.0 \
+ 		libnm \
++		libpipewire-0.3 \
+ 		libpulse \
+ 		libpulse-simple \
+ 		libpulse-mainloop-glib \

--- a/pkgs/by-name/wa/way-shell/package.nix
+++ b/pkgs/by-name/wa/way-shell/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  wrapGAppsHook4,
+  glib,
+  gtk4,
+  gtk4-layer-shell,
+  json-glib,
+  libadwaita,
+  libpulseaudio,
+  pipewire,
+  networkmanager,
+  upower,
+  wayland-protocols,
+  wireplumber,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "way-shell";
+  version = "0.0.7";
+
+  src = fetchFromGitHub {
+    owner = "ldelossa";
+    repo = "way-shell";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-CJSoxWqHvb2AWEhOO+plcPOU2FPsl3wR96uG9Y8sHt4=";
+  };
+
+  patches = [
+    # fatal error: pipewire/keys.h: No such file or directory
+    ./link-against-pw.patch
+  ];
+
+  strictDeps = true;
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    glib
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    gtk4-layer-shell
+    json-glib
+    libadwaita
+    libpulseaudio
+    networkmanager
+    pipewire
+    upower
+    wayland-protocols
+    wireplumber
+  ];
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    make $installFlags install-gschema
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/ldelossa/way-shell/releases/tag/v${version}";
+    description = "GNOME-like shell for wayland compositors";
+    homepage = "https://github.com/ldelossa/way-shell/";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ eclairevoyant ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds the package and module for [way-shell](https://github.com/ldelossa/way-shell/), a GNOME-like shell for Wayland compositors.

- **way-shell: init at 0.0.7**
- **nixos/way-shell: init**

Fixes #329583
Fixes https://github.com/ldelossa/way-shell/issues/17
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
