### PR TITLE
pythonPackages.cron-descriptor: update, add pypaHooks, drop "setup.py test"

### DIFF
--- a/pkgs/development/python-modules/cron-descriptor/default.nix
+++ b/pkgs/development/python-modules/cron-descriptor/default.nix
@@ -1,8 +1,8 @@
 {
   lib,
-  python,
   fetchFromGitHub,
   buildPythonPackage,
+  unittestCheckHook,
   mock,
   setuptools,
 }:
@@ -25,11 +25,11 @@ buildPythonPackage rec {
   '';
 
   build-system = [ setuptools ];
-  checkInputs = [ mock ];
 
-  checkPhase = ''
-    ${python.interpreter} setup.py test
-  '';
+  nativeCheckInputs = [
+    mock
+    unittestCheckHook
+  ];
 
   pythonImportsCheck = [ "cron_descriptor" ];
 

--- a/pkgs/development/python-modules/cron-descriptor/default.nix
+++ b/pkgs/development/python-modules/cron-descriptor/default.nix
@@ -8,7 +8,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "cron_descriptor";
+  pname = "cron-descriptor";
   version = "1.4.3";
   pyproject = true;
 

--- a/pkgs/development/python-modules/cron-descriptor/default.nix
+++ b/pkgs/development/python-modules/cron-descriptor/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage rec {
   pname = "cron_descriptor";
-  version = "1.4";
+  version = "1.4.3";
 
   src = fetchFromGitHub {
     owner = "Salamek";
     repo = "cron-descriptor";
     rev = "refs/tags/${version}";
-    hash = "sha256-r5TMatjNYaPhPxhJbBGGshQf6VxKyBV6Za1lQoblxYA=";
+    hash = "sha256-Bvg2diheQihhiCVJjHqdFxbatb/gXS/aRogpzhIproE=";
   };
 
   # remove tests_require, as we don't do linting anyways

--- a/pkgs/development/python-modules/cron-descriptor/default.nix
+++ b/pkgs/development/python-modules/cron-descriptor/default.nix
@@ -1,14 +1,16 @@
 {
   lib,
   python,
-  buildPythonPackage,
   fetchFromGitHub,
+  buildPythonPackage,
   mock,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "cron_descriptor";
   version = "1.4.3";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Salamek";
@@ -22,6 +24,7 @@ buildPythonPackage rec {
     sed -i "/'pep8\|flake8\|pep8-naming',/d" setup.py
   '';
 
+  build-system = [ setuptools ];
   checkInputs = [ mock ];
 
   checkPhase = ''


### PR DESCRIPTION
## Description of changes

The test runner needed to be changed because of https://github.com/NixOS/nixpkgs/issues/331159, which made me notice that there was a new release and that we could seize the opportunity to opt in to pypaHooks here.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
