### PR TITLE
fish-lsp: 1.0.7 -> 1.0.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7795,6 +7795,12 @@
     githubId = 6578603;
     name = "Jonas Rembser";
   };
+  gungun974 = {
+    email = "xfelix974@gmail.com";
+    name = "Gungun974";
+    github = "gungun974";
+    githubId = 5224459;
+  };
   guserav = {
     github = "guserav";
     githubId = 28863828;

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15742,6 +15742,12 @@
     githubId = 29493551;
     name = "Josh Peters";
   };
+  petertriho = {
+    email = "mail@petertriho.com";
+    github = "petertriho";
+    githubId = 7420227;
+    name = "Peter Tri Ho";
+  };
   peterwilli = {
     email = "peter@codebuffet.co";
     github = "peterwilli";

--- a/pkgs/by-name/fi/fish-lsp/package.json
+++ b/pkgs/by-name/fi/fish-lsp/package.json
@@ -1,0 +1,126 @@
+{
+  "author": "ndonfris",
+  "license": "Apache-2.0",
+  "name": "fish-lsp",
+  "version": "1.0.7",
+  "description": "LSP implementation for fish/fish-shell",
+  "keywords": [
+    "lsp",
+    "fish",
+    "fish-shell",
+    "language-server-protocol",
+    "language-server"
+  ],
+  "homepage": "https://fish-lsp.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ndonfris/fish-lsp.git"
+  },
+  "bin": "./bin/fish-lsp",
+  "main": "./out/out.js",
+  "directories": {
+    "man": "./docs/man/fish-lsp.1",
+    "bin": "./bin/fish-lsp"
+  },
+  "typings": "./out/server.d.ts",
+  "scripts": {
+    "setup": "yarn run sh:setup",
+    "preinstall": "yarn install --ignore-scripts",
+    "postinstall": "yarn run sh:build-wasm && yarn run sh:build-time && yarn run compile && yarn run sh:relink && yarn run sh:build-completions",
+    "sh:build-completions": "fish ./scripts/build-completions.fish",
+    "sh:build-logs": "fish ./scripts/build-logs.fish",
+    "sh:build-time": "fish ./scripts/build-time.fish",
+    "sh:setup": "fish ./scripts/setup.fish",
+    "sh:build-wasm": "fish ./scripts/build-fish-wasm.fish",
+    "sh:relink": "fish ./scripts/relink-locally.fish",
+    "pre:clean": "yarn exec rimraf lib *.tsbuildinfo out",
+    "clean": "yarn run pre:clean && yarn install",
+    "clean-nodemodules": "yarn rimraf out *.tsbuildinfo node_modules",
+    "clean:all": "yarn exec rimraf out *.tsbuildinfo node_modules tree-sitter-fish.wasm",
+    "fresh": "yarn run clean:all && yarn install && yarn run setup",
+    "pretest-hook": "yarn clean:all && yarn install --ignore-scripts && yarn run sh:setup",
+    "test-hook": "yarn jest document.test.ts tree-sitter.test.ts node-types.test.ts fish-syntax-node.test.ts exec.test.ts logger.test.ts test-data/parser.test.ts snippets.test.ts completion-startup-config.test.ts formatting.test.ts executeHandler.test.ts fileOperations.test.ts diagnostics.test.ts",
+    "test": "jest",
+    "compile": "yarn tsc -b",
+    "watch": "yarn tsc -b -w",
+    "refactor": "yarn knip",
+    "lint:verbose": "yarn run prelint && yarn eslint .",
+    "lint": "yarn eslint . --fix",
+    "prelint": "yarn clean:all && yarn install --ignore-scripts && yarn run sh:setup",
+    "generate-man-page": "mkdir -p ./docs/man && cat docs/MAN_FILE.md | npx marked-man --date \"$(date +'%e %B %+4Y')\"  --manual fish-lsp --section 1 --name fish-lsp > ./docs/man/fish-lsp.1"
+  },
+  "man": "./docs/man/fish-lsp.1",
+  "enabledApiProposals": [
+    "inlineCompletions"
+  ],
+  "eslintIgnore": [
+    "!.eslintrc.cjs"
+  ],
+  "husky": {
+    "hooks": {
+      "pre-commit": "yarn run clean",
+      "pre-push": "yarn lint",
+      "post-merge": "yarn"
+    }
+  },
+  "contributes": {
+    "commands": [
+      {
+        "command": "fish-lsp.createTheme",
+        "title": "create a new theme"
+      },
+      {
+        "command": "fish-lsp.executeBuffer",
+        "title": "execute the buffer"
+      },
+      {
+        "command": "fish-lsp.execute",
+        "title": "execute the buffer"
+      },
+      {
+        "command": "fish-lsp.executeLine",
+        "title": "execute the line"
+      }
+    ]
+  },
+  "dependencies": {
+    "@esdmr/tree-sitter-fish": "^3.5.2-0",
+    "colors": "^1.4.0",
+    "commander": "^12.0.0",
+    "deepmerge": "^4.3.1",
+    "husky": "^9.0.11",
+    "marked-man": "^1.3.5",
+    "tree-sitter": "^0.21.0",
+    "tsc": "^2.0.4",
+    "typescript": "^5.4.3",
+    "vscode-languageserver": "^9.0.1",
+    "vscode-languageserver-protocol": "3.17.5",
+    "vscode-languageserver-textdocument": "1.0.11",
+    "vscode-uri": "^3.0.8",
+    "web-tree-sitter": "^0.22.2",
+    "zod": "^3.23.6"
+  },
+  "devDependencies": {
+    "@tsconfig/node-lts": "^20.1.3",
+    "@types/chai": "^4.3.14",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.11.30",
+    "@typescript-eslint/eslint-plugin": "^7.0.1",
+    "@typescript-eslint/parser": "^7.4.0",
+    "all-contributors-cli": "^6.26.1",
+    "chai": "^5.1.0",
+    "eslint": "^8.0.1",
+    "eslint-config-love": "^44.0.0",
+    "eslint-plugin-import": "^2.25.2",
+    "eslint-plugin-n": "^15.0.0",
+    "eslint-plugin-promise": "^6.0.0",
+    "fast-glob": "^3.3.2",
+    "jest": "^29.7.0",
+    "knip": "^5.7.0",
+    "rimraf": "^5.0.5",
+    "tree-sitter-cli": "^0.22.2",
+    "tree-sitter-fish": "https://github.com/ram02z/tree-sitter-fish",
+    "ts-jest": "^29.1.2",
+    "ts-node": "^10.9.2"
+  }
+}

--- a/pkgs/by-name/fi/fish-lsp/package.json
+++ b/pkgs/by-name/fi/fish-lsp/package.json
@@ -1,8 +1,8 @@
 {
   "author": "ndonfris",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "name": "fish-lsp",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "LSP implementation for fish/fish-shell",
   "keywords": [
     "lsp",
@@ -17,52 +17,43 @@
     "url": "https://github.com/ndonfris/fish-lsp.git"
   },
   "bin": "./bin/fish-lsp",
-  "main": "./out/out.js",
+  "man": "./docs/man/fish-lsp.1",
   "directories": {
     "man": "./docs/man/fish-lsp.1",
     "bin": "./bin/fish-lsp"
   },
-  "typings": "./out/server.d.ts",
   "scripts": {
-    "setup": "yarn run sh:setup",
-    "preinstall": "yarn install --ignore-scripts",
-    "postinstall": "yarn run sh:build-wasm && yarn run sh:build-time && yarn run compile && yarn run sh:relink && yarn run sh:build-completions",
+    "prepare": "husky",
+    "setup": "run-s sh:build-time sh:build-logs sh:build-wasm",
+    "preinstall": "yarn install --ignore-scripts --no-progress",
+    "postinstall": "run-s setup compile sh:relink sh:build-completions",
+    "compile": "tsc -b",
+    "watch": "tsc -b -w",
     "sh:build-completions": "fish ./scripts/build-completions.fish",
     "sh:build-logs": "fish ./scripts/build-logs.fish",
     "sh:build-time": "fish ./scripts/build-time.fish",
-    "sh:setup": "fish ./scripts/setup.fish",
     "sh:build-wasm": "fish ./scripts/build-fish-wasm.fish",
     "sh:relink": "fish ./scripts/relink-locally.fish",
-    "pre:clean": "yarn exec rimraf lib *.tsbuildinfo out",
-    "clean": "yarn run pre:clean && yarn install",
-    "clean-nodemodules": "yarn rimraf out *.tsbuildinfo node_modules",
-    "clean:all": "yarn exec rimraf out *.tsbuildinfo node_modules tree-sitter-fish.wasm",
-    "fresh": "yarn run clean:all && yarn install && yarn run setup",
-    "pretest-hook": "yarn clean:all && yarn install --ignore-scripts && yarn run sh:setup",
-    "test-hook": "yarn jest document.test.ts tree-sitter.test.ts node-types.test.ts fish-syntax-node.test.ts exec.test.ts logger.test.ts test-data/parser.test.ts snippets.test.ts completion-startup-config.test.ts formatting.test.ts executeHandler.test.ts fileOperations.test.ts diagnostics.test.ts",
-    "test": "jest",
-    "compile": "yarn tsc -b",
-    "watch": "yarn tsc -b -w",
-    "refactor": "yarn knip",
-    "lint:verbose": "yarn run prelint && yarn eslint .",
-    "lint": "yarn eslint . --fix",
-    "prelint": "yarn clean:all && yarn install --ignore-scripts && yarn run sh:setup",
+    "clean:all": "rimraf out *.tsbuildinfo node_modules tree-sitter-fish.wasm logs.txt",
+    "clean": "rimraf out node_modules",
+    "test": "env -i HOME=$HOME PATH=$PATH NODE_ENV=test jest",
+    "refactor": "knip",
+    "lint:check": "eslint . --ext .ts",
+    "lint:fix": "eslint . --ext .ts --fix ",
+    "lint:check-fix": "eslint . --ext .ts --fix-dry-run",
     "generate-man-page": "mkdir -p ./docs/man && cat docs/MAN_FILE.md | npx marked-man --date \"$(date +'%e %B %+4Y')\"  --manual fish-lsp --section 1 --name fish-lsp > ./docs/man/fish-lsp.1"
   },
-  "man": "./docs/man/fish-lsp.1",
   "enabledApiProposals": [
     "inlineCompletions"
   ],
+  "lint-staged": {
+    "**/*.ts": [
+      "eslint --fix"
+    ]
+  },
   "eslintIgnore": [
     "!.eslintrc.cjs"
   ],
-  "husky": {
-    "hooks": {
-      "pre-commit": "yarn run clean",
-      "pre-push": "yarn lint",
-      "post-merge": "yarn"
-    }
-  },
   "contributes": {
     "commands": [
       {
@@ -88,7 +79,6 @@
     "colors": "^1.4.0",
     "commander": "^12.0.0",
     "deepmerge": "^4.3.1",
-    "husky": "^9.0.11",
     "marked-man": "^1.3.5",
     "tree-sitter": "^0.21.0",
     "tsc": "^2.0.4",
@@ -101,6 +91,8 @@
     "zod": "^3.23.6"
   },
   "devDependencies": {
+    "@commitlint/cli": "^19.3.0",
+    "@commitlint/config-conventional": "^19.2.2",
     "@tsconfig/node-lts": "^20.1.3",
     "@types/chai": "^4.3.14",
     "@types/jest": "^29.5.12",
@@ -115,8 +107,12 @@
     "eslint-plugin-n": "^15.0.0",
     "eslint-plugin-promise": "^6.0.0",
     "fast-glob": "^3.3.2",
+    "husky": "^9.0.11",
     "jest": "^29.7.0",
     "knip": "^5.7.0",
+    "lint-staged": "^15.2.7",
+    "npm-run-all": "^4.1.5",
+    "pinst": "^3.0.0",
     "rimraf": "^5.0.5",
     "tree-sitter-cli": "^0.22.2",
     "tree-sitter-fish": "https://github.com/ram02z/tree-sitter-fish",

--- a/pkgs/by-name/fi/fish-lsp/package.nix
+++ b/pkgs/by-name/fi/fish-lsp/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  mkYarnPackage,
+  fetchFromGitHub,
+  fetchYarnDeps,
+  fish,
+  fixup-yarn-lock,
+  nodejs,
+  yarn,
+}:
+mkYarnPackage
+rec {
+  pname = "fish-lsp";
+  version = "1.0.7";
+  src = fetchFromGitHub {
+    owner = "ndonfris";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-Np7ELQxHqSnkzVkASYSyO9cTiO1yrakDuK88kkACNAI=";
+  };
+  offlineCache = fetchYarnDeps {
+    yarnLock = src + "/yarn.lock";
+    hash = "sha256-hmaLWO1Sj+2VujrGD2A+COfVE2D+tCnxyojjq1512K4=";
+  };
+  nativeBuildInputs = [
+    fish
+    fixup-yarn-lock
+    nodejs
+    yarn
+  ];
+  buildPhase = ''
+    runHook preBuild
+    wasm_file=$(find node_modules -type f -a -name tree-sitter-fish.wasm)
+    cp -f $wasm_file ./deps/fish-lsp
+    yarn run sh:build-time
+    yarn --offline compile
+    yarn run sh:relink
+    # yarn run sh:build-completions
+    runHook postBuild
+  '';
+
+  meta = {
+    description = "LSP implementation for the fish shell language";
+    homepage = "https://github.com/ndonfris/fish-lsp";
+    license = lib.licenses.mit;
+    mainProgram = "fish-lsp";
+    maintainers = with lib.maintainers; [gungun974];
+  };
+}

--- a/pkgs/by-name/fi/fish-lsp/package.nix
+++ b/pkgs/by-name/fi/fish-lsp/package.nix
@@ -1,49 +1,75 @@
 {
-  lib,
-  mkYarnPackage,
   fetchFromGitHub,
   fetchYarnDeps,
   fish,
   fixup-yarn-lock,
+  installShellFiles,
+  lib,
+  makeWrapper,
+  mkYarnPackage,
+  nix-update-script,
   nodejs,
+  which,
   yarn,
 }:
-mkYarnPackage
-rec {
+mkYarnPackage rec {
   pname = "fish-lsp";
-  version = "1.0.7";
+  version = "1.0.8";
+
   src = fetchFromGitHub {
     owner = "ndonfris";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-Np7ELQxHqSnkzVkASYSyO9cTiO1yrakDuK88kkACNAI=";
+    sha256 = "sha256-Lc2AmvcLdgPoLyT/6bPCI/pkb4x6M6XilZDr8IxKeHc=";
   };
+
+  packageJSON = ./package.json;
+
   offlineCache = fetchYarnDeps {
     yarnLock = src + "/yarn.lock";
-    hash = "sha256-hmaLWO1Sj+2VujrGD2A+COfVE2D+tCnxyojjq1512K4=";
+    hash = "sha256-hHw7DbeqaCapqx4dK5Y3sPut94ist9JOU8g9dd6gBdo=";
   };
+
   nativeBuildInputs = [
     fish
     fixup-yarn-lock
+    installShellFiles
+    makeWrapper
     nodejs
+    which
     yarn
   ];
+
   buildPhase = ''
     runHook preBuild
-    wasm_file=$(find node_modules -type f -a -name tree-sitter-fish.wasm)
-    cp -f $wasm_file ./deps/fish-lsp
-    yarn run sh:build-time
+
+    export fish_wasm_file=$(find node_modules -type f -a -name tree-sitter-fish.wasm | xargs realpath)
+    yarn setup
     yarn --offline compile
-    yarn run sh:relink
-    # yarn run sh:build-completions
+
     runHook postBuild
   '';
+
+  postInstall = ''
+    makeWrapper ${lib.getExe nodejs} "$out/bin/fish-lsp" \
+      --add-flags "$out/libexec/fish-lsp/deps/fish-lsp/out/cli.js"
+
+    installShellCompletion --cmd fish-lsp \
+      --fish <($out/bin/fish-lsp complete --fish)
+  '';
+
+  doDist = false;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "LSP implementation for the fish shell language";
     homepage = "https://github.com/ndonfris/fish-lsp";
     license = lib.licenses.mit;
     mainProgram = "fish-lsp";
-    maintainers = with lib.maintainers; [gungun974];
+    maintainers = with lib.maintainers; [
+      gungun974
+      petertriho
+    ];
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Updates `fish-lsp` to `1.0.8` which made some changes to work better with nix (no longer defaults to writing log file in the `src` directory  (read only)

Worked with the creator of [`fish-lsp`](https://github.com/ndonfris/fish-lsp) https://github.com/ndonfris 

Supersedes https://github.com/NixOS/nixpkgs/pull/320463

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
