### PR TITLE
python311Packages.openstacksdk: 3.1.0 -> 3.3.0

### DIFF
--- a/pkgs/development/python-modules/openstacksdk/default.nix
+++ b/pkgs/development/python-modules/openstacksdk/default.nix
@@ -16,21 +16,24 @@
   pythonOlder,
   pyyaml,
   requestsexceptions,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "openstacksdk";
-  version = "3.1.0";
-  format = "setuptools";
+  version = "3.3.0";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-cH8V1+wHSrJDS5peGYT6yrAPgi0nL0wqXeDSKgnrec0=";
+    hash = "sha256-BghpDKN8pzMnsPo3YdF+ZTlb43/yALhzXY8kJ3tPSYA=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     platformdirs
     cryptography
     dogpile-cache

--- a/pkgs/development/python-modules/openstacksdk/tests.nix
+++ b/pkgs/development/python-modules/openstacksdk/tests.nix
@@ -54,6 +54,11 @@ buildPythonPackage {
       openstack.tests.unit.cloud.test_image.TestImage.test_create_image_task
       openstack.tests.unit.image.v2.test_proxy.TestImageProxy.test_wait_for_task_error_396
       openstack.tests.unit.image.v2.test_proxy.TestImageProxy.test_wait_for_task_wait
+      openstack.tests.unit.image.v2.test_proxy.TestTask.test_wait_for_task_error_396
+      openstack.tests.unit.image.v2.test_proxy.TestTask.test_wait_for_task_wait
+      openstack.tests.unit.test_resource.TestWaitForDelete.test_callback_without_progress
+      openstack.tests.unit.test_resource.TestWaitForDelete.test_status
+      openstack.tests.unit.test_resource.TestWaitForDelete.test_success_not_found
       openstack.tests.unit.test_resource.TestWaitForStatus.test_callback
       openstack.tests.unit.test_resource.TestWaitForStatus.test_status_fails
       openstack.tests.unit.test_resource.TestWaitForStatus.test_status_fails_different_attribute


### PR DESCRIPTION
https://github.com/openstack/openstacksdk/compare/3.1.0...3.3.0

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
