### PR TITLE
[WIP] noto-fonts: build from source

### DIFF
--- a/pkgs/by-name/no/noto-kufi-arabic/package.nix
+++ b/pkgs/by-name/no/noto-kufi-arabic/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  notobuilder,
+  installFonts,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noto-kufi-arabic";
+  version = "2.110";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "notofonts";
+    repo = "arabic";
+    tag = "NotoKufiArabic-v${finalAttrs.version}";
+    hash = "sha256-HdoUF+HaiTAIMWjUTFrxuGL/taLzfei2rda9eaxPsFI=";
+  };
+
+  env.GITHUB_REF = finalAttrs.src.rev;
+
+  nativeBuildInputs = [
+    notobuilder
+    installFonts
+  ];
+
+  fontName = "kufi-arabic";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "NotoKufiArabic-v"; };
+
+  meta = {
+    description = "Simplified, unmodulated (“sans serif”) Kufi design mainly for texts in larger font sizes in the Middle Eastern Arabic script";
+    homepage = "https://fonts.google.com/noto/specimen/Noto+Kufi+Arabic";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+  };
+})

--- a/pkgs/by-name/no/noto-music/package.nix
+++ b/pkgs/by-name/no/noto-music/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  notobuilder,
+  installFonts,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noto-music";
+  version = "2.003-unstable-2025-06-18";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "notofonts";
+    repo = "music";
+    # Current release fails building
+    rev = "81817dc4bb0c359588e2f370a8182ea028cbc500";
+    hash = "sha256-o1ugoCy1uAGErjPAZqEasiQW9wY3UwPZCOjO/l35C7w=";
+  };
+
+  env.GITHUB_REF = finalAttrs.src.rev;
+
+  nativeBuildInputs = [
+    notobuilder
+    installFonts
+  ];
+
+  fontName = "music";
+
+  meta = {
+    description = "Font that contains symbols for the modern, Byzantine and Greek musical notations";
+    homepage = "https://fonts.google.com/noto/specimen/Noto+Music";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+  };
+})

--- a/pkgs/by-name/no/noto-naskh-arabic/package.nix
+++ b/pkgs/by-name/no/noto-naskh-arabic/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  notobuilder,
+  installFonts,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noto-naskh-arabic";
+  version = "2.021";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "notofonts";
+    repo = "arabic";
+    tag = "NotoNaskhArabic-v${finalAttrs.version}";
+    hash = "sha256-D4vbL51ZzSFZRH+qOKUUFfw7kq1NXlui5Xx/dVaNG8Y=";
+  };
+
+  env.GITHUB_REF = finalAttrs.src.rev;
+
+  nativeBuildInputs = [
+    notobuilder
+    installFonts
+  ];
+
+  fontName = "naskh-arabic";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "NotoNaskhArabic-v"; };
+
+  meta = {
+    description = "Modulated (“serif”) Naskh design, suitable for texts in the Middle Eastern Arabic script and for use together with serif fonts";
+    homepage = "https://fonts.google.com/noto/specimen/Noto+Naskh+Arabic";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+  };
+})

--- a/pkgs/by-name/no/noto-sans-adlam-unjoined/package.nix
+++ b/pkgs/by-name/no/noto-sans-adlam-unjoined/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  notobuilder,
+  installFonts,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noto-sans-adlam-unjoined";
+  version = "3.003";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "notofonts";
+    repo = "adlam";
+    tag = "NotoSansAdlamUnjoined-v${finalAttrs.version}";
+    hash = "sha256-WcJOhMl+KIXHugvbNILJUhlQW/f3pbqGVO+XCo24ZEw=";
+  };
+
+  env.GITHUB_REF = finalAttrs.src.rev;
+
+  nativeBuildInputs = [
+    notobuilder
+    installFonts
+  ];
+
+  fontName = "sans-adlam-unjoined";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "NotoSansAdlamUnjoined-v"; };
+
+  meta = {
+    description = "Unjoined unmodulated (“sans serif”) design suitable for headlines and for educational content in the African Adlam script";
+    homepage = "https://fonts.google.com/noto/specimen/Noto+Sans+Adlam+Unjoined";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+  };
+})

--- a/pkgs/by-name/no/noto-sans-adlam/package.nix
+++ b/pkgs/by-name/no/noto-sans-adlam/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  notobuilder,
+  installFonts,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noto-sans-adlam";
+  version = "3.002";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "notofonts";
+    repo = "adlam";
+    tag = "NotoSansAdlam-v${finalAttrs.version}";
+    hash = "sha256-VI5mlCzRHCjzqENwepo3BPCLOzdBPmlBLx8+IyxUNS4=";
+  };
+
+  env.GITHUB_REF = finalAttrs.src.rev;
+
+  nativeBuildInputs = [
+    notobuilder
+    installFonts
+  ];
+
+  fontName = "sans-adlam";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "NotoSansAdlam-v"; };
+
+  meta = {
+    description = "Joining (cursive) unmodulated (“sans serif”) design for texts in the African Adlam script";
+    homepage = "https://fonts.google.com/noto/specimen/Noto+Sans+Adlam";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+  };
+})

--- a/pkgs/by-name/no/noto-sans-anatolian-hieroglyphs/package.nix
+++ b/pkgs/by-name/no/noto-sans-anatolian-hieroglyphs/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  notobuilder,
+  installFonts,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noto-sans-anatolian-hieroglyphs";
+  version = "2.001";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "notofonts";
+    repo = "anatolian-hieroglyphs";
+    tag = "NotoSansAnatolianHieroglyphs-v${finalAttrs.version}";
+    hash = "sha256-OkAVkGpFZolQQs/zArSIxytnvZl7Kh/cwVnrpfB/J/Q=";
+  };
+
+  env.GITHUB_REF = finalAttrs.src.rev;
+
+  nativeBuildInputs = [
+    notobuilder
+    installFonts
+  ];
+
+  fontName = "sans-anatolian-hieroglyphs";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "NotoSansAnatolianHieroglyphs-v"; };
+
+  meta = {
+    description = "Unmodulated (“sans serif”) design for texts in the historical Middle Eastern Anatolian hieroglyphs script";
+    homepage = "https://fonts.google.com/noto/specimen/Noto+Sans+Anatolian+Hieroglyphs";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+  };
+})

--- a/pkgs/by-name/no/noto-sans-arabic/package.nix
+++ b/pkgs/by-name/no/noto-sans-arabic/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  notobuilder,
+  installFonts,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noto-sans-arabic";
+  version = "2.013";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "notofonts";
+    repo = "arabic";
+    tag = "NotoSansArabic-v${finalAttrs.version}";
+    hash = "sha256-HdoUF+HaiTAIMWjUTFrxuGL/taLzfei2rda9eaxPsFI=";
+  };
+
+  env.GITHUB_REF = finalAttrs.src.rev;
+
+  nativeBuildInputs = [
+    notobuilder
+    installFonts
+  ];
+
+  fontName = "sans-arabic";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "NotoSansArabic-v"; };
+
+  meta = {
+    description = "Unmodulated (“sans serif”) design for texts in the Middle Eastern Arabic script";
+    homepage = "https://fonts.google.com/noto/specimen/Noto+Sans+Arabic";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+  };
+})

--- a/pkgs/by-name/no/noto-sans-devanagari/package.nix
+++ b/pkgs/by-name/no/noto-sans-devanagari/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  notobuilder,
+  installFonts,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noto-sans-devanagari";
+  version = "2.006";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "notofonts";
+    repo = "devanagari";
+    tag = "NotoSansDevanagari-v${finalAttrs.version}";
+    hash = "sha256-hhzTvFkGAZMvUVSN3nPENvTiHDJIxYSPq6HqdNuOfiI=";
+  };
+
+  env.GITHUB_REF = finalAttrs.src.rev;
+
+  nativeBuildInputs = [
+    notobuilder
+    installFonts
+  ];
+
+  fontName = "sans-devanagari";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "NotoSansDevanagari-v"; };
+
+  meta = {
+    description = "Unmodulated (“sans serif”) design for texts in the Indic Devanagari script";
+    homepage = "https://fonts.google.com/noto/specimen/Noto+Sans+Devanagari";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+  };
+})

--- a/pkgs/by-name/no/noto-sans-math/package.nix
+++ b/pkgs/by-name/no/noto-sans-math/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  notobuilder,
+  installFonts,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noto-sans-math";
+  version = "3.000";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "notofonts";
+    repo = "math";
+    tag = "NotoSansMath-v${finalAttrs.version}";
+    hash = "sha256-cQV8/yerTYazp2n7kWCGNd89/3eQLNI/h978hd4eZYA=";
+  };
+
+  env.GITHUB_REF = finalAttrs.src.rev;
+
+  nativeBuildInputs = [
+    notobuilder
+    installFonts
+  ];
+
+  fontName = "sans-math";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "NotoSansMath-v"; };
+
+  meta = {
+    description = "Font that contains symbols for mathematical notation";
+    homepage = "https://fonts.google.com/noto/specimen/Noto+Sans+Math";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+  };
+})

--- a/pkgs/by-name/no/noto-sans-mongolian/package.nix
+++ b/pkgs/by-name/no/noto-sans-mongolian/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  notobuilder,
+  installFonts,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noto-sans-mongolian";
+  version = "3.002";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "notofonts";
+    repo = "mongolian";
+    tag = "NotoSansMongolian-v${finalAttrs.version}";
+    hash = "sha256-YJ9p+/EBEtKmoF6h2RRyDBhAYJYWHomIxO2cvgzEwBc=";
+  };
+
+  env.GITHUB_REF = finalAttrs.src.rev;
+
+  nativeBuildInputs = [
+    notobuilder
+    installFonts
+  ];
+
+  fontName = "sans-mongolian";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "NotoSansMongolian-v"; };
+
+  meta = {
+    description = "Unmodulated (“sans serif”) design for texts in the Central Asian Mongolian script";
+    homepage = "https://fonts.google.com/noto/specimen/Noto+Sans+Mongolian";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+  };
+})

--- a/pkgs/by-name/no/noto-sans-mono/package.nix
+++ b/pkgs/by-name/no/noto-sans-mono/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  notobuilder,
+  installFonts,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noto-sans-mono";
+  version = "2.014";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "notofonts";
+    repo = "latin-greek-cyrillic";
+    tag = "NotoSansMono-v${finalAttrs.version}";
+    hash = "sha256-guiiPnvlJPA7g5MRFoffj91q3ETljh1bIJDV/vP7qww=";
+  };
+
+  env.GITHUB_REF = finalAttrs.src.rev;
+
+  nativeBuildInputs = [
+    notobuilder
+    installFonts
+  ];
+
+  fontName = "sans-mono";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "NotoSansMono-v"; };
+
+  meta = {
+    description = "Monospaced, unmodulated (“sans serif”) design suitable for programming code and other uses where a fixed-width font is needed";
+    homepage = "https://fonts.google.com/noto/specimen/Noto+Sans+Mono";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+  };
+})

--- a/pkgs/by-name/no/noto-sans-symbols/package.nix
+++ b/pkgs/by-name/no/noto-sans-symbols/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  notobuilder,
+  installFonts,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noto-sans-symbols";
+  version = "2.003";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "notofonts";
+    repo = "symbols";
+    tag = "NotoSansSymbols-v${finalAttrs.version}";
+    hash = "sha256-IXsAvbSweKTPyuy96NC+n6uXQDgwD2Z80ywqYyZJIiQ=";
+  };
+
+  env.GITHUB_REF = finalAttrs.src.rev;
+
+  nativeBuildInputs = [
+    notobuilder
+    installFonts
+  ];
+
+  fontName = "sans-symbols";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "NotoSansSymbols-v"; };
+
+  meta = {
+    description = "Unmodulated (“sans serif”) design for texts in Symbols";
+    homepage = "https://fonts.google.com/noto/specimen/Noto+Sans+Symbols";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+  };
+})

--- a/pkgs/by-name/no/noto-sans-symbols2/package.nix
+++ b/pkgs/by-name/no/noto-sans-symbols2/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  notobuilder,
+  installFonts,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noto-sans-symbols2";
+  version = "2.008";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "notofonts";
+    repo = "symbols";
+    tag = "NotoSansSymbols2-v${finalAttrs.version}";
+    hash = "sha256-ujZ3IJrWmkxKcmVl1FZuMF5ovbMkd2wcGU6DuJTo7Eg=";
+  };
+
+  env.GITHUB_REF = finalAttrs.src.rev;
+
+  nativeBuildInputs = [
+    notobuilder
+    installFonts
+  ];
+
+  fontName = "sans-symbols2";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "NotoSansSymbols2-v"; };
+
+  meta = {
+    description = "Unmodulated (“sans serif”) design for texts in Symbols and in Emoji symbols";
+    homepage = "https://fonts.google.com/noto/specimen/Noto+Sans+Symbols+2";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+  };
+})

--- a/pkgs/by-name/no/noto-sans-test/package.nix
+++ b/pkgs/by-name/no/noto-sans-test/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  notobuilder,
+  installFonts,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noto-sans-test";
+  version = "1.002";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "notofonts";
+    repo = "test";
+    tag = "NotoSansTest-v${finalAttrs.version}";
+    hash = "sha256-PoDF3XVqA5cy1Mcqbj+Grj58G/VTqEYMRuIYnbRumiY=";
+  };
+
+  env.GITHUB_REF = finalAttrs.src.rev;
+
+  nativeBuildInputs = [
+    notobuilder
+    installFonts
+  ];
+
+  fontName = "sans-test";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "NotoSansTest-v"; };
+
+  meta = {
+    description = "Testing font for notofonts";
+    homepage = "https://github.com/notofonts/test";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+  };
+})

--- a/pkgs/by-name/no/noto-sans/package.nix
+++ b/pkgs/by-name/no/noto-sans/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  notobuilder,
+  installFonts,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noto-sans";
+  version = "2.013";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "notofonts";
+    repo = "latin-greek-cyrillic";
+    tag = "NotoSans-v${finalAttrs.version}";
+    hash = "sha256-guiiPnvlJPA7g5MRFoffj91q3ETljh1bIJDV/vP7qww=";
+  };
+
+  env.GITHUB_REF = finalAttrs.src.rev;
+
+  nativeBuildInputs = [
+    notobuilder
+    installFonts
+  ];
+
+  fontName = "sans";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "NotoSans-v"; };
+
+  meta = {
+    description = "Unmodulated (“sans serif”) design for texts in the Latin, Cyrillic and Greek scripts";
+    homepage = "https://fonts.google.com/noto/specimen/Noto+Sans";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+  };
+})

--- a/pkgs/by-name/no/noto-serif-ahom/package.nix
+++ b/pkgs/by-name/no/noto-serif-ahom/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  notobuilder,
+  installFonts,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noto-serif-ahom";
+  version = "2.007";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "notofonts";
+    repo = "ahom";
+    tag = "NotoSerifAhom-v${finalAttrs.version}";
+    hash = "sha256-H9wHSAJPumoX7GK4bKDzDg/AJHkGX38FJTTRxcUXHE0=";
+  };
+
+  env.GITHUB_REF = finalAttrs.src.rev;
+
+  nativeBuildInputs = [
+    notobuilder
+    installFonts
+  ];
+
+  fontName = "serif-ahom";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "NotoSerifAhom-v"; };
+
+  meta = {
+    description = "Modulated (“serif”) design for texts in the Southeast Asian Ahom script";
+    homepage = "https://fonts.google.com/noto/specimen/Noto+Serif+Ahom";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+  };
+})

--- a/pkgs/by-name/no/noto-serif-devanagari/package.nix
+++ b/pkgs/by-name/no/noto-serif-devanagari/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  notobuilder,
+  installFonts,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noto-serif-devanagari";
+  version = "2.006";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "notofonts";
+    repo = "devanagari";
+    tag = "NotoSerifDevanagari-v${finalAttrs.version}";
+    hash = "sha256-V+ikOT0EbtLPsnauNIIOimUUoxFKCCxIJRPIgZusPZE=";
+  };
+
+  env.GITHUB_REF = finalAttrs.src.rev;
+
+  nativeBuildInputs = [
+    notobuilder
+    installFonts
+  ];
+
+  fontName = "serif-devanagari";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "NotoSerifDevanagari-v"; };
+
+  meta = {
+    description = "Modulated (“serif”) design for texts in the Indic Devanagari script";
+    homepage = "https://fonts.google.com/noto/specimen/Noto+Serif+Devanagari";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+  };
+})

--- a/pkgs/by-name/no/noto-serif-test/package.nix
+++ b/pkgs/by-name/no/noto-serif-test/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  notobuilder,
+  installFonts,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noto-serif-test";
+  version = "1.000";
+
+  strictdeps = true;
+  __structuredattrs = true;
+
+  src = fetchFromGitHub {
+    owner = "notofonts";
+    repo = "test";
+    tag = "NotoSerifTest-v${finalAttrs.version}";
+    hash = "sha256-21rSz/WbLCP5lNV4ZbNfmjNJ+4QlwnTtQ8H4/EugTa4=";
+  };
+
+  env.GITHUB_REF = finalAttrs.src.rev;
+
+  nativeBuildInputs = [
+    notobuilder
+    installFonts
+  ];
+
+  fontName = "serif-test";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "NotoSansTest-v"; };
+
+  meta = {
+    description = "Testing font for notofonts";
+    homepage = "https://github.com/notofonts/test";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+  };
+})

--- a/pkgs/by-name/no/noto-serif/package.nix
+++ b/pkgs/by-name/no/noto-serif/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  notobuilder,
+  installFonts,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noto-serif";
+  version = "2.013";
+
+  strictdeps = true;
+  __structuredattrs = true;
+
+  src = fetchFromGitHub {
+    owner = "notofonts";
+    repo = "latin-greek-cyrillic";
+    tag = "NotoSerif-v${finalAttrs.version}";
+    hash = "sha256-guiiPnvlJPA7g5MRFoffj91q3ETljh1bIJDV/vP7qww=";
+  };
+
+  env.GITHUB_REF = finalAttrs.src.rev;
+
+  nativeBuildInputs = [
+    notobuilder
+    installFonts
+  ];
+
+  fontName = "serif";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "NotoSerif-v"; };
+
+  meta = {
+    description = "Modulated (“serif”) design for texts in the Latin, Cyrillic and Greek scripts";
+    homepage = "https://fonts.google.com/noto/specimen/Noto+Serif";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+  };
+})

--- a/pkgs/by-name/no/noto-znamenny-musical-notation/package.nix
+++ b/pkgs/by-name/no/noto-znamenny-musical-notation/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  notobuilder,
+  installFonts,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noto-znamenny-musical-notation";
+  version = "1.003";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "notofonts";
+    repo = "znamenny";
+    tag = "NotoZnamennyMusicalNotation-v${finalAttrs.version}";
+    hash = "sha256-hoe4KocblsEIP59lR+sntZMddMkor8gQAe2ZmKYpvPM=";
+  };
+
+  env.GITHUB_REF = finalAttrs.src.rev;
+
+  nativeBuildInputs = [
+    notobuilder
+    installFonts
+  ];
+
+  fontName = "znamenny";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "NotoZnamennyMusicalNotation-v"; };
+
+  meta = {
+    description = "Font that contains symbols for the Znamenny Chant musical notation";
+    homepage = "https://fonts.google.com/noto/specimen/Noto+Znamenny+Musical+Notation";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+  };
+})

--- a/pkgs/development/python-modules/notobuilder/build-bin.patch
+++ b/pkgs/development/python-modules/notobuilder/build-bin.patch
@@ -1,0 +1,11 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 9496fa46e7..4a3cf3dca1 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -24,3 +24,6 @@
+     "chevron>=0.10.0",
+     "sh>=1.14.1",
+ ]
++
++[project.scripts]
++notobuilder = "notobuilder.__main__:main"

--- a/pkgs/development/python-modules/notobuilder/default.nix
+++ b/pkgs/development/python-modules/notobuilder/default.nix
@@ -17,8 +17,18 @@
   chevron,
   sh,
   ninja,
+  writers,
+  pyyaml,
+  replaceVars,
 }:
 
+let
+  patchConfig = writers.writePython3Bin "notobuilder-patch-config" {
+    libraries = [
+      pyyaml
+    ];
+  } (builtins.readFile ./patchConfig.py);
+in
 buildPythonPackage {
   pname = "notobuilder";
   version = "0-unstable-2026-06-26";
@@ -30,6 +40,10 @@ buildPythonPackage {
     rev = "5b55818eb3f535481135a5f57a337eec6d28cda0";
     hash = "sha256-pdfWl8rp4tizgb7j0UR7hOW/Ae2dPhTSw1IHljM15LE=";
   };
+
+  patches = [
+    ./build-bin.patch
+  ];
 
   postPatch = ''
     substituteInPlace Lib/notobuilder/__main__.py \
@@ -62,7 +76,14 @@ buildPythonPackage {
     "notoqa"
   ];
 
-  passthru.updateScript = unstableGitUpdater { };
+  setupHook = replaceVars ./setup-hook.sh {
+    patchConfig = lib.getExe patchConfig;
+  };
+
+  passthru = {
+    inherit patchConfig;
+    updateScript = unstableGitUpdater { };
+  };
 
   meta = {
     description = "Python module for building Noto fonts";

--- a/pkgs/development/python-modules/notobuilder/patchConfig.py
+++ b/pkgs/development/python-modules/notobuilder/patchConfig.py
@@ -1,0 +1,17 @@
+import sys
+import yaml
+
+
+def main():
+    file_path = sys.argv[1]
+    with open(file_path, 'r') as file:
+        data = yaml.safe_load(file)
+
+    data.pop('includeSubsets', None)
+
+    with open(file_path, 'w') as file:
+        yaml.safe_dump(data, file)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/development/python-modules/notobuilder/setup-hook.sh
+++ b/pkgs/development/python-modules/notobuilder/setup-hook.sh
@@ -1,0 +1,20 @@
+notoConfigureHook() {
+  @patchConfig@ "sources/config-$fontName.yaml"
+}
+
+notoBuildPhase() {
+  export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+  notobuilder "sources/config-$fontName.yaml"
+  rm -rf fonts/*/{unhinted/ttf,googlefonts,unhinted/slim-variable-ttf}
+}
+
+notoInstallPhase() {
+  runHook preInstall
+
+  runHook postInstall
+}
+
+postConfigureHooks+=(notoConfigureHook)
+buildPhase=notoBuildPhase
+installPhase=notoInstallPhase
+dontUseNinjaInstall=true

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8235,6 +8235,8 @@ with pkgs;
 
   mplus-outline-fonts = recurseIntoAttrs (callPackage ../data/fonts/mplus-outline-fonts { });
 
+  notobuilder = with python3Packages; toPythonApplication notobuilder;
+
   noto-fonts-cjk-serif-static = callPackage ../by-name/no/noto-fonts-cjk-serif/package.nix {
     static = true;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11920,7 +11920,7 @@ self: super: with self; {
 
   notmuch2 = callPackage ../development/python-modules/notmuch2 { inherit (pkgs) notmuch; };
 
-  notobuilder = callPackage ../development/python-modules/notobuilder { };
+  notobuilder = callPackage ../development/python-modules/notobuilder { inherit (pkgs) ninja; };
 
   notus-scanner = callPackage ../development/python-modules/notus-scanner { };
 


### PR DESCRIPTION
## Description of changes
This is a work in progress of building noto-fonts from source, the main thing still to-do is adding the rest of the noto fonts from https://github.com/notofonts, but before doing that I wanted to gather some feed back on this.

cc @emilazy @Mathnerd314 as the ones currently maintaining noto-fonts together with me.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
