### PR TITLE
restic-integrity: 1.2.2 -> 1.3.0, add networkexception as maintainer

### DIFF
--- a/pkgs/applications/backup/restic-integrity/default.nix
+++ b/pkgs/applications/backup/restic-integrity/default.nix
@@ -5,17 +5,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "restic-integrity";
-  version = "1.2.2";
+  version = "1.3.0";
 
   src = fetchFromGitea {
     domain = "git.nwex.de";
     owner = "networkException";
     repo = "restic-integrity";
     rev = version;
-    hash = "sha256-QiISJCxxJH8wQeH/klB48POn6W9juQmIMCLGzGSyl6w=";
+    hash = "sha256-mryHePqfEawW/vLgxfm+eh4oSbcALhxvRid4kF9klTs=";
   };
 
-  cargoHash = "sha256-GxehJjDd0AHbEc8kPWyLXAOPbrPCT59LddAL1ydnT5g=";
+  cargoHash = "sha256-0BvB1ijsppblEC2PNLfVt+sgM4wTdSLZ/RoDH4JrQy4=";
 
   meta = with lib; {
     description = "CLI tool to check the integrity of a restic repository without unlocking it";

--- a/pkgs/applications/backup/restic-integrity/default.nix
+++ b/pkgs/applications/backup/restic-integrity/default.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     description = "CLI tool to check the integrity of a restic repository without unlocking it";
     homepage = "https://git.nwex.de/networkException/restic-integrity";
     license = with licenses; [ bsd2 ];
-    maintainers = [ ];
+    maintainers = with maintainers; [ networkexception ];
     mainProgram = "restic-integrity";
   };
 }


### PR DESCRIPTION
## Description of changes

This pull request updates the `restic-integrity` package from `1.2.2` to `1.3.0` and adds myself as a maintainer.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
