### PR TITLE
pavucontrol: 5.0 -> 6.0 and a refactor

### DIFF
--- a/pkgs/applications/audio/pavucontrol/default.nix
+++ b/pkgs/applications/audio/pavucontrol/default.nix
@@ -1,15 +1,16 @@
-{ fetchurl
-, lib
-, stdenv
-, pkg-config
-, intltool
-, libpulseaudio
-, gtkmm3
-, libsigcxx
-, libcanberra-gtk3
-, json-glib
-, adwaita-icon-theme
-, wrapGAppsHook3
+{
+  fetchurl,
+  lib,
+  stdenv,
+  pkg-config,
+  intltool,
+  libpulseaudio,
+  gtkmm3,
+  libsigcxx,
+  libcanberra-gtk3,
+  json-glib,
+  adwaita-icon-theme,
+  wrapGAppsHook3,
 }:
 
 stdenv.mkDerivation rec {
@@ -30,7 +31,11 @@ stdenv.mkDerivation rec {
     adwaita-icon-theme
   ];
 
-  nativeBuildInputs = [ pkg-config intltool wrapGAppsHook3 ];
+  nativeBuildInputs = [
+    pkg-config
+    intltool
+    wrapGAppsHook3
+  ];
 
   configureFlags = [ "--disable-lynx" ];
 

--- a/pkgs/applications/audio/pavucontrol/default.nix
+++ b/pkgs/applications/audio/pavucontrol/default.nix
@@ -5,39 +5,50 @@
   pkg-config,
   intltool,
   libpulseaudio,
-  gtkmm3,
+  gtkmm4,
   libsigcxx,
+  # Since version 6.0, libcanberra is optional
+  withLibcanberra ? true,
   libcanberra-gtk3,
   json-glib,
   adwaita-icon-theme,
-  wrapGAppsHook3,
+  wrapGAppsHook4,
+  meson,
+  ninja,
+  libpressureaudio,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pavucontrol";
-  version = "5.0";
+  version = "6.0";
 
   src = fetchurl {
     url = "https://freedesktop.org/software/pulseaudio/${finalAttrs.pname}/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
-    sha256 = "sha256-zityw7XxpwrQ3xndgXUPlFW9IIcNHTo20gU2ry6PTno=";
+    sha256 = "sha256-hchg1o/x+CzZjHKpJXGEvuOSmVeKsSLSm8Uey+z79ls=";
   };
 
   buildInputs = [
     libpulseaudio
-    gtkmm3
+    gtkmm4
     libsigcxx
-    libcanberra-gtk3
+    (lib.optionals withLibcanberra libcanberra-gtk3)
     json-glib
     adwaita-icon-theme
+    libpressureaudio
   ];
 
   nativeBuildInputs = [
     pkg-config
     intltool
-    wrapGAppsHook3
+    wrapGAppsHook4
+    meson
+    ninja
   ];
 
-  configureFlags = [ "--disable-lynx" ];
+  mesonFlags = [
+    "--prefix=${placeholder "out"}"
+    (lib.mesonBool "lynx" false)
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/audio/pavucontrol/default.nix
+++ b/pkgs/applications/audio/pavucontrol/default.nix
@@ -41,21 +41,18 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  meta = {
+    changelog = "https://freedesktop.org/software/pulseaudio/pavucontrol/#news";
     description = "PulseAudio Volume Control";
-
+    homepage = "http://freedesktop.org/software/pulseaudio/pavucontrol/";
+    license = lib.licenses.gpl2Plus;
     longDescription = ''
       PulseAudio Volume Control (pavucontrol) provides a GTK
       graphical user interface to connect to a PulseAudio server and
       easily control the volume of all clients, sinks, etc.
     '';
-
-    homepage = "http://freedesktop.org/software/pulseaudio/pavucontrol/";
-
-    license = lib.licenses.gpl2Plus;
-
-    maintainers = with maintainers; [ abbradar ];
-    platforms = platforms.linux;
     mainProgram = "pavucontrol";
+    maintainers = with lib.maintainers; [ abbradar ];
+    platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/audio/pavucontrol/default.nix
+++ b/pkgs/applications/audio/pavucontrol/default.nix
@@ -1,5 +1,5 @@
 {
-  fetchurl,
+  fetchFromGitLab,
   lib,
   stdenv,
   pkg-config,
@@ -22,9 +22,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "pavucontrol";
   version = "6.0";
 
-  src = fetchurl {
-    url = "https://freedesktop.org/software/pulseaudio/${finalAttrs.pname}/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
-    sha256 = "sha256-hchg1o/x+CzZjHKpJXGEvuOSmVeKsSLSm8Uey+z79ls=";
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "pulseaudio";
+    repo = "pavucontrol";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-nxzFvD/KUevIJOw9jgcr0Hfvg7KiSOmTBfKN3jLu3Cg=";
   };
 
   buildInputs = [

--- a/pkgs/applications/audio/pavucontrol/default.nix
+++ b/pkgs/applications/audio/pavucontrol/default.nix
@@ -13,12 +13,12 @@
   wrapGAppsHook3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pavucontrol";
   version = "5.0";
 
   src = fetchurl {
-    url = "https://freedesktop.org/software/pulseaudio/${pname}/${pname}-${version}.tar.xz";
+    url = "https://freedesktop.org/software/pulseaudio/${finalAttrs.pname}/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
     sha256 = "sha256-zityw7XxpwrQ3xndgXUPlFW9IIcNHTo20gU2ry6PTno=";
   };
 
@@ -58,4 +58,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     mainProgram = "pavucontrol";
   };
-}
+})


### PR DESCRIPTION
## Description of changes

The main big changes are

> Migrate from Gtk 3 to 4
> Drop autotools build in favour of meson
> Make libcanberra dependency optional

Source: https://freedesktop.org/software/pulseaudio/pavucontrol/#news


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc