### PR TITLE
boost{,-build}: fix building with llvm

### DIFF
--- a/pkgs/development/libraries/boost/fix-clang-target.patch
+++ b/pkgs/development/libraries/boost/fix-clang-target.patch
@@ -1,0 +1,14 @@
+--- a/tools/build/src/tools/clang.jam	2024-07-25 10:38:16.278401900 -0700
++++ b/tools/build/src/tools/clang.jam	2024-07-25 10:38:52.659750666 -0700
+@@ -90,11 +90,6 @@
+                 case x86-64 : arch = x86_64 ;
+                 case x86-32 : arch = i386 ;
+             }
+-
+-            toolset.flags $(toolset)
+-                OPTIONS $(condition)/<target-os>$(target-os)/<architecture>$(_architecture_)/<address-model>$(_address-model_)
+-                : "--target=$(arch)-$(vendor-sys)"
+-                : unchecked ;
+         }
+     }
+ }

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -150,7 +150,8 @@ stdenv.mkDerivation {
       stripLen = 1;
       extraPrefix = "libs/python/";
     })
-  ];
+  ]
+  ++ lib.optional (lib.versionAtLeast version "1.81" && stdenv.cc.isClang) ./fix-clang-target.patch;
 
   meta = with lib; {
     homepage = "http://boost.org/";

--- a/pkgs/development/tools/boost-build/default.nix
+++ b/pkgs/development/tools/boost-build/default.nix
@@ -33,7 +33,8 @@ stdenv.mkDerivation {
     sourceRoot="$sourceRoot/tools/build"
   '';
 
-  patches = useBoost.boostBuildPatches or [];
+  patches = useBoost.boostBuildPatches or []
+    ++ lib.optional (useBoost ? version && lib.versionAtLeast useBoost.version "1.81") ./fix-clang-target.patch;
 
   # Upstream defaults to gcc on darwin, but we use clang.
   postPatch = ''

--- a/pkgs/development/tools/boost-build/fix-clang-target.patch
+++ b/pkgs/development/tools/boost-build/fix-clang-target.patch
@@ -1,0 +1,14 @@
+--- a/src/tools/clang.jam	2024-07-25 10:38:16.278401900 -0700
++++ b/src/tools/clang.jam	2024-07-25 10:38:52.659750666 -0700
+@@ -90,11 +90,6 @@
+                 case x86-64 : arch = x86_64 ;
+                 case x86-32 : arch = i386 ;
+             }
+-
+-            toolset.flags $(toolset)
+-                OPTIONS $(condition)/<target-os>$(target-os)/<architecture>$(_architecture_)/<address-model>$(_address-model_)
+-                : "--target=$(arch)-$(vendor-sys)"
+-                : unchecked ;
+         }
+     }
+ }


### PR DESCRIPTION
## Description of changes

Fixes #320685 

When building `boost` with LLVM, `lld` isn't found. The solution has been to force boost to not override `--target` being specified to clang.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
