### PR TITLE
python3Packages.nifty8: init at 8.5.2

### DIFF
--- a/pkgs/development/python-modules/nifty8/default.nix
+++ b/pkgs/development/python-modules/nifty8/default.nix
@@ -1,0 +1,86 @@
+{
+  config,
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitLab,
+
+  cudaSupport ? config.cudaSupport,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  astropy,
+  ducc0,
+  h5py,
+  jax,
+  jaxlib,
+  matplotlib,
+  mpi,
+  mpi4py,
+  numpy,
+  scipy,
+
+  # test
+  pytestCheckHook,
+  mpiCheckPhaseHook,
+  openssh,
+}:
+
+buildPythonPackage rec {
+  pname = "nifty8";
+  version = "8.5.2";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    domain = "gitlab.mpcdf.mpg.de";
+    owner = "ift";
+    repo = "nifty";
+    rev = "v${version}";
+    hash = "sha256-EWsJX+iqKOhQXEWlQfYUiPYqyfOfrwLtbI+DVn7vCQI=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    astropy
+    ducc0
+    h5py
+    jax
+    (jaxlib.override { inherit cudaSupport; })
+    matplotlib
+    mpi4py
+    mpi
+    numpy
+    scipy
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    mpiCheckPhaseHook
+    openssh
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    python3 -m pytest test
+
+    if [ "${stdenv.buildPlatform.system}" != "aarch64-linux" ] && \
+       [ "${stdenv.buildPlatform.system}" != "x86_64-darwin" ]; then
+    ${mpi}/bin/mpiexec -n 2 --bind-to none python3 -m pytest test/test_mpi
+    fi
+
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [ "nifty8" ];
+
+  meta = {
+    homepage = "https://gitlab.mpcdf.mpg.de/ift/nifty";
+    description = "Bayesian Imaging library for high-dimensional posteriors";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ parras ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9118,6 +9118,8 @@ self: super: with self; {
 
   nidaqmx = callPackage ../development/python-modules/nidaqmx { };
 
+  nifty8 = callPackage ../development/python-modules/nifty8 { };
+
   nikola = callPackage ../development/python-modules/nikola { };
 
   niko-home-control = callPackage ../development/python-modules/niko-home-control { };


### PR DESCRIPTION
## Description of changes

NIFTy8 (https://gitlab.mpcdf.mpg.de/ift/nifty) is a Bayesian imaging library.
It is designed to infer the million to billion dimensional posterior distribution in the image space from noisy input data.
At the core of NIFTy lies a set of powerful Gaussian Process (GP) models and accurate Variational Inference (VI) algorithms.

It has been consistently in development for over a decade and is relied upon by scientists.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
