### PR TITLE
python312Packages.traittypes: unstable-2019-06-23 -> 0.2.1-unstable-2020-07-17

### DIFF
--- a/pkgs/development/python-modules/traittypes/default.nix
+++ b/pkgs/development/python-modules/traittypes/default.nix
@@ -2,10 +2,8 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   isPy27,
   pytestCheckHook,
-  nose,
   numpy,
   pandas,
   xarray,
@@ -14,25 +12,22 @@
 
 buildPythonPackage rec {
   pname = "traittypes";
-  version = "unstable-2019-06-23";
   format = "setuptools";
+  version = "0.2.1-unstable-2020-07-17";
 
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "jupyter-widgets";
     repo = pname;
-    rev = "0a030b928991dec732c17a7a1cb13acbcd7650a2";
-    sha256 = "0rlm5krmq6n8yi47dgdsjyrkz3m079pndpbzkz2gx98pb3jd9pjs";
+    rev = "af2ebeec9e58b73a12d4cf841bd506d6eadb8868";
+    hash = "sha256-q7kt8b+yDHsWML/wCeND9PrZMVjemhzG7Ih1OtHbnTw=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "fix-intarray-test.patch";
-      url = "https://github.com/minrk/traittypes/commit/a02441e5b259e5858453a853207260c9bd4efbb5.patch";
-      sha256 = "120dsvr5nksizw75z1ah3h38mi399fxbvz5anakica557jahi0aw";
-    })
-  ];
+  postPatch = ''
+    substituteInPlace traittypes/tests/test_traittypes.py \
+      --replace-fail "np.int" "int"
+  '';
 
   propagatedBuildInputs = [ traitlets ];
 
@@ -40,13 +35,7 @@ buildPythonPackage rec {
     numpy
     pandas
     xarray
-    nose
     pytestCheckHook
-  ];
-
-  disabledTestPaths = lib.optionals (lib.versionAtLeast numpy.version "1.17") [
-    # https://github.com/jupyter-widgets/traittypes/blob/master/setup.py#L86-L87
-    "traittypes/tests/test_traittypes.py"
   ];
 
   pythonImportsCheck = [ "traittypes" ];

--- a/pkgs/development/python-modules/traittypes/default.nix
+++ b/pkgs/development/python-modules/traittypes/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   isPy27,
   pytestCheckHook,
+  setuptools,
   numpy,
   pandas,
   xarray,
@@ -12,8 +13,8 @@
 
 buildPythonPackage rec {
   pname = "traittypes";
-  format = "setuptools";
   version = "0.2.1-unstable-2020-07-17";
+  pyproject = true;
 
   disabled = isPy27;
 
@@ -29,7 +30,9 @@ buildPythonPackage rec {
       --replace-fail "np.int" "int"
   '';
 
-  propagatedBuildInputs = [ traitlets ];
+  build-system = [ setuptools ];
+
+  dependencies = [ traitlets ];
 
   nativeCheckInputs = [
     numpy
@@ -40,10 +43,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "traittypes" ];
 
-  meta = with lib; {
+  meta = {
     description = "Trait types for NumPy, SciPy, XArray, and Pandas";
     homepage = "https://github.com/jupyter-widgets/traittypes";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ bcdarwin ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ bcdarwin ];
   };
 }


### PR DESCRIPTION
## Description of changes
Fixes test failures, and replaces np.int with int in tests, since that makes tests fail. Also makes the code more in line with modern Nix standards.
Part of #326513

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
