### PR TITLE
wireshark-qt: Fix plugins on darwin

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -9,6 +9,7 @@
 , buildPackages
 , c-ares
 , cmake
+, fixDarwinDylibNames
 , flex
 , gettext
 , glib
@@ -49,7 +50,9 @@
 , withQt ? true
 , qt6 ? null
 }:
-
+let
+  isAppBundle = withQt && stdenv.isDarwin;
+in
 assert withQt -> qt6 != null;
 
 stdenv.mkDerivation rec {
@@ -86,6 +89,8 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals withQt [
     qt6.wrapQtAppsHook
     wrapGAppsHook3
+  ] ++ lib.optionals stdenv.isDarwin [
+    fixDarwinDylibNames
   ];
 
   buildInputs = [
@@ -139,7 +144,7 @@ stdenv.mkDerivation rec {
     "-DBUILD_wireshark=${if withQt then "ON" else "OFF"}"
     # Fix `extcap` and `plugins` paths. See https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=16444
     "-DCMAKE_INSTALL_LIBDIR=lib"
-    "-DENABLE_APPLICATION_BUNDLE=${if withQt && stdenv.isDarwin then "ON" else "OFF"}"
+    "-DENABLE_APPLICATION_BUNDLE=${if isAppBundle then "ON" else "OFF"}"
     "-DLEMON_C_COMPILER=cc"
   ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
     "-DHAVE_C99_VSNPRINTF_EXITCODE__TRYRUN_OUTPUT="
@@ -163,19 +168,34 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     cmake --install . --prefix "''${!outputDev}" --component Development
-  '' + lib.optionalString (stdenv.isDarwin && withQt) ''
+  '' + lib.optionalString isAppBundle ''
     mkdir -p $out/Applications
     mv $out/bin/Wireshark.app $out/Applications/Wireshark.app
+  '' + lib.optionalString stdenv.isDarwin ''
+    local flags=()
+    for file in $out/lib/*.dylib; do
+      flags+=(-change @rpath/"$(basename "$file")" "$file")
+    done
 
-    for f in $(find $out/Applications/Wireshark.app/Contents/PlugIns -name "*.so"); do
-        for dylib in $(otool -L $f | awk '/^\t*lib/ {print $1}'); do
-            install_name_tool -change "$dylib" "$out/lib/$dylib" "$f"
-        done
+    for file in $out/lib/wireshark/extcap/*; do
+      if [ -L "$file" ]; then continue; fi
+      echo "$file: fixing dylib references"
+      # note that -id does nothing on binaries
+      install_name_tool -id "$file" "''${flags[@]}" "$file"
     done
   '';
 
   preFixup = ''
     qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  # This is done to remove some binary wrappers that wrapQtApps adds in *.app directories.
+  # Copying because unfortunately pointing Wireshark (when built as an appbundle) at $out/lib instead is nontrivial.
+  postFixup = lib.optionalString isAppBundle ''
+    rm -rf $out/Applications/Wireshark.app/Contents/MacOS/extcap $out/Applications/Wireshark.app/Contents/PlugIns
+    mkdir -p $out/Applications/Wireshark.app/Contents/PlugIns/wireshark
+    cp -r $out/lib/wireshark/plugins/4-2 $out/Applications/Wireshark.app/Contents/PlugIns/wireshark/4-2
+    cp -r $out/lib/wireshark/extcap $out/Applications/Wireshark.app/Contents/MacOS/extcap
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

When running graphical Wireshark on Darwin, the window hangs and then spits out a bunch of warnings like `The plugin 'profinet.so' has no "plugin_version" symbol`.

The first issue is due to the linker failing to load extcap plugins because Wireshark libraries are searched for using rpath; I borrowed code from [circt-llvm](https://github.com/NixOS/nixpkgs/blob/6668b98f2805c67177f9acdf7801ca8cfb7af1be/pkgs/development/compilers/circt/circt-llvm.nix#L72-L84) to just use the store paths instead.

The second issue is because plugins under Wireshark.app are being wrapped when they shouldn't be (they are meant to be directly loaded by Wireshark). I thought this wrapping came from [wrapQtApps](https://github.com/NixOS/nixpkgs/blob/f27b62e789ceae5531852d8a015bae05ada145de/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh#L79), but it looks like they ignore Mach-O so maybe not.
I fixed this by copying over the "untainted" plugins from `$out/lib` instead of just deleting the wrappers under `$out/Applications`, primarily because I was originally trying to get rid of as many paths inside the application bundle and use paths from `$out/lib` instead. However, these paths are deeply entangled in the Wireshark runtime [itself](https://gitlab.com/wireshark/wireshark/-/blob/254b74b9748cfc915cae1b44b6e2fd045cc7819d/wsutil/filesystem.c#L237), so this isn't really possible without a refactor upstream.

This should fix https://github.com/NixOS/nixpkgs/issues/103944 and https://github.com/NixOS/nixpkgs/issues/217303.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
