### PR TITLE
naja: init at 0-unstable-2024-07-21

### DIFF
--- a/pkgs/by-name/li/libdwarf-lite/package.nix
+++ b/pkgs/by-name/li/libdwarf-lite/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libdwarf-lite";
+  version = "0.10.1";
+
+  src = fetchFromGitHub {
+    owner = "jeremy-rifkin";
+    repo = "libdwarf-lite";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-ouhYapiqBFPJwoUIyiuEtsezF2wR63WZL7VwvnDExoU=";
+  };
+
+  outputs = [
+    "dev"
+    "lib"
+    "out"
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_DWARFDUMP" false)
+    (lib.cmakeBool "PIC_ALWAYS" true)
+  ];
+
+  meta = {
+    description = "Minimal libdwarf mirror for faster cloning and configuration";
+    homepage = "https://github.com/jeremy-rifkin/libdwarf-lite";
+    license = lib.licenses.lgpl21Only;
+    maintainers = [ ];
+    mainProgram = "libdwarf-lite";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/na/naja/package.nix
+++ b/pkgs/by-name/na/naja/package.nix
@@ -62,8 +62,12 @@ stdenv.mkDerivation {
     description = "Structural Netlist API (and more) for EDA post synthesis flow development";
     homepage = "https://github.com/najaeda/naja";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = [
+      # maintained by the team working on NGI-supported software, no group for this yet
+    ];
     mainProgram = "naja_edit";
     platforms = lib.platforms.all;
+    # "aligned deallocation function of type [...] is only available on macOS 10.13 or newer" even with 11.0 SDK
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/na/naja/package.nix
+++ b/pkgs/by-name/na/naja/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  bison,
+  boost,
+  capnproto,
+  doxygen,
+  flex,
+  libdwarf-lite,
+  pkg-config,
+  python3,
+  tbb_2021_11,
+}:
+stdenv.mkDerivation {
+  pname = "naja";
+  version = "0-unstable-2024-07-21";
+
+  src = fetchFromGitHub {
+    owner = "najaeda";
+    repo = "naja";
+    rev = "8c068f3bd1bbd57b851547f191a58a375fd35cda";
+    hash = "sha256-aUYPJGr4D5n92fp0namPT6I/gMRZoF7YHnB7GoRzwYI=";
+    fetchSubmodules = true;
+  };
+
+  outputs = [
+    "dev"
+    "lib"
+    "out"
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    bison
+    capnproto
+    cmake
+    doxygen
+    flex
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    boost
+    capnproto # cmake modules
+    flex # include dir
+    libdwarf-lite
+    tbb_2021_11
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "CPPTRACE_USE_EXTERNAL_LIBDWARF" true)
+    (lib.cmakeBool "CPPTRACE_USE_EXTERNAL_ZSTD" true)
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Structural Netlist API (and more) for EDA post synthesis flow development";
+    homepage = "https://github.com/najaeda/naja";
+    license = lib.licenses.asl20;
+    maintainers = [ ];
+    mainProgram = "naja_edit";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

[naja](https://github.com/najaeda/naja) is a structural Netlist API (and more) for EDA post synthesis flow development.

Work funded by NLNet through the [NGI0 Entrust](https://nlnet.nl/entrust/) fund

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
