### PR TITLE
bash: 5.2p26 -> 5.2p32; add upstream fix for `pop_var_context` error

### DIFF
--- a/pkgs/shells/bash/5.nix
+++ b/pkgs/shells/bash/5.nix
@@ -61,6 +61,8 @@ stdenv.mkDerivation rec {
     #   https://savannah.gnu.org/patch/index.php?10373
     # Had to fetch manually to workaround -p0 default.
     ./parallel.patch
+    # Fix `pop_var_context: head of shell_variables not a function context`.
+    ./fix-pop-var-context-error.patch
   ];
 
   configureFlags = [

--- a/pkgs/shells/bash/5.nix
+++ b/pkgs/shells/bash/5.nix
@@ -57,11 +57,6 @@ stdenv.mkDerivation rec {
 
   patches = upstreamPatches ++ [
     ./pgrp-pipe-5.patch
-    (fetchurl {
-      name = "fix-static.patch";
-      url = "https://cgit.freebsd.org/ports/plain/shells/bash/files/patch-configure?id=3e147a1f594751a68fea00a28090d0792bee0b51";
-      sha256 = "XHFMQ6eXTReNoywdETyrfQEv1rKF8+XFbQZP4YoVKFk=";
-    })
     # Apply parallel build fix pending upstream inclusion:
     #   https://savannah.gnu.org/patch/index.php?10373
     # Had to fetch manually to workaround -p0 default.

--- a/pkgs/shells/bash/bash-5.2-patches.nix
+++ b/pkgs/shells/bash/bash-5.2-patches.nix
@@ -27,4 +27,10 @@ patch: [
 (patch "024" "1hq23djqbr7s9y2324jq9mxr5bwdkmgizn3zgpchbsqp054k85cp")
 (patch "025" "0x9hc4silzl4d3zw4p43i5dm7w86k50j47f87lracwfgwy3z8f2i")
 (patch "026" "1b1fhm1dsi67r8ip17s0xvx2qq31fsxc1g9n3r931dd0k9a1zvln")
+(patch "027" "0fdbhvs9dkf4knncifh98a76q4gylhyvfrffq5p9q3ag5q58jap1")
+(patch "028" "1hdacd6sssjshmry1sscdnxxfb2r51bvdyghlfjaqgc9l85phhk0")
+(patch "029" "11wrlb20w6v89b96krg0gwxipwhvrda6rq1y9f972m32gsrsqp0j")
+(patch "030" "13v9fqgim082dmvkslsr0hs793yzhsij2s91mjswsfhj1qip7zy3")
+(patch "031" "15d7rddj6spwc1fy997lxx6zvzq0zbxgf2h20mhi4wgp5nzbglf2")
+(patch "032" "05ia6yf32hjprmyyxqawhgckxs3684ikfx8xg08zfgx9xkd7g73v")
 ]

--- a/pkgs/shells/bash/fix-pop-var-context-error.patch
+++ b/pkgs/shells/bash/fix-pop-var-context-error.patch
@@ -1,0 +1,17 @@
+Excerpted from <https://git.savannah.gnu.org/cgit/bash.git/commit/?h=devel&id=055a4552c901e43e6a6007f5bc664a33698dbf85>.
+
+Original author: Chet Ramey <chet.ramey@case.edu>
+
+--- variables.c
++++ variables.c
+@@ -5413,7 +5413,9 @@ pop_var_context ()
+   vcxt = shell_variables;
+   if (vc_isfuncenv (vcxt) == 0)
+     {
+-      internal_error (_("pop_var_context: head of shell_variables not a function context"));
++      /* If we haven't flushed all of the local contexts already, flag an error */
++      if (shell_variables != global_variables || variable_context > 0)
++	internal_error (_("pop_var_context: head of shell_variables not a function context"));
+       return;
+     }
+ 


### PR DESCRIPTION
## Description of changes

Tested with the first‐built Bash in stdenv; it applies, builds, and runs. I haven’t tried injecting it into derivations to check that the error doesn’t appear any more because I don’t really know what the best way to do that without rebuilding all of stdenv is and I’m not entirely sure how to arrange the circumstances that cause the error.

Closes: #214822

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
