### PR TITLE
workflows/*: ensure jobs have names

### DIFF
--- a/.github/workflows/basic-eval.yml
+++ b/.github/workflows/basic-eval.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   tests:
+    name: basic-eval-checks
     runs-on: ubuntu-latest
     # we don't limit this action to only NixOS repo since the checks are cheap and useful developer feedback
     steps:

--- a/.github/workflows/check-by-name.yml
+++ b/.github/workflows/check-by-name.yml
@@ -27,6 +27,7 @@ permissions: {}
 
 jobs:
   check:
+    name: pkgs-by-name-check
     # This needs to be x86_64-linux, because we depend on the tooling being pre-built in the GitHub releases
     runs-on: ubuntu-latest
     # This should take 1 minute at most, but let's be generous.

--- a/.github/workflows/check-cherry-picks.yml
+++ b/.github/workflows/check-cherry-picks.yml
@@ -10,6 +10,7 @@ permissions: {}
 
 jobs:
   check:
+    name: cherry-pick-check
     runs-on: ubuntu-latest
     if: github.repository_owner == 'NixOS'
     steps:

--- a/.github/workflows/check-maintainers-sorted.yaml
+++ b/.github/workflows/check-maintainers-sorted.yaml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   nixos:
+    name: maintainer-list-check
     runs-on: ubuntu-latest
     if: github.repository_owner == 'NixOS'
     steps:

--- a/.github/workflows/check-nix-format.yml
+++ b/.github/workflows/check-nix-format.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   nixos:
+    name: nixfmt-check
     runs-on: ubuntu-latest
     if: "!contains(github.event.pull_request.title, '[skip treewide]')"
     steps:

--- a/.github/workflows/check-nixf-tidy.yml
+++ b/.github/workflows/check-nixf-tidy.yml
@@ -8,6 +8,7 @@ permissions:
 
 jobs:
   nixos:
+    name: exp-nixf-tidy-check
     runs-on: ubuntu-latest
     if: "!contains(github.event.pull_request.title, '[skip treewide]')"
     steps:

--- a/.github/workflows/check-shell.yml
+++ b/.github/workflows/check-shell.yml
@@ -7,6 +7,7 @@ permissions: {}
 
 jobs:
   x86_64-linux:
+    name: shell-check-x86_64-linux
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -18,6 +19,7 @@ jobs:
         run: nix-build shell.nix
 
   aarch64-darwin:
+    name: shell-check-aarch64-darwin
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   tests:
+    name: editorconfig-check
     runs-on: ubuntu-latest
     if: "github.repository_owner == 'NixOS' && !contains(github.event.pull_request.title, '[skip treewide]')"
     steps:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   labels:
+    name: label-pr
     runs-on: ubuntu-latest
     if: "github.repository_owner == 'NixOS' && !contains(github.event.pull_request.title, '[skip treewide]')"
     steps:

--- a/.github/workflows/manual-nixos.yml
+++ b/.github/workflows/manual-nixos.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   nixos:
+    name: nixos-manual-build
     runs-on: ubuntu-latest
     if: github.repository_owner == 'NixOS'
     steps:

--- a/.github/workflows/manual-nixpkgs.yml
+++ b/.github/workflows/manual-nixpkgs.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   nixpkgs:
+    name: nixpkgs-manual-build
     runs-on: ubuntu-latest
     if: github.repository_owner == 'NixOS'
     steps:

--- a/.github/workflows/nix-parse.yml
+++ b/.github/workflows/nix-parse.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   tests:
+    name: nix-files-parseable-check
     runs-on: ubuntu-latest
     if: "github.repository_owner == 'NixOS' && !contains(github.event.pull_request.title, '[skip treewide]')"
     steps:

--- a/.github/workflows/ofborg-pending.yml
+++ b/.github/workflows/ofborg-pending.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   action:
+    name: set-ofborg-pending
     if: github.repository_owner == 'NixOS'
     permissions:
       statuses: write


### PR DESCRIPTION
## Description of changes

A number of jobs have no names, which causes the GH UI to show less than helpful information in some scenarios. Let's add some.

For example:
![screenshot_2024-07-31-232912](https://github.com/user-attachments/assets/2c863ca7-28d3-495e-9d04-526a9b51ecae)

I chose short, hyphenated, names and put words like `check` at the end to help for smaller screens.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
