### PR TITLE
[24.05] cups: add patch for CVE-2024-35235

### DIFF
--- a/pkgs/misc/cups/2.4.8-CVE-2024-35235.patch
+++ b/pkgs/misc/cups/2.4.8-CVE-2024-35235.patch
@@ -1,0 +1,86 @@
+Based on upstream ff1f8a623e090dee8a8aadf12a6a4b25efac143d, adjusted to
+apply to 2.4.8
+
+diff --git a/cups/http-addr.c b/cups/http-addr.c
+index 6aeeb8074..73a6b2f37 100644
+--- a/cups/http-addr.c
++++ b/cups/http-addr.c
+@@ -206,27 +206,30 @@ httpAddrListen(http_addr_t *addr,	/* I - Address to bind to */
+     * Remove any existing domain socket file...
+     */
+ 
+-    unlink(addr->un.sun_path);
+-
+-   /*
+-    * Save the current umask and set it to 0 so that all users can access
+-    * the domain socket...
+-    */
+-
+-    mask = umask(0);
++    // Remove any existing domain socket file...
++    if ((status = unlink(addr->un.sun_path)) < 0)
++    {
++      DEBUG_printf(("1httpAddrListen: Unable to unlink \"%s\": %s", addr->un.sun_path, strerror(errno)));
+ 
+-   /*
+-    * Bind the domain socket...
+-    */
++      if (errno == ENOENT)
++	status = 0;
++    }
+ 
+-    status = bind(fd, (struct sockaddr *)addr, (socklen_t)httpAddrLength(addr));
++    if (!status)
++    {
++      // Save the current umask and set it to 0 so that all users can access
++      // the domain socket...
++      mask = umask(0);
+ 
+-   /*
+-    * Restore the umask and fix permissions...
+-    */
++      // Bind the domain socket...
++      if ((status = bind(fd, (struct sockaddr *)addr, (socklen_t)httpAddrLength(addr))) < 0)
++      {
++	DEBUG_printf(("1httpAddrListen: Unable to bind domain socket \"%s\": %s", addr->un.sun_path, strerror(errno)));
++      }
+ 
+-    umask(mask);
+-    chmod(addr->un.sun_path, 0140777);
++      // Restore the umask...
++      umask(mask);
++    }
+   }
+   else
+ #endif /* AF_LOCAL */
+diff --git a/scheduler/conf.c b/scheduler/conf.c
+index defca78aa..ebf8ca8cc 100644
+--- a/scheduler/conf.c
++++ b/scheduler/conf.c
+@@ -3083,6 +3083,26 @@ read_cupsd_conf(cups_file_t *fp)	/* I - File to read from */
+       cupsd_listener_t	*lis;		/* New listeners array */
+ 
+ 
++     /*
++      * If we are launched on-demand, do not use domain sockets from the config
++      * file.  Also check that the domain socket path is not too long...
++      */
++
++#ifdef HAVE_ONDEMAND
++      if (*value == '/' && OnDemand)
++      {
++        if (strcmp(value, CUPS_DEFAULT_DOMAINSOCKET))
++          cupsdLogMessage(CUPSD_LOG_INFO, "Ignoring %s address %s at line %d - only using domain socket from launchd/systemd.", line, value, linenum);
++        continue;
++      }
++#endif // HAVE_ONDEMAND
++
++      if (*value == '/' && strlen(value) > (sizeof(addr->addr.un.sun_path) - 1))
++      {
++        cupsdLogMessage(CUPSD_LOG_INFO, "Ignoring %s address %s at line %d - too long.", line, value, linenum);
++        continue;
++      }
++
+      /*
+       * Get the address list...
+       */

--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -32,6 +32,10 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "lib" "dev" "man" ];
 
+  patches = [
+    ./2.4.8-CVE-2024-35235.patch
+  ];
+
   postPatch = ''
     substituteInPlace cups/testfile.c \
       --replace 'cupsFileFind("cat", "/bin' 'cupsFileFind("cat", "${coreutils}/bin'


### PR DESCRIPTION
## Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2024-35235

Already addressed on unstable with bump to 2.4.10

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
