### PR TITLE
[WIP] devShellTools.buildShellEnv

### DIFF
--- a/pkgs/build-support/dev-shell-tools/default.nix
+++ b/pkgs/build-support/dev-shell-tools/default.nix
@@ -1,5 +1,8 @@
 {
   lib,
+  runtimeShell,
+  bashInteractive,
+  stdenv,
   writeTextFile,
 }:
 let
@@ -72,4 +75,95 @@ rec {
     # https://github.com/NixOS/nix/blob/2.8.0/src/libexpr/primops.cc#L1253
     lib.genAttrs outputList (output: builtins.unsafeDiscardStringContext outputMap.${output}.outPath);
 
+  toBashEnv =
+    { env }:
+    lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (
+        name: value:
+        if lib.isValidPosixName name then ''export ${name}=${lib.escapeShellArg value}'' else ""
+      ) env
+    );
+
+  buildShellEnv =
+    { drvAttrs }:
+    let
+      name = drvAttrs.pname or drvAttrs.name or "shell";
+      env = unstructuredDerivationInputEnv { inherit drvAttrs; };
+    in
+    stdenv.mkDerivation (finalAttrs: {
+      name = "${name}-env";
+      passAsFile = [
+        "bashEnv"
+        "bashrc"
+        "runShell"
+      ];
+      bashEnv = toBashEnv { inherit env; };
+      bashrc = ''
+        export NIXPKGS_SHELL_TMP="$(mktemp -d --tmpdir nixpkgs-shell-${name}.XXXXXX)"
+        export TMPDIR="$NIXPKGS_SHELL_TMP"
+        export TEMPDIR="$NIXPKGS_SHELL_TMP"
+        export TMP="$NIXPKGS_SHELL_TMP"
+        export TEMP="$NIXPKGS_SHELL_TMP"
+
+        echo "Using TMPDIR=$TMPDIR"
+
+        source @envbash@
+
+        mkdir -p $TMP/outputs
+        for _output in $outputs; do
+          export "''${_output}=$TMP/outputs/''${_output}"
+        done
+
+        source @stdenv@/setup
+
+        # Set a distinct prompt to make it clear that we are in a build shell
+        case "$PS1" in
+          *"(build shell $name)"*)
+            echo "It looks like your running a build shell inside a build shell."
+            echo "It might work, but this is probably not what you want."
+            echo "You may want to exit your shell before loading a new one."
+            ;;
+        esac
+
+        # Prefix a line to the prompt to indicate that we are in a build shell
+        PS1=$"\n(\[\033[1;33m\]build shell: \[\033[1;34m\]$name\[\033[1;33m\]\[\033[0m\]) $PS1"
+
+        runHook shellHook
+      '';
+      buildCommand = ''
+        mkdir -p $out/lib $out/bin
+        bashrc="$out/lib/bashrc"
+        envbash="$out/lib/env.bash"
+
+        mv "$bashEnvPath" "$envbash"
+        substitute "$bashrcPath" "$bashrc" \
+          --replace-fail "@envbash@" "$envbash" \
+          --replace-fail "@stdenv@" "$stdenv" \
+          ;
+
+        substitute ${./run-shell.sh} "$out/bin/run-shell" \
+          --replace-fail "@bashrc@" "$bashrc" \
+          --replace-fail "@runtimeShell@" "${runtimeShell}" \
+          --replace-fail "@bashInteractive@" "${bashInteractive}" \
+          ;
+
+        # NOTE: most other files are script for the source command, and not
+        #       standalone executables, so they should not be made executable.
+        chmod a+x $out/bin/run-shell
+      '';
+      preferLocalBuild = true;
+      passthru = {
+        # Work this as a shell environment, so that commands like `nix-shell`
+        # will be able to check it and use it correctly. This also lets Nix know
+        # to stop when the user requests pkg.devShell explicitly, or a different
+        # attribute containing a shell environment.
+        isShellEnv = true;
+        devShell = throw "You're trying to access the devShell attribute of a shell environment. We appreciate that this is very \"meta\" and interesting, but it's usually just not what you want. Most likely you've selected one `.devShell` to deep in an expression or on the command line. Try removing the last one.";
+      };
+      meta = {
+        description = "An environment similar to the build environment of ${name}";
+        # TODO longDescription
+        mainProgram = "run-shell";
+      };
+    });
 }

--- a/pkgs/build-support/dev-shell-tools/default.nix
+++ b/pkgs/build-support/dev-shell-tools/default.nix
@@ -85,7 +85,11 @@ rec {
     );
 
   buildShellEnv =
-    { drvAttrs }:
+    {
+      drvAttrs,
+      promptPrefix ? "build shell",
+      promptName ? null,
+    }:
     let
       name = drvAttrs.pname or drvAttrs.name or "shell";
       env = unstructuredDerivationInputEnv { inherit drvAttrs; };
@@ -126,7 +130,9 @@ rec {
         esac
 
         # Prefix a line to the prompt to indicate that we are in a build shell
-        PS1=$"\n(\[\033[1;33m\]build shell: \[\033[1;34m\]$name\[\033[1;33m\]\[\033[0m\]) $PS1"
+        PS1=$"\n(\[\033[1;33m\]"${lib.escapeShellArg promptPrefix}$": \[\033[1;34m\]"${
+          if promptName != null then lib.escapeShellArg promptName else ''"$name"''
+        }"\[\033[1;33m\]\[\033[0m\]) $PS1"
 
         runHook shellHook
       '';

--- a/pkgs/build-support/dev-shell-tools/run-shell.sh
+++ b/pkgs/build-support/dev-shell-tools/run-shell.sh
@@ -1,0 +1,87 @@
+#!@runtimeShell@
+
+# baked variables, not exported
+bashrc='@bashrc@'
+bash='@bashInteractive@/bin/bash'
+
+# detected variables and option defaults
+shell="$(basename $SHELL)"
+mode=interactive
+
+# remaining args
+args=()
+
+# parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -c)
+      mode=commands
+      shift
+      break
+      ;;
+    *)
+      mode=exec
+      break
+      ;;
+  esac
+done
+
+while [[ $# -gt 0 ]]; do
+  args+=("$1")
+  shift
+done
+
+case "$mode" in
+  interactive)
+    ;;
+  commands)
+    if ${#args[@]} -eq 0; then
+      echo "nixpkgs: You've requested a command shell, but didn't provide a command."
+      echo "         Please provide a command to run."
+      exit 1
+    fi
+    ;;
+  exec)
+    ;;
+esac
+
+invokeWithArgs() {
+  bash -c 'source "'"$bashrc"'"; _script="$(shift)"; _args=("$@"); eval "$_script"' -- "$@"
+}
+
+# For bash, we'll run the interactive variant of the version Nixpkgs uses.
+# For other shells, version correctness can't be a goal, so it's best
+# to launch the user's shell from $SHELL. This also avoids bringing in
+# dependencies of which N-1 aren't needed. Keeps it quick.
+launchBash() {
+  case "$mode" in
+    interactive)
+      exec "$bash" --rcfile "$bashrc" "${args[@]}"
+      ;;
+    commands)
+      exec "$bash" -c 'source "'"$bashrc"'"; _script="$1"; shift; eval "$_script"' -- "${args[@]}"
+      ;;
+    exec)
+      exec "$bash" -c 'source "'"$bashrc"'"; "$@"' -- "${args[@]}"
+      ;;
+  esac
+}
+
+launchShell() {
+  case "$shell" in
+    bash|"")
+      launchBash
+      ;;
+    *)
+      (
+        echo "nixpkgs: I see that you weren't running bash. That's cool, but"
+        echo "         stdenv derivations are built with bash, so that's what"
+        echo "         I'll run for you by default. We'd love to have support"
+        echo "         for many shells, so PRs are welcome!"
+      ) >&2
+      launchBash
+      ;;
+  esac
+}
+
+launchShell

--- a/pkgs/build-support/dev-shell-tools/tests/default.nix
+++ b/pkgs/build-support/dev-shell-tools/tests/default.nix
@@ -1,7 +1,11 @@
 {
+  bash,
+  coreutils,
   devShellTools,
   emptyFile,
+  gnugrep,
   lib,
+  runCommand,
   stdenv,
   hello,
   writeText,
@@ -187,4 +191,70 @@ lib.recurseIntoAttrs {
         "args"
       ]
     );
+
+  # derivation: Call it directly so that we get a minimal environment to run in
+  buildHelloInShell =
+    derivation {
+      inherit (stdenv.buildPlatform) system;
+      name = "buildHelloInShell";
+      builder = "${bash}/bin/bash";
+      PATH = lib.makeBinPath [
+        coreutils
+        gnugrep
+      ];
+      args = [
+        "-euo"
+        "pipefail"
+        "-c"
+        ''
+          ${lib.getExe hello.devShell} -c 'genericBuild && ln -s $out "'"$PWD"'/result"'
+          ls -al
+          ./result/bin/hello | grep -i 'hello, world'
+          (set -x; [[ ! -e $out ]])
+          touch $out
+        ''
+      ];
+    }
+    // {
+      # Required package attributes for Nixpkgs (CI)
+      meta = { };
+    };
+
+  various =
+    let
+      hello2 = hello.overrideAttrs (o: {
+        shellHook = ''
+          echo 'shellHook says hi :)'
+        '';
+      });
+      inherit (hello2) devShell;
+    in
+    derivation {
+      inherit (stdenv.buildPlatform) system;
+      name = "various";
+      builder = "${bash}/bin/bash";
+      PATH = lib.makeBinPath [
+        coreutils
+        gnugrep
+      ];
+      args = [
+        "-euo"
+        "pipefail"
+        "-c"
+        ''
+          ${lib.getExe devShell} -c 'echo "hello, world"' \
+            | grep -F 'hello, world'
+          ${lib.getExe devShell} -c 'echo "hello, world"' \
+            | grep -F 'hello, world'
+
+          ls -al
+          (set -x; [[ ! -e $out ]])
+          touch $out
+        ''
+      ];
+    }
+    // {
+      # Required package attributes for Nixpkgs (CI)
+      meta = { };
+    };
 }

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -11,6 +11,7 @@
   ghcWithHoogle,
   ghcWithPackages,
   nodejs,
+  devShellTools,
 }:
 
 let
@@ -1045,6 +1046,8 @@ lib.fix (
             // env';
           } "echo $nativeBuildInputs $buildInputs > $out";
 
+        # Specialise the devShell attribute, so we get our improved shell.
+        devShell = env.devShell;
         env = envFunc { };
 
       };

--- a/pkgs/stdenv/booter.nix
+++ b/pkgs/stdenv/booter.nix
@@ -97,11 +97,13 @@ let
     let
       args = stageFun prevStage;
       args' = args // {
-        stdenv = args.stdenv // {
-          # For debugging
-          __bootPackages = prevStage;
-          __hatPackages = nextStage;
-        };
+        stdenv = args.stdenv.override (prevArgs: {
+          # Extra package attributes for debugging
+          extraAttrs = prevArgs.extraAttrs or { } // {
+            __bootPackages = prevStage;
+            __hatPackages = nextStage;
+          };
+        });
       };
       thisStage =
         if args.__raw or false then

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -64,6 +64,9 @@ let
       # This is convenient to have as a parameter so the stdenv "adapters" work better
       mkDerivationFromStdenv ?
         stdenv: (import ./make-derivation.nix { inherit lib config; } stdenv).mkDerivation,
+
+      # callPackage for "passthru" utilities only
+      callPackage ? null,
     }:
 
     let
@@ -91,6 +94,11 @@ let
 
       stdenv = (stdenv-overridable argsStdenv);
 
+      devShellTools =
+        if callPackage == null then
+          null
+        else
+          callPackage ../../build-support/dev-shell-tools { inherit stdenv; };
     in
     # The stdenv that we are producing.
     derivation (
@@ -213,6 +221,8 @@ let
       # without running any commands. Because this will also skip `shopt -s extglob`
       # commands and extglob affects the Bash parser, we enable extglob always.
       shellDryRun = "${stdenv.shell} -n -O extglob";
+
+      buildShellEnv = if devShellTools ? buildShellEnv then devShellTools.buildShellEnv else _: null;
 
       tests = {
         succeedOnFailure = import ../tests/succeedOnFailure.nix { inherit stdenv; };

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -17,6 +17,7 @@ let
 
       shell,
       allowedRequisites ? null,
+      # Extra package attributes, like passthru. Not passed to `derivation`.
       extraAttrs ? { },
       overrides ? (self: super: { }),
       config,

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -874,6 +874,8 @@ let
 
         inherit passthru overrideAttrs;
         inherit meta;
+        devShell = stdenv.buildShellEnv { drvAttrs = derivationArg; };
+
       }
       //
         # Pass through extra attributes that are not inputs, but

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -167,6 +167,7 @@ let
       name,
       overrides ? (self: super: { }),
       extraNativeBuildInputs ? [ ],
+      callPackage ? null,
     }:
 
     let
@@ -223,6 +224,7 @@ let
               );
 
         overrides = self: super: (overrides self super) // { fetchurl = thisStdenv.fetchurlBoot; };
+        inherit callPackage;
       };
 
     in

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -170,7 +170,12 @@ let
       pkgs = self.pkgsHostTarget;
       targetPackages = self.pkgsTargetTarget;
 
-      inherit stdenv stdenvNoCC;
+      stdenv = stdenv.override (o: {
+        callPackage = self.callPackage;
+      });
+      stdenvNoCC = stdenvNoCC.override (o: {
+        callPackage = self.callPackage;
+      });
     };
 
   splice = self: super: import ./splice.nix lib self (adjacentPackages != null);

--- a/shell.nix
+++ b/shell.nix
@@ -28,6 +28,7 @@ let
 in
 curPkgs
 // pkgs.mkShellNoCC {
+  name = "nixpkgs";
   inputsFrom = [
     fmt.shell
   ];


### PR DESCRIPTION
## Description of changes

Note: this is currently draft, because it does not have sufficient tests and documentation for a number of features.
Help wanted :) This is a `NixOS/nixpkgs` branch, where all maintainers can push, but maybe sync with me first.

Implement build shells and development shells in Nixpkgs for greater flexibility and evolution of the _Nix shell_ concept.

- This is a Nixpkgs-native implementation of https://github.com/NixOS/nixpkgs/pull/206728
- To be used with (TBD) https://github.com/NixOS/nix/issues/7501
  - or e.g. `nix run -f shell.nix --arg nixpkgs ./. devShell`  (ie like running the output of `nix-build shell.nix -A devShell`)
- Actually solve https://github.com/NixOS/nixpkgs/issues/196753
- Actually solve https://github.com/NixOS/nixpkgs/pull/132617 by allowing you to implement the `devShell` interface yourself.
  - `passthru.devShell = something custom;`
- Builds upon https://github.com/NixOS/nixpkgs/pull/324789

Terminology cheat sheet
- **Nix shell**: the general concept of launch a shell with Nix-provided stuff in its environment
- **`nix shell`**: [`nix env shell`](https://nix.dev/manual/nix/latest/command-ref/new-cli/nix3-env-shell)
- **build shell**: a stdenv-based environment that's automatically derived from a derivation (see `make-derivation.nix`), useful for troubleshooting a build
- **dev shell**: an environment for development. This may be constructed with stdenv-based infra with `mkShell`, or with other projects like `cachix/devenv`, `numtide/devshell`, etc, provided they'll implement the `devShell` interface


TODO
- [ ] enable impure `PATH` by default?
- [ ] more tests
- [ ] docs
  - specifically the `devShell` attribute and the interface of its output
  - example of customizing the `devShell`
  - (a small part of it will also be a Nix interface: the [proposed, extra](https://github.com/NixOS/nix/issues/7501) `nix develop` and `nix print-dev-env` behaviors. This is very small and ok to duplicate.)
- [ ] structuredAttrs support (maybe, or omit its `devShell` attr for now)
- [ ] fine tune the terminology
- [ ] make `mkShell` return an impure shell by default, because it's for dev shells?
- [ ] validate in practice with an implementation of https://github.com/NixOS/nix/issues/7501

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
