### PR TITLE
mailpit: fix `passthru.updateScript`

### DIFF
--- a/pkgs/servers/mail/mailpit/update.sh
+++ b/pkgs/servers/mail/mailpit/update.sh
@@ -28,7 +28,7 @@ TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' exit
 
 NIXPKGS_MAILPIT_PATH=$(cd $(dirname ${BASH_SOURCE[0]}); pwd -P)/
-VERSIONS_NIX="$NIXPKGS_MAILPIT_PATH/versions.nix"
+SOURCE_NIX="$NIXPKGS_MAILPIT_PATH/source.nix"
 
 PREFETCH_JSON=$TMP/prefetch.json
 nix-prefetch-git --rev "$TARGET_TAG" --url "https://github.com/$OWNER/$REPO" > "$PREFETCH_JSON"
@@ -38,7 +38,7 @@ NPM_DEPS_HASH="$(prefetch-npm-deps $PREFETCH_PATH/package-lock.json)"
 
 FAKE_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
 
-cat > $VERSIONS_NIX <<-EOF
+cat > $SOURCE_NIX <<-EOF
 {
   version = "$TARGET_VERSION";
   hash = "$PREFETCH_HASH";
@@ -50,7 +50,7 @@ EOF
 GO_HASH="$(nix-instantiate --eval -A mailpit.vendorHash | tr -d '"')"
 VENDOR_HASH=$(extractVendorHash "$GO_HASH")
 
-cat > $VERSIONS_NIX <<-EOF
+cat > $SOURCE_NIX <<-EOF
 {
   version = "$TARGET_VERSION";
   hash = "$PREFETCH_HASH";
@@ -68,6 +68,6 @@ cat <<-EOF
   "attrPath": "$UPDATE_NIX_ATTR_PATH",
   "oldVersion": "$UPDATE_NIX_OLD_VERSION",
   "newVersion": "$TARGET_VERSION",
-  "files": ["$VERSIONS_NIX"]
+  "files": ["$SOURCE_NIX"]
 }]
 EOF


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This is a little fixup to #324302. I forgot to rename `versions.nix` to `source.nix` in the update script.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
