### PR TITLE
linuxPackages_scx: init at 6.10

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -10,6 +10,8 @@
   This also allows configuring runtime settings of AMDVLK and enabling experimental features.
 - The `moonlight-qt` package ([Moonlight game streaming](https://moonlight-stream.org/)) now has HDR support on Linux systems.
 
+- [Sched-ext](https://github.com/sched-ext/scx) kernel with support for userspace kernel thread schedulers in BPF is now available as `linuxPackages_scx`.
+
 - `authelia` has been upgraded to version 4.38. This version brings several features and improvements which are detailed in the [release blog post](https://www.authelia.com/blog/4.38-release-notes/).
   This release also deprecates some configuration keys, which are likely to be removed in future version 5.0, but they are still supported and expected to be working in the current version.
 

--- a/pkgs/os-specific/linux/kernel/linux-scx.nix
+++ b/pkgs/os-specific/linux/kernel/linux-scx.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  fetchpatch,
+  kernel,
+  kernelPatches,
+  patchCommit ? "04fb9178158a7714aeb908c7a5310c4e0d6ea4b6",
+  patchHash ? "sha256-LFn33xrX00M1WA5+z3ftNZVDEOE7qHNvCHym6QoSrkk=",
+  argsOverride ? { },
+  ...
+}@args:
+# NOTE: scx package should be updated simultaneously to preserve compatibility
+(kernel.override (
+  args
+  // {
+
+    argsOverride = {
+      version = "${kernel.version}-scx";
+      modDirVersion = kernel.modDirVersion;
+
+      extraMeta = {
+        homepage = "https://github.com/sched-ext/scx";
+        description = "Linux kernel with sched ext patches";
+        maintainers = with lib.maintainers; [ johnrtitor ];
+      };
+    } // argsOverride;
+
+    structuredExtraConfig = with lib.kernel; {
+      BPF = option yes;
+      BPF_EVENTS = option yes;
+      BPF_JIT = option yes;
+      BPF_SYSCALL = option yes;
+      BPF_JIT_DEFAULT_ON = option yes;
+      BPF_JIT_ALWAYS_ON = lib.mkForce (option yes);
+      PAHOLE_HAS_SPLIT_BTF = option yes;
+      PAHOLE_HAS_BTF_TAG = option yes;
+      DEBUG_INFO_BTF = option yes;
+      FTRACE = option yes;
+      SCHED_CLASS_EXT = option yes;
+
+    };
+    kernelPatches = [
+      {
+        # This patch is a fork of the original scx patch, which is now maintained by CachyOS team
+        # original scx patches are often outdated and not maintained according to release schedule
+        # of Nixpkgs, can be found in https://github.com/sched-ext/scx-kernel-releases
+        name = "scx-${kernel.version}.patch";
+        patch = fetchpatch {
+          url = "https://raw.githubusercontent.com/CachyOS/kernel-patches/${patchCommit}/${lib.versions.majorMinor kernel.version}/sched/0001-sched-ext.patch";
+          hash = patchHash;
+        };
+      }
+    ] ++ kernelPatches;
+  }
+))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26892,6 +26892,9 @@ with pkgs;
   linuxPackages_testing = linuxKernel.packages.linux_testing;
   linux_testing = linuxKernel.kernels.linux_testing;
 
+  linuxPackages_scx = linuxKernel.packages.linux_scx;
+  linux_scx = linuxKernel.kernels.linux_scx;
+
   # Realtime kernel
   linuxPackages-rt = linuxKernel.packageAliases.linux_rt_default;
   linuxPackages-rt_latest = linuxKernel.packageAliases.linux_rt_latest;

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -216,6 +216,11 @@ in {
       ];
     };
 
+    linux_scx = callPackage ../os-specific/linux/kernel/linux-scx.nix {
+        kernel = linux_6_10;
+        kernelPatches = linux_6_10.kernelPatches;
+    };
+
     linux_testing = let
       testing = callPackage ../os-specific/linux/kernel/mainline.nix {
         # A special branch that tracks the kernel under the release process
@@ -663,6 +668,8 @@ in {
 
     # Intentionally lacks recurseIntoAttrs, as -rc kernels will quite likely break out-of-tree modules and cause failed Hydra builds.
     linux_testing = packagesFor kernels.linux_testing;
+
+    linux_scx = recurseIntoAttrs (packagesFor kernels.linux_scx);
 
     linux_hardened = recurseIntoAttrs (packagesFor kernels.linux_hardened);
 


### PR DESCRIPTION
## Description of changes

Description:- `sched_ext` is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them.
Homepage:- https://github.com/sched-ext/scx
Kernel-source:- https://github.com/sched-ext/scx-kernel-releases

This is my first time packaging a kernel, so go easy on me :)
I have mostly based this like how [bcachefs-kernel was packaged](https://github.com/NixOS/nixpkgs/blob/12c489d36b19907c6def5f73e420cd019857e2eb/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix).

`scx` userspace tools should be inited as well, and I plan to do that in a later PR.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
