### PR TITLE
lib.mapDataRecursiveCond: init

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -7,11 +7,11 @@ let
   inherit (builtins) head length;
   inherit (lib.trivial) isInOldestRelease mergeAttrs warn warnIf;
   inherit (lib.strings) concatStringsSep concatMapStringsSep escapeNixIdentifier sanitizeDerivationName;
-  inherit (lib.lists) foldr foldl' concatMap elemAt all partition groupBy take foldl imap0;
+  inherit (lib.lists) foldr foldl' concatMap elemAt all partition groupBy take foldl imap0 isList;
 in
 
 rec {
-  inherit (builtins) attrNames listToAttrs hasAttr isAttrs isList getAttr removeAttrs intersectAttrs;
+  inherit (builtins) attrNames listToAttrs hasAttr isAttrs getAttr removeAttrs intersectAttrs;
 
 
   /**

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1145,7 +1145,6 @@ rec {
     Like `mapAttrs`, except that it recursively applies itself to the *leaf* attributes of a potentially-nested attribute set:
     the second argument of the function will never be an attrset.
     Also, the first argument of the mapping function is a *list* of the attribute names that form the path to the leaf attribute.
-    This function recursively applies itself to lists too, in which case the list of attribute names will contain a number representing the index.
 
     For a function that gives you control over what counts as a leaf, see [`lib.attrsets.mapAttrsRecursiveCond`](#function-library-lib.attrsets.mapAttrsRecursiveCond).
 
@@ -1168,29 +1167,20 @@ rec {
     # Map over leaf attributes with lists
 
     ```nix
-    mapAttrsRecursive (path: value: concatStringsSep "-" (path ++ [value]))
-      {
-        n = {
-          a = "A";
-          m = [
-            { b = "B"; c = "C"; }
-            { d = "D"; e = "E"; }
-          ];
-        };
-        f = "F";
-      }
+    nix-repl> :p lib.mapAttrsRecursive (path: value: lib.concatStringsSep "-" (path ++ [value])) {
+                f = "F";
+                n = {
+                  a = "A";
+                };
+              }
     ```
     evaluates to
     ```nix
     {
+      f = "f-F";
       n = {
         a = "n-a-A";
-        m = [
-          { b = "n-m-0-b-B"; c = "n-m-0-c-C"; }
-          { d = "n-m-1-d-D"; e = "n-m-1-e-E"; }
-        ];
       };
-      f = "f-F";
     }
     ```
     :::

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1263,9 +1263,9 @@ rec {
     data:
     let
       recurse = path: val:
-        if isAttrs val && cond val
+        if isAttrs val && cond path val
         then mapAttrs (n: v: recurse (path ++ [n]) v) val
-        else if isList val && cond val
+        else if isList val && cond path val
         then imap0 (i: v: recurse (path ++ [i]) v) val
         else f path val;
     in

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -84,7 +84,7 @@ let
       getAttrFromPath attrVals attrNames attrValues getAttrs catAttrs filterAttrs
       filterAttrsRecursive foldlAttrs foldAttrs collect nameValuePair mapAttrs
       mapAttrs' mapAttrsToList attrsToList concatMapAttrs mapAttrsRecursive
-      mapAttrsRecursiveCond genAttrs isDerivation toDerivation optionalAttrs
+      mapAttrsRecursiveCond mapDataRecursiveCond genAttrs isDerivation toDerivation optionalAttrs
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
       recursiveUpdate matchAttrs mergeAttrsList overrideExisting showAttrPath getOutput getFirstOutput
       getBin getLib getStatic getDev getInclude getMan chooseDevOutputs zipWithNames zip

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -2533,7 +2533,7 @@ runTests {
           e = { a = 0; };
         };
       in
-        mapDataRecursiveCond (x: true) (path: x: path) (
+        mapDataRecursiveCond (path: x: true) (path: x: path) (
           attr
           // { nestedAttr = attr; }
           // { nestedList = [ attr attr ]; }

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -2569,4 +2569,51 @@ runTests {
       ];
     };
   };
+
+  testMapDataRecursiveCondTraverseSome = {
+    expr =
+      let
+        attr = {
+          x = { cont = true; x = 0; };
+          y = { cont = false; y = 1; };
+          z = [ { cont = false; z1 = 0; }
+                { cont = true; z2 = 1; } ];
+        };
+      in
+        mapDataRecursiveCond (path: x: if x ? cont then x.cont else true) (path: x: path) (
+          attr
+          // { nestedAttr = attr; }
+          // { nestedList = [ attr attr ]; }
+        );
+    expected = {
+      x = { cont = [ "x" "cont" ]; x = [ "x" "x" ]; };
+      y = [ "y" ];
+      z = [ [ "z" 0 ]
+            { cont = [ "z" 1 "cont" ];
+              z2 = [ "z" 1 "z2" ]; } ];
+      nestedAttr = {
+        x = { cont = [ "nestedAttr" "x" "cont" ]; x = [ "nestedAttr" "x" "x" ]; };
+        y = [ "nestedAttr" "y" ];
+        z = [ [ "nestedAttr" "z" 0 ]
+              { cont = [ "nestedAttr" "z" 1 "cont" ];
+                z2 = [ "nestedAttr" "z" 1 "z2" ]; } ];
+      };
+      nestedList = [
+        {
+          x = { cont = [ "nestedList" 0 "x" "cont" ]; x = [ "nestedList" 0 "x" "x" ]; };
+          y = [ "nestedList" 0 "y" ];
+          z = [ [ "nestedList" 0 "z" 0 ]
+                { cont = [ "nestedList" 0 "z" 1 "cont" ];
+                  z2 = [ "nestedList" 0 "z" 1 "z2" ]; } ];
+        }
+        {
+          x = { cont = [ "nestedList" 1 "x" "cont" ]; x = [ "nestedList" 1 "x" "x" ]; };
+          y = [ "nestedList" 1 "y" ];
+          z = [ [ "nestedList" 1 "z" 0 ]
+                { cont = [ "nestedList" 1 "z" 1 "cont" ];
+                  z2 = [ "nestedList" 1 "z" 1 "z2" ]; } ];
+        }
+      ];
+    };
+  };
 }


### PR DESCRIPTION
## Description of changes

This new 'mapDataRecursiveCond' function is like 'mapAttrsRecursiveCond' and additionally recurses on lists.

This function will be used with user-provided freeform variables - arbitrary combinations of
attrset, lists and values - in the upcoming secret management feature. The PR #328472 shows how it will be used.

The test `testMapAttrRecursiveDoc` is taken verbatim from the documentation of that function.  I added it as some kind of regression test.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
