### PR TITLE
nixos/nextcloud: add nginx.virtualHost option

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -806,6 +806,17 @@ in {
           directive and header.
         '';
       };
+      virtualHost = mkOption {
+        type = types.submodule (import ../web-servers/nginx/vhost-options.nix { inherit config lib; });
+        default = { };
+        example = ''
+          {
+            # Customize port nextcloud is reachable on
+            listen = [ { addr = "0.0.0.0"; port = 12345; } ];
+          }
+        '';
+        description = "Extra configuration for the nginx virtual host of Nextcloud.";
+      };
     };
 
     cli.memoryLimit = mkOption {
@@ -1126,130 +1137,133 @@ in {
 
       services.nginx.enable = mkDefault true;
 
-      services.nginx.virtualHosts.${cfg.hostName} = {
-        root = webroot;
-        locations = {
-          "= /robots.txt" = {
-            priority = 100;
-            extraConfig = ''
-              allow all;
+      services.nginx.virtualHosts.${cfg.hostName} = mkMerge [
+        cfg.nginx.virtualHost
+        {
+          root = webroot;
+          locations = {
+            "= /robots.txt" = {
+              priority = 100;
+              extraConfig = ''
+                allow all;
+                access_log off;
+              '';
+            };
+            "= /" = {
+              priority = 100;
+              extraConfig = ''
+                if ( $http_user_agent ~ ^DavClnt ) {
+                  return 302 /remote.php/webdav/$is_args$args;
+                }
+              '';
+            };
+            "^~ /.well-known" = {
+              priority = 210;
+              extraConfig = ''
+                absolute_redirect off;
+                location = /.well-known/carddav {
+                  return 301 /remote.php/dav/;
+                }
+                location = /.well-known/caldav {
+                  return 301 /remote.php/dav/;
+                }
+                location ~ ^/\.well-known/(?!acme-challenge|pki-validation) {
+                  return 301 /index.php$request_uri;
+                }
+                try_files $uri $uri/ =404;
+              '';
+            };
+            "~ ^/(?:build|tests|config|lib|3rdparty|templates|data)(?:$|/)" = {
+              priority = 450;
+              extraConfig = ''
+                return 404;
+              '';
+            };
+            "~ ^/(?:\\.|autotest|occ|issue|indie|db_|console)" = {
+              priority = 450;
+              extraConfig = ''
+                return 404;
+              '';
+            };
+            "~ \\.php(?:$|/)" = {
+              priority = 500;
+              extraConfig = ''
+                # legacy support (i.e. static files and directories in cfg.package)
+                rewrite ^/(?!index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[s${optionalString (!ocmProviderIsNotAStaticDirAnymore) "m"}]-provider\/.+|.+\/richdocumentscode\/proxy) /index.php$request_uri;
+                include ${config.services.nginx.package}/conf/fastcgi.conf;
+                fastcgi_split_path_info ^(.+?\.php)(\\/.*)$;
+                set $path_info $fastcgi_path_info;
+                try_files $fastcgi_script_name =404;
+                fastcgi_param PATH_INFO $path_info;
+                fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+                fastcgi_param HTTPS ${if cfg.https then "on" else "off"};
+                fastcgi_param modHeadersAvailable true;
+                fastcgi_param front_controller_active true;
+                fastcgi_pass unix:${fpm.socket};
+                fastcgi_intercept_errors on;
+                fastcgi_request_buffering off;
+                fastcgi_read_timeout ${builtins.toString cfg.fastcgiTimeout}s;
+              '';
+            };
+            "~ \\.(?:css|js|mjs|svg|gif|png|jpg|jpeg|ico|wasm|tflite|map|html|ttf|bcmap|mp4|webm|ogg|flac)$".extraConfig = ''
+              try_files $uri /index.php$request_uri;
+              expires 6M;
               access_log off;
-            '';
-          };
-          "= /" = {
-            priority = 100;
-            extraConfig = ''
-              if ( $http_user_agent ~ ^DavClnt ) {
-                return 302 /remote.php/webdav/$is_args$args;
+              location ~ \.mjs$ {
+                default_type text/javascript;
+              }
+              location ~ \.wasm$ {
+                default_type application/wasm;
               }
             '';
-          };
-          "^~ /.well-known" = {
-            priority = 210;
-            extraConfig = ''
-              absolute_redirect off;
-              location = /.well-known/carddav {
-                return 301 /remote.php/dav/;
-              }
-              location = /.well-known/caldav {
-                return 301 /remote.php/dav/;
-              }
-              location ~ ^/\.well-known/(?!acme-challenge|pki-validation) {
-                return 301 /index.php$request_uri;
-              }
-              try_files $uri $uri/ =404;
+            "~ ^\\/(?:updater|ocs-provider${optionalString (!ocmProviderIsNotAStaticDirAnymore) "|ocm-provider"})(?:$|\\/)".extraConfig = ''
+              try_files $uri/ =404;
+              index index.php;
             '';
+            "/remote" = {
+              priority = 1500;
+              extraConfig = ''
+                return 301 /remote.php$request_uri;
+              '';
+            };
+            "/" = {
+              priority = 1600;
+              extraConfig = ''
+                try_files $uri $uri/ /index.php$request_uri;
+              '';
+            };
           };
-          "~ ^/(?:build|tests|config|lib|3rdparty|templates|data)(?:$|/)" = {
-            priority = 450;
-            extraConfig = ''
-              return 404;
-            '';
-          };
-          "~ ^/(?:\\.|autotest|occ|issue|indie|db_|console)" = {
-            priority = 450;
-            extraConfig = ''
-              return 404;
-            '';
-          };
-          "~ \\.php(?:$|/)" = {
-            priority = 500;
-            extraConfig = ''
-              # legacy support (i.e. static files and directories in cfg.package)
-              rewrite ^/(?!index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[s${optionalString (!ocmProviderIsNotAStaticDirAnymore) "m"}]-provider\/.+|.+\/richdocumentscode\/proxy) /index.php$request_uri;
-              include ${config.services.nginx.package}/conf/fastcgi.conf;
-              fastcgi_split_path_info ^(.+?\.php)(\\/.*)$;
-              set $path_info $fastcgi_path_info;
-              try_files $fastcgi_script_name =404;
-              fastcgi_param PATH_INFO $path_info;
-              fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-              fastcgi_param HTTPS ${if cfg.https then "on" else "off"};
-              fastcgi_param modHeadersAvailable true;
-              fastcgi_param front_controller_active true;
-              fastcgi_pass unix:${fpm.socket};
-              fastcgi_intercept_errors on;
-              fastcgi_request_buffering off;
-              fastcgi_read_timeout ${builtins.toString cfg.fastcgiTimeout}s;
-            '';
-          };
-          "~ \\.(?:css|js|mjs|svg|gif|png|jpg|jpeg|ico|wasm|tflite|map|html|ttf|bcmap|mp4|webm|ogg|flac)$".extraConfig = ''
-            try_files $uri /index.php$request_uri;
-            expires 6M;
-            access_log off;
-            location ~ \.mjs$ {
-              default_type text/javascript;
-            }
-            location ~ \.wasm$ {
-              default_type application/wasm;
-            }
-          '';
-          "~ ^\\/(?:updater|ocs-provider${optionalString (!ocmProviderIsNotAStaticDirAnymore) "|ocm-provider"})(?:$|\\/)".extraConfig = ''
-            try_files $uri/ =404;
-            index index.php;
-          '';
-          "/remote" = {
-            priority = 1500;
-            extraConfig = ''
-              return 301 /remote.php$request_uri;
-            '';
-          };
-          "/" = {
-            priority = 1600;
-            extraConfig = ''
-              try_files $uri $uri/ /index.php$request_uri;
-            '';
-          };
-        };
-        extraConfig = ''
-          index index.php index.html /index.php$request_uri;
-          ${optionalString (cfg.nginx.recommendedHttpHeaders) ''
-            add_header X-Content-Type-Options nosniff;
-            add_header X-XSS-Protection "1; mode=block";
-            add_header X-Robots-Tag "noindex, nofollow";
-            add_header X-Download-Options noopen;
-            add_header X-Permitted-Cross-Domain-Policies none;
-            add_header X-Frame-Options sameorigin;
-            add_header Referrer-Policy no-referrer;
-          ''}
-          ${optionalString (cfg.https) ''
-            add_header Strict-Transport-Security "max-age=${toString cfg.nginx.hstsMaxAge}; includeSubDomains" always;
-          ''}
-          client_max_body_size ${cfg.maxUploadSize};
-          fastcgi_buffers 64 4K;
-          fastcgi_hide_header X-Powered-By;
-          gzip on;
-          gzip_vary on;
-          gzip_comp_level 4;
-          gzip_min_length 256;
-          gzip_proxied expired no-cache no-store private no_last_modified no_etag auth;
-          gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
+          extraConfig = ''
+            index index.php index.html /index.php$request_uri;
+            ${optionalString (cfg.nginx.recommendedHttpHeaders) ''
+              add_header X-Content-Type-Options nosniff;
+              add_header X-XSS-Protection "1; mode=block";
+              add_header X-Robots-Tag "noindex, nofollow";
+              add_header X-Download-Options noopen;
+              add_header X-Permitted-Cross-Domain-Policies none;
+              add_header X-Frame-Options sameorigin;
+              add_header Referrer-Policy no-referrer;
+            ''}
+            ${optionalString (cfg.https) ''
+              add_header Strict-Transport-Security "max-age=${toString cfg.nginx.hstsMaxAge}; includeSubDomains" always;
+            ''}
+            client_max_body_size ${cfg.maxUploadSize};
+            fastcgi_buffers 64 4K;
+            fastcgi_hide_header X-Powered-By;
+            gzip on;
+            gzip_vary on;
+            gzip_comp_level 4;
+            gzip_min_length 256;
+            gzip_proxied expired no-cache no-store private no_last_modified no_etag auth;
+            gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
 
-          ${optionalString cfg.webfinger ''
-            rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
-            rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
-          ''}
-        '';
-      };
+            ${optionalString cfg.webfinger ''
+              rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
+              rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
+            ''}
+          '';
+        }
+      ];
     }
   ]);
 


### PR DESCRIPTION
If you want to change something about the nginx virtual host for nextcloud, you have to write something like

```nix
services.nginx.virtualHosts."nextcloud.example.com" = {
    listen = [
        { addr = "0.0.0.0"; port = 12345; }
    ];
};
services.nextcloud = {
    enable = true;
    hostName = "nextcloud.example.com";
};
```

With this change, you can write the entire config as part of the `nextcloud` option:

```nix
services.nextcloud = {
    enable = true;
    hostName = "nextcloud.example.com";
    nginx.virtualHost = {
        listen = [
            { addr = "0.0.0.0"; port = 12345; }
        ];
    };
};
```

This is much nicer and less error-prone. This option has precedent in other nixos modules like monica, radicle, boostack or pixelfed, but because nextcloud already has custom options under `nginx`, I chose the `nginx.virtualHost` attribute instead.

## Description of changes

* The nixos `nextcloud` modules gains an additional `nginx.virtualHost` option

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
