### PR TITLE
cpplint: bump to latest head (2.0-unreleased)

### DIFF
--- a/pkgs/development/tools/analysis/cpplint/default.nix
+++ b/pkgs/development/tools/analysis/cpplint/default.nix
@@ -6,15 +6,15 @@
 
 python3Packages.buildPythonApplication {
   pname = "cpplint";
-  version = "1.7-unreleased";
+  version = "2.0-unreleased";
   pyproject = true;
 
   # Fetch from github instead of pypi, since the test cases are not in the pypi archive
   src = fetchFromGitHub {
     owner = "cpplint";
     repo = "cpplint";
-    rev = "9be08b54bf2621eb8e52f813f33f5310af4b334e";
-    hash = "sha256-OnN0egGviM1zQqwG1KkbO6+QDnGdblyP7KstkUl1xZY=";
+    rev = "a3afd5c9a12a0ca46cc9d435b6aafdeb17d48e9a";
+    hash = "sha256-Uchx9H7yHLlj71BWcQ0DlT8FOpFQ/9dURVzwuZqyBqw=";
   };
 
   postPatch = ''

--- a/pkgs/development/tools/analysis/cpplint/default.nix
+++ b/pkgs/development/tools/analysis/cpplint/default.nix
@@ -1,4 +1,8 @@
-{ lib, python3Packages, fetchFromGitHub }:
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
 
 python3Packages.buildPythonApplication {
   pname = "cpplint";

--- a/pkgs/development/tools/analysis/cpplint/default.nix
+++ b/pkgs/development/tools/analysis/cpplint/default.nix
@@ -1,26 +1,20 @@
 { lib, python3Packages, fetchFromGitHub }:
 
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication {
   pname = "cpplint";
-  version = "1.6.1";
+  version = "1.7-unreleased";
   pyproject = true;
 
   # Fetch from github instead of pypi, since the test cases are not in the pypi archive
   src = fetchFromGitHub {
     owner = "cpplint";
     repo = "cpplint";
-    rev = "refs/tags/${version}";
-    hash = "sha256-N5YrlhEXQGYxhsJ4M5dGYZUzA81GKRSI83goaqbtCkI=";
+    rev = "9be08b54bf2621eb8e52f813f33f5310af4b334e";
+    hash = "sha256-OnN0egGviM1zQqwG1KkbO6+QDnGdblyP7KstkUl1xZY=";
   };
 
   postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail '"pytest-runner==5.2"' ""
-
     patchShebangs cpplint_unittest.py
-
-    substituteInPlace cpplint_unittest.py \
-      --replace-fail "assertEquals" "assertEqual"
   '';
 
   build-system = with python3Packages; [
@@ -29,7 +23,8 @@ python3Packages.buildPythonApplication rec {
 
   nativeCheckInputs = with python3Packages; [
     pytest
-    pytest-runner
+    parameterized
+    wrapPython
   ];
 
   checkPhase = ''


### PR DESCRIPTION
At the moment cpplint is broken in nixpkgs, this fixes the build with python 3.12 as used in the master branch.

Changelog of cpplint:
https://github.com/cpplint/cpplint/blob/develop/CHANGELOG.rst

Even though it is no release version yet, it does work a charm. Better than a broken version anyways.

cc @bhipple

## Description of changes

A **lot** has changed in the past 2 years(!):
https://github.com/cpplint/cpplint/blob/develop/CHANGELOG.rst

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
