### PR TITLE
treewideish: make use of lib.cmakeBool and lib.cmakeFeature

### DIFF
--- a/pkgs/applications/audio/adlplug/default.nix
+++ b/pkgs/applications/audio/adlplug/default.nix
@@ -56,9 +56,9 @@ stdenv.mkDerivation rec {
   };
 
   cmakeFlags = [
-    "-DADLplug_CHIP=${chip}"
-    "-DADLplug_USE_SYSTEM_FMT=ON"
-    "-DADLplug_Jack=${if withJack then "ON" else "OFF"}"
+    (lib.cmakeFeature "ADLplug_CHIP" "${chip}")
+    (lib.cmakeBool "ADLplug_USE_SYSTEM_FMT" true)
+    (lib.cmakeBool "ADLplug_Jack" withJack)
   ];
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin (toString [

--- a/pkgs/applications/audio/airwave/default.nix
+++ b/pkgs/applications/audio/airwave/default.nix
@@ -83,7 +83,7 @@ multiStdenv.mkDerivation {
   # Cf. https://github.com/phantom-code/airwave/issues/57
   hardeningDisable = [ "format" ];
 
-  cmakeFlags = [ "-DVSTSDK_PATH=${vst-sdk}/VST2_SDK" ];
+  cmakeFlags = [ (lib.cmakeFeature "VSTSDK_PATH" "${vst-sdk}/VST2_SDK") ];
 
   postInstall = ''
     mv $out/bin $out/libexec

--- a/pkgs/applications/audio/audacity/default.nix
+++ b/pkgs/applications/audio/audacity/default.nix
@@ -146,20 +146,20 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DAUDACITY_BUILD_LEVEL=2"
-    "-DAUDACITY_REV_LONG=nixpkgs"
-    "-DAUDACITY_REV_TIME=nixpkgs"
-    "-DDISABLE_DYNAMIC_LOADING_FFMPEG=ON"
-    "-Daudacity_conan_enabled=Off"
-    "-Daudacity_use_ffmpeg=loaded"
-    "-Daudacity_has_vst3=Off"
-    "-Daudacity_has_crashreports=Off"
+    (lib.cmakeFeature "AUDACITY_BUILD_LEVEL" "2")
+    (lib.cmakeFeature "AUDACITY_REV_LONG" "nixpkgs")
+    (lib.cmakeFeature "AUDACITY_REV_TIME" "nixpkgs")
+    (lib.cmakeBool "DISABLE_DYNAMIC_LOADING_FFMPEG" true)
+    (lib.cmakeBool "audacity_conan_enabled" false)
+    (lib.cmakeFeature "audacity_use_ffmpeg" "loaded")
+    (lib.cmakeBool "audacity_has_vst3" false)
+    (lib.cmakeBool "audacity_has_crashreports" false)
 
     # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
-    "-DCMAKE_SKIP_BUILD_RPATH=ON"
+    (lib.cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
 
     # Fix duplicate store paths
-    "-DCMAKE_INSTALL_LIBDIR=lib"
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
   ];
 
   # [ 57%] Generating LightThemeAsCeeCode.h...

--- a/pkgs/applications/audio/bespokesynth/default.nix
+++ b/pkgs/applications/audio/bespokesynth/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
 
   cmakeBuildType = "Release";
 
-  cmakeFlags = lib.optionals enableVST2 [ "-DBESPOKE_VST2_SDK_LOCATION=${vst-sdk}/VST2_SDK" ];
+  cmakeFlags = lib.optionals enableVST2 [ (lib.cmakeFeature "BESPOKE_VST2_SDK_LOCATION" "${vst-sdk}/VST2_SDK") ];
 
   nativeBuildInputs = [ python3 makeWrapper cmake pkg-config ninja ];
 

--- a/pkgs/applications/audio/clementine/default.nix
+++ b/pkgs/applications/audio/clementine/default.nix
@@ -117,8 +117,8 @@ in mkDerivation {
   '';
 
   cmakeFlags = [
-    "-DUSE_SYSTEM_PROJECTM=ON"
-    "-DSPOTIFY_BLOB=OFF"
+    (lib.cmakeBool "USE_SYSTEM_PROJECTM" true)
+    (lib.cmakeBool "SPOTIFY_BLOB" false)
   ];
 
   postInstall = ''

--- a/pkgs/applications/audio/csound/default.nix
+++ b/pkgs/applications/audio/csound/default.nix
@@ -30,10 +30,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-O7s92N54+zIl07eIdK/puoSve/qJ3O01fTh0TP+VdZA=";
   };
 
-  cmakeFlags = [ "-DBUILD_CSOUND_AC=0" ] # fails to find Score.hpp
-    ++ lib.optional stdenv.isDarwin "-DCS_FRAMEWORK_DEST=${placeholder "out"}/lib"
+  cmakeFlags = [ (lib.cmakeFeature "BUILD_CSOUND_AC" "0") ] # fails to find Score.hpp
+    ++ lib.optional stdenv.isDarwin (lib.cmakeFeature "CS_FRAMEWORK_DEST" "${placeholder "out"}/lib")
     # Ignore gettext in CMAKE_PREFIX_PATH on cross to prevent find_program picking up the wrong gettext
-    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "-DCMAKE_IGNORE_PATH=${lib.getBin gettext}/bin";
+    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) (lib.cmakeFeature "CMAKE_IGNORE_PATH" "${lib.getBin gettext}/bin");
 
   nativeBuildInputs = [ cmake flex bison gettext ];
   buildInputs = [ libsndfile libsamplerate boost ]

--- a/pkgs/applications/audio/delayarchitect/default.nix
+++ b/pkgs/applications/audio/delayarchitect/default.nix
@@ -19,9 +19,9 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_AR=${gcc-unwrapped}/bin/gcc-ar"
-    "-DCMAKE_RANLIB=${gcc-unwrapped}/bin/gcc-ranlib"
-    "-DCMAKE_NM=${gcc-unwrapped}/bin/gcc-nm"
+    (lib.cmakeFeature "CMAKE_AR" "${gcc-unwrapped}/bin/gcc-ar")
+    (lib.cmakeFeature "CMAKE_RANLIB" "${gcc-unwrapped}/bin/gcc-ranlib")
+    (lib.cmakeFeature "CMAKE_NM" "${gcc-unwrapped}/bin/gcc-nm")
   ];
 
   installPhase = ''

--- a/pkgs/applications/audio/diopser/default.nix
+++ b/pkgs/applications/audio/diopser/default.nix
@@ -70,8 +70,8 @@ in  stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_AR=${stdenv.cc.cc}/bin/gcc-ar"
-    "-DCMAKE_RANLIB=${stdenv.cc.cc}/bin/gcc-ranlib"
+    (lib.cmakeFeature "CMAKE_AR" "${stdenv.cc.cc}/bin/gcc-ar")
+    (lib.cmakeFeature "CMAKE_RANLIB" "${stdenv.cc.cc}/bin/gcc-ranlib")
   ];
 
   meta = with lib; {

--- a/pkgs/applications/audio/faust/faustlive.nix
+++ b/pkgs/applications/audio/faust/faustlive.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
+    (lib.cmakeBool "CMAKE_BUILD_WITH_INSTALL_RPATH" true)
   ];
 
   postPatch = "cd Build";

--- a/pkgs/applications/audio/flac/default.nix
+++ b/pkgs/applications/audio/flac/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = lib.optionals (!stdenv.hostPlatform.isStatic) [
-    "-DBUILD_SHARED_LIBS=ON"
+    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
   ];
 
   CFLAGS = [ "-O3" "-funroll-loops" ];

--- a/pkgs/applications/audio/fluidsynth/default.nix
+++ b/pkgs/applications/audio/fluidsynth/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     ++ lib.optionals stdenv.isDarwin [ AppKit AudioUnit CoreAudio CoreMIDI CoreServices ];
 
   cmakeFlags = [
-    "-Denable-framework=off"
+    (lib.cmakeBool "enable-framework" false)
   ];
 
   meta = with lib; {

--- a/pkgs/applications/audio/geonkick/default.nix
+++ b/pkgs/applications/audio/geonkick/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   # Without this, the lv2 ends up in
   # /nix/store/$HASH/nix/store/$HASH/lib/lv2
   cmakeFlags = [
-    "-DCMAKE_INSTALL_LIBDIR=lib"
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
   ];
 
   meta = with lib; {

--- a/pkgs/applications/audio/giada/default.nix
+++ b/pkgs/applications/audio/giada/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_INSTALL_BINDIR=bin"
+    (lib.cmakeFeature "CMAKE_INSTALL_BINDIR" "bin")
   ];
 
   nativeBuildInputs = [

--- a/pkgs/applications/audio/grandorgue/default.nix
+++ b/pkgs/applications/audio/grandorgue/default.nix
@@ -46,13 +46,13 @@ stdenv.mkDerivation rec {
     ++ lib.optional jackaudioSupport libjack2;
 
   cmakeFlags = lib.optionals (!jackaudioSupport) [
-    "-DRTAUDIO_USE_JACK=OFF"
-    "-DRTMIDI_USE_JACK=OFF"
-    "-DGO_USE_JACK=OFF"
-    "-DINSTALL_DEPEND=OFF"
-  ] ++ lib.optional (!includeDemo) "-DINSTALL_DEMO=OFF";
+    (lib.cmakeBool "RTAUDIO_USE_JACK" false)
+    (lib.cmakeBool "RTMIDI_USE_JACK" false)
+    (lib.cmakeBool "GO_USE_JACK" false)
+    (lib.cmakeBool "INSTALL_DEPEND" false)
+  ] ++ lib.optional (!includeDemo) (lib.cmakeBool "INSTALL_DEMO" false);
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-DTARGET_OS_IPHONE=0";
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin (lib.cmakeFeature "TARGET_OS_IPHONE" "0");
 
   postInstall = lib.optionalString stdenv.isDarwin ''
     mkdir -p $out/{Applications,bin,lib}

--- a/pkgs/applications/audio/hybridreverb2/default.nix
+++ b/pkgs/applications/audio/hybridreverb2/default.nix
@@ -66,8 +66,8 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DHybridReverb2_AdvancedJackStandalone=ON"
-    "-DHybridReverb2_UseLocalDatabase=ON"
+    (lib.cmakeBool "HybridReverb2_AdvancedJackStandalone" true)
+    (lib.cmakeBool "HybridReverb2_UseLocalDatabase" true)
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/applications/audio/hydrogen/default.nix
+++ b/pkgs/applications/audio/hydrogen/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DWANT_DEBUG=OFF"
+    (lib.cmakeBool "WANT_DEBUG" false)
   ];
 
   meta = with lib; {

--- a/pkgs/applications/audio/lmms/default.nix
+++ b/pkgs/applications/audio/lmms/default.nix
@@ -44,7 +44,7 @@ mkDerivation rec {
     })
   ];
 
-  cmakeFlags = [ "-DWANT_QT5=ON" ];
+  cmakeFlags = [ (lib.cmakeBool "WANT_QT5" true) ];
 
   meta = with lib; {
     description = "DAW similar to FL Studio (music production software)";

--- a/pkgs/applications/audio/mellowplayer/default.nix
+++ b/pkgs/applications/audio/mellowplayer/default.nix
@@ -38,7 +38,7 @@ mkDerivation rec {
 
   doCheck = true;
 
-  cmakeFlags = [ "-DBUILD_TESTS=ON" ];
+  cmakeFlags = [ (lib.cmakeBool "BUILD_TESTS" true) ];
 
   preCheck = ''
     # Running the tests requires a location at the home directory for logging.

--- a/pkgs/applications/audio/mixxx/default.nix
+++ b/pkgs/applications/audio/mixxx/default.nix
@@ -129,7 +129,7 @@ mkDerivation rec {
   # let's disable this and install udev rules manually via postInstall
   # see https://github.com/mixxxdj/mixxx/blob/2.3.5/CMakeLists.txt#L1381-L1392
   cmakeFlags = [
-    "-DINSTALL_USER_UDEV_RULES=OFF"
+    (lib.cmakeBool "INSTALL_USER_UDEV_RULES" false)
   ];
 
   postInstall = lib.optionalString stdenv.isLinux ''

--- a/pkgs/applications/audio/munt/libmt32emu.nix
+++ b/pkgs/applications/audio/munt/libmt32emu.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation rec {
   dontFixCmake = true;
 
   cmakeFlags = [
-    "-Dmunt_WITH_MT32EMU_SMF2WAV=OFF"
-    "-Dmunt_WITH_MT32EMU_QT=OFF"
+    (lib.cmakeBool "munt_WITH_MT32EMU_SMF2WAV" false)
+    (lib.cmakeBool "munt_WITH_MT32EMU_QT" false)
   ];
 
   postFixup = ''

--- a/pkgs/applications/audio/munt/mt32emu-qt.nix
+++ b/pkgs/applications/audio/munt/mt32emu-qt.nix
@@ -51,9 +51,9 @@ mkDerivation rec {
   dontFixCmake = true;
 
   cmakeFlags = [
-    "-Dmt32emu-qt_USE_PULSEAUDIO_DYNAMIC_LOADING=OFF"
-    "-Dmunt_WITH_MT32EMU_QT=ON"
-    "-Dmunt_WITH_MT32EMU_SMF2WAV=OFF"
+    (lib.cmakeBool "mt32emu-qt_USE_PULSEAUDIO_DYNAMIC_LOADING" false)
+    (lib.cmakeBool "munt_WITH_MT32EMU_QT" true)
+    (lib.cmakeBool "munt_WITH_MT32EMU_SMF2WAV" false)
   ];
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''

--- a/pkgs/applications/audio/munt/mt32emu-smf2wav.nix
+++ b/pkgs/applications/audio/munt/mt32emu-smf2wav.nix
@@ -38,8 +38,8 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-Dmunt_WITH_MT32EMU_QT=OFF"
-    "-Dmunt_WITH_MT32EMU_SMF2WAV=ON"
+    (lib.cmakeBool "munt_WITH_MT32EMU_QT" false)
+    (lib.cmakeBool "munt_WITH_MT32EMU_SMF2WAV" true)
   ];
 
   meta = with lib; {

--- a/pkgs/applications/audio/musescore/default.nix
+++ b/pkgs/applications/audio/musescore/default.nix
@@ -60,24 +60,24 @@ in stdenv'.mkDerivation (finalAttrs: {
   };
 
   cmakeFlags = [
-    "-DMUSESCORE_BUILD_MODE=release"
+    (lib.cmakeFeature "MUSESCORE_BUILD_MODE" "release")
     # Disable the build and usage of the `/bin/crashpad_handler` utility - it's
     # not useful on NixOS, see:
     # https://github.com/musescore/MuseScore/issues/15571
-    "-DMUE_BUILD_CRASHPAD_CLIENT=OFF"
+    (lib.cmakeBool "MUE_BUILD_CRASHPAD_CLIENT" false)
     # Use our versions of system libraries
-    "-DMUE_COMPILE_USE_SYSTEM_FREETYPE=ON"
-    "-DMUE_COMPILE_USE_SYSTEM_TINYXML=ON"
+    (lib.cmakeBool "MUE_COMPILE_USE_SYSTEM_FREETYPE" true)
+    (lib.cmakeBool "MUE_COMPILE_USE_SYSTEM_TINYXML" true)
     # Implies also -DMUE_COMPILE_USE_SYSTEM_OPUS=ON
-    "-DMUE_COMPILE_USE_SYSTEM_OPUSENC=ON"
-    "-DMUE_COMPILE_USE_SYSTEM_FLAC=ON"
+    (lib.cmakeBool "MUE_COMPILE_USE_SYSTEM_OPUSENC" true)
+    (lib.cmakeBool "MUE_COMPILE_USE_SYSTEM_FLAC" true)
     # From some reason, in $src/build/cmake/SetupBuildEnvironment.cmake,
     # upstream defaults to compiling to x86_64 only, unless this cmake flag is
     # set
-    "-DMUE_COMPILE_BUILD_MACOS_APPLE_SILICON=ON"
+    (lib.cmakeBool "MUE_COMPILE_BUILD_MACOS_APPLE_SILICON" true)
     # Don't bundle qt qml files, relevant really only for darwin, but we set
     # this for all platforms anyway.
-    "-DMUE_COMPILE_INSTALL_QTQML_FILES=OFF"
+    (lib.cmakeBool "MUE_COMPILE_INSTALL_QTQML_FILES" false)
   ];
 
   qtWrapperArgs = [

--- a/pkgs/applications/audio/mympd/default.nix
+++ b/pkgs/applications/audio/mympd/default.nix
@@ -46,9 +46,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     # Otherwise, it tries to parse $out/etc/mympd.conf on startup.
-    "-DCMAKE_INSTALL_SYSCONFDIR=/etc"
+    (lib.cmakeFeature "CMAKE_INSTALL_SYSCONFDIR" "/etc")
     # similarly here
-    "-DCMAKE_INSTALL_LOCALSTATEDIR=/var/lib/mympd"
+    (lib.cmakeFeature "CMAKE_INSTALL_LOCALSTATEDIR" "/var/lib/mympd")
   ];
   hardeningDisable = [
     # causes redefinition of _FORTIFY_SOURCE

--- a/pkgs/applications/audio/nootka/default.nix
+++ b/pkgs/applications/audio/nootka/default.nix
@@ -28,9 +28,9 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_INCLUDE_PATH=${lib.getDev libjack2}/include/jack;${lib.getDev libpulseaudio}/include/pulse"
-    "-DENABLE_JACK=ON"
-    "-DENABLE_PULSEAUDIO=ON"
+    (lib.cmakeFeature "CMAKE_INCLUDE_PATH" "${lib.getDev libjack2}/include/jack;${lib.getDev libpulseaudio}/include/pulse")
+    (lib.cmakeBool "ENABLE_JACK" true)
+    (lib.cmakeBool "ENABLE_PULSEAUDIO" true)
   ];
 
   meta = with lib; {

--- a/pkgs/applications/audio/odin2/default.nix
+++ b/pkgs/applications/audio/odin2/default.nix
@@ -61,9 +61,9 @@ stdenv.mkDerivation rec {
   ]);
 
   cmakeFlags = [
-    "-DCMAKE_AR=${gcc-unwrapped}/bin/gcc-ar"
-    "-DCMAKE_RANLIB=${gcc-unwrapped}/bin/gcc-ranlib"
-    "-DCMAKE_NM=${gcc-unwrapped}/bin/gcc-nm"
+    (lib.cmakeFeature "CMAKE_AR" "${gcc-unwrapped}/bin/gcc-ar")
+    (lib.cmakeFeature "CMAKE_RANLIB" "${gcc-unwrapped}/bin/gcc-ranlib")
+    (lib.cmakeFeature "CMAKE_NM" "${gcc-unwrapped}/bin/gcc-nm")
   ];
 
   installPhase = ''

--- a/pkgs/applications/audio/pianobooster/default.nix
+++ b/pkgs/applications/audio/pianobooster/default.nix
@@ -51,8 +51,8 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DOpenGL_GL_PREFERENCE=GLVND"
-    "-DUSE_JACK=ON"
+    (lib.cmakeFeature "OpenGL_GL_PREFERENCE" "GLVND")
+    (lib.cmakeBool "USE_JACK" true)
   ];
 
   postInstall = ''

--- a/pkgs/applications/audio/qjackctl/default.nix
+++ b/pkgs/applications/audio/qjackctl/default.nix
@@ -32,8 +32,8 @@ mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DCONFIG_JACK_VERSION=1"
-    "-DCONFIG_JACK_SESSION=${toString jackSession}"
+    (lib.cmakeFeature "CONFIG_JACK_VERSION" "1")
+    (lib.cmakeFeature "CONFIG_JACK_SESSION" "${toString jackSession}")
   ];
 
   meta = with lib; {

--- a/pkgs/applications/audio/qpwgraph/default.nix
+++ b/pkgs/applications/audio/qpwgraph/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ qtbase qtsvg qtwayland alsa-lib pipewire ];
 
-  cmakeFlags = [ "-DCONFIG_WAYLAND=ON" ];
+  cmakeFlags = [ (lib.cmakeBool "CONFIG_WAYLAND" true) ];
 
   meta = with lib; {
     description = "Qt graph manager for PipeWire, similar to QjackCtl";

--- a/pkgs/applications/audio/radiotray-ng/default.nix
+++ b/pkgs/applications/audio/radiotray-ng/default.nix
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = [
-    "-DBUILD_TESTS=${if doCheck then "ON" else "OFF"}"
+    (lib.cmakeBool "BUILD_TESTS" doCheck)
   ];
 
   # 'wxFont::wxFont(int, int, int, int, bool, const wxString&, wxFontEncoding)' is deprecated

--- a/pkgs/applications/audio/sayonara/default.nix
+++ b/pkgs/applications/audio/sayonara/default.nix
@@ -52,7 +52,7 @@ mkDerivation rec {
   # we carry the patched taglib 1.11.1 that doesn't break ogg but sayonara just
   # checks for the version
   cmakeFlags = [
-    "-DWITH_SYSTEM_TAGLIB=ON"
+    (lib.cmakeBool "WITH_SYSTEM_TAGLIB" true)
   ];
 
   # gstreamer cannot otherwise be found

--- a/pkgs/applications/audio/scream/default.nix
+++ b/pkgs/applications/audio/scream/default.nix
@@ -23,10 +23,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkg-config ];
 
   cmakeFlags = [
-    "-DPULSEAUDIO_ENABLE=${if pulseSupport then "ON" else "OFF"}"
-    "-DALSA_ENABLE=${if alsaSupport then "ON" else "OFF"}"
-    "-DJACK_ENABLE=${if jackSupport then "ON" else "OFF"}"
-    "-DPCAP_ENABLE=${if pcapSupport then "ON" else "OFF"}"
+    (lib.cmakeBool "PULSEAUDIO_ENABLE" pulseSupport)
+    (lib.cmakeBool "ALSA_ENABLE" alsaSupport)
+    (lib.cmakeBool "JACK_ENABLE" jackSupport)
+    (lib.cmakeBool "PCAP_ENABLE" pcapSupport)
   ];
 
   cmakeDir = "../Receivers/unix";

--- a/pkgs/applications/audio/sfizz/default.nix
+++ b/pkgs/applications/audio/sfizz/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
       --replace '/usr/bin/zenity' '${zenity}/bin/zenity'
   '';
 
-  cmakeFlags = [ "-DSFIZZ_TESTS=ON" ];
+  cmakeFlags = [ (lib.cmakeBool "SFIZZ_TESTS" true) ];
 
   doCheck = true;
 

--- a/pkgs/applications/audio/sonic-pi/default.nix
+++ b/pkgs/applications/audio/sonic-pi/default.nix
@@ -102,9 +102,9 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DUSE_SYSTEM_LIBS=ON"
-    "-DBUILD_IMGUI_INTERFACE=${if withImGui then "ON" else "OFF"}"
-    "-DWITH_QT_GUI_WEBENGINE=${if withTauWidget then "ON" else "OFF"}"
+    (lib.cmakeBool "USE_SYSTEM_LIBS" true)
+    (lib.cmakeBool "BUILD_IMGUI_INTERFACE" withImGui)
+    (lib.cmakeBool "WITH_QT_GUI_WEBENGINE" withTauWidget)
   ];
 
   doCheck = true;

--- a/pkgs/applications/audio/soundkonverter/default.nix
+++ b/pkgs/applications/audio/soundkonverter/default.nix
@@ -67,7 +67,7 @@ mkDerivation rec {
   propagatedBuildInputs = [ libkcddb kconfig kconfigwidgets ki18n kdelibs4support kio solid kwidgetsaddons kxmlgui qtbase phonon];
   buildInputs = [ taglib ] ++ runtimeDeps;
   # encoder plugins go to ${out}/lib so they're found by kbuildsycoca5
-  cmakeFlags = [ "-DCMAKE_INSTALL_PREFIX=$out" ];
+  cmakeFlags = [ (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" "$out") ];
   sourceRoot = "${src.name}/src";
   # add runt-time deps to PATH
   postInstall = ''

--- a/pkgs/applications/audio/spotify-qt/default.nix
+++ b/pkgs/applications/audio/spotify-qt/default.nix
@@ -23,7 +23,7 @@ mkDerivation rec {
 
    nativeBuildInputs = [ cmake ];
 
-   cmakeFlags = [ "-DCMAKE_INSTALL_PREFIX=" ];
+   cmakeFlags = [ (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" "") ];
 
    installFlags = [ "DESTDIR=$(out)" ];
 

--- a/pkgs/applications/audio/surge-XT/default.nix
+++ b/pkgs/applications/audio/surge-XT/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   cmakeFlags = [
-    "-DSURGE_BUILD_LV2=TRUE"
+    (lib.cmakeBool "SURGE_BUILD_LV2" true)
   ];
 
   CXXFLAGS = [

--- a/pkgs/applications/audio/tenacity/default.nix
+++ b/pkgs/applications/audio/tenacity/default.nix
@@ -144,7 +144,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
-    "-DCMAKE_SKIP_BUILD_RPATH=ON"
+    (lib.cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
   ];
 
   meta = with lib; {

--- a/pkgs/applications/audio/traverso/default.nix
+++ b/pkgs/applications/audio/traverso/default.nix
@@ -16,7 +16,7 @@ mkDerivation {
                   libmad libpulseaudio libsamplerate.dev libsndfile.dev libvorbis
                   portaudio qtbase wavpack ];
 
-  cmakeFlags = [ "-DWANT_PORTAUDIO=1" "-DWANT_PULSEAUDIO=1" "-DWANT_MP3_ENCODE=1" "-DWANT_LV2=0" ];
+  cmakeFlags = [ (lib.cmakeFeature "WANT_PORTAUDIO" "1" "-DWANT_PULSEAUDIO=1" "-DWANT_MP3_ENCODE=1" "-DWANT_LV2=0") ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/applications/audio/vcv-rack/default.nix
+++ b/pkgs/applications/audio/vcv-rack/default.nix
@@ -103,10 +103,10 @@ let
     buildInputs = [ alsa-lib libjack2 libpulseaudio ];
 
     cmakeFlags = [
-      "-DRTAUDIO_API_ALSA=ON"
-      "-DRTAUDIO_API_PULSE=ON"
-      "-DRTAUDIO_API_JACK=ON"
-      "-DRTAUDIO_API_CORE=OFF"
+      (lib.cmakeBool "RTAUDIO_API_ALSA" true)
+      (lib.cmakeBool "RTAUDIO_API_PULSE" true)
+      (lib.cmakeBool "RTAUDIO_API_JACK" true)
+      (lib.cmakeBool "RTAUDIO_API_CORE" false)
     ];
   };
 in

--- a/pkgs/applications/audio/vgmstream/default.nix
+++ b/pkgs/applications/audio/vgmstream/default.nix
@@ -41,8 +41,8 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     # It always tries to download it, no option to use the system one
-    "-DUSE_CELT=OFF"
-  ] ++ lib.optional (! buildAudaciousPlugin) "-DBUILD_AUDACIOUS=OFF";
+    (lib.cmakeBool "USE_CELT" false)
+  ] ++ lib.optional (! buildAudaciousPlugin) (lib.cmakeBool "BUILD_AUDACIOUS" false);
 
   meta = with lib; {
     description = "Library for playback of various streamed audio formats used in video games";

--- a/pkgs/applications/audio/yoshimi/default.nix
+++ b/pkgs/applications/audio/yoshimi/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
     zlib
   ];
 
-  cmakeFlags = [ "-DFLTK_MATH_LIBRARY=${stdenv.cc.libc}/lib/libm.so" ];
+  cmakeFlags = [ (lib.cmakeFeature "FLTK_MATH_LIBRARY" "${stdenv.cc.libc}/lib/libm.so") ];
 
   meta = with lib; {
     description = "High quality software synthesizer based on ZynAddSubFX";

--- a/pkgs/applications/audio/zynaddsubfx/default.nix
+++ b/pkgs/applications/audio/zynaddsubfx/default.nix
@@ -87,12 +87,12 @@ in stdenv.mkDerivation rec {
     ++ lib.optionals (guiModule == "ntk") [ ntk cairo libXpm ]
     ++ lib.optionals (guiModule == "zest") [ libGL libX11 ];
 
-  cmakeFlags = [ "-DGuiModule=${guiModule}" ]
+  cmakeFlags = [ (lib.cmakeFeature "GuiModule" "${guiModule}") ]
     # OSS library is included in glibc.
     # Must explicitly disable if support is not wanted.
-    ++ lib.optional (!ossSupport) "-DOssEnable=OFF"
+    ++ lib.optional (!ossSupport) (lib.cmakeBool "OssEnable" false)
     # Find FLTK without requiring an OpenGL library in buildInputs
-    ++ lib.optional (guiModule == "fltk") "-DFLTK_SKIP_OPENGL=ON";
+    ++ lib.optional (guiModule == "fltk") (lib.cmakeBool "FLTK_SKIP_OPENGL" true);
 
   CXXFLAGS = [
     # GCC 13: error: 'uint8_t' does not name a type

--- a/pkgs/applications/blockchains/bitcoin-abc/default.nix
+++ b/pkgs/applications/blockchains/bitcoin-abc/default.nix
@@ -61,7 +61,7 @@ mkDerivation rec {
   ] ++ lib.optionals withGui [ qtbase qttools qrencode ];
 
   cmakeFlags = lib.optionals (!withGui) [
-    "-DBUILD_BITCOIN_QT=OFF"
+    (lib.cmakeBool "BUILD_BITCOIN_QT" false)
   ];
 
   # many of the generated scripts lack execute permissions

--- a/pkgs/applications/blockchains/haven-cli/default.nix
+++ b/pkgs/applications/blockchains/haven-cli/default.nix
@@ -39,12 +39,12 @@ stdenv.mkDerivation rec {
     ++ lib.optionals trezorSupport [ libusb1 protobuf python3 ];
 
   cmakeFlags = [
-    "-DBUILD_GUI_DEPS=ON"
-    "-DReadline_ROOT_DIR=${readline.dev}"
-    "-DReadline_INCLUDE_DIR=${readline.dev}/include/readline"
-    "-DRandomX_ROOT_DIR=${randomx}"
-  ] ++ lib.optional stdenv.isDarwin "-DBoost_USE_MULTITHREADED=OFF"
-    ++ lib.optional (!trezorSupport) "-DUSE_DEVICE_TREZOR=OFF";
+    (lib.cmakeBool "BUILD_GUI_DEPS" true)
+    (lib.cmakeFeature "Readline_ROOT_DIR" "${readline.dev}")
+    (lib.cmakeFeature "Readline_INCLUDE_DIR" "${readline.dev}/include/readline")
+    (lib.cmakeFeature "RandomX_ROOT_DIR" "${randomx}")
+  ] ++ lib.optional stdenv.isDarwin (lib.cmakeBool "Boost_USE_MULTITHREADED" false)
+    ++ lib.optional (!trezorSupport) (lib.cmakeBool "USE_DEVICE_TREZOR" false);
 
   outputs = [ "out" "source" ];
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Replace strings in `cmakeFlags` with [`lib.cmakeBool`](https://github.com/NixOS/nixpkgs/blob/master/lib/strings.nix#L868-L871) and [`lib.cmakeFeature`](https://github.com/NixOS/nixpkgs/blob/master/lib/strings.nix#L886-L889).

This PR is intended to get a conversation going whether there is interest in this type of clean-up work and if yes how to best coordinate it.
Maybe folks have improvement suggestions for the script below to have it function properly in all cases or ideas on how to best break this into more manageable PRs.

For the proposed changes as they are now the `cmake-option.sh` script below was run, note that it intentionally only changes ~50 packages to limit the potential rebuilds. If folks believe this PR is headed into the right direction and provides value the script can be run treewide (possibly in chungs) with the necessary manual adjustments (none were made for this draft PR).

As you've been involved in a previous treewide PR of mine I'm interested in your opinion too, @Aleksanaa, @mweinelt.

<details><summary><code>cmake-option.sh</code></summary>

```sh
#!/usr/bin/env nix-shell
#! nix-shell -i bash -p silver-searcher gnused

cat <<EOF>cmake-option.sed
#!/usr/bin/env sed -En
/cmakeFlags/,/];/s/"-D([^=]*)=(.*)"/(lib.cmake "\1" \2)/
/cmakeFlags/,/];/s/[^a-z](ON|TRUE)\)/ true)/i
/cmakeFlags/,/];/s/[^a-z](OFF|FALSE)\)/ false)/i
/cmakeFlags/,/];/s/(lib.cmake)[[:space:]]("[^"]+") .*if ([^ ]*).*"O(N|FF)".*else.*"O(N|FF)".*/\1Bool \2 \3)/i
/cmakeFlags/,/];/s/(lib.cmake)[[:space:]](.*(true|false))\)/\1Bool \2)/
/cmakeFlags/,/];/s/(lib.cmake)[[:space:]]("[^"]+")[[:space:]](.*)\)/\1Feature \2 "\3")/
# Uncomment the next line for debugging purposes
#/cmakeFlags/,/];/p
EOF

# Remove the | head -XXX
# to run the script treewide.
ag -G '\.nix$' -l 'cmakeFlags *=' \
    | sort \
    | head -50 \
    | xargs sed -i '' -Ef cmake-option.sed
```

</details> 



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
