### PR TITLE
comet-gog: 0-unstable-2024-05-25 -> 0.1.2

### DIFF
--- a/pkgs/by-name/co/comet-gog/package.nix
+++ b/pkgs/by-name/co/comet-gog/package.nix
@@ -10,19 +10,19 @@
 let
   inherit (darwin.apple_sdk.frameworks) CoreFoundation SystemConfiguration;
 in
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage rec {
   pname = "comet-gog";
-  version = "0-unstable-2024-05-25";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "imLinguin";
     repo = "comet";
-    rev = "378ec2abdc2498e7c0c12aa50b71f6d94c3e8e3c";
-    hash = "sha256-r7ZPpJLy2fZsyNijl0+uYWQN941TCbv+Guv3wzD83IQ=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-TdIqdNn5HnIED7LMn4qAzKPHlA5t/Q1Dn+W+ulx5qOU=";
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-dXNAGMVayzgT96ETrph9eCbQv28EK/OOxIRV8ewpVvs=";
+  cargoHash = "sha256-gAGCpcVjOkUZa/CobOjOt07WMHpvE5/q1bw+z4yBeNE=";
 
   # error: linker `aarch64-linux-gnu-gcc` not found
   postPatch = ''
@@ -37,6 +37,7 @@ rustPlatform.buildRustPackage {
   ];
 
   meta = {
+    changelog = "https://github.com/imLinguin/comet/releases/tag/v${version}";
     description = "Open Source implementation of GOG Galaxy's Communication Service";
     homepage = "https://github.com/imLinguin/comet";
     license = lib.licenses.gpl3Plus;


### PR DESCRIPTION
## Description of changes

https://github.com/imLinguin/comet/releases

The package got its first official release a few weeks ago, but has since reached version `0.1.2`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
