### PR TITLE
amneziawg-tools: init at 1.0.20240213

### DIFF
--- a/pkgs/by-name/am/amneziawg-tools/package.nix
+++ b/pkgs/by-name/am/amneziawg-tools/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeWrapper,
+  bash,
+  procps,
+  iproute2,
+  iptables,
+  openresolv,
+  amneziawg-go,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "amneziawg-tools";
+  version = "1.0.20241018";
+
+  src = fetchFromGitHub {
+    owner = "amnezia-vpn";
+    repo = "amneziawg-tools";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-y6xkOLT9KVD6ACCH60Myk2iA1S8/+tGXEQbOYnu+dPI=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/src";
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ bash ];
+
+  makeFlags = [
+    "DESTDIR=${placeholder "out"}"
+    "PREFIX=/"
+    "WITH_BASHCOMPLETION=yes"
+    "WITH_SYSTEMDUNITS=yes"
+    "WITH_WGQUICK=yes"
+  ];
+
+  postFixup =
+    ''
+      substituteInPlace $out/lib/systemd/system/awg-quick@.service \
+        --replace-fail /usr/bin $out/bin
+    ''
+    + lib.optionalString stdenv.isLinux ''
+      for f in $out/bin/*; do
+        # Which firewall and resolvconf implementations to use should be determined by the
+        # environment, we provide the "default" ones as fallback.
+        wrapProgram $f \
+          --prefix PATH : ${
+            lib.makeBinPath [
+              procps
+              iproute2
+            ]
+          } \
+          --suffix PATH : ${
+            lib.makeBinPath [
+              iptables
+              openresolv
+            ]
+          }
+      done
+    ''
+    + lib.optionalString stdenv.isDarwin ''
+      for f in $out/bin/*; do
+        wrapProgram $f \
+          --prefix PATH : ${lib.makeBinPath [ amneziawg-go ]}
+      done
+    '';
+
+  strictDeps = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tools for configuring AmneziaWG";
+    homepage = "https://amnezia.org";
+    changelog = "https://github.com/amnezia-vpn/amneziawg-tools/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ averyanalex ];
+    platforms = lib.platforms.unix;
+    mainProgram = "awg";
+  };
+})


### PR DESCRIPTION
## Init amneziawg-tools at 1.0.20240213

Censorship-resistant VPN based on wireguard.

https://amnezia.org

Depends on #331574.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
