### PR TITLE
deno: make update script independent from CWD

### DIFF
--- a/pkgs/development/web/deno/update/update.ts
+++ b/pkgs/development/web/deno/update/update.ts
@@ -2,17 +2,20 @@
 /*
 #!nix-shell -i "deno run --allow-net --allow-run --allow-read --allow-write" -p deno git nix-prefetch
 */
+import { findUp } from "https://deno.land/x/easy_std@v0.4.6/src/path.ts";
+import { resolve, dirname, fromFileUrl } from "https://deno.land/std@0.224.0/path/mod.ts";
 import { getExistingVersion, getLatestVersion, logger } from "./common.ts";
 import { Architecture, updateLibrustyV8 } from "./librusty_v8.ts";
 import { updateSrc } from "./src.ts";
 
+
+const __dirname = dirname(fromFileUrl(import.meta.url))
 const log = logger("update");
-// TODO: Getting current file position to more-safely point to nixpkgs root
-const nixpkgs = Deno.cwd();
+const nixpkgs = resolve(await findUp('.git', __dirname), '..');
 // TODO: Read values from default.nix
 const owner = "denoland";
 const repo = "deno";
-const denoDir = `${nixpkgs}/pkgs/development/web/${repo}`;
+const denoDir = resolve(__dirname, '..');
 const src = `${denoDir}/default.nix`;
 const librusty_v8 = `${denoDir}/librusty_v8.nix`;
 const architectures: Architecture[] = [


### PR DESCRIPTION
Changes the deno update script to be independent of where it is executed.

references https://github.com/msteen/nix-prefetch/issues/53