### PR TITLE
python312Packages.ffmpy: 0.3.2 -> 0.4.0

### DIFF
--- a/pkgs/development/python-modules/ffmpy/default.nix
+++ b/pkgs/development/python-modules/ffmpy/default.nix
@@ -4,7 +4,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
-  setuptools,
+  poetry-core,
   pytestCheckHook,
   go,
   ffmpeg-headless,
@@ -12,22 +12,24 @@
 
 buildPythonPackage rec {
   pname = "ffmpy";
-  version = "0.3.2";
+  version = "0.4.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.8.1";
 
   src = fetchFromGitHub {
     owner = "Ch00k";
     repo = "ffmpy";
     rev = "refs/tags/${version}";
-    hash = "sha256-q41JjAWcIiD2nJck5Zzb/lhfIZ3xJGU1I2crsMN0T8Q=";
+    hash = "sha256-XWI0Hq4vf9Q0/dRzmu1B7EQHdQRkWaNJaBaqusWW7YM=";
   };
 
   postPatch = ''
     # default to store ffmpeg
     substituteInPlace ffmpy.py \
-      --replace-fail 'executable="ffmpeg",' 'executable="${ffmpeg-headless}/bin/ffmpeg",'
+      --replace-fail \
+        'executable: str = "ffmpeg",' \
+        'executable: str = "${ffmpeg-headless}/bin/ffmpeg",'
 
     #  The tests test a mock that does not behave like ffmpeg. If we default to the nix-store ffmpeg they fail.
     for fname in tests/*.py; do
@@ -37,7 +39,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "ffmpy" ];
 
-  nativeBuildInputs = [ setuptools ];
+  nativeBuildInputs = [ poetry-core ];
 
   nativeCheckInputs = [
     pytestCheckHook
@@ -52,8 +54,8 @@ buildPythonPackage rec {
   # the vendored ffmpeg mock binary assumes FHS
   preCheck = ''
     rm -v tests/ffmpeg/ffmpeg
-    HOME=$(mktemp -d) go build -o ffmpeg tests/ffmpeg/ffmpeg.go
-    export PATH=".:$PATH"
+    echo Building tests/ffmpeg/ffmpeg...
+    HOME=$(mktemp -d) go build -o tests/ffmpeg/ffmpeg tests/ffmpeg/ffmpeg.go
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Diff: https://github.com/Ch00k/ffmpy/compare/refs/tags/0.3.2...0.4.0

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
