### PR TITLE
nvidia-container-toolkit: do not shadow docker executable

### DIFF
--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -256,7 +256,7 @@ in
         live-restore = mkDefault cfg.liveRestore;
         runtimes = mkIf cfg.enableNvidia {
           nvidia = {
-            path = "${pkgs.nvidia-docker}/bin/nvidia-container-runtime";
+            path = "${pkgs.nvidia-docker}/bin/nvidia-container-runtime.legacy";
           };
         };
       };

--- a/pkgs/by-name/nv/nvidia-container-toolkit/package.nix
+++ b/pkgs/by-name/nv/nvidia-container-toolkit/package.nix
@@ -59,6 +59,7 @@ buildGoModule rec {
   subPackages = [
     "cmd/nvidia-ctk"
     "cmd/nvidia-container-runtime"
+    "cmd/nvidia-container-runtime.legacy"
     "cmd/nvidia-container-runtime-hook"
   ];
 
@@ -127,10 +128,10 @@ buildGoModule rec {
     # podman, i.e., there's no need to have mutually exclusivity on what high
     # level runtime can enable the nvidia runtime because each high level
     # runtime has its own config.toml file.
-    wrapProgram $out/bin/nvidia-container-runtime \
-      --run "${warnIfXdgConfigHomeIsSet}" \
-      --prefix PATH : ${isolatedContainerRuntimePath}:${libnvidia-container}/bin \
-      --set-default XDG_CONFIG_HOME $out/etc
+    # wrapProgram $out/bin/nvidia-container-runtime.legacy \
+    #   --run "${warnIfXdgConfigHomeIsSet}" \
+    #   --prefix PATH : ${isolatedContainerRuntimePath}:${libnvidia-container}/bin \
+    #   --set-default XDG_CONFIG_HOME $out/etc
 
     cp ${configToml} $out/etc/nvidia-container-runtime/config.toml
 
@@ -140,7 +141,7 @@ buildGoModule rec {
     # See: https://gitlab.com/nvidia/container-toolkit/container-toolkit/-/blob/03cbf9c6cd26c75afef8a2dd68e0306aace80401/packaging/debian/nvidia-container-toolkit.postinst#L12
     ln -s $out/bin/nvidia-container-runtime-hook $out/bin/nvidia-container-toolkit
 
-    wrapProgram $out/bin/nvidia-container-toolkit \
+    wrapProgram $out/bin/nvidia-ctk \
       --add-flags "-config ${placeholder "out"}/etc/nvidia-container-runtime/config.toml"
   '';
 

--- a/pkgs/by-name/nv/nvidia-container-toolkit/package.nix
+++ b/pkgs/by-name/nv/nvidia-container-toolkit/package.nix
@@ -56,6 +56,12 @@ buildGoModule rec {
     ./0001-Add-dlopen-discoverer.patch
   ];
 
+  subPackages = [
+    "cmd/nvidia-ctk"
+    "cmd/nvidia-container-runtime"
+    "cmd/nvidia-container-runtime-hook"
+  ];
+
   postPatch = ''
     # Replace the default hookDefaultFilePath to the $out path and override
     # default ldconfig locations to the one in nixpkgs.


### PR DESCRIPTION
## Description of changes

At this time, the nvidia-container-toolkit derivation installs a docker executable that shadows the main one, and that is not thought to forward commands to the original docker command, causing issues to users when the `nvidia-container-toolkit` is in scope and they try to call to `docker`.

Fixes: https://github.com/NixOS/nixpkgs/issues/293857

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
