### PR TITLE
redlib: add settings and defaults option to module

### DIFF
--- a/nixos/modules/services/misc/redlib.nix
+++ b/nixos/modules/services/misc/redlib.nix
@@ -1,30 +1,41 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
-
-let
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
   cfg = config.services.redlib;
 
-  args = concatStringsSep " " ([
+  args = concatStringsSep " " [
     "--port ${toString cfg.port}"
     "--address ${cfg.address}"
-  ]);
-in
-{
+  ];
+
+  environment = concatStringsSep " " (
+    (mapAttrsToList (k: v: "LIBREDDIT_${toUpper k}=\"${v}\"") cfg.settings)
+    ++ (mapAttrsToList (k: v: "LIBREDDIT_DEFAULT_${toUpper k}=\"${v}\"") cfg.defaults)
+  );
+
+  boolToFormat = b:
+    if b
+    then "on"
+    else "off";
+in {
   imports = [
-    (mkRenamedOptionModule [ "services" "libreddit" ] [ "services" "redlib" ])
+    (mkRenamedOptionModule ["services" "libreddit"] ["services" "redlib"])
   ];
 
   options = {
     services.redlib = {
       enable = mkEnableOption "Private front-end for Reddit";
 
-      package = mkPackageOption pkgs "redlib" { };
+      package = mkPackageOption pkgs "redlib" {};
 
       address = mkOption {
         default = "0.0.0.0";
         example = "127.0.0.1";
-        type =  types.str;
+        type = types.str;
         description = "The address to listen on";
       };
 
@@ -41,50 +52,222 @@ in
         description = "Open ports in the firewall for the redlib web interface";
       };
 
+      settings = {
+        sfw_only = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Enables SFW-only mode for the instance, i.e. all NSFW content is filtered.";
+          apply = boolToFormat;
+        };
+        banner = mkOption {
+          type = types.str;
+          default = "";
+          description = "Allows the server to set a banner to be displayed. Currently this is displayed on the instance info page.";
+        };
+        robots_disable_indexing = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Disables indexing of the instance by search engines.";
+          apply = boolToFormat;
+        };
+        pushshift_frontend = mkOption {
+          type = types.str;
+          default = "undelete.pullpush.io";
+          example = "www.reveddit.com";
+          description = ''Allows the server to set the Pushshift frontend to be used with "removed" links.'';
+        };
+      };
+      defaults = {
+        theme = mkOption {
+          type = types.enum [
+            "system"
+            "light"
+            "dark"
+            "black"
+            "dracula"
+            "nord"
+            "laserwave"
+            "violet"
+            "gold"
+            "rosebox"
+            "gruvboxdark"
+            "gruvboxlight"
+            "tokyoNight"
+            "icebergDark"
+          ];
+          default = "system";
+          example = "nord";
+          description = "Default site theme";
+        };
+        front_page = mkOption {
+          type = types.enum [
+            "default"
+            "popular"
+            "all"
+          ];
+          default = "default";
+          example = "popular";
+          description = "Default front page";
+        };
+        layout = mkOption {
+          type = types.enum [
+            "card"
+            "clean"
+            "compact"
+          ];
+          default = "card";
+          example = "clean";
+          description = "Default page layout";
+        };
+        wide = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Enable wide UI by default";
+          apply = boolToFormat;
+        };
+        post_sort = mkOption {
+          type = types.enum [
+            "hot"
+            "new"
+            "top"
+            "rising"
+            "controversial"
+          ];
+          default = "hot";
+          example = "new";
+          description = "Default subreddit post sort";
+        };
+        comment_sort = mkOption {
+          type = types.enum [
+            "confidence"
+            "top"
+            "new"
+            "controversial"
+            "old"
+          ];
+          default = "confidence";
+          example = "controversial";
+          description = "Default comment sort";
+        };
+        blur_spoiler = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Blur spoiler previews by default";
+          apply = boolToFormat;
+        };
+        show_nsfw = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Show NSFW posts by default";
+          apply = boolToFormat;
+        };
+        blur_nsfw = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Blur NSFW previews by default";
+          apply = boolToFormat;
+        };
+        use_hls = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Use HLS for videos by default";
+          apply = boolToFormat;
+        };
+        hide_hls_notification = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Hide notification about possible HLS usage by default";
+          apply = boolToFormat;
+        };
+        autoplay_videos = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Autoplay videos by default";
+          apply = boolToFormat;
+        };
+        subscriptions = mkOption {
+          type = with types; listOf str;
+          default = [];
+          example = [
+            "oddlysatisfying"
+            "AskReddit"
+          ];
+          description = "Subreddits to subcribe to by default";
+          apply = subs: concatStringsSep "+" subs;
+        };
+        hide_awards = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Hide awards by default";
+          apply = boolToFormat;
+        };
+        hide_sidebar_summary = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Hide the summary and sidebar by default";
+          apply = boolToFormat;
+        };
+        hide_score = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Hide score by default";
+          apply = boolToFormat;
+        };
+        disable_visit_reddit_confirmation = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Do not confirm before visiting content on Reddit by default";
+          apply = boolToFormat;
+        };
+      };
     };
   };
 
   config = mkIf cfg.enable {
     systemd.services.redlib = {
-        description = "Private front-end for Reddit";
-        wantedBy = [ "multi-user.target" ];
-        after = [ "network.target" ];
-        serviceConfig = {
-          DynamicUser = true;
-          ExecStart = "${lib.getExe cfg.package} ${args}";
-          AmbientCapabilities = lib.mkIf (cfg.port < 1024) [ "CAP_NET_BIND_SERVICE" ];
-          Restart = "on-failure";
-          RestartSec = "2s";
-          # Hardening
-          CapabilityBoundingSet = if (cfg.port < 1024) then [ "CAP_NET_BIND_SERVICE" ] else [ "" ];
-          DeviceAllow = [ "" ];
-          LockPersonality = true;
-          MemoryDenyWriteExecute = true;
-          PrivateDevices = true;
-          # A private user cannot have process capabilities on the host's user
-          # namespace and thus CAP_NET_BIND_SERVICE has no effect.
-          PrivateUsers = (cfg.port >= 1024);
-          ProcSubset = "pid";
-          ProtectClock = true;
-          ProtectControlGroups = true;
-          ProtectHome = true;
-          ProtectHostname = true;
-          ProtectKernelLogs = true;
-          ProtectKernelModules = true;
-          ProtectKernelTunables = true;
-          ProtectProc = "invisible";
-          RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
-          RestrictNamespaces = true;
-          RestrictRealtime = true;
-          RestrictSUIDSGID = true;
-          SystemCallArchitectures = "native";
-          SystemCallFilter = [ "@system-service" "~@privileged" "~@resources" ];
-          UMask = "0077";
-        };
+      description = "Private front-end for Reddit";
+      wantedBy = ["multi-user.target"];
+      after = ["network.target"];
+      serviceConfig = {
+        DynamicUser = true;
+        ExecStart = "${lib.getExe cfg.package} ${args}";
+        Environment = "${environment}";
+        AmbientCapabilities = lib.mkIf (cfg.port < 1024) ["CAP_NET_BIND_SERVICE"];
+        Restart = "on-failure";
+        RestartSec = "2s";
+        # Hardening
+        CapabilityBoundingSet =
+          if (cfg.port < 1024)
+          then ["CAP_NET_BIND_SERVICE"]
+          else [""];
+        DeviceAllow = [""];
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        PrivateDevices = true;
+        # A private user cannot have process capabilities on the host's user
+        # namespace and thus CAP_NET_BIND_SERVICE has no effect.
+        PrivateUsers = cfg.port >= 1024;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        RestrictAddressFamilies = ["AF_INET" "AF_INET6"];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = ["@system-service" "~@privileged" "~@resources"];
+        UMask = "0077";
+      };
     };
 
     networking.firewall = mkIf cfg.openFirewall {
-      allowedTCPPorts = [ cfg.port ];
+      allowedTCPPorts = [cfg.port];
     };
   };
 }


### PR DESCRIPTION
## Description of changes
Additional NixOS module settings for Reblib fork of the Libreddit. Some of the work is based on previous closed attempt in #238493.

Also formatted with `nixfmt-rfc-style`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
