### PR TITLE
gdmd: init at 0.1.0-unstable-2024-05-30

### DIFF
--- a/pkgs/by-name/gd/gdmd/0001-gdc-store-path.diff
+++ b/pkgs/by-name/gd/gdmd/0001-gdc-store-path.diff
@@ -1,0 +1,11 @@
+--- a/dmd-script
++++ b/dmd-script
+@@ -72,7 +72,7 @@ my @run_args;
+ # for the target prefix.
+ basename($0) =~ m/^(.*-)?g?dmd(-.*)?$/;
+ my $target_prefix = $1?$1:"";
+-my $gdc_dir = abs_path(dirname($0));
++my $gdc_dir = "@gdc_dir@";
+ my $gdc = File::Spec->catfile( $gdc_dir, $target_prefix . "gdc" . ($2?$2:""));
+ 
+ sub osHasEXE() {

--- a/pkgs/by-name/gd/gdmd/package.nix
+++ b/pkgs/by-name/gd/gdmd/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  substituteAll,
+  gdc,
+  perl,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "gdmd";
+  version = "0.1.0-unstable-2024-05-30";
+
+  src = fetchFromGitHub {
+    owner = "D-Programming-GDC";
+    repo = "gdmd";
+    rev = "dc0ad9f739795f3ce5c69825efcd5d1d586bb013";
+    hash = "sha256-Sw8ExEPDvGqGKcM9VKnOI6MGgXW0tAu51A90Wi4qrRE=";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./0001-gdc-store-path.diff;
+      gdc_dir = "${gdc}/bin";
+    })
+  ];
+
+  buildInputs = [
+    gdc
+    perl
+  ];
+
+  installFlags = [
+    "DESTDIR=$(out)"
+    "prefix="
+  ];
+
+  preInstall = ''
+    install -d $out/bin $out/share/man/man1
+  '';
+
+  meta = {
+    description = "Wrapper for GDC that emulates DMD's command line";
+    homepage = "https://gdcproject.org";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ jtbx ];
+    mainProgram = "gdmd";
+  };
+}


### PR DESCRIPTION
## Description of changes

Cherry pick of a commit previously part of #324982

gdmd is a wrapper script used with the GDC compiler part of nixpkgs. Usually it is bundled as part of the GDC distribution, but this cannot be done since its source is not in the GCC tree.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
