### PR TITLE
kcl,kclvm,kclvm_cli: remove darwin.cctools

### DIFF
--- a/pkgs/by-name/kc/kcl/package.nix
+++ b/pkgs/by-name/kc/kcl/package.nix
@@ -30,9 +30,7 @@ buildGoModule rec {
     "-X=kcl-lang.io/cli/pkg/version.version=v${version}"
   ];
 
-  nativeBuildInputs = [ makeWrapper installShellFiles ] ++ (
-    lib.optionals stdenv.isDarwin [ darwin.cctools ]
-  );
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
 
   buildInputs = [ kclvm kclvm_cli ] ++ (
     lib.optional stdenv.isDarwin [

--- a/pkgs/by-name/kc/kclvm/package.nix
+++ b/pkgs/by-name/kc/kclvm/package.nix
@@ -29,7 +29,6 @@ rustPlatform.buildRustPackage rec {
   };
 
   buildInputs = [ rustc ] ++ lib.optionals stdenv.isDarwin [
-    darwin.cctools
     darwin.apple_sdk.frameworks.Security
     darwin.apple_sdk.frameworks.CoreServices
     darwin.apple_sdk.frameworks.SystemConfiguration

--- a/pkgs/by-name/kc/kclvm_cli/package.nix
+++ b/pkgs/by-name/kc/kclvm_cli/package.nix
@@ -24,7 +24,6 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ kclvm rustc ] ++ (
     lib.optionals stdenv.isDarwin [
-      darwin.cctools
       darwin.apple_sdk.frameworks.Security
       darwin.apple_sdk.frameworks.CoreServices
       darwin.apple_sdk.frameworks.SystemConfiguration


### PR DESCRIPTION
## Description of changes

darwin.cctools is now just cctools so referencing it in staging and staging-next creates eval errors. However, given that cctools is already part of the darwin stdenv it is not necessary to include the package directly.

Eval failure on staging:
https://gist.github.com/GrahamcOfBorg/cc66a857ef768344f881acbbaacc32bf

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
