### PR TITLE
nixpkgs-manual: use injected revision only

### DIFF
--- a/doc/doc-support/package.nix
+++ b/doc/doc-support/package.nix
@@ -60,7 +60,7 @@ stdenvNoCC.mkDerivation (
 
       nixos-render-docs manual html \
         --manpage-urls ./manpage-urls.json \
-        --revision ${lib.trivial.revisionWithDefault (nixpkgs.rev or "master")} \
+        --revision ${nixpkgs.rev or "master"} \
         --stylesheet style.css \
         --stylesheet highlightjs/mono-blue.css \
         --script ./highlightjs/highlight.pack.js \


### PR DESCRIPTION
## Motivation for change

`nixpkgs-manual` is [listed as a rebuild](https://github.com/NixOS/nixpkgs/pull/311459#issuecomment-2254523011) on every single PR since I introduced it to the top-level packages in #311459. 

## Description of change

The existing derivation used `lib.trivial.revisionWithDefault` in its build phase. Due to that, the derivation will change with every Git commit, which then causes the manual to be rebuilt on every single PR or commit.

Using `nixpkgs.rev` (or the dummy value "master" if it's not present) means that the manual will contain the revision if built on Hydra, but will not otherwise.

Why?

1. https://hydra.nixos.org/jobset/nixos/trunk-combined#tabs-configuration shows that `pkgs/top-level/release.nix` is passed the `nixpkgs` attrset, which is a "Git checkout".
2. Git checkouts come from [`builtins.fetchGit`](https://nix.dev/manual/nix/2.18/language/builtins#builtins-fetchGit) and include the `rev` attribute.
3. The `rev` attribute is what `lib.trivial.revisionWithDefault` would have returned.

So, using `nixpkgs.rev or "master"` exclusively will cause the rebuilds on every commit to cease, but will allow "official" nixpkgs manual built on Hydra to continue to reference a specific commit.

The line this PR replaces was introduced in be4d19ff1a9a327ae805fdb344470ed6450256fc by @pennae (#239636).

https://github.com/NixOS/nixpkgs/blob/be4d19ff1a9a327ae805fdb344470ed6450256fc/doc/default.nix#L80

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested the look and feel of the Nixpkgs manual.
- [x] Made another commit and saw zero rebuilds.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).