### PR TITLE
ocamlPackages.linol: 0.5 → 0.6

### DIFF
--- a/pkgs/development/compilers/ligo/default.nix
+++ b/pkgs/development/compilers/ligo/default.nix
@@ -24,6 +24,8 @@ ocamlPackages.buildDunePackage rec {
     fetchSubmodules = true;
   };
 
+  patches = [ ./make-compatible-with-linol-0_6.patch ];
+
   # The build picks this up for ligo --version
   LIGO_VERSION = version;
 

--- a/pkgs/development/compilers/ligo/make-compatible-with-linol-0_6.patch
+++ b/pkgs/development/compilers/ligo/make-compatible-with-linol-0_6.patch
@@ -1,0 +1,13 @@
+diff --git a/src/bin/cli.ml b/src/bin/cli.ml
+index 36ee98cbec..960bfc85a0 100644
+--- a/src/bin/cli.ml
++++ b/src/bin/cli.ml
+@@ -3537,7 +3537,7 @@ module Lsp_server = struct
+           ~session_id
+           ~skip_analytics
+       in
+-      let server = Linol_lwt.Jsonrpc2.create_stdio (s :> Linol_lwt.Jsonrpc2.server) in
++      let server = Linol_lwt.Jsonrpc2.create_stdio ~env:() (s :> Linol_lwt.Jsonrpc2.server) in
+       let shutdown () = Poly.(s#get_status = `ReceivedExit) in
+       let task = Linol_lwt.Jsonrpc2.run ~shutdown server in
+       let analytics_job =

--- a/pkgs/development/ocaml-modules/linol/default.nix
+++ b/pkgs/development/ocaml-modules/linol/default.nix
@@ -1,22 +1,15 @@
-{ lib, fetchFromGitHub, fetchpatch, buildDunePackage, yojson, logs, lsp, ppx_yojson_conv_lib, trace }:
+{ lib, fetchurl, buildDunePackage, yojson, logs, lsp, ppx_yojson_conv_lib, trace }:
 
 buildDunePackage
 rec {
   pname = "linol";
-  version = "0.5";
+  version = "0.6";
 
   minimalOCamlVersion = "4.14";
 
-  src = fetchFromGitHub {
-    owner = "c-cube";
-    repo = "linol";
-    rev = "v${version}";
-    hash = "sha256-ULPOB/hb+2VXDB/eK66WDDh/wj0bOwUt0tZsiIXqndo=";
-  };
-
-  patches = fetchpatch {
-    url = "https://github.com/c-cube/linol/commit/d8ebcf9a60f1e7251d14cdcd0b2ebd5b7f8eec6d.patch";
-    hash = "sha256-JHR0P0X3ep5HvDWW43dMb452/WsFKS4e+5Qhk4MzaxQ=";
+  src = fetchurl {
+    url = "https://github.com/c-cube/linol/releases/download/v${version}/linol-${version}.tbz";
+    hash = "sha256-MwEisPJdzZN1VRnssotvExNMYOQdffS+Y2B8ZSUDVfo=";
   };
 
   propagatedBuildInputs = [ yojson logs lsp ppx_yojson_conv_lib trace ];


### PR DESCRIPTION
## Description of changes

https://raw.githubusercontent.com/c-cube/linol/main/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
