### PR TITLE
fetch-yarn-deps: fix broken fetching logic for github releases, improve diagnostic messages, 

### DIFF
--- a/pkgs/build-support/node/fetch-yarn-deps/index.js
+++ b/pkgs/build-support/node/fetch-yarn-deps/index.js
@@ -104,11 +104,14 @@ const downloadPkg = (pkg, verbose) => {
 	const [ url, hash ] = pkg.resolved.split('#')
 	if (verbose) console.log('downloading ' + url)
 	const fileName = urlToName(url)
+	const s = url.split('/')
 	if (url.startsWith('https://codeload.github.com/') && url.includes('/tar.gz/')) {
-		const s = url.split('/')
 		return downloadGit(fileName, `https://github.com/${s[3]}/${s[4]}.git`, s[s.length-1])
-	} else if (url.startsWith('https://github.com/') && url.endsWith('.tar.gz')) {
-		const s = url.split('/')
+	} else if (url.startsWith('https://github.com/') && url.endsWith('.tar.gz') &&
+		(
+			s.length <= 5 ||    // https://github.com/owner/repo.tgz#feedface...
+			s[5] == "archive"   // https://github.com/owner/repo/archive/refs/tags/v0.220.1.tar.gz
+		)) {
 		return downloadGit(fileName, `https://github.com/${s[3]}/${s[4]}.git`, s[s.length-1].replace(/.tar.gz$/, ''))
 	} else if (isGitUrl(url)) {
 		return downloadGit(fileName, url.replace(/^git\+/, ''), hash)

--- a/pkgs/build-support/node/fetch-yarn-deps/index.js
+++ b/pkgs/build-support/node/fetch-yarn-deps/index.js
@@ -39,7 +39,7 @@ const downloadFileHttps = (fileName, url, expectedHash, hashType = 'sha1') => {
 				const h = hash.read()
 				if (expectedHash === undefined){
 					console.log(`Warning: lockfile url ${url} doesn't end in "#<hash>" to validate against. Downloaded file had hash ${h}.`);
-				} else if (h != expectedHash) return reject(new Error(`hash mismatch, expected ${expectedHash}, got ${h}`))
+				} else if (h != expectedHash) return reject(new Error(`hash mismatch, expected ${expectedHash}, got ${h} for ${url}`))
 				resolve()
 			})
                         res.on('error', e => reject(e))

--- a/pkgs/build-support/node/fetch-yarn-deps/tests/default.nix
+++ b/pkgs/build-support/node/fetch-yarn-deps/tests/default.nix
@@ -17,6 +17,10 @@
     yarnLock = ./github.lock;
     sha256 = "sha256-DIKrhDKoqm7tHZmcuh9eK9VTqp6BxeW0zqDUpY4F57A=";
   };
+  githubReleaseDep = testers.invalidateFetcherByDrvHash fetchYarnDeps {
+    yarnLock = ./github-release.lock;
+    sha256 = "sha256-g+y/H6k8LZ+IjWvkkwV7JhKQH1ycfeqzsIonNv4fDq8=";
+  };
   gitUrlDep = testers.invalidateFetcherByDrvHash fetchYarnDeps {
     yarnLock = ./giturl.lock;
     sha256 = "sha256-VPnyqN6lePQZGXwR7VhbFnP7/0/LB621RZwT1F+KzVQ=";

--- a/pkgs/build-support/node/fetch-yarn-deps/tests/github-release.lock
+++ b/pkgs/build-support/node/fetch-yarn-deps/tests/github-release.lock
@@ -1,0 +1,6 @@
+"libsession_util_nodejs@https://github.com/oxen-io/libsession-util-nodejs/releases/download/v0.3.19/libsession_util_nodejs-v0.3.19.tar.gz":
+  version "0.3.19"
+  resolved "https://github.com/oxen-io/libsession-util-nodejs/releases/download/v0.3.19/libsession_util_nodejs-v0.3.19.tar.gz#221c1fc34fcc18601aea4ce1b733ebfa55af66ea"
+  dependencies:
+    cmake-js "^7.2.1"
+    node-addon-api "^6.1.0"


### PR DESCRIPTION
## Description of changes
```
commit 9cac7a7475204ad62ce9a863f5e972224f8ddfc6
Author: Adam Joseph <adam@westernsemico.com>
Date:   Wed Jul 24 14:59:35 2024 -0700

    fetch-yarn-deps: improve diagnostic messages
    
    When the hash of an url being fetched does not match the expected value, this
    commit will cause fetch-yarn-deps to include the url in the error message to
    assist debugging.

commit 84a75e9488894098ce8c51aabf23f10fa63fa67e
Author: Adam Joseph <adam@westernsemico.com>
Date:   Wed Jul 24 15:01:12 2024 -0700

    fetchYarnDeps: fix broken fetching logic for github releases
    
    When a dependency references a github *release* URL, that dependency must be
    fetched using https rather than git, since github does not require that
    release tarballs have any relationship whatsoever to the git history.
    
    This commit causes them to be fetched using https, not git.
    
    A test case (which fails prior to this commit, and passes afterwards) is included.
```

From https://lists.sr.ht/~andir/nixpkgs-dev/patches/54068
From https://lists.sr.ht/~andir/nixpkgs-dev/patches/54069

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
