### PR TITLE
wineWow64Packages.unstableFull: 9.12 -> 9.14

### DIFF
--- a/pkgs/applications/emulators/wine/sources.nix
+++ b/pkgs/applications/emulators/wine/sources.nix
@@ -69,9 +69,9 @@ in rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the hash for staging as well.
-    version = "9.12";
+    version = "9.14";
     url = "https://dl.winehq.org/wine/source/9.x/wine-${version}.tar.xz";
-    hash = "sha256-CRRa5yCy+fGBh5cLoGQLvzztWujceK8dfVf1B37CavY=";
+    hash = "sha256-JFcvSc80c/ye8qGtHN31Ec4O9D2qVUE7RyCmw+PInqY=";
     inherit (stable) patches;
 
     ## see http://wiki.winehq.org/Gecko
@@ -117,7 +117,7 @@ in rec {
   staging = fetchFromGitLab rec {
     # https://gitlab.winehq.org/wine/wine-staging
     inherit (unstable) version;
-    hash = "sha256-lvjuohEo4pwCAd1KmLjUBakS5gSN+Ic6+QQ18sS3axw=";
+    hash = "sha256-IvT56lWULfA5MFLEjnpnNX4OhjQwR6XqBGJ3i4nqJrk=";
     domain = "gitlab.winehq.org";
     owner = "wine";
     repo = "wine-staging";

--- a/pkgs/applications/emulators/wine/staging.nix
+++ b/pkgs/applications/emulators/wine/staging.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, callPackage, autoconf, hexdump, perl, python3, wineUnstable }:
+{ lib, stdenv, callPackage, autoconf, hexdump, perl, python3, wineUnstable, gitMinimal }:
 
 with callPackage ./util.nix {};
 
@@ -9,7 +9,7 @@ in assert lib.versions.majorMinor wineUnstable.version == lib.versions.majorMino
 
 (wineUnstable.override { wineRelease = "staging"; }).overrideAttrs (self: {
   buildInputs = build-inputs ([ "perl" "autoconf" "gitMinimal" ] ++ lib.optional stdenv.isLinux "util-linux") self.buildInputs;
-  nativeBuildInputs = [ autoconf hexdump perl python3 ] ++ self.nativeBuildInputs;
+  nativeBuildInputs = [ autoconf hexdump perl python3 gitMinimal ] ++ self.nativeBuildInputs;
 
   prePatch = self.prePatch or "" + ''
     patchShebangs tools


### PR DESCRIPTION
## Description of changes

* Updated wine unstable to 9.14
* Fixed wine staging `patchPhase` failure by adding `gitMinimal` to `nativeBuildInputs`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
