### PR TITLE
nixos/zfs: add option to import extra pools during stage 1

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -224,7 +224,7 @@ in
         default = [];
         example = [ "encrypted_data" ];
         description = ''
-          Name or GUID of extra ZFS pools that you wish to import during boot stage 1.
+          Name of extra ZFS pools that you wish to import during boot stage 1.
 
           Most setups should use {option}`boot.zfs.extraPools` to import extra pools during
           stage 2 instead. The root pool(s) do not need to be listed here, as they are
@@ -272,7 +272,7 @@ in
         default = [];
         example = [ "tank" "data" ];
         description = ''
-          Name or GUID of extra ZFS pools that you wish to import during boot.
+          Name of extra ZFS pools that you wish to import during boot.
 
           Usually this is not necessary. Instead, you should set the mountpoint property
           of ZFS filesystems to `legacy` and add the ZFS filesystems to

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -231,7 +231,7 @@ in
           automatically imported based on NixOS's {option}`fileSystems` options.
 
           This option is needed when encrypted pools will be unlocked over SSH as the
-          SSH server in {option}`boot.initrd.network.ssh` only runs during stage 1.
+          SSH server during stage 2 does not start until after file systems are mounted.
         '';
       };
     };

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -38,6 +38,8 @@ let
 
   rootPools = unique (map fsToPool (filter fsNeededForBoot zfsFilesystems));
 
+  earlyPools = unique ((config.boot.initrd.zfs.extraPools) ++ rootPools);
+
   dataPools = unique (filter (pool: !(elem pool rootPools)) allPools);
 
   snapshotNames = [ "frequent" "hourly" "daily" "weekly" "monthly" ];
@@ -216,6 +218,23 @@ in
   ###### interface
 
   options = {
+    boot.initrd.zfs = {
+      extraPools = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = [ "encrypted_data" ];
+        description = ''
+          Name or GUID of extra ZFS pools that you wish to import during boot stage 1.
+
+          Most setups should use {option}`boot.zfs.extraPools` to import extra pools during
+          stage 2 instead. The root pool(s) do not need to be listed here, as they are
+          automatically imported based on NixOS's {option}`fileSystems` options.
+
+          This option is needed when encrypted pools will be unlocked over SSH as the
+          SSH server in {option}`boot.initrd.network.ssh` only runs during stage 1.
+        '';
+      };
+    };
     boot.zfs = {
       package = mkOption {
         type = types.package;
@@ -639,7 +658,7 @@ in
               else concatMapStrings (fs: ''
                 zfs load-key -- ${escapeShellArg fs}
               '') (filter (x: datasetToPool x == pool) cfgZfs.requestEncryptionCredentials)}
-        '') rootPools)));
+        '') earlyPools)));
 
         # Systemd in stage 1
         systemd = mkIf config.boot.initrd.systemd.enable {
@@ -649,7 +668,7 @@ in
             systemd = config.boot.initrd.systemd.package;
             force = cfgZfs.forceImportRoot;
             prefix = "/sysroot";
-          }) rootPools);
+          }) earlyPools);
           targets.zfs-import.wantedBy = [ "zfs.target" ];
           targets.zfs.wantedBy = [ "initrd.target" ];
           extraBin = {


### PR DESCRIPTION
Datasets in the existing `boot.zfs.extraPools` option are imported too late to be decrypted over the stage 1 SSH server without hacky workarounds.

See https://github.com/NixOS/nixpkgs/issues/291223

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
