### PR TITLE
calamares: 3.3.8, calamares-nixos-extensions: 0.3.18

### DIFF
--- a/pkgs/tools/misc/calamares-nixos-extensions/default.nix
+++ b/pkgs/tools/misc/calamares-nixos-extensions/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, lib }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "calamares-nixos-extensions";
-  version = "0.3.16";
+  version = "0.3.18";
 
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "calamares-nixos-extensions";
-    rev = version;
-    hash = "sha256-ajQWmZVY60Q2cGJcLqMT2ypIi7bMMiyHMgdlp3g9874=";
+    rev = finalAttrs.version;
+    hash = "sha256-j+9iZtw9QIKHLo5sr9nkCVoZS7QQCnDDyTGFXD+R+WU=";
   };
 
   installPhase = ''
@@ -27,4 +27,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ vlinkz ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/tools/misc/calamares/0001-Modifies-the-users-module-to-only-set-passwords-of-u.patch
+++ b/pkgs/tools/misc/calamares/0001-Modifies-the-users-module-to-only-set-passwords-of-u.patch
@@ -1,8 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Victor Fuentes <vmfuentes64@gmail.com>
+Date: Thu, 1 Aug 2024 15:53:16 -0400
+Subject: [PATCH] Modifies the users module to only set passwords of user and
+ root
+
+as the users will have already been created in the configuration.nix
+file
+---
+ src/modules/users/Config.cpp | 15 ---------------
+ 1 file changed, 15 deletions(-)
+
 diff --git a/src/modules/users/Config.cpp b/src/modules/users/Config.cpp
-index eedfd274d..0f3e78848 100644
+index cd56bc3e2..9b09b36cd 100644
 --- a/src/modules/users/Config.cpp
 +++ b/src/modules/users/Config.cpp
-@@ -972,26 +972,11 @@ Config::createJobs() const
+@@ -1028,12 +1028,6 @@ Config::createJobs() const
  
      Calamares::Job* j;
  
@@ -12,6 +24,13 @@ index eedfd274d..0f3e78848 100644
 -        jobs.append( Calamares::job_ptr( j ) );
 -    }
 -
+     if ( getActiveDirectoryUsed() )
+     {
+         j = new ActiveDirectoryJob( m_activeDirectoryAdminUsername,
+@@ -1043,20 +1037,11 @@ Config::createJobs() const
+         jobs.append( Calamares::job_ptr( j ) );
+     }
+ 
 -    j = new SetupGroupsJob( this );
 -    jobs.append( Calamares::job_ptr( j ) );
 -

--- a/pkgs/tools/misc/calamares/0002-Makes-calamares-search-run-current-system-sw-share-c.patch
+++ b/pkgs/tools/misc/calamares/0002-Makes-calamares-search-run-current-system-sw-share-c.patch
@@ -1,3 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Victor Fuentes <vmfuentes64@gmail.com>
+Date: Thu, 1 Aug 2024 15:57:55 -0400
+Subject: [PATCH] Makes calamares search
+ /run/current-system/sw/share/calamares/ for extra configuration files as by
+ default it only searches /usr/share/calamares/ and
+ /nix/store/<hash>-calamares-<version>/share/calamares/ but
+ calamares-nixos-extensions is not in either of these locations
+
+---
+ src/calamares/main.cpp          | 1 +
+ src/libcalamares/utils/Dirs.cpp | 8 ++++++++
+ src/libcalamares/utils/Dirs.h   | 3 +++
+ 3 files changed, 12 insertions(+)
+
 diff --git a/src/calamares/main.cpp b/src/calamares/main.cpp
 index e0491e5f9..faf272016 100644
 --- a/src/calamares/main.cpp
@@ -11,7 +26,7 @@ index e0491e5f9..faf272016 100644
      if ( !is_debug )
      {
 diff --git a/src/libcalamares/utils/Dirs.cpp b/src/libcalamares/utils/Dirs.cpp
-index c42768a08..bac98645a 100644
+index c42768a08..dfce7eb5d 100644
 --- a/src/libcalamares/utils/Dirs.cpp
 +++ b/src/libcalamares/utils/Dirs.cpp
 @@ -114,6 +114,14 @@ setXdgDirs()
@@ -23,7 +38,7 @@ index c42768a08..bac98645a 100644
 +{
 +    s_extraConfigDirs << "/run/current-system/sw/share/calamares/";
 +    s_extraDataDirs << "/run/current-system/sw/share/calamares/";
-+    s_haveExtraDirs = !( s_extraConfigDirs.isEmpty() && s_extraDataDirs.isEmpty() ); 
++    s_haveExtraDirs = !( s_extraConfigDirs.isEmpty() && s_extraDataDirs.isEmpty() );
 +}
 +
  QStringList

--- a/pkgs/tools/misc/calamares/0003-Uses-pkexec-within-modules-in-order-to-run-calamares.patch
+++ b/pkgs/tools/misc/calamares/0003-Uses-pkexec-within-modules-in-order-to-run-calamares.patch
@@ -1,8 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Victor Fuentes <vmfuentes64@gmail.com>
+Date: Thu, 1 Aug 2024 15:59:54 -0400
+Subject: [PATCH] Uses pkexec within modules in order to run calamares without
+ root permissions as a whole.
+
+Also fixes storage check in the welcome module
+---
+ src/libcalamares/utils/Runner.cpp             |  8 +++---
+ src/modules/mount/main.py                     |  8 +++---
+ .../welcome/checker/GeneralRequirements.cpp   | 27 ++++++++++++++++++-
+ .../welcome/checker/GeneralRequirements.h     |  1 +
+ 4 files changed, 35 insertions(+), 9 deletions(-)
+
 diff --git a/src/libcalamares/utils/Runner.cpp b/src/libcalamares/utils/Runner.cpp
-index 632f32028..fe9052449 100644
+index f7872a7d0..a246ca110 100644
 --- a/src/libcalamares/utils/Runner.cpp
 +++ b/src/libcalamares/utils/Runner.cpp
-@@ -137,13 +137,13 @@ Calamares::Utils::Runner::run()
+@@ -145,13 +145,13 @@ Calamares::Utils::Runner::run()
      }
      if ( m_location == RunLocation::RunInTarget )
      {
@@ -21,20 +35,19 @@ index 632f32028..fe9052449 100644
  
      if ( m_output )
 diff --git a/src/modules/mount/main.py b/src/modules/mount/main.py
-index 4202639f3..de2556b91 100644
+index 4a16f8872..6d32916a5 100644
 --- a/src/modules/mount/main.py
 +++ b/src/modules/mount/main.py
-@@ -235,7 +235,8 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
- 
+@@ -244,7 +244,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
      # Ensure that the created directory has the correct SELinux context on
      # SELinux-enabled systems.
+ 
 -    os.makedirs(mount_point, exist_ok=True)
 +    subprocess.check_call(["pkexec", "mkdir", "-p", mount_point])
-+
+ 
      try:
          subprocess.call(['chcon', '--reference=' + raw_mount_point, mount_point])
-     except FileNotFoundError as e:
-@@ -278,13 +279,13 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
+@@ -288,13 +288,13 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
          for s in btrfs_subvolumes:
              if not s["subvolume"]:
                  continue

--- a/pkgs/tools/misc/calamares/0004-Adds-unfree-qml-to-packagechooserq.patch
+++ b/pkgs/tools/misc/calamares/0004-Adds-unfree-qml-to-packagechooserq.patch
@@ -1,3 +1,16 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Victor Fuentes <vmfuentes64@gmail.com>
+Date: Thu, 1 Aug 2024 16:00:43 -0400
+Subject: [PATCH] Adds unfree qml to packagechooserq
+
+---
+ .../packagechooserq/packagechooserq.qrc       |  1 +
+ .../packagechooserq@unfree.qml                | 75 +++++++++++++++++++
+ src/modules/packagechooserq/unfree.conf       | 11 +++
+ 3 files changed, 87 insertions(+)
+ create mode 100644 src/modules/packagechooserq/packagechooserq@unfree.qml
+ create mode 100644 src/modules/packagechooserq/unfree.conf
+
 diff --git a/src/modules/packagechooserq/packagechooserq.qrc b/src/modules/packagechooserq/packagechooserq.qrc
 index 1b892dce1..ee80a934b 100644
 --- a/src/modules/packagechooserq/packagechooserq.qrc
@@ -11,7 +24,7 @@ index 1b892dce1..ee80a934b 100644
  </RCC>
 diff --git a/src/modules/packagechooserq/packagechooserq@unfree.qml b/src/modules/packagechooserq/packagechooserq@unfree.qml
 new file mode 100644
-index 000000000..cb87d864a
+index 000000000..5e36d77d9
 --- /dev/null
 +++ b/src/modules/packagechooserq/packagechooserq@unfree.qml
 @@ -0,0 +1,75 @@
@@ -32,7 +45,7 @@ index 000000000..cb87d864a
 +import QtQuick.Layouts 1.3
 +
 +Item {
-+    
++
 +    SystemPalette {
 +        id: palette
 +        colorGroup: SystemPalette.Active

--- a/pkgs/tools/misc/calamares/0005-Modifies-finished-module-to-add-some-NixOS-resources.patch
+++ b/pkgs/tools/misc/calamares/0005-Modifies-finished-module-to-add-some-NixOS-resources.patch
@@ -1,12 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Victor Fuentes <vmfuentes64@gmail.com>
+Date: Thu, 1 Aug 2024 16:01:53 -0400
+Subject: [PATCH] Modifies finished module to add some NixOS resources.
+
+Modifies packagechooser module to change the UI.
+---
+ src/modules/finished/FinishedPage.cpp         | 12 +++++---
+ .../packagechooser/PackageChooserPage.cpp     |  1 +
+ src/modules/packagechooser/page_package.ui    | 28 +++++++++----------
+ 3 files changed, 23 insertions(+), 18 deletions(-)
+
 diff --git a/src/modules/finished/FinishedPage.cpp b/src/modules/finished/FinishedPage.cpp
-index 23cb194c4..8714937f6 100644
+index 51be52678..307607232 100644
 --- a/src/modules/finished/FinishedPage.cpp
 +++ b/src/modules/finished/FinishedPage.cpp
-@@ -74,7 +74,10 @@ FinishedPage::retranslate()
+@@ -74,8 +74,10 @@ FinishedPage::retranslate()
          {
              ui->mainText->setText( tr( "<h1>All done.</h1><br/>"
                                         "%1 has been set up on your computer.<br/>"
--                                       "You may now start using your new system.", "@info" )
+-                                       "You may now start using your new system.",
+-                                       "@info" )
 +                                       "You may now start using your new system.<br/>"
 +                                       "You can change every setting later except the bootloader.<br/>"
 +                                       "Check the <a href=\"https://nixos.org/manual/nixos/stable/\">manual</a> for instructions on how to install software, upgrade the system or enable services.<br/>"
@@ -14,11 +27,12 @@ index 23cb194c4..8714937f6 100644
                                         .arg( branding->versionedName() ) );
              ui->restartCheckBox->setToolTip( tr( "<html><head/><body>"
                                                   "<p>When this box is checked, your system will "
-@@ -87,7 +90,10 @@ FinishedPage::retranslate()
+@@ -89,8 +91,10 @@ FinishedPage::retranslate()
              ui->mainText->setText( tr( "<h1>All done.</h1><br/>"
                                         "%1 has been installed on your computer.<br/>"
                                         "You may now restart into your new system, or continue "
--                                       "using the %2 Live environment.", "@info" )
+-                                       "using the %2 Live environment.",
+-                                       "@info" )
 +                                       "using the %2 Live environment.<br/>"
 +                                       "You can change every setting later except the bootloader.<br/>"
 +                                       "Check the <a href=\"https://nixos.org/manual/nixos/stable/\">manual</a> for instructions on how to install software, upgrade the system or enable services.<br/>"

--- a/pkgs/tools/misc/calamares/0006-Remove-options-for-unsupported-partition-types.patch
+++ b/pkgs/tools/misc/calamares/0006-Remove-options-for-unsupported-partition-types.patch
@@ -1,8 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Victor Fuentes <vmfuentes64@gmail.com>
+Date: Thu, 1 Aug 2024 16:02:40 -0400
+Subject: [PATCH] Remove options for unsupported partition types
+
+---
+ src/modules/partition/gui/CreatePartitionDialog.cpp       | 3 ++-
+ src/modules/partition/gui/EditExistingPartitionDialog.cpp | 3 ++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
 diff --git a/src/modules/partition/gui/CreatePartitionDialog.cpp b/src/modules/partition/gui/CreatePartitionDialog.cpp
-index c5b17c69e..353b6f964 100644
+index d18676138..60bb8fdaf 100644
 --- a/src/modules/partition/gui/CreatePartitionDialog.cpp
 +++ b/src/modules/partition/gui/CreatePartitionDialog.cpp
-@@ -107,7 +107,8 @@ CreatePartitionDialog::CreatePartitionDialog( Device* device,
+@@ -108,7 +108,8 @@ CreatePartitionDialog::CreatePartitionDialog( Device* device,
      {
          // We need to ensure zfs is added to the list if the zfs module is enabled
          if ( ( fs->type() == FileSystem::Type::Zfs && Calamares::Settings::instance()->isModuleEnabled( "zfs" ) )
@@ -13,10 +23,10 @@ index c5b17c69e..353b6f964 100644
              fsNames << userVisibleFS( fs );  // This is put into the combobox
              if ( fs->type() == defaultFSType )
 diff --git a/src/modules/partition/gui/EditExistingPartitionDialog.cpp b/src/modules/partition/gui/EditExistingPartitionDialog.cpp
-index 0bc35cabe..3cf8a7fa2 100644
+index 7a3f4951a..4c3bfc4b0 100644
 --- a/src/modules/partition/gui/EditExistingPartitionDialog.cpp
 +++ b/src/modules/partition/gui/EditExistingPartitionDialog.cpp
-@@ -95,7 +95,8 @@ EditExistingPartitionDialog::EditExistingPartitionDialog( Device* device,
+@@ -113,7 +113,8 @@ EditExistingPartitionDialog::EditExistingPartitionDialog( Device* device,
      {
          // We need to ensure zfs is added to the list if the zfs module is enabled
          if ( ( fs->type() == FileSystem::Type::Zfs && Calamares::Settings::instance()->isModuleEnabled( "zfs" ) )

--- a/pkgs/tools/misc/calamares/0007-Fix-setting-the-kayboard-layout-on-GNOME-wayland.patch
+++ b/pkgs/tools/misc/calamares/0007-Fix-setting-the-kayboard-layout-on-GNOME-wayland.patch
@@ -1,5 +1,16 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Victor Fuentes <vmfuentes64@gmail.com>
+Date: Thu, 1 Aug 2024 16:03:14 -0400
+Subject: [PATCH] Fix setting the kayboard layout on GNOME wayland.
+
+By default the module uses the setxkbmap, which will not change the
+keyboard
+---
+ src/modules/keyboard/Config.cpp | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
 diff --git a/src/modules/keyboard/Config.cpp b/src/modules/keyboard/Config.cpp
-index d8b1e8e86..b2e1b7b5f 100644
+index ad6bee6f7..4d43abe53 100644
 --- a/src/modules/keyboard/Config.cpp
 +++ b/src/modules/keyboard/Config.cpp
 @@ -307,7 +307,10 @@ Config::xkbApply()

--- a/pkgs/tools/misc/calamares/0008-Change-default-location-where-calamares-searches-for.patch
+++ b/pkgs/tools/misc/calamares/0008-Change-default-location-where-calamares-searches-for.patch
@@ -1,5 +1,14 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Victor Fuentes <vmfuentes64@gmail.com>
+Date: Thu, 1 Aug 2024 16:03:53 -0400
+Subject: [PATCH] Change default location where calamares searches for locales
+
+---
+ src/modules/locale/Config.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 diff --git a/src/modules/locale/Config.cpp b/src/modules/locale/Config.cpp
-index 54ff5eb64..1a2b98c9c 100644
+index 8fa17a768..79b5419b6 100644
 --- a/src/modules/locale/Config.cpp
 +++ b/src/modules/locale/Config.cpp
 @@ -48,7 +48,7 @@ loadLocales( const QString& localeGenPath )

--- a/pkgs/tools/misc/calamares/default.nix
+++ b/pkgs/tools/misc/calamares/default.nix
@@ -7,37 +7,29 @@
 
 mkDerivation rec {
   pname = "calamares";
-  version = "3.3.3";
+  version = "3.3.8";
 
   # release including submodule
   src = fetchurl {
     url = "https://github.com/calamares/calamares/releases/download/v${version}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-XCp2Qc2y9eF2Z0BqfTtzUkf6860KzHl1lZE7kiHZbQM=";
+    sha256 = "sha256-CUNbBOflzuFhdyIwaNinQCw8a4EmrxP/Unr3d0LEM2M=";
   };
 
+  # On major changes, or when otherwise required, you *must* :
+  # 1. reformat the patches,
+  # 2. `git am path/to/00*.patch` them into a calamares worktree,
+  # 3. rebase to the more recent calamares version,
+  # 4. and export the patches again via
+  #   `git -c format.signoff=false format-patch v${version} --no-numbered --zero-commit --no-signature`.
   patches = lib.optionals nixos-extensions [
-    # Modifies the users module to only set passwords of user and root
-    # as the users will have already been created in the configuration.nix file
-    ./userjob.patch
-    # Makes calamares search /run/current-system/sw/share/calamares/ for extra configuration files
-    # as by default it only searches /usr/share/calamares/ and /nix/store/<hash>-calamares-<version>/share/calamares/
-    # but calamares-nixos-extensions is not in either of these locations
-    ./nixos-extensions-paths.patch
-    # Uses pkexec within modules in order to run calamares without root permissions as a whole
-    # Also fixes storage check in the welcome module
-    ./nonroot.patch
-    # Adds unfree qml to packagechooserq
-    ./unfreeq.patch
-    # Modifies finished module to add some NixOS resources
-    # Modifies packagechooser module to change the UI
-    ./uimod.patch
-    # Remove options for unsupported partition types
-    ./partitions.patch
-    # Fix setting the kayboard layout on GNOME wayland
-    # By default the module uses the setxkbmap, which will not change the keyboard
-    ./waylandkbd.patch
-    # Change default location where calamares searches for locales
-    ./supportedlocale.patch
+    ./0001-Modifies-the-users-module-to-only-set-passwords-of-u.patch
+    ./0002-Makes-calamares-search-run-current-system-sw-share-c.patch
+    ./0003-Uses-pkexec-within-modules-in-order-to-run-calamares.patch
+    ./0004-Adds-unfree-qml-to-packagechooserq.patch
+    ./0005-Modifies-finished-module-to-add-some-NixOS-resources.patch
+    ./0006-Remove-options-for-unsupported-partition-types.patch
+    ./0007-Fix-setting-the-kayboard-layout-on-GNOME-wayland.patch
+    ./0008-Change-default-location-where-calamares-searches-for.patch
   ];
 
   nativeBuildInputs = [ cmake extra-cmake-modules ];


### PR DESCRIPTION
## Description of changes

Waiting on https://github.com/NixOS/calamares-nixos-extensions/pull/43
Fixes #322342

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
