### PR TITLE
treewide: cargoSha256 -> cargoHash

### DIFF
--- a/pkgs/by-name/ba/bankstown-lv2/package.nix
+++ b/pkgs/by-name/ba/bankstown-lv2/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-IThXEY+mvT2MCw0PSWU/182xbUafd6dtm6hNjieLlKg=";
   };
 
-  cargoSha256 = "sha256-yRzM4tcYc6mweTpLnnlCeKgP00L2wRgHamtUzK9Kstc=";
+  cargoHash = "sha256-yRzM4tcYc6mweTpLnnlCeKgP00L2wRgHamtUzK9Kstc=";
 
   installPhase = ''
     export LIBDIR=$out/lib

--- a/pkgs/by-name/ba/batmon/package.nix
+++ b/pkgs/by-name/ba/batmon/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-+kjDNQKlaoI5fQ5FqYF6IPCKeE92WKxIhVCKafqfE0o=";
   };
 
-  cargoSha256 = "sha256-DJpWBset6SW7Ahg60+Tu1VpH34LcVOyrEs9suKyTE9g=";
+  cargoHash = "sha256-DJpWBset6SW7Ahg60+Tu1VpH34LcVOyrEs9suKyTE9g=";
 
   meta = with lib; {
     description = "Interactive batteries viewer";

--- a/pkgs/by-name/ca/cargo-profiler/package.nix
+++ b/pkgs/by-name/ca/cargo-profiler/package.nix
@@ -11,7 +11,7 @@ let
   version = "0.2.0";
   rev = "0a8ab772fd5c0f1579e4847c5d05aa443ffa2bc8";
   sha256 = "sha256-ZRAbvSMrPtgaWy9RwlykQ3iiPxHCMh/tS5p67/4XqqA=";
-  cargoSha256 = "sha256-qt3S6ZcLEP9ZQoP5+kSQdmBlxdMgGUqLszdU7JkFNVI=";
+  cargoHash = "sha256-qt3S6ZcLEP9ZQoP5+kSQdmBlxdMgGUqLszdU7JkFNVI=";
 
   inherit (rustPlatform) buildRustPackage;
 in buildRustPackage rec {
@@ -22,7 +22,7 @@ in buildRustPackage rec {
     repo = pname;
   };
 
-  inherit cargoSha256;
+  inherit cargoHash;
 
   meta = with lib; {
     description = "Cargo subcommand for profiling Rust binaries";

--- a/pkgs/by-name/co/commitmsgfmt/package.nix
+++ b/pkgs/by-name/co/commitmsgfmt/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
     rev = "v${version}";
     hash = "sha256-HEkPnTO1HeJg8gpHFSUTkEVBPWJ0OdfUhNn9iGfaDD4=";
   };
-  cargoSha256 = "sha256-jTRB9ogFQGVC4C9xpGxsJYV3cnWydAJLMcjhzUPULTE=";
+  cargoHash = "sha256-jTRB9ogFQGVC4C9xpGxsJYV3cnWydAJLMcjhzUPULTE=";
 
   passthru.tests.version = testers.testVersion {
     package = commitmsgfmt;

--- a/pkgs/by-name/el/elf2nucleus/package.nix
+++ b/pkgs/by-name/el/elf2nucleus/package.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-FAIOtGfGow+0DrPPEBEfvaiinNZLQlGWKJ4DkMj63OA=";
   };
 
-  cargoSha256 = "sha256-IeQnI6WTzxSI/VzoHtVukZtB1jX98wzLOT01NMLD5wQ=";
+  cargoHash = "sha256-IeQnI6WTzxSI/VzoHtVukZtB1jX98wzLOT01NMLD5wQ=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/gp/gpustat/package.nix
+++ b/pkgs/by-name/gp/gpustat/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-M9P/qfw/tp9ogkNOE3b2fD2rGFnii1/VwmqJHqXb7Mg=";
   };
 
-  cargoSha256 = "sha256-po/pEMZEtySZnz7l2FI7Wqbmp2CiWBijchKGkqlIMPU=";
+  cargoHash = "sha256-po/pEMZEtySZnz7l2FI7Wqbmp2CiWBijchKGkqlIMPU=";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/sw/swaycons/package.nix
+++ b/pkgs/by-name/sw/swaycons/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-vyZcfBH2mry8Yd41QPX4+yLv0nS9J1yrgg7lpslJs7M=";
   };
 
-  cargoSha256 = "sha256-cdZ7DpH//c9TulvPYd6aaXpQHYC1b+T7BrxAyr56Pf0=";
+  cargoHash = "sha256-cdZ7DpH//c9TulvPYd6aaXpQHYC1b+T7BrxAyr56Pf0=";
 
   meta = with lib; {
     description = "Window Icons in Sway with Nerd Fonts!";

--- a/pkgs/by-name/sw/swayws/package.nix
+++ b/pkgs/by-name/sw/swayws/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-f0kXy7/31imgHHqKPmW9K+QrLqroaPaXwlJkzOoezRU=";
   };
 
-  cargoSha256 = "sha256-VYT6wV59fraAoJgR/i6GlO8s7LUoehGtxPAggEL1eLo=";
+  cargoHash = "sha256-VYT6wV59fraAoJgR/i6GlO8s7LUoehGtxPAggEL1eLo=";
   # Required patch until upstream fixes https://gitlab.com/w0lff/swayws/-/issues/1
   cargoPatches = [
     ./ws-update-Cargo-lock.patch

--- a/pkgs/by-name/te/termsnap/package.nix
+++ b/pkgs/by-name/te/termsnap/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-FTgbbiDlHXGjkv3a2TAxjAqdClWkuteyUrtjQ8fMSIs=";
   };
 
-  cargoSha256 = "sha256-hXlRkqcMHFEAnm883Q8sR8gcEbSNMutoJQsMW2M5wOY=";
+  cargoHash = "sha256-hXlRkqcMHFEAnm883Q8sR8gcEbSNMutoJQsMW2M5wOY=";
 
   meta = with lib; {
     description = "Create SVGs from terminal output";

--- a/pkgs/by-name/tr/treefmt1/package.nix
+++ b/pkgs/by-name/tr/treefmt1/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-icAe54Mv1xpOjUPSk8QDZaMk2ueNvjER6UyJ9uyUL6s=";
   };
 
-  cargoSha256 = "sha256-bpNIGuh74nwEmHPeXtPmsML9vJOb00xkdjK0Nd7esAc=";
+  cargoHash = "sha256-bpNIGuh74nwEmHPeXtPmsML9vJOb00xkdjK0Nd7esAc=";
 
   meta = {
     description = "one CLI to format the code tree";

--- a/pkgs/by-name/tw/twiggy/package.nix
+++ b/pkgs/by-name/tw/twiggy/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-NbtS7A5Zl8634Q3xyjVzNraNszjt1uIXqmctArfnqkk=";
   };
 
-  cargoSha256 = "sha256-94pfhVZ0CNMn+lCl5O+wOyE+D6fVXbH4NAPx92nMNbM=";
+  cargoHash = "sha256-94pfhVZ0CNMn+lCl5O+wOyE+D6fVXbH4NAPx92nMNbM=";
 
   meta = with lib; {
     homepage = "https://rustwasm.github.io/twiggy/";

--- a/pkgs/by-name/wa/wapm/package.nix
+++ b/pkgs/by-name/wa/wapm/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-T7YEe8xg5iwI/npisW0m+6FLi+eaAQVgYNe6TvMlhAs=";
   };
 
-  cargoSha256 = "sha256-r4123NJ+nxNOVIg6svWr636xbxOJQ7tp76JoAi2m9p8=";
+  cargoHash = "sha256-r4123NJ+nxNOVIg6svWr636xbxOJQ7tp76JoAi2m9p8=";
 
   nativeBuildInputs = [ perl ];
 

--- a/pkgs/by-name/wl/wldash/package.nix
+++ b/pkgs/by-name/wl/wldash/package.nix
@@ -57,7 +57,7 @@ rustPlatform.buildRustPackage {
     ./0002-Update-fontconfig.patch
   ];
 
-  cargoSha256 = "sha256-Y7nhj8VpO6sEzVkM3uPv8Tlk2jPn3c/uPJqFc/HjHI0=";
+  cargoHash = "sha256-Y7nhj8VpO6sEzVkM3uPv8Tlk2jPn3c/uPJqFc/HjHI0=";
 
   dontPatchELF = true;
 


### PR DESCRIPTION
limited to by-name to limit merge conflicts, done with
```
rg 'cargoSha256 = "sha256-' pkgs/by-name/ -l | grep \\\.nix$ | xargs grep buildRustPackage -l | xe sd 'cargoSha256 = "sha256-' 'cargoHash = "sha256-'
```

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
