### PR TITLE
treewide: migrate to pytest-cov-stub 

### DIFF
--- a/pkgs/development/python-modules/aiojobs/default.nix
+++ b/pkgs/development/python-modules/aiojobs/default.nix
@@ -6,6 +6,7 @@
   fetchFromGitHub,
   fetchpatch,
   pytest-aiohttp,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
   setuptools,
@@ -32,11 +33,6 @@ buildPythonPackage rec {
     })
   ];
 
-  postPatch = ''
-    substituteInPlace pytest.ini \
-      --replace "--cov=aiojobs/ --cov=tests/ --cov-report term" ""
-  '';
-
   nativeBuildInputs = [ setuptools ];
 
   propagatedBuildInputs = lib.optionals (pythonOlder "3.11") [ async-timeout ];
@@ -48,6 +44,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-aiohttp
+    pytest-cov-stub
   ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
 
   pythonImportsCheck = [ "aiojobs" ];

--- a/pkgs/development/python-modules/ambee/default.nix
+++ b/pkgs/development/python-modules/ambee/default.nix
@@ -8,6 +8,7 @@
   yarl,
   aresponses,
   pytest-asyncio,
+  pytest-cov-stub,
   pytestCheckHook,
 }:
 
@@ -34,14 +35,14 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     aresponses
     pytest-asyncio
+    pytest-cov-stub
     pytestCheckHook
   ];
 
   postPatch = ''
     # Upstream doesn't set a version for the pyproject.toml
     substituteInPlace pyproject.toml \
-      --replace "0.0.0" "${version}" \
-      --replace "--cov" ""
+      --replace "0.0.0" "${version}"
   '';
 
   pythonImportsCheck = [ "ambee" ];

--- a/pkgs/development/python-modules/anonip/default.nix
+++ b/pkgs/development/python-modules/anonip/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   pytestCheckHook,
+  pytest-cov-stub,
   pythonOlder,
 }:
 
@@ -20,12 +21,10 @@ buildPythonPackage rec {
     sha256 = "0cssdcridadjzichz1vv1ng7jwphqkn8ihh83hpz9mcjmxyb94qc";
   };
 
-  nativeCheckInputs = [ pytestCheckHook ];
-
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace " --cov=anonip --cov-report=term-missing --no-cov-on-fail" ""
-  '';
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
 
   pytestFlagsArray = [ "tests.py" ];
 

--- a/pkgs/development/python-modules/batchspawner/default.nix
+++ b/pkgs/development/python-modules/batchspawner/default.nix
@@ -8,6 +8,7 @@
   jupyterhub,
   pythonOlder,
   pytest-asyncio,
+  pytest-cov-stub,
   pytestCheckHook,
 }:
 
@@ -35,13 +36,9 @@ buildPythonPackage rec {
     jupyterhub
   ];
 
-  preCheck = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "--cov=batchspawner" ""
-  '';
-
   nativeCheckInputs = [
     pytest-asyncio
+    pytest-cov-stub
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/birch/default.nix
+++ b/pkgs/development/python-modules/birch/default.nix
@@ -6,6 +6,7 @@
   setuptools,
   strct,
   pytestCheckHook,
+  pytest-cov-stub,
   pyyaml,
 }:
 
@@ -31,11 +32,6 @@ buildPythonPackage rec {
   ];
 
   postPatch = ''
-    substituteInPlace pytest.ini \
-      --replace-fail  \
-        "--cov" \
-        "#--cov"
-
     # configure correct version, which fails due to missing .git
     substituteInPlace versioneer.py birch/_version.py \
       --replace-fail '"0+unknown"' '"${version}"'
@@ -54,6 +50,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+    pytest-cov-stub
     pyyaml
   ];
 

--- a/pkgs/development/python-modules/cachier/default.nix
+++ b/pkgs/development/python-modules/cachier/default.nix
@@ -7,6 +7,7 @@
   watchdog,
   portalocker,
   pytestCheckHook,
+  pytest-cov-stub,
   pymongo,
   dnspython,
   pymongo-inmemory,
@@ -39,15 +40,9 @@ buildPythonPackage rec {
     portalocker
   ];
 
-  preCheck = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail  \
-        '"--cov' \
-        '#"--cov'
-  '';
-
   nativeCheckInputs = [
     pytestCheckHook
+    pytest-cov-stub
     pymongo
     dnspython
     pymongo-inmemory

--- a/pkgs/development/python-modules/cemm/default.nix
+++ b/pkgs/development/python-modules/cemm/default.nix
@@ -7,6 +7,7 @@
   fetchpatch,
   poetry-core,
   pytest-asyncio,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
   yarl,
@@ -37,8 +38,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace '"0.0.0"' '"${version}"' \
-      --replace 'addopts = "--cov"' ""
+      --replace '"0.0.0"' '"${version}"'
   '';
 
   nativeBuildInputs = [ poetry-core ];
@@ -53,6 +53,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     aresponses
     pytest-asyncio
+    pytest-cov-stub
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/githubkit/default.nix
+++ b/pkgs/development/python-modules/githubkit/default.nix
@@ -8,6 +8,7 @@
   poetry-core,
   pydantic,
   pyjwt,
+  pytest-cov-stub,
   pytest-xdist,
   pytestCheckHook,
   pythonOlder,
@@ -27,11 +28,6 @@ buildPythonPackage rec {
     rev = "refs/tags/v${version}";
     hash = "sha256-bh01m/L1ubQGc4EoHw8If/6yF64M5CsifSwVezZjFDQ=";
   };
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "--cov=githubkit --cov-append --cov-report=term-missing" ""
-  '';
 
   pythonRelaxDeps = [ "hishel" ];
 
@@ -61,6 +57,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+    pytest-cov-stub
     pytest-xdist
   ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
 

--- a/pkgs/development/python-modules/hickle/default.nix
+++ b/pkgs/development/python-modules/hickle/default.nix
@@ -10,6 +10,7 @@
   scipy,
   pandas,
   pytestCheckHook,
+  pytest-cov-stub,
   setuptools,
 }:
 
@@ -25,11 +26,6 @@ buildPythonPackage rec {
     hash = "sha256-An5RzK0nnRaBI6JEUl5shLrA22RgWzEbC9NJiRvgxT4=";
   };
 
-  postPatch = ''
-    substituteInPlace tox.ini \
-      --replace-fail "--cov=./hickle" ""
-  '';
-
   build-system = [ setuptools ];
 
   dependencies = [
@@ -42,6 +38,7 @@ buildPythonPackage rec {
     astropy
     pandas
     pytestCheckHook
+    pytest-cov-stub
     scipy
   ];
 

--- a/pkgs/development/python-modules/oauthenticator/default.nix
+++ b/pkgs/development/python-modules/oauthenticator/default.nix
@@ -10,6 +10,7 @@
   mwoauth,
   pyjwt,
   pytest-asyncio,
+  pytest-cov-stub,
   pytestCheckHook,
   requests,
   requests-mock,
@@ -30,11 +31,6 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-gFhhOCcmorkrLxrup9fICh5ueCrc64fxfuZXTQG1tMk=";
   };
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail " --cov=oauthenticator" ""
-  '';
 
   build-system = [ setuptools ];
 
@@ -58,6 +54,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytest-asyncio
+    pytest-cov-stub
     pytestCheckHook
     requests-mock
   ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);

--- a/pkgs/development/python-modules/pymarshal/default.nix
+++ b/pkgs/development/python-modules/pymarshal/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   bson,
   pytestCheckHook,
+  pytest-cov-stub,
   pyyaml,
   setuptools,
 }:
@@ -23,8 +24,6 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace setup.py \
       --replace "'pytest-runner'" ""
-    substituteInPlace setup.cfg \
-      --replace "--cov=pymarshal --cov-report=html --cov-report=term" ""
   '';
 
   nativeBuildInputs = [ setuptools ];
@@ -33,6 +32,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+    pytest-cov-stub
     bson
     pyyaml
   ];

--- a/pkgs/development/python-modules/pytest-postgresql/default.nix
+++ b/pkgs/development/python-modules/pytest-postgresql/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   pythonOlder,
   pytestCheckHook,
+  pytest-cov-stub,
   setuptools,
   mirakuru,
   port-for,
@@ -28,7 +29,6 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml  \
-      --replace-fail "--cov" ""  \
       --replace-fail "--max-worker-restart=0" ""
     sed -i 's#/usr/lib/postgresql/.*/bin/pg_ctl#${postgresql}/bin/pg_ctl#' pytest_postgresql/plugin.py
   '';
@@ -45,6 +45,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     postgresql
     pytestCheckHook
+    pytest-cov-stub
   ];
   pytestFlagsArray = [
     "-p"

--- a/pkgs/development/python-modules/toggl-cli/default.nix
+++ b/pkgs/development/python-modules/toggl-cli/default.nix
@@ -13,6 +13,7 @@
   prettytable,
   pytest-mock,
   pytestCheckHook,
+  pytest-cov-stub,
   pythonOlder,
   requests,
   setuptools,
@@ -37,7 +38,7 @@ buildPythonPackage rec {
     substituteInPlace requirements.txt \
       --replace-fail "==" ">="
     substituteInPlace pytest.ini \
-      --replace ' --cov toggl -m "not premium"' ""
+      --replace ' -m "not premium"' ""
   '';
 
   build-system = [
@@ -60,6 +61,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+    pytest-cov-stub
     pytest-mock
     faker
     factory-boy


### PR DESCRIPTION
## Description of changes

Migrating a couple of leaf packages to use the new pytest-cov-stub (https://github.com/NixOS/nixpkgs/pull/328550)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
