### PR TITLE
earlyoom: use upstream systemd service and add proper test

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -127,6 +127,11 @@
 
 - `zammad` has had its support for MySQL removed, since it was never working correctly and is now deprecated upstream. Check the [migration guide](https://docs.zammad.org/en/latest/appendix/migrate-to-postgresql.html) for how to convert your database to PostgreSQL.
 
+- The `earlyoom` service is now using upstream systemd service, which enables
+  hardening and filesystem isolation by default. If you need filesystem write
+  access or want to access home directory via `killHook`, hardening setting can
+  be changed via, e.g. `systemd.services.earlyoom.serviceConfig.ProtectSystem`.
+
 - `nodePackages.vls` has been deprecated, as the upstream consumer of it, vetur, has been deprecated by upstream. Upstream suggests migrating to Volar for Vue LSP tooling instead.
 
 - `nodePackages.create-react-native-app` has been removed, as it is deprecated. Upstream suggests using a framework for React Native apps instead.

--- a/nixos/modules/services/system/earlyoom.nix
+++ b/nixos/modules/services/system/earlyoom.nix
@@ -115,6 +115,11 @@ in
         [README](https://github.com/rfjakob/earlyoom#notifications) and
         [the man page](https://github.com/rfjakob/earlyoom/blob/master/MANPAGE.md#-n-pathtoscript)
         for details.
+
+        WARNING: earlyoom is running in a sandbox with ProtectSystem="strict"
+        by default, so filesystem write is also prohibited for the hook.
+        If you want to change these protection rules, override the systemd
+        service via `systemd.services.earlyoom.serviceConfig.ProtectSystem`.
       '';
     };
 
@@ -149,25 +154,33 @@ in
   config = mkIf cfg.enable {
     services.systembus-notify.enable = mkDefault cfg.enableNotifications;
 
+    systemd.packages = [ cfg.package ];
+
     systemd.services.earlyoom = {
-      description = "Early OOM Daemon for Linux";
+      overrideStrategy = "asDropin";
+
       wantedBy = [ "multi-user.target" ];
       path = optionals cfg.enableNotifications [ pkgs.dbus ];
-      serviceConfig = {
-        StandardError = "journal";
-        ExecStart = concatStringsSep " " ([
-          "${lib.getExe cfg.package}"
-          ("-m ${toString cfg.freeMemThreshold}"
-           + optionalString (cfg.freeMemKillThreshold != null) ",${toString cfg.freeMemKillThreshold}")
-          ("-s ${toString cfg.freeSwapThreshold}"
-           + optionalString (cfg.freeSwapKillThreshold != null) ",${toString cfg.freeSwapKillThreshold}")
-          "-r ${toString cfg.reportInterval}"
-        ]
-        ++ optionals cfg.enableDebugInfo [ "-d" ]
-        ++ optionals cfg.enableNotifications [ "-n" ]
-        ++ optionals (cfg.killHook != null) [ "-N ${escapeShellArg cfg.killHook}" ]
-        ++ cfg.extraArgs);
-      };
+
+      # We setup `EARLYOOM_ARGS` via drop-ins, so disable the default import
+      # from /etc/default/earlyoom.
+      serviceConfig.EnvironmentFile = "";
+
+      environment.EARLYOOM_ARGS =
+        lib.cli.toGNUCommandLineShell { } {
+          m =
+            "${toString cfg.freeMemThreshold}"
+            + optionalString (cfg.freeMemKillThreshold != null) ",${toString cfg.freeMemKillThreshold}";
+          s =
+            "${toString cfg.freeSwapThreshold}"
+            + optionalString (cfg.freeSwapKillThreshold != null) ",${toString cfg.freeSwapKillThreshold}";
+          r = "${toString cfg.reportInterval}";
+          d = cfg.enableDebugInfo;
+          n = cfg.enableNotifications;
+          N = if cfg.killHook != null then cfg.killHook else null;
+        }
+        + " "
+        + lib.escapeShellArgs cfg.extraArgs;
     };
   };
 }

--- a/nixos/modules/services/system/earlyoom.nix
+++ b/nixos/modules/services/system/earlyoom.nix
@@ -1,11 +1,14 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   cfg = config.services.earlyoom;
 
   inherit (lib)
-    concatStringsSep
-    escapeShellArg
     literalExpression
     mkDefault
     mkEnableOption
@@ -15,7 +18,8 @@ let
     mkRemovedOptionModule
     optionalString
     optionals
-    types;
+    types
+    ;
 in
 {
   meta = {
@@ -132,8 +136,11 @@ in
 
     extraArgs = mkOption {
       type = types.listOf types.str;
-      default = [];
-      example = [ "-g" "--prefer '(^|/)(java|chromium)$'" ];
+      default = [ ];
+      example = [
+        "-g"
+        "--prefer '(^|/)(java|chromium)$'"
+      ];
       description = "Extra command-line arguments to be passed to earlyoom.";
     };
   };

--- a/nixos/tests/earlyoom.nix
+++ b/nixos/tests/earlyoom.nix
@@ -1,16 +1,43 @@
-import ./make-test-python.nix ({ lib, ... }: {
-  name = "earlyoom";
-  meta = {
-    maintainers = with lib.maintainers; [ ncfavier AndersonTorres ];
-  };
-
-  machine = {
-    services.earlyoom = {
-      enable = true;
+import ./make-test-python.nix (
+  { lib, ... }:
+  {
+    name = "earlyoom";
+    meta = {
+      maintainers = with lib.maintainers; [
+        ncfavier
+        AndersonTorres
+        oxalica
+      ];
     };
-  };
 
-  testScript = ''
-    machine.wait_for_unit("earlyoom.service")
-  '';
-})
+    nodes.machine =
+      { pkgs, ... }:
+      {
+        # Limit VM resource usage.
+        virtualisation.memorySize = 1024;
+
+        services.earlyoom = {
+          enable = true;
+          # Use SIGKILL, or `tail` will catch SIGTERM and exit successfully.
+          freeMemKillThreshold = 90;
+        };
+
+        systemd.services.testbloat = {
+          description = "Create a lot of memory pressure";
+          serviceConfig = {
+            ExecStart = "${pkgs.coreutils}/bin/tail /dev/zero";
+          };
+        };
+      };
+
+    testScript = ''
+      machine.wait_for_unit("earlyoom.service")
+
+      with subtest("earlyoom should kill the bad service"):
+          machine.fail("systemctl start --wait testbloat.service")
+          assert machine.get_unit_info("testbloat.service")["Result"] == "signal"
+          output = machine.succeed('journalctl -u earlyoom.service -b0')
+          assert 'low memory! at or below SIGKILL limits' in output
+    '';
+  }
+)


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- earlyoom ships a system service since 1.8 with additional sandboxing and protection rulees. This installs and uses it.
- A functionality test on earlyoom is added.

~~It seems that we have `withManpage` option even though manual is installed to a separate output `man`. If user only get `out` in their closure when documentation is disabled, why would we need a separate `withManpage` flag? Could we remove and always enable it?~~
Ok, I kept it with a comment. It may be useful when someone is targeting a platform without pandoc.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
