### PR TITLE
[Backport release-24.05] chromium,chromedriver: 126.0.6478.182 -> 127.0.6533.72

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -373,7 +373,7 @@ let
       patchShebangs .
       # Link to our own Node.js and Java (required during the build):
       mkdir -p third_party/node/linux/node-linux-x64/bin
-      ln -s "${pkgsBuildHost.nodejs}/bin/node" third_party/node/linux/node-linux-x64/bin/node
+      ln -s${lib.optionalString (chromiumVersionAtLeast "127") "f"} "${pkgsBuildHost.nodejs}/bin/node" third_party/node/linux/node-linux-x64/bin/node
       ln -s "${pkgsBuildHost.jdk17_headless}/bin/java" third_party/jdk/current/bin/
 
       # Allow building against system libraries in official builds
@@ -478,6 +478,8 @@ let
       # While we technically don't need the cache-invalidation rustc_version provides, rustc_version
       # is still used in some scripts (e.g. build/rust/std/find_std_rlibs.py).
       rustc_version = buildPackages.rustc.version;
+    } // lib.optionalAttrs (chromiumVersionAtLeast "127") {
+      rust_bindgen_root = "${buildPackages.rust-bindgen}";
     } // lib.optionalAttrs (!(stdenv.buildPlatform.canExecute stdenv.hostPlatform)) {
       # https://www.mail-archive.com/v8-users@googlegroups.com/msg14528.html
       arm_control_flow_integrity = "none";

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -59,8 +59,12 @@ let
         src = fetchgit {
           inherit (upstream-info.deps.gn) url rev hash;
         };
+      } // lib.optionalAttrs (chromiumVersionAtLeast "127") {
+        # Relax hardening as otherwise gn unstable 2024-06-06 and later fail with:
+        # cc1plus: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]
+        hardeningDisable = [ "format" ];
       });
-      recompressTarball = callPackage ./recompress-tarball.nix { };
+      recompressTarball = callPackage ./recompress-tarball.nix { inherit chromiumVersionAtLeast; };
     });
 
     browser = callPackage ./browser.nix {

--- a/pkgs/applications/networking/browsers/chromium/recompress-tarball.nix
+++ b/pkgs/applications/networking/browsers/chromium/recompress-tarball.nix
@@ -1,10 +1,11 @@
 { zstd
 , fetchurl
+, lib
+, chromiumVersionAtLeast
 }:
 
 { version
 , hash ? ""
-, ...
 } @ args:
 
 fetchurl ({
@@ -35,6 +36,13 @@ fetchurl ({
       --exclude=third_party/llvm \
       --exclude=third_party/rust-src \
       --exclude='build/linux/debian_*-sysroot' \
+    '' + lib.optionalString (chromiumVersionAtLeast "127") ''
+      --exclude='*.tar.[a-zA-Z0-9][a-zA-Z0-9]' \
+      --exclude='*.tar.[a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9]' \
+      --exclude=third_party/llvm-build \
+      --exclude=third_party/rust-toolchain \
+      --exclude=third_party/instrumented_libs \
+    '' + ''
       --strip-components=1
 
     tar \

--- a/pkgs/applications/networking/browsers/chromium/update.py
+++ b/pkgs/applications/networking/browsers/chromium/update.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i python -p python3 nix nixfmt-classic nix-prefetch-git
+#! nix-shell -i python -p python3Packages.looseversion nix nixfmt-classic nix-prefetch-git
 
 """This script automatically updates chromium, google-chrome, chromedriver, and ungoogled-chromium
 via upstream-info.nix."""
@@ -15,7 +15,7 @@ import sys
 from codecs import iterdecode
 from collections import OrderedDict
 from datetime import datetime
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 from os.path import abspath, dirname
 from urllib.request import urlopen
 
@@ -214,7 +214,7 @@ with urlopen(RELEASES_URL) as resp:
         releases.append(get_latest_ungoogled_chromium_build(linux_stable_versions))
 
     for release in releases:
-        channel_name = re.findall("chrome\/platforms\/linux\/channels\/(.*)\/versions\/", release['name'])[0]
+        channel_name = re.findall("chrome/platforms/linux/channels/(.*)/versions/", release['name'])[0]
 
         # If we've already found a newer release for this channel, we're
         # no longer interested in it.

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -1,22 +1,22 @@
 {
   stable = {
     chromedriver = {
-      hash_darwin = "sha256-YdQgrcTgyGtSfT6wBedSfBt40DaK3fG+uvB0yanvROU=";
+      hash_darwin = "sha256-c/lMkOdoW/tX57opl/weJGh/iyUeTTF5Xejs7IpA+Qg=";
       hash_darwin_aarch64 =
-        "sha256-ht7LoA4ibEcWuXOk+JimCN0sjjPomHBcO8IZFNnMauk=";
-      hash_linux = "sha256-VeCNeBKsKZ2bEM6Z9lJJaBVRjS1pW2gK2DMvmghfNEA=";
-      version = "126.0.6478.182";
+        "sha256-sst73OxUsrs2yWA72qdonARGi/W0FYObNfolidCiXio=";
+      hash_linux = "sha256-p5cQmMdte7TfTPohg+rpIsyyYk1OKSNb0BwaMWmHuCo=";
+      version = "127.0.6533.72";
     };
     deps = {
       gn = {
-        hash = "sha256-mNoQeHSSM+rhR0UHrpbyzLJC9vFqfxK1SD0X8GiRsqw=";
-        rev = "df98b86690c83b81aedc909ded18857296406159";
+        hash = "sha256-vzZu/Mo4/xATSD9KgKcRuBKVg9CoRZC9i0PEajYr4UM=";
+        rev = "b3a0bff47dd81073bfe67a402971bad92e4f2423";
         url = "https://gn.googlesource.com/gn";
-        version = "2024-05-13";
+        version = "2024-06-06";
       };
     };
-    hash = "sha256-vZ7P8+vHTMCo6lXkV84ENqRZVG3/fDEwl+BTNJTGMn4=";
-    version = "126.0.6478.182";
+    hash = "sha256-m99HaGCuIihDdbVnmu6xatnC/QDxgLVby2TWY/L+RHk=";
+    version = "127.0.6533.72";
   };
   ungoogled-chromium = {
     deps = {


### PR DESCRIPTION
## Description of changes

Manual backport of #330023 without the ninja 1.12 compat patches.

Ref https://github.com/NixOS/nixpkgs/pull/330023#issuecomment-2252565461.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
