### PR TITLE
yazi-unwrapped: auto update version, build date & hash

### DIFF
--- a/pkgs/by-name/ya/yazi-unwrapped/package.nix
+++ b/pkgs/by-name/ya/yazi-unwrapped/package.nix
@@ -7,8 +7,6 @@
   stdenv,
   Foundation,
   rust-jemalloc-sys,
-
-  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -49,7 +47,7 @@ rustPlatform.buildRustPackage rec {
     install -Dm444 assets/logo.png $out/share/pixmaps/yazi.png
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript.command = [ ./update.sh ];
 
   meta = {
     description = "Blazing fast terminal file manager written in Rust, based on async I/O";

--- a/pkgs/by-name/ya/yazi-unwrapped/update.sh
+++ b/pkgs/by-name/ya/yazi-unwrapped/update.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash nix-update curl coreutils jq common-updater-scripts nix-prefetch
+
+set -eux
+
+NIXPKGS_DIR="$PWD"
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+# Get latest release
+YAZI_RELEASE=$(
+    curl --silent ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
+        https://api.github.com/repos/sxyazi/yazi/releases/latest
+)
+
+# Get release information
+latestBuildDate=$(echo "$YAZI_RELEASE" | jq -r ".published_at")
+latestVersion=$(echo "$YAZI_RELEASE" | jq -r ".tag_name")
+
+latestBuildDate="${latestBuildDate%T*}" # remove the timestamp and get the date
+latestVersion="${latestVersion:1}"      # remove first char 'v'
+
+oldVersion=$(nix eval --raw -f "$NIXPKGS_DIR" yazi-unwrapped.version)
+
+if [[ "$oldVersion" == "$latestVersion" ]]; then
+    echo "Yazi is up-to-date: ${oldVersion}"
+    exit 0
+fi
+
+echo "Updating Yazi"
+
+# Version
+update-source-version yazi-unwrapped "${latestVersion}"
+
+pushd "$SCRIPT_DIR"
+# Build date
+sed -i 's#env.VERGEN_BUILD_DATE = "[^"]*"#env.VERGEN_BUILD_DATE = "'"${latestBuildDate}"'"#' package.nix
+
+# Hashes
+cargoHash=$(nix-prefetch "{ sha256 }: (import $NIXPKGS_DIR {}).yazi-unwrapped.cargoDeps.overrideAttrs (_: { outputHash = sha256; })")
+sed -i -E 's#\bcargoHash = ".*?"#cargoHash = "'"$cargoHash"'"#' package.nix
+popd


### PR DESCRIPTION
## Description of changes

Automatic update script for cargoHash and build date in addition to the package version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
