### PR TITLE
patch-shebangs: don't patch shebangs with bash builtins

### DIFF
--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -90,8 +90,8 @@ patchShebangs() {
             if [[ $arg0 == "-S" ]]; then
                 arg0=${args%% *}
                 args=${args#* }
-                newPath="$(PATH="${!pathName}" command -v "env" || true)"
-                args="-S $(PATH="${!pathName}" command -v "$arg0" || true) $args"
+                newPath="$(PATH="${!pathName}" type -P "env" || true)"
+                args="-S $(PATH="${!pathName}" type -P "$arg0" || true) $args"
 
             # Check for unsupported 'env' functionality:
             # - options: something starting with a '-' besides '-S'
@@ -100,7 +100,7 @@ patchShebangs() {
                 echo "$f: unsupported interpreter directive \"$oldInterpreterLine\" (set dontPatchShebangs=1 and handle shebang patching yourself)" >&2
                 exit 1
             else
-                newPath="$(PATH="${!pathName}" command -v "$arg0" || true)"
+                newPath="$(PATH="${!pathName}" type -P "$arg0" || true)"
             fi
         else
             if [[ -z $oldPath ]]; then
@@ -109,7 +109,7 @@ patchShebangs() {
                 oldPath="/bin/sh"
             fi
 
-            newPath="$(PATH="${!pathName}" command -v "$(basename "$oldPath")" || true)"
+            newPath="$(PATH="${!pathName}" type -P "$(basename "$oldPath")" || true)"
 
             args="$arg0 $args"
         fi

--- a/pkgs/test/stdenv/patch-shebangs.nix
+++ b/pkgs/test/stdenv/patch-shebangs.nix
@@ -87,6 +87,20 @@ let
       };
     };
 
+    dont-patch-builtins = stdenv.mkDerivation {
+      name = "dont-patch-builtins";
+      strictDeps = false;
+      dontUnpack = true;
+      installPhase = ''
+        mkdir -p $out/bin
+        echo "#!/usr/bin/builtin" > $out/bin/test
+        chmod +x $out/bin/test
+        dontPatchShebangs=
+      '';
+      passthru = {
+        assertion = "grep '^#!/usr/bin/builtin' $out/bin/test > /dev/null";
+      };
+    };
   };
 in
 stdenv.mkDerivation {


### PR DESCRIPTION
## Description of changes

`command -v builtin` returns `builtin`, which doesn't suit us since we're looking for program in the given `PATH`. This could give us shebangs like this:

```bash
#!builtin
```

which is surprising.

Switch to `type -P command` which always returns a path, even if command is both a builtin and an executable (for example `test`), or fail is `command` is just a builtin.

Tests done: built up to the Linux stdenv and a bit more.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc @emilylange & @Artturin as the last people that touched `patch-shebangs`.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
