### PR TITLE
[staging-next] Assorted fixes I found rebuilding my config against -next

### DIFF
--- a/pkgs/by-name/ka/kanidm/package.nix
+++ b/pkgs/by-name/ka/kanidm/package.nix
@@ -71,6 +71,9 @@ rustPlatform.buildRustPackage rec {
     cp -r server/web_ui/pkg $out/ui
   '';
 
+  # Otherwise build breaks on some unused code
+  env.RUSTFLAGS = "-A dead_code";
+
   # Not sure what pathological case it hits when compiling tests with LTO,
   # but disabling it takes the total `cargo check` time from 40 minutes to
   # around 5 on a 16-core machine.

--- a/pkgs/development/libraries/appstream/qt.nix
+++ b/pkgs/development/libraries/appstream/qt.nix
@@ -24,9 +24,13 @@ stdenv.mkDerivation {
 
   dontWrapQtApps = true;
 
+  # AppStreamQt tries to be relocatable, in hacky cmake ways that generally fail
+  # horribly on NixOS. Just hardcode the paths.
   postFixup = ''
     sed -i "$dev/lib/cmake/AppStreamQt${qtSuffix}/AppStreamQt${qtSuffix}Config.cmake" \
       -e "/INTERFACE_INCLUDE_DIRECTORIES/ s@\''${PACKAGE_PREFIX_DIR}@$dev@"
+    sed -i "$dev/lib/cmake/AppStreamQt${qtSuffix}/AppStreamQt${qtSuffix}Config.cmake" \
+      -e "/IMPORTED_LOCATION/ s@\''${PACKAGE_PREFIX_DIR}@$out@"
   '';
 
   passthru = appstream.passthru // {

--- a/pkgs/kde/frameworks/kimageformats/default.nix
+++ b/pkgs/kde/frameworks/kimageformats/default.nix
@@ -4,6 +4,9 @@
   libheif,
   libjxl,
   libavif,
+  dav1d,
+  libaom,
+  libyuv,
   libraw,
   openexr_3,
 }:
@@ -12,5 +15,5 @@ mkKdeDerivation {
 
   extraCmakeFlags = ["-DKIMAGEFORMATS_HEIF=1"];
   extraNativeBuildInputs = [pkg-config];
-  extraBuildInputs = [libheif libjxl libavif libraw openexr_3];
+  extraBuildInputs = [libheif libjxl libavif dav1d libaom libyuv libraw openexr_3];
 }

--- a/pkgs/servers/bazarr/default.nix
+++ b/pkgs/servers/bazarr/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, lib, fetchurl, makeWrapper, unzip, python3, unar, ffmpeg, nixosTests }:
+{ stdenv, lib, fetchurl, makeWrapper, unzip, python3, libarchive, ffmpeg, nixosTests }:
 
 let
   runtimeProgDeps = [
     ffmpeg
-    unar
+    libarchive
   ];
 in
 stdenv.mkDerivation rec {


### PR DESCRIPTION
## Description of changes

The kimageformats thing is a horrible hack, will revert and submit proper change to staging.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
