### PR TITLE
nixos/kanata: fix enabling kanata using `nixos-rebuild switch`

### DIFF
--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -438,6 +438,9 @@ in
 
     systemd.services.systemd-udevd =
       { restartTriggers = cfg.packages;
+        # partial fix for https://github.com/NixOS/nixpkgs/issues/334017
+        requiredBy = [ "sysinit-reactivation.target" ];
+        before = [ "sysinit-reactivation.target" ];
       };
 
   };

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -373,6 +373,9 @@ in
 
         systemd.services.systemd-modules-load =
           { wantedBy = [ "multi-user.target" ];
+            # partial fix for https://github.com/NixOS/nixpkgs/issues/334017
+            requiredBy = [ "sysinit-reactivation.target" ];
+            before = [ "sysinit-reactivation.target" ];
             restartTriggers = [ kernelModulesConf ];
             serviceConfig =
               { # Ignore failed module loads.  Typically some of the


### PR DESCRIPTION
## Description of changes

When enabling `services.kanata` on a running system using `nixos-rebuild switch` (or `nixos-rebuild test`), the kanata service may fail to start if `hardware.uinput` is not enabled before.  Note that this issue never happens if you use `nixos-rebuild boot` to enable `service.kanata`.

kanata needs to use uinput, so the `services.kanata` module sets `hardware.uinput.enable = true`.  The config of `hardware.uinput` is set by `systemd-modules-load.service` and `systemd-udevd.service`.  These two systemd services are dependencies of `sysinit.target`.  According to `man systemd.special`, systemd automatically adds dependencies of the types Requires= and After= for this target unit to all services.  So the kanata service will run after these two services during boot.  However, `nixos-rebuild switch` do not know the dependency and order between the kanata service and these two services, so the kanata service may fail to start.

This patch makes [`sysinit-reactivation.target`][2] depend on these two services so that the dependency and order of the kanata service and these two services are preserved by `nixos-rebuild switch`.

Ideally, `sysinit-reactivation.target` should depend on all ["sysinit units"][1].  This is tracked in https://github.com/NixOS/nixpkgs/issues/334017.  But that is beyond the scope of this PR.  This PR can be seen as a partial fix for https://github.com/NixOS/nixpkgs/issues/334017.

[1]: https://nixos.org/manual/nixos/unstable/#sec-sysinit-reactivation
[2]: https://github.com/NixOS/nixpkgs/pull/271067

Closes https://github.com/NixOS/nixpkgs/issues/317282


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
