### PR TITLE
treewide: fix some comments

### DIFF
--- a/pkgs/applications/version-management/sublime-merge/common.nix
+++ b/pkgs/applications/version-management/sublime-merge/common.nix
@@ -116,7 +116,7 @@ let
 
       # We need to replace the ssh-askpass-sublime executable because the default one
       # will not function properly, in order to work it needs to pass an argv[0] to
-      # the sublime_merge binary, and the built-in version will will try to call the
+      # the sublime_merge binary, and the built-in version will try to call the
       # sublime_merge wrapper script which cannot pass through the original argv[0] to
       # the sublime_merge binary. Thankfully the ssh-askpass-sublime functionality is
       # very simple and can be replaced with a simple wrapper script.

--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -7,7 +7,7 @@ let
   # sandboxed builds, we manually download them and save them so these files
   # are fetched ahead-of-time instead of during the CMake build. To update
   # plex-media-player use the update.sh script, so the versions and hashes
-  # for these files are are also updated!
+  # for these files are also updated!
   depSrcs = import ./deps.nix { inherit fetchurl; };
 in mkDerivation rec {
   pname = "plex-media-player";

--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -49,7 +49,7 @@ let
   helpersBin = symlinkJoin {
     name = "podman-helper-binary-wrapper";
 
-    # this only works for some binaries, others may need to be be added to `binPath` or in the modules
+    # this only works for some binaries, others may need to be added to `binPath` or in the modules
     paths = [
       gvproxy
     ] ++ lib.optionals stdenv.isLinux [

--- a/pkgs/by-name/xm/xmldiff/package.nix
+++ b/pkgs/by-name/xm/xmldiff/package.nix
@@ -32,7 +32,7 @@ python3.pkgs.buildPythonApplication {
       computer readable data, it is also often used as a format for hierarchical
       data that can be rendered into human readable formats. A traditional diff
       on such a format would tell you line by line the differences, but this
-      would not be be readable by a human. xmldiff provides tools to make human
+      would not be readable by a human. xmldiff provides tools to make human
       readable diffs in those situations.
     '';
     license = lib.licenses.mit;

--- a/pkgs/development/libraries/gdcm/default.nix
+++ b/pkgs/development/libraries/gdcm/default.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
     "TestFind"
     "gdcmscu-echo-dicomserver"
     "gdcmscu-find-dicomserver"
-    # seemingly ought to be be disabled when the test data submodule is not present:
+    # seemingly ought to be disabled when the test data submodule is not present:
     "TestvtkGDCMImageReader2_3"
     "TestSCUValidation"
     # errors because 3 classes not wrapped:

--- a/pkgs/development/tools/buildah/wrapper.nix
+++ b/pkgs/development/tools/buildah/wrapper.nix
@@ -32,7 +32,7 @@ let
   helpersBin = symlinkJoin {
     name = "${buildah-unwrapped.pname}-helper-binary-wrapper-${buildah-unwrapped.version}";
 
-    # this only works for some binaries, others may need to be be added to `binPath` or in the modules
+    # this only works for some binaries, others may need to be added to `binPath` or in the modules
     paths = [
     ] ++ lib.optionals stdenv.isLinux [
       aardvark-dns

--- a/pkgs/tools/security/gitleaks/default.nix
+++ b/pkgs/tools/security/gitleaks/default.nix
@@ -29,7 +29,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  # With v8 the config tests are are blocking
+  # With v8 the config tests are blocking
   doCheck = false;
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''


### PR DESCRIPTION
## Description of changes

 fix some comments

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
