### PR TITLE
Xev{d,e} drop lm

### DIFF
--- a/pkgs/by-name/xe/xevd/package.nix
+++ b/pkgs/by-name/xe/xevd/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch2,
   stdenv,
   gitUpdater,
   testers,
@@ -18,6 +19,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Dc2V77t+DrZo9252FAL0eczrmikrseU02ob2RLBdVvU=";
   };
 
+  patches = lib.optionals (!lib.versionOlder "0.5.0" finalAttrs.version) [
+    (fetchpatch2 {
+      url = "https://github.com/mpeg5/xevd/commit/7eda92a6ebb622189450f7b63cfd4dcd32fd6dff.patch?full_index=1";
+      hash = "sha256-Ru7jGk1b+Id5x1zaiGb7YKZGTNaTcArZGYyHbJURfgs=";
+    })
+  ];
+
   postPatch = ''
     echo v$version > version.txt
   '';
@@ -33,8 +41,6 @@ stdenv.mkDerivation (finalAttrs: {
     "lib"
     "dev"
   ];
-
-  env.NIX_CFLAGS_COMPILE = toString [ "-lm" ];
 
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
   passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/by-name/xe/xeve/package.nix
+++ b/pkgs/by-name/xe/xeve/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch2,
   gitUpdater,
   stdenv,
   cmake,
@@ -17,6 +18,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-8jXntm/yFme9ZPImdW54jAr11hEsU1K+N5/7RLmITPs=";
   };
 
+  patches = lib.optionals (!lib.versionOlder "0.5.0" finalAttrs.version) [
+    (fetchpatch2 {
+      url = "https://github.com/mpeg5/xeve/commit/954ed6e0494cd2438fd15c717c0146e88e582b33.patch?full_index=1";
+      hash = "sha256-//NtOUm1fqPFvOM955N6gF+QgmOdmuVunwx/3s/G/J8=";
+    })
+  ];
+
   postPatch = ''
     echo v$version > version.txt
   '';
@@ -26,8 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     ln $dev/include/xeve/* $dev/include/
   '';
-
-  env.NIX_CFLAGS_COMPILE = toString [ "-lm" ];
 
   outputs = [
     "out"


### PR DESCRIPTION
## Description of changes

Add upstream patches that include linking libm into the shared library, mpeg5/xevd#70 and mpeg5/xeve#132. This allows us to drop passing `-lm` in CFLAGS, which should probably actually be in LDFLAGS.

These patches are mostly a nice-to-have for the Darwin PR but taking them now means the next version bump will just be removing the patches rather than remembering the `-lm` flag can be dropped.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
