### PR TITLE
ext4fuse: init at 0.1.3

### DIFF
--- a/pkgs/by-name/ex/ext4fuse/package.nix
+++ b/pkgs/by-name/ex/ext4fuse/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fuse,
+  macfuse-stubs,
+  pkg-config,
+  which,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ext4fuse";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "gerard";
+    repo = "ext4fuse";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-bsFo+aaeNceSme9WBUVg4zpE4DzlmLHv+esQIAlTGGU=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    which
+  ];
+
+  buildInputs = [ (if stdenv.isDarwin then macfuse-stubs else fuse) ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm555 ext4fuse $out/bin/ext4fuse
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "EXT4 implementation for FUSE";
+    mainProgram = "ext4fuse";
+    homepage = "https://github.com/gerard/ext4fuse";
+    maintainers = with maintainers; [ felixalbrigtsen ];
+    platforms = platforms.unix;
+    license = licenses.gpl2Plus;
+  };
+})


### PR DESCRIPTION
## Description of changes

Adds ext4fuse, a utility that allows you to mount ext4 under FUSE, for example on macOS or FreeBSD without native ext4 support. Tested working under macOS 14.5 on aarch64, and tested that it builds on NixOS on x86_64.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>ext4fuse</li>
  </ul>
</details>

Result of `nixpkgs-review` run on aarch64-darwin [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>ext4fuse</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
