### PR TITLE
zf: 0.9.1 -> 0.9.2

### DIFF
--- a/pkgs/tools/misc/zf/default.nix
+++ b/pkgs/tools/misc/zf/default.nix
@@ -23,7 +23,6 @@ stdenv.mkDerivation (finalAttrs: {
     zig_0_13.hook
   ];
 
-  # ln -s fails with error: ... RenameAcrossMountPoints
   postPatch = ''
     cp -a ${callPackage ./deps.nix { }}/. $ZIG_GLOBAL_CACHE_DIR/p
   '';

--- a/pkgs/tools/misc/zf/default.nix
+++ b/pkgs/tools/misc/zf/default.nix
@@ -3,28 +3,29 @@
 , fetchFromGitHub
 , installShellFiles
 , testers
-, zig_0_11
+, zig_0_13
 , callPackage
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zf";
-  version = "0.9.1";
+  version = "0.9.2";
 
   src = fetchFromGitHub {
     owner = "natecraddock";
     repo = "zf";
     rev = "refs/tags/${finalAttrs.version}";
-    hash = "sha256-JPv/59ELh+CS1/akuLNy0qSimMEJsypPO8hiHFAOirI=";
+    hash = "sha256-8KfzsDG9sZ/jMOusz2ydt3oytp891vKOpCUlPAwS8TE=";
   };
 
   nativeBuildInputs = [
     installShellFiles
-    zig_0_11.hook
+    zig_0_13.hook
   ];
 
+  # ln -s fails with error: ... RenameAcrossMountPoints
   postPatch = ''
-    ln -s ${callPackage ./deps.nix { }} $ZIG_GLOBAL_CACHE_DIR/p
+    cp -a ${callPackage ./deps.nix { }}/. $ZIG_GLOBAL_CACHE_DIR/p
   '';
 
   postInstall = ''

--- a/pkgs/tools/misc/zf/deps.nix
+++ b/pkgs/tools/misc/zf/deps.nix
@@ -4,10 +4,10 @@
 
 linkFarm "zig-packages" [
   {
-    name = "1220dee955839b7f267c1bb21e0ee60888c08f408c30f0722b243cabcc8cce8b7508";
+    name = "12207831bce7d4abce57b5a98e8f3635811cfefd160bca022eb91fe905d36a02cf25";
     path = fetchzip {
-      url = "https://codeberg.org/dude_the_builder/ziglyph/archive/v0.11.1.tar.gz";
-      hash = "sha256-tpl4RyCcukKWZehlZf6t2n41gYFDyL27t7+bzcxHP7g=";
+      url = "https://codeberg.org/dude_the_builder/ziglyph/archive/b89d43d1e3fb01b6074bc1f7fc980324b04d26a5.tar.gz";
+      hash = "sha256-e/zYB9w6vvHUBJzjlocSjpJu3qao7sXjBsfUO9oDXyg=";
     };
   }
 ]


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

zf 0.9.2: https://github.com/natecraddock/zf/releases/tag/0.9.2

The zig dependency is updated from 0.11 to 0.13 in this PR (previously, zf couldn't work with zig 0.12+), this also fixes build issues on macOS due to https://github.com/NixOS/nixpkgs/issues/299091.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc @dit7ya @figsoda @mmlb

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
