### PR TITLE
cups-brother-dcpt725dw: init at 3.5.0-1

### DIFF
--- a/pkgs/by-name/cu/cups-brother-dcpt725dw/package.nix
+++ b/pkgs/by-name/cu/cups-brother-dcpt725dw/package.nix
@@ -1,0 +1,113 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  perl,
+  ghostscript,
+  coreutils,
+  gnugrep,
+  which,
+  file,
+  gnused,
+  dpkg,
+  makeWrapper,
+  libredirect,
+  debugLvl ? "0",
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cups-brother-dcpt725dw";
+  version = "3.5.0-1";
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf105181/dcpt725dwpdrv-${version}.i386.deb";
+    hash = "sha256-fK6RHaW/ej1nFgSaTbzWxVgjIW32YTbJbd1xD37ZE7c=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+  ];
+  buildInputs = [ perl ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    dpkg-deb -x $src $out
+
+    LPDDIR=$out/opt/brother/Printers/dcpt725dw/lpd
+    WRAPPER=$out/opt/brother/Printers/dcpt725dw/cupswrapper/brother_lpdwrapper_dcpt725dw
+
+    ln -s $LPDDIR/${stdenv.hostPlatform.linuxArch}/* $LPDDIR/
+
+    substituteInPlace $WRAPPER \
+      --replace-fail "PRINTER =~" "PRINTER = \"dcpt725dw\"; #" \
+      --replace-fail "basedir =~" "basedir = \"$out/opt/brother/Printers/dcpt725dw/\"; #" \
+      --replace-fail "lpdconf = " "lpdconf = \$lpddir.'/'.\$LPDCONFIGEXE.\$PRINTER; #" \
+      --replace-fail "\$DEBUG=0;" "\$DEBUG=${debugLvl};"
+
+    substituteInPlace $LPDDIR/filter_dcpt725dw \
+      --replace-fail "BR_PRT_PATH =~" "BR_PRT_PATH = \"$out/opt/brother/Printers/dcpt725dw/\"; #" \
+      --replace-fail "PRINTER =~" "PRINTER = \"dcpt725dw\"; #"
+
+    wrapProgram $WRAPPER \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          gnugrep
+          gnused
+        ]
+      }
+
+    wrapProgram $LPDDIR/filter_dcpt725dw \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          ghostscript
+          gnugrep
+          gnused
+          which
+          file
+        ]
+      }
+
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $LPDDIR/brdcpt725dwfilter
+
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $LPDDIR/brprintconf_dcpt725dw
+
+    wrapProgram $LPDDIR/brprintconf_dcpt725dw \
+      --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
+      --set NIX_REDIRECTS /opt=$out/opt
+
+    wrapProgram $LPDDIR/brdcpt725dwfilter \
+      --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
+      --set NIX_REDIRECTS /opt=$out/opt
+
+    mkdir -p "$out/lib/cups/filter" "$out/share/cups/model"
+
+    ln -s $out/opt/brother/Printers/dcpt725dw/cupswrapper/brother_lpdwrapper_dcpt725dw \
+      $out/lib/cups/filter/brother_lpdwrapper_dcpt725dw
+
+    ln -s "$out/opt/brother/Printers/dcpt725dw/cupswrapper/brother_dcpt725dw_printer_en.ppd" \
+      "$out/share/cups/model/"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Brother DCP-T725DW printer driver";
+    license = licenses.unfree;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ u2x1 ];
+    platforms = [
+      "x86_64-linux"
+      "i686-linux"
+    ];
+    downloadPage = "https://support.brother.com/g/b/downloadtop.aspx?c=cn_ot&lang=en&prod=dcpt725dw_cn";
+    homepage = "http://www.brother.com/";
+  };
+}


### PR DESCRIPTION
## Description of changes

This commit adds a driver to cups for the Brother DCP-T725DW printer.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
