### PR TITLE
pdal: fix libdir path in pkgconfig file

### DIFF
--- a/pkgs/development/libraries/pdal/default.nix
+++ b/pkgs/development/libraries/pdal/default.nix
@@ -37,6 +37,10 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-ukBZLr/iyYQ68sv9JWrR4YP0ahHfGhytgcWKPzrF3Ps=";
   };
 
+  patches = [
+    ./pdal.pc.in.patch
+  ];
+
   nativeBuildInputs = [
     cmake
     pkg-config
@@ -124,7 +128,9 @@ stdenv.mkDerivation (finalAttrs: {
       version = "pdal ${finalAttrs.finalPackage.version}";
     };
     pdal = callPackage ./tests.nix { pdal = finalAttrs.finalPackage; };
-    pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+    };
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/pdal/pdal.pc.in.patch
+++ b/pkgs/development/libraries/pdal/pdal.pc.in.patch
@@ -1,0 +1,12 @@
+diff --git a/apps/pdal.pc.in b/apps/pdal.pc.in
+index 6885221cacc8..a07ee82cea68 100644
+--- a/apps/pdal.pc.in
++++ b/apps/pdal.pc.in
+@@ -1,6 +1,6 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=@CMAKE_INSTALL_PREFIX@/bin
+-libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+ includedir=@CMAKE_INSTALL_PREFIX@/include
+ 
+ Name: PDAL


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix `libdir` path in `lib/pkgconfig/pdal.pc` file.

`pdal.pc` without the patch: 

```
prefix=/nix/store/65ikg5m0rsl2p4p22gpsgwkqi8cizkvz-pdal-2.7.2
exec_prefix=/nix/store/65ikg5m0rsl2p4p22gpsgwkqi8cizkvz-pdal-2.7.2/bin
libdir=/nix/store/65ikg5m0rsl2p4p22gpsgwkqi8cizkvz-pdal-2.7.2//nix/store/65ikg5m0rsl2p4p22gpsgwkqi8cizkvz-pdal-2.7.2/lib
includedir=/nix/store/65ikg5m0rsl2p4p22gpsgwkqi8cizkvz-pdal-2.7.2/include

Name: PDAL
Description: Point Data Abstraction Library
Requires:   gdal libxml-2.0
Version: 2.7.2
Libs: -L${libdir} -lpdalcpp
Cflags: -I${includedir}/pdal  


```

`pdal.pc` with the patch: 

```
prefix=/nix/store/wmkwbkqj7hzfpnvjzv1jpsd5biv1x26v-pdal-2.7.2
exec_prefix=/nix/store/wmkwbkqj7hzfpnvjzv1jpsd5biv1x26v-pdal-2.7.2/bin
libdir=/nix/store/wmkwbkqj7hzfpnvjzv1jpsd5biv1x26v-pdal-2.7.2/lib
includedir=/nix/store/wmkwbkqj7hzfpnvjzv1jpsd5biv1x26v-pdal-2.7.2/include

Name: PDAL
Description: Point Data Abstraction Library
Requires:   gdal libxml-2.0
Version: 2.7.2
Libs: -L${libdir} -lpdalcpp
Cflags: -I${includedir}/pdal  
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
