### PR TITLE
undmg: 1.1.0 -> 1.1.0-unstable-2024-08-02

### DIFF
--- a/pkgs/tools/archivers/undmg/default.nix
+++ b/pkgs/tools/archivers/undmg/default.nix
@@ -1,4 +1,12 @@
-{ lib, stdenv, fetchFromGitHub, zlib, bzip2, lzfse, pkg-config }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  zlib,
+  bzip2,
+  lzfse,
+  pkg-config,
+}:
 
 stdenv.mkDerivation rec {
   version = "1.1.0";
@@ -13,7 +21,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ zlib bzip2 lzfse ];
+  buildInputs = [
+    zlib
+    bzip2
+    lzfse
+  ];
 
   setupHook = ./setup-hook.sh;
 
@@ -24,7 +36,10 @@ stdenv.mkDerivation rec {
     description = "Extract a DMG file";
     license = licenses.gpl3;
     platforms = platforms.all;
-    maintainers = with maintainers; [ matthewbauer lnl7 ];
+    maintainers = with maintainers; [
+      matthewbauer
+      lnl7
+    ];
     mainProgram = "undmg";
   };
 }

--- a/pkgs/tools/archivers/undmg/default.nix
+++ b/pkgs/tools/archivers/undmg/default.nix
@@ -31,15 +31,15 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  meta = with lib; {
-    homepage = "https://github.com/matthewbauer/undmg";
+  meta = {
     description = "Extract a DMG file";
-    license = licenses.gpl3;
-    platforms = platforms.all;
-    maintainers = with maintainers; [
+    homepage = "https://github.com/matthewbauer/undmg";
+    license = lib.licenses.gpl3;
+    mainProgram = "undmg";
+    maintainers = with lib.maintainers; [
       matthewbauer
       lnl7
     ];
-    mainProgram = "undmg";
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/tools/archivers/undmg/default.nix
+++ b/pkgs/tools/archivers/undmg/default.nix
@@ -5,18 +5,19 @@
   zlib,
   bzip2,
   lzfse,
+  xz,
   pkg-config,
 }:
 
-stdenv.mkDerivation rec {
-  version = "1.1.0";
+stdenv.mkDerivation {
   pname = "undmg";
+  version = "1.1.0-unstable-2024-08-02";
 
   src = fetchFromGitHub {
     owner = "matthewbauer";
     repo = "undmg";
-    rev = "v${version}";
-    sha256 = "0rb4h89jrl04vwf6p679ipa4mp95hzmc1ca11wqbanv3xd1kcpxm";
+    rev = "0d92602b694f810fa4b137d87c743f345b303a14";
+    hash = "sha256-eLxI3enf8EAgQePXvWxw8kOMr7KP2Q1Rsxy++v16zQI=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -25,6 +26,7 @@ stdenv.mkDerivation rec {
     zlib
     bzip2
     lzfse
+    xz
   ];
 
   setupHook = ./setup-hook.sh;


### PR DESCRIPTION
## Description of changes

The main reason for this PR is the addition of `ULMO/LZMA` support, which will allow more Darwin programs to be packaged with `undmg`

I tested it with Google Chrome and [Shottr](https://shottr.cc/) which use `ULMO/LZMA`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc