### PR TITLE
nixos/gdm: make gdm-password pam config in line with upstream

### DIFF
--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -302,10 +302,21 @@ in
       '';
 
       gdm-password.text = ''
-        auth      substack      login
-        account   include       login
-        password  substack      login
-        session   include       login
+        auth       include       login
+        ${lib.optionalString pamCfg.login.enableGnomeKeyring ''
+          auth       optional      ${pkgs.gnome-keyring}/lib/security/pam_gnome_keyring.so
+        ''}
+
+        account    include       login
+        password   include       login
+        ${lib.optionalString pamCfg.login.enableGnomeKeyring ''
+          password   optional      ${pkgs.gnome-keyring}/lib/security/pam_gnome_keyring.so use_authtok
+        ''}
+
+        session    include       login
+        ${lib.optionalString pamCfg.login.enableGnomeKeyring ''
+          session    optional      ${pkgs.gnome-keyring}/lib/security/pam_gnome_keyring.so auto_start
+        ''}
       '';
 
       gdm-autologin.text = ''


### PR DESCRIPTION

## Description of changes

Adapted from [upstream arch pam config](https://gitlab.gnome.org/GNOME/gdm/-/blob/81ee658c11381912131dd4a29e84190f7f9cd039/data/pam-arch/gdm-password.pam).

Tested with both GNOME keyring enabled and disabled.
GNOME keyring is now properly unlocked with this change.

## Things done

- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
