### PR TITLE
nixos/jack: Fix jack-session init script

### DIFF
--- a/nixos/modules/services/audio/jack.nix
+++ b/nixos/modules/services/audio/jack.nix
@@ -260,7 +260,7 @@ in {
       systemd.services.jack-session = {
         description = "JACK session";
         script = ''
-          jack_wait -w
+          ${pkgs.jack-example-tools}/bin/jack_wait -w
           ${cfg.jackd.session}
           ${lib.optionalString cfg.loopback.enable cfg.loopback.session}
         '';


### PR DESCRIPTION
The path of the jack_wait executable in the jack-session script was not a store path for no apparent reason.

- Built on platform(s)
  - [ x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
