### PR TITLE
python312Packages.trafilatura: 1.10.0 -> 1.12.0

### DIFF
--- a/pkgs/development/python-modules/trafilatura/default.nix
+++ b/pkgs/development/python-modules/trafilatura/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "trafilatura";
-  version = "1.10.0";
+  version = "1.12.0";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-exBXPi3Ra2cC9W9WhYsl80/4HWsW5CmvCjsmbwdGru4=";
+    hash = "sha256-F9IHTs/ixWK/CGPefoOfrRTMZtX5gJB0HqqRjqv7+dU=";
   };
 
   # Patch out gui cli because it is not supported in this packaging and
@@ -32,7 +32,8 @@ buildPythonPackage rec {
     substituteInPlace setup.py \
       --replace-fail '"trafilatura_gui=trafilatura.gui:main",' ""
     substituteInPlace tests/cli_tests.py \
-      --replace-fail "trafilatura_bin = 'trafilatura'" "trafilatura_bin = '$out/bin/trafilatura'"
+      --replace-fail 'trafilatura_bin = "trafilatura"' \
+                     'trafilatura_bin = "${placeholder "out"}/bin/trafilatura"'
   '';
 
   build-system = [ setuptools ];
@@ -60,16 +61,17 @@ buildPythonPackage rec {
     "test_queue"
     "test_redirection"
     "test_whole"
+    "test_is_live_page"
   ];
 
   pythonImportsCheck = [ "trafilatura" ];
 
-  meta = with lib; {
+  meta = {
     description = "Python package and command-line tool designed to gather text on the Web";
     homepage = "https://trafilatura.readthedocs.io";
     changelog = "https://github.com/adbar/trafilatura/blob/v${version}/HISTORY.md";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ jokatzke ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jokatzke ];
     mainProgram = "trafilatura";
   };
 }


### PR DESCRIPTION
## Description of changes
Changelog: https://github.com/adbar/trafilatura/blob/v1.12.0/HISTORY.md

Also fix error during substitution due to slight changes in the source code.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
