### PR TITLE
pidginPackages: re-add recurseIntoAttrs

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33222,7 +33222,7 @@ with pkgs;
 
   picosnitch = callPackage ../tools/networking/picosnitch { };
 
-  pidginPackages = callPackage ../applications/networking/instant-messengers/pidgin/pidgin-plugins { };
+  pidginPackages = recurseIntoAttrs (callPackage ../applications/networking/instant-messengers/pidgin/pidgin-plugins { });
 
   inherit (pidginPackages) pidgin;
 


### PR DESCRIPTION
## Description of changes

I erroneously removed this in 3abc5f7093e5849eccc7e1ab82a48861c4ac4489 (part of PR https://github.com/NixOS/nixpkgs/pull/323867). 

https://hydra.nixos.org/eval/1807900?compare=1807880#tabs-removed

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).