### PR TITLE
vala: remove unconditional work around for clang 16 function pointer errors

### DIFF
--- a/pkgs/development/compilers/vala/setup-hook.sh
+++ b/pkgs/development/compilers/vala/setup-hook.sh
@@ -7,15 +7,6 @@ make_vala_find_vapi_files() {
 
 addEnvHooks "$targetOffset" make_vala_find_vapi_files
 
-disable_incompabile_pointer_conversion_warning() {
-    # Work around incompatible function pointer conversion errors with clang 16
-    # by setting ``-Wno-incompatible-function-pointer-types` in an env hook.
-    # See https://gitlab.gnome.org/GNOME/vala/-/issues/1413.
-    NIX_CFLAGS_COMPILE+=" -Wno-incompatible-function-pointer-types"
-}
-
-addEnvHooks "$hostOffset" disable_incompabile_pointer_conversion_warning
-
 _multioutMoveVapiDirs() {
   moveToOutput share/vala/vapi "${!outputDev}"
   moveToOutput share/vala-@apiVersion@/vapi "${!outputDev}"


### PR DESCRIPTION
## Description of changes

Hook accumulates the flag over several executions as observed in:

- https://github.com/NixOS/nixpkgs/issues/301592
- https://github.com/NixOS/nixpkgs/pull/252484#issuecomment-2089095268

Since this has been committed, gcc started emitting a warning on `-Wno-incompatible-function-poniter-types` being an unrecognized flag and additionally upstream vala added its own measure to reduce these new pointer errors to warnings in its generated sources.

https://gitlab.gnome.org/GNOME/vala/-/commit/23ec71b1a5c4cead3d1bdac82e184d0a63fa7b79

Which is part of the current release
branch (https://gitlab.gnome.org/GNOME/vala/-/commits/0.56?ref_type=heads) and released on 0.56.15

```
Vala 0.56.15
============
 * Various improvements and bug fixes:
  - codegen:
...
    + Emit diagnostic pragmas for GCC 14, Clang 16 compatibility [#1408]
```

https://gitlab.gnome.org/GNOME/vala/-/merge_requests/369

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Only tested gcc stdenv, would appreciate testing on clang stdenv platforms.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
