### PR TITLE
treewide: Rename android `sdkVer` and `ndkVer`

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -257,6 +257,22 @@ let
         if final.isMacOS then "MACOSX_DEPLOYMENT_TARGET"
         else if final.isiOS then "IPHONEOS_DEPLOYMENT_TARGET"
         else null;
+
+      # Remove before 25.05
+      androidSdkVersion =
+        if (args ? sdkVer && !args ? androidSdkVersion) then
+          throw "For android `sdkVer` has been renamed to `androidSdkVersion`"
+        else if (args ? androidSdkVersion) then
+          args.androidSdkVersion
+        else
+          null;
+      androidNdkVersion =
+        if (args ? ndkVer && !args ? androidNdkVersion) then
+          throw "For android `ndkVer` has been renamed to `androidNdkVersion`"
+        else if (args ? androidSdkVersion) then
+          args.androidNdkVersion
+        else
+          null;
     } // (
       let
         selectEmulator = pkgs:

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -60,6 +60,8 @@ rec {
   armv7a-android-prebuilt = {
     config = "armv7a-unknown-linux-androideabi";
     rust.rustcTarget = "armv7-linux-androideabi";
+    androidSdkVersion = "33";
+    androidNdkVersion = "26";
     useAndroidPrebuilt = true;
   } // platforms.armv7a-android;
 

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -60,23 +60,21 @@ rec {
   armv7a-android-prebuilt = {
     config = "armv7a-unknown-linux-androideabi";
     rust.rustcTarget = "armv7-linux-androideabi";
-    sdkVer = "33";
-    ndkVer = "26";
     useAndroidPrebuilt = true;
   } // platforms.armv7a-android;
 
   aarch64-android-prebuilt = {
     config = "aarch64-unknown-linux-android";
     rust.rustcTarget = "aarch64-linux-android";
-    sdkVer = "33";
-    ndkVer = "26";
+    androidSdkVersion = "33";
+    androidNdkVersion = "26";
     useAndroidPrebuilt = true;
   };
 
   aarch64-android = {
     config = "aarch64-unknown-linux-android";
-    sdkVer = "33";
-    ndkVer = "26";
+    androidSdkVersion = "33";
+    androidNdkVersion = "26";
     libc = "bionic";
     useAndroidPrebuilt = false;
     useLLVM = true;

--- a/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
+++ b/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
@@ -44,7 +44,7 @@ let
   buildInfo = ndkBuildInfoFun stdenv.buildPlatform;
   targetInfo = ndkTargetInfoFun stdenv.targetPlatform;
 
-  inherit (stdenv.targetPlatform) sdkVer;
+  androidSdkVersion = if (stdenv.targetPlatform ? androidSdkVersion && stdenv.targetPlatform.androidSdkVersion != null) then stdenv.targetPlatform.androidSdkVersion else (throw "`androidSdkVersion` is not set during the importing of nixpkgs");
   suffixSalt = lib.replaceStrings ["-" "."] ["_" "_"] stdenv.targetPlatform.config;
 
   # targetInfo.triple is what Google thinks the toolchain should be, this is a little
@@ -77,8 +77,8 @@ rec {
       cp -r ${androidndk}/libexec/android-sdk/ndk-bundle/toolchains/llvm/prebuilt/${buildInfo.double} $out/toolchain
       find $out/toolchain -type d -exec chmod 777 {} \;
 
-      if [ ! -d $out/toolchain/sysroot/usr/lib/${targetInfo.triple}/${sdkVer} ]; then
-        echo "NDK does not contain libraries for SDK version ${sdkVer}";
+      if [ ! -d $out/toolchain/sysroot/usr/lib/${targetInfo.triple}/${androidSdkVersion} ]; then
+        echo "NDK does not contain libraries for SDK version ${androidSdkVersion}";
         exit 1
       fi
 
@@ -86,8 +86,8 @@ rec {
       ln -s $out/toolchain/sysroot/usr/lib/${targetInfo.triple}/*.so $out/lib/
       ln -s $out/toolchain/sysroot/usr/lib/${targetInfo.triple}/*.a $out/lib/
       chmod +w $out/lib/*
-      ln -s $out/toolchain/sysroot/usr/lib/${targetInfo.triple}/${sdkVer}/*.so $out/lib/
-      ln -s $out/toolchain/sysroot/usr/lib/${targetInfo.triple}/${sdkVer}/*.o $out/lib/
+      ln -s $out/toolchain/sysroot/usr/lib/${targetInfo.triple}/${androidSdkVersion}/*.so $out/lib/
+      ln -s $out/toolchain/sysroot/usr/lib/${targetInfo.triple}/${androidSdkVersion}/*.o $out/lib/
 
       echo "INPUT(-lc++_static)" > $out/lib/libc++.a
 
@@ -130,7 +130,7 @@ rec {
     bintools = binutils;
     libc = targetAndroidndkPkgs.libraries;
     extraBuildCommands = ''
-      echo "-D__ANDROID_API__=${stdenv.targetPlatform.sdkVer}" >> $out/nix-support/cc-cflags
+      echo "-D__ANDROID_API__=${stdenv.targetPlatform.androidSdkVersion}" >> $out/nix-support/cc-cflags
       # Android needs executables linked with -pie since version 5.0
       # Use -fPIC for compilation, and link with -pie if no -shared flag used in ldflags
       echo "-target ${targetInfo.triple} -fPIC" >> $out/nix-support/cc-cflags
@@ -151,9 +151,9 @@ rec {
   # cross-compiling packages to wrap incorrectly wrap binaries we don't include
   # anyways.
   libraries = runCommand "bionic-prebuilt" {} ''
-    lpath=${buildAndroidndk}/libexec/android-sdk/ndk-bundle/toolchains/llvm/prebuilt/${buildInfo.double}/sysroot/usr/lib/${targetInfo.triple}/${sdkVer}
+    lpath=${buildAndroidndk}/libexec/android-sdk/ndk-bundle/toolchains/llvm/prebuilt/${buildInfo.double}/sysroot/usr/lib/${targetInfo.triple}/${androidSdkVersion}
     if [ ! -d $lpath ]; then
-      echo "NDK does not contain libraries for SDK version ${sdkVer} <$lpath>"
+      echo "NDK does not contain libraries for SDK version ${androidSdkVersion} <$lpath>"
       exit 1
     fi
     mkdir -p $out/lib

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -64,7 +64,7 @@ in lib.init bootStages ++ [
         cc = if crossSystem.useiOSPrebuilt or false
                then buildPackages.darwin.iosSdkPkgs.clang
              else if crossSystem.useAndroidPrebuilt or false
-               then buildPackages."androidndkPkgs_${crossSystem.ndkVer}".clang
+               then buildPackages."androidndkPkgs_${crossSystem.androidNdkVersion}".clang
              else if targetPlatform.isGhcjs
                # Need to use `throw` so tryEval for splicing works, ugh.  Using
                # `null` or skipping the attribute would cause an eval failure

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19857,7 +19857,7 @@ with pkgs;
 
   # TODO(@Ericson2314): Build bionic libc from source
   bionic = if stdenv.hostPlatform.useAndroidPrebuilt
-    then pkgs."androidndkPkgs_${stdenv.hostPlatform.ndkVer}".libraries
+    then pkgs."androidndkPkgs_${stdenv.hostPlatform.androidNdkVer}".libraries
     else callPackage ../os-specific/linux/bionic-prebuilt { };
 
   boolstuff = callPackage ../development/libraries/boolstuff { };


### PR DESCRIPTION
`sdkVer` conflicts with the old `sdkVer`(now `darwinSdkVersion` but that still uses `sdkVer` if set) used by darwin

This shouldn't be an issue but due to `pkgs/development/interpreters/python/cpython/default.nix`
running `lib.filterAttrs (n: v: ! lib.isDerivation v && n != "passthruFun")` on it's inputs (2 of them are darwin only)
the `throw "Unsupported sdk...` in `pkgs/top-level/darwin-packages.nix` will be triggered.

After this change `pkgsCross.armv7a-android-prebuilt.python3.pythonOnBuildForHost` won't fail with
`error: Unsupported sdk: 33`

Issue was bisected to 3cb23cec239d4f73bb1b51f26ac7599384fdadd6

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
