### PR TITLE
libtraceevent: 1.8.2 -> 1.8.3

### DIFF
--- a/pkgs/os-specific/linux/libtraceevent/default.nix
+++ b/pkgs/os-specific/linux/libtraceevent/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "libtraceevent";
-  version = "1.8.2";
+  version = "1.8.3";
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git";
     rev = "libtraceevent-${version}";
-    hash = "sha256-2oa3pR8DOPaeHcoqcLX00ihx1lpXablnsf0IZR2sOm8=";
+    hash = "sha256-yftCaZ3mEPOreENd9Q/te/WqM7etokO+D8RZbB1epSA=";
   };
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

Mostly minor fixes: [Changelog](https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/tag/?h=libtraceevent-1.8.3)

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>11 packages marked as broken and skipped:</summary>
  <ul>
    <li>linuxKernel.packages.linux_4_19.perf</li>
    <li>linuxKernel.packages.linux_4_19.perf.debug</li>
    <li>linuxKernel.packages.linux_4_19_hardened.perf</li>
    <li>linuxKernel.packages.linux_4_19_hardened.perf.debug</li>
    <li>rocmPackages.mivisionx</li>
    <li>rocmPackages.mivisionx-cpu</li>
    <li>rocmPackages.mivisionx-hip</li>
    <li>rocmPackages_5.mivisionx</li>
    <li>rocmPackages_5.mivisionx-cpu</li>
    <li>rocmPackages_5.mivisionx-hip</li>
    <li>rocmPackages_5.mivisionx-opencl</li>
  </ul>
</details>
<details>
  <summary>12 packages failed to build:</summary>
  <ul>
    <li>linuxKernel.packages.linux_5_10.perf</li>
    <li>linuxKernel.packages.linux_5_10.perf.debug</li>
    <li>linuxKernel.packages.linux_5_10_hardened.perf</li>
    <li>linuxKernel.packages.linux_5_10_hardened.perf.debug</li>
    <li>linuxKernel.packages.linux_5_15.perf</li>
    <li>linuxKernel.packages.linux_5_15.perf.debug</li>
    <li>linuxKernel.packages.linux_5_15_hardened.perf</li>
    <li>linuxKernel.packages.linux_5_15_hardened.perf.debug</li>
    <li>linuxKernel.packages.linux_5_4.perf</li>
    <li>linuxKernel.packages.linux_5_4.perf.debug</li>
    <li>linuxKernel.packages.linux_5_4_hardened.perf</li>
    <li>linuxKernel.packages.linux_5_4_hardened.perf.debug</li>
  </ul>
</details>

The above packages fail even without this commit.

<details>
  <summary>53 packages built:</summary>
  <ul>
    <li>cargo-flamegraph</li>
    <li>hotspot</li>
    <li>kernelshark</li>
    <li>libtraceevent</li>
    <li>libtraceevent.dev</li>
    <li>libtraceevent.devman</li>
    <li>libtraceevent.doc</li>
    <li>libtracefs</li>
    <li>libtracefs.dev</li>
    <li>libtracefs.devman</li>
    <li>libtracefs.doc</li>
    <li>linuxKernel.packages.linux_6_1.perf</li>
    <li>linuxKernel.packages.linux_6_1.perf.debug</li>
    <li>linuxKernel.packages.linux_6_10.perf</li>
    <li>linuxKernel.packages.linux_6_10.perf.debug</li>
    <li>linuxKernel.packages.linux_6_1_hardened.perf</li>
    <li>linuxKernel.packages.linux_6_1_hardened.perf.debug</li>
    <li>linuxKernel.packages.linux_6_6.perf</li>
    <li>linuxKernel.packages.linux_6_6.perf.debug</li>
    <li>linuxKernel.packages.linux_hardened.perf (linuxKernel.packages.linux_6_6_hardened.perf)</li>
    <li>linuxKernel.packages.linux_hardened.perf.debug (linuxKernel.packages.linux_6_6_hardened.perf.debug)</li>
    <li>linuxKernel.packages.linux_6_8.perf</li>
    <li>linuxKernel.packages.linux_6_8.perf.debug</li>
    <li>linuxKernel.packages.linux_6_8_hardened.perf</li>
    <li>linuxKernel.packages.linux_6_8_hardened.perf.debug</li>
    <li>linuxKernel.packages.linux_6_9.perf</li>
    <li>linuxKernel.packages.linux_6_9.perf.debug</li>
    <li>linuxKernel.packages.linux_6_9_hardened.perf</li>
    <li>linuxKernel.packages.linux_6_9_hardened.perf.debug</li>
    <li>linuxKernel.packages.linux_latest_libre.perf</li>
    <li>linuxKernel.packages.linux_latest_libre.perf.debug</li>
    <li>linuxKernel.packages.linux_libre.perf</li>
    <li>linuxKernel.packages.linux_libre.perf.debug</li>
    <li>linuxKernel.packages.linux_lqx.perf</li>
    <li>linuxKernel.packages.linux_lqx.perf.debug</li>
    <li>linuxKernel.packages.linux_xanmod.perf</li>
    <li>linuxKernel.packages.linux_xanmod.perf.debug</li>
    <li>linuxKernel.packages.linux_xanmod_latest.perf (linuxKernel.packages.linux_xanmod_stable.perf)</li>
    <li>linuxKernel.packages.linux_xanmod_latest.perf.debug (linuxKernel.packages.linux_xanmod_stable.perf.debug)</li>
    <li>linuxKernel.packages.linux_zen.perf</li>
    <li>linuxKernel.packages.linux_zen.perf.debug</li>
    <li>qtcreator</li>
    <li>rasdaemon</li>
    <li>rasdaemon.dev</li>
    <li>rasdaemon.inject</li>
    <li>rasdaemon.man</li>
    <li>trace-cmd</li>
    <li>trace-cmd.dev</li>
    <li>trace-cmd.devman</li>
    <li>trace-cmd.lib</li>
    <li>trace-cmd.man</li>
    <li>uftrace</li>
    <li>uftraceFull</li>
  </ul>
</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
