### PR TITLE
spidermonkey_{91,102}: fix build

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/common.nix
+++ b/pkgs/development/interpreters/spidermonkey/common.nix
@@ -14,6 +14,7 @@
 , pkg-config
 , python3
 , python39
+, python311
 , rustc
 , which
 , zip
@@ -68,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: rec {
   ] ++ lib.optionals (lib.versionAtLeast version "91" && lib.versionOlder version "102") [
     # Fix 91 compatibility with python311
     (fetchpatch {
-      url = "https://src.fedoraproject.org/rpms/mozjs91/raw/rawhide/f/0001-Python-Build-Use-r-instead-of-rU-file-read-modes.patch";
+      url = "https://src.fedoraproject.org/rpms/mozjs91/raw/e3729167646775e60a3d8c602c0412e04f206baf/f/0001-Python-Build-Use-r-instead-of-rU-file-read-modes.patch";
       hash = "sha256-WgDIBidB9XNQ/+HacK7jxWnjOF8PEUt5eB0+Aubtl48=";
     })
   ];
@@ -79,7 +80,16 @@ stdenv.mkDerivation (finalAttrs: rec {
     perl
     pkg-config
     # 78 requires python up to 3.9
-    (if lib.versionOlder version "91" then python39 else python3)
+    # 91 does not build with python 3.12: ModuleNotFoundError: No module named 'six.moves'
+    # 102 does not build with python 3.12: ModuleNotFoundError: No module named 'distutils'
+    (
+      if lib.versionOlder version "91" then
+        python39
+      else if lib.versionOlder version "115" then
+        python311
+      else
+        python3
+    )
     rustc
     rustc.llvmPackages.llvm # for llvm-objdump
     which


### PR DESCRIPTION
## Description of changes

- fix previous patch to a more "stable" url
- use python311 for 91 and 102

Previous url for patch currently returns 404 (there is no files in `rawhide` because fedora dropped it as EOL):
https://src.fedoraproject.org/rpms/mozjs91/raw/rawhide/f/0001-Python-Build-Use-r-instead-of-rU-file-read-modes.patch
New url points to commit that added it:
https://src.fedoraproject.org/rpms/mozjs91/raw/e3729167646775e60a3d8c602c0412e04f206baf/f/0001-Python-Build-Use-r-instead-of-rU-file-read-modes.patch
https://src.fedoraproject.org/rpms/mozjs91/c/e3729167646775e60a3d8c602c0412e04f206baf


Fixes builds of `spidermonkey_91`:
https://hydra.nixos.org/build/267631145
```text
Running phase: configurePhase
evaling implicit 'preConfigure' string hook
/build/firefox-91.13.0/js/src /build/firefox-91.13.0
/build/firefox-91.13.0
calling 'preConfigure' function hook '_multioutConfig'
patching script interpreter paths in ../js/src/configure
../js/src/configure: interpreter directive changed from "#!/bin/sh" to "/nix/store/i1x9sidnvhhbbha2zhgpxkhpysw6ajmr-bash-5.2p26/bin/sh"
configure flags: --prefix=/nix/store/j9cs480wq21bwwclyb4y6yc53szhdpk3-spidermonkey-91.13.0 --with-intl-api --with-system-icu --with-system-nspr --with-system-zlib --enable-optimize --enable-readline --enable-release --enable-shared-js --disable-debug --disable-jemalloc --disable-strip --disable-tests --host=x86_64-unknown-linux-gnu --target=x86_64-unknown-linux-gnu
/build/firefox-91.13.0/python/mozbuild/mozbuild/configure/__init__.py:915: SyntaxWarning: invalid escape sequence '\.'
  RE_MODULE = re.compile("^[a-zA-Z0-9_\.]+$")
Traceback (most recent call last):
  File "/build/firefox-91.13.0/obj/../js/src/../../configure.py", line 22, in <module>
    from mozbuild.configure import (
  File "/build/firefox-91.13.0/python/mozbuild/mozbuild/configure/__init__.py", line 13, in <module>
    from six.moves import builtins as __builtin__
ModuleNotFoundError: No module named 'six.moves'
```
and `spidermonkey_102`
https://hydra.nixos.org/build/267579746
```text
Running phase: configurePhase
evaling implicit 'preConfigure' string hook
/build/firefox-102.15.1/js/src /build/firefox-102.15.1
/build/firefox-102.15.1
calling 'preConfigure' function hook '_multioutConfig'
patching script interpreter paths in ../js/src/configure
../js/src/configure: interpreter directive changed from "#!/bin/sh" to "/nix/store/i1x9sidnvhhbbha2zhgpxkhpysw6ajmr-bash-5.2p26/bin/sh"
configure flags: --prefix=/nix/store/8mhjq3rcfkgqff84z3m9skr4any7m76j-spidermonkey-102.15.1 --with-intl-api --with-system-icu --with-system-nspr --with-system-zlib --enable-optimize --enable-readline --enable-release --enable-shared-js --disable-debug --disable-jemalloc --disable-strip --disable-tests --host=x86_64-unknown-linux-gnu --target=x86_64-unknown-linux-gnu
Traceback (most recent call last):
  File "/build/firefox-102.15.1/obj/../js/src/../../configure.py", line 25, in <module>
    from mach.site import (
  File "/build/firefox-102.15.1/python/mach/mach/site.py", line 26, in <module>
    from mach.requirements import (
  File "/build/firefox-102.15.1/python/mach/mach/requirements.py", line 7, in <module>
    from packaging.requirements import Requirement
  File "/build/firefox-102.15.1/third_party/python/packaging/packaging/requirements.py", line 24, in <module>
    from .markers import MARKER_EXPR, Marker
  File "/build/firefox-102.15.1/third_party/python/packaging/packaging/markers.py", line 25, in <module>
    from .specifiers import InvalidSpecifier, Specifier
  File "/build/firefox-102.15.1/third_party/python/packaging/packaging/specifiers.py", line 14, in <module>
    from .utils import canonicalize_version
  File "/build/firefox-102.15.1/third_party/python/packaging/packaging/utils.py", line 9, in <module>
    from .tags import Tag, parse_tag
  File "/build/firefox-102.15.1/third_party/python/packaging/packaging/tags.py", line 7, in <module>
    import distutils.util
ModuleNotFoundError: No module named 'distutils'
```

Fixes #330281 (build failure of `couchdb3` that depends on `spidermonkey_91`)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
