### PR TITLE
jmol: update hash

### DIFF
--- a/pkgs/applications/science/chemistry/jmol/default.nix
+++ b/pkgs/applications/science/chemistry/jmol/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     baseVersion = "${lib.versions.major version}.${lib.versions.minor version}";
   in fetchurl {
     url = "mirror://sourceforge/jmol/Jmol/Version%20${baseVersion}/Jmol%20${version}/Jmol-${version}-binary.tar.gz";
-    hash = "sha256-Lpy5A7TWxSrBeGSsp+HlEXDrbkB840QZlvIeop6YUTw=";
+    hash = "sha256-uOPRdTmEbU376G7a7om5UpBjemkN170PwGCskJY41HE=";
   };
 
   patchPhase = ''


### PR DESCRIPTION
## Description of changes

Jmol was recently updated to 16.2.19 in #329186. While r-ryantm successfully built this version two days ago, it now fails with
```
error: hash mismatch in fixed-output derivation '/nix/store/3h7dxhp7zbgcw5pqx1w1x61mr5nhgpa6-Jmol-16.2.19-binary.tar.gz.drv':
         specified: sha256-Lpy5A7TWxSrBeGSsp+HlEXDrbkB840QZlvIeop6YUTw=
            got:    sha256-uOPRdTmEbU376G7a7om5UpBjemkN170PwGCskJY41HE=
error: 1 dependencies of derivation '/nix/store/gby7w7sf0l8dgb3cnwnrn2ybajg8pvl8-jmol-16.2.19.drv' failed to build
```

I have compared the two tarballs (thanks Cachix!), and it seems like upstream released a new version of both Jmol and jsmol (which is generated by compiling Java into JavaScript using [java2script](https://github.com/java2script/java2script)) to include the changes in https://sourceforge.net/p/jmol/code/22627/. The three Jmol `.jar` files also changed; I haven't audited the Java bytecode but the list of files changes looks compatible with the above commit. The changes in jsmol are easier to audit since they do not contain binary data, and the full diff is at https://gist.github.com/collares/1c3736e85c7c69b9fb7bb2118bf065d4.

Related: We use the .tar.gz, but the .zip was also regenerated ([Arch's PKGBUILD](https://gitlab.archlinux.org/archlinux/packaging/packages/jmol/-/commit/6c747f32f0583a557a7fa45d213b849d67a9f1ab) contains an invalid sha256 for the .zip now, the most recent one being `e6930e9b9a90b9b686b4a7a2221a862180c5e71ec8e2de2fee6ce7eaf9107eb7`, cc @antonio-rojas).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
