### PR TITLE
av1an: vapoursynth support

### DIFF
--- a/pkgs/by-name/av/av1an/package.nix
+++ b/pkgs/by-name/av/av1an/package.nix
@@ -5,7 +5,7 @@
   testers,
   av1an-unwrapped,
   ffmpeg,
-  python3Packages,
+  python3,
   libaom,
   svt-av1,
   rav1e,
@@ -13,6 +13,8 @@
   x264,
   x265,
   libvmaf,
+  vapoursynth,
+  mkvtoolnix-cli,
   withAom ? true, # AV1 reference encoder
   withSvtav1 ? false, # AV1 encoder/decoder (focused on speed and correctness)
   withRav1e ? false, # AV1 encoder (focused on speed and safety)
@@ -20,6 +22,7 @@
   withX264 ? true, # H.264/AVC encoder
   withX265 ? true, # H.265/HEVC encoder
   withVmaf ? false, # Perceptual video quality assessment algorithm
+  withMkvtoolnix ? true, # mkv editor, recommended concatenation method
 }:
 # av1an requires at least one encoder
 assert lib.assertMsg (lib.elem true [
@@ -40,19 +43,24 @@ symlinkJoin {
   postBuild =
     let
       runtimePrograms =
-        [ (ffmpeg.override { inherit withVmaf; }) ]
+        [
+          vapoursynth
+          (ffmpeg.override { inherit withVmaf; })
+        ]
         ++ lib.optional withAom libaom
         ++ lib.optional withSvtav1 svt-av1
         ++ lib.optional withRav1e rav1e
         ++ lib.optional withVpx libvpx
         ++ lib.optional withX264 x264
         ++ lib.optional withX265 x265
-        ++ lib.optional withVmaf libvmaf;
+        ++ lib.optional withVmaf libvmaf
+        ++ lib.optional withMkvtoolnix mkvtoolnix-cli;
     in
     ''
       wrapProgram $out/bin/av1an \
+        --prefix LD_LIBRARY_PATH : ${vapoursynth}/lib \
         --prefix PATH : ${lib.makeBinPath runtimePrograms} \
-        --prefix PYTHONPATH : ${python3Packages.makePythonPath [ python3Packages.vapoursynth ]}
+        --prefix PYTHONPATH : ${vapoursynth}/${python3.sitePackages}
     '';
 
   passthru = {


### PR DESCRIPTION
This PR is made on the basis of using Av1an's vapoursynth based features.

Corrected wrapper entries:
 - Need to override vapoursynth with `vapoursynth.withPlugins` for av1an to be able to use VS plugins. Changed PYTHON_PATH accordingly.  Passing `pkgs.vapoursynth` to `python3Packages.makePythonPath` makes an incorrect path entry, resulting in segfault when the program is run.
 - Need LD_LIBRARY_PATH to use VS plugins (e.g. ffms2 and lsmash, the recommended chunking method). Otherwise get e.g. `Error: FFMS2 is not installed, but it was specified as the chunk method`.
 - Need vapoursynth in PATH to use VS based chunking methods or VS script as input. At least, `vspipe` binary needs to be visible in PATH.

Add mkvtoolnix option; it is the recommended concatenation method.

An example override:
```nix
    vs-plugin-lsmashsource = pkgs.callPackage ~/source/nix/my-pkgs/vs-plugin-lsmashsource/package.nix { };

    vapoursynthWithPlugins = pkgs.vapoursynth.withPlugins [
      pkgs.ffms
      vs-plugin-lsmashsource
    ];

    av1an = pkgs.av1an.override {
      vapoursynth = vapoursynthWithPlugins;
      withRav1e = true;
      withSvtav1 = true;
    };
```

An example command line:
```bash
av1an -e rav1e -i sample.mkv -o /tmp/sample_enc.mkv -m lsmash -c mkvmerge
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
