### PR TITLE
mpvScripts: Make more of occivink's scripts available

### DIFF
--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -92,7 +92,12 @@ let
         autodeint
         autoload
         ;
-      inherit (callPackage ./occivink.nix { }) blacklistExtensions crop seekTo;
+      inherit (callPackage ./occivink.nix { })
+        blacklistExtensions
+        crop
+        encode
+        seekTo
+        ;
 
       buildLua = callPackage ./buildLua.nix { };
       autosubsync-mpv = callPackage ./autosubsync-mpv.nix { };

--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -92,7 +92,7 @@ let
         autodeint
         autoload
         ;
-      inherit (callPackage ./occivink.nix { }) blacklistExtensions seekTo;
+      inherit (callPackage ./occivink.nix { }) blacklistExtensions crop seekTo;
 
       buildLua = callPackage ./buildLua.nix { };
       autosubsync-mpv = callPackage ./autosubsync-mpv.nix { };

--- a/pkgs/applications/video/mpv/scripts/occivink.nix
+++ b/pkgs/applications/video/mpv/scripts/occivink.nix
@@ -44,6 +44,7 @@ in
 lib.mapAttrs (name: lib.makeOverridable (mkScript name)) {
 
   # Usage: `pkgs.mpv.override { scripts = [ pkgs.mpvScripts.seekTo ]; }`
+  crop.meta.description = "Crop the current video in a visual manner.";
   seekTo.meta.description = "Mpv script for seeking to a specific position";
   blacklistExtensions.meta.description = "Automatically remove playlist entries based on their extension.";
 }

--- a/pkgs/applications/video/mpv/scripts/occivink.nix
+++ b/pkgs/applications/video/mpv/scripts/occivink.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   unstableGitUpdater,
   buildLua,
+  ffmpeg,
 }:
 
 let
@@ -47,4 +48,13 @@ lib.mapAttrs (name: lib.makeOverridable (mkScript name)) {
   crop.meta.description = "Crop the current video in a visual manner.";
   seekTo.meta.description = "Mpv script for seeking to a specific position";
   blacklistExtensions.meta.description = "Automatically remove playlist entries based on their extension.";
+
+  encode = {
+    meta.description = "Make an extract of the video currently playing using ffmpeg.";
+
+    postPatch = ''
+      substituteInPlace scripts/encode.lua \
+          --replace-fail '"ffmpeg"' '"${lib.getExe ffmpeg}"'
+    '';
+  };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Some mpv scripts from [occivink's mpv-scripts](https://github.com/occivink/mpv-scripts) collection were already available from `pkgs.mpvScripts`. This change makes the `crop` and `encode` scripts also available.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
