### PR TITLE
charmcraft: 2.7.0 -> 3.1.1

### DIFF
--- a/pkgs/by-name/ch/charmcraft/package.nix
+++ b/pkgs/by-name/ch/charmcraft/package.nix
@@ -30,7 +30,7 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "charmcraft";
-  version = "2.7.0";
+  version = "3.1.1";
 
   pyproject = true;
 
@@ -38,24 +38,22 @@ python.pkgs.buildPythonApplication rec {
     owner = "canonical";
     repo = "charmcraft";
     rev = "refs/tags/${version}";
-    hash = "sha256-yMcGXi7OxEtfOv3zLEUlnZrR90TkFc0y9RB9jS34ZWs=";
+    hash = "sha256-oxNbAIf7ltdDYkGJj29zvNDNXT6vt1jWaIqHJoMr7gU=";
   };
 
   postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail 'version=determine_version()' 'version="${version}"'
-
-    # TODO remove setuptools from dependencies once this is removed
-    substituteInPlace charmcraft/env.py \
-      --replace-fail "distutils.util" "setuptools.dist"
+    substituteInPlace charmcraft/__init__.py --replace-fail "dev" "${version}"
   '';
 
   dependencies = with python.pkgs; [
+    craft-application
     craft-cli
     craft-parts
+    craft-platforms
     craft-providers
     craft-store
     distro
+    docker
     humanize
     jinja2
     jsonschema
@@ -65,19 +63,22 @@ python.pkgs.buildPythonApplication rec {
     requests
     requests-toolbelt
     requests-unixsocket
-    setuptools # see substituteInPlace above
     snap-helpers
     tabulate
     urllib3
   ];
 
-  build-system = with python.pkgs; [ setuptools ];
+  build-system = with python.pkgs; [
+    setuptools
+    setuptools-scm
+  ];
 
   pythonRelaxDeps = [ "urllib3" ];
 
   nativeCheckInputs =
     with python.pkgs;
     [
+      hypothesis
       pyfakefs
       pytest-check
       pytest-mock

--- a/pkgs/development/python-modules/craft-platforms/default.nix
+++ b/pkgs/development/python-modules/craft-platforms/default.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  buildPythonPackage,
+  annotated-types,
+  distro,
+  fetchFromGitHub,
+  nix-update-script,
+  pytest-check,
+  pytestCheckHook,
+  pythonOlder,
+  setuptools,
+  setuptools-scm,
+}:
+
+buildPythonPackage rec {
+  pname = "craft-platforms";
+  version = "0.1.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "canonical";
+    repo = "craft-platforms";
+    rev = "refs/tags/${version}";
+    hash = "sha256-KzskmSw7NsH1CAYjPf2281Ob71Jd6AhWxtp5tR3IqyU=";
+  };
+
+  postPatch = ''
+    substituteInPlace craft_platforms/__init__.py --replace-fail "dev" "${version}"
+  '';
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    annotated-types
+    distro
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-check
+  ];
+
+  pythonImportsCheck = [ "craft_platforms" ];
+
+  pytestFlagsArray = [ "tests/unit" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Manage platforms and architectures for charm applications";
+    homepage = "https://github.com/canonical/craft-platforms";
+    changelog = "https://github.com/canonical/craft-platforms/releases/tag/${version}";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ jnsgruk ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2567,6 +2567,8 @@ self: super: with self; {
 
   craft-parts = callPackage ../development/python-modules/craft-parts { };
 
+  craft-platforms = callPackage ../development/python-modules/craft-platforms { };
+
   craft-providers = callPackage ../development/python-modules/craft-providers { };
 
   craft-store = callPackage ../development/python-modules/craft-store { };


### PR DESCRIPTION
## Description of changes

Updates Charmcraft to 3.1.1 to follow the upstream, and introduces a new Python library `craft-platforms` along the way.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
