### PR TITLE
amd-ucodegen: init at 0-unstable-2017-06-07

### DIFF
--- a/pkgs/by-name/am/amd-ucodegen/package.nix
+++ b/pkgs/by-name/am/amd-ucodegen/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  nix-update-script,
+  callPackage,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "amd-ucodegen";
+  version = "0-unstable-2017-06-07";
+
+  src = fetchFromGitHub {
+    owner = "AndyLavr";
+    repo = "amd-ucodegen";
+    rev = "0d34b54e396ef300d0364817e763d2c7d1ffff02";
+    hash = "sha256-pgmxzd8tLqdQ8Kmmhl05C5tMlCByosSrwx2QpBu3UB0=";
+  };
+
+  strictDeps = true;
+
+  patches = [
+    # Extract get_family function and validate processor family
+    # instead of processor ID
+    (fetchpatch {
+      name = "validate-family-not-id.patch";
+      url = "https://github.com/AndyLavr/amd-ucodegen/compare/0d34b54e396ef300d0364817e763d2c7d1ffff02...dobo90:amd-ucodegen:7a3c51e821df96910ecb05b22f3e4866b4fb85b2.patch";
+      hash = "sha256-jvsvu9QgXikwsxjPiTaRff+cOg/YQmKg1MYKyBoMRQI=";
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 amd-ucodegen $out/bin/amd-ucodegen
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+    tests.platomav = callPackage ./test-platomav.nix { amd-ucodegen = finalAttrs.finalPackage; };
+  };
+
+  meta = {
+    description = "Tool to generate AMD microcode files";
+    longDescription = ''
+      This tool can be used to generate AMD microcode containers as used by the
+      Linux kernel. It accepts raw AMD microcode files such as those generated
+      by [MCExtractor](https://github.com/platomav/MCExtractor.git) as input.
+      The generated output file can be installed in /lib/firmware/amd-ucode.
+    '';
+    homepage = "https://github.com/AndyLavr/amd-ucodegen";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.unix;
+    mainProgram = "amd-ucodegen";
+    maintainers = with lib.maintainers; [ d-brasher ];
+  };
+})

--- a/pkgs/by-name/am/amd-ucodegen/test-platomav.nix
+++ b/pkgs/by-name/am/amd-ucodegen/test-platomav.nix
@@ -1,0 +1,40 @@
+{
+  stdenvNoCC,
+  fetchFromGitHub,
+  amd-ucodegen,
+}:
+
+stdenvNoCC.mkDerivation {
+  name = "amd-ucodegen-test-platomav";
+  meta.timeout = 60;
+
+  # Repository of dumped CPU microcodes
+  src = fetchFromGitHub {
+    owner = "platomav";
+    repo = "CPUMicrocodes";
+    rev = "dfc37d654cbe294acb0ec0274763321507dd7838";
+    hash = "sha256-Va+ErKID5iyKEee61tlrZwSpujxwMYPC+MAgZKUkrrM=";
+  };
+
+  nativeBuildInputs = [ amd-ucodegen ];
+  buildPhase = ''
+    runHook preBuild
+
+    echo -n "Test normal behavior with single input... "
+    [ "$(amd-ucodegen AMD/cpu00B40F40_ver0B40401A_2024-06-14_544DFCB8.bin)" \
+      == "CPU type 0xb40f40 [0xb440], file AMD/cpu00B40F40_ver0B40401A_2024-06-14_544DFCB8.bin" ]
+    echo "OK"
+    echo -n "Check output hash... "
+    [ "$(sha256sum microcode_amd_fam1ah.bin)" \
+      == "17f25ec78fa677803684e77ce01a21344b4b33463a964f61bae51b173543b190  microcode_amd_fam1ah.bin" ]
+    echo "OK"
+    echo -n "Ensure fail when bad processor ID... "
+    [ "$(amd-ucodegen AMD/cpu00000F00_ver02000008_2007-06-14_C3A923BB.bin 2>&1)" \
+      == "Bad processor ID 0x0n" ]
+    echo "OK"
+
+    touch $out
+
+    runHook postBuild
+  '';
+}


### PR DESCRIPTION
## Description of changes
[amd-ucodegen](https://github.com/AndyLavr/amd-ucodegen) is a tool that can be used to generate AMD microcode containers as used by the Linux kernel. It accepts raw AMD microcode files such as those generated by [MCExtractor](https://github.com/platomav/MCExtractor.git) as input. The generated output file can be installed in /lib/firmware/amd-ucode.

The patch is needed for working with newer CPU microcodes.

The implemented test uses [platomav CPU microcode database](https://github.com/platomav/CPUMicrocodes) as inputs.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
