### PR TITLE
djangorestframework: 3.15.1 -> 3.15.2, add support for django 5

### DIFF
--- a/pkgs/development/python-modules/django-filter/default.nix
+++ b/pkgs/development/python-modules/django-filter/default.nix
@@ -7,6 +7,7 @@
   djangorestframework,
   pytestCheckHook,
   pytest-django,
+  pytz,
 }:
 
 buildPythonPackage rec {
@@ -29,6 +30,7 @@ buildPythonPackage rec {
     djangorestframework
     pytestCheckHook
     pytest-django
+    pytz
   ];
 
   env.DJANGO_SETTINGS_MODULE = "tests.settings";

--- a/pkgs/development/python-modules/django-timezone-field/default.nix
+++ b/pkgs/development/python-modules/django-timezone-field/default.nix
@@ -9,6 +9,7 @@
   pytestCheckHook,
   pytest-django,
   pytest-lazy-fixture,
+  pytz,
 }:
 
 buildPythonPackage rec {
@@ -43,6 +44,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-django
     pytest-lazy-fixture
+    pytz
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/djangorestframework/default.nix
+++ b/pkgs/development/python-modules/djangorestframework/default.nix
@@ -11,46 +11,56 @@
   django,
   pytz,
 
-  # tests
+  # optional-dependencies
   coreapi,
   coreschema,
   django-guardian,
   inflection,
   psycopg2,
+  pygments,
+  pyyaml,
+
+  # tests
   pytestCheckHook,
   pytest-django,
-  pyyaml,
 }:
 
 buildPythonPackage rec {
   pname = "djangorestframework";
-  version = "3.15.1";
-  format = "setuptools";
+  version = "3.15.2";
+  pyproject = true;
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "encode";
     repo = "django-rest-framework";
     rev = version;
-    hash = "sha256-G914NvxRmKGkxrozoWNUIoI74YkYRbeNcQwIG4iSeXU=";
+    hash = "sha256-ne0sk4m11Ha77tNmCsdhj7QVmCkYj5GjLn/dLF4qxU8=";
   };
 
   build-system = [ setuptools ];
 
-  dependencies = [ django ] ++ (lib.optional (lib.versionOlder django.version "5.0.0") pytz);
+  dependencies = [
+    django
+    pygments
+  ] ++ (lib.optional (lib.versionOlder django.version "5.0.0") pytz);
+
+  optional-dependencies = {
+    complete = [
+      coreapi
+      coreschema
+      django-guardian
+      inflection
+      psycopg2
+      pygments
+      pyyaml
+    ];
+  };
 
   nativeCheckInputs = [
     pytest-django
     pytestCheckHook
-
-    # optional tests
-    coreapi
-    coreschema
-    django-guardian
-    inflection
-    psycopg2
-    pyyaml
-  ];
+  ] ++ optional-dependencies.complete;
 
   disabledTests = [
     # https://github.com/encode/django-rest-framework/issues/9422

--- a/pkgs/development/python-modules/djangorestframework/default.nix
+++ b/pkgs/development/python-modules/djangorestframework/default.nix
@@ -35,14 +35,9 @@ buildPythonPackage rec {
     hash = "sha256-G914NvxRmKGkxrozoWNUIoI74YkYRbeNcQwIG4iSeXU=";
   };
 
-  build-system = [
-    setuptools
-  ];
+  build-system = [ setuptools ];
 
-  dependencies = [
-    django
-    pytz
-  ];
+  dependencies = [ django ] ++ (lib.optional (lib.versionOlder django.version "5.0.0") pytz);
 
   nativeCheckInputs = [
     pytest-django


### PR DESCRIPTION
## Description of changes

The djangorestframework tests failed if built with `django_5`, which we'll need for NetBox 4.0

While at it, I upgraded djangorestframework to 3.15.2

See the commit messages for more details.

Changelog for 3.15.2: https://www.django-rest-framework.org/community/release-notes/#3152

My `test.nix` file to check with `django_5`:

```nix
let
  pkgs = import ./. { };
  py = pkgs.python3.override { packageOverrides = _final: prev: { django = prev.django_5; }; };
in
pkgs.releaseTools.aggregate {
  name = "check";
  constituents = with py.pkgs; [
    djangorestframework
    django-timezone-field
    django-celery-beat
  ];
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc @desiderius as maintainer

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
