### PR TITLE
nix-serve: 0.2-e4675e3 -> unstable-2024-04-08

### DIFF
--- a/pkgs/tools/package-management/nix-serve/default.nix
+++ b/pkgs/tools/package-management/nix-serve/default.nix
@@ -3,24 +3,21 @@
 , fetchFromGitHub
 , bzip2
 , nix
+, nixVersions
 , perl
 , makeWrapper
 , nixosTests
 }:
 
-let
-  rev = "e4675e38ab54942e351c7686e40fabec822120b9";
-  sha256 = "1wm24p6pkxl1d7hrvf4ph6mwzawvqi22c60z9xzndn5xfyr4v0yr";
-in
-
 stdenv.mkDerivation {
   pname = "nix-serve";
-  version = "0.2-${lib.substring 0 7 rev}";
+  version = "0.2.0-unstable-2024-04-08";
 
   src = fetchFromGitHub {
     owner = "edolstra";
     repo = "nix-serve";
-    inherit rev sha256;
+    rev = "4a12660e6fa8fce662c0a652280a3309fa822465";
+    hash = "sha256-N7MK+m7hP34ALPy2tKgfPmz+uj/pkbh1Wq771BMHAfI=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -31,8 +28,8 @@ stdenv.mkDerivation {
     install -Dm0755 nix-serve.psgi $out/libexec/nix-serve/nix-serve.psgi
 
     makeWrapper ${perl.withPackages(p: [ p.DBDSQLite p.Plack p.Starman nix.perl-bindings ])}/bin/starman $out/bin/nix-serve \
-                --prefix PATH : "${lib.makeBinPath [ bzip2 nix ]}" \
-                --add-flags $out/libexec/nix-serve/nix-serve.psgi
+      --prefix PATH : "${lib.makeBinPath [ bzip2 nixVersions.nix_2_3 ]}" \
+      --add-flags $out/libexec/nix-serve/nix-serve.psgi
   '';
 
   passthru.tests = {


### PR DESCRIPTION
The current version in nixpkgs is from 2018, and there's been a lot of fixes and features since then.

Passthru tests failed, as nix-serve seems to be shelling out to a `nix-command` which needs an explicitly enabled since some Nix versions:

```
machine # [    5.920336] nix-serve-start[840]: error: experimental Nix feature 'nix-command' is disabled; use '--extra-experimental-features nix-command' to override
```

Rather than patching this, I fixed it by giving nix-serve a Nix binary in $PATH that doesn't require that - while keeping the nix.perlBindings.

The passthru tests now succeed.

Closes #219337.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
