### PR TITLE
python312Packages.misoc: unstable-2022-10-08 -> 0-unstable-2024-05-14

### DIFF
--- a/pkgs/development/python-modules/migen/default.nix
+++ b/pkgs/development/python-modules/migen/default.nix
@@ -1,12 +1,11 @@
 {
   lib,
   buildPythonPackage,
-  pythonOlder,
   fetchFromGitHub,
   colorama,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "migen";
   version = "unstable-2022-09-02";
   format = "setuptools";
@@ -22,10 +21,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "migen" ];
 
-  meta = with lib; {
+  meta = {
     description = " A Python toolbox for building complex digital hardware";
     homepage = "https://m-labs.hk/migen";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ l-as ];
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ l-as ];
   };
 }

--- a/pkgs/development/python-modules/migen/default.nix
+++ b/pkgs/development/python-modules/migen/default.nix
@@ -2,22 +2,28 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   colorama,
+  pytestCheckHook,
 }:
 
 buildPythonPackage {
   pname = "migen";
-  version = "unstable-2022-09-02";
-  format = "setuptools";
+  version = "unstable-2024-07-21";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "m-labs";
     repo = "migen";
-    rev = "639e66f4f453438e83d86dc13491b9403bbd8ec6";
-    hash = "sha256-IPyhoFZLhY8d3jHB8jyvGdbey7V+X5eCzBZYSrJ18ec=";
+    rev = "9279e8623f8433bc4f23ac51e5e2331bfe544417";
+    hash = "sha256-z3LRhNmKZrjr6rFD0yxtccSa/SWvFIYmb+G/D5d2Jd8=";
   };
 
+  nativeBuildInputs = [ setuptools ];
+
   propagatedBuildInputs = [ colorama ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "migen" ];
 

--- a/pkgs/development/python-modules/misoc/default.nix
+++ b/pkgs/development/python-modules/misoc/default.nix
@@ -9,7 +9,7 @@
   numpy,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "misoc";
   version = "unstable-2022-10-08";
   format = "setuptools";
@@ -32,10 +32,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "misoc" ];
 
-  meta = with lib; {
+  meta = {
     description = "Original high performance and small footprint system-on-chip based on Migen";
     homepage = "https://github.com/m-labs/misoc";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ doronbehar ];
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ doronbehar ];
   };
 }

--- a/pkgs/development/python-modules/misoc/default.nix
+++ b/pkgs/development/python-modules/misoc/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage {
   pname = "misoc";
-  version = "unstable-2022-10-08";
+  version = "0-unstable-2024-05-14";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "m-labs";
     repo = "misoc";
-    rev = "6a7c670ab6120b8136f652c41d907eb0fb16ed54";
-    hash = "sha256-dLDp0xg5y5b443hD7vbJFobHxbhtnj68RdZnQ7ckgp4=";
+    rev = "fea9de558c730bc394a5936094ae95bb9d6fa726";
+    hash = "sha256-zZ9LnUwvTvBL9iNFfmNTklQnd0I4PmV0BApMSblTnc0=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
