### PR TITLE
cudaPackages: drop outdated aliases

### DIFF
--- a/pkgs/development/cuda-modules/aliases.nix
+++ b/pkgs/development/cuda-modules/aliases.nix
@@ -1,18 +1,14 @@
-# Packges which have been deprecated or removed from cudaPackages
+# Packages which have been deprecated or removed from cudaPackages
 final: prev:
 let
-  mkRenamed =
-    oldName: newName: newPkg:
-    final.lib.warn "cudaPackages.${oldName} is deprecated, use ${newName} instead" newPkg;
-in
-{
+  inherit (prev.lib) warn;
+  inherit (builtins) mapAttrs;
 
-  # Deprecated: an alias kept for compatibility. Consider removing after 24.05
-  autoFixElfFiles = mkRenamed "autoFixElfFiles" "pkgs.autoFixElfFiles" final.pkgs.autoFixElfFiles; # Added 2024-03-30
-  autoAddDriverRunpath =
-    mkRenamed "autoAddDriverRunpath" "pkgs.autoAddDriverRunpath"
-      final.pkgs.autoAddDriverRunpath; # Added 2024-03-30
-  autoAddOpenGLRunpathHook =
-    mkRenamed "autoAddOpenGLRunpathHook" "pkgs.autoAddDriverRunpathHook"
-      final.pkgs.autoAddDriverRunpath; # Added 2024-03-30
+  mkRenamed =
+    oldName:
+    { path, package }:
+    warn "cudaPackages.${oldName} is deprecated, use ${path} instead" package;
+in
+mapAttrs mkRenamed {
+  # A comment to prevent empty { } from collapsing into a single line
 }

--- a/pkgs/development/python-modules/torch/default.nix
+++ b/pkgs/development/python-modules/torch/default.nix
@@ -202,8 +202,11 @@ let
       ]);
     "MPI cudatoolkit does not match cudaPackages.cudatoolkit" =
       MPISupport && cudaSupport && (mpi.cudatoolkit != cudaPackages.cudatoolkit);
+    # This used to be a deep package set comparison between cudaPackages and
+    # effectiveMagma.cudaPackages, making torch too strict in cudaPackages.
+    # In particular, this triggered warnings from cuda's `aliases.nix`
     "Magma cudaPackages does not match cudaPackages" =
-      cudaSupport && (effectiveMagma.cudaPackages != cudaPackages);
+      cudaSupport && (effectiveMagma.cudaPackages.cudaVersion != cudaPackages.cudaVersion);
     "Rocm support is currently broken because `rocmPackages.hipblaslt` is unpackaged. (2024-06-09)" = rocmSupport;
   };
 in


### PR DESCRIPTION
## Description of changes

Related to #306276

These traces are annoying in a lot of cases, and I think we should be good to remove them by now. I nuked all of aliases.nix for cuda-modules while I was at it. If this is heavy-handed, let me know.

For me personally, I could also live with removing this check in torch, which ends up triggering every alias in cudaPackages because of the equality check;

https://github.com/NixOS/nixpkgs/blob/04404c0900278b51a9c6e8b28b031d8b03bfb966/pkgs/development/python-modules/torch/default.nix#L206

But one or the other has to go. :smile_cat: 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
