### PR TITLE
vscode-extensions: fix typo in README.md

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/README.md
+++ b/pkgs/applications/editors/vscode/extensions/README.md
@@ -31,7 +31,7 @@
   - Naming convention for:
     - Adding a new extension:
 
-      > vscode-extensions.publisher.extension-name: init 1.2.3
+      > vscode-extensions.publisher.extension-name: init at 1.2.3
       >
       > Release: https://github.com/owner/project/releases/tag/1.2.3
     - Updating an extension:


### PR DESCRIPTION
vscode-extensions: fix typo in README.md

To comply with: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#commit-conventions

I particularly don't like adding `at` but, since the documentation says that, so be it.