### PR TITLE
python311Packages.fslpy: init at 3.21.0

### DIFF
--- a/pkgs/development/python-modules/fslpy/default.nix
+++ b/pkgs/development/python-modules/fslpy/default.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitLab,
+  setuptools,
+  dill,
+  h5py,
+  nibabel,
+  numpy,
+  scipy,
+  indexed-gzip,
+  pillow,
+  rtree,
+  trimesh,
+  wxpython,
+  pytestCheckHook,
+  pytest-cov-stub,
+  tomli,
+}:
+
+buildPythonPackage rec {
+  pname = "fslpy";
+  version = "3.21.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "fslpy";
+    rev = "refs/tags/${version}";
+    hash = "sha256-O0bhzu6zZeuGJqXAwlgM8qHkgtaGCmg7xSkOqbZH2eA=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    dill
+    h5py
+    nibabel
+    numpy
+    scipy
+  ];
+
+  optional-dependencies = {
+    extra = [
+      indexed-gzip
+      pillow
+      rtree
+      trimesh
+      wxpython
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+    tomli
+  ] ++ optional-dependencies.extra;
+
+  disabledTestPaths = [
+    # tries to download data:
+    "fsl/tests/test_dicom.py"
+    # tests exit with "SystemExit: Unable to access the X Display, is $DISPLAY set properly?"
+    "fsl/tests/test_idle.py"
+    "fsl/tests/test_platform.py"
+    # require FSL's atlas library (via $FSLDIR), which has an unfree license:
+    "fsl/tests/test_atlases.py"
+    "fsl/tests/test_atlases_query.py"
+    "fsl/tests/test_parse_data.py"
+    "fsl/tests/test_scripts/test_atlasq_list_summary.py"
+    "fsl/tests/test_scripts/test_atlasq_ohi.py"
+    "fsl/tests/test_scripts/test_atlasq_query.py"
+    # requires FSL (unfree and not in Nixpkgs):
+    "fsl/tests/test_fslsub.py"
+    "fsl/tests/test_run.py"
+    "fsl/tests/test_wrappers"
+  ];
+
+  pythonImportsCheck = [
+    "fsl"
+    "fsl.data"
+    "fsl.scripts"
+    "fsl.transform"
+    "fsl.utils"
+    "fsl.wrappers"
+  ];
+
+  meta = {
+    description = "FSL Python library";
+    homepage = "https://git.fmrib.ox.ac.uk/fsl/fslpy";
+    changelog = "https://git.fmrib.ox.ac.uk/fsl/fslpy/-/blob/main/CHANGELOG.rst";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4782,6 +4782,8 @@ self: super: with self; {
 
   fschat = callPackage ../development/python-modules/fschat { };
 
+  fslpy = callPackage ../development/python-modules/fslpy { };
+
   fsspec-xrootd = callPackage ../development/python-modules/fsspec-xrootd { };
 
   fsspec = callPackage ../development/python-modules/fsspec { };


### PR DESCRIPTION
## Description of changes

Init python311Packages.fslpy, a [Python programming library for interacting with the FSL neuroimaging software suite](https://git.fmrib.ox.ac.uk/fsl/fslpy). Note that the functionality of this package is limited since FSL and its atlases are not available in Nixpkgs (unfree license and difficult to install) but the user can always download the atlases, and other functionality is still useful e.g. interacting with image and transform files, and should be able to be used as a dependency for the standalone open source medical image viewer FSLeyes.

Doesn't build on Python 3.12 due to the optional wxPython dependency which is used for tests. I could have patched this out but it doesn't seem worthwhile since FSLeyes itself also depends on wxPython.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
