### PR TITLE
fastapi-cli: refactor to use python3Packages.fastapi-cli

### DIFF
--- a/pkgs/by-name/fa/fastapi-cli/package.nix
+++ b/pkgs/by-name/fa/fastapi-cli/package.nix
@@ -1,42 +1,4 @@
-{
-  lib,
-  python3,
-  fetchFromGitHub,
-}:
+{ python3 }:
 
-python3.pkgs.buildPythonApplication rec {
-  pname = "fastapi-cli";
-  version = "0.0.4";
-  pyproject = true;
-
-  src = fetchFromGitHub {
-    owner = "tiangolo";
-    repo = "fastapi-cli";
-    rev = "refs/tags/${version}";
-    hash = "sha256-eWvZn7ZeLnQZAvGOzY77o6oO5y+QV2cx+peBov9YpJE=";
-  };
-
-  build-system = [ python3.pkgs.pdm-backend ];
-
-  dependencies = with python3.pkgs; [
-    rich
-    typer
-  ];
-
-  optional-dependencies = with python3.pkgs; {
-    standard = [
-      fastapi
-      uvicorn
-    ];
-  };
-
-  pythonImportsCheck = [ "fastapi_cli" ];
-
-  meta = {
-    description = "Run and manage FastAPI apps from the command line with FastAPI CLI";
-    homepage = "https://github.com/tiangolo/fastapi-cli";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ drupol ];
-    mainProgram = "fastapi-cli";
-  };
-}
+with python3.pkgs;
+toPythonApplication fastapi-cli


### PR DESCRIPTION
Previously there were essentially two copies of the same expression in tree.

~Marking as draft until #325223 hits master (currently in staging) since otherwise `fastapi-cli` fails trying to import `rich` which was previously manually added to `dependencies`.~ [merged]

## Description of changes

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
