### PR TITLE
upgrading.chapter.md - Added NixOS-Nix version table

### DIFF
--- a/nixos/doc/manual/installation/upgrading.chapter.md
+++ b/nixos/doc/manual/installation/upgrading.chapter.md
@@ -95,6 +95,30 @@ easily, so in that case you will not be able to go back to your original
 channel.
 :::
 
+|  NixOS version  |  Nix version  |
+| --------------- | ------------- |
+|      24.05      |    2.18       |
+|      23.11      |    2.18       |
+|      23.05      |    2.13       |
+|      22.11      |    2.11       |
+|      22.05      |    2.8        |
+|      21.11      |    2.3        |
+|      21.05      |    2.3        |
+|      20.09      |    2.3.11     |
+|      20.03      |    2.3.6      |
+|      19.09      |    2.3.3      |
+|      19.03      |    2.2.2      |
+|      18.09      |    2.1.3      |
+|      18.03      |    2.0.4      |
+|      17.09      |    1.11.16    |
+|      17.03      |    1.11.14    |
+|      16.09      |    1.11.8     |
+|      16.03      |    1.11.4     |
+|      15.09      |    1.10       |
+|      14.12      |    1.8        |
+|      14.04      |    1.7        |
+|      13.10      |    1.6.1      |
+
 ## Automatic Upgrades {#sec-upgrading-automatic}
 
 You can keep a NixOS system up-to-date automatically by adding the


### PR DESCRIPTION
## Description of changes
The [NixOS manual - upgrading section](https://nixos.org/manual/nixos/stable/index.html#sec-upgrading) warns the following
> It is generally safe to switch back and forth between channels. The only exception is that a newer NixOS may also have a newer Nix version, which may involve an upgrade of Nix’s database schema. This cannot be undone easily, so in that case you will not be able to go back to your original channel.

But it does not expand on what versions those are. The following table has been generated from the `release-{version}/pkgs/tools/package-management/nix/default.nix` nixStable/stable variable. If someone has more or better insight in how to derive the results, please do let me know!

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
