### PR TITLE
skippy-xd: 0.7.2 -> 0.8.0

### DIFF
--- a/pkgs/tools/X11/skippy-xd/default.nix
+++ b/pkgs/tools/X11/skippy-xd/default.nix
@@ -1,25 +1,26 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, xorgproto
-, libX11
-, libXft
-, libXcomposite
-, libXdamage
-, libXext
-, libXinerama
-, libjpeg
-, giflib
-, pkg-config
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  xorgproto,
+  libX11,
+  libXft,
+  libXcomposite,
+  libXdamage,
+  libXext,
+  libXinerama,
+  libjpeg,
+  giflib,
+  pkg-config,
 }:
 stdenv.mkDerivation rec {
   pname = "skippy-xd";
-  version = "0.7.2";
+  version = "0.8.0";
   src = fetchFromGitHub {
     owner = "felixfung";
     repo = "skippy-xd";
-    rev = "e033b9ea80b5bbe922b05c64ed6ba0bf31c3acf6";
-    hash = "sha256-DsoRxbAF0DitgxknJVHDWH7VL5hWMhwH9I6m1SyItMM=";
+    rev = "30da57cb59ccf77f766718f7d533ddbe533ba241";
+    hash = "sha256-YBUDbI1SHsBI/fA3f3W1sPu3wXSodMbTGvAMqOz7RCM=";
   };
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [

--- a/pkgs/tools/X11/skippy-xd/default.nix
+++ b/pkgs/tools/X11/skippy-xd/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
   '';
   meta = with lib; {
     description = "Expose-style compositing-based standalone window switcher";
+    homepage = "https://github.com/felixfung/skippy-xd";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.linux;


### PR DESCRIPTION
## Description of changes

Updates skippy-xd to the latest version of the maintained fork ([changelog](https://github.com/felixfung/skippy-xd/blob/master/CHANGELOG)), also adds a link to the project homepage.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
