### PR TITLE
Bump zola to 0.19.1 — requires Rust 1.79

### DIFF
--- a/pkgs/by-name/zo/zola/package.nix
+++ b/pkgs/by-name/zo/zola/package.nix
@@ -12,16 +12,15 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "zola";
-  version = "0.18.0";
+  version = "0.19.1";
 
-  src = fetchFromGitHub {
-    owner = "getzola";
-    repo = "zola";
-    rev = "v${version}";
-    hash = "sha256-kNlFmCqWEfU2ktAMxXNKe6dmAV25voHjHYaovBYsOu8=";
+  src = builtins.fetchGit {
+    url = "https://github.com/getzola/zola";
+    ref = "refs/tags/v${version}";
+    rev = "041da029eedbca30c195bc9cd8c1acf89b4f60c0";
   };
 
-  cargoHash = "sha256-JWYuolHh/qdWF+i6WTgz/uDrkQ6V+SDFhEzGGkUA0E4=";
+  cargoHash = "sha256-Q2Zx00Gf89TJcsOFqkq0b4e96clv/CLQE51gGONZZl0=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
## Description of changes

- Updates `zola` to version 0.19.1
- Unable to build _yet_ since Rust 1.79 is required by multiple dependencies 
  - Builds and runs correctly via `rust-overlay` generated Rust 1.79 toolchain 

```
       > ++ env CC_AARCH64_APPLE_DARWIN=/nix/store/k8mrxviw965lv59hqbln3297jwfffm2w-clang-wrapper-16.0.6/bin/cc CXX_AARCH64_APPLE_DARWIN=/nix/store/k8mrxviw965lv59hqbln3297jwfffm2w-clang-wrapper-16.0.6/bin/c++ CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER=/nix/store/k8mrxviw965lv59hqbln3297jwfffm2w-clang-wrapper-16.0.6/bin/cc CC_AARCH64_APPLE_DARWIN=/nix/store/k8mrxviw965lv59hqbln3297jwfffm2w-clang-wrapper-16.0.6/bin/cc CXX_AARCH64_APPLE_DARWIN=/nix/store/k8mrxviw965lv59hqbln3297jwfffm2w-clang-wrapper-16.0.6/bin/c++ CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER=/nix/store/k8mrxviw965lv59hqbln3297jwfffm2w-clang-wrapper-16.0.6/bin/cc CARGO_BUILD_TARGET=aarch64-apple-darwin HOST_CC=/nix/store/k8mrxviw965lv59hqbln3297jwfffm2w-clang-wrapper-16.0.6/bin/cc HOST_CXX=/nix/store/k8mrxviw965lv59hqbln3297jwfffm2w-clang-wrapper-16.0.6/bin/c++ cargo build -j 8 --target aarch64-apple-darwin --offline --profile release
       > warning: `/private/tmp/nix-build-zola-0.19.1.drv-0/.cargo/config` is deprecated in favor of `config.toml`
       > note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
       > warning: `/private/tmp/nix-build-zola-0.19.1.drv-0/.cargo/config` is deprecated in favor of `config.toml`
       > note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
       > error: rustc 1.78.0 is not supported by the following packages:
       >   bitstream-io@2.4.1 requires rustc 1.79
       >   ravif@0.11.7 requires rustc 1.79
       > Either upgrade rustc or select compatible dependency versions with
       > `cargo update <name>@<current-ver> --precise <compatible-ver>`
       > where `<compatible-ver>` is the latest version supporting rustc 1.78.0
       >
       For full logs, run 'nix log /nix/store/fl860ma87ym7i9zqinc550hqf3yzqarm-zola-0.19.1.drv'.
```

## Things done

- Updated `pkgs/by-name/zo/zola/package.nix`

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
