### PR TITLE
wp-cli: fix wrapper environment

### DIFF
--- a/pkgs/by-name/wp/wp-cli/package.nix
+++ b/pkgs/by-name/wp/wp-cli/package.nix
@@ -42,6 +42,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ installShellFiles makeWrapper ];
 
+  # Usually --set-default is used to set default environment variables.
+  # But the value is wrapped in single-quotes so our variables would be used literally instead
+  # of the expanded version. Thus we use --run instead.
   installPhase = ''
     runHook preInstall
 
@@ -50,12 +53,12 @@ stdenv.mkDerivation (finalAttrs: {
     installShellCompletion --bash --name wp ${completion}
 
     makeWrapper ${lib.getExe php} $out/bin/${finalAttrs.meta.mainProgram} \
-      --set-default XDG_CACHE_HOME \$HOME/.cache \
-      --set-default XDG_CONFIG_HOME \$HOME/.config \
-      --set-default XDG_DATA_HOME \$HOME/.local/share \
-      --set-default WP_CLI_CONFIG_PATH \$XDG_CONFIG_HOME}/wp-cli \
-      --set-default WP_CLI_PACKAGES_DIR \$XDG_DATA_HOME/wp-cli \
-      --set-default WP_CLI_CACHE_DIR \$XDG_CACHE_HOME/wp-cli \
+      --run 'export XDG_CACHE_HOME=''${XDG_CACHE_HOME-"$HOME/.cache"}' \
+      --run 'export XDG_CONFIG_HOME=''${XDG_CONFIG_HOME-"$HOME/.config"}' \
+      --run 'export XDG_DATA_HOME=''${XDG_DATA_HOME-"$HOME/.local/share"}' \
+      --run 'export WP_CLI_CONFIG_PATH=''${WP_CLI_CONFIG_PATH-"$XDG_CONFIG_HOME/wp-cli"}' \
+      --run 'export WP_CLI_PACKAGES_DIR=''${WP_CLI_PACKAGES_DIR-"$XDG_DATA_HOME/wp-cli"}' \
+      --run 'export WP_CLI_CACHE_DIR=''${WP_CLI_CACHE_DIR-"$XDG_CACHE_HOME/wp-cli"}' \
       --add-flags "-c $out/etc/${ini.name}" \
       --add-flags "-f $out/share/wp-cli/wp-cli.phar" \
       --add-flags "--"


### PR DESCRIPTION
## Description of changes

Currently, when running `wp core download` it downloads the WordPress core files to the working directory.
Additionally a `$XDG_CACHE_HOME/wp-cli` directory is created, where `$XDG_CACHE_HOME` is the literal directory name.
This is because `--set-default` wraps the argument in single-quotes and then the environment variable is not expanded.

I updated the wrapper to use `--run` for exporting the environment variables instead which fixes this issue.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
