### PR TITLE
python312Packages.pylibjpeg-libjpeg: enable tests

### DIFF
--- a/pkgs/development/python-modules/pylibjpeg-libjpeg/default.nix
+++ b/pkgs/development/python-modules/pylibjpeg-libjpeg/default.nix
@@ -8,47 +8,62 @@
   poetry-core,
   setuptools,
   numpy,
+  pydicom,
+  pylibjpeg-data,
+  pylibjpeg,
 }:
 
-buildPythonPackage rec {
-  pname = "pylibjpeg-libjpeg";
-  version = "2.3.0";
-  pyproject = true;
+let
+  self = buildPythonPackage {
+    pname = "pylibjpeg-libjpeg";
+    version = "2.3.0";
+    pyproject = true;
 
-  disabled = pythonOlder "3.9";
+    disabled = pythonOlder "3.9";
 
-  src = fetchFromGitHub {
-    owner = "pydicom";
-    repo = pname;
-    tag = "v${version}";
-    hash = "sha256-xqSA1cutTsH9k4l9CW96n/CURzkAyDi3PZylZeedVjA=";
-    fetchSubmodules = true;
+    src = fetchFromGitHub {
+      owner = "pydicom";
+      repo = "pylibjpeg-libjpeg";
+      tag = "v${self.version}";
+      hash = "sha256-xqSA1cutTsH9k4l9CW96n/CURzkAyDi3PZylZeedVjA=";
+      fetchSubmodules = true;
+    };
+
+    postPatch = ''
+      substituteInPlace pyproject.toml \
+        --replace-fail 'poetry-core >=1.8,<2' 'poetry-core'
+    '';
+
+    build-system = [
+      cython
+      poetry-core
+      setuptools
+    ];
+
+    dependencies = [ numpy ];
+
+    nativeCheckInputs = [
+      pydicom
+      pylibjpeg-data
+      pylibjpeg
+      pytestCheckHook
+    ];
+
+    doCheck = false; # circular test dependency with `pylibjpeg` and `pydicom`
+
+    passthru.tests.check = self.overridePythonAttrs (_: {
+      doCheck = true;
+    });
+
+    pythonImportsCheck = [ "libjpeg" ];
+
+    meta = {
+      description = "JPEG, JPEG-LS and JPEG XT plugin for pylibjpeg";
+      homepage = "https://github.com/pydicom/pylibjpeg-libjpeg";
+      changelog = "https://github.com/pydicom/pylibjpeg-libjpeg/releases/tag/v${self.version}";
+      license = lib.licenses.gpl3Only;
+      maintainers = with lib.maintainers; [ bcdarwin ];
+    };
   };
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail 'poetry-core >=1.8,<2' 'poetry-core'
-  '';
-
-  build-system = [
-    cython
-    poetry-core
-    setuptools
-  ];
-
-  dependencies = [ numpy ];
-
-  nativeCheckInputs = [ pytestCheckHook ];
-
-  doCheck = false; # tests try to import 'libjpeg.data', which errors
-
-  pythonImportsCheck = [ "libjpeg" ];
-
-  meta = with lib; {
-    description = "JPEG, JPEG-LS and JPEG XT plugin for pylibjpeg";
-    homepage = "https://github.com/pydicom/pylibjpeg-libjpeg";
-    changelog = "https://github.com/pydicom/pylibjpeg-libjpeg/releases/tag/v${version}";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ bcdarwin ];
-  };
-}
+in
+self


### PR DESCRIPTION
## Description of changes

~Routine update with~ Minor refactor and enabling tests.

~Note that the pydicom-related tests are skipped even though pydicom is present seemingly because the test for pydicom checks for the presence of as-yet-unreleased pydicom 3.x APIs. Still better than the current situation, though.~ [master has updated to pydicom 3.x]

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
