### PR TITLE
fish-lsp: init at 1.0.8-1

### DIFF
--- a/pkgs/by-name/fi/fish-lsp/package.nix
+++ b/pkgs/by-name/fi/fish-lsp/package.nix
@@ -1,0 +1,83 @@
+{
+  fetchFromGitHub,
+  fetchYarnDeps,
+  fish,
+  installShellFiles,
+  lib,
+  makeWrapper,
+  nix-update-script,
+  nodejs,
+  npmHooks,
+  stdenv,
+  which,
+  yarnBuildHook,
+  yarnConfigHook,
+}:
+stdenv.mkDerivation rec {
+  pname = "fish-lsp";
+  version = "1.0.8-1";
+
+  src = fetchFromGitHub {
+    owner = "ndonfris";
+    repo = "fish-lsp";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-u125EZXQEouVbmJuoW3KNDNqLB5cS/TzblXraClcw6Q=";
+  };
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = src + "/yarn.lock";
+    hash = "sha256-hHw7DbeqaCapqx4dK5Y3sPut94ist9JOU8g9dd6gBdo=";
+  };
+
+  nativeBuildInputs = [
+    yarnBuildHook
+    yarnConfigHook
+    npmHooks.npmInstallHook
+    nodejs
+    installShellFiles
+    makeWrapper
+    fish
+  ];
+
+  yarnBuildScript = "setup";
+
+  postBuild = ''
+    yarn --offline compile
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fish-lsp
+    cp -r . $out/share/fish-lsp
+
+    makeWrapper ${lib.getExe nodejs} "$out/bin/fish-lsp" \
+      --add-flags "$out/share/fish-lsp/out/cli.js" \
+      --prefix PATH : "${
+        lib.makeBinPath [
+          fish
+          which
+        ]
+      }"
+
+    ${lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      installShellCompletion --cmd fish-lsp \
+        --fish <($out/bin/fish-lsp complete --fish)
+    ''}
+
+    runHook postInstall
+  '';
+
+  doDist = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "LSP implementation for the fish shell language";
+    homepage = "https://github.com/ndonfris/fish-lsp";
+    license = lib.licenses.mit;
+    mainProgram = "fish-lsp";
+    maintainers = with lib.maintainers; [ petertriho ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [`fish-lsp`](https://github.com/ndonfris/fish-lsp) https://github.com/NixOS/nixpkgs/issues/305493

Uses `yarnConfigHook` and `yarnBuildHook` instead of `mkYarnPackage`

Supersedes https://github.com/NixOS/nixpkgs/pull/320463 https://github.com/NixOS/nixpkgs/pull/330320

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
