### PR TITLE
nixos/mysql: fix permission error during first startup

### DIFF
--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -337,6 +337,12 @@ in
 
     environment.etc."my.cnf".source = cfg.configFile;
 
+    # The mysql_install_db binary will try to adjust the permissions, but fail to do so with a permission
+    # denied error in some circumstances. Setting the permissions manually with tmpfiles is a workaround.
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir} 0755 ${cfg.user} ${cfg.group} - -"
+    ];
+
     systemd.services.mysql = {
       description = "MySQL Server";
 


### PR DESCRIPTION
When mysql starts up for the first time, the binary `mysql_install_db` will run and try to set up the correct folder structure and permissions.

The very first step is to change the owner and group of the data directory. This can fail in some cases, for example if `cfg.dataDir` is something like `/mnt/mysql`:

```
Jul 31 15:24:35 junction systemd[1]: Starting MySQL Server...
Jul 31 15:24:36 junction mysql-pre-start[1346]: chown: changing ownership of '/mnt/mysql': Operation not permitted
Jul 31 15:24:36 junction mysql-pre-start[1309]: Cannot change ownership of the database directories to the 'mysql'
Jul 31 15:24:36 junction mysql-pre-start[1309]: user.  Check that you have the necessary permissions and try again.
Jul 31 15:24:36 junction systemd[1]: mysql.service: Control process exited, code=exited, status=1/FAILURE
Jul 31 15:24:36 junction systemd[1]: mysql.service: Failed with result 'exit-code'.
Jul 31 15:24:36 junction systemd[1]: Failed to start MySQL Server.
```

This is because `/mnt` usually is owned by root.

To work around this issue, use `systemd.tmpfiles` to set the owner, group and permissions. This will always work, and if the permissions are already set as expected, mysql will not try to alter them again.

## Description of changes

* The `mysql` module ensures the permissions of the `dataDir` are set up as expected

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
