### PR TITLE
nix-doc: fix build for Rust 1.79+

### DIFF
--- a/pkgs/tools/package-management/nix-doc/default.nix
+++ b/pkgs/tools/package-management/nix-doc/default.nix
@@ -49,7 +49,7 @@ rustPlatform.buildRustPackage rec {
     longDescription = "An interactive Nix documentation tool providing a CLI for function search, a Nix plugin for docs in the REPL, and a ctags implementation for Nix script";
     homepage = "https://github.com/lf-/nix-doc";
     license = licenses.lgpl3Plus;
-    maintainers = [ ];
+    maintainers = [ maintainers.philiptaron ];
     platforms = platforms.unix;
     mainProgram = "nix-doc";
   };

--- a/pkgs/tools/package-management/nix-doc/default.nix
+++ b/pkgs/tools/package-management/nix-doc/default.nix
@@ -35,13 +35,11 @@ rustPlatform.buildRustPackage rec {
   # the wrong Nix version (disabling bindnow permits loading libraries
   # requiring unavailable symbols if they are unreached)
   hardeningDisable = lib.optionals withPlugin [ "bindnow" ];
-  # Due to a Rust bug, setting -Z relro-level to anything including "off" on
+
+  # Due to a Rust bug, setting -C relro-level to anything including "off" on
   # macOS will cause link errors
   env = lib.optionalAttrs (withPlugin && stdenv.isLinux) {
-    # nix-doc does not use nightly features, however, there is no other way to
-    # set relro-level
-    RUSTC_BOOTSTRAP = 1;
-    RUSTFLAGS = "-Z relro-level=partial";
+    RUSTFLAGS = "-C relro-level=partial";
   };
 
   cargoHash = "sha256-CHagzXTG9AfrFd3WmHanQ+YddMgmVxSuB8vK98A1Mlw=";


### PR DESCRIPTION
## Description of changes

As of Rust 1.79+ (turned on in a5b2fe73740c) `relro-level` is now stable. 🎉 

- https://github.com/rust-lang/rust/pull/121694

This means `nix-doc` (which uses this option in its unstable form) needs to pass through `-C` instead of `-Z`.

Also, sign up to maintain the tool (unmaintained since #323887). I use it a lot!

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).