### PR TITLE
python312Packages.atomman: 1.4.6-unstable-2023-07-28 -> 1.4.11

### DIFF
--- a/pkgs/development/python-modules/atomman/default.nix
+++ b/pkgs/development/python-modules/atomman/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  ase,
   buildPythonPackage,
   cython,
   datamodeldict,
@@ -11,35 +10,31 @@
   pandas,
   phonopy,
   potentials,
-  pymatgen,
   pytestCheckHook,
   pythonOlder,
   requests,
   scipy,
   setuptools,
   toolz,
-  wheel,
   xmltodict,
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "atomman";
-  version = "1.4.6-unstable-2023-07-28";
+  version = "1.4.11";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "usnistgov";
     repo = "atomman";
-    rev = "b8af21a9285959d38ee26173081db1b4488401bc";
-    hash = "sha256-WfB+OY61IPprT6OCVHl8VA60p7lLVkRGuyYX+nm7bbA=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-2yxHv9fSgLM5BeUkXV9NX+xyplXtyfWodwS9sVUVzqU=";
   };
-
 
   build-system = [
     setuptools
-    wheel
     numpy
     cython
   ];
@@ -57,7 +52,7 @@ buildPythonPackage {
     xmltodict
   ];
 
-  pythonRelaxDeps = [ "potentials" ];
+  pythonRelaxDeps = [ "atomman" ];
 
   preCheck = ''
     # By default, pytestCheckHook imports atomman from the current directory
@@ -68,9 +63,7 @@ buildPythonPackage {
   '';
 
   nativeCheckInputs = [
-    ase
     phonopy
-    pymatgen
     pytestCheckHook
   ];
 
@@ -81,6 +74,7 @@ buildPythonPackage {
   pythonImportsCheck = [ "atomman" ];
 
   meta = with lib; {
+    changelog = "https://github.com/usnistgov/atomman/blob/${src.rev}/UPDATES.rst";
     description = "Atomistic Manipulation Toolkit";
     homepage = "https://github.com/usnistgov/atomman/";
     license = licenses.mit;


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/usnistgov/atomman/compare/b8af21a9285959d38ee26173081db1b4488401bc...v1.4.11

Changelog: https://github.com/usnistgov/atomman/blob/refs/tags/v1.4.11/UPDATES.rst



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
