### PR TITLE
maintainers: temporarily remove myself (hiatus because of stress)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1449,7 +1449,7 @@
     name = "Anselm Schüler";
     matrix = "@schuelermine:matrix.org";
     keys = [ { fingerprint = "CDBF ECA8 36FE E340 1CEB  58FF BA34 EE1A BA3A 0955"; } ];
-  };
+  }; # currently on hiatus, please do not ping until this notice is removed (or if it’s been like two years)
   anthonyroussel = {
     email = "anthony@roussel.dev";
     github = "anthonyroussel";

--- a/pkgs/applications/graphics/curtail/default.nix
+++ b/pkgs/applications/graphics/curtail/default.nix
@@ -72,6 +72,6 @@ python3.pkgs.buildPythonApplication rec {
     mainProgram = "curtail";
     homepage = "https://github.com/Huluti/Curtail";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ anselmschueler ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/graphics/tesseract/tesseract5.nix
+++ b/pkgs/applications/graphics/tesseract/tesseract5.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     description = "OCR engine";
     homepage = "https://github.com/tesseract-ocr/tesseract";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ anselmschueler ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     mainProgram = "tesseract";
   };

--- a/pkgs/applications/misc/hollywood/default.nix
+++ b/pkgs/applications/misc/hollywood/default.nix
@@ -83,6 +83,6 @@ stdenv.mkDerivation {
     mainProgram = "hollywood";
     homepage = "https://a.hollywood.computer/";
     license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers.anselmschueler ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/networking/instant-messengers/fractal/default.nix
+++ b/pkgs/applications/networking/instant-messengers/fractal/default.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.gnome.org/GNOME/fractal";
     changelog = "https://gitlab.gnome.org/World/fractal/-/releases/${version}";
     license = licenses.gpl3Plus;
-    maintainers = teams.gnome.members ++ (with maintainers; [ anselmschueler ]);
+    maintainers = teams.gnome.members;
     platforms = platforms.linux;
     mainProgram = "fractal";
   };

--- a/pkgs/development/libraries/exprtk/default.nix
+++ b/pkgs/development/libraries/exprtk/default.nix
@@ -23,6 +23,6 @@ stdenv.mkDerivation rec {
     description = "C++ Mathematical Expression Toolkit Library";
     homepage = "https://www.partow.net/programming/exprtk/index.html";
     license = licenses.mit;
-    maintainers = with maintainers; [ anselmschueler ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/types-psutil/default.nix
+++ b/pkgs/development/python-modules/types-psutil/default.nix
@@ -23,6 +23,6 @@ buildPythonPackage rec {
     description = "Typing stubs for psutil";
     homepage = "https://github.com/python/typeshed";
     license = licenses.asl20;
-    maintainers = with maintainers; [ anselmschueler ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/tools/rust/genemichaels/default.nix
+++ b/pkgs/development/tools/rust/genemichaels/default.nix
@@ -18,6 +18,6 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "genemichaels";
     homepage = "https://github.com/andrewbaxter/genemichaels";
     license = lib.licenses.isc;
-    maintainers = [ lib.maintainers.anselmschueler ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/tools/misc/see/default.nix
+++ b/pkgs/tools/misc/see/default.nix
@@ -26,7 +26,7 @@ python3.pkgs.buildPythonApplication {
     description = "CLI tool to open files in the terminal";
     homepage = "https://github.com/Textualize/textualize-see";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ anselmschueler ];
+    maintainers = [ ];
     mainProgram = "see";
   };
 }


### PR DESCRIPTION
## Description of changes

- Removed `anselmschueler` from all package maintainer lists
- Added notice on `anselmschueler` entry in `maintainers/maintainer-list.nix` about hiatus

I want to take a break (and arguably have done so already) from maintaining (and even being nominally responsible for maintaining)
anything on nixpkgs, because I have a bunch of other stuff to do.

I intend to return in the near future. If I don’t return in like two years or something you can probably remove me fully (maybe ping me then).

Packages that now have no maintainers:
- `curtail`
- `tesseract5`
- `hollywood`
- `exprtk`
- `python3Packages.types-psutil`
- `genemichaels`
- `see`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
