### PR TITLE
python312Packages.python-hglib: Remove nose dependency; modernize

### DIFF
--- a/pkgs/applications/misc/mozphab/default.nix
+++ b/pkgs/applications/misc/mozphab/default.nix
@@ -57,6 +57,14 @@ python3.pkgs.buildPythonApplication rec {
     export HOME=$(mktemp -d)
   '';
 
+  disabledTests = [
+    # AttributeError: 'called_once' is not a valid assertion.
+    "test_commit"
+    # AttributeError: 'not_called' is not a valid assertion.
+    "test_finalize_no_evolve"
+    "test_patch"
+  ];
+
   disabledTestPaths = [
     # codestyle doesn't matter to us
     "tests/test_style.py"

--- a/pkgs/development/python-modules/glean-parser/default.nix
+++ b/pkgs/development/python-modules/glean-parser/default.nix
@@ -8,43 +8,39 @@
   jinja2,
   jsonschema,
   pytestCheckHook,
-  pythonOlder,
   pyyaml,
   setuptools,
   setuptools-scm,
-  yamllint,
 }:
 
 buildPythonPackage rec {
   pname = "glean-parser";
-  version = "14.1.2";
-  format = "setuptools";
-
-  disabled = pythonOlder "3.8";
+  version = "14.3.0";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "glean_parser";
     inherit version;
-    hash = "sha256-OL59Tg+rD4M0DjQnkU4IqGMcf6sIioxg6bVDyrbqgww=";
+    hash = "sha256-tI1kMCn7gksLdq2ytKAOiKSd5OxHmsnFrdUsUR6b5IE=";
   };
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "pytest-runner" "" \
-      --replace "MarkupSafe>=1.1.1,<=2.0.1" "MarkupSafe>=1.1.1"
+      --replace-fail "pytest-runner" ""
   '';
 
-  nativeBuildInputs = [ setuptools-scm ];
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     appdirs
     click
     diskcache
     jinja2
     jsonschema
     pyyaml
-    setuptools
-    yamllint
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
@@ -63,12 +59,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "glean_parser" ];
 
-  meta = with lib; {
+  meta = {
     description = "Tools for parsing the metadata for Mozilla's glean telemetry SDK";
     mainProgram = "glean_parser";
     homepage = "https://github.com/mozilla/glean_parser";
     changelog = "https://github.com/mozilla/glean_parser/blob/v${version}/CHANGELOG.md";
-    license = licenses.mpl20;
+    license = lib.licenses.mpl20;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/glean-sdk/default.nix
+++ b/pkgs/development/python-modules/glean-sdk/default.nix
@@ -2,55 +2,41 @@
   stdenv,
   lib,
   buildPythonPackage,
-  cargo,
-  cffi,
-  fetchPypi,
+  fetchFromGitHub,
   glean-parser,
-  iso8601,
-  lmdb,
-  pkg-config,
   pytest-localserver,
   pytestCheckHook,
-  python,
-  pythonOlder,
-  rustc,
   rustPlatform,
   semver,
-  setuptools-rust,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "glean-sdk";
-  version = "52.7.0";
-  format = "setuptools";
+  version = "60.4.0";
+  pyproject = true;
 
-  disabled = pythonOlder "3.6";
-
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-sLjdGHiS7Co/oA9gQyAFkD14tAYjmwjWcPr4CRrzw/0=";
+  src = fetchFromGitHub {
+    owner = "mozilla";
+    repo = "glean";
+    rev = "v${version}";
+    hash = "sha256-C3wQdxPNBPQN6eUK6Vq0bA6Wpqb28e9BTBf7c/hTQxU=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-5TlgWcLmjklxhtDbB0aRF71iIRTJwetFj1Jii1DGdvU=";
+    hash = "sha256-XqOCHnvM64kZNifU5Wt/bFAvyRVy28ozWSwlvm/sMk8=";
   };
 
-  nativeBuildInputs = [
-    cargo
-    pkg-config
-    rustc
+  build-system = [
     rustPlatform.cargoSetupHook
-    setuptools-rust
+    rustPlatform.maturinBuildHook
+    setuptools
   ];
 
-  buildInputs = [ lmdb ];
-
-  propagatedBuildInputs = [
-    cffi
+  dependencies = [
     glean-parser
-    iso8601
     semver
   ];
 
@@ -59,23 +45,23 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  pytestFlagsArray = [ "glean-core/python/tests" ];
+
   disabledTests = [
     # RuntimeError: No ping received.
     "test_client_activity_api"
     "test_flipping_upload_enabled_respects_order_of_events"
+    # A warning causes this test to fail
+    "test_get_language_tag_reports_the_tag_for_the_default_locale"
   ];
-
-  postInstallCheck = lib.optionalString stdenv.hostPlatform.isElf ''
-    readelf -a $out/${python.sitePackages}/glean/libglean_ffi.so | grep -F 'Shared library: [liblmdb.so'
-  '';
 
   pythonImportsCheck = [ "glean" ];
 
-  meta = with lib; {
+  meta = {
     broken = stdenv.isDarwin;
     description = "Telemetry client libraries and are a part of the Glean project";
     homepage = "https://mozilla.github.io/glean/book/index.html";
-    license = licenses.mpl20;
-    maintainers = with maintainers; [ melling ];
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ melling ];
   };
 }

--- a/pkgs/development/python-modules/python-hglib/default.nix
+++ b/pkgs/development/python-modules/python-hglib/default.nix
@@ -5,12 +5,13 @@
   mercurial,
   pytestCheckHook,
   fetchpatch2,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "python-hglib";
   version = "2.6.2";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchzip {
     url = "https://repo.mercurial-scm.org/python-hglib/archive/${version}.tar.gz";
@@ -21,15 +22,17 @@ buildPythonPackage rec {
     (fetchpatch2 {
       name = "remove-nose.patch";
       excludes = [ "heptapod-ci.yml" ];
-      url = "https://repo.mercurial-scm.org/python-hglib/raw-rev/8341f2494b3f";
+      url = "https://repo.mercurial-scm.org/python-hglib/raw-rev/8341f2494b3fc1c0d9ee55fa4487c0ac82f64d2a";
       hash = "sha256-4gicVCAH94itxHY0l8ek0L/RVhUrw2lMbbnENbWrV6U=";
     })
     (fetchpatch2 {
       name = "fix-tests.patch";
-      url = "https://repo.mercurial-scm.org/python-hglib/raw-rev/a2afbf236ca8";
+      url = "https://repo.mercurial-scm.org/python-hglib/raw-rev/a2afbf236ca86287e72f54e1248413625d1bc405";
       hash = "sha256-T/yKJ8cMMOBVk24SXwyPOoD321S1fZEIunaPJAxI0KI=";
     })
   ];
+
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [
     mercurial
@@ -43,10 +46,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "hglib" ];
 
-  meta = with lib; {
+  meta = {
     description = "Library with a fast, convenient interface to Mercurial. It uses Mercurial’s command server for communication with hg";
     homepage = "https://www.mercurial-scm.org/wiki/PythonHglibs";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/python-hglib/default.nix
+++ b/pkgs/development/python-modules/python-hglib/default.nix
@@ -1,9 +1,10 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchzip,
   mercurial,
-  nose,
+  pytestCheckHook,
+  fetchpatch2,
 }:
 
 buildPythonPackage rec {
@@ -11,14 +12,28 @@ buildPythonPackage rec {
   version = "2.6.2";
   format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-sYvR7VPJDuV9VxTWata7crZOkw1K7KmDCJLAi7KNpgg=";
+  src = fetchzip {
+    url = "https://repo.mercurial-scm.org/python-hglib/archive/${version}.tar.gz";
+    hash = "sha256-UXersegqJ9VAxy4Kvpb2IiOJfQbWryeeaGvwiR4ncW8=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      name = "remove-nose.patch";
+      excludes = [ "heptapod-ci.yml" ];
+      url = "https://repo.mercurial-scm.org/python-hglib/raw-rev/8341f2494b3f";
+      hash = "sha256-4gicVCAH94itxHY0l8ek0L/RVhUrw2lMbbnENbWrV6U=";
+    })
+    (fetchpatch2 {
+      name = "fix-tests.patch";
+      url = "https://repo.mercurial-scm.org/python-hglib/raw-rev/a2afbf236ca8";
+      hash = "sha256-T/yKJ8cMMOBVk24SXwyPOoD321S1fZEIunaPJAxI0KI=";
+    })
+  ];
 
   nativeCheckInputs = [
     mercurial
-    nose
+    pytestCheckHook
   ];
 
   preCheck = ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4968,9 +4968,7 @@ self: super: with self; {
 
   glean-parser = callPackage ../development/python-modules/glean-parser { };
 
-  glean-sdk = callPackage ../development/python-modules/glean-sdk {
-    inherit (pkgs) lmdb;
-  };
+  glean-sdk = callPackage ../development/python-modules/glean-sdk { };
 
   glfw = callPackage ../development/python-modules/glfw { };
 


### PR DESCRIPTION
## Description of changes
Part of #326513 

This required a few more patches and fixes to other packages than I would like, but this does allow all dependents of python-hglib to build and test properly.

Updates: 
- python312Packages.glean-parser: 4.1.2 -> 4.3.0
- python312Packages.glean-sdk: 52.7.0 -> 60.4.0
Changes:
- `mozphab` has 3 failing tests disabled
- python312Packages.python-hglib is now fetched directly from the upstream repo and has patches applied to remove nose and fix failing tests.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
