### PR TITLE
emacs: clean and fix genericBuild

### DIFF
--- a/pkgs/applications/editors/emacs/build-support/elpa.nix
+++ b/pkgs/applications/editors/emacs/build-support/elpa.nix
@@ -1,10 +1,10 @@
 # builder for Emacs packages built for packages.el
 
-{ lib, stdenv, emacs, texinfo, writeText, gcc }:
+{ lib, stdenv, emacs, texinfo, writeText }:
 
 let
   handledArgs = [ "meta" ];
-  genericBuild = import ./generic.nix { inherit lib stdenv emacs texinfo writeText gcc; };
+  genericBuild = import ./generic.nix { inherit lib stdenv emacs texinfo writeText; };
 
 in
 

--- a/pkgs/applications/editors/emacs/build-support/generic.nix
+++ b/pkgs/applications/editors/emacs/build-support/generic.nix
@@ -3,7 +3,7 @@
 { lib, stdenv, emacs, texinfo, writeText, gcc, ... }:
 
 let
-  inherit (lib) optionalAttrs getLib;
+  inherit (lib) optionalAttrs;
   handledArgs = [ "buildInputs" "packageRequires" "propagatedUserEnvPkgs" "meta" ]
     ++ lib.optionals (emacs.withNativeCompilation or false) [ "nativeBuildInputs" "postInstall" ];
 
@@ -72,8 +72,6 @@ stdenv.mkDerivation (finalAttrs: ({
 }
 
 // optionalAttrs (emacs.withNativeCompilation or false) {
-
-  LIBRARY_PATH = "${getLib stdenv.cc.libc}/lib";
 
   nativeBuildInputs = [ gcc ] ++ nativeBuildInputs;
 

--- a/pkgs/applications/editors/emacs/build-support/generic.nix
+++ b/pkgs/applications/editors/emacs/build-support/generic.nix
@@ -4,7 +4,7 @@
 
 let
   inherit (lib) optionalAttrs;
-  handledArgs = [ "buildInputs" "packageRequires" "propagatedUserEnvPkgs" "meta" ]
+  handledArgs = [ "buildInputs" "nativeBuildInputs" "packageRequires" "propagatedUserEnvPkgs" "meta" ]
     ++ lib.optionals (emacs.withNativeCompilation or false) [ "postInstall" ];
 
   setupHook = writeText "setup-hook.sh" ''
@@ -26,6 +26,7 @@ in
 { pname
 , version
 , buildInputs ? []
+, nativeBuildInputs ? []
 , packageRequires ? []
 , propagatedUserEnvPkgs ? []
 , postInstall ? ""
@@ -54,7 +55,8 @@ stdenv.mkDerivation (finalAttrs: ({
     esac
   '';
 
-  buildInputs = [emacs texinfo] ++ packageRequires ++ buildInputs;
+  buildInputs = packageRequires ++ buildInputs;
+  nativeBuildInputs = [ emacs texinfo ] ++ nativeBuildInputs;
   propagatedBuildInputs = packageRequires;
   propagatedUserEnvPkgs = packageRequires ++ propagatedUserEnvPkgs;
 

--- a/pkgs/applications/editors/emacs/build-support/generic.nix
+++ b/pkgs/applications/editors/emacs/build-support/generic.nix
@@ -1,11 +1,11 @@
 # generic builder for Emacs packages
 
-{ lib, stdenv, emacs, texinfo, writeText, gcc, ... }:
+{ lib, stdenv, emacs, texinfo, writeText, ... }:
 
 let
   inherit (lib) optionalAttrs;
   handledArgs = [ "buildInputs" "packageRequires" "propagatedUserEnvPkgs" "meta" ]
-    ++ lib.optionals (emacs.withNativeCompilation or false) [ "nativeBuildInputs" "postInstall" ];
+    ++ lib.optionals (emacs.withNativeCompilation or false) [ "postInstall" ];
 
   setupHook = writeText "setup-hook.sh" ''
     source ${./emacs-funcs.sh}
@@ -26,7 +26,6 @@ in
 { pname
 , version
 , buildInputs ? []
-, nativeBuildInputs ? []
 , packageRequires ? []
 , propagatedUserEnvPkgs ? []
 , postInstall ? ""
@@ -72,8 +71,6 @@ stdenv.mkDerivation (finalAttrs: ({
 }
 
 // optionalAttrs (emacs.withNativeCompilation or false) {
-
-  nativeBuildInputs = [ gcc ] ++ nativeBuildInputs;
 
   addEmacsNativeLoadPath = true;
 

--- a/pkgs/applications/editors/emacs/build-support/melpa.nix
+++ b/pkgs/applications/editors/emacs/build-support/melpa.nix
@@ -1,11 +1,11 @@
 # builder for Emacs packages built for packages.el
 # using MELPA package-build.el
 
-{ lib, stdenv, fetchFromGitHub, emacs, texinfo, writeText, gcc }:
+{ lib, stdenv, fetchFromGitHub, emacs, texinfo, writeText }:
 
 let
   handledArgs = [ "meta" "preUnpack" "postUnpack" ];
-  genericBuild = import ./generic.nix { inherit lib stdenv emacs texinfo writeText gcc; };
+  genericBuild = import ./generic.nix { inherit lib stdenv emacs texinfo writeText; };
 
   packageBuild = stdenv.mkDerivation {
     name = "package-build";

--- a/pkgs/applications/editors/emacs/build-support/wrapper.nix
+++ b/pkgs/applications/editors/emacs/build-support/wrapper.nix
@@ -32,7 +32,7 @@ in customEmacsPackages.withPackages (epkgs: [ epkgs.evil epkgs.magit ])
 
 */
 
-{ lib, lndir, makeBinaryWrapper, runCommand, gcc }:
+{ lib, lndir, makeBinaryWrapper, runCommand }:
 self:
 let
   inherit (self) emacs;
@@ -60,7 +60,6 @@ runCommand
     deps = runCommand "emacs-packages-deps"
       ({
         inherit explicitRequires lndir emacs;
-        nativeBuildInputs = lib.optional withNativeCompilation gcc;
       } // lib.optionalAttrs withNativeCompilation {
         inherit (emacs) LIBRARY_PATH;
       })


### PR DESCRIPTION
## Description of changes

Also move `emacs` and `texinfo` to `nativeBuildInputs` in `genericBuild` because `emacs` and `texinfo` are binaries run at build time.

Please see commit messages for more info.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
