### PR TITLE
elfutils: fix header colliding with binary in llvm

### DIFF
--- a/pkgs/development/tools/misc/elfutils/cxx-header-collision.patch
+++ b/pkgs/development/tools/misc/elfutils/cxx-header-collision.patch
@@ -1,0 +1,331 @@
+From: Tristan Ross <tristan.ross@midstall.com>
+Date: Wed, 31 Jul 2024 04:03:03 +0000 (-0700)
+Subject: Prevent binaries in src from colliding with libc++ headers
+X-Git-Url: https://sourceware.org/git/?p=elfutils.git;a=commitdiff_plain;h=232b9ede92cbecabbd61291c2fc9aaf3fc61061f;hp=87a60d22299c4ba7b94cbce04a32c2abf015f98a
+
+Prevent binaries in src from colliding with libc++ headers
+
+Discovered with Nix and LLVM 17. Headers inside of libc++ can easily
+collide with binaries being linked in src. This results in clang trying
+to include a binary as a header.
+
+Fix this by removing '-I.' and '-I$(srcdir)' from AM_CPPFLAGS and
+DEFAULT_INCLUDES in src/Makefile.am.
+
+To facilitate this config/eu.am has been refactored.  New file
+config/eu-common.am contains all of the old eu.am but with the
+AM_CPPFLAGS definition removed. eu.am now includes eu-common.am and
+contains the old AM_CPPFLAGS definition.
+
+eu.am functionality does not change, but src/Makefile.am can instead
+include eu-common.am and define its own AM_CPPFLAGS without causing a
+"multiply defined" warning during autoreconf.
+
+Signed-off-by: Tristan Ross <tristan.ross@midstall.com>
+---
+
+diff --git a/config/eu-common.am b/config/eu-common.am
+new file mode 100644
+index 000000000..9cc7f6969
+--- /dev/null
++++ b/config/eu-common.am
+@@ -0,0 +1,148 @@
++## Common automake fragments for elfutils subdirectory makefiles.
++##
++## Copyright (C) 2010, 2014, 2016 Red Hat, Inc.
++## Copyright (C) 2023, Mark J. Wielaard <mark@klomp.org>
++##
++## This file is part of elfutils.
++##
++## This file is free software; you can redistribute it and/or modify
++## it under the terms of either
++##
++##   * the GNU Lesser General Public License as published by the Free
++##     Software Foundation; either version 3 of the License, or (at
++##     your option) any later version
++##
++## or
++##
++##   * the GNU General Public License as published by the Free
++##     Software Foundation; either version 2 of the License, or (at
++##     your option) any later version
++##
++## or both in parallel, as here.
++##
++## elfutils is distributed in the hope that it will be useful, but
++## WITHOUT ANY WARRANTY; without even the implied warranty of
++## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++## General Public License for more details.
++##
++## You should have received copies of the GNU General Public License and
++## the GNU Lesser General Public License along with this program.  If
++## not, see <http://www.gnu.org/licenses/>.
++##
++
++DEFS = -D_GNU_SOURCE -DHAVE_CONFIG_H -DLOCALEDIR='"${localedir}"'
++
++# Drop the 'u' flag that automake adds by default. It is incompatible
++# with deterministic archives.
++ARFLAGS = cr
++
++# Warn about stack usage of more than 256K = 262144 bytes.
++if ADD_STACK_USAGE_WARNING
++STACK_USAGE_WARNING=-Wstack-usage=262144
++STACK_USAGE_NO_ERROR=-Wno-error=stack-usage=
++else
++STACK_USAGE_WARNING=
++STACK_USAGE_NO_ERROR=
++endif
++
++if SANE_LOGICAL_OP_WARNING
++LOGICAL_OP_WARNING=-Wlogical-op
++else
++LOGICAL_OP_WARNING=
++endif
++
++if HAVE_DUPLICATED_COND_WARNING
++DUPLICATED_COND_WARNING=-Wduplicated-cond
++else
++DUPLICATED_COND_WARNING=
++endif
++
++if HAVE_NULL_DEREFERENCE_WARNING
++NULL_DEREFERENCE_WARNING=-Wnull-dereference
++else
++NULL_DEREFERENCE_WARNING=
++endif
++
++if HAVE_IMPLICIT_FALLTHROUGH_WARNING
++# Use strict fallthrough. Only __attribute__((fallthrough)) will prevent the
++# warning
++if HAVE_IMPLICIT_FALLTHROUGH_5_WARNING
++IMPLICIT_FALLTHROUGH_WARNING=-Wimplicit-fallthrough=5
++else
++IMPLICIT_FALLTHROUGH_WARNING=-Wimplicit-fallthrough
++endif
++else
++IMPLICIT_FALLTHROUGH_WARNING=
++endif
++
++if HAVE_TRAMPOLINES_WARNING
++TRAMPOLINES_WARNING=-Wtrampolines
++else
++TRAMPOLINES_WARNING=
++endif
++
++if HAVE_NO_PACKED_NOT_ALIGNED_WARNING
++NO_PACKED_NOT_ALIGNED_WARNING=-Wno-packed-not-aligned
++else
++NO_PACKED_NOT_ALIGNED_WARNING=
++endif
++
++if HAVE_USE_AFTER_FREE3_WARNING
++USE_AFTER_FREE3_WARNING=-Wuse-after-free=3
++else
++USE_AFTER_FREE3_WARNING=
++endif
++
++AM_CFLAGS = -std=gnu99 -Wall -Wshadow -Wformat=2 \
++	    -Wold-style-definition -Wstrict-prototypes $(TRAMPOLINES_WARNING) \
++	    $(LOGICAL_OP_WARNING) $(DUPLICATED_COND_WARNING) \
++	    $(NULL_DEREFERENCE_WARNING) $(IMPLICIT_FALLTHROUGH_WARNING) \
++	    $(USE_AFTER_FREE3_WARNING) \
++	    $(if $($(*F)_no_Werror),,-Werror) \
++	    $(if $($(*F)_no_Wunused),,-Wunused -Wextra) \
++	    $(if $($(*F)_no_Wstack_usage),,$(STACK_USAGE_WARNING)) \
++	    $(if $($(*F)_no_Wpacked_not_aligned),$(NO_PACKED_NOT_ALIGNED_WARNING),) \
++	    $($(*F)_CFLAGS)
++
++AM_CXXFLAGS = -std=c++11 -Wall -Wshadow \
++	   $(TRAMPOLINES_WARNING) \
++	   $(LOGICAL_OP_WARNING) $(DUPLICATED_COND_WARNING) \
++	   $(NULL_DEREFERENCE_WARNING) $(IMPLICIT_FALLTHROUGH_WARNING) \
++	   $(if $($(*F)_no_Werror),,-Werror) \
++	   $(if $($(*F)_no_Wunused),,-Wunused -Wextra) \
++	   $(if $($(*F)_no_Wstack_usage),,$(STACK_USAGE_WARNING)) \
++	   $(if $($(*F)_no_Wpacked_not_aligned),$(NO_PACKED_NOT_ALIGNED_WARNING),) \
++	   $($(*F)_CXXFLAGS)
++
++COMPILE.os = $(filter-out -fprofile-arcs -ftest-coverage, $(COMPILE))
++
++DEFS.os = -DPIC -DSHARED
++if SYMBOL_VERSIONING
++DEFS.os += -DSYMBOL_VERSIONING
++else
++endif
++
++%.os: %.c %.o
++if AMDEP
++	$(AM_V_CC)if $(COMPILE.os) -c -o $@ $(fpic_CFLAGS) $(DEFS.os) -MT $@ -MD -MP \
++	  -MF "$(DEPDIR)/$*.Tpo" `test -f '$<' || echo '$(srcdir)/'`$<; \
++	then cat "$(DEPDIR)/$*.Tpo" >> "$(DEPDIR)/$*.Po"; \
++	     rm -f "$(DEPDIR)/$*.Tpo"; \
++	else rm -f "$(DEPDIR)/$*.Tpo"; exit 1; \
++	fi
++else
++	$(AM_V_CC)$(COMPILE.os) -c -o $@ $(fpic_CFLAGS) $(DEFS.os) $<
++endif
++
++CLEANFILES = *.gcno *.gcda
++
++textrel_msg = echo "WARNING: TEXTREL found in '$@'"
++if FATAL_TEXTREL
++textrel_found = $(textrel_msg); exit 1
++else
++textrel_found = $(textrel_msg)
++endif
++textrel_check = if $(READELF) -d $@ | grep -F -q TEXTREL; then $(textrel_found); fi
++
++print-%:
++	@echo $*=$($*)
+diff --git a/config/eu.am b/config/eu.am
+index e6c241f9d..3aa6048aa 100644
+--- a/config/eu.am
++++ b/config/eu.am
+@@ -1,4 +1,5 @@
+-## Common automake fragments for elfutils subdirectory makefiles.
++## Common automake fragments for elfutils subdirectory makefiles
++## with AM_CPPFLAGS set.
+ ##
+ ## Copyright (C) 2010, 2014, 2016 Red Hat, Inc.
+ ## Copyright (C) 2023, Mark J. Wielaard <mark@klomp.org>
+@@ -30,120 +31,5 @@
+ ## not, see <http://www.gnu.org/licenses/>.
+ ##
+ 
+-DEFS = -D_GNU_SOURCE -DHAVE_CONFIG_H -DLOCALEDIR='"${localedir}"'
+ AM_CPPFLAGS = -I. -I$(srcdir) -I$(top_srcdir)/lib -I..
+-
+-# Drop the 'u' flag that automake adds by default. It is incompatible
+-# with deterministic archives.
+-ARFLAGS = cr
+-
+-# Warn about stack usage of more than 256K = 262144 bytes.
+-if ADD_STACK_USAGE_WARNING
+-STACK_USAGE_WARNING=-Wstack-usage=262144
+-STACK_USAGE_NO_ERROR=-Wno-error=stack-usage=
+-else
+-STACK_USAGE_WARNING=
+-STACK_USAGE_NO_ERROR=
+-endif
+-
+-if SANE_LOGICAL_OP_WARNING
+-LOGICAL_OP_WARNING=-Wlogical-op
+-else
+-LOGICAL_OP_WARNING=
+-endif
+-
+-if HAVE_DUPLICATED_COND_WARNING
+-DUPLICATED_COND_WARNING=-Wduplicated-cond
+-else
+-DUPLICATED_COND_WARNING=
+-endif
+-
+-if HAVE_NULL_DEREFERENCE_WARNING
+-NULL_DEREFERENCE_WARNING=-Wnull-dereference
+-else
+-NULL_DEREFERENCE_WARNING=
+-endif
+-
+-if HAVE_IMPLICIT_FALLTHROUGH_WARNING
+-# Use strict fallthrough. Only __attribute__((fallthrough)) will prevent the
+-# warning
+-if HAVE_IMPLICIT_FALLTHROUGH_5_WARNING
+-IMPLICIT_FALLTHROUGH_WARNING=-Wimplicit-fallthrough=5
+-else
+-IMPLICIT_FALLTHROUGH_WARNING=-Wimplicit-fallthrough
+-endif
+-else
+-IMPLICIT_FALLTHROUGH_WARNING=
+-endif
+-
+-if HAVE_TRAMPOLINES_WARNING
+-TRAMPOLINES_WARNING=-Wtrampolines
+-else
+-TRAMPOLINES_WARNING=
+-endif
+-
+-if HAVE_NO_PACKED_NOT_ALIGNED_WARNING
+-NO_PACKED_NOT_ALIGNED_WARNING=-Wno-packed-not-aligned
+-else
+-NO_PACKED_NOT_ALIGNED_WARNING=
+-endif
+-
+-if HAVE_USE_AFTER_FREE3_WARNING
+-USE_AFTER_FREE3_WARNING=-Wuse-after-free=3
+-else
+-USE_AFTER_FREE3_WARNING=
+-endif
+-
+-AM_CFLAGS = -std=gnu99 -Wall -Wshadow -Wformat=2 \
+-	    -Wold-style-definition -Wstrict-prototypes $(TRAMPOLINES_WARNING) \
+-	    $(LOGICAL_OP_WARNING) $(DUPLICATED_COND_WARNING) \
+-	    $(NULL_DEREFERENCE_WARNING) $(IMPLICIT_FALLTHROUGH_WARNING) \
+-	    $(USE_AFTER_FREE3_WARNING) \
+-	    $(if $($(*F)_no_Werror),,-Werror) \
+-	    $(if $($(*F)_no_Wunused),,-Wunused -Wextra) \
+-	    $(if $($(*F)_no_Wstack_usage),,$(STACK_USAGE_WARNING)) \
+-	    $(if $($(*F)_no_Wpacked_not_aligned),$(NO_PACKED_NOT_ALIGNED_WARNING),) \
+-	    $($(*F)_CFLAGS)
+-
+-AM_CXXFLAGS = -std=c++11 -Wall -Wshadow \
+-	   $(TRAMPOLINES_WARNING) \
+-	   $(LOGICAL_OP_WARNING) $(DUPLICATED_COND_WARNING) \
+-	   $(NULL_DEREFERENCE_WARNING) $(IMPLICIT_FALLTHROUGH_WARNING) \
+-	   $(if $($(*F)_no_Werror),,-Werror) \
+-	   $(if $($(*F)_no_Wunused),,-Wunused -Wextra) \
+-	   $(if $($(*F)_no_Wstack_usage),,$(STACK_USAGE_WARNING)) \
+-	   $(if $($(*F)_no_Wpacked_not_aligned),$(NO_PACKED_NOT_ALIGNED_WARNING),) \
+-	   $($(*F)_CXXFLAGS)
+-
+-COMPILE.os = $(filter-out -fprofile-arcs -ftest-coverage, $(COMPILE))
+-
+-DEFS.os = -DPIC -DSHARED
+-if SYMBOL_VERSIONING
+-DEFS.os += -DSYMBOL_VERSIONING
+-else
+-endif
+-
+-%.os: %.c %.o
+-if AMDEP
+-	$(AM_V_CC)if $(COMPILE.os) -c -o $@ $(fpic_CFLAGS) $(DEFS.os) -MT $@ -MD -MP \
+-	  -MF "$(DEPDIR)/$*.Tpo" `test -f '$<' || echo '$(srcdir)/'`$<; \
+-	then cat "$(DEPDIR)/$*.Tpo" >> "$(DEPDIR)/$*.Po"; \
+-	     rm -f "$(DEPDIR)/$*.Tpo"; \
+-	else rm -f "$(DEPDIR)/$*.Tpo"; exit 1; \
+-	fi
+-else
+-	$(AM_V_CC)$(COMPILE.os) -c -o $@ $(fpic_CFLAGS) $(DEFS.os) $<
+-endif
+-
+-CLEANFILES = *.gcno *.gcda
+-
+-textrel_msg = echo "WARNING: TEXTREL found in '$@'"
+-if FATAL_TEXTREL
+-textrel_found = $(textrel_msg); exit 1
+-else
+-textrel_found = $(textrel_msg)
+-endif
+-textrel_check = if $(READELF) -d $@ | grep -F -q TEXTREL; then $(textrel_found); fi
+-
+-print-%:
+-	@echo $*=$($*)
++include $(top_srcdir)/config/eu-common.am
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 1d592d4de..5fcebc21d 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -16,10 +16,12 @@
+ ## You should have received a copy of the GNU General Public License
+ ## along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ##
+-include $(top_srcdir)/config/eu.am
++include $(top_srcdir)/config/eu-common.am
+ DEFS += $(YYDEBUG) -DDEBUGPRED=@DEBUGPRED@ \
+ 	-DSRCDIR=\"$(shell cd $(srcdir);pwd)\" -DOBJDIR=\"$(shell pwd)\"
+-AM_CPPFLAGS += -I$(srcdir)/../libelf -I$(srcdir)/../libebl \
++DEFAULT_INCLUDES = -I$(top_builddir)
++AM_CPPFLAGS = -I$(top_srcdir)/lib -I.. \
++	    -I$(srcdir)/../libelf -I$(srcdir)/../libebl \
+ 	    -I$(srcdir)/../libdw -I$(srcdir)/../libdwelf \
+ 	    -I$(srcdir)/../libdwfl -I$(srcdir)/../libasm -I../debuginfod


### PR DESCRIPTION
## Description of changes

`stack` in `src` can collide with a header in libc++.

```
  CCLD     nm
  CCLD     ar
  CCLD     elfcompress
  CCLD     strip
  CCLD     unstrip
In file included from srcfiles.cxx:50:
In file included from /nix/store/649b79xp5hfmjc5a5xwq7nxw8lrwjs5y-libcxx-aarch64-unknown-linux-gnu-18.1.8-dev/include/c++/v1/iostream:44:
In file included from /nix/store/649b79xp5hfmjc5a5xwq7nxw8lrwjs5y-libcxx-aarch64-unknown-linux-gnu-18.1.8-dev/include/c++/v1/istream:170:
In file included from /nix/store/649b79xp5hfmjc5a5xwq7nxw8lrwjs5y-libcxx-aarch64-unknown-linux-gnu-18.1.8-dev/include/c++/v1/ostream:189:
In file included from /nix/store/649b79xp5hfmjc5a5xwq7nxw8lrwjs5y-libcxx-aarch64-unknown-linux-gnu-18.1.8-dev/include/c++/v1/format:195:
In file included from /nix/store/649b79xp5hfmjc5a5xwq7nxw8lrwjs5y-libcxx-aarch64-unknown-linux-gnu-18.1.8-dev/include/c++/v1/__format/container_adaptor.h:25:
./stack:1:1: error: expected unqualified-id
```

Patch will be upstreamed.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates)  Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
