### PR TITLE
ghc: bootstrap 9.8 from bindist again on Darwin

### DIFF
--- a/pkgs/development/compilers/ghc/9.6.3-binary.nix
+++ b/pkgs/development/compilers/ghc/9.6.3-binary.nix
@@ -409,8 +409,5 @@ stdenv.mkDerivation rec {
     # `pkgsMusl`.
     platforms = builtins.attrNames ghcBinDists.${distSetName};
     maintainers = lib.teams.haskell.members;
-    # packages involving hsc2hs (clock) produce libraries our
-    # ld can't link against
-    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/development/compilers/ghc/9.6.3-binary.nix
+++ b/pkgs/development/compilers/ghc/9.6.3-binary.nix
@@ -282,6 +282,12 @@ stdenv.mkDerivation rec {
       isScript "$i" || continue
       sed -i -e '2i export PATH="${lib.makeBinPath runtimeDeps}:$PATH"' "$i"
     done
+  '' + lib.optionalString stdenv.targetPlatform.isDarwin ''
+    # Work around building with binary GHC on Darwin due to GHC’s use of `ar -L` when it
+    # detects `llvm-ar` even though the resulting archives are not supported by ld64.
+    # https://gitlab.haskell.org/ghc/ghc/-/issues/23188
+    # https://github.com/haskell/cabal/issues/8882
+    sed -i -e 's/,("ar supports -L", "YES")/,("ar supports -L", "NO")/' "$out/lib/ghc-${version}/lib/settings"
   '';
 
   # Apparently necessary for the ghc Alpine (musl) bindist:

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -342,13 +342,6 @@ in {
           packages.ghc963
         else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
           packages.ghc963
-        else if stdenv.hostPlatform.isDarwin then
-          # it seems like the GHC 9.6.* bindists are built with a different
-          # toolchain than we are using (which I'm guessing from the fact
-          # that 9.6.4 bindists pass linker flags our ld doesn't support).
-          # With both 9.6.3 and 9.6.4 binary it is impossible to link against
-          # the clock package (probably a hsc2hs problem).
-          packages.ghc963
         else
           packages.ghc963Binary;
       inherit (buildPackages.python3Packages) sphinx;
@@ -366,13 +359,6 @@ in {
         if stdenv.hostPlatform.isAarch32 then
           packages.ghc963
         else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
-          packages.ghc963
-        else if stdenv.hostPlatform.isDarwin then
-          # it seems like the GHC 9.6.* bindists are built with a different
-          # toolchain than we are using (which I'm guessing from the fact
-          # that 9.6.4 bindists pass linker flags our ld doesn't support).
-          # With both 9.6.3 and 9.6.4 binary it is impossible to link against
-          # the clock package (probably a hsc2hs problem).
           packages.ghc963
         else
           packages.ghc963Binary;
@@ -418,13 +404,6 @@ in {
         if stdenv.hostPlatform.isAarch32 then
           packages.ghc963
         else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
-          packages.ghc963
-        else if stdenv.hostPlatform.isDarwin then
-          # it seems like the GHC 9.6.* bindists are built with a different
-          # toolchain than we are using (which I'm guessing from the fact
-          # that 9.6.4 bindists pass linker flags our ld doesn't support).
-          # With both 9.6.3 and 9.6.4 binary it is impossible to link against
-          # the clock package (probably a hsc2hs problem).
           packages.ghc963
         else
           packages.ghc963Binary;


### PR DESCRIPTION
## Description of changes

Split off from https://github.com/NixOS/nixpkgs/pull/330559. Targeting staging-next because the required version of ld64 is currently only on staging-next.

The issue was `ar -L` again. When I tried building GHC 9.8 without the fix, the build failed at Shake, but the error was different on staging-next with ld64 951.9.

```
ld: warning: ignoring file /nix/store/gr6f3icxkn8mpk3rdn0gi1qgk1ynk9kk-clock-0.8.4/lib/ghc-9.6.3/lib/aarch64-osx-ghc-9.6.3/clock-0.8.4-Bnns7LmnhG01nLONJf4lGG/libHSclock-0.8.4-Bnns7LmnhG01nLONJf4lGG.a, building for macOS-arm64 but attempting to link with file built for macOS-arm64
ld: in /nix/store/43r6s5nzb96445yy89366qh3y3jiy8ci-hashable-1.4.4.0/lib/ghc-9.6.3/lib/aarch64-osx-ghc-9.6.3/hashable-1.4.4.0-Ayk07ZB4soWJifMLtnGP0H/libHShashable-1.4.4.0-Ayk07ZB4soWJifMLtnGP0H.a(LowLevel.o), archive member 'LowLevel.o' with length 9024 is not mach-o or llvm bitcode file '/nix/store/43r6s5nzb96445yy89366qh3y3jiy8ci-hashable-1.4.4.0/lib/ghc-9.6.3/lib/aarch64-osx-ghc-9.6.3/hashable-1.4.4.0-Ayk07ZB4soWJifMLtnGP0H/libHShashable-1.4.4.0-Ayk07ZB4soWJifMLtnGP0H.a' for architecture arm64
```

After extracting the object from the file and inspecting it, I found that `LowLevel.o` was another archive. Static archives inside static archives are not supported by ld64. Fortunately, it’s possible to override GHC’s settings to suppress using `ar -L`, which allowed me to switch the bootstrap back to the bindist.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
