### PR TITLE
python312Packages.pytest-docker: init at 3.1.1

### DIFF
--- a/pkgs/development/python-modules/pytest-docker/default.nix
+++ b/pkgs/development/python-modules/pytest-docker/default.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  attrs,
+  docker-compose,
+  pytest,
+  pytestCheckHook,
+  requests,
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-docker";
+  version = "3.1.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-I3FSSASnUqqnZsebnu6OY0U0r924JZfztXPafF1v+18=";
+  };
+
+  postPatch = ''
+    sed -i "/addopts =/d" setup.cfg
+  '';
+
+  build-system = [ setuptools ];
+
+  buildInputs = [ pytest ];
+
+  dependencies = [ attrs ];
+
+  optional-dependencies = {
+    docker-compose-v1 = [ docker-compose ];
+  };
+
+  #Bypass the /homeless/shelter error
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    requests
+  ];
+
+  disabledTestPaths = [
+    # These tests require docker and docker compose to be available in path to create containers
+    "tests/test_fixtures.py"
+    "tests/test_integration.py"
+  ];
+  pythonImportsCheck = [ "pytest_docker" ];
+
+  meta = {
+    description = "Simple pytest fixtures for Docker and Docker Compose based tests";
+    homepage = "https://github.com/avast/pytest-docker";
+    changelog = "https://github.com/avast/pytest-docker/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ByteSudoer ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10353,6 +10353,8 @@ self: super: with self; {
 
   pysyncthru = callPackage ../development/python-modules/pysyncthru { };
 
+  pytest-docker = callPackage ../development/python-modules/pytest-docker { };
+
   pytest-mockito = callPackage ../development/python-modules/pytest-mockito { };
 
   pytest-pudb = callPackage ../development/python-modules/pytest-pudb { };


### PR DESCRIPTION
## Description of changes
Simple [pytest](http://doc.pytest.org/) fixtures that help you write integration tests with Docker and [Docker Compose](https://docs.docker.com/compose/). Specify all necessary containers in a docker-compose.yml file and and pytest-docker will spin them up for the duration of your tests.

Metadata
- homepage URL: https://github.com/avast/pytest-docker
- source URL: https://github.com/avast/pytest-docker
- license: MIT
- platforms: Linux

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
