### PR TITLE
nixosTests: pass thru pkgs when available

### DIFF
--- a/nixos/tests/boot.nix
+++ b/nixos/tests/boot.nix
@@ -65,20 +65,22 @@ let
 
   iso =
     (import ../lib/eval-config.nix {
-      inherit system;
       modules = [
         ../modules/installer/cd-dvd/installation-cd-minimal.nix
         ../modules/testing/test-instrumentation.nix
+        { nixpkgs.pkgs = pkgs; }
       ];
     }).config.system.build.isoImage;
 
   sd =
     (import ../lib/eval-config.nix {
-      inherit system;
       modules = [
         ../modules/installer/sd-card/sd-image-x86_64.nix
         ../modules/testing/test-instrumentation.nix
-        { sdImage.compressImage = false; }
+        {
+          sdImage.compressImage = false;
+          nixpkgs.pkgs = pkgs;
+        }
       ];
     }).config.system.build.sdImage;
 
@@ -109,7 +111,6 @@ let
     let
       config =
         (import ../lib/eval-config.nix {
-          inherit system;
           modules = [
             ../modules/installer/netboot/netboot.nix
             ../modules/testing/test-instrumentation.nix
@@ -118,6 +119,8 @@ let
                 "serial"
                 "live.nixos.passwordHash=$6$jnwR50SkbLYEq/Vp$wmggwioAkfmwuYqd5hIfatZWS/bO6hewzNIwIrWcgdh7k/fhUzZT29Vil3ioMo94sdji/nipbzwEpxecLZw0d0" # "password"
               ];
+
+              nixpkgs.pkgs = pkgs;
             }
             {
               key = "serial";

--- a/nixos/tests/ec2.nix
+++ b/nixos/tests/ec2.nix
@@ -12,7 +12,6 @@ with import common/ec2.nix { inherit makeTest pkgs; };
 let
   imageCfg =
     (import ../lib/eval-config.nix {
-      inherit system;
       modules = [
         ../maintainers/scripts/ec2/amazon-image.nix
         ../modules/testing/test-instrumentation.nix
@@ -54,6 +53,8 @@ let
             apacheHttpd.man
             valgrind.doc
           ]);
+
+          nixpkgs.pkgs = pkgs;
         }
       ];
     }).config;

--- a/nixos/tests/image-contents.nix
+++ b/nixos/tests/image-contents.nix
@@ -14,7 +14,6 @@ with import common/ec2.nix { inherit makeTest pkgs; };
 let
   config =
     (import ../lib/eval-config.nix {
-      inherit system;
       modules = [
         ../modules/testing/test-instrumentation.nix
         ../modules/profiles/qemu-guest.nix
@@ -22,6 +21,7 @@ let
           fileSystems."/".device = "/dev/disk/by-label/nixos";
           boot.loader.grub.device = "/dev/vda";
           boot.loader.timeout = 0;
+          nixpkgs.pkgs = pkgs;
         }
       ];
     }).config;

--- a/nixos/tests/openstack-image.nix
+++ b/nixos/tests/openstack-image.nix
@@ -12,7 +12,6 @@ with import common/ec2.nix { inherit makeTest pkgs; };
 let
   image =
     (import ../lib/eval-config.nix {
-      inherit system;
       modules = [
         ../maintainers/scripts/openstack/openstack-image.nix
         ../modules/testing/test-instrumentation.nix
@@ -22,6 +21,8 @@ let
           system.extraDependencies = with pkgs; [
             stdenv
           ];
+
+          nixpkgs.pkgs = pkgs;
         }
       ];
     }).config.system.build.openstackImage

--- a/nixos/tests/systemd-machinectl.nix
+++ b/nixos/tests/systemd-machinectl.nix
@@ -20,11 +20,12 @@ import ./make-test-python.nix (
         imports = [ ../modules/profiles/minimal.nix ];
 
         system.stateVersion = config.system.nixos.release;
+
+        nixpkgs.pkgs = pkgs;
       };
 
     containerSystem =
       (import ../lib/eval-config.nix {
-        inherit (pkgs) system;
         modules = [ container ];
       }).config.system.build.toplevel;
 


### PR DESCRIPTION
## Description of changes

Passes `pkgs` through to each `eval-config.nix` import to ensure the tests contains the supplied `pkgs`. This allows for being able to test cross compilation, musl, LLVM, static nixpkgs, etc.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
