### PR TITLE
openscad-unstable: 2024-03-10 -> 2024-07-24

### DIFF
--- a/pkgs/by-name/op/openscad-unstable/package.nix
+++ b/pkgs/by-name/op/openscad-unstable/package.nix
@@ -41,15 +41,16 @@ let
   # get cccl from source to avoid license issues
   nvidia-cccl = clangStdenv.mkDerivation {
     pname = "nvidia-cccl";
-    # note that v2.2.0 has some cmake issues
-    version = "2.2.0-unstable-2024-01-26";
+    # note, after v2.2.0, manifold dependency fails with some swap() ambiguities
+    version = "2.2.0";
     src = fetchFromGitHub {
       owner = "NVIDIA";
       repo = "cccl";
       fetchSubmodules = true;
-      rev = "0c9d03276206a5f59368e908e3d643610f9fddcd";
-      hash = "sha256-f11CNfa8jF9VbzvOoX1vT8zGIJL9cZ/VBpiklUn0YdU=";
+      rev = "v2.2.0";
+      hash = "sha256-azHDAuK0rAHrH+XkN3gHDrbwZOclP3zbEMe8VRpMjDQ=";
     };
+    patches = [ ./thrust-cmake.patch ];
     nativeBuildInputs = [ cmake pkg-config ];
     buildInputs = [ tbb_2021_11 ];
     cmakeFlags = [
@@ -81,12 +82,12 @@ in
 # clang consume much less RAM than GCC
 clangStdenv.mkDerivation rec {
   pname = "openscad-unstable";
-  version = "2024-03-10";
+  version = "2024-07-24";
   src = fetchFromGitHub {
     owner = "openscad";
     repo = "openscad";
-    rev = "db167b1df31fbd8a2101cf3a13dac148b0c2165d";
-    hash = "sha256-i2ZGYsNfMLDi3wRd/lohs9BuO2KuQ/7kJIXGtV65OQU=";
+    rev = "48f4430b12c29a95ab89ffdd8307205d7189421c";
+    hash = "sha256-A75JHmWVNlgURb5one5JFkztCrVff2RbyaDaObUp4ZY=";
     fetchSubmodules = true;
   };
   patches = [ ./test.diff ];

--- a/pkgs/by-name/op/openscad-unstable/thrust-cmake.patch
+++ b/pkgs/by-name/op/openscad-unstable/thrust-cmake.patch
@@ -1,0 +1,13 @@
+diff --git a/thrust/thrust/cmake/thrust-header-search.cmake.in b/thrust/thrust/cmake/thrust-header-search.cmake.in
+index 8529d89fe..94879ee01 100644
+--- a/thrust/thrust/cmake/thrust-header-search.cmake.in
++++ b/thrust/thrust/cmake/thrust-header-search.cmake.in
+@@ -7,7 +7,6 @@ set(from_install_prefix "@from_install_prefix@")
+ find_path(_THRUST_VERSION_INCLUDE_DIR thrust/version.h
+   NO_CMAKE_FIND_ROOT_PATH # Don't allow CMake to re-root the search
+   NO_DEFAULT_PATH # Only search explicit paths below:
+-  PATHS
+-    "${CMAKE_CURRENT_LIST_DIR}/${from_install_prefix}/@CMAKE_INSTALL_INCLUDEDIR@"
++  PATHS "@CMAKE_INSTALL_INCLUDEDIR@"
+ )
+ set_property(CACHE _THRUST_VERSION_INCLUDE_DIR PROPERTY TYPE INTERNAL)


### PR DESCRIPTION
Update to latest head of openscad. Fixing the cmake issue mentioned in the cccl dependency. Switch to exactly version v2.2.0 of nvidia-cccl as newer versions exhibit a header incompatibility (looks like some ambiguous swap() call differently defined in standard headers and cuda headers).

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
