### PR TITLE
{nix,lix,stdenv}: log hook information only if NIX_DEBUG >= 1; provide means to set it

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -434,6 +434,8 @@ The propagated equivalent of `depsTargetTarget`. This is prefixed for the same r
 
 A number between 0 and 7 indicating how much information to log. If set to 1 or higher, `stdenv` will print moderate debugging information during the build. In particular, the `gcc` and `ld` wrapper scripts will print out the complete command line passed to the wrapped tools. If set to 6 or higher, the `stdenv` setup script will be run with `set -x` tracing. If set to 7 or higher, the `gcc` and `ld` wrapper scripts will also be run with `set -x` tracing.
 
+In order to set the `NIX_DEBUG` environment variable, Nix itself must be re-compiled so that it's set in the local derivation build environment. This ensures that the derivation's hash doesn't change because `NIX_DEBUG` has been set. Most Nix derivation have a `withNixDebug` attribute which can be overridden. Set the `nix.package` option to use this `NIX_DEBUG`-enabled Nix.
+
 ### Attributes affecting build properties {#attributes-affecting-build-properties}
 
 #### `enableParallelBuilding` {#var-stdenv-enableParallelBuilding}
@@ -1421,7 +1423,7 @@ Both parameters take a list of flags as strings. The special `"all"` flag can be
 
 For more in-depth information on these hardening flags and hardening in general, refer to the [Debian Wiki](https://wiki.debian.org/Hardening), [Ubuntu Wiki](https://wiki.ubuntu.com/Security/Features), [Gentoo Wiki](https://wiki.gentoo.org/wiki/Project:Hardened), and the [Arch Wiki](https://wiki.archlinux.org/title/Security).
 
-Note that support for some hardening flags varies by compiler, CPU architecture, target OS and libc. Combinations of these that don't support a particular hardening flag will silently ignore attempts to enable it. To see exactly which hardening flags are being employed in any invocation, the `NIX_DEBUG` environment variable can be used.
+Note that support for some hardening flags varies by compiler, CPU architecture, target OS and libc. Combinations of these that don't support a particular hardening flag will silently ignore attempts to enable it. To see exactly which hardening flags are being employed in any invocation, the [`NIX_DEBUG` environment variable](#var-stdenv-NIX_DEBUG) can be used.
 
 ### Hardening flags enabled by default {#sec-hardening-flags-enabled-by-default}
 

--- a/pkgs/tools/package-management/lix/common.nix
+++ b/pkgs/tools/package-management/lix/common.nix
@@ -80,6 +80,9 @@ assert (hash == null) -> (src != null);
   # RISC-V support in progress https://github.com/seccomp/libseccomp/pull/50
   withLibseccomp ? lib.meta.availableOn stdenv.hostPlatform libseccomp,
   libseccomp,
+  # If non-`null`, the string value is what the environment variable `NIX_DEBUG`
+  # is set to when building any derivation. See the Nixpkgs manual for more.
+  withNixDebug ? null,
 
   confDir,
   stateDir,
@@ -161,6 +164,9 @@ stdenv.mkDerivation {
 
   postPatch = ''
     patchShebangs --build tests
+  '' + lib.optionalString (withNixDebug != null) ''
+    grep -r -l -Z -e 'env."NIX_LOG_FD".*"2"' src | \
+      xargs -0 sed -i '/NIX_LOG_FD.*2/a env["NIX_DEBUG"] = "${toString withNixDebug}";'
   '';
 
   preConfigure =

--- a/pkgs/tools/package-management/nix/common.nix
+++ b/pkgs/tools/package-management/nix/common.nix
@@ -78,6 +78,9 @@ in
 , enableStatic ? stdenv.hostPlatform.isStatic
 , withAWS ? !enableStatic && (stdenv.isLinux || stdenv.isDarwin), aws-sdk-cpp
 , withLibseccomp ? lib.meta.availableOn stdenv.hostPlatform libseccomp, libseccomp
+# If non-`null`, the string value is what the environment variable `NIX_DEBUG` is set to
+# when building any derivation. See the Nixpkgs manual for more.
+, withNixDebug ? null
 
 , confDir
 , stateDir
@@ -169,6 +172,9 @@ self = stdenv.mkDerivation {
 
   postPatch = ''
     patchShebangs --build tests
+  '' + lib.optionalString (withNixDebug != null) ''
+    grep -r -l -Z -e 'env."NIX_LOG_FD".*"2"' src | \
+      xargs -0 sed -i '/NIX_LOG_FD.*2/a env["NIX_DEBUG"] = "${toString withNixDebug}";'
   '';
 
   preConfigure =


### PR DESCRIPTION
## Motivation for changes

- #328229

Ever since Qyriad's excellent PRs (#290081, #310387) to make hooks more visible in the nixpkgs stdenv  landed, we've been caught between two goals:

1. Being able to understand what a hook does.
2. Being overwhelmed by the amount of information to skip over.

In the issue linked above, there's a real tension: we want to understand what's happening with a derivation _without changing its hash_ -- but we also don't want to see this debugging information every time.

## Description of changes

These commits piggyback on the existing `NIX_DEBUG` environment variable to turn on and turn off the hook logging. So, if `NIX_DEBUG` is `1` or greater, the hook logging is turned on.

There was, however, no documented way of setting the `NIX_DEBUG` variable in the Nix build environment.

This patch adds an off-by-default option to the Nix and Lix derivations which allows building Nix such that the `NIX_DEBUG` variable is set in the Nix build environment.

Yes, *this is a total hack*, and has no upstream warranty either express or implied. For such a "deep into the sauce" sort of debugging that needs this variable set, I feel that's OK.

I'll extract the somewhat arcane `grep | sed` thing into an actual patch if people are aligned on this direction.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Fixes #328229.