### PR TITLE
nixos/direnv: Add myself as maintainer, format, add enable{Bash.Fish.Zsh}Integration options

### DIFF
--- a/nixos/modules/programs/direnv.nix
+++ b/nixos/modules/programs/direnv.nix
@@ -3,9 +3,11 @@
   config,
   pkgs,
   ...
-}: let
+}:
+let
   cfg = config.programs.direnv;
-in {
+in
+{
   options.programs.direnv = {
 
     enable = lib.mkEnableOption ''
@@ -14,7 +16,7 @@ in {
       integration. Note that you need to logout and login for this change to apply
     '';
 
-    package = lib.mkPackageOption pkgs "direnv" {};
+    package = lib.mkPackageOption pkgs "direnv" { };
 
     direnvrcExtra = lib.mkOption {
       type = lib.types.lines;
@@ -61,7 +63,11 @@ in {
   };
 
   imports = [
-    (lib.mkRemovedOptionModule ["programs" "direnv" "persistDerivations"] "persistDerivations was removed as it is no longer necessary")
+    (lib.mkRemovedOptionModule [
+      "programs"
+      "direnv"
+      "persistDerivations"
+    ] "persistDerivations was removed as it is no longer necessary")
   ];
 
   config = lib.mkIf cfg.enable {
@@ -91,17 +97,19 @@ in {
 
     environment = {
       systemPackages =
-        if cfg.loadInNixShell then [cfg.package]
-        else [
-          #direnv has a fish library which sources direnv for some reason
-          (cfg.package.overrideAttrs (old: {
-            installPhase =
-              (old.installPhase or "")
-              + ''
-                rm -rf $out/share/fish
-              '';
-          }))
-        ];
+        if cfg.loadInNixShell then
+          [ cfg.package ]
+        else
+          [
+            #direnv has a fish library which sources direnv for some reason
+            (cfg.package.overrideAttrs (old: {
+              installPhase =
+                (old.installPhase or "")
+                + ''
+                  rm -rf $out/share/fish
+                '';
+            }))
+          ];
 
       variables = {
         DIRENV_CONFIG = "/etc/direnv";

--- a/nixos/modules/programs/direnv.nix
+++ b/nixos/modules/programs/direnv.nix
@@ -6,6 +6,13 @@
 }:
 let
   cfg = config.programs.direnv;
+  enabledOption =
+    x:
+    lib.mkEnableOption x
+    // {
+      default = true;
+      example = false;
+    };
 in
 {
   options.programs.direnv = {
@@ -17,6 +24,16 @@ in
     '';
 
     package = lib.mkPackageOption pkgs "direnv" { };
+
+    enableBashIntegration = enabledOption ''
+      Bash integration
+    '';
+    enableZshIntegration = enabledOption ''
+      Zsh integration
+    '';
+    enableFishIntegration = enabledOption ''
+      Fish integration
+    '';
 
     direnvrcExtra = lib.mkOption {
       type = lib.types.lines;
@@ -34,22 +51,14 @@ in
       the hiding of direnv logging
     '';
 
-    loadInNixShell =
-      lib.mkEnableOption ''
-        loading direnv in `nix-shell` `nix shell` or `nix develop`
-      ''
-      // {
-        default = true;
-      };
+    loadInNixShell = enabledOption ''
+      loading direnv in `nix-shell` `nix shell` or `nix develop`
+    '';
 
     nix-direnv = {
-      enable =
-        (lib.mkEnableOption ''
-          a faster, persistent implementation of use_nix and use_flake, to replace the built-in one
-        '')
-        // {
-          default = true;
-        };
+      enable = enabledOption ''
+        a faster, persistent implementation of use_nix and use_flake, to replace the builtin one
+      '';
 
       package = lib.mkOption {
         default = pkgs.nix-direnv.override { nix = config.nix.package; };
@@ -65,7 +74,7 @@ in
   config = lib.mkIf cfg.enable {
 
     programs = {
-      zsh.interactiveShellInit = ''
+      zsh.interactiveShellInit = lib.mkIf cfg.enableZshIntegration ''
         if ${lib.boolToString cfg.loadInNixShell} || printenv PATH | grep -vqc '/nix/store'; then
          eval "$(${lib.getExe cfg.package} hook zsh)"
         fi
@@ -73,13 +82,13 @@ in
 
       #$NIX_GCROOT for "nix develop" https://github.com/NixOS/nix/blob/6db66ebfc55769edd0c6bc70fcbd76246d4d26e0/src/nix/develop.cc#L530
       #$IN_NIX_SHELL for "nix-shell"
-      bash.interactiveShellInit = ''
+      bash.interactiveShellInit = lib.mkIf cfg.enableBashIntegration ''
         if ${lib.boolToString cfg.loadInNixShell} || [ -z "$IN_NIX_SHELL$NIX_GCROOT$(printenv PATH | grep '/nix/store')" ] ; then
          eval "$(${lib.getExe cfg.package} hook bash)"
         fi
       '';
 
-      fish.interactiveShellInit = ''
+      fish.interactiveShellInit = lib.mkIf cfg.enableFishIntegration ''
         if ${lib.boolToString cfg.loadInNixShell};
         or printenv PATH | grep -vqc '/nix/store';
          ${lib.getExe cfg.package} hook fish | source
@@ -88,20 +97,17 @@ in
     };
 
     environment = {
-      systemPackages =
-        if cfg.loadInNixShell then
-          [ cfg.package ]
-        else
-          [
-            #direnv has a fish library which sources direnv for some reason
-            (pkgs.symlinkJoin {
-              inherit (cfg.package) name;
-              paths = [ cfg.package ];
-              postBuild = ''
-                rm -rf $out/share/fish
-              '';
-            })
-          ];
+      systemPackages = [
+        # direnv has a fish library which automatically sources direnv for some reason
+        # I don't see any harm in doing this if we're sourcing it with fish.interactiveShellInit
+        (pkgs.symlinkJoin {
+          inherit (cfg.package) name;
+          paths = [ cfg.package ];
+          postBuild = ''
+            rm -rf $out/share/fish
+          '';
+        })
+      ];
 
       variables = {
         DIRENV_CONFIG = "/etc/direnv";

--- a/nixos/modules/programs/direnv.nix
+++ b/nixos/modules/programs/direnv.nix
@@ -62,14 +62,6 @@ in
     };
   };
 
-  imports = [
-    (lib.mkRemovedOptionModule [
-      "programs"
-      "direnv"
-      "persistDerivations"
-    ] "persistDerivations was removed as it is no longer necessary")
-  ];
-
   config = lib.mkIf cfg.enable {
 
     programs = {

--- a/nixos/modules/programs/direnv.nix
+++ b/nixos/modules/programs/direnv.nix
@@ -102,13 +102,13 @@ in
         else
           [
             #direnv has a fish library which sources direnv for some reason
-            (cfg.package.overrideAttrs (old: {
-              installPhase =
-                (old.installPhase or "")
-                + ''
-                  rm -rf $out/share/fish
-                '';
-            }))
+            (pkgs.symlinkJoin {
+              inherit (cfg.package) name;
+              paths = [ cfg.package ];
+              postBuild = ''
+                rm -rf $out/share/fish
+              '';
+            })
           ];
 
       variables = {

--- a/nixos/modules/programs/direnv.nix
+++ b/nixos/modules/programs/direnv.nix
@@ -149,4 +149,5 @@ in
       };
     };
   };
+  meta.maintainers = with lib.maintainers; [ gerg-l ];
 }


### PR DESCRIPTION
## Description of changes
I initially wrote this module and there was a few thing bugging me with it

- added enable{Bash.Fish.Zsh}Integration options to allow specific disabling of sourcing the hooks

- added myself as a maintainer

- formatted with nixfmt

- use shorthand function for creating enabled by default options

- remove  mkRemovedOptionModule for `programs.direnv.persistDerivations`

- use symlinkJoin to avoid direnv rebuild

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
