### PR TITLE
pkgs/top-level/config.nix: nixfmt, declare options

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -55,7 +55,7 @@ let
     envVar = builtins.getEnv "NIXPKGS_ALLOW_NONSOURCE";
   in if envVar != ""
      then envVar != "0"
-     else config.allowNonSource or true;
+     else config.allowNonSource;
 
   allowlist = config.allowlistedLicenses or config.whitelistedLicenses or [];
   blocklist = config.blocklistedLicenses or config.blacklistedLicenses or [];

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -145,7 +145,7 @@ let
   #   allowNonSource = false;
   #   allowNonSourcePredicate = with pkgs.lib.lists; pkg: !(any (p: !p.isSource && p != lib.sourceTypes.binaryFirmware) pkg.meta.sourceProvenance);
   # }
-  allowNonSourcePredicate = config.allowNonSourcePredicate or (x: false);
+  inherit (config) allowNonSourcePredicate;
 
   # Check whether non-source packages are allowed and if not, whether the
   # package has non-source provenance and is not explicitly allowed by the

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -47,7 +47,7 @@ let
   # import <nixpkgs> { config = { showDerivationWarnings = [ "maintainerless" ]; }; }
   showWarnings = config.showDerivationWarnings;
 
-  getNameWithVersion = attrs: attrs.name or ("${attrs.pname or "«name-missing»"}-${attrs.version or "«version-missing»"}");
+  getNameWithVersion = attrs: attrs.name or "${attrs.pname or "«name-missing»"}-${attrs.version or "«version-missing»"}";
 
   allowUnfree = config.allowUnfree
     || builtins.getEnv "NIXPKGS_ALLOW_UNFREE" == "1";

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -41,7 +41,8 @@ let
 
   # If we're in hydra, we can dispense with the more verbose error
   # messages and make problems easier to spot.
-  inHydra = config.inHydra or false;
+  inherit (config) inHydra;
+
   # Allow the user to opt-into additional warnings, e.g.
   # import <nixpkgs> { config = { showDerivationWarnings = [ "maintainerless" ]; }; }
   showWarnings = config.showDerivationWarnings;

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -123,7 +123,7 @@ let
     !allowUnfree &&
     !allowUnfreePredicate attrs;
 
-  allowInsecureDefaultPredicate = x: builtins.elem (getNameWithVersion x) (config.permittedInsecurePackages or []);
+  allowInsecureDefaultPredicate = x: elem (getNameWithVersion x) config.permittedInsecurePackages;
   allowInsecurePredicate = x: (config.allowInsecurePredicate or allowInsecureDefaultPredicate) x;
 
   hasAllowedInsecure = attrs:

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -113,7 +113,7 @@ let
   #   allowUnfree = false;
   #   allowUnfreePredicate = (x: pkgs.lib.hasPrefix "vscode" x.name);
   # }
-  allowUnfreePredicate = config.allowUnfreePredicate or (x: false);
+  inherit (config) allowUnfreePredicate;
 
   # Check whether unfree packages are allowed and if not, whether the
   # package has an unfree license and is not explicitly allowed by the

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -17,32 +17,39 @@ let
     types
     ;
 
-  mkMassRebuild = args: mkOption (builtins.removeAttrs args [ "feature" ] // {
-    type = args.type or (types.uniq types.bool);
-    default = args.default or false;
-    description = ((args.description or ''
-      Whether to ${args.feature} while building nixpkgs packages.
-    '') + ''
-      Changing the default may cause a mass rebuild.
-    '');
-  });
+  mkMassRebuild =
+    args:
+    mkOption (
+      builtins.removeAttrs args [ "feature" ]
+      // {
+        type = args.type or (types.uniq types.bool);
+        default = args.default or false;
+        description = (
+          (args.description or ''
+            Whether to ${args.feature} while building nixpkgs packages.
+          ''
+          )
+          + ''
+            Changing the default may cause a mass rebuild.
+          ''
+        );
+      }
+    );
 
   options = {
 
-    /* Internal stuff */
+    # Internal stuff
 
     # Hide built-in module system options from docs.
-    _module.args = mkOption {
-      internal = true;
-    };
+    _module.args = mkOption { internal = true; };
 
     warnings = mkOption {
       type = types.listOf types.str;
-      default = [];
+      default = [ ];
       internal = true;
     };
 
-    /* Config options */
+    # Config options
 
     warnUndeclaredOptions = mkOption {
       description = "Whether to warn when `config` contains an unrecognized attribute.";
@@ -50,13 +57,9 @@ let
       default = false;
     };
 
-    doCheckByDefault = mkMassRebuild {
-      feature = "run `checkPhase` by default";
-    };
+    doCheckByDefault = mkMassRebuild { feature = "run `checkPhase` by default"; };
 
-    strictDepsByDefault = mkMassRebuild {
-      feature = "set `strictDeps` to true by default";
-    };
+    strictDepsByDefault = mkMassRebuild { feature = "set `strictDeps` to true by default"; };
 
     structuredAttrsByDefault = mkMassRebuild {
       feature = "set `__structuredAttrs` to true by default";
@@ -142,7 +145,7 @@ let
 
     showDerivationWarnings = mkOption {
       type = types.listOf (types.enum [ "maintainerless" ]);
-      default = [];
+      default = [ ];
       description = ''
         Which warnings to display for potentially dangerous
         or deprecated values passed into `stdenv.mkDerivation`.
@@ -164,21 +167,28 @@ let
     };
   };
 
-in {
+in
+{
 
   freeformType =
-    let t = types.lazyAttrsOf types.raw;
-    in t // {
-      merge = loc: defs:
-        let r = t.merge loc defs;
-        in r // { _undeclared = r; };
+    let
+      t = types.lazyAttrsOf types.raw;
+    in
+    t
+    // {
+      merge =
+        loc: defs:
+        let
+          r = t.merge loc defs;
+        in
+        r // { _undeclared = r; };
     };
 
   inherit options;
 
   config = {
     warnings = optionals config.warnUndeclaredOptions (
-      mapAttrsToList (k: v: "undeclared Nixpkgs option set: config.${k}") config._undeclared or {}
+      mapAttrsToList (k: v: "undeclared Nixpkgs option set: config.${k}") config._undeclared or { }
     );
   };
 

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -12,6 +12,7 @@ let
   inherit (lib)
     literalExpression
     mapAttrsToList
+    mkEnableOption
     mkOption
     optionals
     types
@@ -104,6 +105,15 @@ let
         Whether to allow unfree packages.
 
         See [Installing unfree packages](https://nixos.org/manual/nixpkgs/stable/#sec-allow-unfree) in the NixOS manual.
+      '';
+    };
+
+    allowNonSource = mkEnableOption "" // {
+      default = true;
+      defaultText = literalExpression ''true && builtins.getEnv "NIXPKGS_ALLOW_NONSOURCE" != "0"'';
+      description = ''
+        Whether to allow non-source packages.
+        Can be combined with `config.allowNonSourcePredicate`.
       '';
     };
 

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -250,6 +250,14 @@ let
     };
 
     checkMetaRecursively = mkEnableOption "checking that the `meta` attribute of derivations and their references are correct during evalution";
+
+    handleEvalIssue = mkOption {
+      type = types.functionTo (types.functionTo types.bool);
+      internal = true;
+      description = ''
+        Function to handle evaluation errors and possibly output a more informative message.
+      '';
+    };
   };
 
 in

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -108,6 +108,19 @@ let
       '';
     };
 
+    allowUnfreePredicate = mkOption {
+      type = types.functionTo types.bool;
+      default = _: false;
+      defaultText = literalExpression ''pkg: false'';
+      example = literalExpression ''pkg: lib.hasPrefix "vscode" pkg.name'';
+      description = ''
+        A function that specifies whether a given unfree package may be permitted.
+        Only takes effect if [`config.allowUnfree`](#opt-allowUnfree) is set to false.
+
+        See [Installing unfree packages](https://nixos.org/manual/nixpkgs/stable/#sec-allow-unfree) in the NixOS manual.
+      '';
+    };
+
     allowNonSource = mkEnableOption "" // {
       default = true;
       defaultText = literalExpression ''true && builtins.getEnv "NIXPKGS_ALLOW_NONSOURCE" != "0"'';

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -170,6 +170,33 @@ let
       '';
     };
 
+    permittedInsecurePackages = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = ''
+        List of insecure package names that are permitted.
+        Only takes effect if [`config.allowInsecurePredicate`](#opt-allowInsecurePredicate) is left as default
+        or is written to use the values in this option.
+
+        See [Installing insecure packages](#sec-allow-insecure).
+      '';
+    };
+
+    allowInsecurePredicate = mkOption {
+      type = types.functionTo types.bool;
+      defaultText = literalExpression ''
+        pkg:
+        builtins.elem (pkg.name
+          or "''${pkg.pname or "«name-missing»"}-''${pkg.version or "«version-missing»"}"
+        ) config.permittedInsecurePackages
+      '';
+      description = ''
+        A function that specifies whether a given insecure package may be permitted.
+
+        See [Installing insecure packages](#sec-allow-insecure).
+      '';
+    };
+
     cudaSupport = mkMassRebuild {
       type = types.bool;
       default = false;

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -130,6 +130,22 @@ let
       '';
     };
 
+    allowNonSourcePredicate = mkOption {
+      type = types.functionTo types.bool;
+      default = _: false;
+      defaultText = literalExpression ''pkg: false'';
+      example = literalExpression ''
+        pkg:
+        (lib.all (
+          prov: prov.isSource || prov == lib.sourceTypes.binaryFirmware
+        ) pkg.meta.sourceProvenance);
+      '';
+      description = ''
+        A function that specifies whether a given non-source package may be permitted.
+        Only takes effect if [`config.allowNonSource`](#opt-allowNonSource) is set to false.
+      '';
+    };
+
     allowBroken = mkOption {
       type = types.bool;
       default = false;

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -248,6 +248,8 @@ let
         Whether to check that the `meta` attribute of derivations are correct during evaluation time.
       '';
     };
+
+    checkMetaRecursively = mkEnableOption "checking that the `meta` attribute of derivations and their references are correct during evalution";
   };
 
 in

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -121,6 +121,42 @@ let
       '';
     };
 
+    allowlistedLicenses = mkOption {
+      type = types.listOf (types.lazyAttrsOf types.raw); # list of license attrsets
+      default = [ ];
+      example = literalExpression ''
+        [
+          lib.licenses.cc-by-nc-sa-20
+          ({
+            spdxId = "Abstyles";
+            fullName = "Abstyles License";
+          })
+        ]
+      '';
+      description = ''
+        Permits evaluation of a package, if the package:
+          * only has free licenses or licenses in this allowlist, and
+          * does not fail evaluation for some other reason.
+      '';
+    };
+
+    blocklistedLicenses = mkOption {
+      type = types.listOf (types.lazyAttrsOf types.raw); # list of license attrsets
+      default = [ ];
+      example = literalExpression ''
+        [
+          lib.licenses.cc-by-nc-sa-20
+          ({
+            spdxId = "Abstyles";
+            fullName = "Abstyles License";
+          })
+        ]
+      '';
+      description = ''
+        Disallows evaluation of a package, if the package has a license in this blocklist.
+      '';
+    };
+
     allowNonSource = mkEnableOption "" // {
       default = true;
       defaultText = literalExpression ''true && builtins.getEnv "NIXPKGS_ALLOW_NONSOURCE" != "0"'';

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -182,6 +182,23 @@ let
       feature = "build packages with ROCm support by default";
     };
 
+    packageOverrides = mkOption {
+      type = types.functionTo types.raw;
+      default = lib.id;
+      defaultText = literalExpression ''lib.id'';
+      example = literalExpression ''
+        pkgs: rec {
+          foo = pkgs.foo.override { /* ... */ };
+        };
+      '';
+      description = ''
+        A function that takes the current nixpkgs instance (`pkgs`) as an argument
+        and returns a modified set of packages.
+
+        See [Modify packages via `packageOverrides`](#sec-modify-via-packageOverrides).
+      '';
+    };
+
     showDerivationWarnings = mkOption {
       type = types.listOf (types.enum [ "maintainerless" ]);
       default = [ ];

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -258,6 +258,14 @@ let
         Function to handle evaluation errors and possibly output a more informative message.
       '';
     };
+
+    inHydra = mkEnableOption "" // {
+      internal = true;
+      description = ''
+        Whether the current nixpkgs instance is being evauluated by Hydra.
+        If set to true, evaluation checks will produce less verbose error messages.
+      '';
+    };
   };
 
 in


### PR DESCRIPTION
## Description of changes

Reformat with `nixfmt-rfc-style`, and declare some options:
- `allowNonSource`
- `allowUnfreePredicate`
- `allowNonSourcePredicate`
- `packageOverrides`
  - fixes #330627
- `permittedInsecurePackages`
- `allowInsecurePredicate`
- `checkMetaRecursively`
- `handleEvalIssue`
- `inHydra`
- `allowlistedLicenses`, `blocklistedLicenses`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
