### PR TITLE
k3s: add airgap images to passthru attributes

### DIFF
--- a/nixos/modules/services/cluster/k3s/default.nix
+++ b/nixos/modules/services/cluster/k3s/default.nix
@@ -351,12 +351,16 @@ in
             sha256 = "0imblp0kw9vkcr7sp962jmj20fpmb3hvd3hmf4cs4x04klnq3k90";
             finalImageTag = "21.1.2-debian-11-r0";
           })
+
+          config.services.k3s.package.airgapImages
         ]
       '';
       description = ''
         List of derivations that provide container images.
         All images are linked to {file}`${imageDir}` before k3s starts and consequently imported
-        by the k3s agent. This option only makes sense on nodes with an enabled agent.
+        by the k3s agent. Consider importing the k3s airgap images archive of the k3s package in
+        use, if you want to pre-provision this node with all k3s container images. This option
+        only makes sense on nodes with an enabled agent.
       '';
     };
 

--- a/nixos/tests/k3s/airgap-images.nix
+++ b/nixos/tests/k3s/airgap-images.nix
@@ -1,0 +1,44 @@
+# A test that imports k3s airgapped images and verifies that all expected images are present
+import ../make-test-python.nix (
+  { lib, k3s, ... }:
+  {
+    name = "${k3s.name}-airgap-images";
+    meta.maintainers = lib.teams.k3s.members;
+
+    nodes.machine =
+      { pkgs, ... }:
+      {
+        # k3s uses enough resources the default vm fails.
+        virtualisation.memorySize = 1536;
+        virtualisation.diskSize = 4096;
+
+        services.k3s = {
+          enable = true;
+          role = "server";
+          package = k3s;
+          # Slightly reduce resource usage
+          extraFlags = [
+            "--disable coredns"
+            "--disable local-storage"
+            "--disable metrics-server"
+            "--disable servicelb"
+            "--disable traefik"
+          ];
+          images = [ k3s.airgapImages ];
+        };
+      };
+
+    testScript = ''
+      import json
+
+      start_all()
+      machine.wait_for_unit("k3s")
+      machine.wait_until_succeeds("journalctl -r --no-pager -u k3s | grep \"Imported images from /var/lib/rancher/k3s/agent/images/\"", timeout=60)
+      images = json.loads(machine.succeed("crictl img -o json"))
+      image_names = [i["repoTags"][0] for i in images["images"]]
+      with open("${k3s.imagesList}") as expected_images:
+        for line in expected_images:
+          assert line.rstrip() in image_names, f"The image {line.rstrip()} is not present in the airgap images archive"
+    '';
+  }
+)

--- a/nixos/tests/k3s/airgap-images.nix
+++ b/nixos/tests/k3s/airgap-images.nix
@@ -5,28 +5,26 @@ import ../make-test-python.nix (
     name = "${k3s.name}-airgap-images";
     meta.maintainers = lib.teams.k3s.members;
 
-    nodes.machine =
-      { pkgs, ... }:
-      {
-        # k3s uses enough resources the default vm fails.
-        virtualisation.memorySize = 1536;
-        virtualisation.diskSize = 4096;
+    nodes.machine = _: {
+      # k3s uses enough resources the default vm fails.
+      virtualisation.memorySize = 1536;
+      virtualisation.diskSize = 4096;
 
-        services.k3s = {
-          enable = true;
-          role = "server";
-          package = k3s;
-          # Slightly reduce resource usage
-          extraFlags = [
-            "--disable coredns"
-            "--disable local-storage"
-            "--disable metrics-server"
-            "--disable servicelb"
-            "--disable traefik"
-          ];
-          images = [ k3s.airgapImages ];
-        };
+      services.k3s = {
+        enable = true;
+        role = "server";
+        package = k3s;
+        # Slightly reduce resource usage
+        extraFlags = [
+          "--disable coredns"
+          "--disable local-storage"
+          "--disable metrics-server"
+          "--disable servicelb"
+          "--disable traefik"
+        ];
+        images = [ k3s.airgapImages ];
       };
+    };
 
     testScript = ''
       import json

--- a/nixos/tests/k3s/default.nix
+++ b/nixos/tests/k3s/default.nix
@@ -7,6 +7,9 @@ let
   allK3s = lib.filterAttrs (n: _: lib.strings.hasPrefix "k3s_" n) pkgs;
 in
 {
+  airgap-images = lib.mapAttrs (
+    _: k3s: import ./airgap-images.nix { inherit system pkgs k3s; }
+  ) allK3s;
   auto-deploy = lib.mapAttrs (_: k3s: import ./auto-deploy.nix { inherit system pkgs k3s; }) allK3s;
   etcd = lib.mapAttrs (
     _: k3s:

--- a/pkgs/applications/networking/cluster/k3s/1_28/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_28/images-versions.json
@@ -1,0 +1,18 @@
+{
+  "airgap-images-amd64": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.28.11%2Bk3s2/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "199nxfxwr52cddk2ljchhxaigyi0al3lzyc0jy2am4aljlm0jivy"
+  },
+  "airgap-images-arm": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.28.11%2Bk3s2/k3s-airgap-images-arm.tar.zst",
+    "sha256": "02riiiwwr0h3zhlxxmjn5p8ws354rr2gk44x3kz9d7sxqn17sz4w"
+  },
+  "airgap-images-arm64": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.28.11%2Bk3s2/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "0bs9wj33appb9xpsb2v1xz4xck4qq6g74flnc0mxf9warwr4988r"
+  },
+  "images-list": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.28.11%2Bk3s2/k3s-images.txt",
+    "sha256": "0245zra2h8756kq2v8nwl6gji749xlvy1y1bkab8vz5b0vpqhfxy"
+  }
+}

--- a/pkgs/applications/networking/cluster/k3s/1_28/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_28/versions.nix
@@ -4,6 +4,7 @@
   k3sRepoSha256 = "1k1k3qmxc7n2h2i0g52ad4gnpq0qrvxnl7p2y0g9dss1ancgqwsd";
   k3sVendorHash = "sha256-tzcMcsTmY8lG+9EyYkzYJm1YU/8tGpxpH7oZ4Jl/yNU=";
   chartVersions = import ./chart-versions.nix;
+  imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.12.2";
   k3sRootSha256 = "1gjynvr350qni5mskgm7pcc7alss4gms4jmkiv453vs8mmma9c9k";
   k3sCNIVersion = "1.4.0-k3s2";

--- a/pkgs/applications/networking/cluster/k3s/1_29/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_29/images-versions.json
@@ -1,0 +1,18 @@
+{
+  "airgap-images-amd64": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.6%2Bk3s2/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "1d1adpjxxgkflm4xqzynsib67pga85r1qmhkhh540nl0rppbq7gr"
+  },
+  "airgap-images-arm": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.6%2Bk3s2/k3s-airgap-images-arm.tar.zst",
+    "sha256": "07c085y5qy8h5ja2ms3np61d7wkp6gic82snx70qlsm5fm3ak3z7"
+  },
+  "airgap-images-arm64": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.6%2Bk3s2/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "0ljajvz0n0mmwkdl1rwpwqmhgxqivakdpfyaqsascdzfk0qpv5gp"
+  },
+  "images-list": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.6%2Bk3s2/k3s-images.txt",
+    "sha256": "0245zra2h8756kq2v8nwl6gji749xlvy1y1bkab8vz5b0vpqhfxy"
+  }
+}

--- a/pkgs/applications/networking/cluster/k3s/1_29/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_29/versions.nix
@@ -4,6 +4,7 @@
   k3sRepoSha256 = "0wagfh4vbvyi62np6zx7b4p6myn0xavw691y78rnbl32jckiy14f";
   k3sVendorHash = "sha256-o36gf3q7Vv+RoY681cL44rU2QFrdFW3EbRpw3dLcVTI=";
   chartVersions = import ./chart-versions.nix;
+  imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.13.0";
   k3sRootSha256 = "1jq5f0lm08abx5ikarf92z56fvx4kjpy2nmzaazblb34lajw87vj";
   k3sCNIVersion = "1.4.0-k3s2";

--- a/pkgs/applications/networking/cluster/k3s/1_30/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_30/images-versions.json
@@ -1,0 +1,18 @@
+{
+  "airgap-images-amd64": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.2%2Bk3s2/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "1d1adpjxxgkflm4xqzynsib67pga85r1qmhkhh540nl0rppbq7gr"
+  },
+  "airgap-images-arm": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.2%2Bk3s2/k3s-airgap-images-arm.tar.zst",
+    "sha256": "1hjhlj4b5ddaqhpmqbbvhvgzryi5j84i8bmpl3yij87yjkz3kld7"
+  },
+  "airgap-images-arm64": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.2%2Bk3s2/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "1r9rd70qp8x57j3hdpgwgkzchykphw0x4yd8c1jwjfaqm5df1w0d"
+  },
+  "images-list": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.2%2Bk3s2/k3s-images.txt",
+    "sha256": "0245zra2h8756kq2v8nwl6gji749xlvy1y1bkab8vz5b0vpqhfxy"
+  }
+}

--- a/pkgs/applications/networking/cluster/k3s/1_30/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_30/versions.nix
@@ -4,6 +4,7 @@
   k3sRepoSha256 = "0hy0f44hj5n5nscr0p52dbklvj2ki2vs7k0cgh1r8xlg4p6fn1b0";
   k3sVendorHash = "sha256-Mj9Q3TgqZoJluG4/nyuw2WHnB3OJ+/mlV7duzWt1B1A=";
   chartVersions = import ./chart-versions.nix;
+  imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.13.0";
   k3sRootSha256 = "1jq5f0lm08abx5ikarf92z56fvx4kjpy2nmzaazblb34lajw87vj";
   k3sCNIVersion = "1.4.0-k3s2";


### PR DESCRIPTION
## Description of changes

The k3s update script filters the assets of a
corresponding release for airgap images archives
and provides these as passthru attributes of the
k3s derivation. We use zstd archives, as these
offer the best compression ratios and decompression
speed. Furthermore, the `airgapImages` passthru
provides the images archive that matches the host
platform architecture, however, this only works
for aarch64 and x86_64. In addition, a txt file
listing all container images of a release is made
available via a passthru attribute. The airgap
images archives can be combined nicely with the
`services.k3s.images` option, e.g. to pre-provision
k3s nodes for environments without Internet
connectivity.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

CC @NixOS/k3s

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
