### PR TITLE
cargo-hakari: 0.9.28 -> 0.9.30

### DIFF
--- a/pkgs/development/tools/rust/cargo-hakari/default.nix
+++ b/pkgs/development/tools/rust/cargo-hakari/default.nix
@@ -1,4 +1,8 @@
-{ lib, rustPlatform, fetchFromGitHub }:
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-hakari";
@@ -13,8 +17,14 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-DkPnQcoiytIYz780veSAhPnk70qkP3QvTJJ41csUThY=";
 
-  cargoBuildFlags = [ "-p" "cargo-hakari" ];
-  cargoTestFlags = [ "-p" "cargo-hakari" ];
+  cargoBuildFlags = [
+    "-p"
+    "cargo-hakari"
+  ];
+  cargoTestFlags = [
+    "-p"
+    "cargo-hakari"
+  ];
 
   meta = with lib; {
     description = "Manage workspace-hack packages to speed up builds in large workspaces";
@@ -26,7 +36,13 @@ rustPlatform.buildRustPackage rec {
     '';
     homepage = "https://crates.io/crates/cargo-hakari";
     changelog = "https://github.com/guppy-rs/guppy/blob/cargo-hakari-${version}/tools/cargo-hakari/CHANGELOG.md";
-    license = with licenses; [ mit asl20 ];
-    maintainers = with maintainers; [ figsoda macalinao ];
+    license = with licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with maintainers; [
+      figsoda
+      macalinao
+    ];
   };
 }

--- a/pkgs/development/tools/rust/cargo-hakari/default.nix
+++ b/pkgs/development/tools/rust/cargo-hakari/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-hakari";
-  version = "0.9.28";
+  version = "0.9.30";
 
   src = fetchFromGitHub {
     owner = "guppy-rs";
     repo = "guppy";
     rev = "cargo-hakari-${version}";
-    sha256 = "sha256-mTemccM/C9M2kso9PNpd0UGEZJd/tBd1PjCpbDFFtNo=";
+    sha256 = "sha256-fwqMV8oTEYqS0Y/IXar1DSZ0Gns1qJ9oGhbdehScrgw=";
   };
 
-  cargoHash = "sha256-UaSW9PZMUhqjvRM0/URHaOfofG5Ap3bvKgAHa+H+MFw=";
+  cargoHash = "sha256-DkPnQcoiytIYz780veSAhPnk70qkP3QvTJJ41csUThY=";
 
   cargoBuildFlags = [ "-p" "cargo-hakari" ];
   cargoTestFlags = [ "-p" "cargo-hakari" ];


### PR DESCRIPTION
## Description of changes

- https://github.com/guppy-rs/guppy/releases/tag/cargo-hakari-0.9.30
  - Notable changes: Fixed a panic on some workspaces, rust 1.80 primitives support
- https://github.com/guppy-rs/guppy/releases/tag/cargo-hakari-0.9.29
  - Notable changes: updates for rust 1.75
- format package with rfc style. 

> I noticed that the CI checks formatting with the rfc style formatter, but ignores when the file was previously unformatted. I went ahead and formatted via nixfmt-rfc-style, but if that makes this pr convoluted, I can drop the commit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
