### PR TITLE
Count hard links separately when sizing virtual disks

### DIFF
--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -470,7 +470,7 @@ let format' = format; in let
       additionalSpace=$(( $(numfmt --from=iec '${additionalSpace}') + reservedSpace ))
 
       # Compute required space in filesystem blocks
-      diskUsage=$(find . ! -type d -print0 | du --files0-from=- --apparent-size --block-size "${blockSize}" | cut -f1 | sum_lines)
+      diskUsage=$(find . ! -type d -print0 | du --files0-from=- --apparent-size --count-links --block-size "${blockSize}" | cut -f1 | sum_lines)
       # Each inode takes space!
       numInodes=$(find . | wc -l)
       # Convert to bytes, inodes take two blocks each!


### PR DESCRIPTION
## Description of changes

When creating virtual disk images with `make-disk-image.nix`, there's an option to automatically size the disk image based on the closure to be copied into it. At a high-level, this works by sizing the closure with `du` and then applying some additional factors to account for inodes, etc. The contents are then copied in to the disk image using `cptofs`.  As configured today, `du` and `cptofs` treat hard links differently. `du` deduplicates the size from hard links, but `cptofs` does not preserve hardlinks, so each hardlinked file consumes separate storage in the final disk. This then can lead to a problem where the disk image is undersized and the copy fails.

One way to hit this problem is to have `auto-optimise-store = true` configured on the build machine. In this configuration, `/nix/store/.links` will contain hardlinks to deduplicate files in the nix store, however if this option is set to false, then the _same_ derivation will fail. Perhaps this is a sandbox problem (given that `nix` invocations in derivations can depend on the build machine's nix configuration), but the fix proposed here is to ensure that `du` counts hardlinks separately so that the behaviour of `du` and `cptofs` match in this regard.

## Things done

Modify the `du` invocation in `make-disk-image.nix` to count hardlinked files separately. I have validated that NixOS tests that were failing for me with `auto-optimise-store=true` but succeeding with `auto-optimise-store=false` now pass regardless of this configuration.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

