### PR TITLE
multipass: 1.13.1 -> 1.14.0

### DIFF
--- a/pkgs/tools/virtualization/multipass/cmake_no_fetch.patch
+++ b/pkgs/tools/virtualization/multipass/cmake_no_fetch.patch
@@ -1,22 +1,3 @@
-diff --git a/3rd-party/CMakeLists.txt b/3rd-party/CMakeLists.txt
-index 188ebfc6..4a34a922 100644
---- a/3rd-party/CMakeLists.txt
-+++ b/3rd-party/CMakeLists.txt
-@@ -2,12 +2,8 @@ include(FetchContent)
- set(FETCHCONTENT_QUIET FALSE)
- 
- FetchContent_Declare(gRPC
--  GIT_REPOSITORY https://github.com/CanonicalLtd/grpc.git
--  GIT_TAG e3acf245
--  GIT_SHALLOW TRUE
--  GIT_SUBMODULES "third_party/abseil-cpp third_party/cares/cares third_party/protobuf third_party/re2 third_party/zlib"
--  GIT_SUBMODULES_RECURSE false
--  GIT_PROGRESS TRUE
-+  DOWNLOAD_COMMAND true
-+  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/grpc
- )
- set(gRPC_SSL_PROVIDER "package" CACHE STRING "Provider of ssl library")
- 
 diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
 index 52bd407f..a1100112 100644
 --- a/tests/CMakeLists.txt

--- a/pkgs/tools/virtualization/multipass/default.nix
+++ b/pkgs/tools/virtualization/multipass/default.nix
@@ -1,26 +1,27 @@
-{ cmake
-, dnsmasq
-, fetchFromGitHub
-, git
-, gtest
-, iproute2
-, iptables
-, lib
-, libapparmor
-, libvirt
-, libxml2
-, nixosTests
-, openssl
-, OVMF
-, pkg-config
-, qemu
-, qemu-utils
-, qtbase
-, qtwayland
-, wrapQtAppsHook
-, slang
-, stdenv
-, xterm
+{
+  cmake,
+  dnsmasq,
+  fetchFromGitHub,
+  git,
+  gtest,
+  iproute2,
+  iptables,
+  lib,
+  libapparmor,
+  libvirt,
+  libxml2,
+  nixosTests,
+  openssl,
+  OVMF,
+  pkg-config,
+  qemu,
+  qemu-utils,
+  qtbase,
+  qtwayland,
+  wrapQtAppsHook,
+  slang,
+  stdenv,
+  xterm,
 }:
 
 let
@@ -38,8 +39,7 @@ let
     fetchSubmodules = true;
   };
 in
-stdenv.mkDerivation
-{
+stdenv.mkDerivation {
   inherit pname version;
 
   src = fetchFromGitHub {
@@ -118,15 +118,17 @@ stdenv.mkDerivation
   nativeCheckInputs = [ gtest ];
 
   postInstall = ''
-    wrapProgram $out/bin/multipassd --prefix PATH : ${lib.makeBinPath [
-      dnsmasq
-      iproute2
-      iptables
-      OVMF.fd
-      qemu
-      qemu-utils
-      xterm
-    ]}
+    wrapProgram $out/bin/multipassd --prefix PATH : ${
+      lib.makeBinPath [
+        dnsmasq
+        iproute2
+        iptables
+        OVMF.fd
+        qemu
+        qemu-utils
+        xterm
+      ]
+    }
   '';
 
   passthru.tests = {

--- a/pkgs/tools/virtualization/multipass/default.nix
+++ b/pkgs/tools/virtualization/multipass/default.nix
@@ -59,10 +59,24 @@ stdenv.mkDerivation {
   };
 
   patches = [
+    # Multipass is usually only delivered as a snap package on Linux, and it expects that
+    # the LXD backend will also be delivered via a snap - in which cases the LXD socket
+    # is available at '/var/snap/lxd/...'. Here we patch to ensure that Multipass uses the
+    # LXD socket location on NixOS in '/var/lib/...'
     ./lxd_socket_path.patch
+    # The upstream cmake file attempts to fetch googletest using FetchContent, which fails
+    # in the Nix build environment. This patch disables the fetch in favour of providing
+    # the googletest library from nixpkgs.
     ./cmake_no_fetch.patch
+    # Ensures '-Wno-ignored-attributes' is supported by the compiler before attempting to build.
     ./cmake_warning.patch
+    # As of Multipass 1.14.0, the upstream started using vcpkg for grabbing C++ dependencies,
+    # which doesn't work in the nix build environment. This patch reverts that change, in favour
+    # of providing those dependencies manually in this derivation.
     ./vcpkg_no_install.patch
+    # The compiler flags used in nixpkgs surface an error in the test suite where an
+    # unreachable path was not annotated as such - this patch adds the annotation to ensure
+    # that the test suite passes in the nix build process.
     ./test_unreachable_call.patch
   ];
 

--- a/pkgs/tools/virtualization/multipass/default.nix
+++ b/pkgs/tools/virtualization/multipass/default.nix
@@ -65,13 +65,13 @@ stdenv.mkDerivation {
   postPatch = ''
     # Make sure the version is reported correctly in the compiled binary.
     substituteInPlace ./CMakeLists.txt \
-      --replace "determine_version(MULTIPASS_VERSION)" "" \
-      --replace 'set(MULTIPASS_VERSION ''${MULTIPASS_VERSION})' 'set(MULTIPASS_VERSION "v${version}")'
+      --replace-fail "determine_version(MULTIPASS_VERSION)" "" \
+      --replace-fail 'set(MULTIPASS_VERSION ''${MULTIPASS_VERSION})' 'set(MULTIPASS_VERSION "v${version}")'
 
     # Patch the patch of the OVMF binaries to use paths from the nix store.
     substituteInPlace ./src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp \
-      --replace "OVMF.fd" "${OVMF.fd}/FV/OVMF.fd" \
-      --replace "QEMU_EFI.fd" "${OVMF.fd}/FV/QEMU_EFI.fd"
+      --replace-fail "OVMF.fd" "${OVMF.fd}/FV/OVMF.fd" \
+      --replace-fail "QEMU_EFI.fd" "${OVMF.fd}/FV/QEMU_EFI.fd"
 
     # Copy the grpc submodule we fetched into the source code.
     cp -r --no-preserve=mode ${grpc_src} 3rd-party/grpc

--- a/pkgs/tools/virtualization/multipass/test_unreachable_call.patch
+++ b/pkgs/tools/virtualization/multipass/test_unreachable_call.patch
@@ -1,0 +1,12 @@
+diff --git a/tests/test_common_callbacks.cpp b/tests/test_common_callbacks.cpp
+index ccae78e0..f9ab4423 100644
+--- a/tests/test_common_callbacks.cpp
++++ b/tests/test_common_callbacks.cpp
+@@ -73,6 +73,7 @@ struct TestLoggingSpinnerCallbacks : public TestSpinnerCallbacks, public WithPar
+         default:
+             assert(false && "shouldn't be here");
+         }
++        __builtin_unreachable();
+     }
+ };
+ 

--- a/pkgs/tools/virtualization/multipass/vcpkg_no_install.patch
+++ b/pkgs/tools/virtualization/multipass/vcpkg_no_install.patch
@@ -1,0 +1,83 @@
+diff --git a/3rd-party/CMakeLists.txt b/3rd-party/CMakeLists.txt
+index 73291f6c..c1a38198 100644
+--- a/3rd-party/CMakeLists.txt
++++ b/3rd-party/CMakeLists.txt
+@@ -4,6 +4,24 @@ if (MSVC)
+   add_compile_options(-wd5045) #Disable warning about Spectre mitigation
+ endif()
+ 
++include(FetchContent)
++set(FETCHCONTENT_QUIET FALSE)
++
++FetchContent_Declare(gRPC
++  DOWNLOAD_COMMAND true
++  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/grpc
++)
++
++set(gRPC_SSL_PROVIDER "package" CACHE STRING "Provider of ssl library")
++
++FetchContent_MakeAvailable(gRPC)
++
++# Workaround for zlib placing its generated zconf.h file in the build dir,
++# and protobuf not knowing so finding the system version instead
++include_directories(${grpc_SOURCE_DIR}/third_party/zlib)
++
++set_property(DIRECTORY ${grpc_SOURCE_DIR} PROPERTY EXCLUDE_FROM_ALL YES)
++
+ # Generates gRPC and protobuf C++ sources and headers from the given .proto files
+ #
+ # generate_grpc_cpp (<SRCS> <DEST> [<ARGN>...])
+@@ -34,9 +52,9 @@ function(generate_grpc_cpp SRCS DEST)
+       "${DEST}/${FIL_WE}.grpc.pb.h"
+       "${DEST}/${FIL_WE}.pb.cc"
+       "${DEST}/${FIL_WE}.pb.h"
+-      COMMAND $<TARGET_FILE:protobuf::protoc>
+-      ARGS --grpc_out=${DEST} --cpp_out=${DEST} --proto_path=${FIL_DIR} --proto_path=${grpc_SOURCE_DIR}/third_party/protobuf/src --plugin=protoc-gen-grpc=$<TARGET_FILE:gRPC::grpc_cpp_plugin> ${ABS_FIL}
+-      DEPENDS ${ABS_FIL}
++      COMMAND $<TARGET_FILE:protoc>
++      ARGS --grpc_out=${DEST} --cpp_out=${DEST} --proto_path=${FIL_DIR} --proto_path=${grpc_SOURCE_DIR}/third_party/protobuf/src --plugin=protoc-gen-grpc=$<TARGET_FILE:grpc_cpp_plugin> ${ABS_FIL}
++      DEPENDS ${ABS_FIL} protoc grpc_cpp_plugin
+       COMMENT "Running gRPC C++ protocol buffer compiler on ${FIL}"
+       VERBATIM)
+   endforeach ()
+@@ -47,9 +65,14 @@ endfunction()
+ 
+ add_library(gRPC INTERFACE)
+ 
++target_include_directories(gRPC INTERFACE
++  ${CMAKE_CURRENT_SOURCE_DIR}/grpc/include
++  ${CMAKE_CURRENT_SOURCE_DIR}/grpc/third_party/protobuf/src)
++
+ target_link_libraries(gRPC INTERFACE
+-  gRPC::grpc++
+-  protobuf::libprotobuf)
++  grpc++
++  libprotobuf
++  zlibstatic)
+ 
+ if (NOT MSVC)
+   target_compile_options(gRPC INTERFACE "-Wno-unused-parameter" "-Wno-non-virtual-dtor" "-Wno-pedantic")
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 18e47b74..d5bf5dea 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -49,9 +49,6 @@ if(NOT DEFINED VCPKG_BUILD_DEFAULT)
+   set(VCPKG_TARGET_TRIPLET "${VCPKG_HOST_ARCH}-${VCPKG_HOST_OS}-release")
+ endif()
+ 
+-set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/3rd-party/vcpkg/scripts/buildsystems/vcpkg.cmake"
+-  CACHE STRING "Vcpkg toolchain file")
+-
+ project(Multipass)
+ 
+ option(MULTIPASS_ENABLE_TESTS "Build tests" ON)
+@@ -125,9 +122,6 @@ endif()
+ # OpenSSL config
+ find_package(OpenSSL REQUIRED)
+ 
+-# gRPC config
+-find_package(gRPC CONFIG REQUIRED)
+-
+ # Needs to be here before we set further compilation options
+ add_subdirectory(3rd-party)
+ 


### PR DESCRIPTION
## Description of changes

Update to latest, with some changes to patches as the upstream has adopted `vcpkg`, which makes things more complicated for us to build here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
