### PR TITLE
treewide: Pass self when overriding Python

### DIFF
--- a/pkgs/applications/gis/qgis/unwrapped-ltr.nix
+++ b/pkgs/applications/gis/qgis/unwrapped-ltr.nix
@@ -49,6 +49,7 @@
 
 let
   py = python311.override {
+    self = py;
     packageOverrides = self: super: {
       pyqt5 = super.pyqt5.override {
         withLocation = true;

--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -49,6 +49,7 @@
 
 let
   py = python311.override {
+    self = py;
     packageOverrides = self: super: {
       pyqt5 = super.pyqt5.override {
         withLocation = true;

--- a/pkgs/applications/graphics/textual-paint/default.nix
+++ b/pkgs/applications/graphics/textual-paint/default.nix
@@ -7,6 +7,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = _: super: {
       pillow = super.pillow.overridePythonAttrs rec {
         version = "9.5.0";

--- a/pkgs/applications/misc/archivebox/default.nix
+++ b/pkgs/applications/misc/archivebox/default.nix
@@ -15,6 +15,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       django = super.django_3.overridePythonAttrs (old: rec {
         version = "3.1.14";

--- a/pkgs/applications/misc/archivy/default.nix
+++ b/pkgs/applications/misc/archivy/default.nix
@@ -5,6 +5,7 @@
 
 let
   py = python3.override {
+    self = py;
     packageOverrides = self: super: {
       wtforms = super.wtforms.overridePythonAttrs (oldAttrs: rec {
         version = "2.3.1";

--- a/pkgs/applications/misc/dbx/default.nix
+++ b/pkgs/applications/misc/dbx/default.nix
@@ -5,7 +5,7 @@
   python3,
 }:
 let
-  python = python3.override { packageOverrides = self: super: { pydantic = super.pydantic_1; }; };
+  python = python3.override { self = python; packageOverrides = self: super: { pydantic = super.pydantic_1; }; };
 in
 python.pkgs.buildPythonApplication rec {
   pname = "dbx";

--- a/pkgs/applications/misc/haxor-news/default.nix
+++ b/pkgs/applications/misc/haxor-news/default.nix
@@ -3,9 +3,8 @@
 
 let
   py = python3.override {
+    self = py;
     packageOverrides = self: super: {
-      self = py;
-
       # not compatible with prompt_toolkit >=2.0
       prompt-toolkit = super.prompt-toolkit.overridePythonAttrs (oldAttrs: rec {
         name = "${oldAttrs.pname}-${version}";

--- a/pkgs/applications/misc/pytrainer/default.nix
+++ b/pkgs/applications/misc/pytrainer/default.nix
@@ -18,6 +18,7 @@
 
 let
   python = python310.override {
+    self = python;
     packageOverrides = (self: super: {
       matplotlib = super.matplotlib.override {
         enableGtk3 = true;

--- a/pkgs/applications/misc/tandoor-recipes/default.nix
+++ b/pkgs/applications/misc/tandoor-recipes/default.nix
@@ -6,6 +6,7 @@
 let
   # python-ldap-3.4.4 does not work with python3(12)
   python = python311.override {
+    self = python;
     packageOverrides = self: super: {
       validators = super.validators.overridePythonAttrs (_: rec {
         version = "0.20.0";

--- a/pkgs/applications/networking/cluster/nixops/default.nix
+++ b/pkgs/applications/networking/cluster/nixops/default.nix
@@ -12,6 +12,7 @@ let
   nixopsContextBase = this: {
 
     python = python3.override {
+      self = this.python;
       packageOverrides = self: super: {
         nixops = self.callPackage ./unwrapped.nix { };
       } // (this.plugins self super);

--- a/pkgs/applications/networking/instant-messengers/turses/default.nix
+++ b/pkgs/applications/networking/instant-messengers/turses/default.nix
@@ -7,6 +7,7 @@
 
 let
   py = python3.override {
+    self = py;
     packageOverrides = self: super: {
 
       # Support for later tweepy releases is missing

--- a/pkgs/applications/networking/instant-messengers/zulip-term/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zulip-term/default.nix
@@ -7,6 +7,7 @@
 
 let
   py = python3.override {
+    self = py;
     packageOverrides = self: super: {
 
       # Requires "urwid~=2.1.2", otherwise some tests are failing

--- a/pkgs/applications/networking/seahub/default.nix
+++ b/pkgs/applications/networking/seahub/default.nix
@@ -7,6 +7,7 @@
 }:
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       django = super.django_3;
     };

--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -37,6 +37,7 @@ let
   # https://github.com/NixOS/nixpkgs/issues/298719
   # https://github.com/paperless-ngx/paperless-ngx/issues/5494
   python = python3.override {
+    self = python;
     packageOverrides = final: prev: {
       # tesseract5 may be overwritten in the paperless module and we need to propagate that to make the closure reduction effective
       ocrmypdf = prev.ocrmypdf.override { tesseract = tesseract5; };

--- a/pkgs/applications/version-management/sourcehut/default.nix
+++ b/pkgs/applications/version-management/sourcehut/default.nix
@@ -13,6 +13,7 @@
 # https://github.com/NixOS/nixpkgs/pull/54425#discussion_r250688781
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       srht = self.callPackage ./core.nix { };
 

--- a/pkgs/applications/video/catt/default.nix
+++ b/pkgs/applications/video/catt/default.nix
@@ -6,6 +6,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       pychromecast = super.pychromecast.overridePythonAttrs (_: rec {
         version = "13.1.0";

--- a/pkgs/applications/video/frigate/default.nix
+++ b/pkgs/applications/video/frigate/default.nix
@@ -24,6 +24,7 @@ let
   };
 
   python = python311.override {
+    self = python;
     packageOverrides = self: super: {
       pydantic = super.pydantic_1;
 

--- a/pkgs/applications/video/pyca/default.nix
+++ b/pkgs/applications/video/pyca/default.nix
@@ -8,6 +8,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       # pyCA is incompatible with SQLAlchemy 2.0
       sqlalchemy = super.sqlalchemy_1_4;
@@ -80,4 +81,3 @@ python3.pkgs.buildPythonApplication rec {
     maintainers = with maintainers; [ pmiddend ];
   };
 }
-

--- a/pkgs/by-name/az/azure-cli/python-packages.nix
+++ b/pkgs/by-name/az/azure-cli/python-packages.nix
@@ -23,6 +23,7 @@ let
     });
 
   py = python3.override {
+    self = py;
     packageOverrides = self: super: {
       inherit buildAzureCliPackage;
 

--- a/pkgs/by-name/ca/calibre-web/package.nix
+++ b/pkgs/by-name/ca/calibre-web/package.nix
@@ -7,6 +7,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       sqlalchemy = super.sqlalchemy_1_4;
     };

--- a/pkgs/by-name/ch/charmcraft/package.nix
+++ b/pkgs/by-name/ch/charmcraft/package.nix
@@ -8,6 +8,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       pydantic-yaml = super.pydantic-yaml.overridePythonAttrs (old: rec {
         version = "0.11.2";

--- a/pkgs/by-name/gd/gdtoolkit_3/package.nix
+++ b/pkgs/by-name/gd/gdtoolkit_3/package.nix
@@ -5,6 +5,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       lark = super.lark.overridePythonAttrs (old: rec {
         # gdtoolkit needs exactly this lark version

--- a/pkgs/by-name/gd/gdtoolkit_4/package.nix
+++ b/pkgs/by-name/gd/gdtoolkit_4/package.nix
@@ -5,6 +5,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       lark = super.lark.overridePythonAttrs (old: rec {
         # gdtoolkit needs exactly this lark version

--- a/pkgs/by-name/ir/irrd/package.nix
+++ b/pkgs/by-name/ir/irrd/package.nix
@@ -11,6 +11,7 @@
 
 let
   py = python3.override {
+    self = py;
     packageOverrides = final: prev: {
       # sqlalchemy 1.4.x or 2.x are not supported
       sqlalchemy = prev.sqlalchemy.overridePythonAttrs (oldAttrs: rec {
@@ -174,4 +175,3 @@ py.pkgs.buildPythonPackage rec {
     maintainers = teams.wdz.members;
   };
 }
-

--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -9,6 +9,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       music-assistant-frontend = self.callPackage ./frontend.nix { };
     };

--- a/pkgs/by-name/na/nanopb/package.nix
+++ b/pkgs/by-name/na/nanopb/package.nix
@@ -26,6 +26,7 @@ let
     inherit (self.passthru) generator-out;
   };
   python3 = buildPackages.python3.override {
+    self = python3;
     packageOverrides = _: _: {
       nanopb-proto = self.passthru.python-module;
     };
@@ -119,4 +120,3 @@ in
     '';
   };
 })
-

--- a/pkgs/by-name/od/odoo/package.nix
+++ b/pkgs/by-name/od/odoo/package.nix
@@ -11,6 +11,7 @@
 
 let
   python = python310.override {
+    self = python;
     packageOverrides = final: prev: {
       # requirements.txt fixes docutils at 0.17; the default 0.21.1 tested throws exceptions
       docutils-0_17 = prev.docutils.overridePythonAttrs (old: rec {

--- a/pkgs/by-name/od/odoo15/package.nix
+++ b/pkgs/by-name/od/odoo15/package.nix
@@ -3,6 +3,7 @@
 
 let
   python = python310.override {
+    self = python;
     packageOverrides = self: super: {
       pypdf2 = super.pypdf2.overridePythonAttrs (old: rec {
         version = "1.28.6";

--- a/pkgs/by-name/od/odoo16/package.nix
+++ b/pkgs/by-name/od/odoo16/package.nix
@@ -8,6 +8,7 @@
 
 let
   python = python310.override {
+    self = python;
     packageOverrides = self: super: {
       flask = super.flask.overridePythonAttrs (old: rec {
         version = "2.3.3";

--- a/pkgs/by-name/pa/pacu/package.nix
+++ b/pkgs/by-name/pa/pacu/package.nix
@@ -7,6 +7,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: { sqlalchemy = super.sqlalchemy_1_4; };
   };
 in

--- a/pkgs/by-name/pa/parsedmarc/package.nix
+++ b/pkgs/by-name/pa/parsedmarc/package.nix
@@ -4,6 +4,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       # https://github.com/domainaware/parsedmarc/issues/464
       msgraph-core = super.msgraph-core.overridePythonAttrs (old: rec {

--- a/pkgs/by-name/pr/pretalx/package.nix
+++ b/pkgs/by-name/pr/pretalx/package.nix
@@ -10,6 +10,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = final: prev: {
       django-bootstrap4 = prev.django-bootstrap4.overridePythonAttrs (oldAttrs: rec {
         version = "3.0.0";

--- a/pkgs/by-name/pr/pretix/package.nix
+++ b/pkgs/by-name/pr/pretix/package.nix
@@ -11,6 +11,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       django = super.django_4;
 

--- a/pkgs/by-name/ro/rockcraft/package.nix
+++ b/pkgs/by-name/ro/rockcraft/package.nix
@@ -8,6 +8,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       craft-application = super.craft-application.overridePythonAttrs (old: rec {
         version = "1.2.1";

--- a/pkgs/by-name/sn/snapcraft/package.nix
+++ b/pkgs/by-name/sn/snapcraft/package.nix
@@ -12,6 +12,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       pydantic-yaml = super.pydantic-yaml.overridePythonAttrs (old: rec {
         version = "0.11.2";

--- a/pkgs/by-name/yt/yt-dlg/package.nix
+++ b/pkgs/by-name/yt/yt-dlg/package.nix
@@ -5,7 +5,7 @@
   fetchPypi
 }:
 let
-  python3Packages =
+  python3' =
     (python3.override {
       packageOverrides = final: prev: {
         wxpython = prev.wxpython.overrideAttrs rec {
@@ -17,7 +17,10 @@ let
           };
         };
       };
-    }).pkgs;
+    });
+
+  python3Packages = python3'.pkgs;
+
 in
 python3Packages.buildPythonApplication rec {
   pname = "yt-dlg";

--- a/pkgs/development/tools/continuous-integration/buildbot/default.nix
+++ b/pkgs/development/tools/continuous-integration/buildbot/default.nix
@@ -6,6 +6,7 @@
 # Take packages from self first, then python.pkgs (and secondarily pkgs)
 lib.makeScope (self: newScope (self.python.pkgs // self)) (self: {
   python = python3.override {
+    self = self.python;
     packageOverrides = self: super: {
       sqlalchemy = super.sqlalchemy_1_4;
       moto = super.moto.overridePythonAttrs (oldAttrs: {

--- a/pkgs/development/tools/dt-schema/default.nix
+++ b/pkgs/development/tools/dt-schema/default.nix
@@ -3,6 +3,7 @@
 }:
 
 let python = python3.override {
+  self = python;
   packageOverrides = self: super: {
     # see https://github.com/devicetree-org/dt-schema/issues/108
     jsonschema = super.jsonschema.overridePythonAttrs (old: rec {
@@ -27,4 +28,3 @@ let python = python3.override {
     });
   };
 }; in python.pkgs.toPythonApplication python.pkgs.dtschema
-

--- a/pkgs/servers/apache-airflow/default.nix
+++ b/pkgs/servers/apache-airflow/default.nix
@@ -5,6 +5,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = pySelf: pySuper: {
       connexion = pySuper.connexion.overridePythonAttrs (o: rec {
         version = "2.14.2";

--- a/pkgs/servers/baserow/default.nix
+++ b/pkgs/servers/baserow/default.nix
@@ -8,6 +8,7 @@
 let
 
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       antlr4-python3-runtime = super.antlr4-python3-runtime.override {
         antlr4 = antlr4_9;

--- a/pkgs/servers/etebase/default.nix
+++ b/pkgs/servers/etebase/default.nix
@@ -9,6 +9,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       pydantic = super.pydantic_1;
     };

--- a/pkgs/servers/geospatial/fit-trackee/default.nix
+++ b/pkgs/servers/geospatial/fit-trackee/default.nix
@@ -7,6 +7,7 @@
 }:
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       sqlalchemy = super.sqlalchemy_1_4;
 

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -451,6 +451,7 @@ let
   ];
 
   python = python312.override {
+    self = python;
     packageOverrides = lib.composeManyExtensions (defaultOverrides ++ [ packageOverrides ]);
   };
 

--- a/pkgs/servers/mail/mailman/python.nix
+++ b/pkgs/servers/mail/mailman/python.nix
@@ -1,6 +1,7 @@
 { python3, fetchPypi, lib, overlay ? (_: _: {}) }:
 
-python3.override {
+lib.fix (self: python3.override {
+  inherit self;
   packageOverrides = lib.composeExtensions
     (self: super: {
       /*
@@ -35,4 +36,4 @@ python3.override {
     })
 
     overlay;
-}
+})

--- a/pkgs/servers/mautrix-telegram/default.nix
+++ b/pkgs/servers/mautrix-telegram/default.nix
@@ -7,6 +7,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       tulir-telethon = self.telethon.overridePythonAttrs (oldAttrs: rec {
         version = "1.37.0a1";

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -55,6 +55,7 @@ with lib;
 let
   # samba-tool requires libxcrypt-legacy algorithms
   python = python3Packages.python.override {
+    self = python;
     libxcrypt = libxcrypt-legacy;
   };
   wrapPython = python3Packages.wrapPython.override {

--- a/pkgs/servers/web-apps/healthchecks/default.nix
+++ b/pkgs/servers/web-apps/healthchecks/default.nix
@@ -6,6 +6,7 @@
 }:
 let
   py = python3.override {
+    self = py;
     packageOverrides = final: prev: {
       django = prev.django_5;
     };

--- a/pkgs/tools/admin/gimme-aws-creds/default.nix
+++ b/pkgs/tools/admin/gimme-aws-creds/default.nix
@@ -10,6 +10,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       fido2 = super.fido2.overridePythonAttrs (oldAttrs: rec {
         version = "0.9.3";

--- a/pkgs/tools/admin/gixy/default.nix
+++ b/pkgs/tools/admin/gixy/default.nix
@@ -8,6 +8,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       pyparsing = super.pyparsing.overridePythonAttrs rec {
         version = "2.4.7";

--- a/pkgs/tools/admin/oci-cli/default.nix
+++ b/pkgs/tools/admin/oci-cli/default.nix
@@ -7,6 +7,7 @@
 
 let
   py = python3.override {
+    self = py;
     packageOverrides = self: super: {
 
       click = super.click.overridePythonAttrs (oldAttrs: rec {

--- a/pkgs/tools/audio/piper/train.nix
+++ b/pkgs/tools/audio/piper/train.nix
@@ -3,10 +3,7 @@
 }:
 
 let
-  python = python3.override {
-    packageOverrides = self: super: {
-    };
-  };
+  python = python3;
 in
 
 python.pkgs.buildPythonPackage {

--- a/pkgs/tools/audio/tts/default.nix
+++ b/pkgs/tools/audio/tts/default.nix
@@ -7,6 +7,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       torch = super.torch-bin;
       torchvision = super.torchvision-bin;

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -169,6 +169,7 @@ let
 
   # Watch out for python <> boost compatibility
   python = python311.override {
+    self = python;
     packageOverrides = self: super: let
       cryptographyOverrideVersion = "40.0.1";
       bcryptOverrideVersion = "4.0.1";

--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -78,6 +78,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = final: prev: {
       # version 4 or newer would log the followng error but tests currently don't fail because radare2 is disabled
       # ValueError: argument TNULL is not a TLSH hex string

--- a/pkgs/tools/misc/esphome/default.nix
+++ b/pkgs/tools/misc/esphome/default.nix
@@ -12,6 +12,7 @@
 
 let
   python = python3Packages.python.override {
+    self = python;
     packageOverrides = self: super: {
       esphome-dashboard = self.callPackage ./dashboard.nix { };
     };

--- a/pkgs/tools/misc/lektor/default.nix
+++ b/pkgs/tools/misc/lektor/default.nix
@@ -9,6 +9,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       mistune = super.mistune.overridePythonAttrs (old: rec {
         version = "2.0.5";

--- a/pkgs/tools/misc/ntfy/default.nix
+++ b/pkgs/tools/misc/ntfy/default.nix
@@ -13,6 +13,7 @@
 
 let
   python = python39.override {
+    self = python;
     packageOverrides = self: super: {
       ntfy-webpush = self.callPackage ./webpush.nix { };
 

--- a/pkgs/tools/misc/tvnamer/default.nix
+++ b/pkgs/tools/misc/tvnamer/default.nix
@@ -5,6 +5,7 @@
 
 let
   python' = python3.override {
+    self = python';
     packageOverrides = final: prev: rec {
       # tvdb_api v3.1.0 has a hard requirement on requests-cache < 0.6
       requests-cache = prev.requests-cache.overridePythonAttrs (oldAttrs: rec {

--- a/pkgs/tools/networking/maubot/default.nix
+++ b/pkgs/tools/networking/maubot/default.nix
@@ -9,6 +9,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = final: prev: {
       # aiosqlite>=0.16,<0.19
       aiosqlite = prev.aiosqlite.overridePythonAttrs (old: rec {

--- a/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
+++ b/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
@@ -10,6 +10,7 @@ let
   # uses eliot in a way incompatible after version 1.14.0.
   # These versions should be unpinned, when updating Tahoe-LAFS to a more recent version.
   python = python311.override {
+    self = python;
     packageOverrides = self: super: {
       eliot = super.eliot.overridePythonAttrs (oldAttrs: rec {
         version = "1.14.0";

--- a/pkgs/tools/nix/nixos-render-docs/default.nix
+++ b/pkgs/tools/nix/nixos-render-docs/default.nix
@@ -5,6 +5,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = final: prev: {
       markdown-it-py = prev.markdown-it-py.overridePythonAttrs (_: {
         doCheck = false;

--- a/pkgs/tools/package-management/poetry/default.nix
+++ b/pkgs/tools/package-management/poetry/default.nix
@@ -22,6 +22,7 @@ let
       });
     } // (plugins self);
   python = python3.override (old: {
+    self = python;
     packageOverrides = lib.composeManyExtensions
       ((if old ? packageOverrides then [ old.packageOverrides ] else [ ]) ++ [ newPackageOverrides ]);
   });

--- a/pkgs/tools/security/expliot/default.nix
+++ b/pkgs/tools/security/expliot/default.nix
@@ -4,6 +4,7 @@
 }:
 let
   py = python3.override {
+    self = py;
     packageOverrides = self: super: {
 
       cmd2 = super.cmd2.overridePythonAttrs (oldAttrs: rec {

--- a/pkgs/tools/security/ioccheck/default.nix
+++ b/pkgs/tools/security/ioccheck/default.nix
@@ -5,6 +5,7 @@
 
 let
   py = python3.override {
+    self = py;
     packageOverrides = self: super: {
       emoji = super.emoji.overridePythonAttrs rec {
         version = "1.7.0";

--- a/pkgs/tools/security/netexec/default.nix
+++ b/pkgs/tools/security/netexec/default.nix
@@ -5,6 +5,7 @@
 }:
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       impacket = super.impacket.overridePythonAttrs {
         version = "0.12.0.dev1-unstable-2023-11-30";

--- a/pkgs/tools/security/ssh-mitm/default.nix
+++ b/pkgs/tools/security/ssh-mitm/default.nix
@@ -9,6 +9,7 @@
 
 let
   py = python3.override {
+    self = py;
     packageOverrides = self: super: {
       paramiko = super.paramiko.overridePythonAttrs (oldAttrs: rec {
         version = "3.3.1";

--- a/pkgs/tools/text/mrkd/default.nix
+++ b/pkgs/tools/text/mrkd/default.nix
@@ -5,6 +5,7 @@
 
 let
   python = python3.override {
+    self = python;
     packageOverrides = self: super: {
       # https://github.com/refi64/mrkd/pull/6
       mistune = super.mistune.overridePythonAttrs (old: rec {


### PR DESCRIPTION
## Things done
Adds `self` to all overriden Python interpreters.

Otherwise references to the Python interpreter inside the set are wrong, as demonstrated by:
``` nix
with import <nixpkgs> { };
let
  python' = python3.override {
    packageOverrides = final: prev: { requests = prev.requests.overridePythonAttrs(old: { version = "1337";  }); };
  };
in python'.pkgs.python.pkgs.requests
```
which returns the _non_ overriden requests.

And the same with `self`:
``` nix
with import <nixpkgs> { };
let
  python' = python3.override {
    self = python';
    packageOverrides = final: prev: { requests = prev.requests.overridePythonAttrs(old: { version = "1337";  }); };
  };
in python'.pkgs.python.pkgs.requests
```
which returns the overriden requests.

This can manifest itself as file collisions when constructing environments or as subtly incorrect dependency graphs.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
