### PR TITLE
Nix format check minor fix

### DIFF
--- a/.github/workflows/check-nix-format.yml
+++ b/.github/workflows/check-nix-format.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   nixos:
     runs-on: ubuntu-latest
-    if: "github.repository_owner == 'NixOS' && !contains(github.event.pull_request.title, '[skip treewide]')"
+    if: "!contains(github.event.pull_request.title, '[skip treewide]')"
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:

--- a/.github/workflows/check-nix-format.yml
+++ b/.github/workflows/check-nix-format.yml
@@ -76,7 +76,7 @@ jobs:
             if [[ -n "$source" ]] && ! nixfmt --check ${{ env.base }}/"$source" 2>/dev/null; then
               echo "Ignoring file $file because it's not formatted in the base commit"
             elif ! nixfmt --check "$dest"; then
-              unformattedFiles+=("$file")
+              unformattedFiles+=("$dest")
             fi
           done < <(git diff -z --name-status ${{ env.baseRev }} -- '*.nix')
 


### PR DESCRIPTION
## Description of changes

- Fixes the workflow reporting the old file location needing to be reformatted when it was moved (e.g. see https://github.com/infinisil/nixpkgs/actions/runs/10123400466/job/27996643633?pr=3), discovered in https://github.com/NixOS/nixpkgs/pull/330066#discussion_r1693687418
- Allows testing the workflow from forks. Limiting it to non-forks seems to be a left-over from https://github.com/NixOS/nixpkgs/pull/94079

Ping @NixOS/nix-formatting @Aleksanaa

## Things done

- [x] Tested successfully: https://github.com/infinisil/nixpkgs/pull/4 ([run](https://github.com/infinisil/nixpkgs/actions/runs/10123472868/job/27996786554?pr=4))
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
