### PR TITLE
firewall/nat: use --or-mark and mask to allow other bitmarks to coexist on packets

### DIFF
--- a/nixos/modules/services/networking/nat-iptables.nix
+++ b/nixos/modules/services/networking/nat-iptables.nix
@@ -55,7 +55,7 @@ let
       # mark packets coming from the internal interfaces.
       ${concatMapStrings (iface: ''
         ${iptables} -w -t nat -A nixos-nat-pre \
-          -i '${iface}' -j MARK --set-mark 1
+          -i '${iface}' -j MARK --or-mark 1
         ${iptables} -w -t filter -A nixos-filter-forward \
           -i '${iface}' ${
             optionalString (cfg.externalInterface != null) "-o ${cfg.externalInterface}"
@@ -64,7 +64,7 @@ let
 
       # NAT the marked packets.
       ${optionalString (cfg.internalInterfaces != [ ]) ''
-        ${iptables} -w -t nat -A nixos-nat-post -m mark --mark 1 \
+        ${iptables} -w -t nat -A nixos-nat-post -m mark --mark 1/1 \
           ${optionalString (cfg.externalInterface != null) "-o ${cfg.externalInterface}"} ${dest}
       ''}
 


### PR DESCRIPTION
## Description of changes

`networking.firewall.nat`'s `enable` plus `internalInterfaces` allow to easily masquerading a given network interface, making NixOS work as a gateway.
But the default iptables implementation uses `-j MARK --mark 1` to mark packets for masquerade in `PREROUTING`, and match with `-m mark --mark 1` (i.e. without a mask) in `POSTROUTING`. This prevents the usage of other marks on any packet on these interfaces, since they could be overwritten by the `-j MARK` target, and would prevent proper matching when routing.
The fix is to use masks in both ends, preserving other bits set in PREROUTING, and matching with a mask on first bit, allowing other bits to be set as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
