### PR TITLE
bombono: 1.2.4 -> 1.2.4-unstable-2022-02-06

### DIFF
--- a/pkgs/applications/video/bombono/default.nix
+++ b/pkgs/applications/video/bombono/default.nix
@@ -2,13 +2,14 @@
 , fetchFromGitHub
 , pkg-config
 , fetchpatch
+, fetchpatch2
 , scons
 , boost
 , dvdauthor
 , dvdplusrwtools
 , enca
 , cdrkit
-, ffmpeg_4
+, ffmpeg_6
 , gettext
 , gtk2
 , gtkmm2
@@ -18,22 +19,15 @@
 , wrapGAppsHook3
 }:
 
-let
-  fetchPatchFromAur = {name, sha256}:
-    fetchpatch {
-      inherit name sha256;
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/${name}?h=766dd4ba1715fc921fe26ce1bdcf22c30f4fc073";
-    };
-in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "bombono";
-  version = "1.2.4";
+  version = "1.2.4-unstable-2022-02-06";
 
   src = fetchFromGitHub {
     owner = "bombono-dvd";
     repo = "bombono-dvd";
-    rev = version;
-    sha256 = "sha256-aRW8H8+ca/61jGLxUs7u3R7yEiulwr5viMEuZWbc4dM=";
+    rev = "8680f5803314e4bcfbdae44f555c47ad345dae72";
+    hash = "sha256-8AxXIvShH4HwlPZWAszku33rts13HiNoRsHiLYdZAHA=";
   };
 
   patches = [
@@ -42,17 +36,14 @@ stdenv.mkDerivation rec {
       url = "https://svnweb.mageia.org/packages/cauldron/bombono-dvd/current/SOURCES/bombono-dvd-1.2.4-scons-python3.patch?revision=1447925&view=co&pathrev=1484457";
       sha256 = "sha256-5OKBWrRZvHem2MTdAObfdw76ig3Z4ZdDFtq4CJoJISA=";
     })
-  ] ++ (map fetchPatchFromAur [
-    {name="fix_ffmpeg_codecid.patch";         sha256="sha256-58L+1BJy5HK/R+xALbq2z4+Se4i6yp21lo/MjylgTqs=";}
-    {name="fix_ptr2bool_cast.patch";          sha256="sha256-DyqMw/m2Op9+gBq1CTCjSZ1qM9igV5Y6gTOi8VbNH0c=";}
-    {name="fix_c++11_literal_warnings.patch"; sha256="sha256-iZ/CN5+xg7jPXl5r/KGCys+jyPu0/AsSABLcc6IIbv0=";}
-    {name="autoptr2uniqueptr.patch";          sha256="sha256-teGp6uICB4jAJk18pdbBMcDxC/JJJGkdihtXeh3ffCg=";}
-    {name="fix_deprecated_boost_api.patch";   sha256="sha256-qD5QuO/ndEU1N7vueQiNpPVz8OaX6Y6ahjCWxMdvj6A=";}
-    {name="fix_throw_specifications.patch";   sha256="sha256-NjCDGwXRCSLcuW2HbPOpXRgNvNQHy7i7hoOgyvGIr7g=";}
-    {name="fix_operator_ambiguity.patch";     sha256="sha256-xx7WyrxEdDrDuz5YoFrM/u2qJru9u6X/4+Y5rJdmmmQ=";}
-    {name="fix_ffmpeg30.patch";               sha256="sha256-vKEbvbjYVRzEaVYC8XOJBPmk6FDXI/WA0X/dldRRO8c=";}
-    {name="inc_boost_header.patch";           sha256="sha256-76vjkf62VsNJ5FmBEs+X7ZBqjvJ372mjSIreBxNQym8=";}
-  ]);
+
+    # Fix compilation errors having ffmpeg 2:5.1
+    # https://github.com/bombono-dvd/bombono-dvd/pull/28
+    (fetchpatch2 {
+      url = "https://github.com/bombono-dvd/bombono-dvd/commit/9f2cde1ddc22705bf58264739685086755b2138b.patch?full_index=1";
+      hash = "sha256-ks6c04HEYF4nPfSOjzG+dUt9v7ZmNBb0XH6byPYqX5I=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace src/mbase/SConscript \
@@ -66,7 +57,7 @@ stdenv.mkDerivation rec {
     dvdauthor
     dvdplusrwtools
     enca
-    ffmpeg_4
+    ffmpeg_6
     gtk2
     gtkmm2
     libdvdread
@@ -82,7 +73,7 @@ stdenv.mkDerivation rec {
     # fix iso authoring
     install -Dt  $out/share/bombono/resources/scons_authoring tools/scripts/SConsTwin.py
 
-    wrapProgram $out/bin/bombono-dvd --prefix PATH : ${lib.makeBinPath [ ffmpeg_4 dvdauthor cdrkit ]}
+    wrapProgram $out/bin/bombono-dvd --prefix PATH : ${lib.makeBinPath [ ffmpeg_6 dvdauthor cdrkit ]}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Includes all the fixes we previously bundled AUR patches for, and with another PR from the same author, works with FFmpeg 6.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
