### PR TITLE
python312Packages.nutils: unbreak by adding missing deps; python312Packages.nutils-poly: init

### DIFF
--- a/pkgs/development/python-modules/nutils-poly/default.nix
+++ b/pkgs/development/python-modules/nutils-poly/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  libiconv,
+  numpy,
+  unittestCheckHook,
+  pythonOlder,
+}:
+
+buildPythonPackage rec {
+  pname = "nutils-poly";
+  version = "1.0.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "nutils";
+    repo = "poly-py";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-dxFv4Az3uz6Du5dk5KZJ+unVbt3aZjxXliAQZhmBWDM=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    name = "${pname}-${version}";
+    inherit src;
+    hash = "sha256-+fnKvlSwM197rsyusFH7rs1W6livxel45UGbi1sB05k=";
+  };
+
+  nativeBuildInputs = [ rustPlatform.cargoSetupHook ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
+
+  build-system = [ rustPlatform.maturinBuildHook ];
+
+  dependencies = [ numpy ];
+
+  nativeCheckInputs = [ unittestCheckHook ];
+
+  pythonImportsCheck = [ "nutils_poly" ];
+
+  meta = {
+    description = "Low-level functions for evaluating and manipulating polynomials";
+    homepage = "https://github.com/nutils/poly-py";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tomasajt ];
+  };
+}

--- a/pkgs/development/python-modules/nutils/default.nix
+++ b/pkgs/development/python-modules/nutils/default.nix
@@ -2,11 +2,14 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  numpy,
-  treelog,
-  stringly,
   flit-core,
+  appdirs,
   bottombar,
+  numpy,
+  nutils-poly,
+  psutil,
+  stringly,
+  treelog,
   pytestCheckHook,
   pythonOlder,
 }:
@@ -14,9 +17,9 @@
 buildPythonPackage rec {
   pname = "nutils";
   version = "8.7";
-  format = "pyproject";
+  pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "evalf";
@@ -25,14 +28,19 @@ buildPythonPackage rec {
     hash = "sha256-wxouS0FXrdIhm6nTVBuzkwHceJnZ7f7k8nMFxFsZchE=";
   };
 
-  nativeBuildInputs = [ flit-core ];
+  build-system = [ flit-core ];
 
-  propagatedBuildInputs = [
-    numpy
-    treelog
-    stringly
+  dependencies = [
+    appdirs
     bottombar
+    numpy
+    nutils-poly
+    psutil
+    stringly
+    treelog
   ];
+
+  pythonRelaxDeps = [ "psutil" ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9222,6 +9222,8 @@ self: super: with self; {
 
   nutils = callPackage ../development/python-modules/nutils { };
 
+  nutils-poly = callPackage ../development/python-modules/nutils-poly { };
+
   nvchecker = callPackage ../development/python-modules/nvchecker { };
 
   nvdlib = callPackage ../development/python-modules/nvdlib { };


### PR DESCRIPTION
## Description of changes

CC: @Scriptkiddi 
Saw that this package was failing on hydra, so I tried to fix it.

This PR fixes the `nutils` python package's derivation by adding required dependencies.

The `nutils-poly` package is also a new dependency, but was not yet packaged in nixpkgs.
I added this package in a separate commit.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
