### PR TITLE
Draft: nixos/gitlab: allow registry usage with optional keyFile and certFile

### DIFF
--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -1,4 +1,11 @@
-{ config, lib, options, pkgs, utils, ... }:
+{
+  config,
+  lib,
+  options,
+  pkgs,
+  utils,
+  ...
+}:
 
 with lib;
 
@@ -6,48 +13,49 @@ let
   cfg = config.services.gitlab;
   opt = options.services.gitlab;
 
-  toml = pkgs.formats.toml {};
-  yaml = pkgs.formats.yaml {};
+  toml = pkgs.formats.toml { };
+  yaml = pkgs.formats.yaml { };
 
   git = cfg.packages.gitaly.git;
 
-  postgresqlPackage = if config.services.postgresql.enable then
-                        config.services.postgresql.package
-                      else
-                        pkgs.postgresql_14;
+  postgresqlPackage =
+    if config.services.postgresql.enable then
+      config.services.postgresql.package
+    else
+      pkgs.postgresql_14;
 
   gitlabSocket = "${cfg.statePath}/tmp/sockets/gitlab.socket";
   gitalySocket = "${cfg.statePath}/tmp/sockets/gitaly.socket";
-  pathUrlQuote = url: replaceStrings ["/"] ["%2F"] url;
+  pathUrlQuote = url: replaceStrings [ "/" ] [ "%2F" ] url;
 
   gitlabVersionAtLeast = version: lib.versionAtLeast (lib.getVersion cfg.packages.gitlab) version;
 
-  databaseConfig = let
-    val = {
-      adapter = "postgresql";
-      database = cfg.databaseName;
-      host = cfg.databaseHost;
-      username = cfg.databaseUsername;
-      encoding = "utf8";
-      pool = cfg.databasePool;
-    } // cfg.extraDatabaseConfig;
-  in {
-    production = (
-      if (gitlabVersionAtLeast "15.0")
-      then { main = val; }
-      else val
-    ) // lib.optionalAttrs (gitlabVersionAtLeast "15.9") {
-      ci = val // {
-        database_tasks = false;
-      };
+  databaseConfig =
+    let
+      val = {
+        adapter = "postgresql";
+        database = cfg.databaseName;
+        host = cfg.databaseHost;
+        username = cfg.databaseUsername;
+        encoding = "utf8";
+        pool = cfg.databasePool;
+      } // cfg.extraDatabaseConfig;
+    in
+    {
+      production =
+        (if (gitlabVersionAtLeast "15.0") then { main = val; } else val)
+        // lib.optionalAttrs (gitlabVersionAtLeast "15.9") {
+          ci = val // {
+            database_tasks = false;
+          };
+        };
     };
-  };
 
   # We only want to create a database if we're actually going to connect to it.
   databaseActuallyCreateLocally = cfg.databaseCreateLocally && cfg.databaseHost == "";
 
   gitalyToml = pkgs.writeText "gitaly.toml" ''
-    socket_path = "${lib.escape ["\""] gitalySocket}"
+    socket_path = "${lib.escape [ "\"" ] gitalySocket}"
     runtime_dir = "/run/gitaly"
     bin_dir = "${cfg.packages.gitaly}/bin"
     prometheus_listen_addr = "localhost:9236"
@@ -68,11 +76,15 @@ let
     [gitlab.http-settings]
     self_signed_cert = false
 
-    ${concatStringsSep "\n" (attrValues (mapAttrs (k: v: ''
-    [[storage]]
-    name = "${lib.escape ["\""] k}"
-    path = "${lib.escape ["\""] v.path}"
-    '') gitlabConfig.production.repositories.storages))}
+    ${concatStringsSep "\n" (
+      attrValues (
+        mapAttrs (k: v: ''
+          [[storage]]
+          name = "${lib.escape [ "\"" ] k}"
+          path = "${lib.escape [ "\"" ] v.path}"
+        '') gitlabConfig.production.repositories.storages
+      )
+    )}
   '';
 
   gitlabShellConfig = flip recursiveUpdate cfg.extraShellConfig {
@@ -133,9 +145,7 @@ let
         gitaly_backup_path = "${cfg.packages.gitaly}/bin/gitaly-backup";
         path = cfg.backup.path;
         keep_time = cfg.backup.keepTime;
-      } // (optionalAttrs (cfg.backup.uploadOptions != {}) {
-        upload = cfg.backup.uploadOptions;
-      });
+      } // (optionalAttrs (cfg.backup.uploadOptions != { }) { upload = cfg.backup.uploadOptions; });
       gitlab_shell = {
         path = "${cfg.packages.gitlab-shell}";
         hooks_path = "${cfg.statePath}/shell/hooks";
@@ -147,23 +157,28 @@ let
       gitlab_kas.secret_file = "${cfg.statePath}/.gitlab_kas_secret";
       git.bin_path = "git";
       monitoring = {
-        ip_whitelist = [ "127.0.0.0/8" "::1/128" ];
+        ip_whitelist = [
+          "127.0.0.0/8"
+          "::1/128"
+        ];
         sidekiq_exporter = {
           enable = true;
           address = "localhost";
           port = 3807;
         };
       };
-      registry = lib.optionalAttrs cfg.registry.enable {
-        enabled = true;
-        host = cfg.registry.externalAddress;
-        port = cfg.registry.externalPort;
-        key = cfg.registry.keyFile;
-        api_url = "http://${config.services.dockerRegistry.listenAddress}:${toString config.services.dockerRegistry.port}/";
-        issuer = cfg.registry.issuer;
-      };
+      registry = lib.optionalAttrs cfg.registry.enable (
+        {
+          enabled = true;
+          host = cfg.registry.externalAddress;
+          port = cfg.registry.externalPort;
+          api_url = "http://${config.services.dockerRegistry.listenAddress}:${toString config.services.dockerRegistry.port}/";
+          issuer = cfg.registry.issuer;
+        }
+        // (optionalAttrs (cfg.registry.keyFile != "") { key = cfg.registry.keyFile; })
+      );
       elasticsearch.indexer_path = "${pkgs.gitlab-elasticsearch-indexer}/bin/gitlab-elasticsearch-indexer";
-      extra = {};
+      extra = { };
       uploads.storage_path = cfg.statePath;
       pages = optionalAttrs cfg.pages.enable {
         enabled = cfg.pages.enable;
@@ -174,27 +189,32 @@ let
     };
   };
 
-  gitlabEnv = cfg.packages.gitlab.gitlabEnv // {
-    HOME = "${cfg.statePath}/home";
-    PUMA_PATH = "${cfg.statePath}/";
-    GITLAB_PATH = "${cfg.packages.gitlab}/share/gitlab/";
-    SCHEMA = "${cfg.statePath}/db/structure.sql";
-    GITLAB_UPLOADS_PATH = "${cfg.statePath}/uploads";
-    GITLAB_LOG_PATH = "${cfg.statePath}/log";
-    prometheus_multiproc_dir = "/run/gitlab";
-    RAILS_ENV = "production";
-    MALLOC_ARENA_MAX = "2";
-  } // cfg.extraEnv;
+  gitlabEnv =
+    cfg.packages.gitlab.gitlabEnv
+    // {
+      HOME = "${cfg.statePath}/home";
+      PUMA_PATH = "${cfg.statePath}/";
+      GITLAB_PATH = "${cfg.packages.gitlab}/share/gitlab/";
+      SCHEMA = "${cfg.statePath}/db/structure.sql";
+      GITLAB_UPLOADS_PATH = "${cfg.statePath}/uploads";
+      GITLAB_LOG_PATH = "${cfg.statePath}/log";
+      prometheus_multiproc_dir = "/run/gitlab";
+      RAILS_ENV = "production";
+      MALLOC_ARENA_MAX = "2";
+    }
+    // cfg.extraEnv;
 
-  runtimeDeps = [ git ] ++ (with pkgs; [
-    nodejs
-    gzip
-    gnutar
-    postgresqlPackage
-    coreutils
-    procps
-    findutils # Needed for gitlab:cleanup:orphan_job_artifact_files
-  ]);
+  runtimeDeps =
+    [ git ]
+    ++ (with pkgs; [
+      nodejs
+      gzip
+      gnutar
+      postgresqlPackage
+      coreutils
+      procps
+      findutils # Needed for gitlab:cleanup:orphan_job_artifact_files
+    ]);
 
   gitlab-rake = pkgs.stdenv.mkDerivation {
     name = "gitlab-rake";
@@ -208,7 +228,7 @@ let
           --set PATH '${lib.makeBinPath runtimeDeps}:$PATH' \
           --set RAKEOPT '-f ${cfg.packages.gitlab}/share/gitlab/Rakefile' \
           --chdir '${cfg.packages.gitlab}/share/gitlab'
-     '';
+    '';
   };
 
   gitlab-rails = pkgs.stdenv.mkDerivation {
@@ -222,7 +242,7 @@ let
           ${concatStrings (mapAttrsToList (name: value: "--set ${name} '${value}' ") gitlabEnv)} \
           --set PATH '${lib.makeBinPath runtimeDeps}:$PATH' \
           --chdir '${cfg.packages.gitlab}/share/gitlab'
-     '';
+    '';
   };
 
   extraGitlabRb = pkgs.writeText "extra-gitlab.rb" cfg.extraGitlabRb;
@@ -238,7 +258,9 @@ let
         ${optionalString (cfg.smtp.username != null) ''user_name: "${cfg.smtp.username}",''}
         ${optionalString (cfg.smtp.passwordFile != null) ''password: "@smtpPassword@",''}
         domain: "${cfg.smtp.domain}",
-        ${optionalString (cfg.smtp.authentication != null) "authentication: :${cfg.smtp.authentication},"}
+        ${
+          optionalString (cfg.smtp.authentication != null) "authentication: :${cfg.smtp.authentication},"
+        }
         enable_starttls_auto: ${boolToString cfg.smtp.enableStartTLSAuto},
         tls: ${boolToString cfg.smtp.tls},
         ca_file: "/etc/ssl/certs/ca-certificates.crt",
@@ -247,14 +269,51 @@ let
     end
   '';
 
-in {
+in
+{
 
   imports = [
-    (mkRenamedOptionModule [ "services" "gitlab" "stateDir" ] [ "services" "gitlab" "statePath" ])
-    (mkRenamedOptionModule [ "services" "gitlab" "backupPath" ] [ "services" "gitlab" "backup" "path" ])
-    (mkRemovedOptionModule [ "services" "gitlab" "satelliteDir" ] "")
-    (mkRemovedOptionModule [ "services" "gitlab" "logrotate" "extraConfig" ] "Modify services.logrotate.settings.gitlab directly instead")
-    (mkRemovedOptionModule [ "services" "gitlab" "pagesExtraArgs" ] "Use services.gitlab.pages.settings instead")
+    (mkRenamedOptionModule
+      [
+        "services"
+        "gitlab"
+        "stateDir"
+      ]
+      [
+        "services"
+        "gitlab"
+        "statePath"
+      ]
+    )
+    (mkRenamedOptionModule
+      [
+        "services"
+        "gitlab"
+        "backupPath"
+      ]
+      [
+        "services"
+        "gitlab"
+        "backup"
+        "path"
+      ]
+    )
+    (mkRemovedOptionModule [
+      "services"
+      "gitlab"
+      "satelliteDir"
+    ] "")
+    (mkRemovedOptionModule [
+      "services"
+      "gitlab"
+      "logrotate"
+      "extraConfig"
+    ] "Modify services.logrotate.settings.gitlab directly instead")
+    (mkRemovedOptionModule [
+      "services"
+      "gitlab"
+      "pagesExtraArgs"
+    ] "Use services.gitlab.pages.settings instead")
   ];
 
   options = {
@@ -267,9 +326,7 @@ in {
         '';
       };
 
-      packages.gitlab = mkPackageOption pkgs "gitlab" {
-        example = "gitlab-ee";
-      };
+      packages.gitlab = mkPackageOption pkgs "gitlab" { example = "gitlab-ee"; };
 
       packages.gitlab-shell = mkPackageOption pkgs "gitlab-shell" { };
 
@@ -295,7 +352,7 @@ in {
 
       extraEnv = mkOption {
         type = types.attrsOf types.str;
-        default = {};
+        default = { };
         description = ''
           Additional environment variables for the GitLab environment.
         '';
@@ -303,7 +360,7 @@ in {
 
       backup.startAt = mkOption {
         type = with types; either str (listOf str);
-        default = [];
+        default = [ ];
         example = "03:00";
         description = ''
           The time(s) to run automatic backup of GitLab
@@ -331,22 +388,27 @@ in {
       };
 
       backup.skip = mkOption {
-        type = with types;
-          let value = enum [
-                "db"
-                "uploads"
-                "builds"
-                "artifacts"
-                "lfs"
-                "registry"
-                "pages"
-                "repositories"
-                "tar"
-              ];
+        type =
+          with types;
+          let
+            value = enum [
+              "db"
+              "uploads"
+              "builds"
+              "artifacts"
+              "lfs"
+              "registry"
+              "pages"
+              "repositories"
+              "tar"
+            ];
           in
-            either value (listOf value);
-        default = [];
-        example = [ "artifacts" "lfs" ];
+          either value (listOf value);
+        default = [ ];
+        example = [
+          "artifacts"
+          "lfs"
+        ];
         apply = x: if isString x then x else concatStringsSep "," x;
         description = ''
           Directories to exclude from the backup. The example excludes
@@ -361,7 +423,7 @@ in {
 
       backup.uploadOptions = mkOption {
         type = types.attrs;
-        default = {};
+        default = { };
         example = literalExpression ''
           {
             # Fog storage connection settings, see http://fog.io/storage/
@@ -448,7 +510,7 @@ in {
 
       extraDatabaseConfig = mkOption {
         type = types.attrs;
-        default = {};
+        default = { };
         description = "Extra configuration in config/database.yml.";
       };
 
@@ -542,9 +604,10 @@ in {
         package = mkOption {
           type = types.package;
           default =
-            if versionAtLeast config.system.stateVersion "23.11"
-            then pkgs.gitlab-container-registry
-            else pkgs.docker-distribution;
+            if versionAtLeast config.system.stateVersion "23.11" then
+              pkgs.gitlab-container-registry
+            else
+              pkgs.docker-distribution;
           defaultText = literalExpression "pkgs.docker-distribution";
           description = ''
             Container registry package to use.
@@ -565,11 +628,13 @@ in {
           description = "GitLab container registry port.";
         };
         certFile = mkOption {
-          type = types.path;
+          type = types.nullOr types.path;
+          default = null;
           description = "Path to GitLab container registry certificate.";
         };
         keyFile = mkOption {
-          type = types.path;
+          type = types.nullOr types.path;
+          default = null;
           description = "Path to GitLab container registry certificate-key.";
         };
         defaultForProjects = mkOption {
@@ -695,13 +760,22 @@ in {
         '';
 
         type = types.submodule {
-          freeformType = with types; attrsOf (nullOr (oneOf [ str int bool attrs ]));
+          freeformType =
+            with types;
+            attrsOf (
+              nullOr (oneOf [
+                str
+                int
+                bool
+                attrs
+              ])
+            );
 
           options = {
             listen-http = mkOption {
               type = with types; listOf str;
-              apply = x: if x == [] then null else lib.concatStringsSep "," x;
-              default = [];
+              apply = x: if x == [ ] then null else lib.concatStringsSep "," x;
+              default = [ ];
               description = ''
                 The address(es) to listen on for HTTP requests.
               '';
@@ -709,8 +783,8 @@ in {
 
             listen-https = mkOption {
               type = with types; listOf str;
-              apply = x: if x == [] then null else lib.concatStringsSep "," x;
-              default = [];
+              apply = x: if x == [ ] then null else lib.concatStringsSep "," x;
+              default = [ ];
               description = ''
                 The address(es) to listen on for HTTPS requests.
               '';
@@ -718,7 +792,7 @@ in {
 
             listen-proxy = mkOption {
               type = with types; listOf str;
-              apply = x: if x == [] then null else lib.concatStringsSep "," x;
+              apply = x: if x == [ ] then null else lib.concatStringsSep "," x;
               default = [ "127.0.0.1:8090" ];
               description = ''
                 The address(es) to listen on for proxy requests.
@@ -857,7 +931,7 @@ in {
 
       extraShellConfig = mkOption {
         type = types.attrs;
-        default = {};
+        default = { };
         description = "Extra configuration to merge into shell-config.yml";
       };
 
@@ -987,7 +1061,7 @@ in {
 
       workhorse.config = mkOption {
         type = toml.type;
-        default = {};
+        default = { };
         example = literalExpression ''
           {
             object_storage.provider = "AWS";
@@ -1020,7 +1094,7 @@ in {
 
       extraConfig = mkOption {
         type = yaml.type;
-        default = {};
+        default = { };
         example = literalExpression ''
           {
             gitlab = {
@@ -1079,14 +1153,23 @@ in {
   config = mkIf cfg.enable {
     warnings = [
       (mkIf
-        (cfg.registry.enable && versionAtLeast (getVersion cfg.packages.gitlab) "16.0.0" && cfg.registry.package == pkgs.docker-distribution)
-        ''Support for container registries other than gitlab-container-registry has ended since GitLab 16.0.0 and is scheduled for removal in a future release.
-          Please back up your data and migrate to the gitlab-container-registry package.''
+        (
+          cfg.registry.enable
+          && versionAtLeast (getVersion cfg.packages.gitlab) "16.0.0"
+          && cfg.registry.package == pkgs.docker-distribution
+        )
+        ''
+          Support for container registries other than gitlab-container-registry has ended since GitLab 16.0.0 and is scheduled for removal in a future release.
+                    Please back up your data and migrate to the gitlab-container-registry package.''
       )
       (mkIf
-        (versionAtLeast (getVersion cfg.packages.gitlab) "16.2.0" && versionOlder (getVersion cfg.packages.gitlab) "16.5.0")
-        ''GitLab instances created or updated between versions [15.11.0, 15.11.2] have an incorrect database schema.
-        Check the upstream documentation for a workaround: https://docs.gitlab.com/ee/update/versions/gitlab_16_changes.html#undefined-column-error-upgrading-to-162-or-later''
+        (
+          versionAtLeast (getVersion cfg.packages.gitlab) "16.2.0"
+          && versionOlder (getVersion cfg.packages.gitlab) "16.5.0"
+        )
+        ''
+          GitLab instances created or updated between versions [15.11.0, 15.11.2] have an incorrect database schema.
+                  Check the upstream documentation for a workaround: https://docs.gitlab.com/ee/update/versions/gitlab_16_changes.html#undefined-column-error-upgrading-to-162-or-later''
       )
     ];
 
@@ -1123,9 +1206,20 @@ in {
         assertion = versionAtLeast postgresqlPackage.version "14.9";
         message = "PostgreSQL >= 14.9 is required to run GitLab 17. Follow the instructions in the manual section for upgrading PostgreSQL here: https://nixos.org/manual/nixos/stable/index.html#module-services-postgres-upgrading";
       }
+      {
+        assertion =
+          !cfg.registry.enable
+          || (cfg.registry.keyFile != null && cfg.registry.certFile != null)
+          || (cfg.registry.keyFile == null && cfg.registry.certFile == null);
+        message = "you must specify either both or neither services.gitlab.registry.keyFile and services.gitlab.registry.certFile!";
+      }
     ];
 
-    environment.systemPackages = [ gitlab-rake gitlab-rails cfg.packages.gitlab-shell ];
+    environment.systemPackages = [
+      gitlab-rake
+      gitlab-rails
+      cfg.packages.gitlab-shell
+    ];
 
     systemd.targets.gitlab = {
       description = "Common target for all GitLab services.";
@@ -1164,63 +1258,69 @@ in {
     # The postgresql module doesn't currently support concepts like
     # objects owners and extensions; for now we tack on what's needed
     # here.
-    systemd.services.gitlab-postgresql = let pgsql = config.services.postgresql; in mkIf databaseActuallyCreateLocally {
-      after = [ "postgresql.service" ];
-      bindsTo = [ "postgresql.service" ];
-      wantedBy = [ "gitlab.target" ];
-      partOf = [ "gitlab.target" ];
-      path = [
-        pgsql.package
-        pkgs.util-linux
-      ];
-      script = ''
-        set -eu
+    systemd.services.gitlab-postgresql =
+      let
+        pgsql = config.services.postgresql;
+      in
+      mkIf databaseActuallyCreateLocally {
+        after = [ "postgresql.service" ];
+        bindsTo = [ "postgresql.service" ];
+        wantedBy = [ "gitlab.target" ];
+        partOf = [ "gitlab.target" ];
+        path = [
+          pgsql.package
+          pkgs.util-linux
+        ];
+        script = ''
+          set -eu
 
-        PSQL() {
-            psql --port=${toString pgsql.settings.port} "$@"
-        }
+          PSQL() {
+              psql --port=${toString pgsql.settings.port} "$@"
+          }
 
-        PSQL -tAc "SELECT 1 FROM pg_database WHERE datname = '${cfg.databaseName}'" | grep -q 1 || PSQL -tAc 'CREATE DATABASE "${cfg.databaseName}" OWNER "${cfg.databaseUsername}"'
-        current_owner=$(PSQL -tAc "SELECT pg_catalog.pg_get_userbyid(datdba) FROM pg_catalog.pg_database WHERE datname = '${cfg.databaseName}'")
-        if [[ "$current_owner" != "${cfg.databaseUsername}" ]]; then
-            PSQL -tAc 'ALTER DATABASE "${cfg.databaseName}" OWNER TO "${cfg.databaseUsername}"'
-            if [[ -e "${config.services.postgresql.dataDir}/.reassigning_${cfg.databaseName}" ]]; then
-                echo "Reassigning ownership of database ${cfg.databaseName} to user ${cfg.databaseUsername} failed on last boot. Failing..."
-                exit 1
-            fi
-            touch "${config.services.postgresql.dataDir}/.reassigning_${cfg.databaseName}"
-            PSQL "${cfg.databaseName}" -tAc "REASSIGN OWNED BY \"$current_owner\" TO \"${cfg.databaseUsername}\""
-            rm "${config.services.postgresql.dataDir}/.reassigning_${cfg.databaseName}"
-        fi
-        PSQL '${cfg.databaseName}' -tAc "CREATE EXTENSION IF NOT EXISTS pg_trgm"
-        PSQL '${cfg.databaseName}' -tAc "CREATE EXTENSION IF NOT EXISTS btree_gist;"
-      '';
+          PSQL -tAc "SELECT 1 FROM pg_database WHERE datname = '${cfg.databaseName}'" | grep -q 1 || PSQL -tAc 'CREATE DATABASE "${cfg.databaseName}" OWNER "${cfg.databaseUsername}"'
+          current_owner=$(PSQL -tAc "SELECT pg_catalog.pg_get_userbyid(datdba) FROM pg_catalog.pg_database WHERE datname = '${cfg.databaseName}'")
+          if [[ "$current_owner" != "${cfg.databaseUsername}" ]]; then
+              PSQL -tAc 'ALTER DATABASE "${cfg.databaseName}" OWNER TO "${cfg.databaseUsername}"'
+              if [[ -e "${config.services.postgresql.dataDir}/.reassigning_${cfg.databaseName}" ]]; then
+                  echo "Reassigning ownership of database ${cfg.databaseName} to user ${cfg.databaseUsername} failed on last boot. Failing..."
+                  exit 1
+              fi
+              touch "${config.services.postgresql.dataDir}/.reassigning_${cfg.databaseName}"
+              PSQL "${cfg.databaseName}" -tAc "REASSIGN OWNED BY \"$current_owner\" TO \"${cfg.databaseUsername}\""
+              rm "${config.services.postgresql.dataDir}/.reassigning_${cfg.databaseName}"
+          fi
+          PSQL '${cfg.databaseName}' -tAc "CREATE EXTENSION IF NOT EXISTS pg_trgm"
+          PSQL '${cfg.databaseName}' -tAc "CREATE EXTENSION IF NOT EXISTS btree_gist;"
+        '';
 
-      serviceConfig = {
-        User = pgsql.superUser;
-        Type = "oneshot";
-        RemainAfterExit = true;
+        serviceConfig = {
+          User = pgsql.superUser;
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
       };
-    };
 
-    systemd.services.gitlab-registry-cert = optionalAttrs cfg.registry.enable {
-      path = with pkgs; [ openssl ];
+    systemd.services.gitlab-registry-cert =
+      optionalAttrs (cfg.registry.enable && cfg.registry.keyFile != null && cfg.registry.certFile != null)
+        {
+          path = with pkgs; [ openssl ];
 
-      script = ''
-        mkdir -p $(dirname ${cfg.registry.keyFile})
-        mkdir -p $(dirname ${cfg.registry.certFile})
-        openssl req -nodes -newkey rsa:4096 -keyout ${cfg.registry.keyFile} -out /tmp/registry-auth.csr -subj "/CN=${cfg.registry.issuer}"
-        openssl x509 -in /tmp/registry-auth.csr -out ${cfg.registry.certFile} -req -signkey ${cfg.registry.keyFile} -days 3650
-        chown ${cfg.user}:${cfg.group} $(dirname ${cfg.registry.keyFile})
-        chown ${cfg.user}:${cfg.group} $(dirname ${cfg.registry.certFile})
-        chown ${cfg.user}:${cfg.group} ${cfg.registry.keyFile}
-        chown ${cfg.user}:${cfg.group} ${cfg.registry.certFile}
-      '';
+          script = ''
+            mkdir -p $(dirname ${cfg.registry.keyFile})
+            mkdir -p $(dirname ${cfg.registry.certFile})
+            openssl req -nodes -newkey rsa:4096 -keyout ${cfg.registry.keyFile} -out /tmp/registry-auth.csr -subj "/CN=${cfg.registry.issuer}"
+            openssl x509 -in /tmp/registry-auth.csr -out ${cfg.registry.certFile} -req -signkey ${cfg.registry.keyFile} -days 3650
+            chown ${cfg.user}:${cfg.group} $(dirname ${cfg.registry.keyFile})
+            chown ${cfg.user}:${cfg.group} $(dirname ${cfg.registry.certFile})
+            chown ${cfg.user}:${cfg.group} ${cfg.registry.keyFile}
+            chown ${cfg.user}:${cfg.group} ${cfg.registry.certFile}
+          '';
 
-      unitConfig = {
-        ConditionPathExists = "!${cfg.registry.certFile}";
-      };
-    };
+          unitConfig = {
+            ConditionPathExists = "!${cfg.registry.certFile}";
+          };
+        };
 
     # Ensure Docker Registry launches after the certificate generation job
     systemd.services.docker-registry = optionalAttrs cfg.registry.enable {
@@ -1238,20 +1338,19 @@ in {
           realm = "http${optionalString (cfg.https == true) "s"}://${cfg.host}/jwt/auth";
           service = cfg.registry.serviceName;
           issuer = cfg.registry.issuer;
-          rootcertbundle = cfg.registry.certFile;
-        };
+        } // (optionalAttrs (cfg.registry.certFile != null) { rootcertbundle = cfg.registry.certFile; });
       };
     };
 
     # Use postfix to send out mails.
     services.postfix.enable = mkDefault (cfg.smtp.enable && cfg.smtp.address == "localhost");
 
-    users.users.${cfg.user} =
-      { group = cfg.group;
-        home = "${cfg.statePath}/home";
-        shell = "${pkgs.bash}/bin/bash";
-        uid = config.ids.uids.gitlab;
-      };
+    users.users.${cfg.user} = {
+      group = cfg.group;
+      home = "${cfg.statePath}/home";
+      shell = "${pkgs.bash}/bin/bash";
+      uid = config.ids.uids.gitlab;
+    };
 
     users.groups.${cfg.group}.gid = config.ids.gids.gitlab;
 
@@ -1292,15 +1391,16 @@ in {
       "L+ /run/gitlab/shell-config.yml - - - - ${pkgs.writeText "config.yml" (builtins.toJSON gitlabShellConfig)}"
     ];
 
-
     systemd.services.gitlab-config = {
       wantedBy = [ "gitlab.target" ];
       partOf = [ "gitlab.target" ];
-      path = [ git ] ++ (with pkgs; [
-        jq
-        openssl
-        replace-secret
-      ]);
+      path =
+        [ git ]
+        ++ (with pkgs; [
+          jq
+          openssl
+          replace-secret
+        ]);
       serviceConfig = {
         Type = "oneshot";
         User = cfg.user;
@@ -1310,17 +1410,19 @@ in {
         WorkingDirectory = "${cfg.packages.gitlab}/share/gitlab";
         RemainAfterExit = true;
 
-        ExecStartPre = let
-          preStartFullPrivileges = ''
-            set -o errexit -o pipefail -o nounset
-            shopt -s dotglob nullglob inherit_errexit
+        ExecStartPre =
+          let
+            preStartFullPrivileges = ''
+              set -o errexit -o pipefail -o nounset
+              shopt -s dotglob nullglob inherit_errexit
 
-            chown --no-dereference '${cfg.user}':'${cfg.group}' '${cfg.statePath}'/*
-            if [[ -n "$(ls -A '${cfg.statePath}'/config/)" ]]; then
-              chown --no-dereference '${cfg.user}':'${cfg.group}' '${cfg.statePath}'/config/*
-            fi
-          '';
-        in "+${pkgs.writeShellScript "gitlab-pre-start-full-privileges" preStartFullPrivileges}";
+              chown --no-dereference '${cfg.user}':'${cfg.group}' '${cfg.statePath}'/*
+              if [[ -n "$(ls -A '${cfg.statePath}'/config/)" ]]; then
+                chown --no-dereference '${cfg.user}':'${cfg.group}' '${cfg.statePath}'/config/*
+              fi
+            '';
+          in
+          "+${pkgs.writeShellScript "gitlab-pre-start-full-privileges" preStartFullPrivileges}";
 
         ExecStart = pkgs.writeShellScript "gitlab-config" ''
           set -o errexit -o pipefail -o nounset
@@ -1341,10 +1443,10 @@ in {
           ${cfg.packages.gitlab-shell}/bin/install
 
           ${optionalString cfg.smtp.enable ''
-              install -m u=rw ${smtpSettings} ${cfg.statePath}/config/initializers/smtp_settings.rb
-              ${optionalString (cfg.smtp.passwordFile != null) ''
-                  replace-secret '@smtpPassword@' '${cfg.smtp.passwordFile}' '${cfg.statePath}/config/initializers/smtp_settings.rb'
-              ''}
+            install -m u=rw ${smtpSettings} ${cfg.statePath}/config/initializers/smtp_settings.rb
+            ${optionalString (cfg.smtp.passwordFile != null) ''
+              replace-secret '@smtpPassword@' '${cfg.smtp.passwordFile}' '${cfg.statePath}/config/initializers/smtp_settings.rb'
+            ''}
           ''}
 
           (
@@ -1352,12 +1454,13 @@ in {
 
             openssl rand -hex 32 > ${cfg.statePath}/gitlab_shell_secret
             ${optionalString cfg.pages.enable ''
-                openssl rand -base64 32 > ${cfg.pages.settings.api-secret-key}
+              openssl rand -base64 32 > ${cfg.pages.settings.api-secret-key}
             ''}
 
             rm -f '${cfg.statePath}/config/database.yml'
 
-            ${lib.optionalString (cfg.databasePasswordFile != null) ''
+            ${
+              lib.optionalString (cfg.databasePasswordFile != null) ''
                 db_password="$(<'${cfg.databasePasswordFile}')"
                 export db_password
 
@@ -1365,18 +1468,23 @@ in {
                   >&2 echo "Database password was an empty string!"
                   exit 1
                 fi
-            ''}
+              ''
+            }
 
             # GitLab expects the `production.main` section to be the first entry in the file.
             jq <${pkgs.writeText "database.yml" (builtins.toJSON databaseConfig)} '{
               production: [
-                ${lib.optionalString (cfg.databasePasswordFile != null) (
-                  builtins.concatStringsSep "\n      " (
-                    [ ".production${lib.optionalString (gitlabVersionAtLeast "15.0") ".main"}.password = $ENV.db_password" ]
-                    ++ lib.optional (gitlabVersionAtLeast "15.9") "| .production.ci.password = $ENV.db_password"
-                    ++ [ "|" ]
+                ${
+                  lib.optionalString (cfg.databasePasswordFile != null) (
+                    builtins.concatStringsSep "\n      " (
+                      [
+                        ".production${lib.optionalString (gitlabVersionAtLeast "15.0") ".main"}.password = $ENV.db_password"
+                      ]
+                      ++ lib.optional (gitlabVersionAtLeast "15.9") "| .production.ci.password = $ENV.db_password"
+                      ++ [ "|" ]
+                    )
                   )
-                )} .production
+                } .production
                 | to_entries[]
               ]
               | sort_by(.key)
@@ -1384,10 +1492,7 @@ in {
               | from_entries
             }' >'${cfg.statePath}/config/database.yml'
 
-            ${utils.genJqSecretsReplacementSnippet
-                gitlabConfig
-                "${cfg.statePath}/config/gitlab.yml"
-            }
+            ${utils.genJqSecretsReplacementSnippet gitlabConfig "${cfg.statePath}/config/gitlab.yml"}
 
             rm -f '${cfg.statePath}/config/secrets.yml'
 
@@ -1412,8 +1517,14 @@ in {
     };
 
     systemd.services.gitlab-db-config = {
-      after = [ "gitlab-config.service" "gitlab-postgresql.service" "postgresql.service" ];
-      wants = optional (cfg.databaseHost == "") "postgresql.service" ++ optional databaseActuallyCreateLocally "gitlab-postgresql.service";
+      after = [
+        "gitlab-config.service"
+        "gitlab-postgresql.service"
+        "postgresql.service"
+      ];
+      wants =
+        optional (cfg.databaseHost == "") "postgresql.service"
+        ++ optional databaseActuallyCreateLocally "gitlab-postgresql.service";
       bindsTo = [ "gitlab-config.service" ];
       wantedBy = [ "gitlab.target" ];
       partOf = [ "gitlab.target" ];
@@ -1453,26 +1564,30 @@ in {
       wants = [ "redis-gitlab.service" ] ++ optional (cfg.databaseHost == "") "postgresql.service";
       wantedBy = [ "gitlab.target" ];
       partOf = [ "gitlab.target" ];
-      environment = gitlabEnv // (optionalAttrs cfg.sidekiq.memoryKiller.enable {
-        SIDEKIQ_MEMORY_KILLER_MAX_RSS = cfg.sidekiq.memoryKiller.maxMemory;
-        SIDEKIQ_MEMORY_KILLER_GRACE_TIME = cfg.sidekiq.memoryKiller.graceTime;
-        SIDEKIQ_MEMORY_KILLER_SHUTDOWN_WAIT = cfg.sidekiq.memoryKiller.shutdownWait;
-      });
-      path = [ git ] ++ (with pkgs; [
-        postgresqlPackage
-        ruby
-        openssh
-        nodejs
-        gnupg
+      environment =
+        gitlabEnv
+        // (optionalAttrs cfg.sidekiq.memoryKiller.enable {
+          SIDEKIQ_MEMORY_KILLER_MAX_RSS = cfg.sidekiq.memoryKiller.maxMemory;
+          SIDEKIQ_MEMORY_KILLER_GRACE_TIME = cfg.sidekiq.memoryKiller.graceTime;
+          SIDEKIQ_MEMORY_KILLER_SHUTDOWN_WAIT = cfg.sidekiq.memoryKiller.shutdownWait;
+        });
+      path =
+        [ git ]
+        ++ (with pkgs; [
+          postgresqlPackage
+          ruby
+          openssh
+          nodejs
+          gnupg
 
-        "${cfg.packages.gitlab}/share/gitlab/vendor/gems/sidekiq-${cfg.packages.gitlab.rubyEnv.gems.sidekiq.version}"
+          "${cfg.packages.gitlab}/share/gitlab/vendor/gems/sidekiq-${cfg.packages.gitlab.rubyEnv.gems.sidekiq.version}"
 
-        # Needed for GitLab project imports
-        gnutar
-        gzip
+          # Needed for GitLab project imports
+          gnutar
+          gzip
 
-        procps # Sidekiq MemoryKiller
-      ]);
+          procps # Sidekiq MemoryKiller
+        ]);
       serviceConfig = {
         Type = "simple";
         User = cfg.user;
@@ -1484,26 +1599,36 @@ in {
           [
             "${cfg.packages.gitlab}/share/gitlab/bin/sidekiq-cluster"
             "*" # all queue groups
-          ] ++ lib.optionals (cfg.sidekiq.concurrency != null) [
-            "--concurrency" (toString cfg.sidekiq.concurrency)
-          ] ++ [
-            "--environment" "production"
-            "--require" "."
+          ]
+          ++ lib.optionals (cfg.sidekiq.concurrency != null) [
+            "--concurrency"
+            (toString cfg.sidekiq.concurrency)
+          ]
+          ++ [
+            "--environment"
+            "production"
+            "--require"
+            "."
           ]
         );
       };
     };
 
     systemd.services.gitaly = {
-      after = [ "network.target" "gitlab-config.service" ];
+      after = [
+        "network.target"
+        "gitlab-config.service"
+      ];
       bindsTo = [ "gitlab-config.service" ];
       wantedBy = [ "gitlab.target" ];
       partOf = [ "gitlab.target" ];
-      path = [ git ] ++ (with pkgs; [
-        openssh
-        gzip
-        bzip2
-      ]);
+      path =
+        [ git ]
+        ++ (with pkgs; [
+          openssh
+          gzip
+          bzip2
+        ]);
       serviceConfig = {
         Type = "simple";
         User = cfg.user;
@@ -1526,69 +1651,91 @@ in {
         isSecret = v: isAttrs v && v ? _secret && isString v._secret;
         mkPagesKeyValue = lib.generators.toKeyValue {
           mkKeyValue = lib.flip lib.generators.mkKeyValueDefault "=" rec {
-            mkValueString = v:
-              if isInt           v then toString v
-              else if isString   v then v
-              else if true  ==   v then "true"
-              else if false ==   v then "false"
-              else if isSecret   v then builtins.hashString "sha256" v._secret
-              else throw "unsupported type ${builtins.typeOf v}: ${(lib.generators.toPretty {}) v}";
+            mkValueString =
+              v:
+              if isInt v then
+                toString v
+              else if isString v then
+                v
+              else if true == v then
+                "true"
+              else if false == v then
+                "false"
+              else if isSecret v then
+                builtins.hashString "sha256" v._secret
+              else
+                throw "unsupported type ${builtins.typeOf v}: ${(lib.generators.toPretty { }) v}";
           };
         };
         secretPaths = lib.catAttrs "_secret" (lib.collect isSecret filteredConfig);
         mkSecretReplacement = file: ''
-          replace-secret ${lib.escapeShellArgs [ (builtins.hashString "sha256" file) file "/run/gitlab-pages/gitlab-pages.conf" ]}
+          replace-secret ${
+            lib.escapeShellArgs [
+              (builtins.hashString "sha256" file)
+              file
+              "/run/gitlab-pages/gitlab-pages.conf"
+            ]
+          }
         '';
         secretReplacements = lib.concatMapStrings mkSecretReplacement secretPaths;
         configFile = pkgs.writeText "gitlab-pages.conf" (mkPagesKeyValue filteredConfig);
       in
-        mkIf cfg.pages.enable {
-          description = "GitLab static pages daemon";
-          after = [ "network.target" "gitlab-config.service" "gitlab.service" ];
-          bindsTo = [ "gitlab-config.service" "gitlab.service" ];
-          wantedBy = [ "gitlab.target" ];
-          partOf = [ "gitlab.target" ];
+      mkIf cfg.pages.enable {
+        description = "GitLab static pages daemon";
+        after = [
+          "network.target"
+          "gitlab-config.service"
+          "gitlab.service"
+        ];
+        bindsTo = [
+          "gitlab-config.service"
+          "gitlab.service"
+        ];
+        wantedBy = [ "gitlab.target" ];
+        partOf = [ "gitlab.target" ];
 
-          path = with pkgs; [
-            unzip
-            replace-secret
-          ];
+        path = with pkgs; [
+          unzip
+          replace-secret
+        ];
 
-          serviceConfig = {
-            Type = "simple";
-            TimeoutSec = "infinity";
-            Restart = "on-failure";
+        serviceConfig = {
+          Type = "simple";
+          TimeoutSec = "infinity";
+          Restart = "on-failure";
 
-            User = cfg.user;
-            Group = cfg.group;
+          User = cfg.user;
+          Group = cfg.group;
 
-            ExecStartPre = pkgs.writeShellScript "gitlab-pages-pre-start" ''
-              set -o errexit -o pipefail -o nounset
-              shopt -s dotglob nullglob inherit_errexit
+          ExecStartPre = pkgs.writeShellScript "gitlab-pages-pre-start" ''
+            set -o errexit -o pipefail -o nounset
+            shopt -s dotglob nullglob inherit_errexit
 
-              install -m u=rw ${configFile} /run/gitlab-pages/gitlab-pages.conf
-              ${secretReplacements}
-            '';
-            ExecStart = "${cfg.packages.pages}/bin/gitlab-pages -config=/run/gitlab-pages/gitlab-pages.conf";
-            WorkingDirectory = gitlabEnv.HOME;
-            RuntimeDirectory = "gitlab-pages";
-            RuntimeDirectoryMode = "0700";
-          };
+            install -m u=rw ${configFile} /run/gitlab-pages/gitlab-pages.conf
+            ${secretReplacements}
+          '';
+          ExecStart = "${cfg.packages.pages}/bin/gitlab-pages -config=/run/gitlab-pages/gitlab-pages.conf";
+          WorkingDirectory = gitlabEnv.HOME;
+          RuntimeDirectory = "gitlab-pages";
+          RuntimeDirectoryMode = "0700";
         };
+      };
 
     systemd.services.gitlab-workhorse = {
       after = [ "network.target" ];
       wantedBy = [ "gitlab.target" ];
       partOf = [ "gitlab.target" ];
-      path = [ git ] ++ (with pkgs; [
-        remarshal
-        exiftool
-        git
-        gnutar
-        gzip
-        openssh
-        cfg.packages.gitlab-workhorse
-      ]);
+      path =
+        [ git ]
+        ++ (with pkgs; [
+          remarshal
+          exiftool
+          git
+          gnutar
+          gzip
+          openssh
+          cfg.packages.gitlab-workhorse
+        ]);
       serviceConfig = {
         Type = "simple";
         User = cfg.user;
@@ -1600,17 +1747,13 @@ in {
           set -o errexit -o pipefail -o nounset
           shopt -s dotglob nullglob inherit_errexit
 
-          ${utils.genJqSecretsReplacementSnippet
-              cfg.workhorse.config
-              "${cfg.statePath}/config/gitlab-workhorse.json"}
+          ${utils.genJqSecretsReplacementSnippet cfg.workhorse.config "${cfg.statePath}/config/gitlab-workhorse.json"}
 
           json2toml "${cfg.statePath}/config/gitlab-workhorse.json" "${cfg.statePath}/config/gitlab-workhorse.toml"
           rm "${cfg.statePath}/config/gitlab-workhorse.json"
         '';
         ExecStart =
-          "${cfg.packages.gitlab-workhorse}/bin/${
-              optionalString (lib.versionAtLeast (lib.getVersion cfg.packages.gitlab-workhorse) "16.10") "gitlab-"
-            }workhorse "
+          "${cfg.packages.gitlab-workhorse}/bin/${optionalString (lib.versionAtLeast (lib.getVersion cfg.packages.gitlab-workhorse) "16.10") "gitlab-"}workhorse "
           + "-listenUmask 0 "
           + "-listenNetwork unix "
           + "-listenAddr /run/gitlab/gitlab-workhorse.socket "
@@ -1623,7 +1766,11 @@ in {
 
     systemd.services.gitlab-mailroom = mkIf (gitlabConfig.production.incoming_email.enabled or false) {
       description = "GitLab incoming mail daemon";
-      after = [ "network.target" "redis-gitlab.service" "gitlab-config.service" ];
+      after = [
+        "network.target"
+        "redis-gitlab.service"
+        "gitlab-config.service"
+      ];
       bindsTo = [ "gitlab-config.service" ];
       wantedBy = [ "gitlab.target" ];
       partOf = [ "gitlab.target" ];
@@ -1656,14 +1803,16 @@ in {
       requiredBy = [ "gitlab.target" ];
       partOf = [ "gitlab.target" ];
       environment = gitlabEnv;
-      path = [ git ] ++ (with pkgs; [
-        postgresqlPackage
-        openssh
-        nodejs
-        procps
-        gnupg
-        gzip
-      ]);
+      path =
+        [ git ]
+        ++ (with pkgs; [
+          postgresqlPackage
+          openssh
+          nodejs
+          procps
+          gnupg
+          gzip
+        ]);
       serviceConfig = {
         Type = "notify";
         User = cfg.user;
@@ -1672,7 +1821,9 @@ in {
         Restart = "on-failure";
         WorkingDirectory = "${cfg.packages.gitlab}/share/gitlab";
         ExecStart = concatStringsSep " " [
-          "${cfg.packages.gitlab.rubyEnv}/bin/bundle" "exec" "puma"
+          "${cfg.packages.gitlab.rubyEnv}/bin/bundle"
+          "exec"
+          "puma"
           "-e production"
           "-C ${cfg.statePath}/config/puma.rb"
           "-w ${cfg.puma.workers}"
@@ -1689,9 +1840,7 @@ in {
       environment = {
         RAILS_ENV = "production";
         CRON = "1";
-      } // optionalAttrs (stringLength cfg.backup.skip > 0) {
-        SKIP = cfg.backup.skip;
-      };
+      } // optionalAttrs (stringLength cfg.backup.skip > 0) { SKIP = cfg.backup.skip; };
       serviceConfig = {
         User = cfg.user;
         Group = cfg.group;


### PR DESCRIPTION
This allows one to enable the registry without providing a certificate. This may be useful to, e.g., run the registry behind a TLS terminating reverse proxy.

Related to #327635

## Description of changes

Makes `services.gitlab.registry.{certFile,keyFile}` optional and adjusts configuration to account for this.

This also includes a check to ensure that either both `services.gitlab.registry.{certFile,keyFile}` are defined or neither is defined. 

## Things done

> This is my first PR for a module, any advise on further testing would be appreciated.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
