### PR TITLE
tremor: fix version script with lld 17+

### DIFF
--- a/pkgs/development/libraries/tremor/default.nix
+++ b/pkgs/development/libraries/tremor/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation {
 
   outputs = [ "out" "dev" ];
 
+  configureFlags = lib.optional (stdenv.cc.bintools.isLLVM && lib.versionAtLeast stdenv.cc.bintools.version "17") "LDFLAGS=-Wl,--undefined-version";
+
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   propagatedBuildInputs = [ libogg ];
 


### PR DESCRIPTION
## Description of changes

Fixes this error:
```
/nix/store/zpvgzm6x3dhw0ai7ciw06w1ibhh2ap5r-bash-5.2p26/bin/bash ./libtool  --tag=CC   --mode=link aarch64-unknown-linux-gnu-clang  -O2 -Wall -fsigned-char  -D_REENTRANT -DUSE_MEMORY_H -version-info 1:3:0 -Wl,--version-script=Version_script -o libvorbisidec.la -rpath /nix/store/jpr7mbds6pwxqpkb878qdmcxsamsg4gx-tremor-aarch64-unknown-linux-gnu-unstable-2018-03-16/lib mdct.lo block.lo window.lo synthesis.lo info.lo floor1.lo floor0.lo vorbisfile.lo res012.lo mapping0.lo registry.lo codebook.lo sharedbook.lo -L/nix/store/6m9n1w4jmm74h1469jgwpv4c2wc53g0m-libogg-aarch64-unknown-linux-gnu-1.3.5/lib -logg
libtool: link: aarch64-unknown-linux-gnu-clang -shared  -fPIC -DPIC  .libs/mdct.o .libs/block.o .libs/window.o .libs/synthesis.o .libs/info.o .libs/floor1.o .libs/floor0.o .libs/vorbisfile.o .libs/res012.o .libs/mapping0.o .libs/registry.o .libs/codebook.o .libs/sharedbook.o   -Wl,-rpath -Wl,/nix/store/6m9n1w4jmm74h1469jgwpv4c2wc53g0m-libogg-aarch64-unknown-linux-gnu-1.3.5/lib -Wl,-rpath -Wl,/nix/store/6m9n1w4jmm74h1469jgwpv4c2wc53g0m-libogg-aarch64-unknown-linux-gnu-1.3.5/lib -L/nix/store/6m9n1w4jmm74h1469jgwpv4c2wc53g0m-libogg-aarch64-unknown-linux-gnu-1.3.5/lib /nix/store/6m9n1w4jmm74h1469jgwpv4c2wc53g0m-libogg-aarch64-unknown-linux-gnu-1.3.5/lib/libogg.so  -O2 -Wl,--version-script=Version_script   -Wl,-soname -Wl,libvorbisidec.so.1 -o .libs/libvorbisidec.so.1.0.3
aarch64-unknown-linux-gnu-ld: error: version script assignment of 'libvorbisidec.so.1' to symbol 'vorbis_comment_add' failed: symbol not defined
aarch64-unknown-linux-gnu-ld: error: version script assignment of 'libvorbisidec.so.1' to symbol 'vorbis_comment_add_tag' failed: symbol not defined
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [Makefile:520: libvorbisidec.la] Error 1
make[1]: Leaving directory '/build/source'
make: *** [Makefile:427: all] Error 2
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
