### PR TITLE
python3Packages.discum: init at 1.4.1

### DIFF
--- a/pkgs/development/python-modules/discum/default.nix
+++ b/pkgs/development/python-modules/discum/default.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  pythonRelaxDepsHook,
+  brotli,
+  colorama,
+  filetype,
+  requests,
+  requests-toolbelt,
+  ua-parser,
+  websocket-client,
+  pycryptodome,
+  pypng,
+  pyqrcode,
+}:
+
+buildPythonPackage rec {
+  pname = "discum";
+  version = "1.4.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-/8TaAmfSPv/7kuymockSvC2uxXgHfuP+FXN8vuA9WHY=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
+
+  dependencies = [
+    brotli
+    colorama
+    filetype
+    requests
+    requests-toolbelt
+    ua-parser
+    websocket-client
+  ];
+
+  passthru.optional-dependencies = {
+    ra = [
+      pycryptodome
+      pypng
+      pyqrcode
+    ];
+  };
+
+  pythonImportsCheck = [ "discum" ];
+
+  pythonRelaxDeps = [ "websocket-client" ];
+
+  meta = {
+    description = "Discord API Wrapper for Userbots/Selfbots written in Python";
+    homepage = "https://pypi.org/project/discum/";
+    changelog = "https://github.com/Merubokkusu/Discord-S.C.U.M/blob/v${version}/changelog.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jokatzke ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3111,6 +3111,8 @@ self: super: with self; {
 
   discovery30303 = callPackage ../development/python-modules/discovery30303 { };
 
+  discum = callPackage ../development/python-modules/discum { };
+
   diskcache = callPackage ../development/python-modules/diskcache { };
 
   dissect = callPackage ../development/python-modules/dissect { };


### PR DESCRIPTION
## Description of changes

Add https://github.com/Merubokkusu/Discord-S.C.U.M

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
  - [x] with `--sandbox` flag
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
