### PR TITLE
update fishnet to 2.9.3, use pre-compiled binaries

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20335,6 +20335,12 @@
     name = "Thiago K. Okada";
     matrix = "@k0kada:matrix.org";
   };
+  thibault = {
+    email = "t@lichess.org";
+    github = "ornicar";
+    githubId = 140370;
+    name = "Thibault D";
+  };
   thibaultlemaire = {
     email = "thibault.lemaire@protonmail.com";
     github = "ThibaultLemaire";


### PR DESCRIPTION
## Description of changes

Update fishnet to latest version 2.9.3:
https://github.com/lichess-org/fishnet/releases/tag/v2.9.3

Also switch to pre-compiled binaries. Compiling fishnet and its stockfish flavours takes 6 minutes on a powerful PC.


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin