### PR TITLE
python3.bork: 8.0.0 → 9.0.0

### DIFF
--- a/pkgs/development/python-modules/bork/default.nix
+++ b/pkgs/development/python-modules/bork/default.nix
@@ -67,6 +67,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/duckinator/bork";
     license = licenses.mit;
     maintainers = with maintainers; [ nicoo ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/python-modules/bork/default.nix
+++ b/pkgs/development/python-modules/bork/default.nix
@@ -4,19 +4,20 @@
   fetchFromGitHub,
   pytestCheckHook,
   pythonOlder,
+
   setuptools,
   build,
   coloredlogs,
+  importlib-metadata,
   packaging,
   pip,
-  readme-renderer,
   toml,
-  twine,
+  urllib3,
 }:
 
 buildPythonPackage rec {
   pname = "bork";
-  version = "8.0.0";
+  version = "9.0.0";
   pyproject = true;
   disabled = pythonOlder "3.8";
 
@@ -24,7 +25,7 @@ buildPythonPackage rec {
     owner = "duckinator";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-BDwVhKmZ/F8CvpT6dEI5moQZx8wHy1TwdOl889XogEo=";
+    hash = "sha256-YqvtOwd00TXD4I3fIQolvjHnjREvQgbdrEO9Z96v1Kk=";
   };
 
   build-system = [
@@ -32,11 +33,7 @@ buildPythonPackage rec {
   ];
 
   pythonRelaxDeps = [
-    "build"
     "packaging"
-    "readme-renderer"
-    "twine"
-    "wheel"
   ];
 
   dependencies = [
@@ -44,9 +41,10 @@ buildPythonPackage rec {
     coloredlogs
     packaging
     pip
-    readme-renderer
-    twine
-  ] ++ lib.optionals (pythonOlder "3.11") [ toml ];
+    urllib3
+  ] ++ lib.optionals (pythonOlder "3.11") [ toml ]
+    ++ lib.optionals (pythonOlder "3.10") [ importlib-metadata ]
+  ;
 
   pythonImportsCheck = [
     "bork"

--- a/pkgs/development/python-modules/bork/default.nix
+++ b/pkgs/development/python-modules/bork/default.nix
@@ -65,6 +65,7 @@ buildPythonPackage rec {
     description = "Python build and release management tool";
     mainProgram = "bork";
     homepage = "https://github.com/duckinator/bork";
+    license = licenses.mit;
     maintainers = with maintainers; [ nicoo ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
## Description of changes

Update `bork` to v9.0.0, replacing dependency on `twine` with its own `urllib3`-based uploader.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested compilation of all affected packages using `nixpkgs-review`.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
