### PR TITLE
python3.homf: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/homf/default.nix
+++ b/pkgs/development/python-modules/homf/default.nix
@@ -43,6 +43,7 @@ buildPythonPackage rec {
     description = "Asset download tool for GitHub Releases, PyPi, etc.";
     mainProgram = "homf";
     homepage = "https://github.com/duckinator/homf";
+    license = licenses.mit;
     maintainers = with maintainers; [ nicoo ];
   };
 }

--- a/pkgs/development/python-modules/homf/default.nix
+++ b/pkgs/development/python-modules/homf/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  # pytestCheckHook,
+  pythonOlder,
+
+  hatchling,
+  packaging,
+}:
+
+buildPythonPackage rec {
+  pname = "homf";
+  version = "1.0.0";
+  pyproject = true;
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "duckinator";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-PU5VjBIVSMupTBh/qvVuZSFWpBbJOylCR02lONn9/qw=";
+  };
+
+  build-system = [ hatchling ];
+
+  pythonRelaxDeps = [ "packaging" ];
+
+  dependencies = [ packaging ];
+
+  pythonImportsCheck = [
+    "homf"
+    "homf.api"
+    "homf.api.github"
+    "homf.api.pypi"
+  ];
+
+  # There are currently no checks which do not require network access, which breaks the check hook somehow?
+  # nativeCheckInputs = [ pytestCheckHook ];
+  # pytestFlagsArray = [ "-m 'not network'" ];
+
+  meta = with lib; {
+    description = "Asset download tool for GitHub Releases, PyPi, etc.";
+    mainProgram = "homf";
+    homepage = "https://github.com/duckinator/homf";
+    maintainers = with maintainers; [ nicoo ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/homf/default.nix
+++ b/pkgs/development/python-modules/homf/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "duckinator";
-    repo = pname;
+    repo = "homf";
     rev = "refs/tags/v${version}";
     hash = "sha256-PU5VjBIVSMupTBh/qvVuZSFWpBbJOylCR02lONn9/qw=";
   };
@@ -44,6 +44,5 @@ buildPythonPackage rec {
     mainProgram = "homf";
     homepage = "https://github.com/duckinator/homf";
     maintainers = with maintainers; [ nicoo ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5597,6 +5597,8 @@ self: super: with self; {
 
   homepluscontrol = callPackage ../development/python-modules/homepluscontrol { };
 
+  homf = callPackage ../development/python-modules/homf { };
+
   hoomd-blue = callPackage ../development/python-modules/hoomd-blue { };
 
   hopcroftkarp = callPackage ../development/python-modules/hopcroftkarp { };


### PR DESCRIPTION
## Description of changes

Add new `homf` module for Python 3.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
