### PR TITLE
photini: fix by using pyside6

### DIFF
--- a/pkgs/by-name/ph/photini/package.nix
+++ b/pkgs/by-name/ph/photini/package.nix
@@ -19,8 +19,7 @@ python3Packages.buildPythonApplication rec {
 
   build-system = with python3Packages; [ setuptools-scm ];
   dependencies = with python3Packages; [
-    pyqt6
-    pyqt6-webengine
+    pyside6
     cachetools
     appdirs
     chardet
@@ -33,6 +32,7 @@ python3Packages.buildPythonApplication rec {
     gpxpy
     keyring
     pillow
+    toml
   ];
 
   passthru.updateScript = gitUpdater { };


### PR DESCRIPTION
photini does not like the dev version of `pyqt6` because it fails to parse the version number at runtime. This PR changes the dependencies to use `pyside6` instead. Also the build fails if `toml` is not included in the dependencies so this PR adds it.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
