### PR TITLE
armcord: package from source

### DIFF
--- a/pkgs/applications/networking/instant-messengers/armcord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/armcord/default.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
     homepage = "https://armcord.app";
     downloadPage = "https://github.com/ArmCord/ArmCord";
     license = licenses.osl3;
-    maintainers = with maintainers; [ wrmilling ];
+    maintainers = with maintainers; [ wrmilling water-sucks ];
     platforms = [ "x86_64-linux" "aarch64-linux" ];
     mainProgram = "armcord";
   };

--- a/pkgs/applications/networking/instant-messengers/armcord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/armcord/default.nix
@@ -1,139 +1,81 @@
 { lib
 , stdenv
-, fetchurl
-, autoPatchelfHook
-, dpkg
-, makeShellWrapper
-, wrapGAppsHook3
-, alsa-lib
-, at-spi2-atk
-, at-spi2-core
-, atk
-, cairo
-, cups
-, dbus
-, expat
-, ffmpeg
-, fontconfig
-, freetype
-, gdk-pixbuf
-, glib
-, gtk3
-, libappindicator-gtk3
-, libdrm
-, libnotify
-, libpulseaudio
-, libsecret
-, libuuid
-, libxkbcommon
-, mesa
-, nss
-, pango
-, systemd
-, xdg-utils
-, xorg
-, wayland
-, pipewire
+, fetchFromGitHub
+, pnpm
+, nodejs
+, electron_30
+, makeWrapper
+, copyDesktopItems
+, makeDesktopItem
 }:
-
 stdenv.mkDerivation rec {
   pname = "armcord";
   version = "3.2.7";
 
-  src =
-    let
-      base = "https://github.com/ArmCord/ArmCord/releases/download";
-    in
-      {
-        x86_64-linux = fetchurl {
-          url = "${base}/v${version}/ArmCord_${version}_amd64.deb";
-          hash = "sha256-TFgO9ddz/Svi4QfugjTTejpV/m+xc1548cokzhVgwkw=";
-        };
-        aarch64-linux = fetchurl {
-          url = "${base}/v${version}/ArmCord_${version}_arm64.deb";
-          hash = "sha256-AJ4TSG3ry2P40vzK1fsaWgQ/O0z9r3z8+0uxSmddZKo=";
-        };
-      }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  src = fetchFromGitHub {
+    owner = "ArmCord";
+    repo = "ArmCord";
+    rev = "v${version}";
+    hash = "sha256-+o/w3bYW3IR3APo7HppSMOTl+cU+01J+p1L0YrYgsUU=";
+  };
 
-  nativeBuildInputs = [ autoPatchelfHook dpkg makeShellWrapper wrapGAppsHook3 ];
+  nativeBuildInputs = [ pnpm.configHook nodejs makeWrapper copyDesktopItems ];
 
-  dontWrapGApps = true;
+  pnpmDeps = pnpm.fetchDeps {
+    inherit pname version src;
+    hash = "sha256-UJ3E/2+MspgVbRT7s6K4lGDvTQbWD3bwyICbJjctwDI=";
+  };
 
-  buildInputs = [
-    alsa-lib
-    at-spi2-atk
-    at-spi2-core
-    atk
-    cairo
-    cups
-    dbus
-    expat
-    ffmpeg
-    fontconfig
-    freetype
-    gdk-pixbuf
-    glib
-    gtk3
-    pango
-    systemd
-    mesa # for libgbm
-    nss
-    libuuid
-    libdrm
-    libnotify
-    libsecret
-    libpulseaudio
-    libxkbcommon
-    libappindicator-gtk3
-    xorg.libX11
-    xorg.libxcb
-    xorg.libXcomposite
-    xorg.libXcursor
-    xorg.libXdamage
-    xorg.libXext
-    xorg.libXfixes
-    xorg.libXi
-    xorg.libXrandr
-    xorg.libXrender
-    xorg.libXScrnSaver
-    xorg.libxshmfence
-    xorg.libXtst
-    wayland
-    pipewire
-  ];
+  ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
-  sourceRoot = ".";
-  unpackCmd = "dpkg-deb -x $src .";
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm build
+
+    npm exec electron-builder -- \
+      --dir \
+      -c.electronDist="${electron_30}/libexec/electron" \
+      -c.electronVersion="${electron_30.version}"
+
+    runHook postBuild
+  '';
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p "$out/bin"
-    cp -R "opt" "$out"
-    cp -R "usr/share" "$out/share"
-    chmod -R g-w "$out"
+    mkdir -p "$out/share/lib/armcord"
+    cp -r ./dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/armcord"
 
-    # use makeShellWrapper (instead of the makeBinaryWrapper provided by wrapGAppsHook3) for proper shell variable expansion
-    # see https://github.com/NixOS/nixpkgs/issues/172583
-    makeShellWrapper $out/opt/ArmCord/armcord $out/bin/armcord \
+    install -Dm644 "build/icon.png" "$out/share/icons/hicolor/256x256/apps/armcord.png"
+
+    makeShellWrapper "${lib.getExe electron_30}" "$out/bin/armcord" \
+      --add-flags "$out/share/lib/armcord/resources/app.asar" \
       "''${gappsWrapperArgs[@]}" \
-      --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-features=UseOzonePlatform --enable-features=WebRTCPipeWireCapturer }}" \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}" \
-      --suffix PATH : ${lib.makeBinPath [ xdg-utils ]}
-
-    # Fix desktop link
-    substituteInPlace $out/share/applications/armcord.desktop \
-      --replace /opt/ArmCord/ $out/bin/
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+      --set-default ELECTRON_IS_DEV 0 \
+      --inherit-argv0
 
     runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "armcord";
+      desktopName = "ArmCord";
+      exec = "${placeholder "out"}/bin/armcord %U";
+      icon = "armcord";
+      comment = meta.description;
+      categories = [ "Network" ];
+      startupWMClass = "ArmCord";
+      terminal = false;
+    })
+  ];
 
   meta = with lib; {
     description = "Lightweight, alternative desktop client for Discord";
     homepage = "https://armcord.app";
     downloadPage = "https://github.com/ArmCord/ArmCord";
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.osl3;
     maintainers = with maintainers; [ wrmilling ];
     platforms = [ "x86_64-linux" "aarch64-linux" ];


### PR DESCRIPTION
## Description of changes

This packages ArmCord from source using `pnpm.fetchDeps`, rather than using Debian packages, which allows for easier overriding of sources for applying patches. I intend on also adding macOS support to this later; this lays the groundwork for that.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
