### PR TITLE
rmpc: init at 0.2.1

### DIFF
--- a/pkgs/by-name/rm/rmpc/Cargo.lock.patch
+++ b/pkgs/by-name/rm/rmpc/Cargo.lock.patch
@@ -1,0 +1,28 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index e4e2d1a..72839b4 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -198,9 +198,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "bitstream-io"
+-version = "2.5.0"
++version = "2.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3dcde5f311c85b8ca30c2e4198d4326bc342c76541590106f5fa4a50946ea499"
++checksum = "7c12d1856e42f0d817a835fe55853957c85c8c8a470114029143d3f12671446e"
+ 
+ [[package]]
+ name = "built"
+@@ -1376,9 +1376,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "ravif"
+-version = "0.11.8"
++version = "0.11.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c6ba61c28ba24c0cf8406e025cb29a742637e3f70776e61c27a8a8b72a042d12"
++checksum = "bc13288f5ab39e6d7c9d501759712e6969fcc9734220846fc9ed26cae2cc4234"
+ dependencies = [
+  "avif-serialize",
+  "imgref",

--- a/pkgs/by-name/rm/rmpc/package.nix
+++ b/pkgs/by-name/rm/rmpc/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchpatch,
+  pkg-config,
+  cmake,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rmpc";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "mierak";
+    repo = "rmpc";
+    rev = "v${version}";
+    hash = "sha256-g+yzW0DfaBhJKTikYZ8eqe4pX8nJvbpJ1xaZ3W/O/bo=";
+  };
+
+  cargoHash = "sha256-wFrHgB4wYGeXvfdGf4SJAAL8fE6dAKDLL51Ohmn+1HQ=";
+
+  cargoPatches = [
+    # Patch Cargo.lock to make rmpc compile with older versions of rustc
+    # Remove when Rust 1.79.0 is in master
+    ./Cargo.lock.patch
+  ];
+
+  patches = [
+    # Fix release mode tests compilation issues
+    # Remove when next rmpc version comes out
+    (fetchpatch {
+      url = "https://github.com/mierak/rmpc/commit/f12be6f606f5319523f41576e7c463b6008b9069.patch";
+      hash = "sha256-4L/MrdC/ydTqnkt3qd5H8hLZimiqct6sOkEq8rJN0F4=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+  ];
+
+  meta = {
+    changelog = "https://github.com/mierak/rmpc/releases/tag/${src.rev}";
+    description = "TUI music player client for MPD with album art support via kitty image protocol";
+    homepage = "https://mierak.github.io/rmpc/";
+    license = lib.licenses.bsd3;
+    longDescription = ''
+      Rusty Music Player Client is a beautiful, modern and configurable terminal-based Music Player
+      Daemon client. It was inspired by ncmpcpp and aims to provide an alternative with support for
+      album art through kitty image protocol without any ugly hacks. It also features ranger/lf
+      inspired browsing of songs and other goodies.
+    '';
+    maintainers = with lib.maintainers; [ donovanglover ];
+    mainProgram = "rmpc";
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds [Rusty Music Player Client](https://mierak.github.io/rmpc/), a TUI music player client for mpd with album art support.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
