### PR TITLE
Fix nvidia container toolkit docker contamination

### DIFF
--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -256,7 +256,11 @@ in
         live-restore = mkDefault cfg.liveRestore;
         runtimes = mkIf cfg.enableNvidia {
           nvidia = {
-            path = "${pkgs.nvidia-docker}/bin/nvidia-container-runtime";
+            # Use the legacy nvidia-container-runtime wrapper to allow
+            # the `--runtime=nvidia` approach to expose
+            # GPU's. Starting with Docker > 25, CDI can be used
+            # instead, removing the need for runtime wrappers.
+            path = lib.getExe' pkgs.nvidia-docker "nvidia-container-runtime.legacy";
           };
         };
       };

--- a/nixos/modules/virtualisation/podman/default.nix
+++ b/nixos/modules/virtualisation/podman/default.nix
@@ -170,7 +170,7 @@ in
     lib.mkIf cfg.enable {
       warnings = lib.optionals cfg.enableNvidia [
         ''
-          You have set virtualisation.podman.enableNvidia. This option is deprecated, please set virtualisation.containers.cdi.dynamic.nvidia.enable instead.
+          You have set virtualisation.podman.enableNvidia. This option is deprecated, please set hardware.nvidia-container-toolkit.enable instead.
         ''
       ];
 
@@ -189,11 +189,6 @@ in
         enable = true; # Enable common /etc/containers configuration
         containersConf.settings = {
           network.network_backend = "netavark";
-        } // lib.optionalAttrs cfg.enableNvidia {
-          engine = {
-            conmon_env_vars = [ "PATH=${lib.makeBinPath [ pkgs.nvidia-podman ]}" ];
-            runtimes.nvidia = [ "${pkgs.nvidia-podman}/bin/nvidia-container-runtime" ];
-          };
         };
       };
 

--- a/pkgs/by-name/nv/nvidia-container-toolkit/package.nix
+++ b/pkgs/by-name/nv/nvidia-container-toolkit/package.nix
@@ -3,10 +3,7 @@
 , fetchFromGitLab
 , makeWrapper
 , buildGoModule
-, linkFarm
-, writeShellScript
 , formats
-, containerRuntimePath ? null
 , configTemplate ? null
 , configTemplatePath ? null
 , libnvidia-container
@@ -17,20 +14,6 @@ assert configTemplate != null -> (lib.isAttrs configTemplate && configTemplatePa
 assert configTemplatePath != null -> (lib.isStringLike configTemplatePath && configTemplate == null);
 
 let
-  isolatedContainerRuntimePath = linkFarm "isolated_container_runtime_path" [
-    {
-      name = "runc";
-      path = containerRuntimePath;
-    }
-  ];
-  warnIfXdgConfigHomeIsSet = writeShellScript "warn_if_xdg_config_home_is_set" ''
-    set -eo pipefail
-
-    if [ -n "$XDG_CONFIG_HOME" ]; then
-      echo >&2 "$(tput setaf 3)warning: \$XDG_CONFIG_HOME=$XDG_CONFIG_HOME$(tput sgr 0)"
-    fi
-  '';
-
   configToml = if configTemplatePath != null then configTemplatePath else (formats.toml { }).generate "config.toml" configTemplate;
 
   # From https://gitlab.com/nvidia/container-toolkit/container-toolkit/-/blob/03cbf9c6cd26c75afef8a2dd68e0306aace80401/Makefile#L54
@@ -93,14 +76,6 @@ buildGoModule rec {
     makeWrapper
   ];
 
-  preConfigure = lib.optionalString (containerRuntimePath != null) ''
-    # Ensure the runc symlink isn't broken:
-    if ! readlink --quiet --canonicalize-existing "${isolatedContainerRuntimePath}/runc" ; then
-      echo "${isolatedContainerRuntimePath}/runc: broken symlink" >&2
-      exit 1
-    fi
-  '';
-
   checkFlags =
     let
       skippedTests = [
@@ -112,38 +87,18 @@ buildGoModule rec {
     [ "-skip" "${builtins.concatStringsSep "|" skippedTests}" ];
 
   postInstall = ''
-    mkdir -p $tools/bin
-    mv $out/bin/{containerd,crio,docker,nvidia-toolkit,toolkit} -t $tools/bin
-
     wrapProgram $out/bin/nvidia-container-runtime-hook \
       --prefix PATH : ${libnvidia-container}/bin
+
+    mkdir -p $tools/bin
+    mv $out/bin/{containerd,crio,docker,nvidia-toolkit,toolkit} $tools/bin
   '' + lib.optionalString (configTemplate != null || configTemplatePath != null) ''
     mkdir -p $out/etc/nvidia-container-runtime
-
-    # nvidia-container-runtime invokes docker-runc or runc if that isn't
-    # available on PATH.
-    #
-    # Also set XDG_CONFIG_HOME if it isn't already to allow overriding
-    # configuration. This in turn allows users to have the nvidia container
-    # runtime enabled for any number of higher level runtimes like docker and
-    # podman, i.e., there's no need to have mutually exclusivity on what high
-    # level runtime can enable the nvidia runtime because each high level
-    # runtime has its own config.toml file.
-    wrapProgram $out/bin/nvidia-container-runtime \
-      --run "${warnIfXdgConfigHomeIsSet}" \
-      --prefix PATH : ${isolatedContainerRuntimePath}:${libnvidia-container}/bin \
-      --set-default XDG_CONFIG_HOME $out/etc
 
     cp ${configToml} $out/etc/nvidia-container-runtime/config.toml
 
     substituteInPlace $out/etc/nvidia-container-runtime/config.toml \
       --subst-var-by glibcbin ${lib.getBin glibc}
-
-    # See: https://gitlab.com/nvidia/container-toolkit/container-toolkit/-/blob/03cbf9c6cd26c75afef8a2dd68e0306aace80401/packaging/debian/nvidia-container-toolkit.postinst#L12
-    ln -s $out/bin/nvidia-container-runtime-hook $out/bin/nvidia-container-toolkit
-
-    wrapProgram $out/bin/nvidia-container-toolkit \
-      --add-flags "-config ${placeholder "out"}/etc/nvidia-container-runtime/config.toml"
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/nv/nvidia-container-toolkit/packages.nix
+++ b/pkgs/by-name/nv/nvidia-container-toolkit/packages.nix
@@ -1,9 +1,6 @@
 {
   lib,
   newScope,
-  docker,
-  libnvidia-container,
-  runc,
   symlinkJoin,
 }:
 
@@ -30,7 +27,6 @@ lib.makeScope newScope (
       };
     };
     nvidia-container-toolkit-docker = self.callPackage ./package.nix {
-      containerRuntimePath = "${docker}/libexec/docker/docker";
       configTemplate = self.dockerConfig;
     };
 
@@ -51,15 +47,12 @@ lib.makeScope newScope (
       };
     };
     nvidia-container-toolkit-podman = self.nvidia-container-toolkit-docker.override {
-      containerRuntimePath = lib.getExe runc;
-
       configTemplate = self.podmanConfig;
     };
 
     nvidia-docker = symlinkJoin {
       name = "nvidia-docker";
       paths = [
-        libnvidia-container
         self.nvidia-docker-unwrapped
         self.nvidia-container-toolkit-docker
       ];
@@ -71,7 +64,6 @@ lib.makeScope newScope (
     nvidia-podman = symlinkJoin {
       name = "nvidia-podman";
       paths = [
-        libnvidia-container
         self.nvidia-container-toolkit-podman
       ];
       inherit (self.nvidia-container-toolkit-podman) meta;

--- a/pkgs/by-name/nv/nvidia-container-toolkit/packages.nix
+++ b/pkgs/by-name/nv/nvidia-container-toolkit/packages.nix
@@ -30,26 +30,6 @@ lib.makeScope newScope (
       configTemplate = self.dockerConfig;
     };
 
-    podmanConfig = {
-      disable-require = true;
-      #swarm-resource = "DOCKER_RESOURCE_GPU";
-
-      nvidia-container-cli = {
-        #root = "/run/nvidia/driver";
-        #path = "/usr/bin/nvidia-container-cli";
-        environment = [ ];
-        #debug = "/var/log/nvidia-container-runtime-hook.log";
-        ldcache = "/tmp/ld.so.cache";
-        load-kmods = true;
-        no-cgroups = true;
-        #user = "root:video";
-        ldconfig = "@@glibcbin@/bin/ldconfig";
-      };
-    };
-    nvidia-container-toolkit-podman = self.nvidia-container-toolkit-docker.override {
-      configTemplate = self.podmanConfig;
-    };
-
     nvidia-docker = symlinkJoin {
       name = "nvidia-docker";
       paths = [
@@ -60,13 +40,5 @@ lib.makeScope newScope (
     };
     nvidia-docker-unwrapped =
       self.callPackage ./nvidia-docker.nix { };
-
-    nvidia-podman = symlinkJoin {
-      name = "nvidia-podman";
-      paths = [
-        self.nvidia-container-toolkit-podman
-      ];
-      inherit (self.nvidia-container-toolkit-podman) meta;
-    };
   }
 )

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1051,6 +1051,7 @@ mapAliases ({
   noto-fonts-extra = noto-fonts; # Added 2023-04-08
   NSPlist = nsplist; # Added 2024-01-05
   nushellFull = lib.warn "`nushellFull` has has been replaced by `nushell` as it's features no longer exist" nushell; # Added 2024-05-30
+  nvidia-podman = throw "podman should use the Container Device Interface (CDI) instead. See https://web.archive.org/web/20240729183805/https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#configuring-podman"; # Added 2024-08-02
   nvidia-thrust = throw "nvidia-thrust has been removed because the project was deprecated; use cudaPackages.cuda_cccl";
   nvtop = lib.warn "nvtop has been renamed to nvtopPackages.full" nvtopPackages.full; # Added 2024-02-25
   nvtop-amd = lib.warn "nvtop-amd has been renamed to nvtopPackages.amd" nvtopPackages.amd; # Added 2024-02-25

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22975,7 +22975,6 @@ with pkgs;
       { };
   inherit (nvidiaCtkPackages)
     nvidia-docker
-    nvidia-podman
     ;
 
   nvidia-vaapi-driver = lib.hiPrio (callPackage ../development/libraries/nvidia-vaapi-driver { });


### PR DESCRIPTION
## Description of changes

This PR implements three main changes.

- Do not shadow `containerd`, `crio` or `docker` binaries with tools that are meant to set up the host with the NVIDIA container toolkit (https://github.com/NVIDIA/nvidia-container-toolkit/tree/a470818ba7d9166be282cd0039dd2fc9b0a34d73/tools/container)
- Fix the Docker runtime wrapper for Nvidia GPU's. This makes the `--runtime=nvidia --gpus=` use case work as expected.
- Remove the Nvidia wrapper for podman: according to the Nvidia documentation (https://web.archive.org/web/20240729183805/https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#configuring-podman), the CDI approach is recommended for podman, and it has had support on NixOS for CDI since 22.05 (podman 4.1.0).

## Things done

Tested, with the NixOS options:

```
virtualisation = {
  containers.enable = true;
  podman.enable = true;
  docker = {
    enable = true;
    # Allows the CDI implementation, while also makes it possible to use the nvidia runtime wrappers.
    package = pkgs.docker_25;
    # For the runtime wrappers/non-CDI case...
    enableNvidia = true;
  };
};
hardware = {
  # Required by the runtime wrappers
  graphics.enable32Bit = true;
  # CDI generation
  nvidia-container-toolkit.enable = true;
};
```

The following works as expected:

- Podman

```shell-session
# CDI
❯ podman run --rm --device=nvidia.com/gpu=all ubuntu:latest nvidia-smi
Wed Jul 31 08:27:17 2024
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 555.58.02              Driver Version: 555.58.02      CUDA Version: 12.5     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA GeForce RTX 4090        On  |   00000000:41:00.0 Off |                  Off |
| 61%   49C    P8             17W /  450W |       2MiB /  24564MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
|   1  NVIDIA GeForce RTX 2080 ...    On  |   00000000:61:00.0 Off |                  N/A |
|  0%   53C    P8             35W /  250W |       1MiB /   8192MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+

# Wrapper
# Does not apply. CDI is recommended.
```

- Docker

```
# CDI
❯ docker run --rm --device=nvidia.com/gpu=all ubuntu:latest nvidia-smi
Wed Jul 31 08:28:24 2024
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 555.58.02              Driver Version: 555.58.02      CUDA Version: 12.5     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA GeForce RTX 4090        On  |   00000000:41:00.0 Off |                  Off |
| 48%   50C    P8             17W /  450W |       2MiB /  24564MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
|   1  NVIDIA GeForce RTX 2080 ...    On  |   00000000:61:00.0 Off |                  N/A |
|  0%   54C    P8             35W /  250W |       1MiB /   8192MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+

# Wrapper
❯ docker run --rm -it --runtime=nvidia --gpus=all ubuntu:latest nvidia-smi
Wed Jul 31 08:28:43 2024
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 555.58.02              Driver Version: 555.58.02      CUDA Version: 12.5     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA GeForce RTX 4090        On  |   00000000:41:00.0 Off |                  Off |
| 43%   49C    P8             16W /  450W |       2MiB /  24564MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
|   1  NVIDIA GeForce RTX 2080 ...    On  |   00000000:61:00.0 Off |                  N/A |
|  0%   54C    P8             35W /  250W |       1MiB /   8192MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+
```

Fixes: https://github.com/NixOS/nixpkgs/issues/293857
Fixes: https://github.com/NixOS/nixpkgs/issues/322400

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
