### PR TITLE
chromium,chromedriver: 126.0.6478.182 -> 127.0.6533.72

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -267,6 +267,31 @@ let
         commit = "a976cb05b4024b7a6452d1541378d718cdfe33e6";
         hash = "sha256-K2PSeJAvhGH2/Yp63/4mJ85NyqXqDDkMWY+ptrpgmOI=";
       })
+    ] ++ lib.optionals (versionRange "127" "128") [
+      # Fix missing chrome/browser/ui/webui_name_variants.h dependency
+      # and ninja 1.12 compat in M127.
+      # https://issues.chromium.org/issues/345645751
+      # https://issues.chromium.org/issues/40253918
+      # https://chromium-review.googlesource.com/c/chromium/src/+/5641516
+      (githubPatch {
+        commit = "2c101186b60ed50f2ba4feaa2e963bd841bcca47";
+        hash = "sha256-luu3ggo6XoeeECld1cKZ6Eh8x/qQYmmKI/ThEhuutuY=";
+      })
+      # https://chromium-review.googlesource.com/c/chromium/src/+/5644627
+      (githubPatch {
+        commit = "f2b43c18b8ecfc3ddc49c42c062d796c8b563984";
+        hash = "sha256-uxXxSsiS8R0827Oi3xsG2gtT0X+jJXziwZ1y8+7K+Qg=";
+      })
+      # https://chromium-review.googlesource.com/c/chromium/src/+/5646245
+      (githubPatch {
+        commit = "4ca70656fde83d2db6ed5a8ac9ec9e7443846924";
+        hash = "sha256-iQuRRZjDDtJfr+B7MV+TvUDDX3bvpCnv8OpSLJ1WqCE=";
+      })
+      # https://chromium-review.googlesource.com/c/chromium/src/+/5647662
+      (githubPatch {
+        commit = "50d63ffee3f7f1b1b9303363742ad8ebbfec31fa";
+        hash = "sha256-H+dv+lgXSdry3NkygpbCdTAWWdTVdKdVD3Aa62w091E=";
+      })
     ] ++ [
       # Required to fix the build with a more recent wayland-protocols version
       # (we currently package 1.26 in Nixpkgs while Chromium bundles 1.21):
@@ -365,7 +390,7 @@ let
       patchShebangs .
       # Link to our own Node.js and Java (required during the build):
       mkdir -p third_party/node/linux/node-linux-x64/bin
-      ln -s "${pkgsBuildHost.nodejs}/bin/node" third_party/node/linux/node-linux-x64/bin/node
+      ln -s${lib.optionalString (chromiumVersionAtLeast "127") "f"} "${pkgsBuildHost.nodejs}/bin/node" third_party/node/linux/node-linux-x64/bin/node
       ln -s "${pkgsBuildHost.jdk17_headless}/bin/java" third_party/jdk/current/bin/
 
       # Allow building against system libraries in official builds
@@ -462,6 +487,9 @@ let
       use_system_libffi = true;
       # Use nixpkgs Rust compiler instead of the one shipped by Chromium.
       rust_sysroot_absolute = "${buildPackages.rustc}";
+    } // lib.optionalAttrs (chromiumVersionAtLeast "127") {
+      rust_bindgen_root = "${buildPackages.rust-bindgen}";
+    } // {
       enable_rust = true;
       # While we technically don't need the cache-invalidation rustc_version provides, rustc_version
       # is still used in some scripts (e.g. build/rust/std/find_std_rlibs.py).

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -54,8 +54,12 @@ let
         src = fetchgit {
           inherit (upstream-info.deps.gn) url rev hash;
         };
+      } // lib.optionalAttrs (chromiumVersionAtLeast "127") {
+        # Relax hardening as otherwise gn unstable 2024-06-06 and later fail with:
+        # cc1plus: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]
+        hardeningDisable = [ "format" ];
       });
-      recompressTarball = callPackage ./recompress-tarball.nix { };
+      recompressTarball = callPackage ./recompress-tarball.nix { inherit chromiumVersionAtLeast; };
     });
 
     browser = callPackage ./browser.nix {

--- a/pkgs/applications/networking/browsers/chromium/recompress-tarball.nix
+++ b/pkgs/applications/networking/browsers/chromium/recompress-tarball.nix
@@ -1,10 +1,11 @@
 { zstd
 , fetchurl
+, lib
+, chromiumVersionAtLeast
 }:
 
 { version
 , hash ? ""
-, ...
 } @ args:
 
 fetchurl ({
@@ -35,6 +36,13 @@ fetchurl ({
       --exclude=third_party/llvm \
       --exclude=third_party/rust-src \
       --exclude='build/linux/debian_*-sysroot' \
+    '' + lib.optionalString (chromiumVersionAtLeast "127") ''
+      --exclude='*.tar.[a-zA-Z0-9][a-zA-Z0-9]' \
+      --exclude='*.tar.[a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9]' \
+      --exclude=third_party/llvm-build \
+      --exclude=third_party/rust-toolchain \
+      --exclude=third_party/instrumented_libs \
+    '' + ''
       --strip-components=1
 
     tar \

--- a/pkgs/applications/networking/browsers/chromium/update.py
+++ b/pkgs/applications/networking/browsers/chromium/update.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i python -p python3 nix nixfmt-classic nix-prefetch-git
+#! nix-shell -i python -p python3Packages.looseversion nix nixfmt-classic nix-prefetch-git
 
 """This script automatically updates chromium, google-chrome, chromedriver, and ungoogled-chromium
 via upstream-info.nix."""
@@ -15,7 +15,7 @@ import sys
 from codecs import iterdecode
 from collections import OrderedDict
 from datetime import datetime
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 from os.path import abspath, dirname
 from urllib.request import urlopen
 
@@ -214,7 +214,7 @@ with urlopen(RELEASES_URL) as resp:
         releases.append(get_latest_ungoogled_chromium_build(linux_stable_versions))
 
     for release in releases:
-        channel_name = re.findall("chrome\/platforms\/linux\/channels\/(.*)\/versions\/", release['name'])[0]
+        channel_name = re.findall("chrome/platforms/linux/channels/(.*)/versions/", release['name'])[0]
 
         # If we've already found a newer release for this channel, we're
         # no longer interested in it.

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -1,22 +1,22 @@
 {
   stable = {
     chromedriver = {
-      hash_darwin = "sha256-YdQgrcTgyGtSfT6wBedSfBt40DaK3fG+uvB0yanvROU=";
+      hash_darwin = "sha256-c/lMkOdoW/tX57opl/weJGh/iyUeTTF5Xejs7IpA+Qg=";
       hash_darwin_aarch64 =
-        "sha256-ht7LoA4ibEcWuXOk+JimCN0sjjPomHBcO8IZFNnMauk=";
-      hash_linux = "sha256-VeCNeBKsKZ2bEM6Z9lJJaBVRjS1pW2gK2DMvmghfNEA=";
-      version = "126.0.6478.182";
+        "sha256-sst73OxUsrs2yWA72qdonARGi/W0FYObNfolidCiXio=";
+      hash_linux = "sha256-p5cQmMdte7TfTPohg+rpIsyyYk1OKSNb0BwaMWmHuCo=";
+      version = "127.0.6533.72";
     };
     deps = {
       gn = {
-        hash = "sha256-mNoQeHSSM+rhR0UHrpbyzLJC9vFqfxK1SD0X8GiRsqw=";
-        rev = "df98b86690c83b81aedc909ded18857296406159";
+        hash = "sha256-vzZu/Mo4/xATSD9KgKcRuBKVg9CoRZC9i0PEajYr4UM=";
+        rev = "b3a0bff47dd81073bfe67a402971bad92e4f2423";
         url = "https://gn.googlesource.com/gn";
-        version = "2024-05-13";
+        version = "2024-06-06";
       };
     };
-    hash = "sha256-vZ7P8+vHTMCo6lXkV84ENqRZVG3/fDEwl+BTNJTGMn4=";
-    version = "126.0.6478.182";
+    hash = "sha256-m99HaGCuIihDdbVnmu6xatnC/QDxgLVby2TWY/L+RHk=";
+    version = "127.0.6533.72";
   };
   ungoogled-chromium = {
     deps = {


### PR DESCRIPTION
## Description of changes

This update includes 22 security fixes.

CVEs:
CVE-2024-6988 CVE-2024-6989 CVE-2024-6991 CVE-2024-6994 CVE-2024-6995
CVE-2024-6996 CVE-2024-6997 CVE-2024-6998 CVE-2024-6999 CVE-2024-7000
CVE-2024-7001 CVE-2024-7003 CVE-2024-7004 CVE-2024-7005

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
