### PR TITLE
abpoa: 1.5.1 -> 1.5.2

### DIFF
--- a/pkgs/by-name/ab/abpoa/package.nix
+++ b/pkgs/by-name/ab/abpoa/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "${lib.optionalString enablePython "py"}abpoa";
-  version = "1.5.1";
+  version = "1.5.2";
 
   src = fetchFromGitHub {
     owner = "yangao07";
     repo = "abPOA";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-nPMzkWkjUI+vZExNEvJa24KrR0pWGk89Mvp7TCyka/w=";
+    hash = "sha256-gS0PO7K4hN+3k2NF8enri1FzM80H2I+a3MNaKsm74xM=";
   };
 
   patches = [ ./simd-arch.patch ];
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = lib.optionals enablePython (
     with python3Packages;
     [
-      cython
+      cython_0
       pypaBuildHook
       pypaInstallHook
       pythonImportsCheckHook

--- a/pkgs/by-name/ab/abpoa/simd-arch.patch
+++ b/pkgs/by-name/ab/abpoa/simd-arch.patch
@@ -1,25 +1,25 @@
 diff --git a/setup.py b/setup.py
-index 52c0e7e..f88ec08 100644
+index c6fc019..49fb3c8 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -11,11 +11,12 @@ simde = ['-DUSE_SIMDE', '-DSIMDE_ENABLE_NATIVE_ALIASES']
+@@ -14,11 +14,12 @@ machine_arch = os.popen("uname -m").readlines()[0].rsplit()[0]
  
- if platform.system() == "Darwin":
+ if machine_system == "Darwin":
      # note: see https://github.com/pypa/wheel/issues/406
 -    simd_flag = ['-march=native', '-D__AVX2__', '-mmacosx-version-min=10.9']
-     if platform.machine() in ["aarch64", "arm64"]:
+     if machine_arch in ["aarch64", "arm64"]:
 +        simd_flag = ['-march=armv8-a+simd', '-D__AVX2__', '-mmacosx-version-min=10.9']
          os.environ['_PYTHON_HOST_PLATFORM'] = "macosx-10.9-arm64"
          os.environ['ARCHFLAGS'] = "-arch arm64"
-     else:
+     else: # x86_64
 +        simd_flag = ['-msse2', '-mmacosx-version-min=10.9']
          os.environ['_PYTHON_HOST_PLATFORM'] = "macosx-10.9-x86_64"
          os.environ['ARCHFLAGS'] = "-arch x86_64"
  else:
-@@ -24,7 +25,7 @@ else:
-     elif platform.machine() in ["aarch32"]:
+@@ -27,7 +28,7 @@ else:
+     elif machine_arch in ["aarch32"]:
          simd_flag = ['-march=armv8-a+simd', '-mfpu=auto -D__AVX2__']
-     else:
+     else: # x86_64
 -        simd_flag=['-march=native']
 +        simd_flag=[]
          if os.getenv('SSE4', False):


### PR DESCRIPTION
Diff: https://github.com/yangao07/abPOA/compare/refs/tags/v1.5.1...v1.5.2

Changelog: https://github.com/yangao07/abPOA/releases/tag/refs/tags/v1.5.2

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
