### PR TITLE
nexusmods-app: refactor the unfree variant

### DIFF
--- a/pkgs/by-name/ne/nexusmods-app/package.nix
+++ b/pkgs/by-name/ne/nexusmods-app/package.nix
@@ -12,13 +12,10 @@
   libX11,
   nexusmods-app,
   runCommand,
-  enableUnfree ? false, # Set to true to support RAR format mods
+  pname ? "nexusmods-app",
 }:
-let
-  _7zzWithOptionalUnfreeRarSupport = _7zz.override { inherit enableUnfree; };
-in
 buildDotnetModule rec {
-  pname = "nexusmods-app";
+  inherit pname;
   version = "0.4.1";
 
   src = fetchFromGitHub {
@@ -50,7 +47,7 @@ buildDotnetModule rec {
   '';
 
   postPatch = ''
-    ln --force --symbolic "${lib.getExe _7zzWithOptionalUnfreeRarSupport}" src/ArchiveManagement/NexusMods.FileExtractor/runtimes/linux-x64/native/7zz
+    ln --force --symbolic "${lib.getExe _7zz}" src/ArchiveManagement/NexusMods.FileExtractor/runtimes/linux-x64/native/7zz
 
     # for some reason these tests fail (intermittently?) with a zero timestamp
     touch tests/NexusMods.UI.Tests/WorkspaceSystem/*.verified.png
@@ -84,7 +81,7 @@ buildDotnetModule rec {
           "FullyQualifiedName!=NexusMods.UI.Tests.ImageCacheTests.Test_LoadAndCache_RemoteImage"
           "FullyQualifiedName!=NexusMods.UI.Tests.ImageCacheTests.Test_LoadAndCache_ImageStoredFile"
         ]
-        ++ lib.optionals (!enableUnfree) [
+        ++ lib.optionals (!_7zz.meta.unfree) [
           "FullyQualifiedName!=NexusMods.Games.FOMOD.Tests.FomodXmlInstallerTests.InstallsFilesSimple_UsingRar"
         ]
       )

--- a/pkgs/by-name/ne/nexusmods-app/package.nix
+++ b/pkgs/by-name/ne/nexusmods-app/package.nix
@@ -1,26 +1,24 @@
-{ _7zz
-, buildDotnetModule
-, copyDesktopItems
-, desktop-file-utils
-, dotnetCorePackages
-, fetchFromGitHub
-, fontconfig
-, lib
-, libICE
-, libSM
-, libX11
-, nexusmods-app
-, runCommand
-, enableUnfree ? false # Set to true to support RAR format mods
+{
+  _7zz,
+  buildDotnetModule,
+  copyDesktopItems,
+  desktop-file-utils,
+  dotnetCorePackages,
+  fetchFromGitHub,
+  fontconfig,
+  lib,
+  libICE,
+  libSM,
+  libX11,
+  nexusmods-app,
+  runCommand,
+  enableUnfree ? false, # Set to true to support RAR format mods
 }:
 let
-  _7zzWithOptionalUnfreeRarSupport = _7zz.override {
-    inherit enableUnfree;
-  };
+  _7zzWithOptionalUnfreeRarSupport = _7zz.override { inherit enableUnfree; };
 in
 buildDotnetModule rec {
   pname = "nexusmods-app";
-
   version = "0.4.1";
 
   src = fetchFromGitHub {
@@ -39,9 +37,7 @@ buildDotnetModule rec {
   projectFile = "src/NexusMods.App/NexusMods.App.csproj";
   testProjectFile = "NexusMods.App.sln";
 
-  nativeBuildInputs = [
-    copyDesktopItems
-  ];
+  nativeBuildInputs = [ copyDesktopItems ];
 
   nugetDeps = ./deps.nix;
 
@@ -61,7 +57,7 @@ buildDotnetModule rec {
   '';
 
   makeWrapperArgs = [
-    "--prefix PATH : ${lib.makeBinPath [desktop-file-utils]}"
+    "--prefix PATH : ${lib.makeBinPath [ desktop-file-utils ]}"
     "--set APPIMAGE $out/bin/${meta.mainProgram}" # Make associating with nxm links work on Linux
   ];
 
@@ -72,26 +68,27 @@ buildDotnetModule rec {
     libX11
   ];
 
-  executables = [
-    nexusmods-app.meta.mainProgram
-  ];
+  executables = [ nexusmods-app.meta.mainProgram ];
 
   doCheck = true;
 
   dotnetTestFlags = [
     "--environment=USER=nobody"
-    (lib.strings.concatStrings [
+    (
       "--filter="
-      (lib.strings.concatStrings (lib.strings.intersperse "&" ([
-        "Category!=Disabled"
-        "FlakeyTest!=True"
-        "RequiresNetworking!=True"
-        "FullyQualifiedName!=NexusMods.UI.Tests.ImageCacheTests.Test_LoadAndCache_RemoteImage"
-        "FullyQualifiedName!=NexusMods.UI.Tests.ImageCacheTests.Test_LoadAndCache_ImageStoredFile"
-      ] ++ lib.optionals (! enableUnfree) [
-        "FullyQualifiedName!=NexusMods.Games.FOMOD.Tests.FomodXmlInstallerTests.InstallsFilesSimple_UsingRar"
-       ])))
-    ])
+      + lib.strings.concatStringsSep "&" (
+        [
+          "Category!=Disabled"
+          "FlakeyTest!=True"
+          "RequiresNetworking!=True"
+          "FullyQualifiedName!=NexusMods.UI.Tests.ImageCacheTests.Test_LoadAndCache_RemoteImage"
+          "FullyQualifiedName!=NexusMods.UI.Tests.ImageCacheTests.Test_LoadAndCache_ImageStoredFile"
+        ]
+        ++ lib.optionals (!enableUnfree) [
+          "FullyQualifiedName!=NexusMods.Games.FOMOD.Tests.FomodXmlInstallerTests.InstallsFilesSimple_UsingRar"
+        ]
+      )
+    )
   ];
 
   passthru = {

--- a/pkgs/by-name/ne/nexusmods-app/package.nix
+++ b/pkgs/by-name/ne/nexusmods-app/package.nix
@@ -121,7 +121,6 @@ buildDotnetModule rec {
   };
 
   meta = {
-    description = "Game mod installer, creator and manager";
     mainProgram = "NexusMods.App";
     homepage = "https://github.com/Nexus-Mods/NexusMods.App";
     changelog = "https://github.com/Nexus-Mods/NexusMods.App/releases/tag/${src.rev}";
@@ -131,5 +130,32 @@ buildDotnetModule rec {
       MattSturgeon
     ];
     platforms = lib.platforms.linux;
+    description = "Game mod installer, creator and manager";
+    longDescription = ''
+      A mod installer, creator and manager for all your popular games.
+
+      Currently experimental and undergoing active development,
+      new releases may include breaking changes!
+
+      ${
+        if _7zz.meta.unfree then
+          ''
+            This "unfree" variant includes support for mods packaged as RAR archives.
+          ''
+        else
+          ''
+            It is strongly recommended that you use the "unfree" variant of this package,
+            which provides support for mods packaged as RAR archives.
+
+            You can also enable unrar support manually, by overriding the `_7zz` used:
+
+            ```nix
+            pkgs.nexusmods-app.override {
+              _7zz = pkgs._7zz-rar;
+            }
+            ```
+          ''
+      }
+    '';
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18792,8 +18792,9 @@ with pkgs;
 
   nix-build-uncached = callPackage ../development/tools/misc/nix-build-uncached { };
 
-  nexusmods-app-unfree = callPackage ../by-name/ne/nexusmods-app/package.nix {
-    enableUnfree = true;
+  nexusmods-app-unfree = nexusmods-app.override {
+    pname = "nexusmods-app-unfree";
+    _7zz = _7zz-rar;
   };
 
   nmrpflash = callPackage ../development/embedded/nmrpflash { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Reformat with nixfmt
- ~~Cherry picked some fixes by @corngood.
  If #327651 is merged before this, they can be dropped in a rebase.~~
- Removed the `enableUnfree` argument; instead users should override the `_7zz` argument.
- Refactor **nexusmods-app-unfree**'s implementation to use `override` instead of `callPackage`
- Set **nexusmods-app-unfree**'s `pname` using `overrideAttrs`
- Add a long description, which varies depending on `_7zz.meta.unfree`
  - This attempts to warn users that the free variant doesn't support RAR archive mods
  - It also documents how to enable RAR support

Merging this early should hopefully make #331150 easier to work on and review.

See also: #327651 #331150
Closes #321405

cc @l0b0 @corngood @GGG-KILLER @erri120

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
