### PR TITLE
Revert "nixos/podman: use given package for dockerCompat"

### DIFF
--- a/nixos/modules/virtualisation/podman/default.nix
+++ b/nixos/modules/virtualisation/podman/default.nix
@@ -5,7 +5,7 @@ let
 
   inherit (lib) mkOption types;
 
-  podmanPackage = (cfg.package.override {
+  podmanPackage = (pkgs.podman.override {
     extraPackages = cfg.extraPackages
       # setuid shadow
       ++ [ "/run/wrappers" ]


### PR DESCRIPTION
## Description of changes

This reverts commit df74ebcabb0252fa5e0a8a5d803d1e9d042ad3fb, which breaks eval when Podman is enabled [0].

I take full responsibility for merging this without looking too closely nor running the NixOS test.

[0]: https://github.com/NixOS/nixpkgs/commit/df74ebcabb0252fa5e0a8a5d803d1e9d042ad3fb#commitcomment-145003824

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - (n/a, but evals now)
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).