### PR TITLE
sidequest: fix gsettings schema missing on kde

### DIFF
--- a/pkgs/applications/misc/sidequest/default.nix
+++ b/pkgs/applications/misc/sidequest/default.nix
@@ -25,6 +25,7 @@
 , icu
 , openssl
 , zlib
+, wrapGAppsHook
 }:
   let
     pname = "sidequest";
@@ -47,7 +48,7 @@
       };
       dontUnpack = true;
 
-      nativeBuildInputs = [ makeWrapper ];
+      nativeBuildInputs = [ makeWrapper wrapGAppsHook ];
 
       installPhase = ''
         mkdir -p "$out/lib/SideQuest" "$out/bin"


### PR DESCRIPTION
## Description of changes

On my KDE, the current version of sidequest crashes/closes when trying to load an APK file to it, with the following message:

`GLib-GIO-ERROR: No GSettings schemas are installed on the system`.

This is because the app uses a GTK dialog to let the user choose the file. 

After some digging around, I found that adding `wrapGAppsHook` to `nativeBuildInputs` ensures that the SGettings schema is in place, along with other things.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I tested it using `NIX_PATH=nixpkgs=${PWD} nix-shell -p sidequest`
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
