### PR TITLE
SDL_image: fix build with clang 16

### DIFF
--- a/pkgs/by-name/sd/SDL_image/clang16-webp-errors.patch
+++ b/pkgs/by-name/sd/SDL_image/clang16-webp-errors.patch
@@ -1,0 +1,16 @@
+diff -ur a/IMG_webp.c b/IMG_webp.c
+--- a/IMG_webp.c	2012-01-20 20:51:33.000000000 -0500
++++ b/IMG_webp.c	2024-07-24 20:48:58.697398200 -0400
+@@ -47,9 +47,9 @@
+ static struct {
+ 	int loaded;
+ 	void *handle;
+-	int/*VP8StatuCode*/ (*webp_get_features_internal) (const uint8_t *data, uint32_t data_size, WebPBitstreamFeatures* const features, int decoder_abi_version);
+-	uint8_t*	(*webp_decode_rgb_into) (const uint8_t* data, uint32_t data_size, uint8_t* output_buffer, int output_buffer_size, int output_stride);
+-	uint8_t*	(*webp_decode_rgba_into) (const uint8_t* data, uint32_t data_size, uint8_t* output_buffer, int output_buffer_size, int output_stride);
++	VP8StatusCode	(*webp_get_features_internal) (const uint8_t *data, size_t data_size, WebPBitstreamFeatures* const features, int decoder_abi_version);
++	uint8_t*	(*webp_decode_rgb_into) (const uint8_t* data, size_t data_size, uint8_t* output_buffer, size_t output_buffer_size, int output_stride);
++	uint8_t*	(*webp_decode_rgba_into) (const uint8_t* data, size_t data_size, uint8_t* output_buffer, size_t output_buffer_size, int output_stride);
+ } lib;
+ 
+ #ifdef LOAD_WEBP_DYNAMIC

--- a/pkgs/by-name/sd/SDL_image/package.nix
+++ b/pkgs/by-name/sd/SDL_image/package.nix
@@ -8,6 +8,7 @@
   libjpeg,
   libpng,
   libtiff,
+  libwebp,
   pkg-config,
   stdenv,
 }:
@@ -29,6 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
       includes = [ "IMG_xcf.c" ];
       hash = "sha256-Z0nyEtE1LNGsGsN9SFG8ZyPDdunmvg81tUnEkrJQk5w=";
     })
+    # Fixes incompatible function pointer type errors with clang 16
+    ./clang16-webp-errors.patch
   ];
 
   configureFlags = [
@@ -37,6 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.enableFeature false "jpg-shared")
     (lib.enableFeature false "png-shared")
     (lib.enableFeature false "tif-shared")
+    (lib.enableFeature false "webp-shared")
     (lib.enableFeature (!stdenv.isDarwin) "sdltest")
   ];
 
@@ -52,9 +56,13 @@ stdenv.mkDerivation (finalAttrs: {
     libjpeg
     libpng
     libtiff
+    libwebp
   ];
 
-  outputs = [ "out" "dev" ];
+  outputs = [
+    "out"
+    "dev"
+  ];
 
   strictDeps = true;
 
@@ -62,8 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "http://www.libsdl.org/projects/SDL_image/";
     description = "SDL image library";
     license = lib.licenses.zlib;
-    maintainers = lib.teams.sdl.members
-                  ++ (with lib.maintainers; [ ]);
+    maintainers = lib.teams.sdl.members ++ (with lib.maintainers; [ ]);
     inherit (SDL.meta) platforms;
   };
 })


### PR DESCRIPTION
## Description of changes

Use the correct function pointer types to avoid incompatible function pointer type assignment errors with clang 16. Also disable `webp-shared` like the other image formats already do and add it as an explicit dependency.

Found this while triaging staging-next https://github.com/NixOS/nixpkgs/pull/328673, but it’s been broken for a while.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
