### PR TITLE
Revert "faiss: 1.7.4 -> 1.8.0"

### DIFF
--- a/pkgs/development/libraries/science/math/faiss/default.nix
+++ b/pkgs/development/libraries/science/math/faiss/default.nix
@@ -26,7 +26,7 @@
 
 let
   pname = "faiss";
-  version = "1.8.0";
+  version = "1.7.4";
 
   inherit (cudaPackages) flags backendStdenv;
 
@@ -51,7 +51,7 @@ stdenv.mkDerivation {
     owner = "facebookresearch";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-nS8nhkNGGb2oAJKfr/MIAZjAwMxBGbNd16/CkEtv67I=";
+    hash = "sha256-WSce9X6sLZmGM5F0ZkK54VqpIy8u1VB0e9/l78co29M=";
   };
 
   patches = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#313192

As indicated by nixpkgs-review, ofBorg and the prior discussion, `faissCuda` still does not build.