### PR TITLE
flashrom: 1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/tools/misc/flashrom/0001-sb600spi.c-Drop-Promontory-support.patch
+++ b/pkgs/tools/misc/flashrom/0001-sb600spi.c-Drop-Promontory-support.patch
@@ -1,0 +1,103 @@
+From 38b2cb092e866dede6b6ffddd135ff54a9bda69e Mon Sep 17 00:00:00 2001
+From: Angel Pons <th3fanbus@gmail.com>
+Date: Wed, 2 Nov 2022 22:45:52 +0100
+Subject: [PATCH] sb600spi.c: Drop "Promontory" support
+
+The "Promontory" code is riddled with issues, some of them can result in
+soft bricks. Moreover, Promontory doesn't have a SPI controller.
+
+Drop support for "Promontory" in flashrom for now: it's holding back the
+entire project and it's unlikely that it'll be fixed in a timely manner.
+
+Change-Id: I1457946dce68321b496d9ffa40a0c5ab46455f72
+Signed-off-by: Angel Pons <th3fanbus@gmail.com>
+Reviewed-on: https://review.coreboot.org/c/flashrom/+/68824
+Tested-by: build bot (Jenkins) <no-reply@coreboot.org>
+Reviewed-by: Felix Singer <felixsinger@posteo.net>
+Reviewed-by: Swift Geek (Sebastian Grzywna) <swiftgeek@gmail.com>
+Reviewed-by: Edward O'Callaghan <quasisec@chromium.org>
+(cherry picked from commit 664c58f32af45b2acf7520c05bb40ef2c2f0891e)
+---
+ sb600spi.c | 31 ++-----------------------------
+ 1 file changed, 2 insertions(+), 29 deletions(-)
+
+diff --git a/sb600spi.c b/sb600spi.c
+index cec7e0a5..e84bb8d6 100644
+--- a/sb600spi.c
++++ b/sb600spi.c
+@@ -48,7 +48,6 @@ enum amd_chipset {
+ 	CHIPSET_HUDSON234,
+ 	CHIPSET_BOLTON,
+ 	CHIPSET_YANGTZE,
+-	CHIPSET_PROMONTORY,
+ };
+ 
+ #define FIFO_SIZE_OLD		8
+@@ -135,7 +134,8 @@ static enum amd_chipset determine_generation(struct pci_dev *dev)
+ 		 */
+ 		} else if (rev == 0x4b || rev == 0x51 || rev == 0x59 || rev == 0x61 || rev == 0x71) {
+ 			msg_pdbg("Promontory (rev 0x%02x) detected.\n", rev);
+-			return CHIPSET_PROMONTORY;
++			msg_perr("AMD \"Promontory\" chipsets are currently not supported (https://ticket.coreboot.org/issues/370)");
++			return CHIPSET_AMD_UNKNOWN;
+ 		} else {
+ 			msg_pwarn("FCH device found but SMBus revision 0x%02x does not match known values.\n"
+ 				  "Please report this to flashrom@flashrom.org and include this log and\n"
+@@ -572,18 +572,6 @@ static int handle_imc(const struct programmer_cfg *cfg, struct pci_dev *dev, enu
+ 	return amd_imc_shutdown(dev);
+ }
+ 
+-static int promontory_read_memmapped(struct flashctx *flash, uint8_t *buf,
+-		unsigned int start, unsigned int len)
+-{
+-	struct sb600spi_data * data = (struct sb600spi_data *)flash->mst->spi.data;
+-	if (!data->flash) {
+-		map_flash(flash);
+-		data->flash = flash; /* keep a copy of flashctx for unmap() on tear-down. */
+-	}
+-	mmio_readn((void *)(flash->virtual_memory + start), buf, len);
+-	return 0;
+-}
+-
+ static int sb600spi_shutdown(void *data)
+ {
+ 	struct sb600spi_data *sb600_data = data;
+@@ -617,17 +605,6 @@ static const struct spi_master spi_master_yangtze = {
+ 	.shutdown	= sb600spi_shutdown,
+ };
+ 
+-static const struct spi_master spi_master_promontory = {
+-	.max_data_read	= MAX_DATA_READ_UNLIMITED,
+-	.max_data_write	= FIFO_SIZE_YANGTZE - 3,
+-	.command	= spi100_spi_send_command,
+-	.map_flash_region	= physmap,
+-	.unmap_flash_region	= physunmap,
+-	.read		= promontory_read_memmapped,
+-	.write_256	= default_spi_write_256,
+-	.shutdown	= sb600spi_shutdown,
+-};
+-
+ int sb600_probe_spi(const struct programmer_cfg *cfg, struct pci_dev *dev)
+ {
+ 	struct pci_dev *smbus_dev;
+@@ -731,8 +708,6 @@ int sb600_probe_spi(const struct programmer_cfg *cfg, struct pci_dev *dev)
+ 	case CHIPSET_SB89XX:
+ 	case CHIPSET_HUDSON234:
+ 	case CHIPSET_YANGTZE:
+-	case CHIPSET_PROMONTORY:
+-		msg_pdbg(", SpiBusy=%"PRIi32"", (tmp >> 31) & 0x1);
+ 	default: break;
+ 	}
+ 	msg_pdbg("\n");
+@@ -808,8 +783,6 @@ int sb600_probe_spi(const struct programmer_cfg *cfg, struct pci_dev *dev)
+ 		register_spi_master(&spi_master_sb600, data);
+ 	else if (amd_gen == CHIPSET_YANGTZE)
+ 		register_spi_master(&spi_master_yangtze, data);
+-	else
+-		register_spi_master(&spi_master_promontory, data);
+ 
+ 	return 0;
+ }
+-- 
+2.45.2
+

--- a/pkgs/tools/misc/flashrom/0002-tests-erase-parenthesize-braced-initializer.patch
+++ b/pkgs/tools/misc/flashrom/0002-tests-erase-parenthesize-braced-initializer.patch
@@ -1,0 +1,50 @@
+From ba84c4aba56420315973026288e7b336006336a9 Mon Sep 17 00:00:00 2001
+From: edef <edef@edef.eu>
+Date: Tue, 30 Jul 2024 03:14:37 +0000
+Subject: [PATCH] tests/erase: parenthesize braced initializer
+
+memcpy is a macro on Darwin, and thus requires braced initializer lists
+to be parenthesized.
+---
+ tests/erase_func_algo.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/tests/erase_func_algo.c b/tests/erase_func_algo.c
+index 576923f8..b13ee70c 100644
+--- a/tests/erase_func_algo.c
++++ b/tests/erase_func_algo.c
+@@ -1233,13 +1233,13 @@ static void erase_unwritable_regions_skipflag_on_test_success(void **state)
+ 
+ 	// This test needs special block erase to emulate protected regions.
+ 	memcpy(g_test_erase_injector,
+-		(erasefunc_t *const[]){
++		((erasefunc_t *const[]){
+ 			block_erase_chip_with_protected_region_1,
+ 			block_erase_chip_with_protected_region_2,
+ 			block_erase_chip_with_protected_region_3,
+ 			block_erase_chip_with_protected_region_4,
+ 			block_erase_chip_with_protected_region_5,
+-		},
++		}),
+ 		sizeof(g_test_erase_injector)
+ 	);
+ 
+@@ -1322,13 +1322,13 @@ static void write_unwritable_regions_skipflag_on_test_success(void **state) {
+ 
+ 	// This test needs special block erase to emulate protected regions.
+ 	memcpy(g_test_erase_injector,
+-		(erasefunc_t *const[]){
++		((erasefunc_t *const[]){
+ 			block_erase_chip_with_protected_region_1,
+ 			block_erase_chip_with_protected_region_2,
+ 			block_erase_chip_with_protected_region_3,
+ 			block_erase_chip_with_protected_region_4,
+ 			block_erase_chip_with_protected_region_5,
+-		},
++		}),
+ 		sizeof(g_test_erase_injector)
+ 	);
+ 
+-- 
+2.45.2
+

--- a/pkgs/tools/misc/flashrom/default.nix
+++ b/pkgs/tools/misc/flashrom/default.nix
@@ -12,11 +12,11 @@
 
 stdenv.mkDerivation rec {
   pname = "flashrom";
-  version = "1.3.0";
+  version = "1.4.0";
 
   src = fetchurl {
-    url = "https://download.flashrom.org/releases/flashrom-v${version}.tar.bz2";
-    hash = "sha256-oFMjRFPM0BLnnzRDvcxhYlz5e3/Xy0zdi/v/vosUliM=";
+    url = "https://download.flashrom.org/releases/flashrom-${version}.tar.xz";
+    hash = "sha256-rX7htJI5xvtPj1XjZwb81zFDXbGkvS+rPYDx9yUIzO4=";
   };
 
   nativeBuildInputs = [ pkg-config installShellFiles ];

--- a/pkgs/tools/misc/flashrom/default.nix
+++ b/pkgs/tools/misc/flashrom/default.nix
@@ -23,14 +23,17 @@ stdenv.mkDerivation rec {
     hash = "sha256-rX7htJI5xvtPj1XjZwb81zFDXbGkvS+rPYDx9yUIzO4=";
   };
 
-  patches = [
-    # Release notes for 1.4.0 state that Promontory chipsets are unsupported, and that attempting to read flash on those systems may crash the system.
-    # The patch that removes this (broken) support only made it into the 1.3.0 release, seemingly by mistake, and the relevant code has been essentially untouched since.
-    # We cherry-pick the upstream patch from 1.3.0, though amended to reference the relevant bug in the error message, rather than requesting the user email upstream.
-    # https://ticket.coreboot.org/issues/370
-    # https://review.coreboot.org/c/flashrom/+/68824
-    ./0001-sb600spi.c-Drop-Promontory-support.patch
-  ];
+  patches =
+    [
+      # Release notes for 1.4.0 state that Promontory chipsets are unsupported, and that attempting to read flash on those systems may crash the system.
+      # The patch that removes this (broken) support only made it into the 1.3.0 release, seemingly by mistake, and the relevant code has been essentially untouched since.
+      # We cherry-pick the upstream patch from 1.3.0, though amended to reference the relevant bug in the error message, rather than requesting the user email upstream.
+      # https://ticket.coreboot.org/issues/370
+      # https://review.coreboot.org/c/flashrom/+/68824
+      ./0001-sb600spi.c-Drop-Promontory-support.patch
+    ]
+    # Darwin's memcpy is a macro, and requires braced initializer lists to be parenthesized
+    ++ lib.optional stdenv.isDarwin ./0002-tests-erase-parenthesize-braced-initializer.patch;
 
   nativeBuildInputs = [ meson ninja pkg-config sphinx bash-completion ];
   buildInputs = [ cmocka libftdi1 libusb1 ]

--- a/pkgs/tools/misc/flashrom/default.nix
+++ b/pkgs/tools/misc/flashrom/default.nix
@@ -23,6 +23,15 @@ stdenv.mkDerivation rec {
     hash = "sha256-rX7htJI5xvtPj1XjZwb81zFDXbGkvS+rPYDx9yUIzO4=";
   };
 
+  patches = [
+    # Release notes for 1.4.0 state that Promontory chipsets are unsupported, and that attempting to read flash on those systems may crash the system.
+    # The patch that removes this (broken) support only made it into the 1.3.0 release, seemingly by mistake, and the relevant code has been essentially untouched since.
+    # We cherry-pick the upstream patch from 1.3.0, though amended to reference the relevant bug in the error message, rather than requesting the user email upstream.
+    # https://ticket.coreboot.org/issues/370
+    # https://review.coreboot.org/c/flashrom/+/68824
+    ./0001-sb600spi.c-Drop-Promontory-support.patch
+  ];
+
   nativeBuildInputs = [ meson ninja pkg-config sphinx bash-completion ];
   buildInputs = [ cmocka libftdi1 libusb1 ]
     ++ lib.optionals (!stdenv.isDarwin) [ pciutils ]


### PR DESCRIPTION
## Description of changes

[Release notes](https://flashrom.org/release_notes/v_1_4.html)

The most significant change for us is that future versions won't support Makefile builds, with Meson becoming the only supported build system. I've switched the build to Meson, rather than saving that surprise for the next update.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
