### PR TITLE
fh: 0.1.10 -> 0.1.16, fix build

### DIFF
--- a/pkgs/tools/nix/fh/default.nix
+++ b/pkgs/tools/nix/fh/default.nix
@@ -6,28 +6,32 @@
 , darwin
 , gcc
 , libcxx
+, cacert
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "fh";
-  version = "0.1.10";
+  version = "0.1.16";
 
   src = fetchFromGitHub {
     owner = "DeterminateSystems";
     repo = "fh";
     rev = "v${version}";
-    hash = "sha256-fRaKydMSwd1zl6ptBKvn5ej2pqtI8xi9dioFmR8QA+g=";
+    hash = "sha256-HC/PNdBOm4mR2p6qI2P+aS+lFabKWSiPhiBSJUsmcv4=";
   };
 
-  cargoHash = "sha256-iOP5llFtySG8Z2Mj7stt6fYpQWqiQqJuftuYBrbkmyU=";
+  cargoHash = "sha256-pWPFiDRF9avZSSUtxDaTfl9ZVUEcnO/CY0VWByaGimo=";
 
   nativeBuildInputs = [
     installShellFiles
     rustPlatform.bindgenHook
   ];
 
+  checkInputs = [ cacert ];
+
   buildInputs = lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.Security
+    darwin.apple_sdk.frameworks.SystemConfiguration
     gcc.cc.lib
   ];
 


### PR DESCRIPTION
## Description of changes

Changelog:
https://github.com/DeterminateSystems/fh/compare/v0.1.10...v0.1.16

Update includes build fixes:

- `bindgen` over version `0.62.2`, fixes generating no bindings on `clang_18` from `extern "C"` declarations:
https://github.com/rust-lang/rust-bindgen/pull/2689
https://github.com/rust-lang/rust-bindgen/commit/aaa8883ceb0d08b23e39ae78531dfabec6b12d0f

<details>
<summary>Log</summary>

```text
error[E0425]: cannot find function `parse` in module `crate::ffi`
  --> /build/fh-0.1.10-vendor.tar.gz/nixel/src/parse.rs:23:39
   |
23 |     let parsed = unsafe { crate::ffi::parse(input.as_mut_ptr(), len) };
   |                                       ^^^^^ not found in `crate::ffi`
   |
help: consider importing this function through its public re-export
   |
5  + use crate::parse;
   |
help: if you import `parse`, refer to it directly
   |
23 -     let parsed = unsafe { crate::ffi::parse(input.as_mut_ptr(), len) };
23 +     let parsed = unsafe { parse(input.as_mut_ptr(), len) };
   |

For more information about this error, try `rustc --explain E0425`.
error: could not compile `nixel` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

</details>

- `time` over version `0.3.35`, fixes 1.80.0 rust issue:
https://github.com/rust-lang/rust/issues/127343
<details>
<summary>Log</summary>

```text
error[E0282]: type annotations needed for `Box<_>`
  --> /private/tmp/nix-build-fh-0.1.10.drv-0/fh-0.1.10-vendor.tar.gz/time/src/format_description/parse/mod.rs:83:9
   |
83 |     let items = format_items
   |         ^^^^^
...
86 |     Ok(items.into())
   |              ---- type must be known at this point
   |
help: consider giving `items` an explicit type, where the placeholders `_` are specified
   |
83 |     let items: Box<_> = format_items
   |              ++++++++
   Compiling serde_path_to_error v0.1.14
For more information about this error, try `rustc --explain E0282`.
error: could not compile `time` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

</details>

Fixes #331240 - Build falure: fh

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc