### PR TITLE
openbabel: fix build errors with python 3.12

### DIFF
--- a/pkgs/development/libraries/openbabel/default.nix
+++ b/pkgs/development/libraries/openbabel/default.nix
@@ -12,6 +12,9 @@
 , pkg-config
 , swig
 , rapidjson
+, boost
+, maeparser
+, coordgenlibs
 }:
 
 stdenv.mkDerivation rec {
@@ -29,7 +32,7 @@ stdenv.mkDerivation rec {
     sed '1i#include <ctime>' -i include/openbabel/obutil.h # gcc12
   '';
 
-  buildInputs = [ perl zlib libxml2 eigen python cairo pcre swig rapidjson ];
+  buildInputs = [ perl zlib libxml2 eigen python cairo pcre swig rapidjson boost maeparser coordgenlibs ];
 
   nativeBuildInputs = [ cmake pkg-config ];
 

--- a/pkgs/development/libraries/openbabel/default.nix
+++ b/pkgs/development/libraries/openbabel/default.nix
@@ -1,4 +1,18 @@
-{ stdenv, lib, fetchFromGitHub, cmake, perl, zlib, libxml2, eigen, python, cairo, pcre, pkg-config, swig, rapidjson }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, perl
+, zlib
+, libxml2
+, eigen
+, python
+, cairo
+, pcre
+, pkg-config
+, swig
+, rapidjson
+}:
 
 stdenv.mkDerivation rec {
   pname = "openbabel";
@@ -19,18 +33,19 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkg-config ];
 
-  pythonMajorMinor = "${python.sourceVersion.major}.${python.sourceVersion.minor}";
-
-  cmakeFlags = [
-    "-DRUN_SWIG=ON"
-    "-DPYTHON_BINDINGS=ON"
-  ];
+  preConfigure = ''
+    cmakeFlagsArray+=(
+      "-DRUN_SWIG=ON"
+      "-DPYTHON_BINDINGS=ON"
+      "-DPYTHON_INSTDIR=$out/${python.sitePackages}"
+    )
+  '';
 
   # Setuptools only accepts PEP 440 version strings. The "unstable" identifier
   # can not be used. Instead we pretend to be the 3.2 beta release.
   postFixup = ''
-    cat <<EOF > $out/lib/python$pythonMajorMinor/site-packages/setup.py
-    from distutils.core import setup
+    cat << EOF > $out/${python.sitePackages}/setup.py
+    from setuptools import setup
 
     setup(
         name = 'pyopenbabel',

--- a/pkgs/development/python-modules/openbabel-bindings/default.nix
+++ b/pkgs/development/python-modules/openbabel-bindings/default.nix
@@ -8,9 +8,9 @@
 buildPythonPackage rec {
   inherit (openbabel) pname version;
 
-  src = "${openbabel}/lib/python${python.sourceVersion.major}.${python.sourceVersion.minor}/site-packages";
+  src = "${openbabel}/${python.sitePackages}";
 
-  nativeBuildInputs = [ openbabel ];
+  buildInputs = [ openbabel ];
 
   # these env variables are used by the bindings to find libraries
   # they need to be included explicitly in your nix-shell for


### PR DESCRIPTION
## Description of changes

Fixes #325741

Python 3.12 removed distutils, which are used within OpenBabel's CMake and in the nix expression to generate a custom setup.py. I'm working around the first issue by simply specifying the Python installation directory explicitly, to avoid the problematic CMake code block, that calls distutils.

The second issue is fixed by using setuptools instead of distutils in the nix expression.

At some point upstream OpenBabel finds a better option for the python bindings and we may be able to simplify this process again.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
