### PR TITLE
python312Packages.rioxarray: extend disabled failing tests to aarch64-darwin

### DIFF
--- a/pkgs/development/python-modules/rioxarray/default.nix
+++ b/pkgs/development/python-modules/rioxarray/default.nix
@@ -49,11 +49,13 @@ buildPythonPackage rec {
 
   disabledTests =
     [ "test_clip_geojson__no_drop" ]
-    ++ lib.optionals (stdenv.hostPlatform.system == "aarch64-linux") [
-      # numerical errors
-      "test_clip_geojson"
-      "test_open_rasterio_mask_chunk_clip"
-    ];
+    ++ lib.optionals
+      (stdenv.hostPlatform.system == "aarch64-linux" || stdenv.hostPlatform.system == "aarch64-darwin")
+      [
+        # numerical errors
+        "test_clip_geojson"
+        "test_open_rasterio_mask_chunk_clip"
+      ];
 
   pythonImportsCheck = [ "rioxarray" ];
 


### PR DESCRIPTION
## Description of changes

Disables failing tests for `rioxarray` on `aarch64-darwin`, which extends the original condition for `aarch64-linux` as these are the same tests noted in #320524.

```
=========================== short test summary info ============================
FAILED test/integration/test_integration__io.py::test_open_rasterio_mask_chunk_clip - AssertionError:
FAILED test/integration/test_integration_rioxarray.py::test_clip_geojson[open_rasterio-True] - AssertionError:
FAILED test/integration/test_integration_rioxarray.py::test_clip_geojson[open_rasterio-False] - AssertionError:
FAILED test/integration/test_integration_rioxarray.py::test_clip_geojson[open_func1-True] - AssertionError:
FAILED test/integration/test_integration_rioxarray.py::test_clip_geojson[open_func1-False] - AssertionError:
FAILED test/integration/test_integration_rioxarray.py::test_clip_geojson[open_func2-True] - AssertionError:
FAILED test/integration/test_integration_rioxarray.py::test_clip_geojson[open_func2-False] - AssertionError:
FAILED test/integration/test_integration_rioxarray.py::test_clip_geojson[open_func3-True] - AssertionError:
FAILED test/integration/test_integration_rioxarray.py::test_clip_geojson[open_func3-False] - AssertionError:
FAILED test/integration/test_integration_rioxarray.py::test_clip_geojson[open_func4-True] - AssertionError:
FAILED test/integration/test_integration_rioxarray.py::test_clip_geojson[open_func4-False] - AssertionError:
FAILED test/integration/test_integration_rioxarray.py::test_clip_geojson[open_func5-True] - AssertionError:
FAILED test/integration/test_integration_rioxarray.py::test_clip_geojson[open_func5-False] - AssertionError:
= 13 failed, 440 passed, 17 skipped, 8 deselected, 1 xfailed, 3 xpassed, 385 warnings in 13.64s =
/nix/store/89ghmy7qxyggz4sycc9qr1klinmrlgbx-stdenv-darwin/setup: line 1650: pop_var_context: head of shell_variables not a function context
error: builder for '/nix/store/zcf3qwcfb8kpcxqz5h9hg5xjp3x8gh7c-python3.12-rioxarray-0.17.0.drv' failed with exit code 1;
       last 10 log lines:
       > FAILED test/integration/test_integration_rioxarray.py::test_clip_geojson[open_func2-True] - AssertionError:
       > FAILED test/integration/test_integration_rioxarray.py::test_clip_geojson[open_func2-False] - AssertionError:
       > FAILED test/integration/test_integration_rioxarray.py::test_clip_geojson[open_func3-True] - AssertionError:
       > FAILED test/integration/test_integration_rioxarray.py::test_clip_geojson[open_func3-False] - AssertionError:
       > FAILED test/integration/test_integration_rioxarray.py::test_clip_geojson[open_func4-True] - AssertionError:
       > FAILED test/integration/test_integration_rioxarray.py::test_clip_geojson[open_func4-False] - AssertionError:
       > FAILED test/integration/test_integration_rioxarray.py::test_clip_geojson[open_func5-True] - AssertionError:
       > FAILED test/integration/test_integration_rioxarray.py::test_clip_geojson[open_func5-False] - AssertionError:
       > = 13 failed, 440 passed, 17 skipped, 8 deselected, 1 xfailed, 3 xpassed, 385 warnings in 13.64s =
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
