### PR TITLE
pkgsMusl.systemd: fix build

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -248,33 +248,36 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ lib.optional stdenv.hostPlatform.isMusl (
     let
       oe-core = fetchzip {
-        url = "https://git.openembedded.org/openembedded-core/snapshot/openembedded-core-6fdf03bd950e55ef7881041606f6e76141033716.tar.gz";
-        sha256 = "/+9aJdOxBY8Y4vJPftOCxmyK8L2nvR82KmJxil1a2aY=";
+        url = "https://git.openembedded.org/openembedded-core/snapshot/openembedded-core-89b75b46371d5e9172cb496b461824d8551a2af5.tar.gz";
+        hash = "sha256-etdIIdo3FezVafEYP5uAS9pO36Rdea2A+Da1P44cPXg=";
       };
       musl-patches = oe-core + "/meta/recipes-core/systemd/systemd";
     in
     [
-      (musl-patches + "/0017-Adjust-for-musl-headers.patch")
-      (musl-patches + "/0016-pass-correct-parameters-to-getdents64.patch")
-      (musl-patches + "/0018-test-bus-error-strerror-is-assumed-to-be-GNU-specifi.patch")
-      (musl-patches + "/0001-missing_type.h-add-comparison_fn_t.patch")
-      (musl-patches + "/0002-add-fallback-parse_printf_format-implementation.patch")
-      (musl-patches + "/0003-src-basic-missing.h-check-for-missing-strndupa.patch")
-      (musl-patches + "/0004-don-t-fail-if-GLOB_BRACE-and-GLOB_ALTDIRFUNC-is-not-.patch")
-      (musl-patches + "/0005-add-missing-FTW_-macros-for-musl.patch")
-      (musl-patches + "/0006-Use-uintmax_t-for-handling-rlim_t.patch")
-      (musl-patches + "/0007-don-t-pass-AT_SYMLINK_NOFOLLOW-flag-to-faccessat.patch")
-      (musl-patches + "/0008-Define-glibc-compatible-basename-for-non-glibc-syste.patch")
-      (musl-patches + "/0009-Do-not-disable-buffering-when-writing-to-oom_score_a.patch")
-      (musl-patches + "/0010-distinguish-XSI-compliant-strerror_r-from-GNU-specif.patch")
-      (musl-patches + "/0011-avoid-redefinition-of-prctl_mm_map-structure.patch")
-      (musl-patches + "/0012-do-not-disable-buffer-in-writing-files.patch")
-      (musl-patches + "/0013-Handle-__cpu_mask-usage.patch")
-      (musl-patches + "/0014-Handle-missing-gshadow.patch")
-      (musl-patches + "/0015-missing_syscall.h-Define-MIPS-ABI-defines-for-musl.patch")
-      (musl-patches + "/0020-sd-event-Make-malloc_trim-conditional-on-glibc.patch")
-      (musl-patches + "/0021-shared-Do-not-use-malloc_info-on-musl.patch")
-      (musl-patches + "/0022-avoid-missing-LOCK_EX-declaration.patch")
+      (musl-patches + "/0004-missing_type.h-add-comparison_fn_t.patch")
+      (musl-patches + "/0005-add-fallback-parse_printf_format-implementation.patch")
+      (musl-patches + "/0006-don-t-fail-if-GLOB_BRACE-and-GLOB_ALTDIRFUNC-is-not-.patch")
+      (musl-patches + "/0007-add-missing-FTW_-macros-for-musl.patch")
+      (musl-patches + "/0008-Use-uintmax_t-for-handling-rlim_t.patch")
+      (musl-patches + "/0009-don-t-pass-AT_SYMLINK_NOFOLLOW-flag-to-faccessat.patch")
+      (musl-patches + "/0010-Define-glibc-compatible-basename-for-non-glibc-syste.patch")
+      (musl-patches + "/0011-Do-not-disable-buffering-when-writing-to-oom_score_a.patch")
+      (musl-patches + "/0012-distinguish-XSI-compliant-strerror_r-from-GNU-specif.patch")
+      (musl-patches + "/0013-avoid-redefinition-of-prctl_mm_map-structure.patch")
+      (musl-patches + "/0014-do-not-disable-buffer-in-writing-files.patch")
+      (musl-patches + "/0015-Handle-__cpu_mask-usage.patch")
+      (musl-patches + "/0016-Handle-missing-gshadow.patch")
+      (musl-patches + "/0017-missing_syscall.h-Define-MIPS-ABI-defines-for-musl.patch")
+      (musl-patches + "/0018-pass-correct-parameters-to-getdents64.patch")
+      (musl-patches + "/0019-Adjust-for-musl-headers.patch")
+      (musl-patches + "/0020-test-bus-error-strerror-is-assumed-to-be-GNU-specifi.patch")
+      (musl-patches + "/0022-sd-event-Make-malloc_trim-conditional-on-glibc.patch")
+      (musl-patches + "/0023-shared-Do-not-use-malloc_info-on-musl.patch")
+      (musl-patches + "/0024-avoid-missing-LOCK_EX-declaration.patch")
+      (musl-patches + "/0025-include-signal.h-to-avoid-the-undeclared-error.patch")
+      (musl-patches + "/0026-undef-stdin-for-references-using-stdin-as-a-struct-m.patch")
+      (musl-patches + "/0027-adjust-header-inclusion-order-to-avoid-redeclaration.patch")
+      (musl-patches + "/0028-build-path.c-avoid-boot-time-segfault-for-musl.patch")
     ]
   );
 


### PR DESCRIPTION
## Description of changes

Updated patches for 256.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
