### PR TITLE
smlnj: 110.95 -> 110.99.6.1

### DIFF
--- a/pkgs/development/compilers/smlnj/default.nix
+++ b/pkgs/development/compilers/smlnj/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, Libsystem }:
 let
-  version = "110.95";
+  version = "110.99.6.1";
   baseurl = "http://smlnj.cs.uchicago.edu/dist/working/${version}";
 
   arch = if stdenv.hostPlatform.is64bit
@@ -8,9 +8,9 @@ let
     else "32";
 
   boot32 = { url = "${baseurl}/boot.x86-unix.tgz";
-             sha256 = "07bcrvjphyin1ygjbymcqhd1mbfk4hff82wmxcllh77lr28l5dxf"; };
+             hash = "sha256-2yBY0wGZ8B1jYC5os9SfH6eKJoWlQ4rAclBC3Pnacoc="; };
   boot64 = { url = "${baseurl}/boot.amd64-unix.tgz";
-             sha256 = "1zn96a83kb6bn6228yfjsvb58m2qxw9k4j3qz0p9c8za479w4ch6"; };
+             hash = "sha256-kUabK03MdSYVRWhWKl3kS32SExUYpM3MtLU0mCxhiaQ="; };
 
   bootBinary = if stdenv.hostPlatform.is64bit
                then boot64
@@ -18,44 +18,32 @@ let
 
   sources = map fetchurl [
     bootBinary
-    { url = "${baseurl}/config.tgz";              sha256 = "09srqxkxl86iaz6l6dz83c1apsac0pxpfq6b74i6l0nfl261jibw"; }
-    { url = "${baseurl}/cm.tgz";                  sha256 = "0gh8inrb07z597axw8qipwyx52m8nac5d5r0rvgzvdnnjg9nr9zy"; }
-    { url = "${baseurl}/compiler.tgz";            sha256 = "1kk6jwzyc261l5nii3n8rwccmgvcj1mg5fgycfsfsiyyy1v8xfx7"; }
-    { url = "${baseurl}/runtime.tgz";             sha256 = "17i069h5cv411sgzx3ynlf4v3wlrxiba9bwy1b0x0cyhs879kppc"; }
-    { url = "${baseurl}/system.tgz";              sha256 = "0s8ij3wfxpjrmrwxrgrirfxjj8vkda6l32j88al5q1ic3ncwc58s"; }
-    { url = "${baseurl}/MLRISC.tgz";              sha256 = "1v2d3gjxrcgc95x5glqcw0nfp13aapkcw03fyi70m3k1yc61izmz"; }
-    { url = "${baseurl}/smlnj-lib.tgz";           sha256 = "04i11ki8v9s7yz3lg6b0djhi03zzkzav0b5cr81ypxlkmf4hh6bp"; }
-    { url = "${baseurl}/old-basis.tgz";           sha256 = "1ryqpy0n7c9gd995ndmjvaci74f95nr8n1jjgm28yd1sn7hnavhi"; }
-    { url = "${baseurl}/ckit.tgz";                sha256 = "18mcs3j8c5gq9cmck7r175am60blaznqmhzyir622yfc8fpw1map"; }
-    { url = "${baseurl}/nlffi.tgz";               sha256 = "16mrl5aqbgsgljxa3z8kj5max9drddml34bq7rn1i78594jfvkwk"; }
-    { url = "${baseurl}/cml.tgz";                 sha256 = "00x784nv1pi6534k3vva26i9qx84cvw242vgwbs5020zkm6gvrmn"; }
-    { url = "${baseurl}/eXene.tgz";               sha256 = "143825h36v6z77kwvrvpszgwnhmjs3yldb18i9z4lwkqfb4kn7f7"; }
-    { url = "${baseurl}/ml-lpt.tgz";              sha256 = "17ly9h9ry8r94dx6lkas6w2cxknwkpma4z9pj8rgzmd3w6qm7j1z"; }
-    { url = "${baseurl}/ml-lex.tgz";              sha256 = "1ja3l2kiq17754c58mwdiqi25f7ax0cji2wk0vq4872iwwxc22px"; }
-    { url = "${baseurl}/ml-yacc.tgz";             sha256 = "1m48nkwvw87yg39sjihlw8na5m34bzz3d4zpfbjaj2f75fkjy3jf"; }
-    { url = "${baseurl}/ml-burg.tgz";             sha256 = "13nbvbah7bn8gjm4gi41m412vpl69wd6d3x3wzbb6xpia9vm4z4j"; }
-    { url = "${baseurl}/pgraph.tgz";              sha256 = "1aizkl8avz01kx221xy5z7a1a1b5xqn2hrk66wr8d0iav2nh5c98"; }
-    { url = "${baseurl}/trace-debug-profile.tgz"; sha256 = "1c80xgck9sb2rm554nfg4f5mpjkdbrwkcx88pj120056225l10vx"; }
-    { url = "${baseurl}/heap2asm.tgz";            sha256 = "1n68drd7as5dy20ccfvgd9cmnhfpfvz7g3f0gc8kpaqaz3vpy36g"; }
-    { url = "${baseurl}/smlnj-c.tgz";             sha256 = "1b6svh2kk5211rq73fdwx3sf80d2rshf0dmkkrq5mw4852nzqz3p"; }
-    { url = "${baseurl}/doc.tgz";                 sha256 = "021yzhy9maypq4ahz0d0qpr601spndg583fn9mapv6rl42kwhjq6"; }
-    { url = "${baseurl}/asdl.tgz";                sha256 = "0nqavqcbidwnphbbwjrxhpy8glbyad51wy0cpqimbsw3sgns0zkd"; }
+    { url = "${baseurl}/config.tgz";              hash = "sha256-9BJPpa/xouqi3j39WsfzlRys4z1yxTdbYttHF5VwCVw="; }
+    { url = "${baseurl}/cm.tgz";                  hash = "sha256-A3crC5EWX4kEB6olwdaObglQgkBBNqcBSCi/pQR5Wdw="; }
+    { url = "${baseurl}/compiler.tgz";            hash = "sha256-cTgkc5opaEXskdzt5yYsdjyF5m9846t2SyEiwY6W3HU="; }
+    { url = "${baseurl}/runtime.tgz";             hash = "sha256-JiNzfuZnp1eWQPNZBb9SPmQXtwgknpoGl+38iqUU3W4="; }
+    { url = "${baseurl}/system.tgz";              hash = "sha256-HUn8YCxlLe6+e5H9oMJjIoG23GBF3thMlHEkSGLZTus="; }
+    { url = "${baseurl}/MLRISC.tgz";              hash = "sha256-MPNpYhrbsIbVEOzJ7GIEQCm/7F/Jnxj0UXS7FeTp+7o="; }
+    { url = "${baseurl}/smlnj-lib.tgz";           hash = "sha256-1tp5waPl7MCWS4kIUFm/woQeeRfCjkpgSxHpGb+ymTM="; }
+    { url = "${baseurl}/old-basis.tgz";           hash = "sha256-I6DJRfIx+09ynFKXZ63dDWRpv0pEljWciAarK/EhQ/s="; }
+    { url = "${baseurl}/ckit.tgz";                hash = "sha256-vi6dSZISL+KWkpp/jxLPCNBno+qTYThvbExZ5R5L7Wc="; }
+    { url = "${baseurl}/nlffi.tgz";               hash = "sha256-WfYmX7dhrBqtE4juDVNyjuFtsJ1H+B7rJY2BXJYtKNM="; }
+    { url = "${baseurl}/cml.tgz";                 hash = "sha256-5rZzp5IUj/xZX0fyeoNMohyTz1ifdY6Anu/Hg0spDQw="; }
+    { url = "${baseurl}/eXene.tgz";               hash = "sha256-c5QnjAQTtlBgYE6DGFMNDbu9ILSEVZgzs/u0bIowfHc="; }
+    { url = "${baseurl}/ml-lpt.tgz";              hash = "sha256-aRYFTEEl4td7LQ0LhsXGLtJ/ptwCDV1m9GeDtM7+vlo="; }
+    { url = "${baseurl}/ml-lex.tgz";              hash = "sha256-ZwO3xQUDaD2f7Tsro6kkahT7vSN1JvQbLkwY/m7xSIs="; }
+    { url = "${baseurl}/ml-yacc.tgz";             hash = "sha256-DBR4xmKiSA5on7+YDz7Zr8qBA6aD1fS64+g69ukSprc="; }
+    { url = "${baseurl}/ml-burg.tgz";             hash = "sha256-4ruWhGjxny97eUD9Gk4FakqEZzNHwJp7uSa97ET20p0="; }
+    { url = "${baseurl}/pgraph.tgz";              hash = "sha256-kDyaAMB6Pt3CdAna+V8aLfTx8Tj6a5vPfuSxtpga08w="; }
+    { url = "${baseurl}/trace-debug-profile.tgz"; hash = "sha256-AD9KWsskRkjTFYiRCIm0qj02sIBHG6HtBM5wKMBqeXY="; }
+    { url = "${baseurl}/heap2asm.tgz";            hash = "sha256-OHNPMErNoLpYuatgbgYlU/mMB4JXQ4aA50WZ2BHtt3I="; }
+    { url = "${baseurl}/smlnj-c.tgz";             hash = "sha256-Vure6h0TKqne5+5MJBX9cRkBgmrJ/kKVLUzrIIiH7lE="; }
+    { url = "${baseurl}/doc.tgz";                 hash = "sha256-PliWxCffISPrAO7Zan33recFLRmGoqZLKHOzSEP0PEk="; }
+    { url = "${baseurl}/asdl.tgz";                hash = "sha256-O6/g20/hsMTG3CvMA59btjG+4UdUbGhMHkizESKJDEA="; }
   ];
 in stdenv.mkDerivation {
   pname = "smlnj";
-  inherit version;
-
-  inherit sources;
-
-  patchPhase = ''
-    sed -i '/PATH=/d' config/_arch-n-opsys base/runtime/config/gen-posix-names.sh
-    echo SRCARCHIVEURL="file:/$TMP" > config/srcarchiveurl
-    patch --verbose config/_heap2exec ${./heap2exec.diff}
-  '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    # Locate standard headers like <unistd.h>
-    substituteInPlace base/runtime/config/gen-posix-names.sh \
-      --replace "\$SDK_PATH/usr" "${Libsystem}"
-  '';
+  inherit version sources;
 
   unpackPhase = ''
     for s in $sources; do
@@ -65,6 +53,15 @@ in stdenv.mkDerivation {
     unpackFile config.tgz
     mkdir base
     ./config/unpack $TMP runtime
+  '';
+
+  patchPhase = ''
+    sed -i '/^PATH=/d' config/_arch-n-opsys base/runtime/config/gen-posix-names.sh
+    echo SRCARCHIVEURL="file:/$TMP" > config/srcarchiveurl
+  '' + lib.optionalString stdenv.isDarwin ''
+    # Locate standard headers like <unistd.h>
+    substituteInPlace base/runtime/config/gen-posix-names.sh \
+      --replace "\$SDK_PATH/usr" "${Libsystem}"
   '';
 
   buildPhase = ''
@@ -81,12 +78,12 @@ in stdenv.mkDerivation {
     done
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Standard ML of New Jersey, a compiler";
     homepage    = "http://smlnj.org";
-    license     = licenses.bsd3;
+    license     = lib.licenses.bsd3;
     platforms   = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
-    maintainers = with maintainers; [ skyesoss thoughtpolice ];
+    maintainers = with lib.maintainers; [ skyesoss thoughtpolice ];
     mainProgram = "sml";
     # never built on x86_64-darwin since first introduction in nixpkgs
     broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64;

--- a/pkgs/development/compilers/smlnj/heap2exec.diff
+++ b/pkgs/development/compilers/smlnj/heap2exec.diff
@@ -1,9 +1,0 @@
-@@ -35,7 +35,7 @@
-     BIN_DIR=${SMLNJ_HOME}/bin
- fi
- 
--ARCH_N_OPSYS=`"$BIN_DIR/.arch-n-opsys $SIZE_OPT"`
-+ARCH_N_OPSYS=`$BIN_DIR/.arch-n-opsys $SIZE_OPT`
- if [ "$?" != "0" ]; then
- 	die "unable to determine architecture/operating system"
- fi


### PR DESCRIPTION
## Description of changes

Standard ML of New Jersey is updated to 110.99.6.1.
Change log can be found on the [smlnj.org website](https://www.smlnj.org/dist/working/110.99.5/HISTORY.html).

Outside of updating hashes, this version bump allows the removal of the `heap2exec.diff` file, since the build system issue was fixed. It also requires a slightly different regex to pass to `sed` during patching.

The compiler binary and libraries have been extensively tested. The other binaries all run but have not yet been as extensively tested.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
