### PR TITLE
cudaPackages.cmake-cuda-tests: init at 2.29.6

### DIFF
--- a/pkgs/development/cuda-modules/cmake-cuda-tests/data.nix
+++ b/pkgs/development/cuda-modules/cmake-cuda-tests/data.nix
@@ -1,0 +1,173 @@
+{
+  backendStdenv,
+  cmake,
+  cuda_cccl ? null,
+  cuda_nvrtc ? null,
+  cuda_nvtx ? null,
+  cuda_opencl ? null,
+  cudaAtLeast,
+  cudaOlder,
+  lib,
+  libcublas ? null,
+  libcufft ? null,
+  libcurand ? null,
+  libcusolver ? null,
+  libcusparse ? null,
+  libnpp ? null,
+  libnvjitlink ? null,
+  testCudaPackageType,
+}:
+let
+  inherit (lib.asserts) assertMsg;
+  inherit (lib.attrsets) optionalAttrs;
+  inherit (lib.lists) elem optionals;
+  inherit (lib.strings) versionAtLeast;
+  inherit (lib.trivial) id const;
+  inherit (backendStdenv.cc) isClang;
+  optional = cond: if cond then id else const null;
+
+  Tests = {
+    # The selection logic comes from Tests/Cuda/CMakeLists.txt.
+    Cuda = {
+      # Complex = {}; # TODO(@connorbaker): Why does this fail with "error while loading shared libraries: libcudart.so.12: cannot open shared object file: No such file or directory"?
+      CXXStandardSetTwice = { };
+      IncludePathNoToolkit = { };
+      MixedStandardLevels1 = { };
+      MixedStandardLevels2 = { };
+      MixedStandardLevels3 = { };
+      ${optional (!isClang) "MixedStandardLevels4"} = { };
+      ${optional (!isClang) "MixedStandardLevels5"} = { };
+      NotEnabled = { };
+      ObjectLibrary = { };
+      ${optional (!isClang) "ProperDeviceLibraries"} = {
+        extraBuildInputs = optionals (testCudaPackageType == "redist") (
+          [ libcublas ] ++ optionals (cudaAtLeast "12.0") [ cuda_cccl ]
+        );
+        extraBrokenConditions = {
+          "testCudaPackageType 'redist' requires libcublas" =
+            testCudaPackageType == "redist" && libcublas == null;
+          "testCudaPackageType 'redist' with CUDA 12.0+ requires cuda_cccl" =
+            testCudaPackageType == "redist" && (cudaAtLeast "12.0") && cuda_cccl == null;
+        };
+      };
+      ProperLinkFlags = { };
+      SeparableCompCXXOnly = { };
+      SharedRuntimePlusToolkit = {
+        extraBuildInputs = optionals (testCudaPackageType == "redist") [
+          libcurand
+          libnpp
+        ];
+        extraBrokenConditions = {
+          "testCudaPackageType 'redist' requires libcurand" =
+            testCudaPackageType == "redist" && libcurand == null;
+          "testCudaPackageType 'redist' requires libnpp" = testCudaPackageType == "redist" && libnpp == null;
+        };
+      };
+      StaticRuntimePlusToolkit = {
+        extraBuildInputs = optionals (testCudaPackageType == "redist") [
+          libcurand
+          libnpp
+        ];
+        extraBrokenConditions = {
+          "testCudaPackageType 'redist' requires libcurand" =
+            testCudaPackageType == "redist" && libcurand == null;
+          "testCudaPackageType 'redist' requires libnpp" = testCudaPackageType == "redist" && libnpp == null;
+        };
+      };
+      StubRPATH = { };
+      Toolkit = {
+        extraBuildInputs = optionals (testCudaPackageType == "redist") (
+          [
+            cuda_nvrtc
+            cuda_nvtx
+            libcublas
+            libcufft
+            libcurand
+            libcusolver
+            libcusparse
+            libnpp
+          ]
+          ++ optionals (cudaAtLeast "12.0") [
+            cuda_opencl
+            libnvjitlink
+          ]
+        );
+        extraBrokenConditions = {
+          # TODO: Figure out why CMake requires cuda_opencl even when it appears to be new to CUDA 12.0.
+          "testCudaPackageType 'cudatoolkit' does not provide cuda_opencl prior to CUDA 12.0" =
+            testCudaPackageType == "cudatoolkit" && cudaOlder "12.0";
+          # TODO: Figure out why cudatoolkit-legacy-runfile doesn't seem to provide cuda_opencl at all.
+          "testCudaPackageType 'cudatoolkit-legacy-runfile' does not provide cuda_opencl" =
+            testCudaPackageType == "cudatoolkit-legacy-runfile";
+          "testCudaPackageType 'redist' requires cuda_nvrtc" =
+            testCudaPackageType == "redist" && cuda_nvrtc == null;
+          "testCudaPackageType 'redist' requires cuda_nvtx" =
+            testCudaPackageType == "redist" && cuda_nvtx == null;
+          "testCudaPackageType 'redist' requires libcublas" =
+            testCudaPackageType == "redist" && libcublas == null;
+          "testCudaPackageType 'redist' requires libcufft" =
+            testCudaPackageType == "redist" && libcufft == null;
+          "testCudaPackageType 'redist' requires libcurand" =
+            testCudaPackageType == "redist" && libcurand == null;
+          "testCudaPackageType 'redist' requires libcusolver" =
+            testCudaPackageType == "redist" && libcusolver == null;
+          "testCudaPackageType 'redist' requires libcusparse" =
+            testCudaPackageType == "redist" && libcusparse == null;
+          "testCudaPackageType 'redist' requires libnpp" = testCudaPackageType == "redist" && libnpp == null;
+          "testCudaPackageType 'redist' with CUDA 12.0+ requires cuda_opencl" =
+            testCudaPackageType == "redist" && (cudaAtLeast "12.0") && cuda_opencl == null;
+          "testCudaPackageType 'redist' with CUDA 12.0+ requires libnvjitlink" =
+            testCudaPackageType == "redist" && (cudaAtLeast "12.0") && libnvjitlink == null;
+        };
+      };
+      ${optional (!isClang && versionAtLeast cmake.version "3.30.0") "ToolkitBeforeLang"} = { };
+      WithC = { };
+    };
+    # NOTE: While CudaOnly contains strictly CUDA files, some tests must have CXX enabled in order for
+    # find_package(CUDA) or find_package(CUDAToolkit) to work, as some codepaths invoke find_package(Threads),
+    # which requires CXX to be enabled.
+    CudaOnly = {
+      Architecture = { };
+      # "ArchSpecial" # TODO: Architectures used for "native" don't match the reference ("52" != "No CUDA devices found.").
+      CircularLinkLine = { };
+      CompileFlags = { };
+      # ${optional (!isClang) "CUBIN"} = {}; # TODO: make: *** No rule to make target 'install'.  Stop.
+      # DeviceLTO = { }; # TODO: Fix this. Broken on 11.5 with at least redist.
+      DontResolveDeviceSymbols = { }; # TODO: Additional arguments to add
+      EnableStandard = { };
+      ExportPTX.enableCXX = true;
+      ${optional (!isClang) "Fatbin"}.enableCXX = true;
+      ${optional (!isClang) "GPUDebugFlag"} = { };
+      # ${optional (!isClang) "OptixIR"}.enableCXX = true; # TODO: Fix this. Broken on 11.4/5 with at least redist.
+      # "PDB" # NOTE: Only availble on Windows MSVC
+      ResolveDeviceSymbols = { };
+      RuntimeControls = { }; # TODO: Additional arguments to add
+      SeparateCompilation = { };
+      # SeparateCompilationPTX.enableCXX = true; # TODO: Fix this. Broken 11.4+ with at least redist.
+      SeparateCompilationTargetObjects = { };
+      SharedRuntimePlusToolkit = Tests.Cuda.SharedRuntimePlusToolkit // {
+        enableCXX = true;
+      };
+      ${optional (!isClang) "SharedRuntimeViaCUDAFlags"}.enableCXX = true;
+      ${optional (!isClang) "Standard98"} = { };
+      StaticRuntimePlusToolkit = Tests.Cuda.StaticRuntimePlusToolkit // {
+        enableCXX = true;
+      };
+      Toolkit = Tests.Cuda.Toolkit // {
+        enableCXX = true;
+      };
+      ToolkitBeforeLang = { };
+      ToolkitMultipleDirs.enableCXX = true;
+      TryCompileTargetStatic = { };
+      WithDefs = { };
+    };
+  };
+in
+assert assertMsg (elem testCudaPackageType [
+  "redist"
+  "cudatoolkit"
+  "cudatoolkit-legacy-runfile"
+]) "testCudaPackageType must be one of 'redist', 'cudatoolkit', or 'cudatoolkit-legacy-runfile'";
+{
+  inherit Tests;
+}

--- a/pkgs/development/cuda-modules/cmake-cuda-tests/default.nix
+++ b/pkgs/development/cuda-modules/cmake-cuda-tests/default.nix
@@ -1,0 +1,36 @@
+{ callPackage, lib }:
+let
+  inherit (lib.attrsets) genAttrs mapAttrs;
+
+  # Attribute set of {redist,cudatoolkit,cudatoolkit-legacy-runfile}.{*testGroup}.{*testName} = testConfig
+  data =
+    genAttrs
+      [
+        "redist"
+        "cudatoolkit"
+        "cudatoolkit-legacy-runfile"
+      ]
+      (
+        testCudaPackageType:
+        # Explicitly access Tests to avoid the extra attribute callPackage adds to the attribute set.
+        (callPackage ./data.nix { inherit testCudaPackageType; }).Tests
+      );
+
+  testBuilder =
+    testCudaPackageType: testGroup: testName: testConfig:
+    callPackage ./generic.nix {
+      inherit testCudaPackageType testGroup testName;
+      testConfig = {
+        # Provide default values for testConfig.
+        enableCXX = testConfig.enableCXX or false;
+        extraNativeBuildInputs = testConfig.extraNativeBuildInputs or [ ];
+        extraBuildInputs = testConfig.extraBuildInputs or [ ];
+        extraBrokenConditions = testConfig.extraBrokenConditions or { };
+      };
+    };
+
+  testDrvs = mapAttrs (
+    testCudaPackageType: mapAttrs (testGroup: mapAttrs (testBuilder testCudaPackageType testGroup))
+  ) data;
+in
+testDrvs

--- a/pkgs/development/cuda-modules/cmake-cuda-tests/generic.nix
+++ b/pkgs/development/cuda-modules/cmake-cuda-tests/generic.nix
@@ -1,0 +1,145 @@
+{
+  autoAddDriverRunpath,
+  backendStdenv,
+  cmake,
+  cudaOlder,
+  cuda_nvcc ? null,
+  cuda_cudart ? null,
+  cudatoolkit ? null,
+  cudatoolkit-legacy-runfile ? null,
+  cudaMajorMinorVersion,
+  lib,
+  testGroup,
+  testName,
+  testCudaPackageType,
+  testConfig,
+  writeShellApplication,
+}:
+let
+  inherit (lib.asserts) assertMsg;
+  inherit (lib.attrsets) attrValues getBin;
+  inherit (lib.lists) any elem;
+  inherit (lib.strings) optionalString;
+  inherit (lib.trivial) id;
+
+  # NOTE: This block allows us to decide on the base packages for each testCudaPackageType. Individual tests
+  # can have additional dependencies, but these are common to all tests.
+  # NOTE: Using an if expression to make clear that these options are mutually exclusive, which optionals does not
+  # convey.
+  inherit
+    (
+      if (testCudaPackageType == "redist") then
+        {
+          baseNativeBuildInputs = [ cuda_nvcc ];
+          baseBuildInputs = [ cuda_cudart ];
+        }
+      else if (testCudaPackageType == "cudatoolkit") then
+        {
+          baseNativeBuildInputs = [ cudatoolkit ];
+          baseBuildInputs = [ cudatoolkit ];
+        }
+      else if (testCudaPackageType == "cudatoolkit-legacy-runfile") then
+        {
+          baseNativeBuildInputs = [ cudatoolkit-legacy-runfile ];
+          baseBuildInputs = [ cudatoolkit-legacy-runfile ];
+        }
+      else
+        builtins.throw "Unknown testCudaPackageType: ${testCudaPackageType}"
+    )
+    baseNativeBuildInputs
+    baseBuildInputs
+    ;
+in
+assert assertMsg (elem testCudaPackageType [
+  "redist"
+  "cudatoolkit"
+  "cudatoolkit-legacy-runfile"
+]) "testCudaPackageType must be one of 'redist', 'cudatoolkit', or 'cudatoolkit-legacy-runfile'";
+backendStdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  pname = "cmake-test-${testCudaPackageType}-${testGroup}.${testName}";
+  inherit (cmake) version;
+  name = "cuda${cudaMajorMinorVersion}-${finalAttrs.pname}-${finalAttrs.version}";
+
+  # NOTE: Our sourceRoot is different from the default because the tests are in a subdirectory.
+  inherit (cmake) src;
+  sourceRoot = "${cmake.name}/Tests/${testGroup}/${testName}";
+
+  brokenConditions = {
+    "testCudaPackageType 'redist' requires CUDA 11.4+" =
+      testCudaPackageType == "redist" && cudaOlder "11.4";
+    "testCudaPackageType 'redist' requires cuda_nvcc" =
+      testCudaPackageType == "redist" && cuda_nvcc == null;
+    "testCudaPackageType 'redist' requires cuda_cudart" =
+      testCudaPackageType == "redist" && cuda_cudart == null;
+    "testCudaPackageType 'cudatoolkit' requires cudatoolkit" =
+      testCudaPackageType == "cudatoolkit" && cudatoolkit == null;
+    "testCudaPackageType 'cudatoolkit-legacy-runfile' requires cudatoolkit-legacy-runfile" =
+      testCudaPackageType == "cudatoolkit-legacy-runfile" && cudatoolkit-legacy-runfile == null;
+  } // testConfig.extraBrokenConditions;
+
+  postPatch =
+    # FindThreads, called as part of enabling the CUDA language only works if either C or CXX language is enabled.
+    # https://github.com/Kitware/CMake/blob/cdc901797ac4ce0d1feeec454ecdd29e8ef5d4ff/Modules/FindCUDA.cmake#L1071
+    # https://github.com/Kitware/CMake/blob/cdc901797ac4ce0d1feeec454ecdd29e8ef5d4ff/Modules/FindCUDAToolkit.cmake#L1146
+    # Patch around that by enabling the CXX language on line three, as the first two lines declare the minimum
+    # CMake version and the project name.
+    optionalString testConfig.enableCXX ''
+      sed -i '3i enable_language(CXX)' CMakeLists.txt
+    ''
+    # We need to modify CMakeLists.txt so it installs all executables and libraries.
+    + ''
+      cat <<'EOF' >>CMakeLists.txt
+      # Install all targets
+      get_directory_property(_targets DIRECTORY ''${CMAKE_CURRENT_SOURCE_DIR} BUILDSYSTEM_TARGETS)
+      message(STATUS "Targets: ''${_targets}")
+      foreach(target ''${_targets})
+        install(TARGETS ''${target}
+                RUNTIME DESTINATION bin
+                LIBRARY DESTINATION lib
+                ARCHIVE DESTINATION lib)
+      endforeach()
+      EOF
+    '';
+
+  nativeBuildInputs = [
+    autoAddDriverRunpath
+    cmake
+  ] ++ baseNativeBuildInputs ++ testConfig.extraNativeBuildInputs;
+
+  buildInputs = baseBuildInputs ++ testConfig.extraBuildInputs;
+
+  passthru.tests.test = writeShellApplication {
+    name = "run-${finalAttrs.name}";
+    runtimeInputs = [ finalAttrs.finalPackage ];
+    derivationArgs = {
+      strictDeps = true;
+      meta.mainProgram = "run-${finalAttrs.name}";
+    };
+    # Run the executables present in the bin directory.
+    # If any of them fail, the test will fail.
+    text = ''
+      for test_bin in ${getBin finalAttrs.finalPackage}/bin/*
+      do
+        echo "Running test binary $test_bin"
+        if ! $test_bin
+        then
+          echo "Failed to run test binary $test_bin"
+          exit 1
+        fi
+        echo "Test binary $test_bin passed"
+      done
+      echo "All test binaries in ${finalAttrs.name} passed"
+    '';
+  };
+
+  meta = {
+    description = "CMake CUDA test ${testGroup}.${testName}";
+    platforms = lib.platforms.linux;
+    broken = any id (attrValues finalAttrs.brokenConditions);
+    license = cmake.meta.license;
+    maintainers = lib.teams.cuda.members;
+  };
+})

--- a/pkgs/development/cuda-modules/cuda/overrides.nix
+++ b/pkgs/development/cuda-modules/cuda/overrides.nix
@@ -138,6 +138,34 @@ filterAndCreateOverrides {
         '';
     };
 
+  cuda_cupti =
+    { }:
+    prevAttrs: {
+      # CMake expects CUPTI to be in an "extras/CUPTI" directory, so we add symlinks to the actual locations.
+      postInstall =
+        prevAttrs.postInstall or ""
+        + ''
+          for outputName in $(getAllOutputNames); do
+            [[ "$outputName" == "out" ]] && continue
+            mkdir -p "''${!outputName}/extras/CUPTI"
+            case "$outputName" in
+              dev)
+                ln -s "''${!outputName}/include" "''${!outputName}/extras/CUPTI/include"
+                ;;
+              sample)
+                ln -s "''${!outputName}/samples" "''${!outputName}/extras/CUPTI/samples"
+                ;;
+              lib|static)
+                ln -s "''${!outputName}/lib" "''${!outputName}/extras/CUPTI/lib"
+                ;;
+              *)
+                echo "Unexpected output name: $outputName" >&2
+                exit 1
+            esac
+          done
+        '';
+    };
+
   cuda_compat =
     { flags, lib }:
     prevAttrs: {

--- a/pkgs/development/cuda-modules/cudatoolkit/redist-wrapper.nix
+++ b/pkgs/development/cuda-modules/cudatoolkit/redist-wrapper.nix
@@ -2,6 +2,7 @@
   lib,
   symlinkJoin,
   backendStdenv,
+  cudaAtLeast,
   cudaOlder,
   cudatoolkit-legacy-runfile,
   cudaVersion,
@@ -17,6 +18,7 @@
   cuda_nvprune ? null,
   cuda_nvrtc ? null,
   cuda_nvtx ? null,
+  cuda_opencl ? null,
   cuda_profiler_api ? null,
   cuda_sanitizer_api ? null,
   libcublas ? null,
@@ -25,13 +27,16 @@
   libcusolver ? null,
   libcusparse ? null,
   libnpp ? null,
+  libnvjitlink ? null,
 }:
 
 let
+  inherit (lib.attrsets) getBin getDev getLib;
+  inherit (lib.lists) concatMap map optionals;
   getAllOutputs = p: [
-    (lib.getBin p)
-    (lib.getLib p)
-    (lib.getDev p)
+    (getBin p)
+    (getLib p)
+    (getDev p)
   ];
   hostPackages = [
     cuda_cuobjdump
@@ -40,23 +45,29 @@ let
     cuda_nvdisasm
     cuda_nvprune
   ];
-  targetPackages = [
-    cuda_cccl
-    cuda_cudart
-    cuda_cupti
-    cuda_cuxxfilt
-    cuda_nvml_dev
-    cuda_nvrtc
-    cuda_nvtx
-    cuda_profiler_api
-    cuda_sanitizer_api
-    libcublas
-    libcufft
-    libcurand
-    libcusolver
-    libcusparse
-    libnpp
-  ];
+  targetPackages =
+    [
+      cuda_cccl
+      cuda_cudart
+      cuda_cudart.static # NOTE: We need the static output specifically
+      cuda_cupti
+      cuda_cuxxfilt
+      cuda_nvml_dev
+      cuda_nvrtc
+      cuda_nvtx
+      cuda_profiler_api
+      cuda_sanitizer_api
+      libcublas
+      libcufft
+      libcurand
+      libcusolver
+      libcusparse
+      libnpp
+    ]
+    ++ optionals (cudaAtLeast "12.0") [
+      cuda_opencl
+      libnvjitlink
+    ];
 
   # This assumes we put `cudatoolkit` in `buildInputs` instead of `nativeBuildInputs`:
   allPackages = (map (p: p.__spliced.buildHost or p) hostPackages) ++ targetPackages;
@@ -69,13 +80,13 @@ else
     name = "cuda-merged-${cudaVersion}";
     version = cudaVersion;
 
-    paths = builtins.concatMap getAllOutputs allPackages;
+    paths = concatMap getAllOutputs allPackages;
 
     passthru = {
       cc = lib.warn "cudaPackages.cudatoolkit is deprecated, refer to the manual and use splayed packages instead" backendStdenv.cc;
       lib = symlinkJoin {
         inherit name;
-        paths = map (p: lib.getLib p) allPackages;
+        paths = map getLib allPackages;
       };
     };
 

--- a/pkgs/test/cuda/default.nix
+++ b/pkgs/test/cuda/default.nix
@@ -24,13 +24,15 @@
   cudaPackages_12_1,
   cudaPackages_12_2,
   cudaPackages_12_3,
+  cudaPackages_12_4,
   cudaPackages_12,
 }@args:
 
 let
   isTest =
     name: package:
-    builtins.elem (package.pname or null) [
+    name == "cmake-cuda-tests"
+    || builtins.elem (package.pname or null) [
       "cuda-samples"
       "cuda-library-samples"
       "saxpy"

--- a/pkgs/top-level/cuda-packages.nix
+++ b/pkgs/top-level/cuda-packages.nix
@@ -82,6 +82,9 @@ let
     nccl-tests = final.callPackage ../development/cuda-modules/nccl-tests { };
 
     writeGpuTestPython = final.callPackage ../development/cuda-modules/write-gpu-test-python.nix { };
+    cmake-cuda-tests = builtins.import ../development/cuda-modules/cmake-cuda-tests {
+      inherit (final) callPackage lib;
+    };
   });
 
   mkVersionedPackageName =


### PR DESCRIPTION
## Description of changes

Adds derivations to build the CMake CUDA test suite to verify our setup hooks and build environments are functioning as intended.

Exposed through passthrough are derivations which require NixOS systems to have the `"cuda"` system feature, as some of the tests require access to the GPU.

> [!IMPORTANT]
>
> TODO:
> - [ ] Update CMake files to build test executables and *run* test executables separately.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
