### PR TITLE
swiProlog: 9.2.5 -> 9.2.6, update dependencies

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12592,6 +12592,12 @@
     githubId = 1711539;
     name = "matklad";
   };
+  matko = {
+    email = "maren.van.otterdijk@gmail.com";
+    github = "matko";
+    githubId = 155603;
+    name = "Maren van Otterdijk";
+  };
   matrss = {
     name = "Matthias Riße";
     email = "matthias.risze@t-online.de";

--- a/pkgs/development/compilers/swi-prolog/default.nix
+++ b/pkgs/development/compilers/swi-prolog/default.nix
@@ -1,9 +1,37 @@
-{ lib, stdenv, fetchFromGitHub, jdk, gmp, readline, openssl, unixODBC, zlib
-, libarchive, db, pcre2, libedit, libossp_uuid, libxcrypt,libXpm
-, libSM, libXt, freetype, pkg-config, fontconfig
-, cmake, libyaml, Security
-, libjpeg, libX11, libXext, libXft, libXinerama
-, extraLibraries ? [ jdk unixODBC libXpm libSM libXt freetype fontconfig ]
+{
+  lib, stdenv, fetchFromGitHub,
+  cmake, ninja,
+
+  libxcrypt, zlib, openssl,
+  gmp, gperftools, readline,
+  libedit, libarchive, Security,
+
+  # optional dependencies
+  withDb ? true,
+  db,
+
+  withJava ? true,
+  jdk,
+
+  withOdbc ? true,
+  unixODBC,
+
+  withPcre ? true,
+  pcre2,
+
+  withPython ? true,
+  python3,
+
+  withYaml ? true,
+  libyaml,
+
+
+  withGui ? false,
+  libX11, libXpm, libXext, libXft, libXinerama, libjpeg, libXt, libSM, freetype, fontconfig,
+
+  # gcc/g++ as runtime dependency
+  withNativeCompiler ? true
+
 # Packs must be installed from a local directory during the build, with dependencies
 # resolved manually, e.g. to install the 'julian' pack, which depends on the 'delay', 'list_util' and 'typedef' packs:
 #   julian = pkgs.fetchzip {
@@ -30,15 +58,35 @@
 #     julian delay list_util typedef
 #   ]; };
 , extraPacks ? []
-, withGui ? false
+, extraLibraries ? [] # removed option - see below
 }:
 
 let
   # minorVersion is even for stable, odd for unstable
-  version = "9.2.5";
+  version = "9.2.6";
+
+  # This package provides several with* options, which replaces the old extraLibraries option.
+  # This error should help users that still use this option find their way to these flags.
+  # We can probably remove this after one NixOS version.
+  extraLibraries' = if extraLibraries == [] then [] else throw
+    "option 'extraLibraries' removed - use 'with*' options (e.g., 'withJava'), or overrideAttrs to inject extra build dependencies";
+
   packInstall = swiplPath: pack:
-    ''${swiplPath}/bin/swipl -g "pack_install(${pack}, [package_directory(\"${swiplPath}/lib/swipl/pack\"), silent(true), interactive(false)])." -t "halt."
+    ''${swiplPath}/bin/swipl -g "pack_install(${pack}, [package_directory(\"${swiplPath}/lib/swipl/extra-pack\"), silent(true), interactive(false)])." -t "halt."
     '';
+  withGui' = withGui && !stdenv.isDarwin;
+  optionalDependencies = []
+                         ++ (lib.optional withDb db)
+                         ++ (lib.optional withJava jdk)
+                         ++ (lib.optional withOdbc unixODBC)
+                         ++ (lib.optional withPcre pcre2)
+                         ++ (lib.optional withPython python3)
+                         ++ (lib.optional withYaml libyaml)
+                         ++ (lib.optionals withGui' [ libXt libXext libXpm libXft libXinerama
+                                                      libjpeg libSM freetype fontconfig
+                                                    ])
+                         ++ (lib.optional stdenv.isDarwin Security)
+                         ++ extraLibraries';
 in
 stdenv.mkDerivation {
   pname = "swi-prolog";
@@ -51,30 +99,39 @@ stdenv.mkDerivation {
     owner = "SWI-Prolog";
     repo = "swipl";
     rev = "V${version}";
-    hash = "sha256-WbpYu6b0WPfKoAOkBZduWK20vwOYuDUDpJuj19qzPtw=";
+    hash = "sha256-FgEn+Ht45++GFpfcdaJ5In5x+NyIOopSlSAs+t7sPDE=";
     fetchSubmodules = true;
   };
 
   # Add the packInstall path to the swipl pack search path
   postPatch = ''
-    echo "user:file_search_path(pack, '$out/lib/swipl/pack')." >> boot/init.pl
+    echo "user:file_search_path(pack, '$out/lib/swipl/extra-pack')." >> boot/init.pl
   '';
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  nativeBuildInputs = [ cmake ninja ];
 
-  buildInputs = [ gmp readline openssl
-    libarchive libyaml db pcre2 libedit libossp_uuid libxcrypt
-    zlib ]
-  ++ lib.optionals (withGui && !stdenv.isDarwin) [ libXpm libX11 libXext libXft libXinerama libjpeg ]
-  ++ extraLibraries
-  ++ lib.optional stdenv.isDarwin Security;
+  buildInputs = [
+    libarchive
+    libxcrypt
+    zlib
+    openssl
+    gperftools
+    gmp
+    readline
+    libedit
+  ] ++ optionalDependencies;
 
   hardeningDisable = [ "format" ];
 
-  cmakeFlags = [ "-DSWIPL_INSTALL_IN_LIB=ON" ];
+  cmakeFlags = [ "-DSWIPL_INSTALL_IN_LIB=ON" ]
+               ++ lib.optionals (!withNativeCompiler) [
+                 # without these options, the build will embed full compiler paths
+                 "-DSWIPL_CC=${if stdenv.isDarwin then "clang" else "gcc"}"
+                 "-DSWIPL_CXX=${if stdenv.isDarwin then "clang++" else "g++"}"
+               ];
 
   preInstall = ''
-    mkdir -p $out/lib/swipl/pack
+    mkdir -p $out/lib/swipl/extra-pack
   '';
 
   postInstall = builtins.concatStringsSep "\n"
@@ -87,6 +144,6 @@ stdenv.mkDerivation {
     license = lib.licenses.bsd2;
     mainProgram = "swipl";
     platforms = lib.platforms.linux ++ lib.optionals (!withGui) lib.platforms.darwin;
-    maintainers = [ lib.maintainers.meditans ];
+    maintainers = [ lib.maintainers.meditans lib.maintainers.matko ];
   };
 }


### PR DESCRIPTION
## Description of changes
This updates SWI-Prolog to the latest upstream stable version, 9.2.6. [Changelog](https://www.swi-prolog.org/ChangeLog?branch=stable&from=9.2.5&to=9.2.6)

Additionally, this PR modifies the dependencies to pass SWI-Prolog's self test, which is not passing with the packaging currently in nixpkgs. A special predicate, `check_installation/0`, can be run on a SWI-Prolog install to make it report issues in the installation. This self-test is now all green for `swiPrologWithGui`, and only reports that the gui elements are missing in `swiProlog`.

Changes:
- Import SWI-Prolog 9.2.6
- switch to ninja for building (same as upstream)
- add gperftools for tcmalloc
- include python dependency
- move extra pack install option directory to another name which doesn't clash with standard SWI-Prolog locations
- remove `extraLibraries`, which appears to be a hacky way to inject dependencies like java and odbc. In my view this is fully replaced by the next point.
- add several `withX` options to turn dependencies on or off. The complete list of 'with' variables is now
  - withDb
  - withGui
  - withJava
  - withNativeCompiler (to include gcc and g++ as runtime dependenciess for pack install)
  - withOdbc
  - withPcre
  - withPython
  - withYaml
 
All are true by default, except withGui, which defaults to false.

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
