### PR TITLE
cinny: add wrapper

### DIFF
--- a/pkgs/by-name/ci/cinny-unwrapped/package.nix
+++ b/pkgs/by-name/ci/cinny-unwrapped/package.nix
@@ -1,23 +1,18 @@
-{ lib
-, buildNpmPackage
-, fetchFromGitHub
-, writeText
-, jq
-, python3
-, pkg-config
-, pixman
-, cairo
-, pango
-, stdenv
-, darwin
-, conf ? { }
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  python3,
+  pkg-config,
+  pixman,
+  cairo,
+  pango,
+  stdenv,
+  darwin,
 }:
 
-let
-  configOverrides = writeText "cinny-config-overrides.json" (builtins.toJSON conf);
-in
 buildNpmPackage rec {
-  pname = "cinny";
+  pname = "cinny-unwrapped";
   version = "4.0.3";
 
   src = fetchFromGitHub {
@@ -35,7 +30,6 @@ buildNpmPackage rec {
   ) "-D_LIBCPP_HAS_NO_LIBRARY_ALIGNED_ALLOCATION=1";
 
   nativeBuildInputs = [
-    jq
     python3
     pkg-config
   ];
@@ -44,15 +38,12 @@ buildNpmPackage rec {
     pixman
     cairo
     pango
-  ] ++ lib.optionals stdenv.isDarwin [
-    darwin.apple_sdk.frameworks.CoreText
-  ];
+  ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.CoreText ];
 
   installPhase = ''
     runHook preInstall
 
     cp -r dist $out
-    jq -s '.[0] * .[1]' "config.json" "${configOverrides}" > "$out/config.json"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ci/cinny/package.nix
+++ b/pkgs/by-name/ci/cinny/package.nix
@@ -1,0 +1,32 @@
+{
+  cinny-unwrapped,
+  jq,
+  stdenvNoCC,
+  writeText,
+  conf ? { },
+}:
+let
+  configOverrides = writeText "cinny-config-overrides.json" (builtins.toJSON conf);
+in
+if (conf == { }) then
+  cinny-unwrapped
+else
+  stdenvNoCC.mkDerivation {
+    pname = "cinny";
+    inherit (cinny-unwrapped) version meta;
+
+    dontUnpack = true;
+
+    nativeBuildInputs = [ jq ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      ln -s ${cinny-unwrapped}/* $out
+      rm $out/config.json
+      jq -s '.[0] * .[1]' "${cinny-unwrapped}/config.json" "${configOverrides}" > "$out/config.json"
+
+      runHook postInstall
+    '';
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4484,8 +4484,6 @@ with pkgs;
 
   cht-sh = callPackage ../tools/misc/cht.sh { };
 
-  cinny = callPackage ../applications/networking/instant-messengers/cinny { };
-
   cinny-desktop = callPackage ../applications/networking/instant-messengers/cinny-desktop { };
 
   ckbcomp = callPackage ../tools/X11/ckbcomp { };


### PR DESCRIPTION
## Description of changes

Similar to element-web, to avoid rebuilding the entire thing when changing configuration.
https://github.com/NixOS/nixpkgs/blob/f73ed219335199067ae839ae4db2a32af2b879ed/pkgs/applications/networking/instant-messengers/element/element-web-wrapper.nix#L1-L26

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
