### PR TITLE
logseq: add darwin support

### DIFF
--- a/pkgs/by-name/lo/logseq/package.nix
+++ b/pkgs/by-name/lo/logseq/package.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchurl
 , appimageTools
+, unzip
 , makeWrapper
 # Notice: graphs will not sync without matching upstream's major electron version
 #         the specific electron version is set at top-level file to preserve override interface.
@@ -13,32 +14,44 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: let
-  inherit (finalAttrs) pname version src appimageContents;
-
+  inherit (finalAttrs) pname version src;
+  inherit (stdenv.hostPlatform) system;
+  selectSystem = attrs: attrs.${system} or (throw "Unsupported system: ${system}");
+  suffix = selectSystem {
+    x86_64-linux = "linux-x64-${version}.AppImage";
+    x86_64-darwin = "darwin-x64-${version}.zip";
+    aarch64-darwin = "darwin-arm64-${version}.zip";
+  };
+  hash = selectSystem {
+    x86_64-linux = "sha256-XROuY2RlKnGvK1VNvzauHuLJiveXVKrIYPppoz8fCmc=";
+    x86_64-darwin = "sha256-0i9ozqBSeV/y8v+YEmQkbY0V6JHOv6tKub4O5Fdx2fQ=";
+    aarch64-darwin = "sha256-Uvv96XWxpFj14wPH0DwPT+mlf3Z2dy1g/z8iBt5Te7Q=";
+  };
 in {
   pname = "logseq";
   version = "0.10.9";
-
   src = fetchurl {
-    url = "https://github.com/logseq/logseq/releases/download/${version}/logseq-linux-x64-${version}.AppImage";
-    hash = "sha256-XROuY2RlKnGvK1VNvzauHuLJiveXVKrIYPppoz8fCmc=";
-    name = "${pname}-${version}.AppImage";
+    inherit hash;
+    url = "https://github.com/logseq/logseq/releases/download/${version}/logseq-${suffix}";
+    name = lib.optionalString stdenv.isLinux "${pname}-${version}.AppImage";
   };
 
-  appimageContents = appimageTools.extract {
-    inherit pname src version;
-  };
+  nativeBuildInputs = [ makeWrapper ]
+    ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ]
+    ++ lib.optionals stdenv.isDarwin [ unzip ];
+  buildInputs = [ stdenv.cc.cc.lib ];
 
-  dontUnpack = true;
+  dontUnpack = stdenv.isLinux;
   dontConfigure = true;
   dontBuild = true;
 
-  nativeBuildInputs = [ makeWrapper autoPatchelfHook ];
-  buildInputs = [ stdenv.cc.cc.lib ];
-
   installPhase = ''
     runHook preInstall
-
+  '' + lib.optionalString stdenv.isLinux (
+  let
+   appimageContents = appimageTools.extract { inherit pname src version; };
+  in
+  ''
     mkdir -p $out/bin $out/share/${pname} $out/share/applications
     cp -a ${appimageContents}/{locales,resources} $out/share/${pname}
     cp -a ${appimageContents}/Logseq.desktop $out/share/applications/${pname}.desktop
@@ -55,11 +68,15 @@ in {
     substituteInPlace $out/share/applications/${pname}.desktop \
       --replace Exec=Logseq Exec=${pname} \
       --replace Icon=Logseq Icon=${pname}
-
+  '') + lib.optionalString stdenv.isDarwin ''
+    mkdir -p $out/{Applications/Logseq.app,bin}
+    cp -R . $out/Applications/Logseq.app
+    makeWrapper $out/Applications/Logseq.app/Contents/MacOS/Logseq $out/bin/${pname}
+  '' + ''
     runHook postInstall
   '';
 
-  postFixup = ''
+  postFixup = lib.optionalString stdenv.isLinux ''
     # set the env "LOCAL_GIT_DIRECTORY" for dugite so that we can use the git in nixpkgs
     makeWrapper ${electron}/bin/electron $out/bin/${pname} \
       --set "LOCAL_GIT_DIRECTORY" ${git} \
@@ -76,7 +93,7 @@ in {
     license = lib.licenses.agpl3Plus;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     maintainers = [ ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" ] ++ lib.platforms.darwin;
     mainProgram = "logseq";
   };
 })


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds support for Logseq on Darwin, although there are still a few unresolved issues:

1. An alert stating "This file was downloaded on an unknown date." prevents the app from opening. This can be resolved by allowing it in Settings > Privacy & Security > Allow. The cause of this issue is unclear, but it may be related to #320494.
2. Unlike the Linux version, I am unsure how to remove the internal git and sign the app again.

Additionally, there is an issue (#296939) tracking the requirement for Electron apps to be built from source. I attempted to build it from source, which involves converting ClojureScript to JavaScript, but encountered problems with [clj2nix](https://github.com/hlolli/clj2nix/) due to [clj2nix#12](https://github.com/hlolli/clj2nix/issues/12). Furthermore, [clj-nix](https://github.com/jlesquembre/clj-nix) is not currently upstreamed ([clj-nix#72](https://github.com/jlesquembre/clj-nix/issues/72)).

Some issues remain unaddressed, and I am drafting this PR to look for your help. I would greatly appreciate any solutions, examples for creating Clojure applications, or packaging samples.

Thank you in advance for any help or additional information.

Closes #258818


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
