### PR TITLE
ananicy-cpp: make bpfSupport optional

### DIFF
--- a/pkgs/by-name/an/ananicy-cpp/package.nix
+++ b/pkgs/by-name/an/ananicy-cpp/package.nix
@@ -1,27 +1,28 @@
-{ lib
-, clangStdenv
-, fetchFromGitLab
-, fetchpatch
-, cmake
-, pkg-config
-, spdlog
-, nlohmann_json
-, systemd
-, libbpf
-, elfutils
-, bpftools
-, pcre2
-, zlib
+{
+  lib,
+  clangStdenv,
+  fetchFromGitLab,
+  fetchpatch,
+  cmake,
+  pkg-config,
+  spdlog,
+  nlohmann_json,
+  systemd,
+  libbpf,
+  elfutils,
+  bpftools,
+  pcre2,
+  zlib,
 }:
 
-clangStdenv.mkDerivation rec {
+clangStdenv.mkDerivation (finalAttrs: {
   pname = "ananicy-cpp";
   version = "1.1.1";
 
   src = fetchFromGitLab {
     owner = "ananicy-cpp";
     repo = "ananicy-cpp";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-oPinSc00+Z6SxjfTh7DttcXSjsLv1X0NI+O37C8M8GY=";
   };
@@ -55,17 +56,22 @@ clangStdenv.mkDerivation rec {
   ];
 
   # BPF A call to built-in function '__stack_chk_fail' is not supported.
-  hardeningDisable = [ "stackprotector" "zerocallusedregs" ];
+  hardeningDisable = [
+    "stackprotector"
+    "zerocallusedregs"
+  ];
 
   cmakeFlags = [
-    "-DUSE_EXTERNAL_JSON=ON"
-    "-DUSE_EXTERNAL_SPDLOG=ON"
-    "-DUSE_EXTERNAL_FMTLIB=ON"
-    "-DUSE_BPF_PROC_IMPL=ON"
-    "-DBPF_BUILD_LIBBPF=OFF"
-    "-DENABLE_SYSTEMD=ON"
-    "-DENABLE_REGEX_SUPPORT=ON"
-    "-DVERSION=${version}"
+    (lib.mapAttrsToList lib.cmakeBool {
+      "USE_EXTERNAL_JSON" = true;
+      "USE_EXTERNAL_SPDLOG" = true;
+      "USE_EXTERNAL_FMTLIB" = true;
+      "USE_BPF_PROC_IMPL" = true;
+      "BPF_BUILD_LIBBPF" = false;
+      "ENABLE_SYSTEMD" = true;
+      "ENABLE_REGEX_SUPPORT" = true;
+    })
+    (lib.cmakeFeature "VERSION" finalAttrs.version)
   ];
 
   postInstall = ''
@@ -85,4 +91,4 @@ clangStdenv.mkDerivation rec {
     ];
     mainProgram = "ananicy-cpp";
   };
-}
+})

--- a/pkgs/by-name/an/ananicy-cpp/package.nix
+++ b/pkgs/by-name/an/ananicy-cpp/package.nix
@@ -13,6 +13,7 @@
   bpftools,
   pcre2,
   zlib,
+  withBpf ? true,
 }:
 
 clangStdenv.mkDerivation (finalAttrs: {
@@ -42,6 +43,7 @@ clangStdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
+  ] ++ lib.optionals withBpf [
     bpftools
   ];
 
@@ -50,9 +52,10 @@ clangStdenv.mkDerivation (finalAttrs: {
     spdlog
     nlohmann_json
     systemd
+    zlib
+  ] ++ lib.optionals withBpf [
     libbpf
     elfutils
-    zlib
   ];
 
   # BPF A call to built-in function '__stack_chk_fail' is not supported.
@@ -66,7 +69,7 @@ clangStdenv.mkDerivation (finalAttrs: {
       "USE_EXTERNAL_JSON" = true;
       "USE_EXTERNAL_SPDLOG" = true;
       "USE_EXTERNAL_FMTLIB" = true;
-      "USE_BPF_PROC_IMPL" = true;
+      "USE_BPF_PROC_IMPL" = withBpf;
       "BPF_BUILD_LIBBPF" = false;
       "ENABLE_SYSTEMD" = true;
       "ENABLE_REGEX_SUPPORT" = true;


### PR DESCRIPTION
## Description of changes

ananicy-cpp compiled with bpfSupport does not work on hardened kernels
So we make it optional to allow users to disable it.

https://github.com/NixOS/nixpkgs/issues/327382

**_This is still enabled by default._**

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
