### PR TITLE
pretix: 2024.6.0 -> 2024.7.0

### DIFF
--- a/nixos/modules/services/web-apps/pretix.nix
+++ b/nixos/modules/services/web-apps/pretix.nix
@@ -249,7 +249,7 @@ in
             };
 
             host = mkOption {
-              type = with types; nullOr types.path;
+              type = with types; nullOr path;
               default = if cfg.settings.database.backend == "postgresql" then "/run/postgresql" else null;
               defaultText = literalExpression ''
                 if config.services.pretix.settings..database.backend == "postgresql" then "/run/postgresql"
@@ -535,7 +535,7 @@ in
           fi
         '';
         serviceConfig = {
-          TimeoutStartSec = "5min";
+          TimeoutStartSec = "15min";
           ExecStart = "${getExe' pythonEnv "gunicorn"} --bind unix:/run/pretix/pretix.sock ${cfg.gunicorn.extraArgs} pretix.wsgi";
           RuntimeDirectory = "pretix";
         };

--- a/pkgs/by-name/pr/pretix/package.nix
+++ b/pkgs/by-name/pr/pretix/package.nix
@@ -40,13 +40,13 @@ let
   };
 
   pname = "pretix";
-  version = "2024.6.0";
+  version = "2024.7.0";
 
   src = fetchFromGitHub {
     owner = "pretix";
     repo = "pretix";
     rev = "refs/tags/v${version}";
-    hash = "sha256-erI3Ai6zwNSvMiF3YKfnU9ePb9R92rfi5rsxfAOh6EQ=";
+    hash = "sha256-08ykuFPcG3WvinJd9zadirXFqsMt9GbdOGU2CGbW7ls=";
   };
 
   npmDeps = buildNpmPackage {
@@ -54,7 +54,7 @@ let
     inherit version src;
 
     sourceRoot = "${src.name}/src/pretix/static/npm_dir";
-    npmDepsHash = "sha256-//CLPnx5eUxIHIUGc7x2UF8qsfAYRtvHbHXSDNtI/eI=";
+    npmDepsHash = "sha256-BfvKuwB5VLX09Lxji+EpMBvZeKTIQvptVtrHSRYY+14=";
 
     dontBuild = true;
 
@@ -76,6 +76,26 @@ python.pkgs.buildPythonApplication rec {
     # Discover pretix.plugin entrypoints during build and add them into
     # INSTALLED_APPS, so that their static files are collected.
     ./plugin-build.patch
+
+    # https://github.com/pretix/pretix/pull/4362
+    # Fix TOCTOU race in directory creation
+    ./pr4362.patch
+  ];
+
+  pythonRelaxDeps = [
+    "bleach"
+    "importlib-metadata"
+    "pillow"
+    "protobuf"
+    "python-bidi"
+    "requests"
+    "sentry-sdk"
+  ];
+
+  pythonRemoveDeps = [
+    "phonenumberslite" # we provide phonenumbers instead
+    "psycopg2-binary" # we provide psycopg2 instead
+    "vat-moss-forked" # we provide a patched vat-moss package
   ];
 
   postPatch = ''
@@ -88,22 +108,8 @@ python.pkgs.buildPythonApplication rec {
     sed -i "/setuptools-rust/d" pyproject.toml
 
     substituteInPlace pyproject.toml \
-      --replace-fail phonenumberslite phonenumbers \
-      --replace-fail psycopg2-binary psycopg2 \
-      --replace-fail vat_moss_forked==2020.3.20.0.11.0 vat-moss \
-      --replace-fail "bleach==5.0.*" bleach \
-      --replace-fail "djangorestframework==3.15.*" djangorestframework \
-      --replace-fail "django-compressor==4.5" django-compressor \
-      --replace-fail "dnspython==2.6.*" dnspython \
-      --replace-fail "importlib_metadata==7.*" importlib_metadata \
-      --replace-fail "markdown==3.6" markdown \
-      --replace-fail "protobuf==5.27.*" protobuf \
-      --replace-fail "pycryptodome==3.20.*" pycryptodome \
-      --replace-fail "pypdf==4.2.*" pypdf \
-      --replace-fail "python-dateutil==2.9.*" python-dateutil \
-      --replace-fail "requests==2.31.*" "requests" \
-      --replace-fail "sentry-sdk==2.5.*" "sentry-sdk>=2" \
-      --replace-fail "stripe==7.9.*" stripe
+      --replace-fail '"backend"' '"setuptools.build_meta"' \
+      --replace-fail 'backend-path = ["_build"]' ""
   '';
 
   build-system = with python.pkgs; [

--- a/pkgs/by-name/pr/pretix/plugins/default.nix
+++ b/pkgs/by-name/pr/pretix/plugins/default.nix
@@ -10,4 +10,6 @@
   reluctant-stripe = callPackage ./reluctant-stripe.nix { };
 
   stretchgoals = callPackage ./stretchgoals.nix { };
+
+  zugferd = callPackage ./zugferd.nix { };
 }

--- a/pkgs/by-name/pr/pretix/plugins/zugferd.nix
+++ b/pkgs/by-name/pr/pretix/plugins/zugferd.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pretix-plugin-build,
+  setuptools,
+  drafthorse,
+  ghostscript_headless,
+}:
+
+buildPythonPackage rec {
+  pname = "pretix-zugferd";
+  version = "2.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pretix";
+    repo = "pretix-zugferd";
+    rev = "v${version}";
+    hash = "sha256-ozFDNIA+0feHrHHvxcf+6Jh4L83svmPEE/rerd4Yim8=";
+  };
+
+  postPatch = ''
+    substituteInPlace pretix_zugferd/invoice.py \
+      --replace-fail 'fallback="gs"' 'fallback="${lib.getExe ghostscript_headless}"'
+  '';
+
+  pythonRelaxDeps = [ "drafthorse" ];
+
+  build-system = [
+    pretix-plugin-build
+    setuptools
+  ];
+
+  dependencies = [ drafthorse ];
+
+  doCheck = false; # no tests
+
+  pythonImportsCheck = [ "pretix_zugferd" ];
+
+  meta = with lib; {
+    description = "Annotate pretix' invoices with ZUGFeRD data";
+    homepage = "https://github.com/pretix/pretix-zugferd";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/by-name/pr/pretix/pr4362.patch
+++ b/pkgs/by-name/pr/pretix/pr4362.patch
@@ -1,0 +1,50 @@
+From 5688f3624005d02803f2a434db025f367b4963d3 Mon Sep 17 00:00:00 2001
+From: Martin Weinelt <hexa@darmstadt.ccc.de>
+Date: Thu, 1 Aug 2024 02:39:59 +0200
+Subject: [PATCH] Prevent race condition in directory creation
+
+Checking whether a path does not exist before trying to create it does
+not follow the Python paradigm of asking for forgiveness, rather than
+permission, and opens up a time-of-check to time-of-use race.
+---
+ src/pretix/settings.py | 17 +++++++++--------
+ 1 file changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/src/pretix/settings.py b/src/pretix/settings.py
+index 81ff644be..854187f05 100644
+--- a/src/pretix/settings.py
++++ b/src/pretix/settings.py
+@@ -37,6 +37,7 @@ import configparser
+ import logging
+ import os
+ import sys
++from contextlib import suppress
+ from json import loads
+ from urllib.parse import urlparse
+ 
+@@ -70,14 +71,14 @@ MEDIA_ROOT = os.path.join(DATA_DIR, 'media')
+ PROFILE_DIR = os.path.join(DATA_DIR, 'profiles')
+ CACHE_DIR = config.get('pretix', 'cachedir', fallback=os.path.join(DATA_DIR, 'cache'))
+ 
+-if not os.path.exists(DATA_DIR):
+-    os.mkdir(DATA_DIR)
+-if not os.path.exists(LOG_DIR):
+-    os.mkdir(LOG_DIR)
+-if not os.path.exists(MEDIA_ROOT):
+-    os.mkdir(MEDIA_ROOT)
+-if not os.path.exists(CACHE_DIR):
+-    os.mkdir(CACHE_DIR)
++def mkdir(path):
++    with suppress(FileExistsError):
++        os.mkdir(path)
++
++mkdir(DATA_DIR)
++mkdir(LOG_DIR)
++mkdir(MEDIA_ROOT)
++mkdir(CACHE_DIR)
+ 
+ if config.has_option('django', 'secret'):
+     SECRET_KEY = config.get('django', 'secret')
+-- 
+2.45.2
+

--- a/pkgs/development/python-modules/django-hijack/default.nix
+++ b/pkgs/development/python-modules/django-hijack/default.nix
@@ -21,14 +21,14 @@
 
 buildPythonPackage rec {
   pname = "django-hijack";
-  version = "3.5.4";
+  version = "3.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "django-hijack";
     repo = "django-hijack";
     rev = "refs/tags/${version}";
-    hash = "sha256-d8rKn4Hab7y/e/VLhVfr3A3TUhoDtjP7RhCj+o6IbyE=";
+    hash = "sha256-uece+tR3Nd32nfKn1gtcWqckN4z5iUP+C0dJxyDPXBA=";
   };
 
   postPatch = ''
@@ -58,7 +58,7 @@ buildPythonPackage rec {
   ];
 
   preCheck = ''
-    export DJANGO_SETTINGS_MODULE=hijack.tests.test_app.settings
+    export DJANGO_SETTINGS_MODULE=tests.test_app.settings
   '';
 
   # needed for npmDeps update

--- a/pkgs/development/python-modules/drafthorse/default.nix
+++ b/pkgs/development/python-modules/drafthorse/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  lxml,
+  pypdf,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "drafthorse";
+  version = "2.4.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pretix";
+    repo = "python-drafthorse";
+    rev = version;
+    hash = "sha256-3W5rQ0YhyhIoZ+KsaOjlEJOrcoejPoTIJaylK7DOwKc=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    lxml
+    pypdf
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "drafthorse" ];
+
+  meta = with lib; {
+    description = "Pure-python ZUGFeRD implementation";
+    homepage = "https://github.com/pretix/python-drafthorse";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/python-bidi/default.nix
+++ b/pkgs/development/python-modules/python-bidi/default.nix
@@ -1,21 +1,39 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  six,
+  fetchFromGitHub,
+  rustPlatform,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "python-bidi";
-  version = "0.4.2";
-  format = "setuptools";
+  version = "0.6.0";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "U0f3HoKz6Zdtxlfwne0r/jm6jWd3yoGlssVsMBIcSW4=";
+  src = fetchFromGitHub {
+    owner = "MeirKriheli";
+    repo = "python-bidi";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-LrXt9qaXfy8Rn9HjU4YSTFT4WsqzwCgh0flcxXOTF6E=";
   };
 
-  propagatedBuildInputs = [ six ];
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-34R8T8cXiX1iRx/Zb51Eb/nf0wLpN38hz0VnsmzPzws=";
+  };
+
+  build-system = [
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  preCheck = ''
+    rm -rf bidi
+  '';
+
+  nativeCheckInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     homepage = "https://github.com/MeirKriheli/python-bidi";

--- a/pkgs/development/python-modules/sentry-sdk/default.nix
+++ b/pkgs/development/python-modules/sentry-sdk/default.nix
@@ -63,14 +63,14 @@
 
 buildPythonPackage rec {
   pname = "sentry-sdk";
-  version = "2.11.0";
+  version = "2.12.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "getsentry";
     repo = "sentry-python";
     rev = version;
-    hash = "sha256-ajinOND8MC9Z69WPxF65wjOmJfU5CZUzTRWJwLLh/OQ=";
+    hash = "sha256-34/QDus1KKCD2fe0ZTmgB1hTqMC7M6/fuuqKYRRsJ2E=";
   };
 
   postPatch = ''
@@ -189,6 +189,7 @@ buildPythonPackage rec {
     "test_auto_session_tracking_with_aggregates"
     # timing sensitive
     "test_profile_captured"
+    "test_continuous_profiler_manual_start_and_stop"
   ];
 
   pythonImportsCheck = [ "sentry_sdk" ];

--- a/pkgs/development/python-modules/webauthn/default.nix
+++ b/pkgs/development/python-modules/webauthn/default.nix
@@ -2,8 +2,10 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   asn1crypto,
   cbor2,
+  cryptography,
   pythonOlder,
   pyopenssl,
   pytestCheckHook,
@@ -11,8 +13,8 @@
 
 buildPythonPackage rec {
   pname = "webauthn";
-  version = "2.1.0";
-  format = "setuptools";
+  version = "2.2.0";
+  pyproject = true;
 
   disabled = pythonOlder "3.8";
 
@@ -20,12 +22,15 @@ buildPythonPackage rec {
     owner = "duo-labs";
     repo = "py_webauthn";
     rev = "refs/tags/v${version}";
-    hash = "sha256-AfQ3lt0WvoThU5kCE7MzhAXwbqmNaCrUqOMWI937hO4=";
+    hash = "sha256-NBCR5GwmXA6COP9NOYnoD3l1vuOpym/kyNawd8FstLc=";
   };
+
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [
     asn1crypto
     cbor2
+    cryptography
     pyopenssl
   ];
 
@@ -35,7 +40,7 @@ buildPythonPackage rec {
 
   disabledTests = [
     # TypeError: X509StoreContextError.__init__() missing 1 required...
-    "test_throws_on_bad_root_cert"
+    #"test_throws_on_bad_root_cert"
   ];
 
   meta = with lib; {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3617,6 +3617,8 @@ self: super: with self; {
 
   dploot = callPackage ../development/python-modules/dploot { };
 
+  drafthorse = callPackage ../development/python-modules/drafthorse { };
+
   draftjs-exporter = callPackage ../development/python-modules/draftjs-exporter { };
 
   dragonfly = callPackage ../development/python-modules/dragonfly { };


### PR DESCRIPTION
https://github.com/getsentry/sentry-python/blob/2.12.0/CHANGELOG.md
https://github.com/django-hijack/django-hijack/releases/tag/3.6.0
https://github.com/duo-labs/py_webauthn/blob/v2.2.0/CHANGELOG.md
https://pretix.eu/about/en/blog/20240726-release-2024-7/

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
