### PR TITLE
python312Packages.aiohttp: 3.9.5 -> 3.10.0

### DIFF
--- a/pkgs/development/python-modules/aiohappyeyeballs/default.nix
+++ b/pkgs/development/python-modules/aiohappyeyeballs/default.nix
@@ -60,11 +60,6 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "aiohappyeyeballs" ];
 
-  disabledTestPaths = [
-    # https://github.com/bdraco/aiohappyeyeballs/issues/30
-    "tests/test_impl.py"
-  ];
-
   meta = with lib; {
     description = "Happy Eyeballs for pre-resolved hosts";
     homepage = "https://github.com/bdraco/aiohappyeyeballs";

--- a/pkgs/development/python-modules/aiohttp-fast-url-dispatcher/default.nix
+++ b/pkgs/development/python-modules/aiohttp-fast-url-dispatcher/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "aiohttp-fast-url-dispatcher";
-  version = "0.3.0";
+  version = "0.3.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "bdraco";
     repo = "aiohttp-fast-url-dispatcher";
     rev = "refs/tags/v${version}";
-    hash = "sha256-DZTW9CazcUY3hyxr0MbVfM/yJzUzwN43c2n07Sloxa8=";
+    hash = "sha256-RBS17LhbaAOxFYGjmoEyrq2DCEHeZNpkITPDdCd7Jk0=";
   };
 
   postPatch = ''
@@ -44,7 +44,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Faster URL dispatcher for aiohttp";
     homepage = "https://github.com/bdraco/aiohttp-fast-url-dispatcher";
-    changelog = "https://github.com/bdraco/aiohttp-fast-url-dispatcher/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/bdraco/aiohttp-fast-url-dispatcher/blob/${src.rev}/CHANGELOG.md";
     license = licenses.asl20;
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/aiohttp-fast-url-dispatcher/default.nix
+++ b/pkgs/development/python-modules/aiohttp-fast-url-dispatcher/default.nix
@@ -30,6 +30,8 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ poetry-core ];
 
+  pythonRelaxDeps = [ "aiohttp" ];
+
   propagatedBuildInputs = [ aiohttp ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -11,6 +11,7 @@
   cython,
   setuptools,
   # install_requires
+  aiohappyeyeballs,
   attrs,
   multidict,
   async-timeout,
@@ -22,6 +23,7 @@
   # tests_require
   freezegun,
   gunicorn,
+  proxy-py,
   pytest-mock,
   pytest7CheckHook,
   python-on-whales,
@@ -31,7 +33,7 @@
 
 buildPythonPackage rec {
   pname = "aiohttp";
-  version = "3.9.5";
+  version = "3.10.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -40,7 +42,7 @@ buildPythonPackage rec {
     owner = "aio-libs";
     repo = "aiohttp";
     rev = "refs/tags/v${version}";
-    hash = "sha256-FRtirmwgU8v+ee3db7rOFsmy0rNW8A7+yRZC5d6uYNA=";
+    hash = "sha256-8B5WyG3XUAxjoY08PTbkNM11K/ytlvdplhf2VV+I+JU=";
   };
 
   patches = [
@@ -69,6 +71,7 @@ buildPythonPackage rec {
   '';
 
   dependencies = [
+    aiohappyeyeballs
     attrs
     multidict
     async-timeout
@@ -85,20 +88,16 @@ buildPythonPackage rec {
   '';
 
   # NOTE: pytest-xdist cannot be added because it is flaky. See https://github.com/NixOS/nixpkgs/issues/230597 for more info.
-  nativeCheckInputs =
-    [
-      freezegun
-      gunicorn
-      pytest-mock
-      pytest7CheckHook
-      python-on-whales
-      re-assert
-    ]
-    ++ lib.optionals (!(stdenv.isDarwin && stdenv.isAarch64)) [
-      # Optional test dependency. Depends indirectly on pyopenssl, which is
-      # broken on aarch64-darwin.
-      trustme
-    ];
+  nativeCheckInputs = [
+    freezegun
+    gunicorn
+    proxy-py
+    pytest-mock
+    pytest7CheckHook
+    python-on-whales
+    re-assert
+    trustme
+  ];
 
   disabledTests =
     [
@@ -115,17 +114,15 @@ buildPythonPackage rec {
       "test_close"
     ];
 
-  disabledTestPaths = [
-    "tests/test_proxy_functional.py" # FIXME package proxy.py
-  ];
-
   __darwinAllowLocalNetworking = true;
 
-  # aiohttp in current folder shadows installed version
   preCheck =
     ''
+      # aiohttp in current folder shadows installed version
       rm -r aiohttp
       touch tests/data.unknown_mime_type # has to be modified after 1 Jan 1990
+
+      export HOME=$(mktemp -d)
     ''
     + lib.optionalString stdenv.isDarwin ''
       # Work around "OSError: AF_UNIX path too long"

--- a/pkgs/development/python-modules/async-upnp-client/default.nix
+++ b/pkgs/development/python-modules/async-upnp-client/default.nix
@@ -23,7 +23,7 @@
 
 buildPythonPackage rec {
   pname = "async-upnp-client";
-  version = "0.39.0";
+  version = "0.40.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     owner = "StevenLooman";
     repo = "async_upnp_client";
     rev = "refs/tags/${version}";
-    hash = "sha256-2A46/j6DkZ7rz/B64aBAp0NvRG5TBuL4VwMVS50+fQs=";
+    hash = "sha256-KaX1TNP6IP2wAijR2y9cqI+Pyc+Ygk3LqKwu5Yrv5LM=";
   };
 
   pythonRelaxDeps = [ "defusedxml" ];

--- a/pkgs/development/python-modules/uvloop/default.nix
+++ b/pkgs/development/python-modules/uvloop/default.nix
@@ -15,7 +15,6 @@
   ApplicationServices,
 
   # tests
-  aiohttp,
   psutil,
   pyopenssl,
   pytestCheckHook,
@@ -48,7 +47,6 @@ buildPythonPackage rec {
     ];
 
   nativeCheckInputs = [
-    aiohttp
     pyopenssl
     pytestCheckHook
     psutil


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/aio-libs/aiohttp/compare/refs/tags/v3.9.5...v3.10.0

Changelog: https://github.com/aio-libs/aiohttp/blob/v3.10.0/CHANGES.rst
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
