### PR TITLE
libreoffice-collabora: fix Hydra failure by splitting src derivation

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -200,9 +200,8 @@ let
       }) // {
         inherit (x) md5name md5;
       }) srcsAttributes.deps;
-  } // optionalAttrs (variant != "collabora") {
-    translations = fetchurl srcsAttributes.translations;
-    help = fetchurl srcsAttributes.help;
+    translations = srcsAttributes.translations { inherit fetchurl fetchgit; };
+    help = srcsAttributes.help { inherit fetchurl fetchgit; };
   };
 
   qtMajor = lib.versions.major qtbase.version;
@@ -235,14 +234,17 @@ in stdenv.mkDerivation (finalAttrs: {
       ln -sfv ${f} $sourceRoot/${tarballPath}/${f.md5name}
       ln -sfv ${f} $sourceRoot/${tarballPath}/${f.name}
     '')}
-  '' + optionalString (variant != "collabora") ''
 
+  '' + (if (variant != "collabora") then ''
     ln -sv ${srcs.help} $sourceRoot/${tarballPath}/${srcs.help.name}
     ln -svf ${srcs.translations} $sourceRoot/${tarballPath}/${srcs.translations.name}
 
     tar -xf ${srcs.help}
     tar -xf ${srcs.translations}
-  '';
+  '' else ''
+    cp -r --no-preserve=mode ${srcs.help}/. $sourceRoot/helpcontent2/
+    cp -r --no-preserve=mode ${srcs.translations}/. $sourceRoot/translations/
+  '');
 
   patches = [
     # Skip some broken tests:

--- a/pkgs/applications/office/libreoffice/src-collabora/help.nix
+++ b/pkgs/applications/office/libreoffice/src-collabora/help.nix
@@ -1,0 +1,6 @@
+{ fetchgit, ... }:
+fetchgit {
+  url = "https://gerrit.libreoffice.org/help";
+  rev = "27f62cdb52fe23f6090a3249fcd1433777b2598d";
+  hash = "sha256-lyBuj7FI1jwVLLBkB6JJcmQVtm1FKExYWvRUoGqRbJ0=";
+}

--- a/pkgs/applications/office/libreoffice/src-collabora/main.nix
+++ b/pkgs/applications/office/libreoffice/src-collabora/main.nix
@@ -2,6 +2,6 @@
 fetchgit {
   url = "https://gerrit.libreoffice.org/core";
   rev = "refs/tags/cp-24.04.5-4";
-  hash = "sha256-27uLK1u8XWNigxZUCUu8nNZP3p5eFUsS2gCcfSYJK2k=";
-  fetchSubmodules = true;
+  hash = "sha256-OJ3R8qs8/R8QnXGCRgn/ZJK7Nn8cWwYbZxjEWg0VpBc=";
+  fetchSubmodules = false;
 }

--- a/pkgs/applications/office/libreoffice/src-collabora/translations.nix
+++ b/pkgs/applications/office/libreoffice/src-collabora/translations.nix
@@ -1,0 +1,6 @@
+{ fetchgit, ... }:
+fetchgit {
+  url = "https://gerrit.libreoffice.org/translations";
+  rev = "5fd34a953e6861cb8e392363c0a3500059ed6b01";
+  hash = "sha256-1j0kTvPbytsCWszXz+xFE+n53zPkR8gNgVaawn+rjfI=";
+}

--- a/pkgs/applications/office/libreoffice/src-fresh/help.nix
+++ b/pkgs/applications/office/libreoffice/src-fresh/help.nix
@@ -1,4 +1,5 @@
-{
+{ fetchurl, ... }:
+fetchurl {
   sha256 = "090pi8dnj5izpvng94hgmjid14n7xvy3rlqqvang3pqdn35xnpsl";
   url = "https://download.documentfoundation.org/libreoffice/src/24.2.5/libreoffice-help-24.2.5.2.tar.xz";
 }

--- a/pkgs/applications/office/libreoffice/src-fresh/translations.nix
+++ b/pkgs/applications/office/libreoffice/src-fresh/translations.nix
@@ -1,4 +1,5 @@
-{
+{ fetchurl, ... }:
+fetchurl {
   sha256 = "0fri41y59zhm8lq0kh6hvf5rpdjdqx0lg1sl40mhh1d6lf1izc1w";
   url = "https://download.documentfoundation.org/libreoffice/src/24.2.5/libreoffice-translations-24.2.5.2.tar.xz";
 }

--- a/pkgs/applications/office/libreoffice/src-still/help.nix
+++ b/pkgs/applications/office/libreoffice/src-still/help.nix
@@ -1,4 +1,5 @@
-{
+{ fetchurl, ... }:
+fetchurl {
   sha256 = "1l543k603mbr3rnwlnv9j52mblmvkgj9y49w4v7w3xm8b15331rs";
   url = "https://download.documentfoundation.org/libreoffice/src/7.6.7/libreoffice-help-7.6.7.2.tar.xz";
 }

--- a/pkgs/applications/office/libreoffice/src-still/translations.nix
+++ b/pkgs/applications/office/libreoffice/src-still/translations.nix
@@ -1,4 +1,5 @@
-{
+{ fetchurl, ... }:
+fetchurl {
   sha256 = "1bzmpa04bv8afhl3p68dlicamh0zyckmbdgqb3v72fjmx2h8i64a";
   url = "https://download.documentfoundation.org/libreoffice/src/7.6.7/libreoffice-translations-7.6.7.2.tar.xz";
 }


### PR DESCRIPTION
## Description of changes

The [Hydra build of the `libreoffice-collabora`][1] derivation introduced in #329525 fails with the status "Output limit exceeded", particularly at fetchgit of its sources.  Indeed, the full checkout of the git repo along with its submodules takes 4.2 GB which is past the [3.4 GB Hydra's `max_output_size`][2].  Unfortunately, the Collabora branch lacks the tarball releases like the upstream fresh/still variants, so we still have to fetch these submodules.  This PR gives up on the usage of `fetchSubmodules` and instead fetches the submodules using separate `fetchgit` calls.  This makes the structure of the nix expression for the collabora variant closer to the fresh/still variants than the initial version of the collabora variant.

TLDR: replace one huge `fetchgit { fetchSubmodules = true; }` with three smaller `fetchgit` to slip under Hydra limits.

[1]: https://hydra.nixos.org/build/267358376
[2]: https://github.com/NixOS/infra/blob/4b5dd4f974d3f707b64ad60793b8182e645631ed/build/hydra.nix#L51

cc: @7c6f434c

### Checklist

The size of each source and output derivations is less than 3.4 GB.
```console
$ du -sh $(nix-build --no-out-link . -A libreoffice-collabora.src -A libreoffice-collabora.srcs -A libreoffice-collabora)     
1,4G	/nix/store/143dvkjjrq0xl0bl144bzpvjid6c8kxp-core
276M	/nix/store/srg5k7i5qrclih88p5bf26qv9f8i3nrz-help-27f62cd
1,8G	/nix/store/ah72333hkawhmnfwhq1yv3b3nicl0k9j-translations-5fd34a9
1,3G	/nix/store/7vi3x03hbrc967d01yngikw75b5jl85x-libreoffice-24.04.5-4
```

All variants' `.passthru` attributes evaluate without an error. https://github.com/NixOS/nixpkgs/pull/329525#issuecomment-2249505863
```console
$ nix-instantiate --eval --json -E 'with import ./. {}; builtins.stringLength (builtins.toJSON [libreoffice-fresh.unwrapped.passthru libreoffice-still.unwrapped.passthru libreoffice-collabora.passthru])'
32387
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
