### PR TITLE
vcpkg: support builtin-baseline without git

### DIFF
--- a/pkgs/by-name/vc/vcpkg-tool/package.nix
+++ b/pkgs/by-name/vc/vcpkg-tool/package.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./change-lock-location.patch
+    ./read-bundle-info-from-root.patch
   ];
 
   cmakeFlags = [

--- a/pkgs/by-name/vc/vcpkg-tool/read-bundle-info-from-root.patch
+++ b/pkgs/by-name/vc/vcpkg-tool/read-bundle-info-from-root.patch
@@ -1,0 +1,43 @@
+diff --git a/include/vcpkg/vcpkgpaths.h b/include/vcpkg/vcpkgpaths.h
+index 90fd4d09..ebc6342b 100644
+--- a/include/vcpkg/vcpkgpaths.h
++++ b/include/vcpkg/vcpkgpaths.h
+@@ -28,6 +28,8 @@
+ 
+ namespace vcpkg
+ {
++    Path exported_determine_root(const ReadOnlyFilesystem& fs, const Path& original_cwd, const VcpkgCmdArguments& args);
++
+     struct ToolsetArchOption
+     {
+         ZStringView name;
+diff --git a/src/vcpkg.cpp b/src/vcpkg.cpp
+index 2b62cb55..d7b8ead5 100644
+--- a/src/vcpkg.cpp
++++ b/src/vcpkg.cpp
+@@ -296,7 +296,8 @@ int main(const int argc, const char* const* const argv)
+         Debug::println("To include the environment variables in debug output, pass --debug-env");
+     }
+     args.check_feature_flag_consistency();
+-    const auto current_exe_path = get_exe_path_of_current_process();
++    const auto current_exe_path =
++        exported_determine_root(real_filesystem, real_filesystem.current_path(VCPKG_LINE_INFO), args) / "vcpkg";
+ 
+     bool to_enable_metrics = true;
+     {
+diff --git a/src/vcpkg/vcpkgpaths.cpp b/src/vcpkg/vcpkgpaths.cpp
+index 77e107f5..132050ba 100644
+--- a/src/vcpkg/vcpkgpaths.cpp
++++ b/src/vcpkg/vcpkgpaths.cpp
+@@ -518,6 +518,11 @@ namespace
+ 
+ namespace vcpkg
+ {
++    Path exported_determine_root(const ReadOnlyFilesystem& fs, const Path& original_cwd, const VcpkgCmdArguments& args)
++    {
++        return determine_root(fs, original_cwd, args);
++    }
++
+     Path InstalledPaths::listfile_path(const BinaryParagraph& pgh) const
+     {
+         return this->vcpkg_dir_info() / (pgh.fullstem() + ".list");

--- a/pkgs/by-name/vc/vcpkg/package.nix
+++ b/pkgs/by-name/vc/vcpkg/package.nix
@@ -67,7 +67,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     '';
 
   meta = {
-    description = "C++ Library Manager";
+    description = "C++ Library Manager for Windows, Linux, and macOS";
     mainProgram = "vcpkg";
     homepage = "https://vcpkg.io/";
     license = lib.licenses.mit;

--- a/pkgs/by-name/vc/vcpkg/package.nix
+++ b/pkgs/by-name/vc/vcpkg/package.nix
@@ -14,7 +14,24 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "microsoft";
     repo = "vcpkg";
     rev = finalAttrs.version;
-    hash = "sha256-HT7IcznN5W+Innzg0aeOvZnpVUTf/uJFlYflE91YJQA=";
+    hash = "sha256-WE+BeF9BYR9/Gmi60g6ApXsWQ2vch2N6XhH1A9HAHsc=";
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      VCPKG_BASELINE_COMMIT_SHA=$(git rev-parse --verify HEAD)
+      # We only needed the .git folder for that previous command, so we can safely delete it now.
+      # If we don’t delete it, then we might run into problems (see #8567).
+      rm -r .git
+      # Here's the code that Creates this json file in Visual Studio deployment and the code that reads it:
+      #   https://github.com/microsoft/vcpkg-tool/blob/f098d3e0aaa7e46ea84a1f7079586e1ec5af8ab5/vcpkg-init/mint-standalone-bundle.ps1#L21
+      #   https://github.com/microsoft/vcpkg-tool/blob/f098d3e0aaa7e46ea84a1f7079586e1ec5af8ab5/src/vcpkg/bundlesettings.cpp#L87
+      #
+      # Here's the code that we target with this setting. If we use embeddedsha combined with usegitregistry, vcpkg
+      # will checkout a remote instead of trying to do git operation in the vcpkg root
+      #   https://github.com/microsoft/vcpkg-tool/blob/d272c0d4f5175b26bd56c6109d4c4935b791a157/src/vcpkg/vcpkgpaths.cpp#L920
+      #   https://github.com/microsoft/vcpkg-tool/blob/d272c0d4f5175b26bd56c6109d4c4935b791a157/src/vcpkg/configuration.cpp#L718
+      echo '{ "readonly": true, "usegitregistry": true, "deployment": "Git", "embeddedsha": "'"$VCPKG_BASELINE_COMMIT_SHA"'" }' > vcpkg-bundle.json
+    '';
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -36,7 +53,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       runHook preInstall
 
       mkdir -p "$out/bin" "$out/share/vcpkg/scripts/buildsystems"
-      cp --preserve=mode -r ./{docs,ports,triplets,scripts,.vcpkg-root,versions,LICENSE.txt} "$out/share/vcpkg/"
+      cp --preserve=mode -r ./{docs,ports,triplets,scripts,.vcpkg-root,versions,LICENSE.txt,vcpkg-bundle.json} "$out/share/vcpkg/"
 
       ${lib.optionalString doWrap ''
         makeWrapper "${vcpkg-tool}/bin/vcpkg" "$out/bin/vcpkg" \


### PR DESCRIPTION
## Description of changes

This change is another take on #328937.

This PR is taking a different approach. Instead of adding the git directory in the install folder, I use the `vcpkg-bundle.json` file. That file can instruct vcpkg of the current git revision without shipping the actual git history in the repo. It can also instruct vcpkg that the filesystem is immutable, so it won't attempt to fetch a different revisions.

This as for effect of supporting arbitrary baselines, since vcpkg will use the mutable tree instead as it's download location instead of its own git root.

There was one problem implementing this PR is that vcpkg expects to read `vcpkg-bundle.json` as a sibling file to the executable file. Since the vcpkg root is using a wrapper script, it tries to read at the wrong location. I don't think we can move the `vcpkg-bundle.json` file to vcpkg-tool, since it contains the git revision of vcpkg. I instead opted to patch vcpkg to read the bundle json file from the root directory instead.

Bonus, it fixes the disable metrics, which suffered from the same problem as the bundle file.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
