### PR TITLE
freesasa: init at 2.1.2; python312Packages.freesasa: init at 2.2.1

### DIFF
--- a/pkgs/by-name/fr/freesasa/package.nix
+++ b/pkgs/by-name/fr/freesasa/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  autoreconfHook,
+  libtool,
+  pkg-config,
+  libxml2,
+  json_c,
+  testers,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "freesasa";
+  version = "2.1.2";
+
+  src = fetchFromGitHub {
+    owner = "mittinatten";
+    repo = "freesasa";
+    rev = "refs/tags/${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-OH1/GGFtMBnHuoOu3pdR+ohVO1m0I/jmCZbxPQ0C0jo=";
+  };
+
+  patches = [
+    (fetchpatch {
+      # https://github.com/mittinatten/freesasa/issues/85
+      name = "fix-linker-error.patch";
+      url = "https://github.com/mittinatten/freesasa/commit/d5898c13af0f272697726c567a22f1c48af53d62.patch";
+      includes = [ "src/Makefile.am" ];
+      hash = "sha256-NA4jMue9ATxP+A0tYIptwz0qCXTmAqoMRBsi5d5uv3E=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    libtool
+    pkg-config
+  ];
+
+  buildInputs = [
+    json_c
+    libxml2
+  ];
+
+  passthru.tests = {
+    version = testers.testVersion { package = finalAttrs.finalPackage; };
+  };
+
+  meta = {
+    description = "C-library for calculating Solvent Accessible Surface Areas";
+    homepage = "https://github.com/mittinatten/freesasa";
+    changelog = "https://github.com/mittinatten/freesasa/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ natsukium ];
+    mainProgram = "freesasa";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/development/python-modules/freesasa/default.nix
+++ b/pkgs/development/python-modules/freesasa/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  cython,
+  freesasa,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "freesasa";
+  version = "2.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "freesasa";
+    repo = "freesasa-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-/7ymItwXOemY0+IL0k6rWnJI8fAwTFjNXzTV+uf9x9A=";
+  };
+
+  postPatch = ''
+    ln -s ${freesasa.src}/* lib/
+  '';
+
+  build-system = [
+    cython
+    setuptools
+  ];
+
+  env.USE_CYTHON = true;
+
+  pythonImportsCheck = [ "freesasa" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pytestFlagsArray = [ "test.py" ];
+
+  meta = {
+    description = "FreeSASA Python Module";
+    homepage = "https://github.com/freesasa/freesasa-python";
+    changelog = "https://github.com/freesasa/freesasa-python/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ natsukium ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4590,6 +4590,10 @@ self: super: with self; {
 
   freertos-gdb = callPackage ../development/python-modules/freertos-gdb { };
 
+  freesasa = callPackage ../development/python-modules/freesasa {
+    inherit (pkgs) freesasa;
+  };
+
   freetype-py = callPackage ../development/python-modules/freetype-py { };
 
   freezegun = callPackage ../development/python-modules/freezegun { };


### PR DESCRIPTION
## Description of changes

FreeSASA is a C library and C++ command line tool for calculating Solvent Accessible Surface Area (SASA) of biomolecules. It is designed to be simple to use with defaults, but allows customization of all parameters of the calculation and provides a few different tools to analyze the results. Python bindings are provided separately (see below).

https://github.com/mittinatten/freesasa

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
