### PR TITLE
magnetico: unstable-2022-08-10 -> 0.12.1

### DIFF
--- a/pkgs/applications/networking/p2p/magnetico/default.nix
+++ b/pkgs/applications/networking/p2p/magnetico/default.nix
@@ -1,55 +1,37 @@
 { lib
-, fetchFromGitHub
-, fetchpatch
-, nixosTests
+, stdenv
+, fetchFromGitea
 , buildGoModule
+, nixosTests
 , sqlite
 }:
 
-buildGoModule {
+buildGoModule rec {
   pname = "magnetico";
-  version = "unstable-2022-08-10";
+  version = "0.12.1";
 
-  src = fetchFromGitHub {
-    owner  = "ireun";
+  src = fetchFromGitea {
+    domain = "maxwell.ydns.eu/git";
+    owner  = "rnhmjoj";
     repo   = "magnetico";
-    rev    = "828e230d3b3c0759d3274e27f5a7b70400f4d6ea";
-    hash   = "sha256-V1pBzillWTk9iuHAhFztxYaq4uLL3U3HYvedGk6ffbk=";
+    rev    = "v${version}";
+    hash   = "sha256-cO5TVtQ1jdW1YkFtj35kmRfJG46/lXjXyz870NCPT0g=";
   };
 
-  patches = [
-    # https://github.com/ireun/magnetico/pull/15
-    (fetchpatch {
-      url = "https://github.com/ireun/magnetico/commit/90db34991aa44af9b79ab4710c638607c6211c1c.patch";
-      hash = "sha256-wC9lVQqfngQ5AaRgb4TtoWSgbQ2iSHeQ2UBDUyWjMK8=";
-     })
-  ];
-
-  vendorHash = "sha256-JDrBXjnQAcWp8gKvnm+q1F5oV+FozKUvhHK/Me/Cyj8=";
+  vendorHash = "sha256-jIVMQtPCq9RYaYsH4LSZJFspH6TpCbgzHN0GX8cM/CI=";
 
   buildInputs = [ sqlite ];
 
-  buildPhase = ''
-    runHook preBuild
+  tags = [ "fts5" "libsqlite3" ];
+  ldflags = [ "-s" "-w" ];
 
-    make magneticow magneticod
-
-    runHook postBuild
-  '';
-
-  checkPhase = ''
-    runHook preCheck
-
-    make test
-
-    runHook postCheck
-  '';
+  doCheck = !stdenv.hostPlatform.isStatic;
 
   passthru.tests = { inherit (nixosTests) magnetico; };
 
   meta = with lib; {
     description  = "Autonomous (self-hosted) BitTorrent DHT search engine suite";
-    homepage     = "https://github.com/ireun/magnetico";
+    homepage     = "https://maxwell.ydns.eu/git/rnhmjoj/magnetico";
     license      = licenses.agpl3Only;
     badPlatforms = platforms.darwin;
     maintainers  = with maintainers; [ rnhmjoj ];


### PR DESCRIPTION
## Description of changes

Switched to a release of my own fork.
This fixes:

  - build on Go ≥ 1.22
  - database errors on sqlite ≥ 3.33
  - reproducibility
  - static build

## Things done

- Built on platform(s)
  - [x] x86_64-linux (shared and static)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested via nixosTests.magnetico
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
