### PR TITLE
rke2: fix nixos tests

### DIFF
--- a/pkgs/applications/networking/cluster/rke2/builder.nix
+++ b/pkgs/applications/networking/cluster/rke2/builder.nix
@@ -1,4 +1,4 @@
-lib: { rke2Version, rke2RepoSha256, rke2VendorHash, updateScript
+lib: { releaseName, rke2Version, rke2RepoSha256, rke2VendorHash, updateScript
 
 , rke2Commit, k8sImageTag, etcdVersion, pauseVersion, ccmVersion, dockerizedVersion, ... }:
 
@@ -91,9 +91,9 @@ buildGoModule rec {
       package = rke2;
       version = "v${version}";
     };
-  } // lib.optionalAttrs stdenv.isLinux {
-    inherit (nixosTests) rke2;
-  };
+  } // (lib.optionalAttrs stdenv.isLinux (lib.mapAttrs (
+      name: value: nixosTests.rke2.${name}.${releaseName}
+    ) nixosTests.rke2));
 
   meta = with lib; {
     homepage = "https://github.com/rancher/rke2";

--- a/pkgs/applications/networking/cluster/rke2/latest/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/latest/versions.nix
@@ -1,4 +1,5 @@
 {
+  releaseName = "rke2_latest";
   rke2Version = "1.30.1+rke2r1";
   rke2RepoSha256 = "0jrvvpj9fnlbykyr06w1f92ay708xzaizg8dhg1z4bsq1cdgs33k";
   rke2Commit = "e7f87c6dd56fdd76a7dab58900aeea8946b2c008";

--- a/pkgs/applications/networking/cluster/rke2/stable/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/stable/versions.nix
@@ -1,4 +1,5 @@
 {
+  releaseName = "rke2_stable";
   rke2Version = "1.28.10+rke2r1";
   rke2RepoSha256 = "1pbanikvrl6rqrplrpvjc9ym8qq1yrs621gwy99shp0prfw5zvsx";
   rke2Commit = "b0d0d687d98f4fa015e7b30aaf2807b50edcc5d7";

--- a/pkgs/applications/networking/cluster/rke2/testing/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/testing/versions.nix
@@ -1,4 +1,5 @@
 {
+  releaseName = "rke2_testing";
   rke2Version = "1.30.1-rc3+rke2r1";
   rke2RepoSha256 = "0jrvvpj9fnlbykyr06w1f92ay708xzaizg8dhg1z4bsq1cdgs33k";
   rke2Commit = "e7f87c6dd56fdd76a7dab58900aeea8946b2c008";

--- a/pkgs/applications/networking/cluster/rke2/update-script.sh
+++ b/pkgs/applications/networking/cluster/rke2/update-script.sh
@@ -39,6 +39,7 @@ FAKE_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
 
 cat > ./${CHANNEL_NAME}/versions.nix << EOF
 {
+  releaseName = "rke2_${CHANNEL_NAME}";
   rke2Version = "${RKE2_VERSION}";
   rke2RepoSha256 = "${RKE2_REPO_SHA256}";
   rke2Commit = "${RKE2_COMMIT}";


### PR DESCRIPTION
The `passthru.tests` on RKE2 packages didn't build any tests, which is probably why failing tests haven't been noticed. This assigns tests for the corresponding package in `passthru.tests` instead of just inheriting `nixosTests.rke2`, which should show that tests are actually failing.

Related issue: https://github.com/NixOS/nixpkgs/issues/330638

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
