### PR TITLE
corefreq: init at 1.98.4

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -171,6 +171,7 @@
   ./programs/cpu-energy-meter.nix
   ./programs/command-not-found/command-not-found.nix
   ./programs/coolercontrol.nix
+  ./programs/corefreq.nix
   ./programs/criu.nix
   ./programs/darling.nix
   ./programs/dconf.nix

--- a/nixos/modules/programs/corefreq.nix
+++ b/nixos/modules/programs/corefreq.nix
@@ -1,0 +1,42 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.corefreq;
+  kernelPackages = config.boot.kernelPackages;
+in
+{
+  options = {
+    programs.corefreq = {
+      enable = lib.mkEnableOption "Whether to enable the corefreq daemon and kernel module";
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = kernelPackages.corefreq;
+        defaultText = lib.literalExpression "config.boot.kernelPackages.corefreq";
+        description = ''
+          The corefreq package to use.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    boot.extraModulePackages = [ cfg.package ];
+    boot.kernelModules = [ "corefreqk" ];
+
+    # Create a systemd service for the corefreq daemon
+    systemd.services.corefreq = {
+      description = "CoreFreq daemon";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = lib.getExe' cfg.package "corefreqd";
+      };
+    };
+  };
+}

--- a/pkgs/os-specific/linux/corefreq/default.nix
+++ b/pkgs/os-specific/linux/corefreq/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  kernel,
+  hostPlatform,
+  # See the official readme for a list of optional flags:
+  # https://github.com/cyring/CoreFreq/blob/master/README.md
+  extraFlags ? [ ],
+}:
+
+stdenv.mkDerivation rec {
+  pname = "corefreq";
+  version = "1.98.4";
+
+  src = fetchFromGitHub {
+    owner = "cyring";
+    repo = "CoreFreq";
+    rev = version;
+    hash = "sha256-ljo8EDoJmcdfVvC8s+Xbf5TsYruvSOU1OSYBPwQst1c=";
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  env.NIX_CFLAGS_COMPILE = "-I${src}/${hostPlatform.qemuArch}";
+  makeFlags = [
+    "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "INSTALL_MOD_PATH=$(out)"
+  ] ++ extraFlags;
+
+  preInstall = ''
+    mkdir -p $out/bin
+  '';
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = {
+    description = "CPU monitoring and tuning software designed for 64-bit processors";
+    homepage = "https://github.com/cyring/CoreFreq";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ mrene ];
+    mainProgram = "corefreq-cli";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -531,6 +531,8 @@ in {
 
     turbostat = callPackage ../os-specific/linux/turbostat { };
 
+    corefreq = callPackage ../os-specific/linux/corefreq { };
+
     trelay = callPackage ../os-specific/linux/trelay { };
 
     universal-pidff = callPackage ../os-specific/linux/universal-pidff { };


### PR DESCRIPTION
## Description of changes
[CoreFreq](https://github.com/cyring/CoreFreq), a CPU monitoring software with BIOS like functionalities, is designed for the 64-bits Processors of architecture Intel Atom, Core2, Nehalem, SandyBridge and superiors; AMD Families from 0Fh ... up to 17h (Zen , Zen+ , Zen 2), 18h (Hygon Dhyana), 19h (Zen 3, Zen 3+, Zen 4, Zen 4c); Arm A64


## Things done
Added `program.corefreq` which sets up the mandatory daemon and loads the kernel module. Once enabled, `corefreq-cli` can be used to observe and manipulate cpu power settings (amongst other things).

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
