### PR TITLE
python312Packages.{mwtypes,mwxml}: drop nose dependency; modernize

### DIFF
--- a/pkgs/development/python-modules/mwtypes/default.nix
+++ b/pkgs/development/python-modules/mwtypes/default.nix
@@ -5,6 +5,7 @@
   jsonable,
   pytestCheckHook,
   fetchpatch2,
+  setuptools,
 }:
 
 buildPythonPackage rec {
@@ -26,7 +27,9 @@ buildPythonPackage rec {
     })
   ];
 
-  propagatedBuildInputs = [ jsonable ];
+  build-system = [ setuptools ];
+
+  dependencies = [ jsonable ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
@@ -35,10 +38,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "mwtypes" ];
 
-  meta = with lib; {
+  meta = {
     description = "Set of classes for working with MediaWiki data types";
     homepage = "https://github.com/mediawiki-utilities/python-mwtypes";
-    license = licenses.mit;
-    maintainers = with maintainers; [ GaetanLepage ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
   };
 }

--- a/pkgs/development/python-modules/mwtypes/default.nix
+++ b/pkgs/development/python-modules/mwtypes/default.nix
@@ -3,31 +3,35 @@
   buildPythonPackage,
   fetchPypi,
   jsonable,
-  nose,
   pytestCheckHook,
+  fetchpatch2,
 }:
 
 buildPythonPackage rec {
   pname = "mwtypes";
-  version = "0.3.2";
-  format = "setuptools";
+  version = "0.4.0";
+  pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-3BF2xZZWKcEj6FmzGa5hUdTjhVMemngWBMDUyjQ045k=";
+    inherit version pname;
+    hash = "sha256-PgcGUk/27cAIvzfLvRoVX2vHOCab59m+4bciDPmtlW8=";
   };
+
+  patches = [
+    # https://github.com/mediawiki-utilities/python-mwtypes/pull/6
+    (fetchpatch2 {
+      name = "nose-to-pytest.patch";
+      url = "https://github.com/mediawiki-utilities/python-mwtypes/commit/58d7f59e4927aaa6278f84576794df713c673058.patch";
+      hash = "sha256-jh1uEqqhIK2DyNvVN0XYGM7BXTmypnoC4VoB0V+9JmE=";
+    })
+  ];
 
   propagatedBuildInputs = [ jsonable ];
 
-  nativeCheckInputs = [
-    nose
-    pytestCheckHook
-  ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
-  disabledTests = [
-    "test_normalize_path_bad_extension"
-    "test_open_file"
-  ];
+  # Even with 7z included, this test does not pass
+  disabledTests = [ "test_open_file" ];
 
   pythonImportsCheck = [ "mwtypes" ];
 

--- a/pkgs/development/python-modules/mwxml/default.nix
+++ b/pkgs/development/python-modules/mwxml/default.nix
@@ -12,8 +12,8 @@
 
 buildPythonPackage rec {
   pname = "mwxml";
-  format = "setuptools";
   version = "0.3.4";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
@@ -29,6 +29,8 @@ buildPythonPackage rec {
     })
   ];
 
+  build-system = [ setuptools ];
+
   dependencies = [
     jsonschema
     mwcli
@@ -39,11 +41,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "mwxml" ];
 
-  meta = with lib; {
+  meta = {
     description = "Set of utilities for processing MediaWiki XML dump data";
     mainProgram = "mwxml";
     homepage = "https://github.com/mediawiki-utilities/python-mwxml";
-    license = licenses.mit;
-    maintainers = with maintainers; [ GaetanLepage ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
   };
 }

--- a/pkgs/development/python-modules/mwxml/default.nix
+++ b/pkgs/development/python-modules/mwxml/default.nix
@@ -2,35 +2,40 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  fetchpatch2,
   jsonschema,
   mwcli,
   mwtypes,
-  nose,
   pytestCheckHook,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "mwxml";
-  version = "0.3.3";
   format = "setuptools";
+  version = "0.3.4";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-CEjfDPLik3GPVUMRrPRxW9Z59jn05Sy+R9ggZYnbHTE=";
+    hash = "sha256-ejf3RfdwcEp0Ge+96dORuHS5Bx28GSs7H4HD1LUnde4=";
   };
 
-  propagatedBuildInputs = [
+  patches = [
+    # https://github.com/mediawiki-utilities/python-mwxml/pull/21
+    (fetchpatch2 {
+      name = "nose-to-pytest.patch";
+      url = "https://github.com/mediawiki-utilities/python-mwxml/compare/2b477be6aa9794064d03b5be38c7759d1570488b...71bbfd2b309e0720a34a4e783b71169aebc571ef.patch";
+      hash = "sha256-4XxNvda1Dj+kFbD9t9gzucrMjdfXcoqYlvecXO2B2R0=";
+    })
+  ];
+
+  dependencies = [
     jsonschema
     mwcli
     mwtypes
   ];
 
-  nativeCheckInputs = [
-    nose
-    pytestCheckHook
-  ];
-
-  disabledTests = [ "test_page_with_discussion" ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "mwxml" ];
 


### PR DESCRIPTION
## Description of changes
Updates these two packages to their latest releases to pull in new fixes, as well as adding patches that remove nose from their test suites. Upstream PRs have been sent, and they are linked next to the patches.
Part of #326513
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
