### PR TITLE
nixos/gotify-server: support all config options and custom package

### DIFF
--- a/nixos/modules/services/web-apps/gotify-server.nix
+++ b/nixos/modules/services/web-apps/gotify-server.nix
@@ -12,6 +12,8 @@ in
   options.services.gotify = {
     enable = lib.mkEnableOption "Gotify webserver";
 
+    package = lib.mkPackageOption pkgs "gotify-server" { };
+
     port = lib.mkOption {
       type = lib.types.port;
       description = ''
@@ -44,7 +46,7 @@ in
         StateDirectory = cfg.stateDirectoryName;
         Restart = "always";
         DynamicUser = true;
-        ExecStart = "${pkgs.gotify-server}/bin/server";
+        ExecStart = lib.getExe cfg.package;
       };
     };
   };

--- a/nixos/modules/services/web-apps/gotify-server.nix
+++ b/nixos/modules/services/web-apps/gotify-server.nix
@@ -48,4 +48,6 @@ in
       };
     };
   };
+
+  meta.maintainers = with lib.maintainers; [ DCsunset ];
 }

--- a/nixos/modules/services/web-apps/gotify-server.nix
+++ b/nixos/modules/services/web-apps/gotify-server.nix
@@ -1,33 +1,35 @@
-{ pkgs, lib, config, ... }:
-
-with lib;
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
 
 let
   cfg = config.services.gotify;
-in {
-  options = {
-    services.gotify = {
-      enable = mkEnableOption "Gotify webserver";
+in
+{
+  options.services.gotify = {
+    enable = lib.mkEnableOption "Gotify webserver";
 
-      port = mkOption {
-        type = types.port;
-        description = ''
-          Port the server listens to.
-        '';
-      };
+    port = lib.mkOption {
+      type = lib.types.port;
+      description = ''
+        Port the server listens to.
+      '';
+    };
 
-      stateDirectoryName = mkOption {
-        type = types.str;
-        default = "gotify-server";
-        description = ''
-          The name of the directory below {file}`/var/lib` where
-          gotify stores its runtime data.
-        '';
-      };
+    stateDirectoryName = lib.mkOption {
+      type = lib.types.str;
+      default = "gotify-server";
+      description = ''
+        The name of the directory below {file}`/var/lib` where
+        gotify stores its runtime data.
+      '';
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     systemd.services.gotify-server = {
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
@@ -41,7 +43,7 @@ in {
         WorkingDirectory = "/var/lib/${cfg.stateDirectoryName}";
         StateDirectory = cfg.stateDirectoryName;
         Restart = "always";
-        DynamicUser = "yes";
+        DynamicUser = true;
         ExecStart = "${pkgs.gotify-server}/bin/server";
       };
     };

--- a/nixos/tests/gotify-server.nix
+++ b/nixos/tests/gotify-server.nix
@@ -9,7 +9,9 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : {
 
     services.gotify = {
       enable = true;
-      port = 3000;
+      environment = {
+        GOTIFY_SERVER_PORT = 3000;
+      };
     };
   };
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR adds support for all config options for gotify-server using environment variables and allows user to override the package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
