### PR TITLE
firefly-iii-data-importer: init at 1.5.4

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -32,6 +32,8 @@
 
 - [Flood](https://flood.js.org/), a beautiful WebUI for various torrent clients. Available as [services.flood](options.html#opt-services.flood).
 
+- [Firefly-iii Data Importer](https://github.com/firefly-iii/data-importer), a data importer for Firefly-III. Available as [services.firefly-iii-data-importer](options.html#opt-services.firefly-iii-data-importer)
+
 - [QGroundControl], a ground station support and configuration manager for the PX4 and APM Flight Stacks. Available as [programs.qgroundcontrol](options.html#opt-programs.qgroundcontrol.enable).
 
 - [Eintopf](https://eintopf.info), community event and calendar web application. Available as [services.eintopf](options.html#opt-services.eintopf).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1395,6 +1395,7 @@
   ./services/web-apps/ethercalc.nix
   ./services/web-apps/filesender.nix
   ./services/web-apps/firefly-iii.nix
+  ./services/web-apps/firefly-iii-data-importer.nix
   ./services/web-apps/flarum.nix
   ./services/web-apps/fluidd.nix
   ./services/web-apps/freshrss.nix

--- a/nixos/modules/services/web-apps/firefly-iii-data-importer.nix
+++ b/nixos/modules/services/web-apps/firefly-iii-data-importer.nix
@@ -1,0 +1,301 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.firefly-iii-data-importer;
+
+  user = cfg.user;
+  group = cfg.group;
+
+  defaultUser = "firefly-iii-data-importer";
+  defaultGroup = "firefly-iii-data-importer";
+
+  artisan = "${cfg.package}/artisan";
+
+  env-file-values = lib.attrsets.mapAttrs' (
+    n: v: lib.attrsets.nameValuePair (lib.strings.removeSuffix "_FILE" n) v
+  ) (lib.attrsets.filterAttrs (n: v: lib.strings.hasSuffix "_FILE" n) cfg.settings);
+  env-nonfile-values = lib.attrsets.filterAttrs (n: v: !lib.strings.hasSuffix "_FILE" n) cfg.settings;
+
+  data-importer-maintenance = pkgs.writeShellScript "data-importer-maintenance.sh" ''
+    set -a
+    ${lib.strings.toShellVars env-nonfile-values}
+    ${lib.strings.concatLines (
+      lib.attrsets.mapAttrsToList (n: v: "${n}=\"$(< ${v})\"") env-file-values
+    )}
+    set +a
+    ${artisan} package:discover
+    ${artisan} cache:clear
+    ${artisan} config:cache
+  '';
+
+  commonServiceConfig = {
+    Type = "oneshot";
+    User = user;
+    Group = group;
+    StateDirectory = "firefly-iii-data-importer";
+    ReadWritePaths = [ cfg.dataDir ];
+    WorkingDirectory = cfg.package;
+    PrivateTmp = true;
+    PrivateDevices = true;
+    CapabilityBoundingSet = "";
+    AmbientCapabilities = "";
+    ProtectSystem = "strict";
+    ProtectKernelTunables = true;
+    ProtectKernelModules = true;
+    ProtectControlGroups = true;
+    ProtectClock = true;
+    ProtectHostname = true;
+    ProtectHome = "tmpfs";
+    ProtectKernelLogs = true;
+    ProtectProc = "invisible";
+    ProcSubset = "pid";
+    PrivateNetwork = false;
+    RestrictAddressFamilies = "AF_INET AF_INET6 AF_UNIX";
+    SystemCallArchitectures = "native";
+    SystemCallFilter = [
+      "@system-service @resources"
+      "~@obsolete @privileged"
+    ];
+    RestrictSUIDSGID = true;
+    RemoveIPC = true;
+    NoNewPrivileges = true;
+    RestrictRealtime = true;
+    RestrictNamespaces = true;
+    LockPersonality = true;
+    PrivateUsers = true;
+  };
+
+in
+{
+
+  options.services.firefly-iii-data-importer = {
+    enable = lib.mkEnableOption "Firefly III Data Importer";
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = defaultUser;
+      description = "User account under which firefly-iii-data-importer runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = if cfg.enableNginx then "nginx" else defaultGroup;
+      defaultText = "If `services.firefly-iii-data-importer.enableNginx` is true then `nginx` else ${defaultGroup}";
+      description = ''
+        Group under which firefly-iii-data-importer runs. It is best to set this to the group
+        of whatever webserver is being used as the frontend.
+      '';
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/firefly-iii-data-importer";
+      description = ''
+        The place where firefly-iii data importer stores its state.
+      '';
+    };
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.firefly-iii-data-importer;
+      defaultText = lib.literalExpression "pkgs.firefly-iii-data-importer";
+      description = ''
+        The firefly-iii-data-importer package served by php-fpm and the webserver of choice.
+        This option can be used to point the webserver to the correct root. It
+        may also be used to set the package to a different version, say a
+        development version.
+      '';
+      apply =
+        firefly-iii-data-importer:
+        firefly-iii-data-importer.override (prev: {
+          dataDir = cfg.dataDir;
+        });
+    };
+
+    enableNginx = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable nginx or not. If enabled, an nginx virtual host will
+        be created for access to firefly-iii data importer. If not enabled, then you may use
+        `''${config.services.firefly-iii-data-importer.package}` as your document root in
+        whichever webserver you wish to setup.
+      '';
+    };
+
+    virtualHost = lib.mkOption {
+      type = lib.types.str;
+      default = "localhost";
+      description = ''
+        The hostname at which you wish firefly-iii-data-importer to be served. If you have
+        enabled nginx using `services.firefly-iii-data-importer.enableNginx` then this will
+        be used.
+      '';
+    };
+
+    poolConfig = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.oneOf [
+          lib.types.str
+          lib.types.int
+          lib.types.bool
+        ]
+      );
+      default = { };
+      defaultText = lib.literalExpression ''
+        {
+          "pm" = "dynamic";
+          "pm.max_children" = 32;
+          "pm.start_servers" = 2;
+          "pm.min_spare_servers" = 2;
+          "pm.max_spare_servers" = 4;
+          "pm.max_requests" = 500;
+        }
+      '';
+      description = ''
+        Options for the Firefly III Data Importer PHP pool. See the documentation on <literal>php-fpm.conf</literal>
+        for details on configuration directives.
+      '';
+    };
+
+    settings = lib.mkOption {
+      default = { };
+      description = ''
+        Options for firefly-iii data importer configuration. Refer to
+        <https://github.com/firefly-iii/data-importer/blob/main/.env.example> for
+        details on supported values. All <option>_FILE values supported by
+        upstream are supported here.
+
+        APP_URL will be the same as `services.firefly-iii-data-importer.virtualHost` if the
+        former is unset in `services.firefly-iii-data-importer.settings`.
+      '';
+      example = lib.literalExpression ''
+        {
+          APP_ENV = "local";
+          LOG_CHANNEL = "syslog";
+          FIREFLY_III_ACCESS_TOKEN= = "/var/secrets/firefly-iii-access-token.txt";
+        }
+      '';
+      type = lib.types.submodule {
+        freeformType = lib.types.attrsOf (
+          lib.types.oneOf [
+            lib.types.str
+            lib.types.int
+            lib.types.bool
+          ]
+        );
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.phpfpm.pools.firefly-iii-data-importer = {
+      inherit user group;
+      phpPackage = cfg.package.phpPackage;
+      phpOptions = ''
+        log_errors = on
+      '';
+      settings = {
+        "listen.mode" = "0660";
+        "listen.owner" = user;
+        "listen.group" = group;
+        "pm" = lib.mkDefault "dynamic";
+        "pm.max_children" = lib.mkDefault 32;
+        "pm.start_servers" = lib.mkDefault 2;
+        "pm.min_spare_servers" = lib.mkDefault 2;
+        "pm.max_spare_servers" = lib.mkDefault 4;
+        "pm.max_requests" = lib.mkDefault 500;
+      } // cfg.poolConfig;
+    };
+
+    systemd.services.firefly-iii-data-importer-setup = {
+      requiredBy = [ "phpfpm-firefly-iii-data-importer.service" ];
+      before = [ "phpfpm-firefly-iii-data-importer.service" ];
+      serviceConfig = {
+        ExecStart = data-importer-maintenance;
+        RemainAfterExit = true;
+      } // commonServiceConfig;
+      unitConfig.JoinsNamespaceOf = "phpfpm-firefly-iii-data-importer.service";
+      restartTriggers = [ cfg.package ];
+    };
+
+    services.nginx = lib.mkIf cfg.enableNginx {
+      enable = true;
+      recommendedTlsSettings = lib.mkDefault true;
+      recommendedOptimisation = lib.mkDefault true;
+      recommendedGzipSettings = lib.mkDefault true;
+      virtualHosts.${cfg.virtualHost} = {
+        root = "${cfg.package}/public";
+        locations = {
+          "/" = {
+            tryFiles = "$uri $uri/ /index.php?$query_string";
+            index = "index.php";
+            extraConfig = ''
+              sendfile off;
+            '';
+          };
+          "~ \.php$" = {
+            extraConfig = ''
+              include ${config.services.nginx.package}/conf/fastcgi_params ;
+              fastcgi_param SCRIPT_FILENAME $request_filename;
+              fastcgi_param modHeadersAvailable true;
+              fastcgi_pass unix:${config.services.phpfpm.pools.firefly-iii-data-importer.socket};
+            '';
+          };
+        };
+      };
+    };
+
+    systemd.tmpfiles.settings."10-firefly-iii-data-importer" =
+      lib.attrsets.genAttrs
+        [
+          "${cfg.dataDir}/storage"
+          "${cfg.dataDir}/storage/app"
+          "${cfg.dataDir}/storage/app/public"
+          "${cfg.dataDir}/storage/configurations"
+          "${cfg.dataDir}/storage/conversion-routines"
+          "${cfg.dataDir}/storage/debugbar"
+          "${cfg.dataDir}/storage/framework"
+          "${cfg.dataDir}/storage/framework/cache"
+          "${cfg.dataDir}/storage/framework/sessions"
+          "${cfg.dataDir}/storage/framework/testing"
+          "${cfg.dataDir}/storage/framework/views"
+          "${cfg.dataDir}/storage/jobs"
+          "${cfg.dataDir}/storage/logs"
+          "${cfg.dataDir}/storage/submission-routines"
+          "${cfg.dataDir}/storage/uploads"
+          "${cfg.dataDir}/cache"
+        ]
+        (n: {
+          d = {
+            group = group;
+            mode = "0710";
+            user = user;
+          };
+        })
+      // {
+        "${cfg.dataDir}".d = {
+          group = group;
+          mode = "0700";
+          user = user;
+        };
+      };
+
+    users = {
+      users = lib.mkIf (user == defaultUser) {
+        ${defaultUser} = {
+          description = "Firefly-iii Data Importer service user";
+          inherit group;
+          isSystemUser = true;
+          home = cfg.dataDir;
+        };
+      };
+      groups = lib.mkIf (group == defaultGroup) { ${defaultGroup} = { }; };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -324,6 +324,7 @@ in {
   filesender = handleTest ./filesender.nix {};
   filesystems-overlayfs = runTest ./filesystems-overlayfs.nix;
   firefly-iii = handleTest ./firefly-iii.nix {};
+  firefly-iii-data-importer = handleTest ./firefly-iii-data-importer.nix {};
   firefox = handleTest ./firefox.nix { firefoxPackage = pkgs.firefox; };
   firefox-beta = handleTest ./firefox.nix { firefoxPackage = pkgs.firefox-beta; };
   firefox-devedition = handleTest ./firefox.nix { firefoxPackage = pkgs.firefox-devedition; };

--- a/nixos/tests/firefly-iii-data-importer.nix
+++ b/nixos/tests/firefly-iii-data-importer.nix
@@ -1,0 +1,27 @@
+import ./make-test-python.nix (
+  { lib, ... }:
+
+  {
+    name = "firefly-iii-data-importer";
+    meta.maintainers = [ lib.maintainers.savyajha ];
+
+    nodes.dataImporter =
+      { ... }:
+      {
+        services.firefly-iii-data-importer = {
+          enable = true;
+          enableNginx = true;
+          settings = {
+            LOG_CHANNEL = "stdout";
+            USE_CACHE = true;
+          };
+        };
+      };
+
+    testScript = ''
+      dataImporter.wait_for_unit("phpfpm-firefly-iii-data-importer.service")
+      dataImporter.wait_for_unit("nginx.service")
+      dataImporter.succeed("curl -fvvv -Ls http://localhost/token | grep 'Firefly III Data Import Tool'")
+    '';
+  }
+)

--- a/pkgs/by-name/fi/firefly-iii-data-importer/package.nix
+++ b/pkgs/by-name/fi/firefly-iii-data-importer/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenvNoCC,
+  nodejs,
+  fetchNpmDeps,
+  buildPackages,
+  php83,
+  nixosTests,
+  nix-update-script,
+  dataDir ? "/var/lib/firefly-iii-data-importer",
+}:
+
+let
+  pname = "firefly-iii-data-importer";
+  version = "1.5.4";
+
+  src = fetchFromGitHub {
+    owner = "firefly-iii";
+    repo = "data-importer";
+    rev = "v${version}";
+    hash = "sha256-XnPdoNtUoJpOpKVzQlFirh7u824H4xKAe2VRXfGIKeg=";
+  };
+in
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  inherit pname src version;
+
+  buildInputs = [ php83 ];
+
+  nativeBuildInputs = [
+    nodejs
+    nodejs.python
+    buildPackages.npmHooks.npmConfigHook
+    php83.composerHooks.composerInstallHook
+    php83.packages.composer-local-repo-plugin
+  ];
+
+  composerNoDev = true;
+  composerNoPlugins = true;
+  composerNoScripts = true;
+  composerStrictValidation = true;
+  strictDeps = true;
+
+  vendorHash = "sha256-EjEco8zBR787eQuPhNsRScfuPQ6eS6TIJmMJOcmZA+Q=";
+
+  npmDeps = fetchNpmDeps {
+    inherit src;
+    name = "${pname}-npm-deps";
+    hash = "sha256-VP1wM0+ca17aQU4FJ9gSbT2Np/sxb8wZ4pCJ6FV1V7w=";
+  };
+
+  composerRepository = php83.mkComposerRepository {
+    inherit (finalAttrs)
+      pname
+      src
+      vendorHash
+      version
+      ;
+    composerNoDev = true;
+    composerNoPlugins = true;
+    composerNoScripts = true;
+    composerStrictValidation = true;
+  };
+
+  preInstall = ''
+    npm run build --workspace=v2
+  '';
+
+  passthru = {
+    phpPackage = php83;
+    tests = nixosTests.firefly-iii-data-importer;
+    updateScript = nix-update-script { };
+  };
+
+  postInstall = ''
+    rm -R $out/share/php/firefly-iii-data-importer/{storage,bootstrap/cache,node_modules}
+    mv $out/share/php/firefly-iii-data-importer/* $out/
+    rm -R $out/share
+    ln -s ${dataDir}/storage $out/storage
+    ln -s ${dataDir}/cache $out/bootstrap/cache
+  '';
+
+  meta = {
+    changelog = "https://github.com/firefly-iii/data-importer/releases/tag/v${version}";
+    description = "Firefly III Data Importer can import data into Firefly III.";
+    homepage = "https://github.com/firefly-iii/data-importer";
+    license = lib.licenses.agpl3Only;
+    maintainers = [ lib.maintainers.savyajha ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Added [Firefly III Data Importer](https://github.com/firefly-iii/data-importer). Closes [#32942](https://github.com/NixOS/nixpkgs/issues/329422)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
