### PR TITLE
goofcord: 1.5.0 -> 1.6.0; build from source

### DIFF
--- a/pkgs/by-name/go/goofcord/package.nix
+++ b/pkgs/by-name/go/goofcord/package.nix
@@ -1,148 +1,121 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  autoPatchelfHook,
-  dpkg,
-  makeShellWrapper,
-  wrapGAppsHook3,
-  alsa-lib,
-  at-spi2-atk,
-  at-spi2-core,
-  atk,
-  cairo,
-  cups,
-  dbus,
-  expat,
-  ffmpeg,
-  fontconfig,
-  freetype,
-  gdk-pixbuf,
-  glib,
-  gtk3,
-  libappindicator-gtk3,
-  libdrm,
-  libnotify,
-  libpulseaudio,
-  libsecret,
-  libuuid,
-  libxkbcommon,
-  mesa,
-  nss,
-  pango,
-  systemd,
-  xdg-utils,
-  xorg,
-  wayland,
+  fetchFromGitHub,
+  pnpm,
+  nodejs_22,
+  nix-update-script,
+  electron,
   pipewire,
+  libpulseaudio,
+  makeShellWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
 }:
 
+let
+  pnpm' = pnpm.override { nodejs = nodejs_22; };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "goofcord";
-  version = "1.5.0";
+  version = "1.6.0";
 
-  src =
-    let
-      base = "https://github.com/Milkshiift/GoofCord/releases/download";
-    in
-    {
-      x86_64-linux = fetchurl {
-        url = "${base}/v${finalAttrs.version}/GoofCord-${finalAttrs.version}-linux-amd64.deb";
-        hash = "sha256-T7z8myiNBaoDf04zynNhPekFtzoj435de09PVz8MWDM=";
-      };
-      aarch64-linux = fetchurl {
-        url = "${base}/v${finalAttrs.version}/GoofCord-${finalAttrs.version}-linux-arm64.deb";
-        hash = "sha256-u+qY1UWr9opjTBnIhqw62F9HYTdEnqagevJ+eg8XYr8=";
-      };
-    }
-    .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  src = fetchFromGitHub {
+    owner = "Milkshiift";
+    repo = "GoofCord";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-hG8nHAuEHw/tjFnGKhSXwO+2l91OOnQUIAK05SvEquU=";
+  };
 
   nativeBuildInputs = [
-    autoPatchelfHook
-    dpkg
+    pnpm'.configHook
+    nodejs_22
     makeShellWrapper
-    wrapGAppsHook3
+    copyDesktopItems
   ];
 
-  dontWrapGApps = true;
-
-  buildInputs = [
-    alsa-lib
-    at-spi2-atk
-    at-spi2-core
-    atk
-    cairo
-    cups
-    dbus
-    expat
-    ffmpeg
-    fontconfig
-    freetype
-    gdk-pixbuf
-    glib
-    gtk3
-    pango
-    systemd
-    mesa # for libgbm
-    nss
-    libuuid
-    libdrm
-    libnotify
-    libsecret
+  buildInputs = lib.optionals stdenv.isLinux [
     libpulseaudio
-    libxkbcommon
-    libappindicator-gtk3
-    xorg.libX11
-    xorg.libxcb
-    xorg.libXcomposite
-    xorg.libXcursor
-    xorg.libXdamage
-    xorg.libXext
-    xorg.libXfixes
-    xorg.libXi
-    xorg.libXrandr
-    xorg.libXrender
-    xorg.libXScrnSaver
-    xorg.libxshmfence
-    xorg.libXtst
-    wayland
     pipewire
+    stdenv.cc.cc.lib
   ];
 
-  sourceRoot = ".";
-  unpackCmd = "dpkg-deb -x $src .";
+  pnpmDeps = pnpm'.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-wF7G8rs1Fg7whEftQ554s4C2CixP5/1oFudR5yY07Rk=";
+  };
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm build
+
+    npm exec electron-builder -- \
+      --dir \
+      -c.electronDist="${electron}/libexec/electron" \
+      -c.electronVersion="${electron.version}"
+
+    runHook postBuild
+  '';
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p "$out/bin"
-    cp -R "opt" "$out"
-    cp -R "usr/share" "$out/share"
-    chmod -R g-w "$out"
+    mkdir -p "$out/share/lib/goofcord"
+    cp -r ./dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/goofcord"
+
+    install -Dm644 "build/icon.png" "$out/share/icons/hicolor/256x256/apps/goofcord.png"
 
     # use makeShellWrapper (instead of the makeBinaryWrapper provided by wrapGAppsHook3) for proper shell variable expansion
     # see https://github.com/NixOS/nixpkgs/issues/172583
-    makeShellWrapper $out/opt/GoofCord/goofcord $out/bin/goofcord \
+    makeShellWrapper "${lib.getExe electron}" "$out/bin/goofcord" \
+      --add-flags "$out/share/lib/goofcord/resources/app.asar" \
       "''${gappsWrapperArgs[@]}" \
-      --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=UseOzonePlatform,WaylandWindowDecorations,WebRTCPipeWireCapturer}}" \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath finalAttrs.buildInputs}" \
-      --suffix PATH : ${lib.makeBinPath [ xdg-utils ]}
-
-    # Fix desktop link
-    substituteInPlace $out/share/applications/goofcord.desktop \
-      --replace /opt/GoofCord/ ""
+      --set-default ELECTRON_IS_DEV 0 \
+      --inherit-argv0
 
     runHook postInstall
   '';
 
-  meta = with lib; {
+  desktopItems = [
+    (makeDesktopItem {
+      name = "goofcord";
+      genericName = "Internet Messenger";
+      desktopName = "GoofCord";
+      exec = "goofcord %U";
+      icon = "goofcord";
+      comment = finalAttrs.meta.description;
+      keywords = [
+        "discord"
+        "vencord"
+        "electron"
+        "chat"
+      ];
+      categories = [
+        "Network"
+        "InstantMessaging"
+        "Chat"
+      ];
+      startupWMClass = "GoofCord";
+      terminal = false;
+    })
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
     description = "Highly configurable and privacy-focused Discord client";
     homepage = "https://github.com/Milkshiift/GoofCord";
     downloadPage = "https://github.com/Milkshiift/GoofCord";
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    license = licenses.osl3;
-    maintainers = with maintainers; [ nyanbinary ];
+    license = lib.licenses.osl3;
+    maintainers = with lib.maintainers; [ nyanbinary ];
     platforms = [
       "x86_64-linux"
       "aarch64-linux"


### PR DESCRIPTION
## Description of changes
Updated GoofCord to 1.6.0
Build from source :3
Technically, GoofCord relies on Electron 31, but that isn't packaged in nixpkgs yet (#325428), I'm 95% sure it's fine though, since GoofCord doesn't rely on anything introduced in Electron 31
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
