### PR TITLE
treewide: normalize empty maintainers list formatting

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage rec {
     description = "Fast line-oriented regex search tool, similar to ag and ack";
     homepage = "https://github.com/BurntSushi/ripgrep";
     license = lib.licenses.unlicense;
-    maintainers = [];
+    maintainers = [ ];
   };
 }
 ```

--- a/nixos/tests/networking-proxy.nix
+++ b/nixos/tests/networking-proxy.nix
@@ -12,7 +12,7 @@ let default-config = {
 in import ./make-test-python.nix ({ pkgs, ...} : {
   name = "networking-proxy";
   meta = with pkgs.lib.maintainers; {
-    maintainers = [  ];
+    maintainers = [ ];
   };
 
   nodes = {

--- a/nixos/tests/sogo.nix
+++ b/nixos/tests/sogo.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "sogo";
   meta = with pkgs.lib.maintainers; {
-    maintainers = [];
+    maintainers = [ ];
   };
 
   nodes = {

--- a/pkgs/applications/audio/gmpc/default.nix
+++ b/pkgs/applications/audio/gmpc/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
     homepage = "https://gmpclient.org";
     description = "GTK2 frontend for Music Player Daemon";
     license = licenses.gpl2;
-    maintainers = [];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/audio/mopidy/moped.nix
+++ b/pkgs/applications/audio/mopidy/moped.nix
@@ -20,7 +20,7 @@ pythonPackages.buildPythonApplication rec {
     homepage = "https://github.com/martijnboland/moped";
     description = "Web client for Mopidy";
     license = licenses.mit;
-    maintainers = [];
+    maintainers = [ ];
     hydraPlatforms = [];
   };
 }

--- a/pkgs/applications/kde/kde-inotify-survey.nix
+++ b/pkgs/applications/kde/kde-inotify-survey.nix
@@ -26,6 +26,6 @@ mkDerivation {
     mainProgram = "kde-inotify-survey";
     homepage = "https://invent.kde.org/system/kde-inotify-survey";
     license = lib.licenses.gpl2Plus;
-    maintainers = [];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/kde/kongress.nix
+++ b/pkgs/applications/kde/kongress.nix
@@ -31,6 +31,6 @@ mkDerivation {
     description = "Companion application for conferences";
     homepage = "https://apps.kde.org/kongress/";
     license = lib.licenses.gpl3;
-    maintainers = [];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/kde/telly-skout.nix
+++ b/pkgs/applications/kde/telly-skout.nix
@@ -20,6 +20,6 @@ mkDerivation {
     mainProgram = "telly-skout";
     homepage = "https://apps.kde.org/telly-skout/";
     license = lib.licenses.gpl2Plus;
-    maintainers = [];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/misc/bikeshed/default.nix
+++ b/pkgs/applications/misc/bikeshed/default.nix
@@ -73,6 +73,6 @@ buildPythonApplication rec {
     '';
     homepage = "https://tabatkins.github.io/bikeshed/";
     license = licenses.cc0;
-    maintainers = [];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/misc/findex/default.nix
+++ b/pkgs/applications/misc/findex/default.nix
@@ -39,6 +39,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/mdgaziur/findex";
     license = licenses.gpl3Only;
     platforms = platforms.linux;
-    maintainers = [];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/misc/gmrun/default.nix
+++ b/pkgs/applications/misc/gmrun/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://sourceforge.net/projects/gmrun/";
     license = licenses.gpl2;
-    maintainers = [];
+    maintainers = [ ];
     platforms = platforms.all;
     mainProgram = "gmrun";
   };

--- a/pkgs/applications/misc/moonlight-embedded/default.nix
+++ b/pkgs/applications/misc/moonlight-embedded/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     description = "Open source implementation of NVIDIA's GameStream";
     homepage = "https://github.com/moonlight-stream/moonlight-embedded";
     license = licenses.gpl3Plus;
-    maintainers = [];
+    maintainers = [ ];
     mainProgram = "moonlight";
     platforms = platforms.linux;
   };

--- a/pkgs/applications/misc/volnoti/default.nix
+++ b/pkgs/applications/misc/volnoti/default.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/davidbrazdil/volnoti";
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = [];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/networking/browsers/vimb/default.nix
+++ b/pkgs/applications/networking/browsers/vimb/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://fanglingsu.github.io/vimb/";
     license = lib.licenses.gpl3;
-    maintainers = [];
+    maintainers = [ ];
     platforms = with lib.platforms; linux;
   };
 }

--- a/pkgs/applications/networking/cluster/kubelogin/default.nix
+++ b/pkgs/applications/networking/cluster/kubelogin/default.nix
@@ -23,6 +23,6 @@ buildGoModule rec {
     mainProgram = "kubelogin";
     inherit (src.meta) homepage;
     license = licenses.mit;
-    maintainers = [];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/networking/cluster/nixops/plugins/nixos-modules-contrib.nix
+++ b/pkgs/applications/networking/cluster/nixops/plugins/nixos-modules-contrib.nix
@@ -40,6 +40,6 @@ buildPythonPackage {
     description = "Useful NixOS modules which may not belong in the Nixpkgs repository itself";
     homepage = "https://github.com/nix-community/nixos-modules-contrib";
     license = licenses.lgpl3;
-    maintainers = [];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/networking/irc/epic5/default.nix
+++ b/pkgs/applications/networking/irc/epic5/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     homepage = "http://epicsol.org";
     description = "IRC client that offers a great ircII interface";
     license = licenses.bsd3;
-    maintainers = [];
+    maintainers = [ ];
   };
 }
 

--- a/pkgs/applications/version-management/nitpick/default.nix
+++ b/pkgs/applications/version-management/nitpick/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     '';
     homepage = "http://travisbrown.ca/projects/nitpick/docs/nitpick.html";
     license = with lib.licenses; gpl2;
-    maintainers = [];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/virtualization/youki/default.nix
+++ b/pkgs/applications/virtualization/youki/default.nix
@@ -44,7 +44,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://containers.github.io/youki/";
     changelog = "https://github.com/containers/youki/releases/tag/v${version}";
     license = licenses.asl20;
-    maintainers = [];
+    maintainers = [ ];
     platforms = platforms.linux;
     mainProgram = "youki";
   };

--- a/pkgs/by-name/li/libertine-g/package.nix
+++ b/pkgs/by-name/li/libertine-g/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Graphite versions of Linux Libertine and Linux Biolinum font families for LibreOffice and OpenOffice.org";
     homepage = "https://numbertext.org/linux/";
-    maintainers = [];
+    maintainers = [ ];
     license = lib.licenses.ofl;
   };
 }

--- a/pkgs/by-name/li/libgnome-keyring/package.nix
+++ b/pkgs/by-name/li/libgnome-keyring/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = with lib.licenses; [ gpl2Plus lgpl2Plus ];
     pkgConfigModules = [ "gnome-keyring-1" ];
     platforms = lib.platforms.unix;
-    maintainers = [];
+    maintainers = [ ];
 
     longDescription = ''
       gnome-keyring is a program that keeps password and other secrets for

--- a/pkgs/by-name/li/liborcus/package.nix
+++ b/pkgs/by-name/li/liborcus/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.com/orcus/orcus";
     changelog = "https://gitlab.com/orcus/orcus/-/blob/${src.rev}/CHANGELOG";
     license = licenses.mpl20;
-    maintainers = [];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/data/fonts/smiley-sans/default.nix
+++ b/pkgs/data/fonts/smiley-sans/default.nix
@@ -25,7 +25,7 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://atelier-anchor.com/typefaces/smiley-sans/";
     changelog = "https://github.com/atelier-anchor/smiley-sans/blob/main/CHANGELOG.md";
     license = licenses.ofl;
-    maintainers = [];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/data/misc/clash-geoip/default.nix
+++ b/pkgs/data/misc/clash-geoip/default.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation rec {
     description = "GeoLite2 data created by MaxMind";
     homepage = "https://github.com/Dreamacro/maxmind-geoip";
     license = licenses.unfree;
-    maintainers = [];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/fox/default.nix
+++ b/pkgs/development/libraries/fox/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://fox-toolkit.org";
     license = licenses.lgpl3Plus;
-    maintainers = [];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/fox/fox-1.6.nix
+++ b/pkgs/development/libraries/fox/fox-1.6.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
       '';
     homepage = "http://fox-toolkit.org";
     license = lib.licenses.lgpl3;
-    maintainers = [];
+    maintainers = [ ];
     platforms = lib.platforms.mesaPlatforms;
   };
 }

--- a/pkgs/development/libraries/functionalplus/default.nix
+++ b/pkgs/development/libraries/functionalplus/default.nix
@@ -18,6 +18,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/Dobiasd/FunctionalPlus";
     license = licenses.boost;
     platforms = platforms.all;
-    maintainers = [];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/ktextaddons/default.nix
+++ b/pkgs/development/libraries/ktextaddons/default.nix
@@ -15,6 +15,6 @@ mkDerivation rec {
     description = "Various text handling addons for KDE applications";
     homepage = "https://invent.kde.org/libraries/ktextaddons/";
     license = licenses.gpl2Plus;
-    maintainers = [];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/libivykis/default.nix
+++ b/pkgs/development/libraries/libivykis/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
       notification facilities
     '';
     license = licenses.zlib;
-    maintainers = [];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/podofo/0.10.x.nix
+++ b/pkgs/development/libraries/podofo/0.10.x.nix
@@ -58,6 +58,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Library to work with the PDF file format";
     platforms = lib.platforms.all;
     license = with lib.licenses; [ gpl2Plus lgpl2Plus ];
-    maintainers = [];
+    maintainers = [ ];
   };
 })

--- a/pkgs/development/libraries/unittest-cpp/default.nix
+++ b/pkgs/development/libraries/unittest-cpp/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/unittest-cpp/unittest-cpp";
     description = "Lightweight unit testing framework for C++";
     license = lib.licenses.mit;
-    maintainers = [];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/development/tools/renderizer/default.nix
+++ b/pkgs/development/tools/renderizer/default.nix
@@ -22,6 +22,6 @@ buildGoModule rec {
     mainProgram = "renderizer";
     inherit (src.meta) homepage;
     license = licenses.gpl3;
-    maintainers = [];
+    maintainers = [ ];
   };
 }

--- a/pkgs/os-specific/linux/system76-power/default.nix
+++ b/pkgs/os-specific/linux/system76-power/default.nix
@@ -28,6 +28,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/pop-os/system76-power";
     license = licenses.gpl3Plus;
     platforms = [ "i686-linux" "x86_64-linux" ];
-    maintainers = [];
+    maintainers = [ ];
   };
 }

--- a/pkgs/servers/http/hiawatha/default.nix
+++ b/pkgs/servers/http/hiawatha/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.gpl2Only;
     platforms = platforms.unix;    # "Hiawatha runs perfectly on Linux, BSD and MacOS X"
     mainProgram = "hiawatha";
-    maintainers = [];
+    maintainers = [ ];
   };
 
 })

--- a/pkgs/servers/monitoring/riemann/default.nix
+++ b/pkgs/servers/monitoring/riemann/default.nix
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.epl10;
     platforms = platforms.all;
-    maintainers = [];
+    maintainers = [ ];
   };
 }

--- a/pkgs/tools/X11/xcalib/default.nix
+++ b/pkgs/tools/X11/xcalib/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     inherit (src.meta) homepage;
     description = "Tiny monitor calibration loader for X and MS-Windows";
     license = licenses.gpl2Plus;
-    maintainers = [];
+    maintainers = [ ];
     platforms = platforms.linux;
     mainProgram = "xcalib";
   };

--- a/pkgs/tools/admin/tightvnc/default.nix
+++ b/pkgs/tools/admin/tightvnc/default.nix
@@ -106,7 +106,7 @@ stdenv.mkDerivation rec {
       GUI, many bugfixes, and more.
     '';
 
-    maintainers = [];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
 
     knownVulnerabilities = [ "CVE-2021-42785" ];

--- a/pkgs/tools/archivers/sharutils/default.nix
+++ b/pkgs/tools/archivers/sharutils/default.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
       '';
     homepage = "https://www.gnu.org/software/sharutils/";
     license = licenses.gpl3Plus;
-    maintainers = [];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/tools/compression/bzip2/1_1.nix
+++ b/pkgs/tools/compression/bzip2/1_1.nix
@@ -42,6 +42,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.bsdOriginal;
     pkgConfigModules = [ "bz2" ];
     platforms = platforms.all;
-    maintainers = [];
+    maintainers = [ ];
   };
 })

--- a/pkgs/tools/graphics/argyllcms/default.nix
+++ b/pkgs/tools/graphics/argyllcms/default.nix
@@ -148,7 +148,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.argyllcms.com/";
     description = "Color management system (compatible with ICC)";
     license = licenses.gpl3;
-    maintainers = [];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/misc/dbacl/default.nix
+++ b/pkgs/tools/misc/dbacl/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://dbacl.sourceforge.net/";
     longDescription = "a digramic Bayesian classifier for text recognition.";
-    maintainers = [];
+    maintainers = [ ];
     license = lib.licenses.gpl3;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/tools/networking/surfraw/default.nix
+++ b/pkgs/tools/networking/surfraw/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Provides a fast unix command line interface to a variety of popular WWW search engines and other artifacts of power";
     homepage = "https://gitlab.com/surfraw/Surfraw";
-    maintainers = [];
+    maintainers = [ ];
     platforms = lib.platforms.all;
     license = lib.licenses.publicDomain;
   };

--- a/pkgs/tools/text/autocorrect/default.nix
+++ b/pkgs/tools/text/autocorrect/default.nix
@@ -32,6 +32,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://huacnlee.github.io/autocorrect";
     changelog = "https://github.com/huacnlee/autocorrect/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = [];
+    maintainers = [ ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19432,7 +19432,7 @@ with pkgs;
       # tests fail on old version
       doCheck = false;
       meta = libgit2.meta // {
-        maintainers = [];
+        maintainers = [ ];
         knownVulnerabilities = [ "CVE-2024-24575" "CVE-2024-24577" "CVE-2022-29187" "CVE 2022-24765" ];
       };
     };


### PR DESCRIPTION
changed all occurrences of `maintainers = [];` (and `maintainers = [  ];`) to `maintainers = [ ];` (single space) to respect `nixfmt-rfc-style` and makes them easier to find (hopefully they'll get adopted).

Currently, using simple github search queries like [repo:NixOS/nixpkgs "maintainers = [ ];"](https://github.com/search?q=repo%3ANixOS%2Fnixpkgs%20%22maintainers%20%3D%20%5B%20%5D%3B%22&type=code) wont show them.

Used the following command, and fixed them by hand.
```
grep -rP 'maintainers = \[\];'
```


## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
