### PR TITLE
photoprism: 240420-ef5f14bc4 -> 240711-2197af848

### DIFF
--- a/pkgs/servers/photoprism/backend.nix
+++ b/pkgs/servers/photoprism/backend.nix
@@ -1,12 +1,20 @@
-{ lib, buildGoModule, coreutils, libtensorflow, src, version, ... }:
+{ lib, buildGoModule, coreutils, libtensorflow, src, version
+, pkg-config
+, vips
+}:
 
 buildGoModule rec {
   inherit src version;
   pname = "photoprism-backend";
 
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
   buildInputs = [
     coreutils
     libtensorflow
+    vips
   ];
 
   ldflags = [
@@ -19,7 +27,7 @@ buildGoModule rec {
     substituteInPlace internal/commands/passwd.go --replace '/bin/stty' "${coreutils}/bin/stty"
   '';
 
-  vendorHash = "sha256-ogJ/FwWJt1L0NGKX29tqWmHo4WslzC7ck5r7vn5PEuY=";
+  vendorHash = "sha256-6xE1j/Vh9ltE6TpBkvjK4rzLyXv8OJzy84vf9Iqw3yU=";
 
   subPackages = [ "cmd/photoprism" ];
 

--- a/pkgs/servers/photoprism/default.nix
+++ b/pkgs/servers/photoprism/default.nix
@@ -1,14 +1,15 @@
-{ pkgs, lib, stdenv, fetchFromGitHub, fetchzip, darktable, rawtherapee, ffmpeg, libheif, exiftool, imagemagick, makeWrapper, testers }:
+{ pkgs, lib, stdenv, fetchFromGitHub, fetchzip, darktable, rawtherapee, ffmpeg_7, libheif, exiftool, imagemagick, makeWrapper, testers
+, librsvg }:
 
 let
-  version = "240420-ef5f14bc4";
+  version = "240711-2197af848";
   pname = "photoprism";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    hash = "sha256-oJRd4eTwoTYKAJAsG9y0mnG+zF+eeLlSXNgaKLcb43w=";
+    hash = "sha256-ihDv5c5RUjDbFcAHJjzp/8qCwKfA+rlFXPziaYarzs8=";
   };
 
   libtensorflow = pkgs.callPackage ./libtensorflow.nix { };
@@ -61,7 +62,8 @@ stdenv.mkDerivation {
       --set PHOTOPRISM_DARKTABLE_BIN ${darktable}/bin/darktable-cli \
       --set PHOTOPRISM_RAWTHERAPEE_BIN ${rawtherapee}/bin/rawtherapee-cli \
       --set PHOTOPRISM_HEIFCONVERT_BIN ${libheif}/bin/heif-convert \
-      --set PHOTOPRISM_FFMPEG_BIN ${ffmpeg}/bin/ffmpeg \
+      --set PHOTOPRISM_RSVGCONVERT_BIN ${librsvg}/bin/rsvg-convert \
+      --set PHOTOPRISM_FFMPEG_BIN ${ffmpeg_7}/bin/ffmpeg \
       --set PHOTOPRISM_EXIFTOOL_BIN ${exiftool}/bin/exiftool \
       --set PHOTOPRISM_IMAGEMAGICK_BIN ${imagemagick}/bin/convert
 

--- a/pkgs/servers/photoprism/frontend.nix
+++ b/pkgs/servers/photoprism/frontend.nix
@@ -8,7 +8,7 @@ buildNpmPackage {
     cd frontend
   '';
 
-  npmDepsHash = "sha256-mgDg6awsEHkZyMzvFLwlfXGjdvjtwkNJiiNcnRBSJVo=";
+  npmDepsHash = "sha256-y2Mj0sJP2urTDrsVPReVFi7G9fLjuKz76vDPLvkaMFA=";
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
## Description of changes
https://github.com/photoprism/photoprism/releases/tag/240523-923ee0cf7
https://github.com/photoprism/photoprism/releases/tag/240528-977d6c0de
https://github.com/photoprism/photoprism/releases/tag/240531-60b3a4628
https://github.com/photoprism/photoprism/releases/tag/240711-2197af848

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
