### PR TITLE
xfce.xfce4-screenshooter: 1.10.6 -> 1.11.0

### DIFF
--- a/pkgs/desktops/xfce/applications/xfce4-screenshooter/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-screenshooter/default.nix
@@ -8,7 +8,6 @@
 , libXfixes
 , libXtst
 , libxml2
-, libsoup_3
 , libxfce4ui
 , libxfce4util
 , wayland
@@ -24,10 +23,10 @@
 mkXfceDerivation {
   category = "apps";
   pname = "xfce4-screenshooter";
-  version = "1.10.6";
+  version = "1.11.0";
   odd-unstable = false;
 
-  sha256 = "sha256-g3wYIyJEnYCFhCs6YXzfEe5lnvIY8ACN/m7He+ww3mA=";
+  sha256 = "sha256-DMLGaDHmwDDHvOMev/QKvmDr6AQ6Qnzxf3YCbf0/nXg=";
 
   nativeBuildInputs = [
     wayland-scanner
@@ -41,7 +40,6 @@ mkXfceDerivation {
     libXfixes
     libXtst
     libxml2
-    libsoup_3
     libxfce4ui
     libxfce4util
     wayland


### PR DESCRIPTION
https://gitlab.xfce.org/apps/xfce4-screenshooter/-/compare/xfce4-screenshooter-1.10.6...xfce4-screenshooter-1.11.0



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

