### PR TITLE
[Backport release-24.05] pyhton3Packages.databricks-sql-connector: Fix broken

### DIFF
--- a/pkgs/applications/misc/databricks-sql-cli/default.nix
+++ b/pkgs/applications/misc/databricks-sql-cli/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , fetchpatch
 , python3
+, pythonRelaxDepsHook
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -24,15 +25,20 @@ python3.pkgs.buildPythonApplication rec {
     })
   ];
 
+  pythonRelaxDeps = [
+    "pandas"
+    "databricks-sql-connector"
+    "sqlparse"
+  ];
+
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace 'python = ">=3.7.1,<4.0"' 'python = ">=3.8,<4.0"' \
-      --replace 'pandas = "1.3.4"' 'pandas = "~1.5"'
   '';
 
-  nativeBuildInputs = with python3.pkgs; [
+  nativeBuildInputs = (with python3.pkgs; [
     poetry-core
-  ];
+  ]) ++ [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = with python3.pkgs; [
     cli-helpers

--- a/pkgs/development/python-modules/databricks-sql-connector/default.nix
+++ b/pkgs/development/python-modules/databricks-sql-connector/default.nix
@@ -12,28 +12,41 @@
   pyarrow,
   pytestCheckHook,
   pythonOlder,
+  pythonAtLeast,
   pythonRelaxDepsHook,
   sqlalchemy,
   thrift,
+  requests,
+  urllib3,
+  fetchpatch,
 }:
 
 buildPythonPackage rec {
   pname = "databricks-sql-connector";
-  version = "3.1.0";
+  version = "3.3.0";
   format = "pyproject";
 
-  disabled = pythonOlder "3.7";
+  # Depends on thrift that at the moment do not work in Python 3.12
+  # see PR 328415 fix this.
+  disabled = pythonOlder "3.7" || pythonAtLeast "3.12";
 
   src = fetchFromGitHub {
     owner = "databricks";
     repo = "databricks-sql-python";
     rev = "refs/tags/v${version}";
-    hash = "sha256-LiA+zZuhPPXgBb8B1vZ/PuAYMrBXzxgd1CXwugf0mk8=";
+    hash = "sha256-a3OeKJ3c2UCClsPMah7iJY2YvIVLfHmmBuHAx8vdXZs=";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "fix-pandas.patch";
+      url = "https://patch-diff.githubusercontent.com/raw/databricks/databricks-sql-python/pull/416.patch";
+      sha256 = "sha256-sNCp8xSSmKP2yNzDK4wyWC5Hoe574AeHnKTeNcIxaek=";
+    })
+  ];
+
   pythonRelaxDeps = [
-    "numpy"
-    "thrift"
+    "pyarrow"
   ];
 
   nativeBuildInputs = [
@@ -51,6 +64,8 @@ buildPythonPackage rec {
     pyarrow
     sqlalchemy
     thrift
+    requests
+    urllib3
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
@@ -65,8 +80,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/databricks/databricks-sql-python/blob/v${version}/CHANGELOG.md";
     license = licenses.asl20;
     maintainers = with maintainers; [ harvidsen ];
-    # No SQLAlchemy 2.0 support
-    # https://github.com/databricks/databricks-sql-python/issues/91
-    broken = true;
   };
 }


### PR DESCRIPTION
## Description of changes
The package `pyhton3Packages.databricks-sql-connector` is broken and are marked as broken in `nixos-24.05`. The problem is fixed by upgrading to 3.3.0 from 3.1.0. Since the package is broken in `nixos-24.05 ` I think it's reasonable to accept update of package to fix it. 

This PR is a backport of #329134 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
