### PR TITLE
ocamlPackages.algaeff: 1.1.0 → 2.0.0; asai: 0.1.1 → 0.3.0; yuujinchou: 5.1.0 → 5.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/algaeff/default.nix
+++ b/pkgs/development/ocaml-modules/algaeff/default.nix
@@ -7,7 +7,7 @@
 
 buildDunePackage rec {
   pname = "algaeff";
-  version = "1.1.0";
+  version = "2.0.0";
 
   minimalOCamlVersion = "5.0";
 
@@ -15,7 +15,7 @@ buildDunePackage rec {
     owner = "RedPRL";
     repo = pname;
     rev = version;
-    hash = "sha256-7kwQmoT8rpQWPHc+BZQi9fcZhgHxS99158ebXAXlpQ8=";
+    hash = "sha256-VRZfULbXKRcExU1bnEu/X1KPX+L+dzcRYZVD985rQT4=";
   };
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/asai/default.nix
+++ b/pkgs/development/ocaml-modules/asai/default.nix
@@ -1,29 +1,21 @@
 { lib, fetchFromGitHub, buildDunePackage
 , algaeff
 , bwd
-, eio
-, eio_main
-, lsp
-, notty
 }:
 
 buildDunePackage rec {
   pname = "asai";
-  version = "0.1.1";
+  version = "0.3.0";
   src = fetchFromGitHub {
     owner = "RedPRL";
     repo = pname;
     rev = version;
-    hash = "sha256-Jd90WhSjK4K2amFA5uyGF57NzsgHA8QiccX6qtxO1rQ=";
+    hash = "sha256-Rp4TvSbRz+5+X4XJ1tKUDDgldpLzHHtaF7G7AG6HgKU=";
   };
 
   propagatedBuildInputs = [
     algaeff
     bwd
-    lsp
-    eio
-    eio_main
-    notty
   ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/yuujinchou/default.nix
+++ b/pkgs/development/ocaml-modules/yuujinchou/default.nix
@@ -4,8 +4,8 @@
 }:
 
 let params = if lib.versionAtLeast ocaml.version "5.0" then {
-    version = "5.1.0";
-    hash = "sha256-J3qkytgJkk2gT83KJ47nNM4cXqVHbx4iTPK+fLwR7Wk=";
+    version = "5.2.0";
+    hash = "sha256-DJzXjV5Tjf69FKUiRioeHghks72pOOHYd73vqhmecS8=";
     propagatedBuildInputs = [ algaeff bwd ];
   } else {
     version = "2.0.0";


### PR DESCRIPTION
## Description of changes

https://raw.githubusercontent.com/RedPRL/algaeff/2.0.0/CHANGELOG.markdown
https://raw.githubusercontent.com/RedPRL/asai/0.3.0/CHANGELOG.markdown
https://raw.githubusercontent.com/RedPRL/yuujinchou/5.2.0/CHANGELOG.markdown

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
