### PR TITLE
platformio: 6.1.11 -> 6.1.15

### DIFF
--- a/pkgs/development/embedded/platformio/core.nix
+++ b/pkgs/development/embedded/platformio/core.nix
@@ -11,7 +11,7 @@
 
 with python3Packages; buildPythonApplication rec {
   pname = "platformio";
-  version = "6.1.11";
+  version = "6.1.15";
   pyproject = true;
 
   # pypi tarballs don't contain tests - https://github.com/platformio/platformio-core/issues/1964
@@ -19,7 +19,7 @@ with python3Packages; buildPythonApplication rec {
     owner = "platformio";
     repo = "platformio-core";
     rev = "v${version}";
-    hash = "sha256-NR4UyAt8q5sUGtz1Sy6E8Of7y9WrH9xpcAWzLBeDQmo=";
+    hash = "sha256-w5JUAqQRNxq8ZrX8ffny2K7xWBkGr2H3+apYqCPXw9c=";
   };
 
   outputs = [ "out" "udev" ];
@@ -132,6 +132,7 @@ with python3Packages; buildPythonApplication rec {
     # requires internet connection
     "test_api_cache"
     "test_ping_internet_ips"
+    "test_metadata_dump"
   ];
 
   pytestFlagsArray = [

--- a/pkgs/development/embedded/platformio/use-local-spdx-license-list.patch
+++ b/pkgs/development/embedded/platformio/use-local-spdx-license-list.patch
@@ -1,12 +1,12 @@
 diff --git a/platformio/package/manifest/schema.py b/platformio/package/manifest/schema.py
-index 95e08108..6c2cfaed 100644
+index c1d22ab5..6c2cfaed 100644
 --- a/platformio/package/manifest/schema.py
 +++ b/platformio/package/manifest/schema.py
 @@ -276,9 +276,6 @@ class ManifestSchema(BaseSchema):
      @staticmethod
      @memoized(expire="1h")
      def load_spdx_licenses():
--        version = "3.21"
+-        version = "3.23"
 -        spdx_data_url = (
 -            "https://raw.githubusercontent.com/spdx/license-list-data/"
 -            f"v{version}/json/licenses.json"


### PR DESCRIPTION
https://github.com/platformio/platformio-core/releases/tag/v6.1.12
https://github.com/platformio/platformio-core/releases/tag/v6.1.13
https://github.com/platformio/platformio-core/releases/tag/v6.1.14
https://github.com/platformio/platformio-core/releases/tag/v6.1.15

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
