### PR TITLE
sequoia-sq: 0.34.0 -> 0.37.0

### DIFF
--- a/pkgs/by-name/se/sequoia-sq/package.nix
+++ b/pkgs/by-name/se/sequoia-sq/package.nix
@@ -47,7 +47,6 @@ rustPlatform.buildRustPackage rec {
     nettle
   ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Security SystemConfiguration ]);
 
-  # Sometimes, tests fail on CI (ofborg) & hydra without this
   checkFlags = [
     # doctest for sequoia-ipc fail for some reason
     "--skip=macros::assert_send_and_sync"
@@ -69,12 +68,12 @@ rustPlatform.buildRustPackage rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "Cool new OpenPGP implementation";
     homepage = "https://sequoia-pgp.org/";
     changelog = "https://gitlab.com/sequoia-pgp/sequoia-sq/-/blob/v${version}/NEWS";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ minijackson doronbehar ];
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ minijackson doronbehar ];
     mainProgram = "sq";
   };
 }

--- a/pkgs/by-name/se/sequoia-sq/package.nix
+++ b/pkgs/by-name/se/sequoia-sq/package.nix
@@ -1,6 +1,5 @@
 { stdenv
 , fetchFromGitLab
-, fetchpatch
 , lib
 , darwin
 , nettle
@@ -15,24 +14,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "sequoia-sq";
-  version = "0.34.0";
+  version = "0.37.0";
 
   src = fetchFromGitLab {
     owner = "sequoia-pgp";
     repo = "sequoia-sq";
     rev = "v${version}";
-    hash = "sha256-voFektWZnkmIQzI7s5nKzVVWQtEhzk2GKtxX926RtxU=";
+    hash = "sha256-D22ECJvbGbnyvusWXfU5F1aLF/ETuMyhAStT5HPWR2U=";
   };
-  patches = [
-    # Fixes test failing on Darwin, see:
-    # https://gitlab.com/sequoia-pgp/sequoia-sq/-/issues/211
-    (fetchpatch {
-      url = "https://gitlab.com/sequoia-pgp/sequoia-sq/-/commit/21221a935e0d058ed269ae6c8f45c5fa7ea0d598.patch";
-      hash = "sha256-ZjTl3EumeFwMJUl+qMpX+P2maYz4Ow/Tn9KwYbHDbes=";
-    })
-  ];
 
-  cargoHash = "sha256-3ncBpRi0v6g6wwPkSASDwt0d8cOOAUv9BwZaYvnif1U=";
+  cargoHash = "sha256-jFpqZKyRCMkMtOezsYJy3Fy1WXUPyn709wZxuwKlSYI=";
 
   nativeBuildInputs = [
     pkg-config
@@ -48,10 +39,14 @@ rustPlatform.buildRustPackage rec {
   ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Security SystemConfiguration ]);
 
   checkFlags = [
-    # doctest for sequoia-ipc fail for some reason
-    "--skip=macros::assert_send_and_sync"
-    "--skip=macros::time_it"
+    # https://gitlab.com/sequoia-pgp/sequoia-sq/-/issues/297
+    "--skip=sq_autocrypt_import"
   ];
+
+  # Needed for tests to be able to create a ~/.local/share/sequoia directory
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
 
   env.ASSET_OUT_DIR = "/tmp/";
 

--- a/pkgs/by-name/se/sequoia-wot/package.nix
+++ b/pkgs/by-name/se/sequoia-wot/package.nix
@@ -13,16 +13,16 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "sequoia-wot";
-  version = "0.11.0";
+  version = "0.12.0";
 
   src = fetchFromGitLab {
     owner = "sequoia-pgp";
     repo = "sequoia-wot";
     rev = "v${version}";
-    hash = "sha256-qSf2uESsMGUEvAiRefpwxHKyizbq5Sst3SpjKaMIWTQ=";
+    hash = "sha256-Xbj1XLZQxyEYf/+R5e6EJMmL0C5ohfwZMZPVK5PwmUU=";
   };
 
-  cargoHash = "sha256-vGseKdHqyncScS57UF3SR3EVdUGKVMue8fnRftefSY0=";
+  cargoHash = "sha256-BidSKnsIEEEU8UarbhqALcp44L0pes6O4m2mSEL1r4Q=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/se/sequoia-wot/package.nix
+++ b/pkgs/by-name/se/sequoia-wot/package.nix
@@ -80,11 +80,11 @@ rustPlatform.buildRustPackage rec {
       target/*/release/build/sequoia-wot-*/out/sq-wot-path.1
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Rust CLI tool for authenticating bindings and exploring a web of trust";
     homepage = "https://gitlab.com/sequoia-pgp/sequoia-wot";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ Cryolitia ];
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ Cryolitia ];
     mainProgram = "sq-wot";
   };
 }

--- a/pkgs/by-name/se/sequoia-wot/package.nix
+++ b/pkgs/by-name/se/sequoia-wot/package.nix
@@ -84,7 +84,7 @@ rustPlatform.buildRustPackage rec {
     description = "Rust CLI tool for authenticating bindings and exploring a web of trust";
     homepage = "https://gitlab.com/sequoia-pgp/sequoia-wot";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ Cryolitia ];
+    maintainers = with lib.maintainers; [ doronbehar Cryolitia ];
     mainProgram = "sq-wot";
   };
 }

--- a/pkgs/tools/security/sequoia-sqop/default.nix
+++ b/pkgs/tools/security/sequoia-sqop/default.nix
@@ -48,11 +48,11 @@ rustPlatform.buildRustPackage rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "Implementation of the Stateless OpenPGP Command Line Interface using Sequoia";
     homepage = "https://docs.sequoia-pgp.org/sqop/";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ doronbehar ];
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ doronbehar ];
     mainProgram = "sqop";
   };
 }

--- a/pkgs/tools/security/sequoia-sqv/default.nix
+++ b/pkgs/tools/security/sequoia-sqv/default.nix
@@ -9,17 +9,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "sequoia-sqv";
-  version = "1.1.0";
+  version = "1.2.1";
 
   src = fetchFromGitLab {
     owner = "sequoia-pgp";
     repo = "sequoia-sqv";
     rev = "v${version}";
-    hash = "sha256-KoB9YnPNE2aB5MW5G9r6Bk+1QnANVSKA2dp3ufSJ44M=";
+    hash = "sha256-frGukJDsxq+BWLPC/4imfc42lDKVF8BPIQQDazaLaQ0=";
   };
-  cargoPatches = [ ./Cargo.lock.patch ];
 
-  cargoHash = "sha256-E6tNOc3omg6yLwCP+MdyBF/HmFTBFCiXd5r+jflfs4k=";
+  cargoHash = "sha256-1h1nXtXMTwL8ICxWTV8My0IdE+6w0L7xXZD012Cv5U8=";
 
   nativeBuildInputs = [
     pkg-config
@@ -30,20 +29,18 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [
     nettle
   ];
-  # Otherwise, the shell completion files are not built
-  cargoBuildFlags = [
-    "--package" "sequoia-sqv"
-  ];
-  # Use a predictable target directory, to access it when installing shell
-  # completion files.
-  preBuild = ''
-    export CARGO_TARGET_DIR="$(pwd)/target"
-  '';
+  # Install shell completion files and manual pages. Unfortunatly it is hard to
+  # predict the paths to all of these files generated during the build, and it
+  # is impossible to control these using `$OUT_DIR` or alike, as implied by
+  # upstream's `build.rs`. This is a general Rust issue also discussed in
+  # https://github.com/rust-lang/cargo/issues/9661, also discussed upstream at:
+  # https://gitlab.com/sequoia-pgp/sequoia-wot/-/issues/56
   postInstall = ''
+    installManPage target/*/release/build/*/out/man-pages/sqv.1
     installShellCompletion --cmd sqv \
-      --zsh target/_sqv \
-      --bash target/sqv.bash \
-      --fish target/sqv.fish
+      --zsh target/*/release/build/*/out/shell-completions/_sqv \
+      --bash target/*/release/build/*/out/shell-completions/sqv.bash \
+      --fish target/*/release/build/*/out/shell-completions/sqv.fish
   '';
 
   doCheck = true;

--- a/pkgs/tools/security/sequoia-sqv/default.nix
+++ b/pkgs/tools/security/sequoia-sqv/default.nix
@@ -50,11 +50,11 @@ rustPlatform.buildRustPackage rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "Command-line OpenPGP signature verification tool";
     homepage = "https://docs.sequoia-pgp.org/sqv/";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ doronbehar ];
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ doronbehar ];
     mainProgram = "sqv";
   };
 }


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
