### PR TITLE
workflows/check-nixf-tidy.yml: temporarily ignore sema-escaping-with

### DIFF
--- a/.github/workflows/check-nixf-tidy.yml
+++ b/.github/workflows/check-nixf-tidy.yml
@@ -41,6 +41,16 @@ jobs:
         run: "nix-env -f '<nixpkgs>' -iAP nixf jq"
       - name: Check that Nix files pass nixf-tidy
         run: |
+          # Filtering error messages we don't like
+          nixf_wrapper(){
+            nixf-tidy --variable-lookup < "$1" | jq -r '
+              [
+                "sema-escaping-with"
+              ]
+              as $ignored_errors|[.[]|select(.sname as $s|$ignored_errors|index($s)|not)]
+            '
+          }
+
           failedFiles=()
 
           # Don't report errors to file overview
@@ -74,11 +84,11 @@ jobs:
                 continue
             esac
 
-            if [[ -n "$source" ]] && [[ "$(nixf-tidy --variable-lookup < ${{ env.base }}/"$source")" != '[]' ]] 2>/dev/null; then
+            if [[ -n "$source" ]] && [[ "$(nixf_wrapper ${{ env.base }}/"$source")" != '[]' ]] 2>/dev/null; then
               echo "Ignoring file $file because it doesn't pass nixf-tidy in the base commit"
               echo # insert blank line
             else
-              nixf_report="$(nixf-tidy --variable-lookup < "$dest")"
+              nixf_report="$(nixf_wrapper "$dest")"
               if [[ "$nixf_report" != '[]' ]]; then
                 echo "$dest doesn't pass nixf-tidy. Reported by nixf-tidy:"
                 errors=$(echo "$nixf_report" | jq -r --arg dest "$dest" '


### PR DESCRIPTION
## Description of changes

Looks like there are more than enough "escaping with" in our codebase, and we cannot conveniently avoid it sometimes. @inclyc also said this is not very appropriate, and may improve the diagnosis for `with` in future.

This is partly tested locally.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
