### PR TITLE
faiss.passthru.tests: unbreak eval

### DIFF
--- a/pkgs/development/libraries/science/math/faiss/default.nix
+++ b/pkgs/development/libraries/science/math/faiss/default.nix
@@ -137,7 +137,9 @@ stdenv.mkDerivation {
           ''
             demo_ivfpq_indexing && touch $out
           '';
-    } // lib.optionalAttrs pythonSupport { pytest = pythonPackages.callPackage ./tests.nix { }; };
+      pythonFaiss = pythonPackages.faiss;
+      pytest = pythonPackages.faiss.tests.pytest;
+    };
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/faiss/default.nix
+++ b/pkgs/development/python-modules/faiss/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildPythonPackage,
+  callPackage,
   faiss-build,
   numpy,
   packaging,
@@ -38,6 +39,14 @@ buildPythonPackage {
   dontBuild = true;
 
   pythonImportsCheck = [ "faiss" ];
+
+  passthru = {
+    inherit (faiss-build) cudaSupport cudaPackages pythonSupport;
+
+    tests = {
+      pytest = callPackage ./pytest.nix { inherit faiss-build; };
+    };
+  };
 
   meta = lib.pipe (faiss-build.meta or { }) [
     (lib.flip builtins.removeAttrs [ "mainProgram" ])

--- a/pkgs/development/python-modules/faiss/pytest.nix
+++ b/pkgs/development/python-modules/faiss/pytest.nix
@@ -1,8 +1,10 @@
-{ lib
-, buildPythonPackage
-, faiss
-, scipy
-, pytestCheckHook
+{
+  lib,
+  buildPythonPackage,
+  faiss,
+  faiss-build,
+  scipy,
+  pytestCheckHook,
 }:
 
 assert faiss.pythonSupport;
@@ -13,15 +15,13 @@ buildPythonPackage {
 
   format = "other";
 
-  src = "${faiss.src}/tests";
+  src = "${faiss-build.src}/tests";
 
   dontBuild = true;
   dontInstall = true;
 
   # Tests that need GPUs and would fail in the sandbox
-  disabledTestPaths = lib.optionals faiss.cudaSupport [
-    "test_contrib.py"
-  ];
+  disabledTestPaths = lib.optionals faiss.cudaSupport [ "test_contrib.py" ];
 
   disabledTests = [
     # https://github.com/facebookresearch/faiss/issues/2836
@@ -32,6 +32,9 @@ buildPythonPackage {
     faiss
     pytestCheckHook
     scipy
-  ] ++
-  faiss.extra-requires.all;
+  ];
+
+  meta = faiss.meta // {
+    description = "Faiss test suite";
+  };
 }


### PR DESCRIPTION
The new python3Packages.faiss derivation needs to have the same passthru for tests. More info: https://github.com/NixOS/nixpkgs/pull/330555#issuecomment-2254575573

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
