### PR TITLE
eg25-manager: init at 0.4.6

### DIFF
--- a/nixos/modules/hardware/network/eg25-manager.nix
+++ b/nixos/modules/hardware/network/eg25-manager.nix
@@ -1,0 +1,27 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib) mkEnableOption mkIf mkPackageOption;
+  cfg = config.services.eg25-manager;
+in
+{
+  options.services.eg25-manager = {
+    enable = mkEnableOption "Quectel EG25 modem manager service";
+
+    package = mkPackageOption pkgs "eg25-manager" { };
+  };
+  config = mkIf cfg.enable {
+    systemd.packages = [ cfg.package ];
+    services.udev.packages = [ cfg.package ];
+    systemd.services.eg25-manager.wantedBy = [ "multi-user.target" ];
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ Luflosi ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -81,6 +81,7 @@
   ./hardware/mcelog.nix
   ./hardware/network/ath-user-regd.nix
   ./hardware/network/b43.nix
+  ./hardware/network/eg25-manager.nix
   ./hardware/network/intel-2200bg.nix
   ./hardware/new-lg4ff.nix
   ./hardware/nitrokey.nix

--- a/pkgs/by-name/eg/eg25-manager/package.nix
+++ b/pkgs/by-name/eg/eg25-manager/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  gnugrep,
+  meson,
+  ninja,
+  pkg-config,
+  scdoc,
+  curl,
+  glib,
+  libgpiod_1,
+  libgudev,
+  libusb1,
+  modemmanager,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "eg25-manager";
+  version = "0.4.6";
+
+  src = fetchFromGitLab {
+    owner = "mobian1";
+    repo = "eg25-manager";
+    rev = finalAttrs.version;
+    hash = "sha256-2JsdwK1ZOr7ljNHyuUMzVCpl+HV0C5sA5LAOkmELqag=";
+  };
+
+  postPatch = ''
+    substituteInPlace 'udev/80-modem-eg25.rules' \
+      --replace-fail '/bin/grep' '${lib.getExe gnugrep}'
+  '';
+
+  depsBuildBuild = [ pkg-config ];
+
+  nativeBuildInputs = [
+    glib # Contains gdbus-codegen program
+    meson
+    ninja
+    pkg-config
+    scdoc
+  ];
+
+  buildInputs = [
+    curl
+    glib
+    libgpiod_1 # Tracking issue for compatibility with libgpiod 2.0: https://gitlab.com/mobian1/eg25-manager/-/issues/45
+    libgudev
+    libusb1
+    modemmanager
+  ];
+
+  strictDeps = true;
+
+  meta = {
+    description = "Manager daemon for the Quectel EG25 mobile broadband modem found on the Pine64 PinePhone and PinePhone Pro";
+    homepage = "https://gitlab.com/mobian1/eg25-manager";
+    changelog = "https://gitlab.com/mobian1/eg25-manager/-/tags/${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "eg25-manager";
+    maintainers = with lib.maintainers; [ Luflosi ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes
https://gitlab.com/mobian1/eg25-manager
Manager daemon for the Quectel EG25 mobile broadband modem found on the Pine64 PinePhone and PinePhone Pro.
There was a previous attempt to add this package to Nixpkgs (#129229) but it was rejected because "This is very specific to the pinephone, I feel like it would make more sense to include in mobile-nixos." However I disagree with this reasoning.
- It is absolutely possible to run NixOS on the PinePhones using U-Boot or Tow-Boot without using Mobile NixOS.
- I also like to track all packages I maintain using Repology (https://repology.org/project/eg25-manager/versions) to see if any packages need updating but Mobile NixOS is not supported. Adding this Package to NixOS would allow me to better keep track of it.
- While Hydra does build Mobile NixOS and with it eg25-manager, it does not always use the latest Nixpkgs version. Looking at https://hydra.nixos.org/jobset/mobile-nixos/unstable one can see that currently the last evaluation was on 2024-07-11 which is definitely older than the latest unstable channel. I therefore have to build eg25-manager myself most of the time since I mostly use the latest Nixpkgs (unstable).
- Someone else also argued that eg25-manager should be upstreamed to Nixpkgs: https://github.com/mobile-nixos/mobile-nixos/issues/667. The original reason stated in the issue isn't valid since eg25-manager doesn't work with USB versions of this modem but @wentam commented "Personally I think it would make sense to have this in nixpkgs [...]".
- Last year I added eg25-manager to Mobile NixOS in https://github.com/mobile-nixos/mobile-nixos/pull/573 but I always felt that it should live in Nixpkgs instead.

The code in this PR is the code currently in Mobile NixOS with some minor cleanups.

Cc @Pacman99 @tomfitzhenry @kurnevsky @rvl @justinlovinger

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
