### PR TITLE
ruby.rubygems: fix delete binstub lock files

### DIFF
--- a/pkgs/development/interpreters/ruby/rubygems/0004-delete-binstub-lock-file.patch
+++ b/pkgs/development/interpreters/ruby/rubygems/0004-delete-binstub-lock-file.patch
@@ -1,0 +1,36 @@
+A change introduced in PR https://github.com/rubygems/rubygems/pull/7797
+does not delete the binstub lock files after the binstub file is created.
+
+This change was introduced in rubygems 3.5.15,
+and this version causes Hydra builds to fail, in particular mastodon.
+
+A resolution is delete these binstub lock files after the binstub file is created
+to prevent lock files from ending up in the bin folders of the various derivations
+which will cause the build to fail.
+
+---
+diff --git a/bundler/lib/bundler/rubygems_ext.rb b/bundler/lib/bundler/rubygems_ext.rb
+index 503959bba7..603b30e277 100644
+--- a/bundler/lib/bundler/rubygems_ext.rb
++++ b/bundler/lib/bundler/rubygems_ext.rb
+@@ -47,6 +47,8 @@ def self.open_file_with_flock(path, &block)
+         else
+           File.open(path, flags, &block)
+         end
++      ensure
++        FileUtils.rm_f(path) if File.exist?(path)
+       end
+     end
+   end
+diff --git a/lib/rubygems.rb b/lib/rubygems.rb
+index 569041f3d7..bcc95ae85c 100644
+--- a/lib/rubygems.rb
++++ b/lib/rubygems.rb
+@@ -796,6 +796,8 @@ def self.open_file_with_flock(path, &block)
+       else
+         open_file(path, flags, &block)
+       end
++    ensure
++      FileUtils.rm_f(path) if File.exist?(path)
+     end
+   end

--- a/pkgs/development/interpreters/ruby/rubygems/default.nix
+++ b/pkgs/development/interpreters/ruby/rubygems/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
     ./0001-add-post-extract-hook.patch
     ./0002-binaries-with-env-shebang.patch
     ./0003-gem-install-default-to-user.patch
+    ./0004-delete-binstub-lock-file.patch
   ];
 
   installPhase = ''


### PR DESCRIPTION
## Description of changes

A change introduced with this PR https://github.com/rubygems/rubygems/pull/7806 does not delete the binstub lock files after the binstub file is created.

This change was introduced in rubygems 3.5.15, and this version causes Hydra builds to fail, in particular mastodon.

A resolution is delete these binstub lock files after the binstub file is created to prevent lock files from ending up in the bin folders of the various derivations which will cause the build to fail.

Introduced in nixpkgs with these PRs:

* https://github.com/NixOS/nixpkgs/pull/321040
* https://github.com/NixOS/nixpkgs/pull/328638

See the failing Hydra build for mastodon: https://hydra.nixos.org/build/267248005

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
