### PR TITLE
hack: support 'devicetree' with systemd-boot + hardware.device-tree

### DIFF
--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -353,6 +353,14 @@ in
             ln -s ${config.system.build.initialRamdiskSecretAppender}/bin/append-initrd-secrets $out
 
             ln -s ${config.hardware.firmware}/lib/firmware $out/firmware
+
+            ${lib.optionalString (
+              config.hardware.deviceTree.enable
+              && config.hardware.deviceTree.package != null
+              && config.hardware.deviceTree.name != null)
+             # "ln -s ${config.boot.kernelPackages.package}/dtbs/${config.hardware.deviceTree.name} $out/dtb"
+             "ln -s ${config.hardware.deviceTree.package}/${config.hardware.deviceTree.name} $out/dtb"
+            }
           '';
 
         # Implement consoleLogLevel both in early boot and using sysctl

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -305,6 +305,29 @@ def write_entry(profile: str | None,
         sort_key=bootspec.sortKey,
         default=current
     ).write(sorted_first)
+ 
+    devicetree = None
+    dtb_link = f"{system_dir(profile, generation, specialisation)}/dtb"
+    if os.path.exists(dtb_link):
+        dtb_path = os.path.realpath(dtb_link)
+        if os.path.exists(dtb_path):
+            devicetree = copy_from_file(dtb_path)
+
+     with open(tmp_path, 'w') as f:
+         f.write(BOOT_ENTRY.format(title=title,
+                     sort_key=bootspec.sortKey,
+                     generation=generation,
+                     kernel=kernel,
+                     initrd=initrd,
+                     kernel_params=kernel_params,
+                     description=f"{bootspec.label}, built on {build_date}"))
+         if machine_id is not None:
+             f.write("machine-id %s\n" % machine_id)
+        if devicetree is not None:
+            f.write("devicetree %s\n" % devicetree)
+         f.flush()
+         os.fsync(f.fileno())
+     os.rename(tmp_path, entry_file)
 
 def get_generations(profile: str | None = None) -> list[SystemIdentifier]:
     gen_list = run(


### PR DESCRIPTION
## Description of changes

1. Hack the toplevel derivation to output a `/dtb` symlink if it's enabled/configured with `hardware.device-tree.{enable,name}`.
2. Hack the systemd-boot-builder.py to output the extra appropriate `devicetree=` line into the config file if it exists in the generation toplevel.

I'm not sure if this supports specialisations. The more appropriate path probably involves trying to get this into bootspec v2 and lanzaboote, but this was easier for now.

I've used this to build `make-disk-image.nix` for a snapdragon X elite laptop, and booted into initrd (pending stage-2 when some usb/msd/uas issue sorted).

Mostly throwing this out for consideration, I realize it's probably too hacky (and certainlyuntested) to merge as-is. Marking as draft to reflect that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
