### PR TITLE
imhex-bin: init at 1.35.4

### DIFF
--- a/pkgs/by-name/im/imhex-bin/package.nix
+++ b/pkgs/by-name/im/imhex-bin/package.nix
@@ -1,0 +1,46 @@
+{
+  stdenvNoCC,
+  _7zz,
+  fetchurl,
+  makeWrapper,
+  lib,
+  nix-update-script,
+}:
+let
+  arch = if stdenvNoCC.hostPlatform.isAarch64 then "arm64" else "x86_64";
+in
+stdenvNoCC.mkDerivation rec {
+  pname = "imhex-bin";
+  version = "1.35.4";
+
+  src = fetchurl {
+    url = "https://github.com/WerWolv/ImHex/releases/download/v${version}/imhex-${version}-macOS-${arch}.dmg";
+    hash = "sha256-mGnYl/c4j9fbhEj1akxMthS0+c6eL5lyOe1DXtmOdIs=";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    _7zz
+    makeWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,Applications}
+    cp -r ImHex.app $out/Applications/
+    makeWrapper $out/Applications/ImHex.app/Contents/MacOS/imhex $out/bin/imhex
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "Hex Editor for Reverse Engineers, Programmers and people who value their retinas when working at 3 AM";
+    homepage = "https://github.com/WerWolv/ImHex";
+    mainProgram = "imhex";
+    license = with licenses; [ gpl2Only ];
+    maintainers = with maintainers; [ pcasaretto ];
+    platforms = platforms.darwin;
+  };
+}


### PR DESCRIPTION
## Description of changes

After failing to [build imhex from source](https://github.com/WerWolv/ImHex/issues/1807#event-13632163534) I'm adding a pre-built option for ImHex for darwin users.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
