### PR TITLE
nose2pytest: init at 1.0.12

### DIFF
--- a/pkgs/by-name/no/nose2pytest/package.nix
+++ b/pkgs/by-name/no/nose2pytest/package.nix
@@ -1,0 +1,3 @@
+{ python3Packages }:
+
+python3Packages.toPythonApplication python3Packages.nose2pytest

--- a/pkgs/development/python-modules/fissix/default.nix
+++ b/pkgs/development/python-modules/fissix/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  flit-core,
+  appdirs,
+  pytestCheckHook,
+}:
+
+let
+  version = "24.4.24";
+in
+
+buildPythonPackage {
+  pname = "fissix";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "amyreese";
+    repo = "fissix";
+    rev = "v${version}";
+    hash = "sha256-geGctke+1PWFqJyiH1pQ0zWj9wVIjV/SQ5njOOk9gOw=";
+  };
+
+  build-system = [ flit-core ];
+
+  dependencies = [ appdirs ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  pythonImportsCheck = [ "fissix" ];
+
+  meta = {
+    description = "Backport of latest lib2to3, with enhancements";
+    homepage = "https://github.com/amyreese/fissix";
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+    license = lib.licenses.psfl;
+    maintainers = [ lib.maintainers.emily ];
+  };
+}

--- a/pkgs/development/python-modules/nose2pytest/default.nix
+++ b/pkgs/development/python-modules/nose2pytest/default.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchpatch2,
+  setuptools,
+  fissix,
+  pytestCheckHook,
+  nose,
+}:
+
+let
+  version = "1.0.12";
+in
+
+buildPythonPackage {
+  pname = "nose2pytest";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pytest-dev";
+    repo = "nose2pytest";
+    rev = "v${version}";
+    hash = "sha256-BYyj2ZOZvWBpmzQACpmxAzCdQhlZlDYt+HLMdft+wYY=";
+  };
+
+  patches = [
+    # Drop Python 3.6 and 3.7 support
+    #
+    # Relaxes the runtime check for Python < 3.12.
+    (fetchpatch2 {
+      url = "https://github.com/pytest-dev/nose2pytest/commit/75ff506aaf11b5e20672441730657ee7540387e1.patch?full_index=1";
+      hash = "sha256-BpazrsB4b1oMBx9OemdVxhj/Jqbc8RKv2GC6gqkdGK8=";
+    })
+  ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [ fissix ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    nose
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  pythonImportsCheck = [ "nose2pytest.assert_tools" ];
+
+  meta = {
+    description = "Scripts to convert Python Nose tests to PyTest";
+    homepage = "https://github.com/pytest-dev/nose2pytest";
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.emily ];
+    mainProgram = "nose2pytest";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9120,6 +9120,8 @@ self: super: with self; {
 
   nose2 = callPackage ../development/python-modules/nose2 { };
 
+  nose2pytest = callPackage ../development/python-modules/nose2pytest { };
+
   nose3 = callPackage ../development/python-modules/nose3 { };
 
   nose-timer = callPackage ../development/python-modules/nose-timer { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4332,6 +4332,8 @@ self: super: with self; {
 
   first = callPackage ../development/python-modules/first { };
 
+  fissix = callPackage ../development/python-modules/fissix { };
+
   fitbit = callPackage ../development/python-modules/fitbit { };
 
   fivem-api = callPackage ../development/python-modules/fivem-api { };


### PR DESCRIPTION
## Description of changes

They said nobody could get a new package using nose into Nixpkgs… they were wrong!!!

Obviously there is an element of farce here, but I just used this to accomplish https://github.com/yandex/gixy/pull/146 and I suspect it may come in handy for others working on https://github.com/NixOS/nixpkgs/issues/326513 or who just have their own nose test suites they’d like to migrate. The upstream package declares that it doesn’t work on Python 3.12, I guess because the nose‐using tests won’t natively run on that version, but it seems to work fine for me.

Of course, I’ll remove the nose `nativeCheckInput` and just disable the tests when the time comes. (Or now, if other people don’t find it as amusing as I do.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
