### PR TITLE
ugit: init at 5.8

### DIFF
--- a/pkgs/by-name/ug/ugit/package.nix
+++ b/pkgs/by-name/ug/ugit/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  git,
+  fzf,
+  bash,
+  ncurses,
+  curl,
+  nix-update-script,
+  testers,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "ugit";
+  version = "5.8";
+
+  src = fetchFromGitHub {
+    owner = "Bhupesh-V";
+    repo = "ugit";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-WnEyS2JKH6rrsYOeGEwughWq2LKrHPSjio3TOI0Xm4g=";
+  };
+
+  strictDeps = true;
+  doInstallCheck = true;
+
+  buildInputs = [
+    fzf
+    curl
+    bash
+    ncurses
+  ];
+
+  propagatedBuildInputs = [ git ];
+  nativeInstallCheckInputs = [ ncurses ];
+
+  postPatch = ''
+    substituteInPlace ugit \
+      --replace-fail "fzf " "${lib.getExe fzf} " \
+      --replace-fail "curl" "${lib.getExe curl}" \
+      --replace-fail "tput " "${ncurses}/bin/tput "
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 ugit $out/bin/ugit
+    ln -s $out/bin/ugit $out/bin/git-undo
+    install -Dm644 ugit.plugin.zsh $out/share/zsh/ugit/ugit.zsh
+
+    runHook postInstall
+  '';
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    PATH=$PATH:$out/bin ugit --help
+
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Tool that helps undoing the last git command with grace";
+    homepage = "https://github.com/Bhupesh-V/ugit";
+    downloadPage = "https://github.com/Bhupesh-V/ugit/releases";
+    license = lib.licenses.mit;
+    mainProgram = "ugit";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ d-brasher ];
+  };
+})


### PR DESCRIPTION
## Description of changes

[ugit](https://github.com/Bhupesh-V/ugit) is a tool that helps undoing the last git command interactively.

I'd like to add some tests, but I have no idea how since this is an interactive CLI tool.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
