### PR TITLE
{nix,lix}: add withNixDebug overrideable

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -434,6 +434,8 @@ The propagated equivalent of `depsTargetTarget`. This is prefixed for the same r
 
 A number between 0 and 7 indicating how much information to log. If set to 1 or higher, `stdenv` will print moderate debugging information during the build. In particular, the `gcc` and `ld` wrapper scripts will print out the complete command line passed to the wrapped tools. If set to 6 or higher, the `stdenv` setup script will be run with `set -x` tracing. If set to 7 or higher, the `gcc` and `ld` wrapper scripts will also be run with `set -x` tracing.
 
+In order to set the `NIX_DEBUG` environment variable, Nix itself must be re-compiled so that it's set in the local derivation build environment. This ensures that the derivation's hash doesn't change because `NIX_DEBUG` has been set. Most Nix derivation have a `withNixDebug` attribute which can be overridden. Set the `nix.package` option to use this `NIX_DEBUG`-enabled Nix.
+
 ### Attributes affecting build properties {#attributes-affecting-build-properties}
 
 #### `enableParallelBuilding` {#var-stdenv-enableParallelBuilding}
@@ -1421,7 +1423,7 @@ Both parameters take a list of flags as strings. The special `"all"` flag can be
 
 For more in-depth information on these hardening flags and hardening in general, refer to the [Debian Wiki](https://wiki.debian.org/Hardening), [Ubuntu Wiki](https://wiki.ubuntu.com/Security/Features), [Gentoo Wiki](https://wiki.gentoo.org/wiki/Project:Hardened), and the [Arch Wiki](https://wiki.archlinux.org/title/Security).
 
-Note that support for some hardening flags varies by compiler, CPU architecture, target OS and libc. Combinations of these that don't support a particular hardening flag will silently ignore attempts to enable it. To see exactly which hardening flags are being employed in any invocation, the `NIX_DEBUG` environment variable can be used.
+Note that support for some hardening flags varies by compiler, CPU architecture, target OS and libc. Combinations of these that don't support a particular hardening flag will silently ignore attempts to enable it. To see exactly which hardening flags are being employed in any invocation, the [`NIX_DEBUG` environment variable](#var-stdenv-NIX_DEBUG) can be used.
 
 ### Hardening flags enabled by default {#sec-hardening-flags-enabled-by-default}
 

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -54,6 +54,7 @@ lib.makeExtensible (self: ({
       version = "2.90.0";
       hash = "sha256-f8k+BezKdJfmE+k7zgBJiohtS3VkkriycdXYsKOm3sc=";
       docCargoHash = "sha256-vSf9MyD2XzofZlbzsmh6NP69G+LiX72GX4Um9UJp3dc=";
+      withNixDebugPatch = ./patches/set-NIX_DEBUG-on-lix-2.90.patch;
     }
   );
 

--- a/pkgs/tools/package-management/lix/patches/set-NIX_DEBUG-on-lix-2.90.patch
+++ b/pkgs/tools/package-management/lix/patches/set-NIX_DEBUG-on-lix-2.90.patch
@@ -1,0 +1,11 @@
+diff --git a/src/libstore/build/local-derivation-goal.cc b/src/libstore/build/local-derivation-goal.cc
+--- a/src/libstore/build/local-derivation-goal.cc
++++ b/src/libstore/build/local-derivation-goal.cc
+@@ -1164,6 +1164,7 @@ void LocalDerivationGoal::initEnv()
+        may change that in the future. So tell the builder which file
+        descriptor to use for that. */
+     env["NIX_LOG_FD"] = "2";
++    env["NIX_DEBUG"] = "@NIX_DEBUG@";
+ 
+     /* Trigger colored output in various tools. */
+     env["TERM"] = "xterm-256color";

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -140,6 +140,7 @@ in lib.makeExtensible (self: ({
     patches = [
       patch-monitorfdhup
     ];
+    withNixDebugPatch = ./patches/set-NIX_DEBUG-on-nix-2.3.patch;
     self_attribute_name = "nix_2_3";
     maintainers = with lib.maintainers; [ flokli ];
   }).override { boehmgc = boehmgc-nix_2_3; }).overrideAttrs {
@@ -152,36 +153,42 @@ in lib.makeExtensible (self: ({
     version = "2.18.5";
     hash = "sha256-xEcYQuJz6DjdYfS6GxIYcn8U+3Hgopne3CvqrNoGguQ=";
     self_attribute_name = "nix_2_18";
+    withNixDebugPatch = ./patches/set-NIX_DEBUG-on-nix-2.18.patch;
   };
 
   nix_2_19 = common {
     version = "2.19.6";
     hash = "sha256-XT5xiwOLgXf+TdyOjbJVOl992wu9mBO25WXHoyli/Tk=";
     self_attribute_name = "nix_2_19";
+    withNixDebugPatch = ./patches/set-NIX_DEBUG-on-nix-2.19.patch;
   };
 
   nix_2_20 = common {
     version = "2.20.8";
     hash = "sha256-M2tkMtjKi8LDdNLsKi3IvD8oY/i3rtarjMpvhybS3WY=";
     self_attribute_name = "nix_2_20";
+    withNixDebugPatch = ./patches/set-NIX_DEBUG-on-nix-2.20.patch;
   };
 
   nix_2_21 = common {
     version = "2.21.4";
     hash = "sha256-c6nVZ0pSrfhFX3eVKqayS+ioqyAGp3zG9ZPO5rkXFRQ=";
     self_attribute_name = "nix_2_21";
+    withNixDebugPatch = ./patches/set-NIX_DEBUG-on-nix-2.21.patch;
   };
 
   nix_2_22 = common {
     version = "2.22.3";
     hash = "sha256-l04csH5rTWsK7eXPWVxJBUVRPMZXllFoSkYFTq/i8WU=";
     self_attribute_name = "nix_2_22";
+    withNixDebugPatch = ./patches/set-NIX_DEBUG-on-nix-2.22.patch;
   };
 
   nix_2_23 = common {
     version = "2.23.3";
     hash = "sha256-lAoLGVIhRFrfgv7wcyduEkyc83QKrtsfsq4of+WrBeg=";
     self_attribute_name = "nix_2_23";
+    withNixDebugPatch = ./patches/set-NIX_DEBUG-on-nix-2.23.patch;
   };
 
   git = (common rec {

--- a/pkgs/tools/package-management/nix/patches/set-NIX_DEBUG-on-nix-2.18.patch
+++ b/pkgs/tools/package-management/nix/patches/set-NIX_DEBUG-on-nix-2.18.patch
@@ -1,0 +1,11 @@
+diff --git a/src/libstore/build/local-derivation-goal.cc b/src/libstore/build/local-derivation-goal.cc
+--- a/src/libstore/build/local-derivation-goal.cc
++++ b/src/libstore/build/local-derivation-goal.cc
+@@ -1165,6 +1165,7 @@ void LocalDerivationGoal::initEnv()
+        may change that in the future. So tell the builder which file
+        descriptor to use for that. */
+     env["NIX_LOG_FD"] = "2";
++    env["NIX_DEBUG"] = "@NIX_DEBUG@";
+ 
+     /* Trigger colored output in various tools. */
+     env["TERM"] = "xterm-256color";

--- a/pkgs/tools/package-management/nix/patches/set-NIX_DEBUG-on-nix-2.19.patch
+++ b/pkgs/tools/package-management/nix/patches/set-NIX_DEBUG-on-nix-2.19.patch
@@ -1,0 +1,11 @@
+diff --git a/src/libstore/build/local-derivation-goal.cc b/src/libstore/build/local-derivation-goal.cc
+--- a/src/libstore/build/local-derivation-goal.cc
++++ b/src/libstore/build/local-derivation-goal.cc
+@@ -1184,6 +1184,7 @@ void LocalDerivationGoal::initEnv()
+        may change that in the future. So tell the builder which file
+        descriptor to use for that. */
+     env["NIX_LOG_FD"] = "2";
++    env["NIX_DEBUG"] = "@NIX_DEBUG@";
+ 
+     /* Trigger colored output in various tools. */
+     env["TERM"] = "xterm-256color";

--- a/pkgs/tools/package-management/nix/patches/set-NIX_DEBUG-on-nix-2.20.patch
+++ b/pkgs/tools/package-management/nix/patches/set-NIX_DEBUG-on-nix-2.20.patch
@@ -1,0 +1,11 @@
+diff --git a/src/libstore/build/local-derivation-goal.cc b/src/libstore/build/local-derivation-goal.cc
+--- a/src/libstore/build/local-derivation-goal.cc
++++ b/src/libstore/build/local-derivation-goal.cc
+@@ -1186,6 +1186,7 @@ void LocalDerivationGoal::initEnv()
+        may change that in the future. So tell the builder which file
+        descriptor to use for that. */
+     env["NIX_LOG_FD"] = "2";
++    env["NIX_DEBUG"] = "@NIX_DEBUG@";
+ 
+     /* Trigger colored output in various tools. */
+     env["TERM"] = "xterm-256color";

--- a/pkgs/tools/package-management/nix/patches/set-NIX_DEBUG-on-nix-2.21.patch
+++ b/pkgs/tools/package-management/nix/patches/set-NIX_DEBUG-on-nix-2.21.patch
@@ -1,0 +1,11 @@
+diff --git a/src/libstore/build/local-derivation-goal.cc b/src/libstore/build/local-derivation-goal.cc
+--- a/src/libstore/build/local-derivation-goal.cc
++++ b/src/libstore/build/local-derivation-goal.cc
+@@ -1187,6 +1187,7 @@ void LocalDerivationGoal::initEnv()
+        may change that in the future. So tell the builder which file
+        descriptor to use for that. */
+     env["NIX_LOG_FD"] = "2";
++    env["NIX_DEBUG"] = "@NIX_DEBUG@";
+ 
+     /* Trigger colored output in various tools. */
+     env["TERM"] = "xterm-256color";

--- a/pkgs/tools/package-management/nix/patches/set-NIX_DEBUG-on-nix-2.22.patch
+++ b/pkgs/tools/package-management/nix/patches/set-NIX_DEBUG-on-nix-2.22.patch
@@ -1,0 +1,11 @@
+diff --git a/src/libstore/unix/build/local-derivation-goal.cc b/src/libstore/unix/build/local-derivation-goal.cc
+--- a/src/libstore/unix/build/local-derivation-goal.cc
++++ b/src/libstore/unix/build/local-derivation-goal.cc
+@@ -1189,6 +1189,7 @@ void LocalDerivationGoal::initEnv()
+        may change that in the future. So tell the builder which file
+        descriptor to use for that. */
+     env["NIX_LOG_FD"] = "2";
++    env["NIX_DEBUG"] = "@NIX_DEBUG@";
+ 
+     /* Trigger colored output in various tools. */
+     env["TERM"] = "xterm-256color";

--- a/pkgs/tools/package-management/nix/patches/set-NIX_DEBUG-on-nix-2.23.patch
+++ b/pkgs/tools/package-management/nix/patches/set-NIX_DEBUG-on-nix-2.23.patch
@@ -1,0 +1,11 @@
+diff --git a/src/libstore/unix/build/local-derivation-goal.cc b/src/libstore/unix/build/local-derivation-goal.cc
+--- a/src/libstore/unix/build/local-derivation-goal.cc
++++ b/src/libstore/unix/build/local-derivation-goal.cc
+@@ -1191,6 +1191,7 @@ void LocalDerivationGoal::initEnv()
+        may change that in the future. So tell the builder which file
+        descriptor to use for that. */
+     env["NIX_LOG_FD"] = "2";
++    env["NIX_DEBUG"] = "@NIX_DEBUG@";
+ 
+     /* Trigger colored output in various tools. */
+     env["TERM"] = "xterm-256color";

--- a/pkgs/tools/package-management/nix/patches/set-NIX_DEBUG-on-nix-2.3.patch
+++ b/pkgs/tools/package-management/nix/patches/set-NIX_DEBUG-on-nix-2.3.patch
@@ -1,0 +1,11 @@
+diff --git a/src/libstore/build.cc b/src/libstore/build.cc
+--- a/src/libstore/build.cc
++++ b/src/libstore/build.cc
+@@ -2543,6 +2543,7 @@ void DerivationGoal::initEnv()
+        may change that in the future. So tell the builder which file
+        descriptor to use for that. */
+     env["NIX_LOG_FD"] = "2";
++    env["NIX_DEBUG"] = "@NIX_DEBUG@";
+ 
+     /* Trigger colored output in various tools. */
+     env["TERM"] = "xterm-256color";


### PR DESCRIPTION
## Motivation for change

The Nixpkgs stdenv documents an environment variable called [`NIX_DEBUG`](https://nixos.org/manual/nixpkgs/unstable/#var-stdenv-NIX_DEBUG) but provides no mechanism to set it. After a thorough search through Nix and Nixpkgs history, it must be set _inside Nix_ when the derivation build environment is concocted.

What's the value of this environment variable? It allows the nixpkgs stdenv to produce more verbose logging output, allowing curious users such as myself deeper insight into how the stdenv works and what the impact of my changes might be.

Why does Nix itself have to be recompiled? Any other solution changes the input hash of the derivation, and changing the stdenv's hash means recompiling a _lot_.

The upstream Nix and Lix projects provide no such functionality to edit the environment variables while building. Nor really should they. This is a fast path to unsoundness in the general case. (We'll leave FODs and impureEnvVars alone.)

### What would better look like?

Both projects support *structured output logging* (through the `@nix { "action": "msg", "level": "[0-7]", "msg": "some message" }` special messages output to the file descriptor that `$NIX_LOG_FD` points to.

I haven't deeply explored how these log messages show up in the `nix-build`, `nix build`, and family of Nix tools, nor how they get persisted to disk or propagated over the network for remote builders.

My intuition, and those of everyone I've spoken to on Matrix about this, is that better looks like using this structured logging functionality to _always_ output diagnostic logging from the nixpkgs stdenv, then using the log level filtering behavior to control how and where it's displayed.

## Description of changes

This is a complete hack: a set of patches to each Nix and Lix that allows a variant version that sets the `NIX_DEBUG` environment value to the user's choice.

I (@philiptaron) do not honestly believe this PR will or even ought to be merged. It exists in part to have something that people can search for if they also wonder how the heck to set `NIX_DEBUG` to get this diagnostic logging.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).