### PR TITLE
sieve: init at 0.6.1-unstable-2025-01-06

### DIFF
--- a/pkgs/by-name/si/sieve/package.nix
+++ b/pkgs/by-name/si/sieve/package.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  electron,
+  copyDesktopItems,
+  makeDesktopItem,
+  stdenv,
+  xcbuild,
+}:
+
+buildNpmPackage {
+  pname = "sieve";
+  version = "0.6.1-unstable-2025-01-06";
+
+  src = fetchFromGitHub {
+    owner = "thsmi";
+    repo = "sieve";
+    rev = "a9f2e682fd972bd0e12bde3dac7d2a1516f66456";
+    hash = "sha256-PL17gh+nS90Y9Rli7XCoHOjl0NJOxko79ouYzLeou6Y=";
+  };
+
+  npmDepsHash = "sha256-66VnbYe6j7i6sxKQ/RHzGlFoNLig9yBTXby6meN0nOE=";
+
+  ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  npmBuildScript = "gulp";
+  npmBuildFlags = "app:package";
+
+  nativeBuildInputs =
+    lib.optionals stdenv.hostPlatform.isLinux [ copyDesktopItems ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcbuild ];
+
+  installPhase = ''
+    runHook preInstall
+
+    build_dir=build/electron/resources
+
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      mkdir -p $out/{share,bin}
+      cp -r $build_dir $out/share/sieve
+
+      # copy icon
+      install -D $build_dir/libs/icons/linux.png $out/share/icons/hicolor/64x64/apps/sieve.png
+
+      makeWrapper '${lib.getExe electron}' $out/bin/sieve \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime}}" \
+        --add-flags $out/share/sieve
+    ''}
+
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      app_dir=$out/Applications/Sieve.app
+
+      # copy electron
+      mkdir -p $out/Applications
+      cp -r ${electron}/Applications/Electron.app $app_dir
+      chmod -R +w $app_dir
+      mv $app_dir/Contents/MacOS/{Electron,Sieve}
+
+      # copy built app
+      cp -r $build_dir $app_dir/Contents/Resources/app
+      cp $app_dir/Contents/Resources/{app/libs/icons/mac.icns,sieve.icns}
+
+      # rebranding
+      info_plist="$app_dir/Contents/Info.plist"
+      plutil -replace CFBundleDisplayName -string Sieve "$info_plist"
+      plutil -replace CFBundleIdentifier -string net.tschmid.sieve "$info_plist"
+      plutil -replace CFBundleName -string Sieve "$info_plist"
+      plutil -replace CFBundleExecutable -string Sieve "$info_plist"
+      plutil -replace CFBundleIconFile -string sieve.icns "$info_plist"
+
+      # add wrapper for main executable
+      mkdir -p $out/bin
+      makeWrapper $app_dir/Contents/MacOS/Sieve $out/bin/sieve
+    ''}
+
+    runHook postInstall
+  '';
+
+  desktopItems = lib.optionals stdenv.hostPlatform.isLinux [
+    (makeDesktopItem {
+      name = "sieve";
+      exec = "sieve";
+      desktopName = "Sieve";
+      icon = "sieve";
+      comment = "Sieve script editor";
+      categories = [
+        "Network"
+        "Email"
+      ];
+    })
+  ];
+
+  meta = {
+    description = "Sieve script editor";
+    homepage = "https://github.com/thsmi/sieve";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "sieve";
+    maintainers = with lib.maintainers; [ fugi ];
+    inherit (electron.meta) platforms;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds [Sieve](https://github.com/thsmi/sieve), an Electron-based sieve script editor, for Linux and Darwin.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
