### PR TITLE
treewide: finalAttrs.doCheck -> finalAttrs.finalPackage.doCheck

### DIFF
--- a/pkgs/applications/science/logic/bitwuzla/default.nix
+++ b/pkgs/applications/science/logic/bitwuzla/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     # but setting it to shared works even in pkgsStatic
     "-Ddefault_library=shared"
 
-    (lib.strings.mesonEnable "testing" finalAttrs.doCheck)
+    (lib.strings.mesonEnable "testing" finalAttrs.finalPackage.doCheck)
   ];
 
   nativeCheckInputs = [ python3 ];

--- a/pkgs/by-name/ay/ayatana-indicator-messages/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-messages/package.nix
@@ -95,7 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DENABLE_TESTS=${lib.boolToString finalAttrs.doCheck}"
+    "-DENABLE_TESTS=${lib.boolToString finalAttrs.finalPackage.doCheck}"
     "-DGSETTINGS_LOCALINSTALL=ON"
     "-DGSETTINGS_COMPILE=ON"
   ];

--- a/pkgs/by-name/bn/bngblaster/package.nix
+++ b/pkgs/by-name/bn/bngblaster/package.nix
@@ -30,10 +30,10 @@ stdenv.mkDerivation (finalAttrs: {
     jansson
     openssl
     cmocka
-  ] ++ lib.optionals finalAttrs.doCheck [ libpcap ];
+  ] ++ lib.optionals finalAttrs.finalPackage.doCheck [ libpcap ];
 
   cmakeFlags = [
-    "-DBNGBLASTER_TESTS=${if finalAttrs.doCheck then "ON" else "OFF"}"
+    "-DBNGBLASTER_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
     "-DBNGBLASTER_VERSION=${finalAttrs.version}"
   ];
 

--- a/pkgs/by-name/cp/cppitertools/package.nix
+++ b/pkgs/by-name/cp/cppitertools/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
       substituteInPlace CMakeLists.txt \
         --replace-fail "  DIRECTORY ." "  DIRECTORY . EXCLUDE_FROM_ALL"
     ''
-    + lib.optionalString finalAttrs.doCheck ''
+    + lib.optionalString finalAttrs.finalPackage.doCheck ''
       # Required for tests.
       cp ${lib.getDev catch2}/include/catch2/catch.hpp test/
     '';

--- a/pkgs/by-name/di/digikam/package.nix
+++ b/pkgs/by-name/di/digikam/package.nix
@@ -149,7 +149,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   checkInputs = [ kdePackages.qtdeclarative ];
 
-  postConfigure = lib.optionalString finalAttrs.doCheck ''
+  postConfigure = lib.optionalString finalAttrs.finalPackage.doCheck ''
     ln -s ${testData} $cmakeDir/test-data
   '';
 

--- a/pkgs/by-name/ei/eiwd/package.nix
+++ b/pkgs/by-name/ei/eiwd/package.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $doc/share/doc
     cp -a doc $doc/share/doc/iwd
     cp -a README AUTHORS TODO $doc/share/doc/iwd
-  '' + lib.optionalString finalAttrs.doCheck ''
+  '' + lib.optionalString finalAttrs.finalPackage.doCheck ''
     mkdir -p $test/bin
     cp -a test/* $test/bin/
   '';

--- a/pkgs/by-name/fo/fooyin/package.nix
+++ b/pkgs/by-name/fo/fooyin/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    (lib.cmakeBool "BUILD_TESTING" (finalAttrs.doCheck or false))
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doCheck)
     # we need INSTALL_FHS to be true as the various artifacts are otherwise just dumped in the root
     # of $out and the fixupPhase cleans things up anyway
     (lib.cmakeBool "INSTALL_FHS" true)

--- a/pkgs/by-name/gf/gfal2/package.nix
+++ b/pkgs/by-name/gf/gfal2/package.nix
@@ -98,8 +98,8 @@ stdenv.mkDerivation (finalAttrs: {
       (pluginName: "-DPLUGIN_${lib.toUpper pluginName}=${lib.toUpper (lib.boolToString finalAttrs.passthru.enablePluginStatus.${pluginName})}")
       (lib.attrNames finalAttrs.passthru.enablePluginStatus)
   )
-  ++ [ "-DSKIP_TESTS=${lib.toUpper (lib.boolToString (!finalAttrs.doCheck))}" ]
-  ++ lib.optionals finalAttrs.doCheck [ "-DGTEST_INCLUDE_DIR=${gtest.dev}/include" ]
+  ++ [ "-DSKIP_TESTS=${lib.toUpper (lib.boolToString (!finalAttrs.finalPackage.doCheck))}" ]
+  ++ lib.optionals finalAttrs.finalPackage.doCheck [ "-DGTEST_INCLUDE_DIR=${gtest.dev}/include" ]
   ++ lib.optionals finalAttrs.passthru.enablePluginStatus.http [ "-DCRYPTOPP_INCLUDE_DIRS=${cryptopp.dev}/include/cryptopp" ]
   ++ lib.optionals finalAttrs.passthru.enablePluginStatus.xrootd [ "-DXROOTD_INCLUDE_DIR=${xrootd.dev}/include/xrootd" ]
   ;

--- a/pkgs/by-name/in/influxdb-cxx/package.nix
+++ b/pkgs/by-name/in/influxdb-cxx/package.nix
@@ -26,10 +26,10 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ boost libcpr ]
-    ++ lib.optionals finalAttrs.doCheck [ catch2_3 trompeloeil ];
+    ++ lib.optionals finalAttrs.finalPackage.doCheck [ catch2_3 trompeloeil ];
 
   cmakeFlags = [
-    (lib.cmakeBool "INFLUXCXX_TESTING" finalAttrs.doCheck)
+    (lib.cmakeBool "INFLUXCXX_TESTING" finalAttrs.finalPackage.doCheck)
     (lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" "-E;BoostSupportTest") # requires network access
   ];
 

--- a/pkgs/by-name/li/libdict/package.nix
+++ b/pkgs/by-name/li/libdict/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DLIBDICT_TESTS=${if finalAttrs.doCheck then "ON" else "OFF"}"
+    "-DLIBDICT_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
     "-DLIBDICT_SHARED=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
   ];
 

--- a/pkgs/by-name/ne/neovim-unwrapped/package.nix
+++ b/pkgs/by-name/ne/neovim-unwrapped/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs:
     (nvim-lpeg-dylib ps)
     luabitop
     mpack
-  ] ++ lib.optionals finalAttrs.doCheck [
+  ] ++ lib.optionals finalAttrs.finalPackage.doCheck [
     luv
     coxpcall
     busted
@@ -105,7 +105,7 @@ in {
       tree-sitter
       unibilium
     ] ++ lib.optionals stdenv.isDarwin [ libiconv CoreServices ]
-      ++ lib.optionals finalAttrs.doCheck [ glibcLocales procps ]
+      ++ lib.optionals finalAttrs.finalPackage.doCheck [ glibcLocales procps ]
     ;
 
     doCheck = false;

--- a/pkgs/by-name/pa/parallel-hashmap/package.nix
+++ b/pkgs/by-name/pa/parallel-hashmap/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DPHMAP_BUILD_TESTS=${if finalAttrs.doCheck then "ON" else "OFF"}"
+    "-DPHMAP_BUILD_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
     "-DPHMAP_BUILD_EXAMPLES=OFF"
   ];
 

--- a/pkgs/desktops/lomiri/applications/morph-browser/default.nix
+++ b/pkgs/desktops/lomiri/applications/morph-browser/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace src/app/webbrowser/morph-browser.desktop.in.in \
       --replace 'Icon=@CMAKE_INSTALL_FULL_DATADIR@/morph-browser/morph-browser.svg' 'Icon=/run/current-system/sw/share/icons/hicolor/scalable/apps/morph-browser.svg' \
       --replace 'X-Lomiri-Splash-Image=@CMAKE_INSTALL_FULL_DATADIR@/morph-browser/morph-browser-splash.svg' 'X-Lomiri-Splash-Image=lomiri-app-launch/splash/morph-browser.svg'
-  '' + lib.optionalString (!finalAttrs.doCheck) ''
+  '' + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
     substituteInPlace CMakeLists.txt \
       --replace 'add_subdirectory(tests)' ""
   '';

--- a/pkgs/desktops/lomiri/development/trust-store/default.nix
+++ b/pkgs/desktops/lomiri/development/trust-store/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace src/core/trust/terminal_agent.h \
       --replace-fail '/bin/whiptail' '${lib.getExe' newt "whiptail"}'
-  '' + lib.optionalString (!finalAttrs.doCheck) ''
+  '' + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
     substituteInPlace CMakeLists.txt \
       --replace-fail 'add_subdirectory(tests)' ""
   '';

--- a/pkgs/desktops/lomiri/development/u1db-qt/default.nix
+++ b/pkgs/desktops/lomiri/development/u1db-qt/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     # For our automatic pkg-config output patcher to work, prefix must be used here
     substituteInPlace libu1db-qt.pc.in \
       --replace-fail 'libdir=''${exec_prefix}/lib' 'libdir=''${prefix}/lib'
-  '' + lib.optionalString (!finalAttrs.doCheck) ''
+  '' + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
     # Other locations add dependencies to custom check target from tests
     substituteInPlace CMakeLists.txt \
       --replace-fail 'add_subdirectory(tests)' 'add_custom_target(check COMMAND "echo check dummy")'

--- a/pkgs/desktops/lomiri/qml/lomiri-settings-components/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-settings-components/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace CMakeLists.txt \
       --replace "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" '${placeholder "out"}/${qtbase.qtQmlPrefix}'
-  '' + lib.optionalString (!finalAttrs.doCheck) ''
+  '' + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
     sed -i CMakeLists.txt \
       -e '/add_subdirectory(tests)/d'
   '';

--- a/pkgs/desktops/lomiri/services/biometryd/default.nix
+++ b/pkgs/desktops/lomiri/services/biometryd/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace data/biometryd.pc.in \
       --replace-fail 'libdir=''${exec_prefix}' 'libdir=''${prefix}' \
       --replace-fail 'includedir=''${exec_prefix}' 'includedir=''${prefix}' \
-  '' + lib.optionalString (!finalAttrs.doCheck) ''
+  '' + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
     sed -i -e '/add_subdirectory(tests)/d' CMakeLists.txt
   '';
 

--- a/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
@@ -96,7 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "GSETTINGS_LOCALINSTALL" true)
     (lib.cmakeBool "GSETTINGS_COMPILE" true)
-    (lib.cmakeBool "ENABLE_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
     (lib.cmakeBool "ENABLE_UBUNTU_COMPAT" true) # just in case something needs it
     (lib.cmakeBool "BUILD_DOC" true) # lacks QML docs, needs qdoc: https://github.com/NixOS/nixpkgs/pull/245379
   ];

--- a/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
@@ -124,7 +124,7 @@ stdenv.mkDerivation (finalAttrs: {
     doxygen
     gdk-pixbuf # setup hook
     pkg-config
-    (python3.withPackages (ps: with ps; lib.optionals finalAttrs.doCheck [
+    (python3.withPackages (ps: with ps; lib.optionals finalAttrs.finalPackage.doCheck [
       python-dbusmock
       tornado
     ]))

--- a/pkgs/desktops/lomiri/services/mediascanner2/default.nix
+++ b/pkgs/desktops/lomiri/services/mediascanner2/default.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DENABLE_TESTS=${lib.boolToString finalAttrs.doCheck}"
+    "-DENABLE_TESTS=${lib.boolToString finalAttrs.finalPackage.doCheck}"
   ];
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;

--- a/pkgs/development/libraries/accounts-qml-module/default.nix
+++ b/pkgs/development/libraries/accounts-qml-module/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Don't install test binary
     sed -i tests/tst_plugin.pro \
       -e '/TARGET = tst_plugin/a INSTALLS -= target'
-  '' + lib.optionalString (!finalAttrs.doCheck) ''
+  '' + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
     sed -i accounts-qml-module.pro -e '/tests/d'
   '';
 

--- a/pkgs/development/libraries/box2d/default.nix
+++ b/pkgs/development/libraries/box2d/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    (cmakeBool "BOX2D_BUILD_UNIT_TESTS" finalAttrs.doCheck)
+    (cmakeBool "BOX2D_BUILD_UNIT_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
   prePatch = ''

--- a/pkgs/development/libraries/folks/default.nix
+++ b/pkgs/development/libraries/folks/default.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
   mesonFlags = [
     "-Ddocs=true"
     "-Dtelepathy_backend=${lib.boolToString telepathySupport}"
-    "-Dtests=${lib.boolToString (finalAttrs.doCheck && stdenv.isLinux)}"
+    "-Dtests=${lib.boolToString (finalAttrs.finalPackage.doCheck && stdenv.isLinux)}"
   ];
 
   # backends/eds/lib/libfolks-eds.so.26.0.0.p/edsf-persona-store.c:10697:4:

--- a/pkgs/development/libraries/gvfs/default.nix
+++ b/pkgs/development/libraries/gvfs/default.nix
@@ -137,7 +137,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   doCheck = false; # fails with "ModuleNotFoundError: No module named 'gi'"
-  doInstallCheck = finalAttrs.doCheck;
+  doInstallCheck = finalAttrs.finalPackage.doCheck;
 
   separateDebugInfo = true;
 

--- a/pkgs/development/libraries/iniparser/default.nix
+++ b/pkgs/development/libraries/iniparser/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-R069LuOmjCFj7dHXiMjuK7WUupk5+dVd8IDKY/wBn2o=";
   };
 
-  patches = lib.optionals finalAttrs.doCheck [
+  patches = lib.optionals finalAttrs.finalPackage.doCheck [
     (substituteAll {
       # Do not let cmake's fetchContent download unity
       src = ./remove-fetchcontent-usage.patch;
@@ -48,9 +48,9 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     doxygen
     validatePkgConfig
-  ] ++ lib.optionals finalAttrs.doCheck [ ruby ];
+  ] ++ lib.optionals finalAttrs.finalPackage.doCheck [ ruby ];
 
-  cmakeFlags = [ "-DBUILD_TESTING=${if finalAttrs.doCheck then "ON" else "OFF"}" ];
+  cmakeFlags = [ "-DBUILD_TESTING=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}" ];
 
   doCheck = false;
 

--- a/pkgs/development/libraries/libadwaita/default.nix
+++ b/pkgs/development/libraries/libadwaita/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   mesonFlags = [
     "-Dgtk_doc=true"
-  ] ++ lib.optionals (!finalAttrs.doCheck) [
+  ] ++ lib.optionals (!finalAttrs.finalPackage.doCheck) [
     "-Dtests=false"
   ];
 

--- a/pkgs/development/libraries/libe57format/default.nix
+++ b/pkgs/development/libraries/libe57format/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     # See https://github.com/asmaloney/libE57Format/blob/9372bdea8db2cc0c032a08f6d655a53833d484b8/test/README.md
-    (if finalAttrs.doCheck
+    (if finalAttrs.finalPackage.doCheck
       then "-DE57_TEST_DATA_PATH=${finalAttrs.libE57Format-test-data_src}"
       else "-DE57_BUILD_TEST=OFF"
     )

--- a/pkgs/development/libraries/libepoxy/default.nix
+++ b/pkgs/development/libraries/libepoxy/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
   mesonFlags = [
     "-Degl=${if (x11Support && !stdenv.isDarwin) then "yes" else "no"}"
     "-Dglx=${if x11Support then "yes" else "no"}"
-    "-Dtests=${lib.boolToString finalAttrs.doCheck}"
+    "-Dtests=${lib.boolToString finalAttrs.finalPackage.doCheck}"
     "-Dx11=${lib.boolToString x11Support}"
   ];
 

--- a/pkgs/development/tools/analysis/rr/default.nix
+++ b/pkgs/development/tools/analysis/rr/default.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "disable32bit" true)
-    (lib.cmakeBool "BUILD_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "BUILD_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
   # we turn on additional warnings due to hardening

--- a/pkgs/games/gcompris/default.nix
+++ b/pkgs/games/gcompris/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeFeature "QML_BOX2D_LIBRARY" "${qmlbox2d}/${qtbase.qtQmlPrefix}/Box2D.2.1")
-    (lib.cmakeBool "BUILD_TESTING" (finalAttrs.doCheck or false))
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doCheck)
   ];
 
   nativeBuildInputs = [ cmake extra-cmake-modules gettext ninja qttools wrapQtAppsHook ];

--- a/pkgs/tools/compression/lz4/default.nix
+++ b/pkgs/tools/compression/lz4/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
   ];
 
-  buildInputs = lib.optionals finalAttrs.doCheck [
+  buildInputs = lib.optionals finalAttrs.finalPackage.doCheck [
     valgrind
   ];
 

--- a/pkgs/tools/package-management/nix/nix-perl.nix
+++ b/pkgs/tools/package-management/nix/nix-perl.nix
@@ -76,7 +76,7 @@ in stdenv.mkDerivation (finalAttrs: {
       value = "${perl.pkgs.DBDSQLite}/${perl.libPrefix}";
     })
   ] ++ lib.optionals atLeast223 [
-    (lib.mesonEnable "tests" finalAttrs.doCheck)
+    (lib.mesonEnable "tests" finalAttrs.finalPackage.doCheck)
   ];
 
   preConfigure = "export NIX_STATE_DIR=$TMPDIR";

--- a/pkgs/tools/security/bkcrack/default.nix
+++ b/pkgs/tools/security/bkcrack/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [
-    "-DBKCRACK_BUILD_TESTING=${if finalAttrs.doCheck then "ON" else "OFF"}"
+    "-DBKCRACK_BUILD_TESTING=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
   ];
 
   postInstall = ''


### PR DESCRIPTION
## Description of changes

repeat of #271241
discussion: #272978

I did not replace the other instance in eiwd, since it causes an infinite recursion.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
