### PR TITLE
python312Packages.opentelemetry-api: 1.25.0 -> 1.26.0; opentelemetry-instrumentation: 0.46b0 -> 0.47b0

### DIFF
--- a/pkgs/development/python-modules/opentelemetry-api/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-api/default.nix
@@ -15,7 +15,7 @@
 let
   self = buildPythonPackage rec {
     pname = "opentelemetry-api";
-    version = "1.25.0";
+    version = "1.26.0";
     pyproject = true;
 
     disabled = pythonOlder "3.8";
@@ -25,7 +25,7 @@ let
       owner = "open-telemetry";
       repo = "opentelemetry-python";
       rev = "refs/tags/v${version}";
-      hash = "sha256-9mxgPYliGkNsZGOhF9YCmxZjP3hc2UUmxSpWY4IMLCo=";
+      hash = "sha256-slb1ZKGnfJRZiBh++S20en7U6RckspHHuMohHOz2Hts=";
     };
 
     sourceRoot = "${src.name}/opentelemetry-api";

--- a/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-grpc/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-grpc/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage {
     pytestCheckHook
   ];
 
-  disabledTestPaths = [ "tests/performance/benchmarks/" ];
+  pytestFlagsArray = [ "tests" ];
 
   pythonImportsCheck = [ "opentelemetry.exporter.otlp.proto.grpc" ];
 

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-grpc/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-grpc/default.nix
@@ -6,7 +6,6 @@
   hatchling,
   opentelemetry-api,
   opentelemetry-instrumentation,
-  opentelemetry-sdk,
   opentelemetry-semantic-conventions,
   opentelemetry-test-utils,
   wrapt,
@@ -28,7 +27,6 @@ buildPythonPackage {
   dependencies = [
     opentelemetry-api
     opentelemetry-instrumentation
-    opentelemetry-sdk
     opentelemetry-semantic-conventions
     wrapt
   ];
@@ -55,5 +53,7 @@ buildPythonPackage {
   meta = opentelemetry-instrumentation.meta // {
     homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-grpc";
     description = "OpenTelemetry Instrumentation for grpc";
+    # https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2483
+    broken = lib.versionAtLeast grpcio.version "1.63";
   };
 }

--- a/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "opentelemetry-instrumentation";
-  version = "0.46b0";
+  version = "0.47b0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "open-telemetry";
     repo = "opentelemetry-python-contrib";
     rev = "refs/tags/v${version}";
-    hash = "sha256-BC/RJL4GgC3vGe4bC9mavPNpE+j8ZIkOKCbK4I4LuGQ=";
+    hash = "sha256-XtJ4u891vI7wDtReoucm+qk3BkKJ+aZrYy7zfxmqfgk=";
   };
 
   sourceRoot = "${src.name}/opentelemetry-instrumentation";


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/open-telemetry/opentelemetry-python/releases/tag/refs/tags/v1.26.0

Changelog: https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.47b0


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
