### PR TITLE
freebsd: Handle MACHINE/MACHINE_ARCH/MACHINE_CPUARCH differences

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/lib/default.nix
+++ b/pkgs/os-specific/bsd/freebsd/lib/default.nix
@@ -11,10 +11,50 @@
     stdenv':
     {
       x86_64 = "amd64";
+      aarch64 = "aarch64";
+      i486 = "i386";
+      i586 = "i386";
+      i686 = "i386";
+      armv6l = "armv6";
+      armv7l = "armv7";
+      powerpc = "powerpc";
+      powerpc64 = "powerpc64";
+      powerpc64le = "powerpc64le";
+      riscv64 = "riscv64";
+    }
+    .${stdenv'.hostPlatform.parsed.cpu.name} or stdenv'.hostPlatform.parsed.cpu.name;
+
+  mkBsdCpuArch =
+    stdenv':
+    {
+      x86_64 = "amd64";
+      aarch64 = "aarch64";
+      i486 = "i386";
+      i586 = "i386";
+      i686 = "i386";
+      armv6l = "arm";
+      armv7l = "arm";
+      powerpc = "powerpc";
+      powerpc64 = "powerpc";
+      powerpc64le = "powerpc";
+      riscv64 = "riscv";
+    }
+    .${stdenv'.hostPlatform.parsed.cpu.name} or stdenv'.hostPlatform.parsed.cpu.name;
+
+  mkBsdMachine =
+    stdenv':
+    {
+      x86_64 = "amd64";
       aarch64 = "arm64";
       i486 = "i386";
       i586 = "i386";
       i686 = "i386";
+      armv6l = "arm";
+      armv7l = "arm";
+      powerpc = "powerpc";
+      powerpc64 = "powerpc";
+      powerpc64le = "powerpc";
+      riscv64 = "riscv";
     }
     .${stdenv'.hostPlatform.parsed.cpu.name} or stdenv'.hostPlatform.parsed.cpu.name;
 

--- a/pkgs/os-specific/bsd/freebsd/pkgs/compat/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/compat/package.nix
@@ -14,7 +14,7 @@
 }:
 
 let
-  inherit (freebsd-lib) mkBsdArch;
+  inherit (freebsd-lib) mkBsdMachine;
 in
 
 mkDerivation {
@@ -78,7 +78,7 @@ mkDerivation {
       "sys/sys/elf64.h"
       "sys/sys/elf_common.h"
       "sys/sys/elf_generic.h"
-      "sys/${mkBsdArch stdenv}/include"
+      "sys/${mkBsdMachine stdenv}/include"
     ]
     ++ lib.optionals stdenv.hostPlatform.isx86 [ "sys/x86/include" ]
     ++ [
@@ -118,8 +118,8 @@ mkDerivation {
     ''
       NIX_CFLAGS_COMPILE+=' -I../../include -I../../sys'
 
-      cp ../../sys/${mkBsdArch stdenv}/include/elf.h ../../sys/sys
-      cp ../../sys/${mkBsdArch stdenv}/include/elf.h ../../sys/sys/${mkBsdArch stdenv}
+      cp ../../sys/${mkBsdMachine stdenv}/include/elf.h ../../sys/sys
+      cp ../../sys/${mkBsdMachine stdenv}/include/elf.h ../../sys/sys/${mkBsdMachine stdenv}
     ''
     + lib.optionalString stdenv.hostPlatform.isx86 ''
       cp ../../sys/x86/include/elf.h ../../sys/x86

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
@@ -65,9 +65,9 @@ lib.makeOverridable (
       # amd64 not x86_64 for this on unlike NetBSD
       MACHINE_ARCH = freebsd-lib.mkBsdArch stdenv';
 
-      MACHINE = freebsd-lib.mkBsdArch stdenv';
+      MACHINE = freebsd-lib.mkBsdMachine stdenv';
 
-      MACHINE_CPUARCH = MACHINE_ARCH;
+      MACHINE_CPUARCH = freebsd-lib.mkBsdCpuArch stdenv';
 
       COMPONENT_PATH = attrs.path or null;
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Change freebsd-lib to handle the differences between `MACHINE`, `MACHINE_ARCH`, and `MACHINE_CPUARCH`.

This does not matter for x86_64, but will matter for aarch64 and armv7. The values are based off `man 7 arch` on FreeBSD, also available on the [FreeBSD website](https://man.freebsd.org/cgi/man.cgi?query=arch&apropos=0&sektion=0&manpath=FreeBSD+14.1-RELEASE+and+Ports&arch=default&format=html)

This should not change any derivations.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
