### PR TITLE
python3Packages.discordpy: refactor

### DIFF
--- a/pkgs/development/python-modules/discordpy/default.nix
+++ b/pkgs/development/python-modules/discordpy/default.nix
@@ -62,6 +62,6 @@ buildPythonPackage rec {
     homepage = "https://discordpy.rtfd.org/";
     changelog = "https://github.com/Rapptz/discord.py/blob/v${version}/docs/whats_new.rst";
     license = licenses.mit;
-    maintainers = [ ];
+    maintainers = with maintainers; [ getpsyched ];
   };
 }

--- a/pkgs/development/python-modules/discordpy/default.nix
+++ b/pkgs/development/python-modules/discordpy/default.nix
@@ -6,62 +6,56 @@
   fetchFromGitHub,
   libopus,
   pynacl,
-  pythonOlder,
   withVoice ? true,
   ffmpeg,
+  setuptools,
 }:
 
-buildPythonPackage rec {
+let
   pname = "discord.py";
   version = "2.4.0";
-  format = "setuptools";
-
-  disabled = pythonOlder "3.8";
+in
+buildPythonPackage {
+  inherit pname version;
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Rapptz";
-    repo = pname;
+    repo = "discord.py";
     rev = "refs/tags/v${version}";
     hash = "sha256-GIwXx7bRCH2+G3zlilJ/Tb8el50SDbxGGX2/1bqL3+U=";
   };
 
-  propagatedBuildInputs =
-    [ aiohttp ]
-    ++ lib.optionals withVoice [
-      libopus
-      pynacl
-      ffmpeg
-    ];
+  build-system = [ setuptools ];
 
-  patchPhase =
-    ''
-      substituteInPlace "discord/opus.py" \
-        --replace "ctypes.util.find_library('opus')" "'${libopus}/lib/libopus${stdenv.hostPlatform.extensions.sharedLibrary}'"
-    ''
-    + lib.optionalString withVoice ''
-      substituteInPlace "discord/player.py" \
-        --replace "executable='ffmpeg'" "executable='${ffmpeg}/bin/ffmpeg'"
-    '';
+  dependencies = [ aiohttp ] ++ lib.optionals withVoice [ pynacl ];
+
+  patchPhase = lib.optionalString withVoice ''
+    substituteInPlace "discord/opus.py" \
+      --replace-fail "ctypes.util.find_library('opus')" "'${libopus}/lib/libopus${stdenv.hostPlatform.extensions.sharedLibrary}'"
+
+    substituteInPlace "discord/player.py" \
+      --replace-fail "executable: str = 'ffmpeg'" "executable: str = '${lib.getExe ffmpeg}'"
+  '';
 
   # Only have integration tests with discord
   doCheck = false;
 
   pythonImportsCheck = [
     "discord"
-    "discord.file"
-    "discord.member"
-    "discord.user"
-    "discord.state"
-    "discord.guild"
+    "discord.types"
+    "discord.ui"
     "discord.webhook"
-    "discord.ext.commands.bot"
+    "discord.app_commands"
+    "discord.ext.commands"
+    "discord.ext.tasks"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Python wrapper for the Discord API";
     homepage = "https://discordpy.rtfd.org/";
     changelog = "https://github.com/Rapptz/discord.py/blob/v${version}/docs/whats_new.rst";
-    license = licenses.mit;
-    maintainers = with maintainers; [ getpsyched ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ getpsyched ];
   };
 }


### PR DESCRIPTION
## Description of changes

- Make consistent with newer Python package and nixpkgs rules
- Move general postPatch to lib.optionalString withVoice
- Align imports in pythonImportsCheck with upstream packages

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
