### PR TITLE
koboldcpp: Fix Package Build Failure with CUDA Enabled

### DIFF
--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -22,7 +22,7 @@
   cublasSupport ? config.cudaSupport,
   # You can find a full list here: https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
   # For example if you're on an GTX 1080 that means you're using "Pascal" and you need to pass "sm_60"
-  cudaArches ? cudaPackages.cudaFlags.arches or [ ],
+  cudaArches ? cudaPackages.cudaFlags.realArches or [ ],
 
   clblastSupport ? stdenv.isLinux,
   clblast,
@@ -129,7 +129,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     (makeBool "LLAMA_CLBLAST" clblastSupport)
     (makeBool "LLAMA_VULKAN" vulkanSupport)
     (makeBool "LLAMA_METAL" metalSupport)
-    (lib.optionals cublasSupport "CUDA_DOCKER_ARCH=sm_${builtins.head cudaArches}")
+    (lib.optionals cublasSupport "CUDA_DOCKER_ARCH=${builtins.head cudaArches}")
   ];
 
   installPhase = ''

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -40,7 +40,7 @@ let
   makeBool = option: bool: (if bool then "${option}=1" else "");
 
   libraryPathWrapperArgs = lib.optionalString config.cudaSupport ''
-    --prefix LD_LIBRARY_PATH: "${lib.makeLibraryPath [ addDriverRunpath.driverLink ]}"
+    --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ addDriverRunpath.driverLink ]}"
   '';
 
   darwinFrameworks =
@@ -158,7 +158,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     wrapPythonProgramsIn "$out/bin" "$pythonPath"
     makeWrapper "$out/bin/koboldcpp.unwrapped" "$out/bin/koboldcpp" \
-      --prefix PATH ${lib.makeBinPath [ tk ]} ${libraryPathWrapperArgs}
+      --prefix PATH : ${lib.makeBinPath [ tk ]} ${libraryPathWrapperArgs}
   '';
 
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };


### PR DESCRIPTION
## Description of changes

When attempting to build the latest `koboldcpp` with `cublasSupport` setting to `true`, I encountered the following error:

```
koboldcpp> nvcc fatal   : Value 'sm_sm_89' is not defined for option 'gpu-architecture'
koboldcpp> make: *** [Makefile:228: ggml-cuda.o] Error 1
koboldcpp> make: *** Waiting for unfinished jobs....
```

This PR fixes the following issue by
* Fix the value of `CUDA_DOCKER_ARCH`, and use `cudaFlags.realArches` instead of `cudaFlags.arches`.
* Correct the usage of `makeWrapper`.

### Issue 1: `CUDA_DOCKER_ARCH` Contains Duplicated `sm_` Prefix

The error appears to stem from the `CUDA_DOCKER_ARCH` variable being defined with a duplicated `sm_` prefix. This occurs in the [`makeFlags` definition](https://github.com/NixOS/nixpkgs/blob/79ba441d002128b9685ee9e11de0c6a6037f93d3/pkgs/by-name/ko/koboldcpp/package.nix#L132):

```nix
(lib.optionals cublasSupport "CUDA_DOCKER_ARCH=sm_${builtins.head cudaArches}")
```

The `cudaArches` argument, which defaults to `cudaPackages.cudaFlags.arches`, already includes the `sm_` prefix, as seen [here](https://github.com/NixOS/nixpkgs/blob/c19d62ad2265b16e2199c5feb4650fe459ca1c46/pkgs/development/cuda-modules/flags.nix#L180-L195):

```nix
# realArches :: List String
# The real architectures are physical architectures supported by the CUDA version.
# E.g. [ "sm_75" "sm_86" ]
realArches = archMapper "sm" cudaCapabilities;

# virtualArches :: List String
# The virtual architectures are typically used for forward compatibility, when trying to support
# an architecture newer than the CUDA version allows.
# E.g. [ "compute_75" "compute_86" ]
virtualArches = archMapper "compute" cudaCapabilities;

# arches :: List String
# By default, build for all supported architectures and forward compatibility via a virtual
# architecture for the newest supported architecture.
# E.g. [ "sm_75" "sm_86" "compute_86" ]
arches = realArches ++ lists.optional enableForwardCompat (lists.last virtualArches);
```

On my machine, `cudaFlags.arches` evaluates to:

```shell
$ nix eval github:NixOS/nixpkgs/master#cudaPackages.cudaFlags.arches
[ "sm_60" "sm_61" "sm_70" "sm_75" "sm_80" "sm_86" "sm_89" "sm_90" "sm_90a" "compute_90a" ]
```

As a result, `koboldcpp.makeFlags[-1]` evaluates to `CUDA_DOCKER_ARCH=sm_sm_60`:

```shell
$ nix eval 'github:NixOS/nixpkgs/master#koboldcpp' --apply 'x: (x.override { cublasSupport = true; }).makeFlags'
[ "LLAMA_OPENBLAS=1" "LLAMA_CUBLAS=1" "LLAMA_CLBLAST=1" "LLAMA_VULKAN=1" "" "CUDA_DOCKER_ARCH=sm_sm_60" ]
```

This causes the build to fail since the Makefile is effectively being passed `-arch=sm_sm_XX`:

```makefile
ifdef CUDA_DOCKER_ARCH
    NVCCFLAGS += -Wno-deprecated-gpu-targets -arch=$(CUDA_DOCKER_ARCH)
else
```

### Issue 2: Incorrect Usage of `makeWrapper`

There is also an issue with the usage of `makeWrapper` in the `postFixup` phase:

```shell
$ nix eval --raw nixpkgs#koboldcpp.postFixup  
wrapPythonProgramsIn "$out/bin" "$pythonPath"  
makeWrapper "$out/bin/koboldcpp.unwrapped" "$out/bin/koboldcpp" \  
  --prefix PATH /nix/store/a79hjvwbgnn5xrf571hslxgw987ivj4d-tk-8.6.13/bin --prefix LD_LIBRARY_PATH : "/run/opengl-driver/lib"
```

According to the [comments and definition](https://github.com/NixOS/nixpkgs/blob/989d72f3b56fa33bf0afc99df18370a757eb6c0a/pkgs/build-support/setup-hooks/make-wrapper.sh#L30) in `make-wrapper.sh`, the `--prefix` option requires three arguments:

```
--prefix ENV SEP VAL   : suffix/prefix ENV with VAL, separated by SEP
```

### Note on Further Improvements

It seems that each `-arch` option only supports a single value like `sm_XX`. When using `CUDA_DOCKER_ARCH`, supporting multiple architectures simultaneously becomes challenging.

I am unsure if it would be better to patch the original Makefile to use `cudaPackages.cudaFlags.gencode` instead.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
