### PR TITLE
live-server: init at 0.7.0

### DIFF
--- a/pkgs/by-name/li/live-server/package.nix
+++ b/pkgs/by-name/li/live-server/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  darwin,
+  openssl,
+  pkg-config,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "live-server";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "lomirus";
+    repo = "live-server";
+    rev = "v${version}";
+    hash = "sha256-BSAsD9nRlHaTDbBpLBxN9OOQ9SekRwQeYUWV1CZO4oY=";
+  };
+
+  cargoHash = "sha256-RwueYpa/CMriSOWwGZhkps6jHmqOdRuz+ECRq/ThPs0=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs =
+    [ openssl ]
+    ++ lib.optionals stdenv.isDarwin (
+      with darwin.apple_sdk.frameworks;
+      [
+        CoreServices
+        SystemConfiguration
+      ]
+    );
+
+  meta = with lib; {
+    description = "Local network server with live reload feature for static pages";
+    downloadPage = "https://github.com/lomirus/live-server/releases";
+    homepage = "https://github.com/lomirus/live-server";
+    license = licenses.mit;
+    mainProgram = "live-server";
+    maintainers = [ maintainers.philiptaron ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

https://github.com/lomirus/live-server. It's a simple live server.

This is the "Rust alternative to live-server" referred to in [`pkgs/tools/nix/web-devmode.nix`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/nix/web-devmode.nix#L74).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).