### PR TITLE
python312Packages.multiscale-spatial-image: init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/multiscale-spatial-image/default.nix
+++ b/pkgs/development/python-modules/multiscale-spatial-image/default.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  hatchling,
+  dask,
+  numpy,
+  python-dateutil,
+  spatial-image,
+  xarray,
+  xarray-datatree,
+  zarr,
+  dask-image,
+  fsspec,
+  jsonschema,
+  nbmake,
+  pooch,
+  pytestCheckHook,
+  pytest-mypy,
+  urllib3,
+}:
+
+buildPythonPackage rec {
+  pname = "multiscale-spatial-image";
+  version = "1.0.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "spatial-image";
+    repo = "multiscale-spatial-image";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-s/88N8IVkj+9MZYAtEJSpmmDdjIxf4S6U5gYr86Ikrw=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    dask
+    numpy
+    python-dateutil
+    spatial-image
+    xarray
+    xarray-datatree
+    zarr
+  ];
+
+  optional-dependencies = {
+    dask-image = [ dask-image ];
+    #itk = [
+    #  itk-filtering # not in nixpkgs yet
+    #];
+    test = [
+      dask-image
+      fsspec
+      #ipfsspec # not in nixpkgs
+      #itk-filtering # not in nixpkgs
+      jsonschema
+      nbmake
+      pooch
+      pytest-mypy
+      urllib3
+    ];
+  };
+
+  nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.test;
+
+  doCheck = false; # all test files try to download data
+
+  pythonImportsCheck = [ "multiscale_spatial_image" ];
+
+  meta = {
+    description = "Generate a multiscale, chunked, multi-dimensional spatial image data structure that can serialized to OME-NGFF";
+    homepage = "https://github.com/spatial-image/multiscale-spatial-image";
+    changelog = "https://github.com/spatial-image/multiscale-spatial-image/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/xarray-datatree/default.nix
+++ b/pkgs/development/python-modules/xarray-datatree/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  check-manifest,
+  setuptools,
+  setuptools-scm,
+  packaging,
+  pytestCheckHook,
+  xarray,
+  zarr,
+}:
+
+buildPythonPackage rec {
+  pname = "datatree";
+  version = "0.0.14";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "xarray-contrib";
+    repo = "datatree";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-C6+WcHc2+sftJ5Yyh/9TTIHhAEwhAqSsSkaDwtq7J90=";
+  };
+
+  build-system = [
+    check-manifest
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    packaging
+    xarray
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    zarr
+  ];
+
+  pythonImportsCheck = [ "datatree" ];
+
+  disabledTests = [
+    # output formatting issue, likely due to underlying library version difference:
+    "test_diff_node_data"
+  ];
+
+  meta = with lib; {
+    description = "Tree-like hierarchical data structure for xarray";
+    homepage = "https://xarray-datatree.readthedocs.io";
+    changelog = "https://github.com/xarray-contrib/datatree/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17422,6 +17422,8 @@ self: super: with self; {
 
   xarray-dataclasses = callPackage ../development/python-modules/xarray-dataclasses { };
 
+  xarray-datatree = callPackage ../development/python-modules/xarray-datatree { };
+
   xarray-einstats = callPackage ../development/python-modules/xarray-einstats { };
 
   xattr = callPackage ../development/python-modules/xattr { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8017,6 +8017,8 @@ self: super: with self; {
 
   multiprocess = callPackage ../development/python-modules/multiprocess { };
 
+  multiscale-spatial-image = callPackage ../development/python-modules/multiscale-spatial-image { };
+
   multiset = callPackage ../development/python-modules/multiset { };
 
   multitasking = callPackage ../development/python-modules/multitasking { };


### PR DESCRIPTION
python312Packages.xarray-datatree: init at 0.0.14

## Description of changes

Init python312Packages.multiscale-spatial-image, a [package](https://github.com/spatial-image/multiscale-spatial-image) for generating multiscale chunked image data that can be serialized to OME-NGFF.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
