### PR TITLE
Add hmac-sha2-512 to default Macs for OpenSSH

### DIFF
--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -439,6 +439,8 @@ in
                 "hmac-sha2-256-etm@openssh.com"
                 "umac-128-etm@openssh.com"
                 "hmac-sha2-512"
+                "hmac-sha2-256"
+                "umac-128@openssh.com"
               ];
               description = ''
                 Allowed MACs

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -438,6 +438,7 @@ in
                 "hmac-sha2-512-etm@openssh.com"
                 "hmac-sha2-256-etm@openssh.com"
                 "umac-128-etm@openssh.com"
+                "hmac-sha2-512"
               ];
               description = ''
                 Allowed MACs


### PR DESCRIPTION
## Description of changes

Add `hmac-sha2-512` to default list of `services.openssh.settings.Macs`.

I recently faced an issue communication issue by SSH between my NixOS machine and my iPad, reported in this issue: https://github.com/mssun/passforios/issues/620

Adding `hmac-sha2-512` to the list of Macs of openssh solved the issue.

Furthermore, NixOS refers to recommended settings published by [mozilla](https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67) which do include `hmac-sha2-512` in the default Macs for "modern" SSH server configuration.

Therefore, to solve compatibility issues with iOS, I suggest this PR.