### PR TITLE
lib.recursiveCollect: init

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -82,7 +82,7 @@ let
       composeManyExtensions makeExtensible makeExtensibleWithCustomName;
     inherit (self.attrsets) attrByPath hasAttrByPath setAttrByPath
       getAttrFromPath attrVals attrNames attrValues getAttrs catAttrs filterAttrs
-      filterAttrsRecursive foldlAttrs foldAttrs collect nameValuePair mapAttrs
+      filterAttrsRecursive foldlAttrs foldAttrs collect recursiveCollect nameValuePair mapAttrs
       mapAttrs' mapAttrsToList attrsToList concatMapAttrs mapAttrsRecursive
       mapAttrsRecursiveCond genAttrs isDerivation toDerivation optionalAttrs
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -35,6 +35,8 @@ let
     callPackageWith
     cartesianProduct
     cli
+    collect
+    recursiveCollect
     composeExtensions
     composeManyExtensions
     concatLines
@@ -61,6 +63,7 @@ let
     getLicenseFromSpdxIdOr
     groupBy
     groupBy'
+    hasAttr
     hasAttrByPath
     hasInfix
     id
@@ -1216,6 +1219,62 @@ runTests {
   testAttrsToListsCanDealWithFunctions = testingEval (
     attrsToList { someFunc= a: a + 1;}
   );
+
+  testCollect = {
+    expr = collect (x: x ? "collect-me") {
+      a.collect-me = "a";
+      a.other-attr = "other";
+      b = "b";
+      c.c.collect-me = "c.c";
+      d = [ { a.collect-me = "d.0.a"; } ];
+    };
+    expected = [
+      { collect-me = "a";
+        other-attr = "other";
+      }
+      { collect-me = "c.c"; }
+    ];
+  };
+
+  testCollectDoc = {
+    expr = collect (x: x ? "outPath") {
+      a = { outPath = "a/"; };
+      b.b = { outPath = "b/"; };
+      c = [ { outPath = "c/"; } ];
+    };
+    expected = [
+      { outPath = "a/"; }
+      { outPath = "b/"; }
+    ];
+  };
+
+  testRecursiveCollect = {
+    expr = recursiveCollect (x: x ? "collect-me") {
+      a.collect-me = "a";
+      a.other-attr = "other";
+      b = "b";
+      c.c.collect-me = "c.c";
+      d = [ { a.collect-me = "d.0.a"; } ];
+    };
+    expected = [
+      { collect-me = "a"; other-attr = "other"; }
+      { collect-me = "c.c"; }
+      { collect-me = "d.0.a"; }
+    ];
+  };
+
+  testRecursiveCollectDoc = {
+    expr = recursiveCollect (x: x ? "outPath") {
+      a = { outPath = "a/"; };
+      b.b = { outPath = "b/"; };
+      c = [ { outPath = "c/"; } ];
+    };
+    expected = [
+      { outPath = "a/"; }
+      { outPath = "b/"; }
+      { outPath = "c/"; }
+    ];
+  };
 
 # GENERATORS
 # these tests assume attributes are converted to lists


### PR DESCRIPTION
## Description of changes

Compared to the existing 'collect' function, this one descends into lists too.

This function will be used with user-provided freeform variables - arbitrary combinations of attrset, lists and values - in the upcoming secret management feature. The PR #328472 shows how it will be used.

I purposely created a new function instead of updating the existing 'collect' one because to avoid changing the implementation of such a base function.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
