### PR TITLE
nixos/ananicy: disable ananicy-cpp's BPF on hardened kernels, cleanup

### DIFF
--- a/nixos/modules/services/misc/ananicy.nix
+++ b/nixos/modules/services/misc/ananicy.nix
@@ -1,77 +1,107 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   cfg = config.services.ananicy;
   configFile = pkgs.writeText "ananicy.conf" (lib.generators.toKeyValue { } cfg.settings);
-  extraRules = pkgs.writeText "extraRules" (lib.concatMapStringsSep "\n" (l: builtins.toJSON l) cfg.extraRules);
-  extraTypes = pkgs.writeText "extraTypes" (lib.concatMapStringsSep "\n" (l: builtins.toJSON l) cfg.extraTypes);
-  extraCgroups = pkgs.writeText "extraCgroups" (lib.concatMapStringsSep "\n" (l: builtins.toJSON l) cfg.extraCgroups);
-  servicename = if ((lib.getName cfg.package) == (lib.getName pkgs.ananicy-cpp)) then "ananicy-cpp" else "ananicy";
+  extraRules = pkgs.writeText "extraRules" (
+    lib.concatMapStringsSep "\n" (l: builtins.toJSON l) cfg.extraRules
+  );
+  extraTypes = pkgs.writeText "extraTypes" (
+    lib.concatMapStringsSep "\n" (l: builtins.toJSON l) cfg.extraTypes
+  );
+  extraCgroups = pkgs.writeText "extraCgroups" (
+    lib.concatMapStringsSep "\n" (l: builtins.toJSON l) cfg.extraCgroups
+  );
+  servicename =
+    if ((lib.getName cfg.package) == (lib.getName pkgs.ananicy-cpp)) then "ananicy-cpp" else "ananicy";
 in
 {
-  options = {
-    services.ananicy = {
-      enable = lib.mkEnableOption "Ananicy, an auto nice daemon";
+  options.services.ananicy = {
+    enable = lib.mkEnableOption "Ananicy, an auto nice daemon";
 
-      package = lib.mkPackageOption pkgs "ananicy" {
-        example = "ananicy-cpp";
-      };
+    package = lib.mkPackageOption pkgs "ananicy" { example = "ananicy-cpp"; };
 
-      rulesProvider = lib.mkPackageOption pkgs "ananicy" {
-        example = "ananicy-cpp";
-      } // {
-        description = ''
-          Which package to copy default rules,types,cgroups from.
-        '';
-      };
+    rulesProvider = lib.mkPackageOption pkgs "ananicy" { example = "ananicy-cpp"; } // {
+      description = ''
+        Which package to copy default rules,types,cgroups from.
+      '';
+    };
 
-      settings = lib.mkOption {
-        type = with lib.types; attrsOf (oneOf [ int bool str ]);
-        default = { };
-        example = {
-          apply_nice = false;
-        };
-        description = ''
-          See <https://github.com/Nefelim4ag/Ananicy/blob/master/ananicy.d/ananicy.conf>
-        '';
+    settings = lib.mkOption {
+      type =
+        with lib.types;
+        attrsOf (oneOf [
+          int
+          bool
+          str
+        ]);
+      default = { };
+      example = {
+        apply_nice = false;
       };
+      description = ''
+        See <https://github.com/Nefelim4ag/Ananicy/blob/master/ananicy.d/ananicy.conf>
+      '';
+    };
 
-      extraRules = lib.mkOption {
-        type = with lib.types; listOf attrs;
-        default = [ ];
-        description = ''
-          Rules to write in 'nixRules.rules'. See:
-          <https://github.com/Nefelim4ag/Ananicy#configuration>
-          <https://gitlab.com/ananicy-cpp/ananicy-cpp/#global-configuration>
-        '';
-        example = [
-          { name = "eog"; type = "Image-Viewer"; }
-          { name = "fdupes"; type = "BG_CPUIO"; }
-        ];
-      };
-      extraTypes = lib.mkOption {
-        type = with lib.types; listOf attrs;
-        default = [ ];
-        description = ''
-          Types to write in 'nixTypes.types'. See:
-          <https://gitlab.com/ananicy-cpp/ananicy-cpp/#types>
-        '';
-        example = [
-          { type = "my_type"; nice = 19; other_parameter = "value"; }
-          { type = "compiler"; nice = 19; sched = "batch"; ioclass = "idle"; }
-        ];
-      };
-      extraCgroups = lib.mkOption {
-        type = with lib.types; listOf attrs;
-        default = [ ];
-        description = ''
-          Cgroups to write in 'nixCgroups.cgroups'. See:
-          <https://gitlab.com/ananicy-cpp/ananicy-cpp/#cgroups>
-        '';
-        example = [
-          { cgroup = "cpu80"; CPUQuota = 80; }
-        ];
-      };
+    extraRules = lib.mkOption {
+      type = with lib.types; listOf attrs;
+      default = [ ];
+      description = ''
+        Rules to write in 'nixRules.rules'. See:
+        <https://github.com/Nefelim4ag/Ananicy#configuration>
+        <https://gitlab.com/ananicy-cpp/ananicy-cpp/#global-configuration>
+      '';
+      example = [
+        {
+          name = "eog";
+          type = "Image-Viewer";
+        }
+        {
+          name = "fdupes";
+          type = "BG_CPUIO";
+        }
+      ];
+    };
+    extraTypes = lib.mkOption {
+      type = with lib.types; listOf attrs;
+      default = [ ];
+      description = ''
+        Types to write in 'nixTypes.types'. See:
+        <https://gitlab.com/ananicy-cpp/ananicy-cpp/#types>
+      '';
+      example = [
+        {
+          type = "my_type";
+          nice = 19;
+          other_parameter = "value";
+        }
+        {
+          type = "compiler";
+          nice = 19;
+          sched = "batch";
+          ioclass = "idle";
+        }
+      ];
+    };
+    extraCgroups = lib.mkOption {
+      type = with lib.types; listOf attrs;
+      default = [ ];
+      description = ''
+        Cgroups to write in 'nixCgroups.cgroups'. See:
+        <https://gitlab.com/ananicy-cpp/ananicy-cpp/#cgroups>
+      '';
+      example = [
+        {
+          cgroup = "cpu80";
+          CPUQuota = 80;
+        }
+      ];
     };
   };
 
@@ -111,16 +141,22 @@ in
         apply_sched = mkOD true;
         apply_oom_score_adj = mkOD true;
         apply_cgroup = mkOD true;
-      } // (if ((lib.getName cfg.package) == (lib.getName pkgs.ananicy-cpp)) then {
-        # https://gitlab.com/ananicy-cpp/ananicy-cpp/-/blob/master/src/config.cpp#L12
-        loglevel = mkOD "warn"; # default is info but its spammy
-        cgroup_realtime_workaround = true;
-        log_applied_rule = mkOD false;
-      } else {
-        # https://github.com/Nefelim4ag/Ananicy/blob/master/ananicy.d/ananicy.conf
-        check_disks_schedulers = mkOD true;
-        check_freq = mkOD 5;
-      });
+      }
+      // (
+        if servicename == "ananicy-cpp" then
+          {
+            # https://gitlab.com/ananicy-cpp/ananicy-cpp/-/blob/master/src/config.cpp#L12
+            loglevel = mkOD "warn"; # default is info but its spammy
+            cgroup_realtime_workaround = true;
+            log_applied_rule = mkOD false;
+          }
+        else
+          {
+            # https://github.com/Nefelim4ag/Ananicy/blob/master/ananicy.d/ananicy.conf
+            check_disks_schedulers = mkOD true;
+            check_freq = mkOD 5;
+          }
+      );
 
     systemd = {
       packages = [ cfg.package ];
@@ -130,7 +166,5 @@ in
     };
   };
 
-  meta = {
-    maintainers = with lib.maintainers; [ artturin ];
-  };
+  meta.maintainers = with lib.maintainers; [ artturin ];
 }

--- a/nixos/modules/services/misc/ananicy.nix
+++ b/nixos/modules/services/misc/ananicy.nix
@@ -1,25 +1,23 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
   cfg = config.services.ananicy;
-  configFile = pkgs.writeText "ananicy.conf" (generators.toKeyValue { } cfg.settings);
-  extraRules = pkgs.writeText "extraRules" (concatMapStringsSep "\n" (l: builtins.toJSON l) cfg.extraRules);
-  extraTypes = pkgs.writeText "extraTypes" (concatMapStringsSep "\n" (l: builtins.toJSON l) cfg.extraTypes);
-  extraCgroups = pkgs.writeText "extraCgroups" (concatMapStringsSep "\n" (l: builtins.toJSON l) cfg.extraCgroups);
+  configFile = pkgs.writeText "ananicy.conf" (lib.generators.toKeyValue { } cfg.settings);
+  extraRules = pkgs.writeText "extraRules" (lib.concatMapStringsSep "\n" (l: builtins.toJSON l) cfg.extraRules);
+  extraTypes = pkgs.writeText "extraTypes" (lib.concatMapStringsSep "\n" (l: builtins.toJSON l) cfg.extraTypes);
+  extraCgroups = pkgs.writeText "extraCgroups" (lib.concatMapStringsSep "\n" (l: builtins.toJSON l) cfg.extraCgroups);
   servicename = if ((lib.getName cfg.package) == (lib.getName pkgs.ananicy-cpp)) then "ananicy-cpp" else "ananicy";
 in
 {
   options = {
     services.ananicy = {
-      enable = mkEnableOption "Ananicy, an auto nice daemon";
+      enable = lib.mkEnableOption "Ananicy, an auto nice daemon";
 
-      package = mkPackageOption pkgs "ananicy" {
+      package = lib.mkPackageOption pkgs "ananicy" {
         example = "ananicy-cpp";
       };
 
-      rulesProvider = mkPackageOption pkgs "ananicy" {
+      rulesProvider = lib.mkPackageOption pkgs "ananicy" {
         example = "ananicy-cpp";
       } // {
         description = ''
@@ -27,8 +25,8 @@ in
         '';
       };
 
-      settings = mkOption {
-        type = with types; attrsOf (oneOf [ int bool str ]);
+      settings = lib.mkOption {
+        type = with lib.types; attrsOf (oneOf [ int bool str ]);
         default = { };
         example = {
           apply_nice = false;
@@ -38,8 +36,8 @@ in
         '';
       };
 
-      extraRules = mkOption {
-        type = with types; listOf attrs;
+      extraRules = lib.mkOption {
+        type = with lib.types; listOf attrs;
         default = [ ];
         description = ''
           Rules to write in 'nixRules.rules'. See:
@@ -51,8 +49,8 @@ in
           { name = "fdupes"; type = "BG_CPUIO"; }
         ];
       };
-      extraTypes = mkOption {
-        type = with types; listOf attrs;
+      extraTypes = lib.mkOption {
+        type = with lib.types; listOf attrs;
         default = [ ];
         description = ''
           Types to write in 'nixTypes.types'. See:
@@ -63,8 +61,8 @@ in
           { type = "compiler"; nice = 19; sched = "batch"; ioclass = "idle"; }
         ];
       };
-      extraCgroups = mkOption {
-        type = with types; listOf attrs;
+      extraCgroups = lib.mkOption {
+        type = with lib.types; listOf attrs;
         default = [ ];
         description = ''
           Cgroups to write in 'nixCgroups.cgroups'. See:
@@ -77,7 +75,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     environment = {
       systemPackages = [ cfg.package ];
       etc."ananicy.d".source = pkgs.runCommandLocal "ananicyfiles" { } ''
@@ -92,16 +90,16 @@ in
         # configured through .setings
         rm -f $out/ananicy.conf
         cp ${configFile} $out/ananicy.conf
-        ${optionalString (cfg.extraRules != [ ]) "cp ${extraRules} $out/nixRules.rules"}
-        ${optionalString (cfg.extraTypes != [ ]) "cp ${extraTypes} $out/nixTypes.types"}
-        ${optionalString (cfg.extraCgroups != [ ]) "cp ${extraCgroups} $out/nixCgroups.cgroups"}
+        ${lib.optionalString (cfg.extraRules != [ ]) "cp ${extraRules} $out/nixRules.rules"}
+        ${lib.optionalString (cfg.extraTypes != [ ]) "cp ${extraTypes} $out/nixTypes.types"}
+        ${lib.optionalString (cfg.extraCgroups != [ ]) "cp ${extraCgroups} $out/nixCgroups.cgroups"}
       '';
     };
 
     # ananicy and ananicy-cpp have different default settings
     services.ananicy.settings =
       let
-        mkOD = mkOptionDefault;
+        mkOD = lib.mkOptionDefault;
       in
       {
         cgroup_load = mkOD true;
@@ -133,6 +131,6 @@ in
   };
 
   meta = {
-    maintainers = with maintainers; [ artturin ];
+    maintainers = with lib.maintainers; [ artturin ];
   };
 }


### PR DESCRIPTION
## Description of changes

Ananicy-Cpp does not work with hardened kernels, because bpf support is fully supported on hardened. So let's disable it.
Fixes https://github.com/NixOS/nixpkgs/issues/327382
Follow up to https://github.com/NixOS/nixpkgs/pull/330488

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
