### PR TITLE
emacs.pkgs.melpaPackages: Refactor internal melpaDerivation fetcher invocation

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/libgenerated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/libgenerated.nix
@@ -1,6 +1,9 @@
 lib: self:
 
 let
+  inherit (lib) elemAt;
+
+  matchForgeRepo = builtins.match "(.+)/(.+)";
 
   fetchers = lib.mapAttrs (_: fetcher: self.callPackage fetcher { }) {
     github =
@@ -10,9 +13,13 @@ let
         ...
       }:
       { sha256, commit, ... }:
+      let
+        m = matchForgeRepo repo;
+      in
+      assert m != null;
       fetchFromGitHub {
-        owner = lib.head (lib.splitString "/" repo);
-        repo = lib.head (lib.tail (lib.splitString "/" repo));
+        owner = elemAt m 0;
+        repo = elemAt m 1;
         rev = commit;
         inherit sha256;
       };
@@ -24,9 +31,13 @@ let
         ...
       }:
       { sha256, commit, ... }:
+      let
+        m = matchForgeRepo repo;
+      in
+      assert m != null;
       fetchFromGitLab {
-        owner = lib.head (lib.splitString "/" repo);
-        repo = lib.head (lib.tail (lib.splitString "/" repo));
+        owner = elemAt m 0;
+        repo = elemAt m 1;
         rev = commit;
         inherit sha256;
       };

--- a/pkgs/applications/editors/emacs/elisp-packages/libgenerated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/libgenerated.nix
@@ -2,62 +2,99 @@ lib: self:
 
 let
 
-    fetcherGenerators = { repo ? null
-                        , url ? null
-                        , ... }:
-                        { sha256
-                        , commit
-                        , ...}: {
-      github = self.callPackage ({ fetchFromGitHub }:
-        fetchFromGitHub {
-          owner = lib.head (lib.splitString "/" repo);
-          repo = lib.head (lib.tail (lib.splitString "/" repo));
-          rev = commit;
-          inherit sha256;
-        }
-      ) {};
-      gitlab = self.callPackage ({ fetchFromGitLab }:
-        fetchFromGitLab {
-          owner = lib.head (lib.splitString "/" repo);
-          repo = lib.head (lib.tail (lib.splitString "/" repo));
-          rev = commit;
-          inherit sha256;
-        }
-      ) {};
-      git = self.callPackage ({ fetchgit }:
-        (fetchgit {
-          rev = commit;
-          inherit sha256 url;
-        }).overrideAttrs(_: {
-          GIT_SSL_NO_VERIFY = true;
-        })
-      ) {};
-      bitbucket = self.callPackage ({ fetchhg }:
-        fetchhg {
-          rev = commit;
-          url = "https://bitbucket.com/${repo}";
-          inherit sha256;
-        }
-      ) {};
-      hg = self.callPackage ({ fetchhg }:
-        fetchhg {
-          rev = commit;
-          inherit sha256 url;
-        }
-      ) {};
-      sourcehut = self.callPackage ({ fetchzip }:
-        fetchzip {
-          url = "https://git.sr.ht/~${repo}/archive/${commit}.tar.gz";
-          inherit sha256;
-        }
-      ) {};
-      codeberg = self.callPackage ({ fetchzip }:
-        fetchzip {
-          url = "https://codeberg.org/${repo}/archive/${commit}.tar.gz";
-          inherit sha256;
-        }
-      ) {};
-    };
+  fetchers = lib.mapAttrs (_: fetcher: self.callPackage fetcher { }) {
+    github =
+      { fetchFromGitHub }:
+      {
+        repo ? null,
+        ...
+      }:
+      { sha256, commit, ... }:
+      fetchFromGitHub {
+        owner = lib.head (lib.splitString "/" repo);
+        repo = lib.head (lib.tail (lib.splitString "/" repo));
+        rev = commit;
+        inherit sha256;
+      };
+
+    gitlab =
+      { fetchFromGitLab }:
+      {
+        repo ? null,
+        ...
+      }:
+      { sha256, commit, ... }:
+      fetchFromGitLab {
+        owner = lib.head (lib.splitString "/" repo);
+        repo = lib.head (lib.tail (lib.splitString "/" repo));
+        rev = commit;
+        inherit sha256;
+      };
+
+    git = (
+      { fetchgit }:
+      {
+        url ? null,
+        ...
+      }:
+      { sha256, commit, ... }:
+      (fetchgit {
+        rev = commit;
+        inherit sha256 url;
+      }).overrideAttrs(_: {
+        GIT_SSL_NO_VERIFY = true;
+      })
+    );
+
+    bitbucket =
+      { fetchhg }:
+      {
+        repo ? null,
+        ...
+      }:
+      { sha256, commit, ... }:
+      fetchhg {
+        rev = commit;
+        url = "https://bitbucket.com/${repo}";
+        inherit sha256;
+      };
+
+    hg =
+      { fetchhg }:
+      {
+        url ? null,
+        ...
+      }:
+      { sha256, commit, ... }:
+      fetchhg {
+        rev = commit;
+        inherit sha256 url;
+      };
+
+    sourcehut =
+      { fetchzip }:
+      {
+        repo ? null,
+        ...
+      }:
+      { sha256, commit, ... }:
+      fetchzip {
+        url = "https://git.sr.ht/~${repo}/archive/${commit}.tar.gz";
+        inherit sha256;
+      };
+
+    codeberg =
+      { fetchzip }:
+      {
+        repo ? null,
+        ...
+      }:
+      { sha256, commit, ... }:
+      fetchzip {
+        url = "https://codeberg.org/${repo}/archive/${commit}.tar.gz";
+        inherit sha256;
+      };
+  };
 
 in {
 
@@ -88,7 +125,7 @@ in {
                 (builtins.filter (n: n >= 0) version)));
             # TODO: Broken should not result in src being null (hack to avoid eval errors)
             src = if (sha256 == null || broken) then null else
-              lib.getAttr fetcher (fetcherGenerators args sourceArgs);
+              fetchers.${fetcher} args sourceArgs;
             recipe = if commit == null then null else
               fetchurl {
                 name = pname + "-recipe";


### PR DESCRIPTION
## Description of changes

The previous behaviour resulted in the fetchers being recreated for every call to melpaDerivation, now we amortize that.
The performance impact is tiny but I think this is much more readable.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
