### PR TITLE
guake: use python311

### DIFF
--- a/pkgs/applications/terminal-emulators/guake/default.nix
+++ b/pkgs/applications/terminal-emulators/guake/default.nix
@@ -1,7 +1,8 @@
 { lib
 , fetchFromGitHub
 , fetchpatch
-, python3
+, python311
+, python311Packages
 , glibcLocales
 , gobject-introspection
 , wrapGAppsHook3
@@ -15,7 +16,7 @@
 , nixosTests
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python311Packages.buildPythonApplication rec {
   pname = "guake";
   version = "3.10";
 
@@ -55,7 +56,7 @@ python3.pkgs.buildPythonApplication rec {
   nativeBuildInputs = [
     gobject-introspection
     wrapGAppsHook3
-    python3.pkgs.pip
+    python311Packages.pip
   ];
 
   buildInputs = [
@@ -64,13 +65,13 @@ python3.pkgs.buildPythonApplication rec {
     keybinder3
     libnotify
     libwnck
-    python3
+    python311
     vte
   ];
 
   makeWrapperArgs = [ "--set LOCALE_ARCHIVE ${glibcLocales}/lib/locale/locale-archive" ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = with python311Packages; [
     dbus-python
     pycairo
     pygobject3
@@ -96,7 +97,7 @@ python3.pkgs.buildPythonApplication rec {
     description = "Drop-down terminal for GNOME";
     homepage = "http://guake-project.org";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.msteen ];
+    maintainers = [ maintainers.msteen maintainers.heywoodlh ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
## Description of changes

Fixes #330913 by using Python 3.11 instead of Python 3.12. Not sure why Python 3 .12 causes this issue, I will probably dig into that at some point -- but I wanted to provide a fix for Guake in unstable since the executable missing is a pretty big issue.

I added myself as a maintainer for guake since I use it daily.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
