### PR TITLE
pdf-sign: 0-unstable-2023-08-08 -> 0-unstable-2024-07-16

### DIFF
--- a/pkgs/by-name/pd/pdf-sign/package.nix
+++ b/pkgs/by-name/pd/pdf-sign/package.nix
@@ -1,27 +1,33 @@
-{ lib
-, stdenv
-, fetchFromGitHub
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
 
-, python3
-, ghostscript
-, pdftk
-, poppler_utils
-, makeBinaryWrapper
+  python3,
+  ghostscript,
+  qpdf,
+  poppler_utils,
+  makeBinaryWrapper,
 }:
 
 let
   python = python3.withPackages (ps: with ps; [ tkinter ]);
-  binPath = lib.makeBinPath [ ghostscript pdftk poppler_utils ];
+
+  binPath = lib.makeBinPath [
+    ghostscript
+    qpdf
+    poppler_utils
+  ];
 in
 stdenv.mkDerivation {
   pname = "pdf-sign";
-  version = "0-unstable-2023-08-08";
+  version = "0-unstable-2024-07-16";
 
   src = fetchFromGitHub {
     owner = "svenssonaxel";
     repo = "pdf-sign";
-    rev = "98742c6b12ebe2ca3ba375c695f43b52fe38b362";
-    hash = "sha256-5GRk0T1iLqmvWI8zvZE3OWEHPS0/zN/Ie9brjZiFpqc=";
+    rev = "6c373e3df2ac53af74ea84c3b5f299b13d7dae9c";
+    hash = "sha256-yx1ff1JMTydCd5sCIoiT30zRwxNEwFbgEM9++nkJKY4=";
   };
 
   nativeBuildInputs = [ makeBinaryWrapper ];
@@ -31,9 +37,10 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    install -Dm755 pdf-sign pdf-create-empty -t $out/bin
-    wrapProgram $out/bin/pdf-sign --prefix PATH : ${binPath}
-    wrapProgram $out/bin/pdf-create-empty --prefix PATH : ${binPath}
+    for exe in "pdf-sign" "pdf-create-empty" "pdf-from-text"; do
+      install -Dm755 $exe -t $out/bin
+      wrapProgram $out/bin/$exe --prefix PATH : ${binPath}
+    done
 
     runHook postInstall
   '';
@@ -47,4 +54,3 @@ stdenv.mkDerivation {
     platforms = lib.platforms.unix;
   };
 }
-


### PR DESCRIPTION
## Description of changes

This PR bumps the used git revision for the `pdf-sign` package.

The program now allows using either `pdftk` or `qpdf` for processing pdf files, so I changed `pdftk` over to `qpdf`, since that doesn't depend on `jdk`. (`jdk` has a big closure size).

A new executable was also added, so I used `for in` instead of code duplication

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
