### PR TITLE
python312Packages.python-etcd: 0.4.5 -> 0.5.0-unstable-2023-10-31; dr…

### DIFF
--- a/pkgs/development/python-modules/python-etcd/default.nix
+++ b/pkgs/development/python-modules/python-etcd/default.nix
@@ -1,41 +1,48 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  nose,
-  mock,
-  pyopenssl,
+  fetchFromGitHub,
+  setuptools,
   urllib3,
   dnspython,
+  pytestCheckHook,
+  etcd_3_4,
+  mock,
+  pyopenssl,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "python-etcd";
-  version = "0.4.5";
-  format = "setuptools";
+  version = "0.5.0-unstable-2023-10-31";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "f1b5ebb825a3e8190494f5ce1509fde9069f2754838ed90402a8c11e1f52b8cb";
+  src = fetchFromGitHub {
+    owner = "jplana";
+    repo = "python-etcd";
+    rev = "5aea0fd4461bd05dd96e4ad637f6be7bceb1cee5";
+    hash = "sha256-eVirStLOPTbf860jfkNMWtGf+r0VygLZRjRDjBMCVKg=";
   };
 
-  buildInputs = [
-    nose
-    mock
-    pyopenssl
-  ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     urllib3
     dnspython
   ];
 
-  postPatch = ''
-    sed -i '19s/dns/"dnspython"/' setup.py
-  '';
+  nativeCheckInputs = [
+    pytestCheckHook
+    etcd_3_4
+    mock
+    pyopenssl
+  ];
 
-  # Some issues with etcd not in path even though most tests passed
-  doCheck = false;
+  preCheck = ''
+    for file in "test_auth" "integration/test_simple"; do
+      substituteInPlace src/etcd/tests/$file.py \
+        --replace-fail "assertEquals" "assertEqual"
+    done
+  '';
 
   meta = with lib; {
     description = "Python client for Etcd";


### PR DESCRIPTION
## Description of changes

- #326513

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
