### PR TITLE
dockerTools: add useFUSEOverlayFS

### DIFF
--- a/doc/build-helpers/images/dockertools.section.md
+++ b/doc/build-helpers/images/dockertools.section.md
@@ -153,6 +153,18 @@ Similarly, if you encounter errors similar to `Error_Protocol ("certificate has 
 
   _Default value:_ 512.
 
+`useFUSEOverlayFS` (Boolean; _optional_)
+
+: Controls whether the FUSE version of OverlayFS is used to run the script specified in `runAsRoot`.
+  This attribute is ignored if `runAsRoot` or `fromImage` are `null`.
+  It can be set to `true` to work around an error such as the following when building the image:
+
+  ```
+  mount: /tmp/disk/mnt: wrong fs type, bad option, bad superblock on overlay, missing codepage or helper program, or other error.
+  ```
+
+  _Default value:_ false.
+
 `created` (String; _optional_)
 
 : Specifies the time of creation of the generated image.
@@ -976,6 +988,17 @@ Because of this, using this function requires the `kvm` device to be available, 
 : Controls the disk size (in megabytes) of the VM used to unpack the image.
 
   _Default value:_ 1024.
+
+`useFUSEOverlayFS` (Boolean; _optional_)
+
+: Controls whether the FUSE version of OverlayFS is used when exporting the image.
+  It can be set to `true` to work around an error such as the following:
+
+  ```
+  mount: /tmp/disk/mnt: wrong fs type, bad option, bad superblock on overlay, missing codepage or helper program, or other error.
+  ```
+
+  _Default value:_ false.
 
 `name` (String; _optional_)
 

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -644,5 +644,10 @@ in {
             "${examples.nix-layered} | docker load",
             "docker run --rm ${examples.nix-layered.imageName} nix-store -q --references /bin/bash"
         )
+
+    with subtest("Ensure runAsRoot works with useFUSEOverlayFS"):
+        docker.succeed(
+            "docker load --input='${examples.useFUSEOverlayFS}'"
+        )
   '';
 })

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -913,4 +913,12 @@ rec {
     };
   };
 
+  useFUSEOverlayFS = buildImage {
+    name = "useFUSEOverlayFS";
+    tag = "latest";
+    runAsRoot = "touch /example-file";
+    fromImage = bash;
+    useFUSEOverlayFS = true;
+  };
+
 }


### PR DESCRIPTION
## Description of changes

In some cases, the Linux kernel native overlay filesystem [bugs out with a "page allocation failure"](https://www.google.com/search?q=overlayfs+"page+allocation+failure%3A").  Add an option to allow using the FUSE version of OverlayFS, as a workaround.

Fixes https://github.com/NixOS/nixpkgs/issues/325308

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
