### PR TITLE
linuxPackages.amneziawg: init at 1.0.20240711

### DIFF
--- a/pkgs/os-specific/linux/amneziawg/default.nix
+++ b/pkgs/os-specific/linux/amneziawg/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  srcOnly,
+  kernel,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "amneziawg";
+  version = "1.0.20240711";
+
+  src = fetchFromGitHub {
+    owner = "amnezia-vpn";
+    repo = "amneziawg-linux-kernel-module";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-WOcBTxetVz2Sr62c+2aGNyohG2ydi+R+az+4qHbKprI=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/src";
+  hardeningDisable = [ "pic" ];
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  buildFlags = [
+    "apply-patches"
+    "module"
+  ];
+
+  makeFlags =
+    kernel.makeFlags
+    ++ [ "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" ]
+    ++ lib.optional (lib.versionAtLeast kernel.version "5.6") "KERNEL_SOURCE_DIR=${srcOnly kernel}";
+
+  enableParallelBuilding = true;
+
+  installFlags = [
+    "DEPMOD=true"
+    "INSTALL_MOD_PATH=${placeholder "out"}"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Kernel module for the AmneziaWG";
+    homepage = "https://amnezia.org";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ averyanalex ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -321,6 +321,8 @@ in {
 
     akvcam = callPackage ../os-specific/linux/akvcam { };
 
+    amneziawg = callPackage ../os-specific/linux/amneziawg { };
+
     apfs = callPackage ../os-specific/linux/apfs { };
 
     ax99100 = callPackage ../os-specific/linux/ax99100 {};


### PR DESCRIPTION
## Init linuxPackages.amneziawg at 1.0.20240711

Censorship-resistant VPN based on wireguard.

https://amnezia.org

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of ~~all binary files (usually in `./result/bin/`)~~ kernel module
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
