### PR TITLE
gpodder2go: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1,68 +1,68 @@
 /*
   List of NixOS maintainers.
-   ```nix
-   handle = {
-     # Required
-     name = "Your name";
+  ```nix
+  handle = {
+    # Required
+    name = "Your name";
 
-     # Optional, but at least one of email, matrix or githubId must be given
-     email = "address@example.org";
-     matrix = "@user:example.org";
-     github = "GithubUsername";
-     githubId = your-github-id;
+    # Optional, but at least one of email, matrix or githubId must be given
+    email = "address@example.org";
+    matrix = "@user:example.org";
+    github = "GithubUsername";
+    githubId = your-github-id;
 
-     keys = [{
-       fingerprint = "AAAA BBBB CCCC DDDD EEEE  FFFF 0000 1111 2222 3333";
-     }];
-   };
-   ```
+    keys = [{
+      fingerprint = "AAAA BBBB CCCC DDDD EEEE  FFFF 0000 1111 2222 3333";
+    }];
+  };
+  ```
 
-   where
+  where
 
-   - `handle` is the handle you are going to use in nixpkgs expressions,
-   - `name` is a name that people would know and recognize you by,
-   - `email` is your maintainer email address,
-   - `matrix` is your Matrix user ID,
-   - `github` is your GitHub handle (as it appears in the URL of your profile page, `https://github.com/<userhandle>`),
-   - `githubId` is your GitHub user ID, which can be found at `https://api.github.com/users/<userhandle>`,
-   - `keys` is a list of your PGP/GPG key fingerprints.
+  - `handle` is the handle you are going to use in nixpkgs expressions,
+  - `name` is a name that people would know and recognize you by,
+  - `email` is your maintainer email address,
+  - `matrix` is your Matrix user ID,
+  - `github` is your GitHub handle (as it appears in the URL of your profile page, `https://github.com/<userhandle>`),
+  - `githubId` is your GitHub user ID, which can be found at `https://api.github.com/users/<userhandle>`,
+  - `keys` is a list of your PGP/GPG key fingerprints.
 
-   Specifying a GitHub account ensures that you automatically:
-   - get invited to the @NixOS/nixpkgs-maintainers team ;
-   - once you are part of the @NixOS org, OfBorg will request you review
-     pull requests that modify a package for which you are a maintainer.
+  Specifying a GitHub account ensures that you automatically:
+  - get invited to the @NixOS/nixpkgs-maintainers team ;
+  - once you are part of the @NixOS org, OfBorg will request you review
+    pull requests that modify a package for which you are a maintainer.
 
-   `handle == github` is strongly preferred whenever `github` is an acceptable attribute name and is short and convenient.
+  `handle == github` is strongly preferred whenever `github` is an acceptable attribute name and is short and convenient.
 
-   If `github` begins with a numeral, `handle` should be prefixed with an underscore.
-   ```nix
-   _1example = {
-     github = "1example";
-   };
-   ```
+  If `github` begins with a numeral, `handle` should be prefixed with an underscore.
+  ```nix
+  _1example = {
+    github = "1example";
+  };
+  ```
 
-   Add PGP/GPG keys only if you actually use them to sign commits and/or mail.
+  Add PGP/GPG keys only if you actually use them to sign commits and/or mail.
 
-   To get the required PGP/GPG values for a key run
-   ```shell
-   gpg --fingerprint <email> | head -n 2
-   ```
+  To get the required PGP/GPG values for a key run
+  ```shell
+  gpg --fingerprint <email> | head -n 2
+  ```
 
-   !!! Note that PGP/GPG values stored here are for informational purposes only, don't use this file as a source of truth.
+  !!! Note that PGP/GPG values stored here are for informational purposes only, don't use this file as a source of truth.
 
-   More fields may be added in the future, however, in order to comply with GDPR this file should stay as minimal as possible.
+  More fields may be added in the future, however, in order to comply with GDPR this file should stay as minimal as possible.
 
-   When editing this file:
-    * keep the list alphabetically sorted, check with:
-        nix-instantiate --eval maintainers/scripts/check-maintainers-sorted.nix
-    * test the validity of the format with:
-        nix-build lib/tests/maintainers.nix
+  When editing this file:
+   * keep the list alphabetically sorted, check with:
+       nix-instantiate --eval maintainers/scripts/check-maintainers-sorted.nix
+   * test the validity of the format with:
+       nix-build lib/tests/maintainers.nix
 
-   See `./scripts/check-maintainer-github-handles.sh` for an example on how to work with this data.
+  See `./scripts/check-maintainer-github-handles.sh` for an example on how to work with this data.
 
-   When adding a new maintainer, be aware of the current commit conventions
-   documented at [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#commit-conventions)
-   file located in the root of the Nixpkgs repo.
+  When adding a new maintainer, be aware of the current commit conventions
+  documented at [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#commit-conventions)
+  file located in the root of the Nixpkgs repo.
 */
 {
   _0b11stan = {
@@ -1353,7 +1353,7 @@
     name = "Stanislas Lange";
   };
   AngryAnt = {
-    name = "Emil \"AngryAnt\" Johansen";
+    name = ''Emil "AngryAnt" Johansen'';
     email = "git@eej.dk";
     matrix = "@angryant:envs.net";
     github = "AngryAnt";
@@ -6811,6 +6811,12 @@
     github = "fmthoma";
     githubId = 5918766;
     name = "Franz Thoma";
+  };
+  foehammer = {
+    name = "Lorenzo Good";
+    github = "foehammer127";
+    githubId = 44120040;
+    keys = [ { fingerprint = "DA70 992D B220 25BF C3BF  20D0 A972 C206 3F4F 2554"; } ];
   };
   foo-dogsquared = {
     email = "foodogsquared@foodogsquared.one";
@@ -19556,7 +19562,7 @@
     email = "strager.nds@gmail.com";
     github = "strager";
     githubId = 48666;
-    name = "Matthew \"strager\" Glazar";
+    name = ''Matthew "strager" Glazar'';
   };
   strawbee = {
     email = "henigingames@gmail.com";

--- a/pkgs/by-name/gp/gpodder2go/package.nix
+++ b/pkgs/by-name/gp/gpodder2go/package.nix
@@ -1,0 +1,31 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+}:
+buildGoModule rec {
+  pname = "gpodder2go";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "oxtyped";
+    repo = "gpodder2go";
+    rev = "v${version}";
+    hash = "sha256-DLUVANrePlnzEGmyjmrtQbus8zjPytBJUIg2MSqD8go=";
+  };
+
+  # Skip checks due to reliance on an external database.
+  doCheck = false;
+
+  vendorHash = "sha256-7VkpRyoqWFfZODrNq5YjgHFKM3/7u/4G5b/930aoqyA=";
+
+  CGO_ENABLED = 0;
+
+  meta = with lib; {
+    description = "Single Binary Podcast Subscription Management";
+    homepage = "https://github.com/oxtyped/gpodder2go";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ foehammer ];
+    mainProgram = "gpodder2go";
+  };
+}


### PR DESCRIPTION
## Description of changes

Add the gpodder2go package, which allows users to easily manage podcast subscriptions.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
