### PR TITLE
nixos/rosetta: Support AOT caching

### DIFF
--- a/nixos/modules/virtualisation/rosetta.nix
+++ b/nixos/modules/virtualisation/rosetta.nix
@@ -19,6 +19,19 @@ in
       '';
     };
 
+    virtualisation.rosetta.cachingUnixSocket = lib.mkOption {
+      type = types.str;
+      description = ''
+        The unix socket path for the Rosetta AOT caching daemon.
+
+        The default corrseponds to
+        [`VZLinuxRosettaDirectoryShare.CachingOptions.defaultUnixSocket`](https://developer.apple.com/documentation/virtualization/vzlinuxrosettadirectoryshare/cachingoptions/4230791-defaultunixsocket)
+        which is also what UTM uses.
+
+      '';
+      default = "/run/rosettad/rosetta.sock";
+    };
+
     virtualisation.rosetta.mountPoint = lib.mkOption {
       type = types.str;
       default = "/run/rosetta";
@@ -76,6 +89,18 @@ in
 
       # Remove the shell wrapper and call the runtime directly
       wrapInterpreterInShell = false;
+    };
+  };
+  systemd.services.rosettad = {
+    wantedBy = [ "multi-user.target" ];
+    unitConfig = {
+      ConditionPathExists = "${cfg.mountPoint}/rosettad";
+    };
+    serviceConfig = {
+      CacheDirectory = "rosettad";
+      RuntimeDirectory = "rosettad";
+      ExecStart = "${cfg.mountPoint}/rosettad daemon $CACHE_DIRECTORY";
+      Restart = "always";
     };
   };
 }


### PR DESCRIPTION

## Description of changes

When AOT Caching is enabled on the MacOS host, Rosetta will mount a caching daemon `rosettad` which can be run to do AOT translation.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
