### PR TITLE
wvdial, wvstreams: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1242,6 +1242,7 @@
   ./services/networking/websockify.nix
   ./services/networking/wg-access-server.nix
   ./services/networking/wg-netmanager.nix
+  ./services/networking/wvdial.nix
   ./services/networking/webhook.nix
   ./services/networking/wg-quick.nix
   ./services/networking/wgautomesh.nix

--- a/nixos/modules/services/networking/wvdial.nix
+++ b/nixos/modules/services/networking/wvdial.nix
@@ -1,0 +1,47 @@
+# Global configuration for wvdial.
+
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.environment.wvdial;
+in
+{
+  options = {
+    environment.wvdial = {
+      dialerDefaults = lib.mkOption {
+        default = "";
+        type = lib.types.str;
+        example = ''Init1 = AT+CGDCONT=1,"IP","internet.t-mobile"'';
+        description = ''
+          Contents of the "Dialer Defaults" section of
+          <filename>/etc/wvdial.conf</filename>.
+        '';
+      };
+      pppDefaults = lib.mkOption {
+        default = ''
+          noipdefault
+          usepeerdns
+          defaultroute
+          persist
+          noauth
+        '';
+        type = lib.types.str;
+        description = "Default ppp settings for wvdial.";
+      };
+    };
+  };
+
+  config = lib.mkIf (cfg.dialerDefaults != "") {
+    environment.etc."wvdial.conf".source = pkgs.writeText "wvdial.conf" ''
+      [Dialer Defaults]
+      PPPD PATH = ${pkgs.ppp}/sbin/pppd
+      ${config.environment.wvdial.dialerDefaults}
+    '';
+    environment.etc."ppp/peers/wvdial".source = pkgs.writeText "wvdial" cfg.pppDefaults;
+  };
+}

--- a/pkgs/by-name/wv/wvdial/package.nix
+++ b/pkgs/by-name/wv/wvdial/package.nix
@@ -1,0 +1,44 @@
+{
+  stdenv,
+  fetchFromGitea,
+  fetchpatch,
+  wvstreams,
+  pkg-config,
+  lib,
+}:
+
+stdenv.mkDerivation {
+  pname = "wvdial";
+  version = "unstable-2016-06-15";
+
+  src = fetchFromGitea {
+    domain = "gitea.osmocom.org";
+    owner = "retronetworking";
+    repo = "wvdial";
+    rev = "42d084173cc939586c1963b8835cb00ec56b2823";
+    hash = "sha256-q7pFvpJvv+ZvbN4xxolI9ZRULr+N5sqO9BOXUqSG5v4=";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://git.openembedded.org/meta-openembedded/plain/meta-oe/recipes-connectivity/wvdial/wvdial/typo_pon.wvdial.1.patch?h=73a68490efe05cdbec540ec6f17782816632a24d";
+      hash = "sha256-fsneoB5GeKH/nxwW0z8Mk6892PtnZ3J77wP4BGo3Tj8=";
+    })
+  ];
+
+  buildInputs = [ wvstreams ];
+  nativeBuildInputs = [ pkg-config ];
+
+  makeFlags = [
+    "prefix=${placeholder "out"}"
+    "PPPDIR=${placeholder "out"}/etc/ppp/peers"
+  ];
+
+  meta = {
+    description = "A dialer that automatically recognises the modem";
+    homepage = "https://gitea.osmocom.org/retronetworking/wvdial";
+    license = lib.licenses.lgpl2;
+    maintainers = with lib.maintainers; [ flokli ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/wv/wvstreams/package.nix
+++ b/pkgs/by-name/wv/wvstreams/package.nix
@@ -1,0 +1,110 @@
+{
+  stdenv,
+  fetchpatch,
+  fetchurl,
+  dbus,
+  zlib,
+  openssl,
+  readline,
+  lib,
+  perl,
+}:
+
+stdenv.mkDerivation {
+  pname = "wvstreams";
+  version = "4.6.1";
+
+  # See https://layers.openembedded.org/layerindex/recipe/190863/
+  src = fetchurl {
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/wvstreams/wvstreams-4.6.1.tar.gz";
+    hash = "sha256-hAP1+/g6qawMbOFdl/2FYHSIFSqoTgB7fQYhuOvAdjM=";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://cgit.openembedded.org/meta-openembedded/plain/meta-oe/recipes-connectivity/wvdial/wvstreams/04_signed_request.diff?id=0e6c34f82ca4d43cbca3754c5fe37c5b3bdd0f37";
+      hash = "sha256-zlPiME+KYjesmKt3a+JoE087qE1MbnlVPjC75qQoIks=";
+    })
+    (fetchpatch {
+      url = "https://cgit.openembedded.org/meta-openembedded/plain/meta-oe/recipes-connectivity/wvdial/wvstreams/05_gcc.diff?id=0e6c34f82ca4d43cbca3754c5fe37c5b3bdd0f37";
+      hash = "sha256-Twqk0J8E05kAvhHjAoAuYEpS445t3mb/BvuxTmaaGoM=";
+    })
+    (fetchpatch {
+      url = "https://cgit.openembedded.org/meta-openembedded/plain/meta-oe/recipes-connectivity/wvdial/wvstreams/06_gcc-4.7.diff?id=0e6c34f82ca4d43cbca3754c5fe37c5b3bdd0f37";
+      hash = "sha256-JMPNUdfAJ/gq+am/F1DE2q3+35ItiLAve1+LLl8+Oe4=";
+    })
+    (fetchpatch {
+      url = "https://cgit.openembedded.org/meta-openembedded/plain/meta-oe/recipes-connectivity/wvdial/wvstreams/07_buildflags.diff?id=0e6c34f82ca4d43cbca3754c5fe37c5b3bdd0f37";
+      hash = "sha256-N3HmuBakD5VHoToOqU6EmTHlgFG6A7x84Gbf2P2u+s8=";
+    })
+    (fetchpatch {
+      url = "https://cgit.openembedded.org/meta-openembedded/plain/meta-oe/recipes-connectivity/wvdial/wvstreams/gcc-6.patch?id=0e6c34f82ca4d43cbca3754c5fe37c5b3bdd0f37";
+      hash = "sha256-fXhBUKaHD27mspwrKNY5G7F6UHqq/dmnPlf9cIvM7hM=";
+    })
+    (fetchpatch {
+      url = "https://cgit.openembedded.org/meta-openembedded/plain/meta-oe/recipes-connectivity/wvdial/wvstreams/argp.patch?id=0e6c34f82ca4d43cbca3754c5fe37c5b3bdd0f37";
+      hash = "sha256-55vWFfd/SDa9dE+GmSHDMU2kTrn+tNUW2clPknSdi7g=";
+    })
+    (fetchpatch {
+      url = "https://cgit.openembedded.org/meta-openembedded/plain/meta-oe/recipes-connectivity/wvdial/wvstreams/0001-Check-for-limits.h-during-configure.patch?id=0e6c34f82ca4d43cbca3754c5fe37c5b3bdd0f37";
+      hash = "sha256-XRJCZMnygcQie9sUc1iCe9HVE9lEFCed4JRDtd/C/84=";
+    })
+    (fetchpatch {
+      url = "https://cgit.openembedded.org/meta-openembedded/plain/meta-oe/recipes-connectivity/wvdial/wvstreams/0003-wvtask-Check-for-HAVE_LIBC_STACK_END-only-on-glibc-s.patch?id=0e6c34f82ca4d43cbca3754c5fe37c5b3bdd0f37";
+      hash = "sha256-v0WAFyWwQ70dpq1BEXQjkOrdUUk4tBFJVKeHffs4FmA=";
+    })
+    (fetchpatch {
+      url = "https://cgit.openembedded.org/meta-openembedded/plain/meta-oe/recipes-connectivity/wvdial/wvstreams/0004-wvcrash-Replace-use-of-basename-API.patch?id=0e6c34f82ca4d43cbca3754c5fe37c5b3bdd0f37";
+      hash = "sha256-1UZziDaE0BCM/YmYjBgFA2Q8zfnWpQcal08a0qcClmo=";
+    })
+    (fetchpatch {
+      url = "https://cgit.openembedded.org/meta-openembedded/plain/meta-oe/recipes-connectivity/wvdial/wvstreams/0005-check-for-libexecinfo-during-configure.patch?id=0e6c34f82ca4d43cbca3754c5fe37c5b3bdd0f37";
+      hash = "sha256-4Ad10pijea/qusrdCJAEjpc1/qfQNE32t/M2YMk5jNg=";
+    })
+    (fetchpatch {
+      url = "https://cgit.openembedded.org/meta-openembedded/plain/meta-oe/recipes-connectivity/wvdial/wvstreams/0001-build-fix-parallel-make.patch?id=0e6c34f82ca4d43cbca3754c5fe37c5b3bdd0f37";
+      hash = "sha256-zWREskvLoAH2sYn6kbemTC1V5KrF9jX0B0d+ASExQBA=";
+    })
+    (fetchpatch {
+      url = "https://cgit.openembedded.org/meta-openembedded/plain/meta-oe/recipes-connectivity/wvdial/wvstreams/0002-wvrules.mk-Use-_DEFAULT_SOURCE.patch?id=0e6c34f82ca4d43cbca3754c5fe37c5b3bdd0f37";
+      hash = "sha256-ACiuwqwg5nUbzqoJR5h9GENXmN3ELzkBjujZivBoM4g=";
+    })
+    (fetchpatch {
+      url = "https://cgit.openembedded.org/meta-openembedded/plain/meta-oe/recipes-connectivity/wvdial/wvstreams/openssl-buildfix.patch?id=0e6c34f82ca4d43cbca3754c5fe37c5b3bdd0f37";
+      hash = "sha256-pMHopuBEge7Llq1Syb8sZJArhUOWBNmcOvVcNtFgnbA=";
+    })
+    (fetchpatch {
+      url = "https://cgit.openembedded.org/meta-openembedded/plain/meta-oe/recipes-connectivity/wvdial/wvstreams/0001-Forward-port-to-OpenSSL-1.1.x.patch?id=0e6c34f82ca4d43cbca3754c5fe37c5b3bdd0f37";
+      hash = "sha256-R5pfYxefEvvxB1k+gZzRQgsbmkgpK9cBqZxCXHQnQlM=";
+    })
+    (fetchpatch {
+      url = "https://cgit.openembedded.org/meta-openembedded/plain/meta-oe/recipes-connectivity/wvdial/wvstreams/0001-Fix-narrowing-conversion-error.patch?id=0e6c34f82ca4d43cbca3754c5fe37c5b3bdd0f37";
+      hash = "sha256-esCD7jMVxD1sC2C4jx+pnnIWHpXAVGF/CGXvwHc9rhU=";
+    })
+  ];
+
+  outputs = [
+    "bin"
+    "dev"
+    "lib"
+    "out"
+  ];
+
+  enableParallelBuilding = true;
+
+  buildInputs = [
+    dbus
+    zlib
+    openssl
+    readline
+    perl
+  ];
+
+  meta = {
+    description = "Network programming library in C++";
+    homepage = "http://alumnit.ca/wiki/index.php?page=WvStreams";
+    license = lib.licenses.lgpl2;
+    maintainers = [ lib.maintainers.flokli ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes
This (re-)adds the wvdial package and wvstreams dependency.

They were initially removed as upstream was dead, and it could only build with an old openssl version.

However, there's a [patchset at openembedded](https://layers.openembedded.org/layerindex/recipe/190863/) that allows building it with a current set of libraries, and [Øl Telecom](https://bornhack.dk/bornhack-2023/villages/l-telecom-business-center/) also offered to maintain this over at [osmocom](https://gitea.osmocom.org/retronetworking/wvdial) in the future.

I successfully used `wvdialconf` to determine the modem parameters, and with this config:

```nix
  environment.wvdial = {
    dialerDefaults = ''
      Init2 = ATQ0 V1 E1 S0=0 &C1 &D2 +FCLASS=0
      Modem Type = Analog Modem
      ; Phone = <Target Phone Number>
      ISDN = 0
      ; Username = <Your Login Name>
      Init1 = ATZ
      ; Password = <Your Password>
      Modem = /dev/ttyUSB0
      Baud = 230400
    '';
  };
```

I was able to talk to the modem. Due to heavy rainfall, my ISP couldn't provide a cable connection in time, but I'm pretty convinced it'd work. I'd like to re-introduce this to nixpkgs, and actively maintain its packaging.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
