### PR TITLE
linux-cachyos: init at 6.6.43/6.10.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5384,6 +5384,12 @@
     githubId = 20759788;
     name = "JP Lippold";
   };
+  drakon64 = {
+    email = "adam@drakon.cloud";
+    github = "drakon64";
+    githubId = 6444703;
+    name = "Adam Chance";
+  };
   dramaturg = {
     email = "seb@ds.ag";
     github = "dramaturg";

--- a/pkgs/os-specific/linux/kernel/cachyos-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/cachyos-kernels.nix
@@ -1,0 +1,258 @@
+{
+  lib,
+  fetchFromGitHub,
+  pkgs,
+  stdenv,
+  buildLinux,
+  ...
+}@args:
+
+let
+  # When updating this package, make sure to account for important config changes in https://github.com/CachyOS/linux-cachyos/blob/master/linux-cachyos/config and https://github.com/CachyOS/linux-cachyos/blob/master/linux-cachyos-lts/config as well
+  cachyPatches = fetchFromGitHub {
+    owner = "CachyOS";
+    repo = "kernel-patches";
+    rev = "04fb9178158a7714aeb908c7a5310c4e0d6ea4b6";
+    hash = "sha256-KTvZxYy+UgLNg1DYBMrJrRdxDo3N5ususlrHyRBS7C8=";
+  };
+
+  ltsVariant = {
+    version = "6.6.43";
+    variantDescription = "Linux EEVDF-BORE scheduler Kernel by CachyOS with other patches and improvements";
+    source = {
+      url = "mirror://kernel/linux/kernel/v6.x/linux-6.6.43.tar.xz";
+      hash = "sha256-Ctg7Ghp4ChqtlI1VqlXuY8UMYm8tRpELnSGAAo0QCl4=";
+    };
+    patches = [
+      {
+        name = "cachyos-base-all";
+        patch = "${cachyPatches}/6.6/all/0001-cachyos-base-all.patch";
+      }
+      {
+        name = "bore-cachy";
+        patch = "${cachyPatches}/6.6/sched/0001-bore-cachy.patch";
+      }
+    ];
+
+    config = with lib.kernel; {
+      # CachyOS config
+      CACHY = yes;
+
+      # CPU Scheduler
+      SCHED_BORE = yes;
+
+      # LLVM level
+      LTO_NONE = yes;
+
+      # Tick rate
+      HZ_300 = unset;
+      HZ_1000 = yes;
+      HZ = freeform "1000";
+
+      NR_CPUS = lib.mkOverride 60 (freeform "320");
+
+      # Tick type
+      HZ_PERIODIC = unset;
+      NO_HZ_IDLE = unset;
+      CONTEXT_TRACKING_FORCE = unset;
+      NO_HZ_FULL = yes;
+      NO_HZ = yes;
+      NO_HZ_COMMON = yes;
+      CONTEXT_TRACKING = yes;
+
+      # Preempt type
+      PREEMPT_BUILD = yes;
+      PREEMPT_NONE = unset;
+      PREEMPT_VOLUNTARY = lib.mkOverride 60 unset;
+      PREEMPT = lib.mkOverride 60 yes;
+      PREEMPT_COUNT = yes;
+      PREEMPTION = yes;
+      PREEMPT_DYNAMIC = yes;
+
+      # Enable O3
+      CC_OPTIMIZE_FOR_PERFORMANCE = unset;
+      CC_OPTIMIZE_FOR_PERFORMANCE_O3 = yes;
+
+      # Enable bbr3
+      DEFAULT_CUBIC = unset;
+      TCP_CONG_BBR = yes;
+      DEFAULT_BBR = yes;
+      DEFAULT_TCP_CONG = freeform "bbr";
+
+      # LRU config
+      LRU_GEN = yes;
+      LRU_GEN_ENABLED = yes;
+      LRU_GEN_STATS = unset;
+
+      # VMA config
+      PER_VMA_LOCK = yes;
+      PER_VMA_LOCK_STATS = unset;
+
+      # THP
+      TRANSPARENT_HUGEPAGE_MADVISE = lib.mkOverride 60 unset;
+      TRANSPARENT_HUGEPAGE_ALWAYS = lib.mkOverride 60 yes;
+
+      USER_NS = yes;
+
+      # Modules
+      ## Apple T2 https://github.com/t2linux/linux-t2-patches/blob/main/extra_config
+      APPLE_GMUX = module;
+      BRCMFMAC = module;
+      BT_BCM = module;
+      BT_HCIBCM4377 = module;
+      BT_HCIUART_BCM = yes;
+      BT_HCIUART = module;
+      HID_APPLE = module;
+      HID_SENSOR_ALS = module;
+      SENSORS_APPLESMC = module;
+      SND_PCM = module;
+      STAGING = yes;
+
+      I2C_NCT6775 = module;
+      LEDS_TRIGGER_BLKDEV = module;
+      STEAMDECK = module;
+    };
+  };
+
+  # If updating this, remember to raise the version constraints in:
+  # * pkgs/os-specific/linux/mbp-modules/mbp2018-bridge-drv/default.nix
+  # * pkgs/os-specific/linux/v4l2loopback/default.nix
+  mainVariant = {
+    version = "6.10.2";
+    variantDescription = "Linux SCHED-EXT + BORE + Cachy Sauce Kernel by CachyOS with other patches and improvements";
+    source = {
+      url = "mirror://kernel/linux/kernel/v6.x/linux-6.10.2.tar.xz";
+      hash = "sha256-c9hSDdnLpaz8XnII52s12XQLiq44IQqSJOMuxMDSm3A=";
+    };
+    patches = [
+      {
+        name = "cachyos-base-all";
+        patch = "${cachyPatches}/6.10/all/0001-cachyos-base-all.patch";
+      }
+      {
+        name = "sched-ext";
+        patch = "${cachyPatches}/6.10/sched/0001-sched-ext.patch";
+      }
+      {
+        name = "bore-cachy-ext";
+        patch = "${cachyPatches}/6.10/sched/0001-bore-cachy-ext.patch";
+      }
+    ];
+
+    config = with lib.kernel; {
+      # CachyOS config
+      CACHY = yes;
+
+      # CPU Scheduler
+      SCHED_CLASS_EXT = yes;
+      SCHED_BORE = yes;
+      MIN_BASE_SLICE_NS = freeform "1000000";
+
+      # LLVM level
+      LTO_NONE = yes;
+
+      # Tick rate
+      HZ_300 = unset;
+      HZ_1000 = yes;
+      HZ = freeform "1000";
+
+      NR_CPUS = lib.mkOverride 60 (freeform "320");
+
+      # Tick type
+      HZ_PERIODIC = unset;
+      NO_HZ_IDLE = unset;
+      CONTEXT_TRACKING_FORCE = unset;
+      NO_HZ_FULL = yes;
+      NO_HZ = yes;
+      NO_HZ_COMMON = yes;
+      CONTEXT_TRACKING = yes;
+
+      # Preempt type
+      PREEMPT_BUILD = yes;
+      PREEMPT_NONE = unset;
+      PREEMPT_VOLUNTARY = lib.mkOverride 60 unset;
+      PREEMPT = lib.mkOverride 60 yes;
+      PREEMPT_COUNT = yes;
+      PREEMPTION = yes;
+      PREEMPT_DYNAMIC = yes;
+
+      # Enable O3
+      CC_OPTIMIZE_FOR_PERFORMANCE = unset;
+      CC_OPTIMIZE_FOR_PERFORMANCE_O3 = yes;
+
+      # Enable bbr3
+      TCP_CONG_CUBIC = lib.mkOverride 60 module;
+      DEFAULT_CUBIC = unset;
+      TCP_CONG_BBR = yes;
+      DEFAULT_BBR = yes;
+      DEFAULT_TCP_CONG = freeform "bbr";
+
+      # Select THP
+      TRANSPARENT_HUGEPAGE_MADVISE = lib.mkOverride 60 unset;
+      TRANSPARENT_HUGEPAGE_ALWAYS = lib.mkOverride 60 yes;
+
+      USER_NS = yes;
+
+      # Modules
+      ## Apple T2 https://github.com/t2linux/linux-t2-patches/blob/main/extra_config
+      APPLE_BCE = module;
+      APPLE_GMUX = module;
+      BRCMFMAC = module;
+      BT_BCM = module;
+      BT_HCIBCM4377 = module;
+      BT_HCIUART_BCM = yes;
+      BT_HCIUART = module;
+      HID_APPLETB_BL = module;
+      HID_APPLETB_KBD = module;
+      HID_APPLE = module;
+      DRM_APPLETBDRM = module;
+      HID_SENSOR_ALS = module;
+      SENSORS_APPLESMC = module;
+      SND_PCM = module;
+      STAGING = yes;
+
+      I2C_NCT6775 = module;
+      NTSYNC = module;
+      V4L2_LOOPBACK = module;
+    };
+  };
+
+  cachyosKernelFor =
+    {
+      version,
+      variantDescription,
+      source,
+      patches,
+      config,
+    }:
+    buildLinux (
+      args
+      // rec {
+        inherit version;
+        pname = "linux-cachyos";
+        modDirVersion = version;
+        isCachy = true;
+
+        src = pkgs.fetchurl {
+          url = source.url;
+          hash = source.hash;
+        };
+
+        kernelPatches = patches;
+
+        structuredExtraConfig = config;
+
+        extraMeta = {
+          branch = lib.versions.majorMinor version;
+          maintainers = with lib.maintainers; [ drakon64 ];
+          description = variantDescription;
+          broken = stdenv.isAarch64;
+        };
+      }
+      // (args.argsOverride or { })
+    );
+in
+{
+  lts = cachyosKernelFor ltsVariant;
+  main = cachyosKernelFor mainVariant;
+}

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -66,6 +66,7 @@ lib.makeOverridable ({ # The kernel source tarball.
 , isZen      ? false
 , isLibre    ? false
 , isHardened ? false
+, isCachy    ? false
 
 # easy overrides to stdenv.hostPlatform.linux-kernel members
 , autoModules ? stdenv.hostPlatform.linux-kernel.autoModules
@@ -229,7 +230,7 @@ kernel.overrideAttrs (finalAttrs: previousAttrs: {
 
   passthru = previousAttrs.passthru or { } // basicArgs // {
     features = kernelFeatures;
-    inherit commonStructuredConfig structuredExtraConfig extraMakeFlags isZen isHardened isLibre;
+    inherit commonStructuredConfig structuredExtraConfig extraMakeFlags isCachy isZen isHardened isLibre;
     isXen = lib.warn "The isXen attribute is deprecated. All Nixpkgs kernels that support it now have Xen enabled." true;
 
     # Adds dependencies needed to edit the config:

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -48,6 +48,7 @@ in lib.makeOverridable ({
   isZen      ? false,
   isLibre    ? false,
   isHardened ? false,
+  isCachy    ? false,
 
   # Whether to utilize the controversial import-from-derivation feature to parse the config
   allowImportFromDerivation ? false,
@@ -132,7 +133,7 @@ let
       passthru = rec {
         inherit version modDirVersion config kernelPatches configfile
           moduleBuildDependencies stdenv;
-        inherit isZen isHardened isLibre withRust;
+        inherit isZen isHardened isLibre isCachy withRust;
         isXen = lib.warn "The isXen attribute is deprecated. All Nixpkgs kernels that support it now have Xen enabled." true;
         baseVersion = lib.head (lib.splitString "-rc" version);
         kernelOlder = lib.versionOlder baseVersion;

--- a/pkgs/os-specific/linux/mbp-modules/mbp2018-bridge-drv/default.nix
+++ b/pkgs/os-specific/linux/mbp-modules/mbp2018-bridge-drv/default.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Only;
     platforms = platforms.linux;
     maintainers = [ lib.maintainers.hlolli ];
-    broken = kernel.kernelOlder "5.4";
+    broken = kernel.kernelOlder "5.4" || (kernel.isCachy && (lib.versionAtLeast kernel.version "6.10"));
   };
 }

--- a/pkgs/os-specific/linux/v4l2loopback/default.nix
+++ b/pkgs/os-specific/linux/v4l2loopback/default.nix
@@ -39,5 +39,6 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ moni ];
     platforms = platforms.linux;
     outputsToInstall = [ "out" ];
+    broken = kernel.isCachy && (lib.versionAtLeast kernel.version "6.10");
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26938,6 +26938,14 @@ with pkgs;
   linuxPackages_xanmod_latest = linuxKernel.packages.linux_xanmod_latest;
   linux_xanmod_latest = linuxKernel.kernels.linux_xanmod_latest;
 
+  # CachyOS kernel
+  linuxPackages_cachyos = linuxKernel.packages.linux_cachyos;
+  linux_cachyos = linuxKernel.kernels.linux_cachyos;
+  linuxPackages_cachyos_stable = linuxKernel.packages.linux_cachyos_stable;
+  linux_cachyos_stable = linuxKernel.kernels.linux_cachyos_stable;
+  linuxPackages_cachyos_latest = linuxKernel.packages.linux_cachyos_latest;
+  linux_cachyos_latest = linuxKernel.kernels.linux_cachyos_latest;
+
   linux-doc = callPackage ../os-specific/linux/kernel/htmldocs.nix { };
 
   cryptodev = linuxPackages.cryptodev;

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -261,6 +261,18 @@ in {
     linux_xanmod_stable = xanmodKernels.main;
     linux_xanmod_latest = xanmodKernels.main;
 
+    # This contains the variants of the CachyOS kernel
+    cachyosKernels = callPackage ../os-specific/linux/kernel/cachyos-kernels.nix {
+      kernelPatches = [
+        kernelPatches.bridge_stp_helper
+        kernelPatches.request_key_helper
+      ];
+    };
+
+    linux_cachyos = cachyosKernels.lts;
+    linux_cachyos_stable = cachyosKernels.main;
+    linux_cachyos_latest = cachyosKernels.main;
+
     linux_libre = deblobKernel packageAliases.linux_default.kernel;
 
     linux_latest_libre = deblobKernel packageAliases.linux_latest.kernel;
@@ -314,7 +326,7 @@ in {
     inherit (kernel) stdenv; # in particular, use the same compiler by default
 
     # to help determine module compatibility
-    inherit (kernel) isZen isHardened isLibre;
+    inherit (kernel) isZen isHardened isLibre isCachy;
     inherit (kernel) kernelOlder kernelAtLeast;
     # Obsolete aliases (these packages do not depend on the kernel).
     inherit (pkgs) odp-dpdk pktgen; # added 2018-05
@@ -680,6 +692,9 @@ in {
     linux_xanmod = recurseIntoAttrs (packagesFor kernels.linux_xanmod);
     linux_xanmod_stable = recurseIntoAttrs (packagesFor kernels.linux_xanmod_stable);
     linux_xanmod_latest = recurseIntoAttrs (packagesFor kernels.linux_xanmod_latest);
+    linux_cachyos = recurseIntoAttrs (packagesFor kernels.linux_cachyos);
+    linux_cachyos_stable = recurseIntoAttrs (packagesFor kernels.linux_cachyos_stable);
+    linux_cachyos_latest = recurseIntoAttrs (packagesFor kernels.linux_cachyos_latest);
 
     linux_libre = recurseIntoAttrs (packagesFor kernels.linux_libre);
 


### PR DESCRIPTION
## Description of changes

CachyOS adds some patches to the Linux kernel to improve performance. The most prominent of these are the replacement CPU schedulers. More information is available at https://wiki.cachyos.org/kernel/kernel/.

This PR implements the default [`linux-cachyos`](https://github.com/CachyOS/linux-cachyos/tree/3728444ae7d3ba1ac6b6fa7401089143597b5aba/linux-cachyos) and [`linux-cachyos-lts`](https://github.com/CachyOS/linux-cachyos/tree/3728444ae7d3ba1ac6b6fa7401089143597b5aba/linux-cachyos-lts) patch sets. This includes the [BORE scheduler](https://github.com/firelzrd/bore-scheduler).

Resolves https://github.com/NixOS/nixpkgs/issues/214819

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
