### PR TITLE
pkgs/development: remove unused arguments

### DIFF
--- a/pkgs/development/ada-modules/gnatcoll/bindings.nix
+++ b/pkgs/development/ada-modules/gnatcoll/bindings.nix
@@ -9,7 +9,6 @@
 , gmp
 , libiconv
 , xz
-, gcc-unwrapped
 , readline
 , zlib
 , python3

--- a/pkgs/development/ada-modules/gnatcoll/core.nix
+++ b/pkgs/development/ada-modules/gnatcoll/core.nix
@@ -3,7 +3,6 @@
 , gnat
 , gprbuild
 , fetchFromGitHub
-, xmlada
 , which
 }:
 

--- a/pkgs/development/ada-modules/gnatcoll/db.nix
+++ b/pkgs/development/ada-modules/gnatcoll/db.nix
@@ -5,7 +5,6 @@
 , gprbuild
 , which
 , gnatcoll-core
-, xmlada
 , component
 # components built by this derivation other components depend on
 , gnatcoll-sql

--- a/pkgs/development/beam-modules/elvis-erlang/default.nix
+++ b/pkgs/development/beam-modules/elvis-erlang/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, fetchgit, fetchHex, rebar3WithPlugins, rebar3-nix, rebar3Relx
+{ fetchFromGitHub, fetchgit, fetchHex, rebar3Relx
 , buildRebar3, writeScript, lib }:
 
 let

--- a/pkgs/development/beam-modules/erlang-ls/default.nix
+++ b/pkgs/development/beam-modules/erlang-ls/default.nix
@@ -1,5 +1,5 @@
 { fetchFromGitHub, fetchgit, fetchHex, rebar3Relx, buildRebar3, rebar3-proper
-, stdenv, writeScript, lib, erlang }:
+, stdenv, writeScript, lib }:
 let
   version = "0.52.0";
   owner = "erlang-ls";

--- a/pkgs/development/compilers/clasp/default.nix
+++ b/pkgs/development/compilers/clasp/default.nix
@@ -9,7 +9,6 @@
 , boost
 , libunwind
 , ninja
-, cacert
 }:
 
 let

--- a/pkgs/development/compilers/dotnet/stage0.nix
+++ b/pkgs/development/compilers/dotnet/stage0.nix
@@ -1,5 +1,4 @@
 { stdenv
-, stdenvNoCC
 , callPackage
 , lib
 , writeShellScript

--- a/pkgs/development/compilers/dotnet/vmr.nix
+++ b/pkgs/development/compilers/dotnet/vmr.nix
@@ -1,5 +1,4 @@
 { clangStdenv
-, stdenvNoCC
 , lib
 , fetchurl
 , dotnetCorePackages
@@ -20,7 +19,6 @@
 , swiftPackages
 , openssl
 , getconf
-, makeWrapper
 , python3
 , xmlstarlet
 , nodejs

--- a/pkgs/development/compilers/gambit/build.nix
+++ b/pkgs/development/compilers/gambit/build.nix
@@ -1,6 +1,5 @@
 { gccStdenv, lib, pkgs,
-  git, openssl, autoconf, gcc, coreutils, gnused, gnugrep,
-  makeStaticLibraries,
+  git, openssl, autoconf, coreutils,
   src, version, git-version,
   stampYmd ? 0, stampHms ? 0,
   gambit-support,

--- a/pkgs/development/compilers/gerbil/build.nix
+++ b/pkgs/development/compilers/gerbil/build.nix
@@ -1,4 +1,4 @@
-{ pkgs, gccStdenv, lib, coreutils,
+{ gccStdenv, lib, coreutils,
   openssl, zlib, sqlite,
   version, git-version, src,
   gambit-support,

--- a/pkgs/development/compilers/gerbil/default.nix
+++ b/pkgs/development/compilers/gerbil/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, fetchFromGitHub, gambit-unstable, gambit-support, pkgs, gccStdenv }:
+{ callPackage, fetchFromGitHub, gambit-support }:
 
 callPackage ./build.nix rec {
   version = "0.18.1";

--- a/pkgs/development/compilers/gerbil/gerbil-leveldb.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-leveldb.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, fetchFromGitHub, gerbilPackages, leveldb, ... }:
+{ pkgs, lib, fetchFromGitHub, leveldb, ... }:
 
 {
   pname = "gerbil-leveldb";

--- a/pkgs/development/compilers/gerbil/gerbil-libxml.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-libxml.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, fetchFromGitHub, gerbilPackages, libxml2, ... }:
+{ pkgs, lib, fetchFromGitHub, libxml2, ... }:
 
 {
   pname = "gerbil-libxml";

--- a/pkgs/development/compilers/gerbil/gerbil-libyaml.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-libyaml.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, fetchFromGitHub, gerbilPackages, libyaml, ... }:
+{ pkgs, lib, fetchFromGitHub, libyaml, ... }:
 
 {
   pname = "gerbil-libyaml";

--- a/pkgs/development/compilers/gerbil/gerbil-lmdb.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-lmdb.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, fetchFromGitHub, gerbilPackages, lmdb, ... }:
+{ pkgs, lib, fetchFromGitHub, lmdb, ... }:
 
 {
   pname = "gerbil-lmdb";

--- a/pkgs/development/compilers/gerbil/gerbil-mysql.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-mysql.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, fetchFromGitHub, gerbilPackages, mariadb-connector-c, ... }:
+{ pkgs, lib, fetchFromGitHub, mariadb-connector-c, ... }:
 
 {
   pname = "gerbil-mysql";

--- a/pkgs/development/compilers/gerbil/unstable.nix
+++ b/pkgs/development/compilers/gerbil/unstable.nix
@@ -1,4 +1,4 @@
-{ callPackage, fetchFromGitHub, gambit-unstable, gambit-support, pkgs, gccStdenv }:
+{ callPackage, fetchFromGitHub, gambit-support }:
 
 callPackage ./build.nix rec {
   version = "unstable-2023-12-06";

--- a/pkgs/development/compilers/ghcjs/8.10/default.nix
+++ b/pkgs/development/compilers/ghcjs/8.10/default.nix
@@ -17,7 +17,6 @@
 , gcc
 , lib
 , ghcjsDepOverrides ? (_:_:{})
-, haskell
 , linkFarm
 , buildPackages
 }:

--- a/pkgs/development/compilers/gmqcc/default.nix
+++ b/pkgs/development/compilers/gmqcc/default.nix
@@ -1,5 +1,4 @@
 { lib
-, pkgs
 , stdenv
 , fetchFromGitHub
 }:

--- a/pkgs/development/compilers/gnu-cobol/default.nix
+++ b/pkgs/development/compilers/gnu-cobol/default.nix
@@ -16,7 +16,6 @@
 , texinfo
 , texliveBasic
 # test
-, writeText
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/compilers/go/binary.nix
+++ b/pkgs/development/compilers/go/binary.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, version, hashes }:
+{ stdenv, fetchurl, version, hashes }:
 let
   toGoKernel = platform:
     if platform.isDarwin then "darwin"

--- a/pkgs/development/compilers/jetbrains-jdk/jcef.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/jcef.nix
@@ -6,7 +6,6 @@
 , python3
 , jdk
 , git
-, libcef
 , rsync
 , lib
 , ant

--- a/pkgs/development/compilers/koka/default.nix
+++ b/pkgs/development/compilers/koka/default.nix
@@ -2,7 +2,6 @@
 , pkgsHostTarget
 , cmake
 , makeWrapper
-, fetchpatch
 , mkDerivation
 , fetchFromGitHub
 , alex

--- a/pkgs/development/compilers/lingua-franca/default.nix
+++ b/pkgs/development/compilers/lingua-franca/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, stdenv, fetchzip, jdk17_headless }:
+{ lib, stdenv, fetchzip, jdk17_headless }:
 
 stdenv.mkDerivation rec {
   pname = "lfc";

--- a/pkgs/development/compilers/llvm/common/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/common/libcxx/default.nix
@@ -6,7 +6,6 @@
 , src ? null
 , patches ? []
 , runCommand
-, substitute
 , cmake
 , lndir
 , ninja

--- a/pkgs/development/compilers/llvm/common/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/common/openmp/default.nix
@@ -14,7 +14,6 @@
 , clang-unwrapped
 , perl
 , pkg-config
-, xcbuild
 , version
 }:
 let

--- a/pkgs/development/compilers/mrustc/bootstrap.nix
+++ b/pkgs/development/compilers/mrustc/bootstrap.nix
@@ -3,7 +3,6 @@
 , mrustc
 , mrustc-minicargo
 , llvm_12
-, llvmPackages_12
 , libffi
 , cmake
 , python3

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, pkgsBuildHost, pkgsHostHost
+{ lib, stdenv, pkgsHostHost
 , file, curl, pkg-config, python3, openssl, cmake, zlib
 , installShellFiles, makeWrapper, rustPlatform, rustc
 , CoreFoundation, Security

--- a/pkgs/development/compilers/rust/clippy.nix
+++ b/pkgs/development/compilers/rust/clippy.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, rustPlatform, rustc, Security, patchelf }:
+{ stdenv, lib, rustPlatform, rustc, Security }:
 
 rustPlatform.buildRustPackage {
   pname = "clippy";

--- a/pkgs/development/compilers/terra/default.nix
+++ b/pkgs/development/compilers/terra/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, llvmPackages_16, ncurses, cmake, libxml2
-, symlinkJoin, breakpointHook, cudaPackages, enableCUDA ? false
+, symlinkJoin, cudaPackages, enableCUDA ? false
 , libffi, libobjc, libpfm, Cocoa, Foundation
 }:
 

--- a/pkgs/development/compilers/tinygo/default.nix
+++ b/pkgs/development/compilers/tinygo/default.nix
@@ -1,6 +1,5 @@
 { stdenv
 , lib
-, buildPackages
 , buildGoModule
 , fetchFromGitHub
 , makeWrapper

--- a/pkgs/development/coq-modules/compcert/default.nix
+++ b/pkgs/development/coq-modules/compcert/default.nix
@@ -1,5 +1,5 @@
 { lib, mkCoqDerivation
-, coq, flocq, compcert
+, coq, flocq
 , ocamlPackages, fetchpatch, makeWrapper, coq2html
 , stdenv, tools ? stdenv.cc
 , version ? null

--- a/pkgs/development/coq-modules/coqprime/default.nix
+++ b/pkgs/development/coq-modules/coqprime/default.nix
@@ -1,4 +1,4 @@
-{ which, lib, mkCoqDerivation, coq, bignums, version ? null }:
+{ lib, mkCoqDerivation, coq, bignums, version ? null }:
 
 mkCoqDerivation {
 

--- a/pkgs/development/coq-modules/flocq/default.nix
+++ b/pkgs/development/coq-modules/flocq/default.nix
@@ -1,5 +1,4 @@
-{ lib, bash, autoconf, automake,
-  mkCoqDerivation, coq, version ? null }:
+{ lib, bash, autoconf, mkCoqDerivation, coq, version ? null }:
 
 mkCoqDerivation {
   pname = "flocq";

--- a/pkgs/development/coq-modules/gappalib/default.nix
+++ b/pkgs/development/coq-modules/gappalib/default.nix
@@ -1,4 +1,4 @@
-{ which, lib, mkCoqDerivation, autoconf, coq, flocq, version ? null }:
+{ lib, mkCoqDerivation, autoconf, coq, flocq, version ? null }:
 
 mkCoqDerivation {
   pname = "gappalib";

--- a/pkgs/development/coq-modules/ltac2/default.nix
+++ b/pkgs/development/coq-modules/ltac2/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkCoqDerivation, which, coq, version ? null }:
+{ lib, mkCoqDerivation, coq, version ? null }:
 
 mkCoqDerivation {
   pname = "ltac2";

--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -12,7 +12,7 @@
 
 { lib, ncurses, graphviz, lua, fetchzip,
   mkCoqDerivation, withDoc ? false, single ? false,
-  coqPackages, coq, hierarchy-builder, version ? null }@args:
+  coq, hierarchy-builder, version ? null }@args:
 
 let
   repo  = "math-comp";

--- a/pkgs/development/coq-modules/metacoq/default.nix
+++ b/pkgs/development/coq-modules/metacoq/default.nix
@@ -1,6 +1,6 @@
-{ lib, fetchzip,
+{ lib,
   mkCoqDerivation, single ? false,
-  coqPackages, coq, equations, version ? null }@args:
+  coq, equations, version ? null }@args:
 
 let
   repo  = "metacoq";

--- a/pkgs/development/coq-modules/smtcoq/default.nix
+++ b/pkgs/development/coq-modules/smtcoq/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, pkgs, mkCoqDerivation, coq, veriT, zchaff, fetchurl, cvc5, version ? null }:
+{ lib, pkgs, mkCoqDerivation, coq, veriT, zchaff, fetchurl, cvc5, version ? null }:
 
 let
   # version of veriT that works with SMTCoq

--- a/pkgs/development/coq-modules/topology/default.nix
+++ b/pkgs/development/coq-modules/topology/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkCoqDerivation, coq, mathcomp, zorns-lemma, version ? null }:
+{ lib, mkCoqDerivation, coq, zorns-lemma, version ? null }:
 
 mkCoqDerivation rec {
   pname = "topology";

--- a/pkgs/development/coq-modules/vscoq-language-server/default.nix
+++ b/pkgs/development/coq-modules/vscoq-language-server/default.nix
@@ -1,4 +1,4 @@
-{ metaFetch, mkCoqDerivation, coq, lib, glib, adwaita-icon-theme, wrapGAppsHook3,
+{ metaFetch, coq, lib, glib, adwaita-icon-theme, wrapGAppsHook3,
   version ? null }:
 
 let ocamlPackages = coq.ocamlPackages;

--- a/pkgs/development/cuda-modules/generic-builders/manifest.nix
+++ b/pkgs/development/cuda-modules/generic-builders/manifest.nix
@@ -6,7 +6,6 @@
   backendStdenv,
   fetchurl,
   lib,
-  lndir,
   markForCudatoolkitRootHook,
   flags,
   stdenv,

--- a/pkgs/development/embedded/bossa/arduino.nix
+++ b/pkgs/development/embedded/bossa/arduino.nix
@@ -1,4 +1,4 @@
-{ bossa, git, fetchFromGitHub }:
+{ bossa, fetchFromGitHub }:
 
 bossa.overrideAttrs (attrs: rec {
   pname = "bossa-arduino";

--- a/pkgs/development/gnuradio-modules/limesdr/default.nix
+++ b/pkgs/development/gnuradio-modules/limesdr/default.nix
@@ -5,7 +5,6 @@
 , thrift
 , cmake
 , pkg-config
-, doxygen
 , swig
 , python
 , logLib

--- a/pkgs/development/haskell-modules/package-list.nix
+++ b/pkgs/development/haskell-modules/package-list.nix
@@ -1,4 +1,4 @@
-{ runCommand, haskellPackages, lib, all-cabal-hashes, writeShellScript }:
+{ runCommand, haskellPackages, lib, all-cabal-hashes }:
 let
   # Checks if the version looks like a Haskell PVP version which is the format
   # Hackage enforces. This will return false if the version strings is empty or

--- a/pkgs/development/interpreters/cling/default.nix
+++ b/pkgs/development/interpreters/cling/default.nix
@@ -7,7 +7,6 @@
 , makeWrapper
 , ncurses
 , python3
-, runCommand
 , zlib
 
 # *NOT* from LLVM 9!

--- a/pkgs/development/interpreters/octave/build-env.nix
+++ b/pkgs/development/interpreters/octave/build-env.nix
@@ -1,6 +1,5 @@
 { lib, stdenv, octave, buildEnv
 , makeWrapper, texinfo
-, octavePackages
 , wrapOctave
 , computeRequiredOctavePackages
 , extraLibs ? []

--- a/pkgs/development/interpreters/yex-lang/default.nix
+++ b/pkgs/development/interpreters/yex-lang/default.nix
@@ -1,5 +1,4 @@
 { lib
-, stdenv
 , rustPlatform
 , fetchFromGitHub
 }:

--- a/pkgs/development/libraries/blst/default.nix
+++ b/pkgs/development/libraries/blst/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, autoreconfHook }:
+{ stdenv, lib, fetchFromGitHub }:
 
 stdenv.mkDerivation ( finalAttrs: {
   pname = "blst";

--- a/pkgs/development/libraries/cegui/default.nix
+++ b/pkgs/development/libraries/cegui/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, writeShellScript
 , cmake
 , ogre
 , freetype

--- a/pkgs/development/libraries/codec2/default.nix
+++ b/pkgs/development/libraries/codec2/default.nix
@@ -4,7 +4,6 @@
 , cmake
 , freedvSupport ? false
 , lpcnetfreedv
-, codec2
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/dbus/make-dbus-conf.nix
+++ b/pkgs/development/libraries/dbus/make-dbus-conf.nix
@@ -1,5 +1,4 @@
 { runCommand
-, writeText
 , libxslt
 , dbus
 , findXMLCatalogs

--- a/pkgs/development/libraries/doctest/default.nix
+++ b/pkgs/development/libraries/doctest/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, installShellFiles, cmake }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake }:
 
 stdenv.mkDerivation rec {
   pname = "doctest";

--- a/pkgs/development/libraries/elpa/default.nix
+++ b/pkgs/development/libraries/elpa/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, autoreconfHook, mpiCheckPhaseHook
-, gfortran, perl, mpi, blas, lapack, scalapack, openssh
+, perl, mpi, blas, lapack, scalapack, openssh
 # CPU optimizations
 , avxSupport ? stdenv.hostPlatform.avxSupport
 , avx2Support ? stdenv.hostPlatform.avx2Support

--- a/pkgs/development/libraries/folly/default.nix
+++ b/pkgs/development/libraries/folly/default.nix
@@ -1,6 +1,5 @@
 { lib
 , stdenv
-, overrideSDK
 , fetchFromGitHub
 , boost
 , cmake

--- a/pkgs/development/libraries/gfbgraph/default.nix
+++ b/pkgs/development/libraries/gfbgraph/default.nix
@@ -10,7 +10,6 @@
 , json-glib
 , gobject-introspection
 , gtk-doc
-, pkgs
 , docbook-xsl-nons
 }:
 

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -17,7 +17,7 @@
 , buildPackages
 
 # this is just for tests (not in the closure of any regular package)
-, coreutils, dbus, tzdata
+, dbus, tzdata
 , desktop-file-utils, shared-mime-info
 , darwin
 , makeHardcodeGsettingsPatch

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -8,7 +8,6 @@
 , ninja
 , gtk-doc
 , docbook-xsl-nons
-, docbook_xml_dtd_43
 , docbook_xml_dtd_45
 , pkg-config
 , libffi

--- a/pkgs/development/libraries/grilo-plugins/default.nix
+++ b/pkgs/development/libraries/grilo-plugins/default.nix
@@ -14,7 +14,6 @@
 , libxml2
 , lua5_4
 , liboauth
-, libgdata
 , libmediaart
 , grilo
 , gst_all_1

--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -30,7 +30,6 @@
 , libepoxy
 , libxkbcommon
 , libxml2
-, gmp
 , gnome
 , gsettings-desktop-schemas
 , sassc

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -17,7 +17,6 @@
 , glib
 , cairo
 , pango
-, pandoc
 , gdk-pixbuf
 , gobject-introspection
 , fribidi

--- a/pkgs/development/libraries/gtkd/default.nix
+++ b/pkgs/development/libraries/gtkd/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchzip, atk, cairo, dcompiler, gdk-pixbuf, gnome, gst_all_1, librsvg
+{ lib, stdenv, fetchzip, atk, cairo, dcompiler, gdk-pixbuf, gst_all_1, librsvg
 , glib, gtk3, gtksourceview4, libgda, libpeas, pango, pkg-config, which, vte }:
 
 let

--- a/pkgs/development/libraries/gvfs/default.nix
+++ b/pkgs/development/libraries/gvfs/default.nix
@@ -41,7 +41,6 @@
 , libgdata
 , libmsgraph
 , python3
-, python3Packages
 , gsettings-desktop-schemas
 }:
 

--- a/pkgs/development/libraries/hamlib/default.nix
+++ b/pkgs/development/libraries/hamlib/default.nix
@@ -12,7 +12,6 @@
 , pkg-config
 , boost
 , libtool
-, perlPackages
 , pythonBindings ? true
 , tclBindings ? true
 , perlBindings ? stdenv.buildPlatform == stdenv.hostPlatform

--- a/pkgs/development/libraries/hpx/default.nix
+++ b/pkgs/development/libraries/hpx/default.nix
@@ -6,7 +6,6 @@
 , cmake
 , hwloc
 , gperftools
-, ninja
 , pkg-config
 , python3
 }:

--- a/pkgs/development/libraries/irrlicht/mac.nix
+++ b/pkgs/development/libraries/irrlicht/mac.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchzip, libGLU, libGL, fetchFromGitHub, cmake, Cocoa, OpenGL, IOKit }:
+{ lib, stdenv, fetchzip, fetchFromGitHub, cmake, Cocoa, OpenGL, IOKit }:
 
 let
   common = import ./common.nix { inherit fetchzip; };

--- a/pkgs/development/libraries/kde-frameworks/kcalendarcore.nix
+++ b/pkgs/development/libraries/kde-frameworks/kcalendarcore.nix
@@ -2,7 +2,6 @@
   mkDerivation,
   extra-cmake-modules,
   libical,
-  qtbase
 }:
 
 mkDerivation {

--- a/pkgs/development/libraries/kde-frameworks/ki18n.nix
+++ b/pkgs/development/libraries/kde-frameworks/ki18n.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation,
   extra-cmake-modules, gettext, python3,
-  qtbase, qtdeclarative, qtscript,
+  qtdeclarative, qtscript,
 }:
 
 mkDerivation {

--- a/pkgs/development/libraries/kde-frameworks/kquickcharts.nix
+++ b/pkgs/development/libraries/kde-frameworks/kquickcharts.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation,
   extra-cmake-modules,
-  qtquickcontrols2, qtbase,
+  qtquickcontrols2,
 }:
 
 mkDerivation {

--- a/pkgs/development/libraries/kerberos/heimdal.nix
+++ b/pkgs/development/libraries/kerberos/heimdal.nix
@@ -17,7 +17,6 @@
 , db
 , libedit
 , pam
-, krb5
 , libmicrohttpd
 , cjson
 

--- a/pkgs/development/libraries/lensfun/default.nix
+++ b/pkgs/development/libraries/lensfun/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, glib, zlib, libpng, cmake, libxml2, python3 }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, glib, zlib, libpng, cmake, python3 }:
 
 let
   version = "0.3.4";

--- a/pkgs/development/libraries/libagar/default.nix
+++ b/pkgs/development/libraries/libagar/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, pkg-config, libtool, perl, bsdbuild, gettext, mandoc
-, libpng, libjpeg, libXinerama, freetype, SDL, libGLU, libGL
+, libpng, libjpeg, libXinerama, freetype, SDL, libGL
 , libsndfile, portaudio, libmysqlclient, fontconfig
 }:
 

--- a/pkgs/development/libraries/libdatachannel/default.nix
+++ b/pkgs/development/libraries/libdatachannel/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, srcOnly
 , cmake
 , ninja
 , pkg-config

--- a/pkgs/development/libraries/libdatrie/default.nix
+++ b/pkgs/development/libraries/libdatrie/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper
+{ lib, stdenv, fetchFromGitHub
 , autoreconfHook, autoconf-archive
 , installShellFiles, libiconv }:
 

--- a/pkgs/development/libraries/libdwarf/common.nix
+++ b/pkgs/development/libraries/libdwarf/common.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, buildInputs, hash, version, libelf, url, knownVulnerabilities }:
+{ lib, stdenv, fetchurl, buildInputs, hash, version, url, knownVulnerabilities }:
 
 stdenv.mkDerivation rec {
   pname = "libdwarf";

--- a/pkgs/development/libraries/libfprint/default.nix
+++ b/pkgs/development/libraries/libfprint/default.nix
@@ -9,7 +9,6 @@
 , glib
 , nss
 , gobject-introspection
-, coreutils
 , cairo
 , libgudev
 , gtk-doc

--- a/pkgs/development/libraries/libgpod/default.nix
+++ b/pkgs/development/libraries/libgpod/default.nix
@@ -9,7 +9,6 @@
 , glib
 , libxml2
 , sqlite
-, zlib
 , sg3_utils
 , gdk-pixbuf
 , taglib

--- a/pkgs/development/libraries/libmx/default.nix
+++ b/pkgs/development/libraries/libmx/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub
 , libtool, pkg-config, automake, autoconf, intltool
-, glib, gobject-introspection, gtk2, gtk-doc
+, gobject-introspection, gtk2, gtk-doc
 , clutter, clutter-gtk
 }:
 

--- a/pkgs/development/libraries/libpsl/default.nix
+++ b/pkgs/development/libraries/libpsl/default.nix
@@ -10,7 +10,6 @@
 , libxslt
 , pkg-config
 , python3
-, valgrind
 , publicsuffix-list
 }:
 

--- a/pkgs/development/libraries/libsixel/default.nix
+++ b/pkgs/development/libraries/libsixel/default.nix
@@ -5,7 +5,6 @@
 , ninja
 , gdk-pixbuf
 , gd
-, libjpeg
 , pkg-config
 }:
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/libthai/default.nix
+++ b/pkgs/development/libraries/libthai/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, makeWrapper, installShellFiles, pkg-config, libdatrie }:
+{ lib, stdenv, fetchurl, installShellFiles, pkg-config, libdatrie }:
 
 stdenv.mkDerivation rec {
   pname = "libthai";

--- a/pkgs/development/libraries/libusbgx/default.nix
+++ b/pkgs/development/libraries/libusbgx/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, cmake, bash-completion, pkg-config, libconfig, autoreconfHook }:
+{ stdenv, lib, fetchFromGitHub, pkg-config, libconfig, autoreconfHook }:
 stdenv.mkDerivation {
   pname = "libusbgx";
   version = "unstable-2021-10-31";

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -9,7 +9,6 @@
 , dnsmasq
 , docutils
 , fetchFromGitLab
-, fetchpatch
 , gettext
 , glib
 , gnutls

--- a/pkgs/development/libraries/libwebp/default.nix
+++ b/pkgs/development/libraries/libwebp/default.nix
@@ -13,7 +13,6 @@
 , libwebpdecoderSupport ? true # Build libwebpdecoder
 
 # for passthru.tests
-, freeimage
 , gd
 , graphicsmagick
 , haskellPackages

--- a/pkgs/development/libraries/lpcnetfreedv/default.nix
+++ b/pkgs/development/libraries/lpcnetfreedv/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchurl, cmake, codec2 }:
+{ lib, stdenv, fetchFromGitHub, fetchurl, cmake }:
 
 let
   dataVersion = "191005_v1.0";

--- a/pkgs/development/libraries/lrdf/default.nix
+++ b/pkgs/development/libraries/lrdf/default.nix
@@ -1,6 +1,5 @@
 { config, lib, stdenv, fetchFromGitHub, pkg-config, autoreconfHook
-, librdf_raptor2, ladspaH, openssl, zlib
-, doCheck ? config.doCheckByDefault or false, ladspaPlugins
+, librdf_raptor2, doCheck ? config.doCheckByDefault or false, ladspaPlugins
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/lyra/default.nix
+++ b/pkgs/development/libraries/lyra/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, installShellFiles, meson, ninja }:
+{ lib, stdenv, fetchFromGitHub, meson, ninja }:
 
 stdenv.mkDerivation rec {
   pname = "lyra";

--- a/pkgs/development/libraries/maui-core/default.nix
+++ b/pkgs/development/libraries/maui-core/default.nix
@@ -1,5 +1,4 @@
 { lib
-, pkgs
 , mkDerivation
 , libcanberra
 , pulseaudio

--- a/pkgs/development/libraries/mediastreamer/msopenh264.nix
+++ b/pkgs/development/libraries/mediastreamer/msopenh264.nix
@@ -1,9 +1,7 @@
-{ autoreconfHook
-, cmake
+{ cmake
 , fetchFromGitLab
 , mediastreamer
 , openh264
-, pkg-config
 , lib
 , stdenv
 }:

--- a/pkgs/development/libraries/neardal/default.nix
+++ b/pkgs/development/libraries/neardal/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, pkg-config, glib, readline, makeWrapper }:
+{ lib, stdenv, fetchFromGitHub, autoconf, automake, pkg-config, glib, readline, makeWrapper }:
 
 stdenv.mkDerivation {
   pname = "neardal";

--- a/pkgs/development/libraries/ocl-icd/default.nix
+++ b/pkgs/development/libraries/ocl-icd/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , ruby
 , opencl-headers
-, addDriverRunpath
 , autoreconfHook
 , windows
 }:

--- a/pkgs/development/libraries/opencl-clang/default.nix
+++ b/pkgs/development/libraries/opencl-clang/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , applyPatches
 , fetchFromGitHub
-, fetchpatch
 , cmake
 , git
 , llvmPackages_14

--- a/pkgs/development/libraries/openjpeg/default.nix
+++ b/pkgs/development/libraries/openjpeg/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, cmake, pkg-config
-, libdeflate, libpng, libtiff, zlib, lcms2, jpylyzer
+, libpng, libtiff, zlib, lcms2, jpylyzer
 , jpipLibSupport ? false # JPIP library & executables
 , jpipServerSupport ? false, curl, fcgi # JPIP Server
 , jdk

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, removeReferencesTo, gfortran, perl, libnl
-, rdma-core, zlib, numactl, libevent, hwloc, targetPackages, symlinkJoin
+, rdma-core, zlib, numactl, libevent, hwloc, targetPackages
 , libpsm2, libfabric, pmix, ucx, ucc, makeWrapper
 , config
 # Enable CUDA support

--- a/pkgs/development/libraries/openzwave/default.nix
+++ b/pkgs/development/libraries/openzwave/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch
+{ lib, stdenv, fetchFromGitHub
 , doxygen, fontconfig, graphviz-nox, libxml2, pkg-config, which
 , systemd }:
 

--- a/pkgs/development/libraries/qgnomeplatform/default.nix
+++ b/pkgs/development/libraries/qgnomeplatform/default.nix
@@ -10,7 +10,6 @@
 , gtk3
 , qtbase
 , qtwayland
-, pantheon
 , substituteAll
 , gsettings-desktop-schemas
 , useQt6 ? false

--- a/pkgs/development/libraries/qt-6/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase.nix
@@ -3,11 +3,8 @@
 , src
 , patches ? [ ]
 , version
-, coreutils
-, buildPackages
 , bison
 , flex
-, gdb
 , gperf
 , lndir
 , perl
@@ -36,7 +33,6 @@
 , libdatrie
 , lttng-ust
 , libepoxy
-, libiconv
 , dbus
 , fontconfig
 , freetype

--- a/pkgs/development/libraries/qtfeedback/default.nix
+++ b/pkgs/development/libraries/qtfeedback/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , perl
 , qmake
-, qtbase
 , qtdeclarative
 }:
 

--- a/pkgs/development/libraries/retro-gtk/default.nix
+++ b/pkgs/development/libraries/retro-gtk/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , fetchurl
 , fetchpatch
-, cmake
 , meson
 , ninja
 , pkg-config

--- a/pkgs/development/libraries/rnnoise-plugin/default.nix
+++ b/pkgs/development/libraries/rnnoise-plugin/default.nix
@@ -4,12 +4,10 @@
 , fetchFromGitHub
 , freetype
 , gtk3-x11
-, mount
 , pcre
 , pkg-config
 , webkitgtk
 , xorg
-, llvmPackages
 , WebKit
 , MetalKit
 , CoreAudioKit

--- a/pkgs/development/libraries/rustls-ffi/default.nix
+++ b/pkgs/development/libraries/rustls-ffi/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  Security,
+  apacheHttpd,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rustls-ffi";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "rustls";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-IDIWN5g1aaE6SDdXSm4WYK6n+BpuypPYQITuDj1WJEc=";
+  };
+
+  propagatedBuildInputs = lib.optionals stdenv.isDarwin [ Security ];
+
+  cargoLock.lockFile = ./Cargo.lock;
+  postPatch = ''
+    cp ${./Cargo.lock} Cargo.lock
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    make install DESTDIR=${placeholder "out"}
+
+    runHook postInstall
+  '';
+
+  passthru.tests = {
+    apacheHttpd = apacheHttpd.override { modTlsSupport = true; };
+    # Currently broken notably because of https://github.com/curl/curl/issues/13248
+    # curl = curl.override { opensslSupport = false; rustlsSupport = true; };
+  };
+
+  meta = with lib; {
+    description = "C-to-rustls bindings";
+    homepage = "https://github.com/rustls/rustls-ffi/";
+    license = with lib.licenses; [
+      mit
+      asl20
+      isc
+    ];
+    maintainers = [ maintainers.lesuisse ];
+  };
+}

--- a/pkgs/development/libraries/safefile/default.nix
+++ b/pkgs/development/libraries/safefile/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, path, runtimeShell }:
+{ lib, stdenv, fetchurl }:
 stdenv.mkDerivation rec {
   pname = "safefile";
   version = "1.0.5";

--- a/pkgs/development/libraries/science/chemistry/avogadrolibs/default.nix
+++ b/pkgs/development/libraries/science/chemistry/avogadrolibs/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, zlib, eigen, libGL, doxygen, spglib
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, zlib, eigen, libGL, spglib
 , mmtf-cpp, glew, python3, libarchive, libmsym, msgpack, qttools, wrapQtAppsHook
 }:
 

--- a/pkgs/development/libraries/science/chemistry/simple-dftd3/python.nix
+++ b/pkgs/development/libraries/science/chemistry/simple-dftd3/python.nix
@@ -1,6 +1,4 @@
 { buildPythonPackage
-, pkg-config
-, meson
 , simple-dftd3
 , cffi
 , numpy

--- a/pkgs/development/libraries/science/math/tensorflow-lite/default.nix
+++ b/pkgs/development/libraries/science/math/tensorflow-lite/default.nix
@@ -1,5 +1,4 @@
 { stdenv
-, bash
 , buildPackages
 , buildBazelPackage
 , fetchFromGitHub

--- a/pkgs/development/libraries/swiftshader/default.nix
+++ b/pkgs/development/libraries/swiftshader/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchgit, python3, cmake, jq, libX11, libXext, zlib }:
+{ lib, stdenv, fetchgit, python3, cmake, jq }:
 
 stdenv.mkDerivation rec {
   pname = "swiftshader";

--- a/pkgs/development/libraries/sycl-info/default.nix
+++ b/pkgs/development/libraries/sycl-info/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv
 , fetchFromGitHub
-, installShellFiles
 , cmake
 , ninja
 , ocl-icd

--- a/pkgs/development/libraries/usbredir/default.nix
+++ b/pkgs/development/libraries/usbredir/default.nix
@@ -1,6 +1,5 @@
 { lib
 , stdenv
-, cmake
 , fetchFromGitLab
 , pkg-config
 , meson

--- a/pkgs/development/libraries/v8/default.nix
+++ b/pkgs/development/libraries/v8/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchgit
 , gn, ninja, python3, glib, pkg-config, icu
-, xcbuild, darwin
+, xcbuild
 , fetchpatch
 , llvmPackages
 , symlinkJoin

--- a/pkgs/development/libraries/vapoursynth/default.nix
+++ b/pkgs/development/libraries/vapoursynth/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, pkg-config, autoreconfHook, makeWrapper
-, runCommandCC, runCommand, vapoursynth, writeText, patchelf, buildEnv
+, runCommandCC, runCommand, vapoursynth, writeText, buildEnv
 , zimg, libass, python3, libiconv, testers
 , ApplicationServices
 }:

--- a/pkgs/development/libraries/volume-key/default.nix
+++ b/pkgs/development/libraries/volume-key/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv, fetchgit, autoreconfHook, pkg-config, gettext, python3
 , ncurses, swig, glib, util-linux, cryptsetup, nss, gpgme
-, autoconf, automake, libtool
 , buildPackages
 }:
 

--- a/pkgs/development/libraries/wxwidgets/wxGTK32.nix
+++ b/pkgs/development/libraries/wxwidgets/wxGTK32.nix
@@ -32,7 +32,6 @@
 , AVFoundation
 , AVKit
 , WebKit
-, fetchpatch
 }:
 let
   catch = fetchFromGitHub {

--- a/pkgs/development/libraries/xtensor/default.nix
+++ b/pkgs/development/libraries/xtensor/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , cmake
 , doctest
 , enableAssertions ? false

--- a/pkgs/development/libraries/xtl/default.nix
+++ b/pkgs/development/libraries/xtl/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , cmake
 , doctest
-, gtest
 }:
 stdenv.mkDerivation rec {
   pname = "xtl";

--- a/pkgs/development/lua-modules/nfd/default.nix
+++ b/pkgs/development/lua-modules/nfd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildLuarocksPackage, lua51Packages, lua, pkg-config, lib, substituteAll, zenity, AppKit}:
+{ stdenv, fetchFromGitHub, buildLuarocksPackage, lua, pkg-config, lib, substituteAll, zenity, AppKit}:
 
 buildLuarocksPackage {
   pname = "nfd";

--- a/pkgs/development/misc/or1k/newlib.nix
+++ b/pkgs/development/misc/or1k/newlib.nix
@@ -1,4 +1,4 @@
-{ stdenv, texinfo, flex, bison, fetchFromGitHub, crossLibcStdenv, buildPackages }:
+{ stdenv, fetchFromGitHub, crossLibcStdenv, buildPackages }:
 
 crossLibcStdenv.mkDerivation {
   name = "newlib";

--- a/pkgs/development/misc/resholve/default.nix
+++ b/pkgs/development/misc/resholve/default.nix
@@ -1,5 +1,4 @@
 { lib
-, pkgs
 , pkgsBuildHost
 , ...
 }:

--- a/pkgs/development/mobile/androidenv/cmdline-tools.nix
+++ b/pkgs/development/mobile/androidenv/cmdline-tools.nix
@@ -1,4 +1,4 @@
-{deployAndroidPackage, lib, package, autoPatchelfHook, makeWrapper, os, pkgs, pkgsi686Linux, stdenv, postInstall}:
+{deployAndroidPackage, lib, package, autoPatchelfHook, makeWrapper, os, pkgs, stdenv, postInstall}:
 
 deployAndroidPackage {
   name = "androidsdk";

--- a/pkgs/development/mobile/androidenv/patcher.nix
+++ b/pkgs/development/mobile/androidenv/patcher.nix
@@ -1,4 +1,4 @@
-{deployAndroidPackage, lib, package, os, autoPatchelfHook, pkgs, stdenv}:
+{deployAndroidPackage, lib, package, os, autoPatchelfHook, stdenv}:
 
 deployAndroidPackage {
   inherit package os;

--- a/pkgs/development/ocaml-modules/ounit2/default.nix
+++ b/pkgs/development/ocaml-modules/ounit2/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildDunePackage, fetchurl, seq, stdlib-shims, ncurses }:
+{ lib, buildDunePackage, fetchurl, seq, stdlib-shims }:
 
 buildDunePackage rec {
   minimalOCamlVersion = "4.08";

--- a/pkgs/development/octave-modules/financial/default.nix
+++ b/pkgs/development/octave-modules/financial/default.nix
@@ -1,8 +1,6 @@
 { buildOctavePackage
 , lib
 , fetchurl
-, io
-, statistics
 }:
 
 buildOctavePackage rec {

--- a/pkgs/development/octave-modules/level-set/default.nix
+++ b/pkgs/development/octave-modules/level-set/default.nix
@@ -1,5 +1,4 @@
 { buildOctavePackage
-, stdenv
 , lib
 , fetchgit
 , automake

--- a/pkgs/development/php-packages/couchbase/default.nix
+++ b/pkgs/development/php-packages/couchbase/default.nix
@@ -2,10 +2,8 @@
   lib,
   buildPecl,
   fetchFromGitHub,
-  writeText,
   libcouchbase,
   zlib,
-  php,
   substituteAll,
 }:
 let

--- a/pkgs/development/python-modules/cocotb/default.nix
+++ b/pkgs/development/python-modules/cocotb/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,

--- a/pkgs/development/python-modules/httpie/default.nix
+++ b/pkgs/development/python-modules/httpie/default.nix
@@ -14,7 +14,6 @@
   requests-toolbelt,
   setuptools,
   rich,
-  pysocks,
   pip,
   pytest-httpbin,
   pytest-lazy-fixture,

--- a/pkgs/development/python-modules/levenshtein/default.nix
+++ b/pkgs/development/python-modules/levenshtein/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   cmake,
   cython,

--- a/pkgs/development/python-modules/pillow/generic.nix
+++ b/pkgs/development/python-modules/pillow/generic.nix
@@ -1,7 +1,6 @@
 {
   pname,
   version,
-  disabled,
   src,
   patches ? [ ],
   meta,

--- a/pkgs/development/python-modules/pytest-cov-stub/default.nix
+++ b/pkgs/development/python-modules/pytest-cov-stub/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  python,
   hatchling,
 }:
 

--- a/pkgs/development/python-modules/typer/default.nix
+++ b/pkgs/development/python-modules/typer/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildPythonPackage,
   click,
-  colorama,
   coverage,
   fetchPypi,
   pdm-backend,

--- a/pkgs/development/python2-modules/attrs/default.nix
+++ b/pkgs/development/python2-modules/attrs/default.nix
@@ -1,5 +1,4 @@
 { lib
-, callPackage
 , buildPythonPackage
 , fetchPypi
 }:

--- a/pkgs/development/rocm-modules/5/llvm/stage-3/mlir.nix
+++ b/pkgs/development/rocm-modules/5/llvm/stage-3/mlir.nix
@@ -6,7 +6,6 @@
 , vulkan-loader
 , glslang
 , shaderc
-, lit
 }:
 
 callPackage ../base.nix rec {

--- a/pkgs/development/rocm-modules/5/rocblas/default.nix
+++ b/pkgs/development/rocm-modules/5/rocblas/default.nix
@@ -3,7 +3,6 @@
 , stdenv
 , fetchFromGitHub
 , rocmUpdateScript
-, runCommand
 , cmake
 , rocm-cmake
 , clr

--- a/pkgs/development/rocm-modules/6/llvm/stage-3/mlir.nix
+++ b/pkgs/development/rocm-modules/6/llvm/stage-3/mlir.nix
@@ -6,7 +6,6 @@
 , vulkan-loader
 , glslang
 , shaderc
-, lit
 , fetchpatch
 }:
 

--- a/pkgs/development/rocm-modules/6/rocblas/default.nix
+++ b/pkgs/development/rocm-modules/6/rocblas/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , fetchpatch
 , rocmUpdateScript
-, runCommand
 , cmake
 , rocm-cmake
 , clr

--- a/pkgs/development/ruby-modules/rbenv/default.nix
+++ b/pkgs/development/ruby-modules/rbenv/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, bash, installShellFiles }:
+{ lib, stdenv, fetchFromGitHub, installShellFiles }:
 
 stdenv.mkDerivation rec {
   pname = "rbenv";

--- a/pkgs/development/skaware-packages/sdnotify-wrapper/default.nix
+++ b/pkgs/development/skaware-packages/sdnotify-wrapper/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, runCommandCC, skawarePackages, skalibs }:
+{ lib, runCommandCC, skalibs }:
 
 let
   # From https://skarnet.org/software/misc/sdnotify-wrapper.c,

--- a/pkgs/development/tools/analysis/hopper/default.nix
+++ b/pkgs/development/tools/analysis/hopper/default.nix
@@ -3,7 +3,6 @@
 , lib
 , autoPatchelfHook
 , wrapQtAppsHook
-, gmpxx
 , gnustep
 , libbsd
 , libffi_3_3

--- a/pkgs/development/tools/ashpd-demo/default.nix
+++ b/pkgs/development/tools/ashpd-demo/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, nix-update-script
 , cargo
 , meson
 , ninja
@@ -13,8 +12,6 @@
 , gst_all_1
 , gtk4
 , libadwaita
-, llvmPackages
-, glibc
 , pipewire
 , wayland
 , wrapGAppsHook4

--- a/pkgs/development/tools/azure-functions-core-tools/default.nix
+++ b/pkgs/development/tools/azure-functions-core-tools/default.nix
@@ -1,6 +1,5 @@
 { lib,
   stdenv,
-  callPackage,
   fetchFromGitHub,
   buildDotnetModule,
   buildGoModule,

--- a/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
@@ -1,8 +1,8 @@
 { stdenv, callPackage, lib, fetchurl, fetchFromGitHub, installShellFiles
-, runCommand, runCommandCC, makeWrapper, recurseIntoAttrs
+, runCommand, runCommandCC, makeWrapper
 # this package (through the fixpoint glass)
 , bazel_self
-, lr, xe, zip, unzip, bash, writeCBin, coreutils
+, lr, xe, zip, unzip, bash, coreutils
 , which, gawk, gnused, gnutar, gnugrep, gzip, findutils
 # updater
 , python3, writeScript
@@ -14,8 +14,6 @@
 # Always assume all markers valid (this is needed because we remove markers; they are non-deterministic).
 # Also, don't clean up environment variables (so that NIX_ environment variables are passed to compilers).
 , enableNixHacks ? false
-, gcc-unwrapped
-, autoPatchelfHook
 , file
 , substituteAll
 , writeTextFile

--- a/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
@@ -2,7 +2,7 @@
 , runCommand, runCommandCC, makeWrapper, recurseIntoAttrs
 # this package (through the fixpoint glass)
 , bazel_self
-, lr, xe, zip, unzip, bash, writeCBin, coreutils
+, lr, xe, zip, unzip, bash, coreutils
 , which, gawk, gnused, gnutar, gnugrep, gzip, findutils
 , diffutils, gnupatch
 # updater
@@ -15,8 +15,6 @@
 # Always assume all markers valid (this is needed because we remove markers; they are non-deterministic).
 # Also, don't clean up environment variables (so that NIX_ environment variables are passed to compilers).
 , enableNixHacks ? false
-, gcc-unwrapped
-, autoPatchelfHook
 , file
 , substituteAll
 , writeTextFile

--- a/pkgs/development/tools/cocogitto/default.nix
+++ b/pkgs/development/tools/cocogitto/default.nix
@@ -1,4 +1,4 @@
-{ lib, rustPlatform, fetchFromGitHub, installShellFiles, stdenv, Security, makeWrapper, libgit2 }:
+{ lib, rustPlatform, fetchFromGitHub, installShellFiles, stdenv, Security, libgit2 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "cocogitto";

--- a/pkgs/development/tools/dbus-test-runner/default.nix
+++ b/pkgs/development/tools/dbus-test-runner/default.nix
@@ -4,7 +4,6 @@
 , testers
 , autoreconfHook
 , bash
-, coreutils
 , dbus
 , dbus-glib
 , glib

--- a/pkgs/development/tools/haskell/ihaskell/wrapper.nix
+++ b/pkgs/development/tools/haskell/ihaskell/wrapper.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, writeScriptBin, makeWrapper, buildEnv, haskell, ghcWithPackages, jupyter, packages }:
+{ lib, stdenv, writeScriptBin, makeWrapper, buildEnv, ghcWithPackages, jupyter, packages }:
 let
   ihaskellEnv = ghcWithPackages (self: [
     self.ihaskell

--- a/pkgs/development/tools/hover/default.nix
+++ b/pkgs/development/tools/hover/default.nix
@@ -6,7 +6,6 @@
 , pkg-config
 , fetchFromGitHub
 , roboto
-, writeScript
 , xorg
 , libglvnd
 , addDriverRunpath

--- a/pkgs/development/tools/java/visualvm/default.nix
+++ b/pkgs/development/tools/java/visualvm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, lib, makeWrapper, makeDesktopItem, jdk, gawk }:
+{ stdenv, fetchzip, lib, makeWrapper, makeDesktopItem, jdk }:
 
 stdenv.mkDerivation rec {
   version = "2.1.8";

--- a/pkgs/development/tools/ldid/default.nix
+++ b/pkgs/development/tools/ldid/default.nix
@@ -1,6 +1,5 @@
 { lib
 , stdenv
-, callPackage
 , fetchgit
 , libplist
 , libxml2

--- a/pkgs/development/tools/mblock-mlink/default.nix
+++ b/pkgs/development/tools/mblock-mlink/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, dpkg, makeWrapper, autoPatchelfHook }:
+{ stdenv, lib, fetchurl, dpkg, autoPatchelfHook }:
 
 stdenv.mkDerivation rec {
   pname = "mblock-mlink";

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -14,7 +14,6 @@ in
 , lib
 , noSysDirs
 , perl
-, substitute
 , zlib
 , CoreServices
 

--- a/pkgs/development/tools/misc/cvise/default.nix
+++ b/pkgs/development/tools/misc/cvise/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonApplication
 , fetchFromGitHub
-, bash
 , cmake
 , colordiff
 , flex

--- a/pkgs/development/tools/misc/hydra/unstable.nix
+++ b/pkgs/development/tools/misc/hydra/unstable.nix
@@ -43,7 +43,6 @@
 , cacert
 , glibcLocales
 , fetchFromGitHub
-, fetchpatch2
 , nixosTests
 }:
 

--- a/pkgs/development/tools/misc/jscoverage/default.nix
+++ b/pkgs/development/tools/misc/jscoverage/default.nix
@@ -1,4 +1,4 @@
-{ autoconf, fetchurl, makedepend, perl, python3, lib, stdenv, zip }:
+{ fetchurl, perl, python3, lib, stdenv, zip }:
 
 stdenv.mkDerivation rec {
   pname = "jscoverage";

--- a/pkgs/development/tools/misc/ptags/default.nix
+++ b/pkgs/development/tools/misc/ptags/default.nix
@@ -1,5 +1,4 @@
 { fetchFromGitHub
-, cargo
 , ctags
 , lib
 , makeWrapper

--- a/pkgs/development/tools/nap/default.nix
+++ b/pkgs/development/tools/nap/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, callPackage }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
 buildGoModule rec {
   pname = "nap";

--- a/pkgs/development/tools/ocaml/utop/default.nix
+++ b/pkgs/development/tools/ocaml/utop/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, ocaml, findlib
 , lambda-term, cppo, makeWrapper, buildDunePackage
-, xdg, zed, logs, lwt, react, lwt_react
+, xdg, zed, logs
 }:
 
 buildDunePackage rec {

--- a/pkgs/development/tools/profiling/EZTrace/default.nix
+++ b/pkgs/development/tools/profiling/EZTrace/default.nix
@@ -9,7 +9,6 @@
   # is released we can switch to latest binutils.
   libbfd_2_38,
   libopcodes_2_38,
-  buildPackages,
   autoreconfHook
 }:
 

--- a/pkgs/development/tools/react-native-debugger/default.nix
+++ b/pkgs/development/tools/react-native-debugger/default.nix
@@ -7,7 +7,6 @@
 , gdk-pixbuf
 , fontconfig
 , pango
-, gnome
 , atk
 , at-spi2-atk
 , at-spi2-core

--- a/pkgs/development/tools/rust/bindgen/unwrapped.nix
+++ b/pkgs/development/tools/rust/bindgen/unwrapped.nix
@@ -1,6 +1,4 @@
 { lib, fetchCrate, rustPlatform, clang, rustfmt
-, runtimeShell
-, bash
 }:
 let
   # bindgen hardcodes rustfmt outputs that use nightly features

--- a/pkgs/development/tools/rust/cargo-espmonitor/default.nix
+++ b/pkgs/development/tools/rust/cargo-espmonitor/default.nix
@@ -1,8 +1,6 @@
 { lib
 , fetchFromGitHub
 , rustPlatform
-, pkg-config
-, systemd
 ,
 }:
 rustPlatform.buildRustPackage rec {

--- a/pkgs/development/tools/rust/cargo-leptos/default.nix
+++ b/pkgs/development/tools/rust/cargo-leptos/default.nix
@@ -1,7 +1,6 @@
 { darwin
 , fetchFromGitHub
 , lib
-, pkg-config
 , rustPlatform
 , stdenv
 }:

--- a/pkgs/development/tools/rust/duckscript/default.nix
+++ b/pkgs/development/tools/rust/duckscript/default.nix
@@ -1,6 +1,5 @@
 { lib
 , stdenv
-, runCommand
 , fetchCrate
 , rustPlatform
 , Security

--- a/pkgs/development/tools/smlfmt/default.nix
+++ b/pkgs/development/tools/smlfmt/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, mlton }:
+{ lib, stdenv, fetchFromGitHub, mlton }:
 
 stdenv.mkDerivation rec {
   pname = "smlfmt";

--- a/pkgs/development/tools/steamos-devkit/default.nix
+++ b/pkgs/development/tools/steamos-devkit/default.nix
@@ -1,7 +1,6 @@
 { lib
 , fetchFromGitHub
 , fetchFromGitLab
-, writeScript
 , python3
 , copyDesktopItems
 , makeDesktopItem

--- a/pkgs/development/tools/swiftformat/default.nix
+++ b/pkgs/development/tools/swiftformat/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, runCommand }:
+{ stdenv, lib, fetchFromGitHub }:
 
 # This derivation is impure: it relies on an Xcode toolchain being installed
 # and available in the expected place. The values of sandboxProfile and

--- a/pkgs/development/tools/trunk/default.nix
+++ b/pkgs/development/tools/trunk/default.nix
@@ -4,8 +4,6 @@ rustPlatform,
 fetchFromGitHub,
 pkg-config,
 openssl,
-jq,
-moreutils,
 CoreServices,
 SystemConfiguration
 }:

--- a/pkgs/development/web/cypress/default.nix
+++ b/pkgs/development/web/cypress/default.nix
@@ -1,6 +1,5 @@
 { alsa-lib
 , autoPatchelfHook
-, callPackage
 , fetchzip
 , gtk2
 , gtk3

--- a/pkgs/development/web/nodejs/v22.nix
+++ b/pkgs/development/web/nodejs/v22.nix
@@ -1,4 +1,4 @@
-{ callPackage, fetchpatch2, openssl, python3, enableNpm ? true }:
+{ callPackage, openssl, python3, enableNpm ? true }:
 
 let
   buildNodejs = callPackage ./nodejs.nix {


### PR DESCRIPTION
## Description of changes

A lot of progress has been made and over 2000 unused args of them were removed!
With previous bits, ocaml & python packages cleaned-up, there is few enough to to a whole pass on `pkgs/development`. 

- #313981

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
