### PR TITLE
prismlauncher: support all openal binary backends

### DIFF
--- a/pkgs/by-name/pr/prismlauncher/package.nix
+++ b/pkgs/by-name/pr/prismlauncher/package.nix
@@ -4,6 +4,7 @@
   symlinkJoin,
   prismlauncher-unwrapped,
   addDriverRunpath,
+  alsa-lib,
   flite,
   gamemode,
   glfw,
@@ -14,11 +15,13 @@
   jdk21,
   kdePackages,
   libGL,
+  libjack2,
   libpulseaudio,
   libusb1,
   makeWrapper,
   openal,
   pciutils,
+  pipewire,
   udev,
   vulkan-loader,
   xorg,
@@ -102,21 +105,28 @@ symlinkJoin {
       runtimeLibs =
         [
           # lwjgl
-          glfw
-          libpulseaudio
-          libGL
-          openal
           stdenv.cc.cc.lib
+          ## native versions
+          glfw
+          openal
 
-          vulkan-loader # VulkanMod's lwjgl
+          ## openal
+          alsa-lib
+          libjack2
+          libpulseaudio
+          pipewire
 
-          udev # oshi
-
+          ## glfw
+          libGL
           xorg.libX11
           xorg.libXext
           xorg.libXcursor
           xorg.libXrandr
           xorg.libXxf86vm
+
+          udev # oshi
+
+          vulkan-loader # VulkanMod's lwjgl
         ]
         ++ lib.optional textToSpeechSupport flite
         ++ lib.optional gamemodeSupport gamemode.lib


### PR DESCRIPTION
## Description of changes

Previously we only included `libpulseaudio` in the wrapper, which limited the binary version of OpenAL provided by the launcher from using it's other backends. This also better documents what dependencies are for what part of lwjgl

Fixes #330154


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
