### PR TITLE
vscode-extensions.ms-vscode-cpptools: 1.20.5 -> 1.21.4

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/ms-vscode.cpptools/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-vscode.cpptools/default.nix
@@ -43,11 +43,11 @@ let
   isx86Linux = stdenv.hostPlatform.system == "x86_64-linux";
   supported = {
     x86_64-linux = {
-      hash = "sha256-arTBt3UWA5zoo0dL044Sx/NT1LUS76XfGIS96NOMvJk=";
+      hash = "sha256-jibImnpRtshbHu21JeS4VxL1jETm3Ein8S/M73UXc2w=";
       arch = "linux-x64";
     };
     aarch64-linux = {
-      hash = "sha256-oVuDxx117bVd/jDqn9KivTwR5T2X5UZMHk/nZ/e/IOg=";
+      hash = "sha256-7UagRO7qHyT1JIvvTSx9+USYrnDRXJ2wnXPLaBHRc3k=";
       arch = "linux-arm64";
     };
   };
@@ -60,7 +60,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = base // {
     name = "cpptools";
     publisher = "ms-vscode";
-    version = "1.20.5";
+    version = "1.21.4";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/editors/vscode/extensions/ms-vscode.cpptools/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-vscode.cpptools/default.nix
@@ -40,6 +40,7 @@
 
 let
   gdbDefaultsTo = if gdbUseFixed then "${gdb}/bin/gdb" else "gdb";
+  isx86Linux = stdenv.hostPlatform.system == "x86_64-linux";
   supported = {
     x86_64-linux = {
       hash = "sha256-arTBt3UWA5zoo0dL044Sx/NT1LUS76XfGIS96NOMvJk=";
@@ -51,7 +52,9 @@ let
     };
   };
 
-  base = supported.${stdenv.system} or (throw "unsupported platform ${stdenv.system}");
+  base =
+    supported.${stdenv.hostPlatform.system}
+      or (throw "unsupported platform ${stdenv.hostPlatform.system}");
 in
 vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = base // {
@@ -73,35 +76,40 @@ vscode-utils.buildVscodeMarketplaceExtension {
     stdenv.cc.cc.lib
   ];
 
-  dontAutoPatchelf = true;
+  dontAutoPatchelf = isx86Linux;
 
-  postPatch = ''
-    mv ./package.json ./package_orig.json
-
-    # 1. Add activation events so that the extension is functional. This listing is empty when unpacking the extension but is filled at runtime.
-    # 2. Patch `package.json` so that nix's *gdb* is used as default value for `miDebuggerPath`.
-    cat ./package_orig.json | \
-      jq --slurpfile actEvts ${./package-activation-events.json} '(.activationEvents) = $actEvts[0]' | \
-      jq '(.contributes.debuggers[].configurationAttributes | .attach , .launch | .properties.miDebuggerPath | select(. != null) | select(.default == "/usr/bin/gdb") | .default) = "${gdbDefaultsTo}"' > \
-      ./package.json
-
-    # Prevent download/install of extensions
-    touch "./install.lock"
-
-    # Clang-format from nix package.
-    rm -rf ./LLVM
-    mkdir "./LLVM/"
-    find "${clang-tools}" -mindepth 1 -maxdepth 1 | xargs ln -s -t "./LLVM"
-
-    # Patching binaries
-    chmod +x bin/cpptools bin/cpptools-srv bin/cpptools-wordexp bin/libc.so debugAdapters/bin/OpenDebugAD7
-    patchelf --replace-needed liblttng-ust.so.0 liblttng-ust.so.1 ./debugAdapters/bin/libcoreclrtraceptprovider.so
-  '';
-
-  postFixup =
+  postPatch =
     ''
-      autoPatchelf $out/share/vscode/extensions/ms-vscode.cpptools/debugAdapters
+      mv ./package.json ./package_orig.json
 
+      # 1. Add activation events so that the extension is functional. This listing is empty when unpacking the extension but is filled at runtime.
+      # 2. Patch `package.json` so that nix's *gdb* is used as default value for `miDebuggerPath`.
+      cat ./package_orig.json | \
+        jq --slurpfile actEvts ${./package-activation-events.json} '(.activationEvents) = $actEvts[0]' | \
+        jq '(.contributes.debuggers[].configurationAttributes | .attach , .launch | .properties.miDebuggerPath | select(. != null) | select(.default == "/usr/bin/gdb") | .default) = "${gdbDefaultsTo}"' > \
+        ./package.json
+
+      # Prevent download/install of extensions
+      touch "./install.lock"
+
+      # Clang-format from nix package.
+      rm -rf ./LLVM
+      mkdir "./LLVM/"
+      find "${clang-tools}" -mindepth 1 -maxdepth 1 | xargs ln -s -t "./LLVM"
+
+      # Patching binaries
+      chmod +x bin/cpptools bin/cpptools-srv bin/cpptools-wordexp debugAdapters/bin/OpenDebugAD7
+      patchelf --replace-needed liblttng-ust.so.0 liblttng-ust.so.1 ./debugAdapters/bin/libcoreclrtraceptprovider.so
+    ''
+    + lib.optionalString isx86Linux ''
+      chmod +x bin/libc.so
+    '';
+
+  # On aarch64 the binaries are statically linked
+  # but on x86 they are not.
+  postFixup =
+    lib.optionalString isx86Linux ''
+      autoPatchelf $out/share/vscode/extensions/ms-vscode.cpptools/debugAdapters
       # cpptools* are distributed by the extension and need to be run through the distributed musl interpretter
       patchelf --set-interpreter $out/share/vscode/extensions/ms-vscode.cpptools/bin/libc.so $out/share/vscode/extensions/ms-vscode.cpptools/bin/cpptools
       patchelf --set-interpreter $out/share/vscode/extensions/ms-vscode.cpptools/bin/libc.so $out/share/vscode/extensions/ms-vscode.cpptools/bin/cpptools-srv


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
