### PR TITLE
lib.strings.concatMapAttrsStringSep: init

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -100,7 +100,7 @@ let
       length head tail elem elemAt isList;
     inherit (self.strings) concatStrings concatMapStrings concatImapStrings
       stringLength substring isString replaceStrings
-      intersperse concatStringsSep concatMapStringsSep
+      intersperse concatStringsSep concatMapStringsSep concatMapAttrsStringSep
       concatImapStringsSep concatLines makeSearchPath makeSearchPathOutput
       makeLibraryPath makeIncludePath makeBinPath optionalString
       hasInfix hasPrefix hasSuffix stringToCharacters stringAsChars escape

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -270,6 +270,43 @@ rec {
     list: concatStringsSep sep (lib.imap1 f list);
 
   /**
+    Like [`concatMapStringsSep`](#function-library-lib.strings.concatMapStringsSep)
+    but takes an attribute set instead of a list.
+
+    # Inputs
+
+    `sep`
+    : Separator to add between item strings
+
+    `f`
+    : Function that takes each key and value and return a string
+
+    `attrs`
+    : Attribute set to map from
+
+    # Type
+
+    ```
+    concatMapAttrsStringSep :: String -> (String -> Any -> String) -> AttrSet -> String
+    ```
+
+    # Examples
+
+    :::{.example}
+    ## `lib.strings.concatMapAttrsStringSep` usage example
+
+    ```nix
+    concatMapAttrsStringSep "\n" (name: value: "${name}: foo-${value}") { a = "0.1.0"; b = "0.2.0"; }
+    => "a: foo-0.1.0\nb: foo-0.2.0"
+    ```
+
+    :::
+  */
+  concatMapAttrsStringSep =
+    sep: f: attrs:
+    concatStringsSep sep (lib.attrValues (lib.mapAttrs f attrs));
+
+  /**
     Concatenate a list of strings, adding a newline at the end of each one.
     Defined as `concatMapStrings (s: s + "\n")`.
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -39,6 +39,7 @@ let
     composeManyExtensions
     concatLines
     concatMapAttrs
+    concatMapAttrsStringSep
     concatMapStrings
     concatStrings
     concatStringsSep
@@ -326,6 +327,11 @@ runTests {
   testConcatStringsSep = {
     expr = concatStringsSep "," ["a" "b" "c"];
     expected = "a,b,c";
+  };
+
+  testConcatMapAttrsStringSepExamples = {
+    expr = concatMapAttrsStringSep "\n" (name: value: "${name}: foo-${value}") { a = "0.1.0"; b = "0.2.0"; };
+    expected = "a: foo-0.1.0\nb: foo-0.2.0";
   };
 
   testConcatLines = {

--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -102,10 +102,6 @@ in
 }@args:
 
 let
-  concatMapStringAttrsSep =
-    sep: f: attrs:
-    lib.concatMapStringsSep sep (name: f name attrs.${name}) (lib.attrNames attrs);
-
   addShellDoubleQuotes = s: lib.escapeShellArg ''"'' + s + lib.escapeShellArg ''"'';
 in
 (buildGoModule {
@@ -210,7 +206,7 @@ in
     patchShebangs --build "$configureScript" makeit e2e scripts mlocal/scripts
 
     # Patching the hard-coded defaultPath by prefixing the packages in defaultPathInputs
-    ${concatMapStringAttrsSep "\n" (fileName: originalDefaultPaths: ''
+    ${lib.concatMapAttrsStringSep "\n" (fileName: originalDefaultPaths: ''
       substituteInPlace ${lib.escapeShellArg fileName} \
         ${
           lib.concatMapStringsSep " \\\n  " (

--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -158,5 +158,5 @@ stdenvNoCC.mkDerivation {
   passthru = { inherit tests; };
   buildCommand = ''
     touch $out
-  '' + lib.concatStringsSep "\n" (lib.attrValues (lib.mapAttrs (name: t: "([[ ${lib.boolToString t.expr} == ${lib.boolToString t.expected} ]] && echo '${name} success') || (echo '${name} fail' && exit 1)") tests));
+  '' + lib.concatMapAttrsStringSep "\n" (name: t: "([[ ${lib.boolToString t.expr} == ${lib.boolToString t.expected} ]] && echo '${name} success') || (echo '${name} fail' && exit 1)") tests;
 }


### PR DESCRIPTION
## Description of changes

This pull request introduces `lib.concatMapAttrsStringSep`, the attribute set version of `lib.concatMapAttrsStringSet`. This function is initially defined locally in the Nix expression of `apptainer` and `singularity` packages. It increases the readability of attribute-set-to-string expressions.

**Before**

```nix
lib.concatStringsSep "\n" (lib.attrValues (lib.mapAttrs (name: package: "${name}: ${package.version}") packages))
```

or

```nix
lib.concatMapStringsSep "\n" (name: "${name}: ${packages.${name}.version}") (lib.attrNames packages)
```

**After**
```nix
lib.concatMapAttrsStringSep "\n" (name: package: "${name}: ${package.version}") packages
```

Cc:
@infinisil for the new library function
@roberth for the restructuring of `tests.overriding`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux (only the manuals are rebuilt)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
