### PR TITLE
yx: support cross-compiling

### DIFF
--- a/pkgs/tools/text/yx/0001-Don-t-strip-binary-when-installing.patch
+++ b/pkgs/tools/text/yx/0001-Don-t-strip-binary-when-installing.patch
@@ -1,0 +1,26 @@
+From b90b2c5989e9ddd3cfc79f56cb8a9194561bd4d7 Mon Sep 17 00:00:00 2001
+From: Tom Wieczorek <tom@bibbu.net>
+Date: Fri, 26 Jul 2024 11:08:45 +0200
+Subject: [PATCH] Don't strip binary when installing
+
+Doesn't play well with cross-compiling.
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 724c962..284cab3 100644
+--- a/Makefile
++++ b/Makefile
+@@ -12,7 +12,7 @@ test: yx
+ 	(cd tests && ./do_tests.sh)
+ 
+ install: yx
+-	install -sDm0755 -t "$(PREFIX)"/bin yx
++	install -Dm0755 -t "$(PREFIX)"/bin yx
+ 	install -Dm0644 -t "$(PREFIX)"/share/man/man1 yx.1
+ 
+ clean:
+-- 
+2.42.2
+

--- a/pkgs/tools/text/yx/default.nix
+++ b/pkgs/tools/text/yx/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitLab
+, fetchpatch
 , libyaml
 , testers
 , yx
@@ -15,6 +16,16 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-uuso+hsmdsB7VpIRKob8rfMaWvRMCBHvCFnYrHPC6iw=";
   };
+
+  patches = [
+    # https://gitlab.com/tomalok/yx/-/issues/2
+    ./0001-Don-t-strip-binary-when-installing.patch
+    (fetchpatch {
+      # https://gitlab.com/tomalok/yx/-/merge_requests/10
+      url = "https://gitlab.com/tomalok/yx/-/commit/5747ca40f4b0acb56d67fd29a818734d7b19d61a.patch";
+      hash = "sha256-0tNtkq1tZ96Ag5EJfUfDao/QxpRB4Jadop3OPBvhnlo=";
+    })
+  ];
 
   makeFlags = [
     "PREFIX=${placeholder "out"}"


### PR DESCRIPTION
## Description of changes

The upstream Makefile needed some tweaks to make it work.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


```console
$ nix-build -A yx
/nix/store/a2rsgs5g9wmadm4fpc4fchfrx0mi075d-yx-1.0.2

$ find /nix/store/a2rsgs5g9wmadm4fpc4fchfrx0mi075d-yx-1.0.2 -type f
/nix/store/a2rsgs5g9wmadm4fpc4fchfrx0mi075d-yx-1.0.2/bin/yx
/nix/store/a2rsgs5g9wmadm4fpc4fchfrx0mi075d-yx-1.0.2/share/man/man1/yx.1.gz

$ nix-build --attr pkgs.yx.passthru.tests
/nix/store/r8b3ml7fn4ixq8hdydlc8xppj6k8axfk-yx-1.0.2-test-version

$ nix-build --arg crossSystem '{ config = "aarch64-unknown-linux-gnu"; }' -A yx
/nix/store/p077j48pvg73xq2f64r57sx8kzibk51x-yx-aarch64-unknown-linux-gnu-1.0.2

$ find /nix/store/p077j48pvg73xq2f64r57sx8kzibk51x-yx-aarch64-unknown-linux-gnu-1.0.2 -type f
/nix/store/p077j48pvg73xq2f64r57sx8kzibk51x-yx-aarch64-unknown-linux-gnu-1.0.2/bin/yx
/nix/store/p077j48pvg73xq2f64r57sx8kzibk51x-yx-aarch64-unknown-linux-gnu-1.0.2/share/man/man1/yx.1.gz

$ file /nix/store/p077j48pvg73xq2f64r57sx8kzibk51x-yx-aarch64-unknown-linux-gnu-1.0.2/bin/yx
/nix/store/p077j48pvg73xq2f64r57sx8kzibk51x-yx-aarch64-unknown-linux-gnu-1.0.2/bin/yx: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /nix/store/585wgmdaa952yyla33kffm733a8xbh32-glibc-aarch64-unknown-linux-gnu-2.39-52/lib/ld-linux-aarch64.so.1, for GNU/Linux 3.10.0, not stripped

$ nix-build --arg crossSystem '{ config = "aarch64-unknown-linux-gnu"; }' --attr pkgs.yx.passthru.tests
/nix/store/i3sm9b4cvk5phr82lv7r95zqad1ajh3n-yx-aarch64-unknown-linux-gnu-1.0.2-test-version
```

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
