### PR TITLE
stdenv: `runPhase` returns status

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1624,7 +1624,7 @@ showPhaseFooter() {
 
 
 runPhase() {
-    local status=0
+    local retval=0
     local curPhase="$*"
     if [[ "$curPhase" = unpackPhase && -n "${dontUnpack:-}" ]]; then return; fi
     if [[ "$curPhase" = patchPhase && -n "${dontPatch:-}" ]]; then return; fi
@@ -1645,13 +1645,9 @@ runPhase() {
     startTime=$(date +"%s")
 
     # Evaluate the variable named $curPhase if it exists, otherwise the
-    # function named $curPhase. Trap errors in subshell to set error status.
-    trap 'status=1; trap - ERR' ERR
+    # function named $curPhase. Trap errors in subshell to set non-zero retval.
+    trap 'retval=1; trap - ERR' ERR
     eval "set -o errtrace; ${!curPhase:-$curPhase}"
-
-    # Evaluate the variable named $curPhase if it exists, otherwise the
-    # function named $curPhase.
-    eval "${!curPhase:-$curPhase}"
 
     endTime=$(date +"%s")
 
@@ -1664,7 +1660,7 @@ runPhase() {
         cd -- "${sourceRoot:-.}"
     fi
 
-    return $status
+    return $retval
 }
 
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1624,6 +1624,7 @@ showPhaseFooter() {
 
 
 runPhase() {
+    local status=0
     local curPhase="$*"
     if [[ "$curPhase" = unpackPhase && -n "${dontUnpack:-}" ]]; then return; fi
     if [[ "$curPhase" = patchPhase && -n "${dontPatch:-}" ]]; then return; fi
@@ -1644,6 +1645,11 @@ runPhase() {
     startTime=$(date +"%s")
 
     # Evaluate the variable named $curPhase if it exists, otherwise the
+    # function named $curPhase. Trap errors in subshell to set error status.
+    trap 'status=1; trap - ERR' ERR
+    eval "set -o errtrace; ${!curPhase:-$curPhase}"
+
+    # Evaluate the variable named $curPhase if it exists, otherwise the
     # function named $curPhase.
     eval "${!curPhase:-$curPhase}"
 
@@ -1657,6 +1663,8 @@ runPhase() {
 
         cd -- "${sourceRoot:-.}"
     fi
+
+    return $status
 }
 
 


### PR DESCRIPTION
## Description of changes

The [relatively new `runPhase`](https://github.com/NixOS/nixpkgs/pull/230874/files) function in stdenv seems to be the best practice for building packages within a devshell, rather than manually executing sub-commands (e.g., `cmake .. && make`). This creates better consistency between dev workflow and the eventual realized derivation created by `nix build`. 

However, the `runPhase` command obscures any failures which take place within the individual build phases. To fix that problem, this PR installs an ERR trap handler which sets a return value to 1 on the first non-zero exit status. The `errtrace` shell option is also set to pass the new trap handler to any subsequent shell functions, command substitutions, and commands executed in a subshell environment.

My primary motivation was to allow better scripting around `runPhase`, e.g., run phases consecutively only if prior phases succeed, alert on errors. ~However it seems like this would facilitate a change to make `genericBuild` halt on any failed phases, which could be meaningful for CI pipelines. Happy to have that conversation here or in a separate forum. Also would appreciate links to any prior conversations about this behavior within stdenv genericBuild/runPhase.~

(Edit: I have since discovered that stdenv invokes genericBuild with `-e` shell option, causing immediate exit on failure when using e.g., `nix build`. Importantly, `set -e` is not a viable option in the devshell since it causes the devshell to exit on failure.)

I realize this PR has broad impact, despite being relatively low risk. In light of that and [Hyrum's Law](https://www.hyrumslaw.com/), I'm also open to making a flag or separate function so that the return value of `runPhase` is unaffected in current usage.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
