### PR TITLE
Add sphinx immaterial theme at version 12.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10148,6 +10148,12 @@
     name = "John Soo";
     githubId = 10039785;
   };
+  jsqu4re = {
+    email = "johannes.jeising+nixpkgs@gmail.com";
+    github = "jsqu4re";
+    name = "Johannes Jeising";
+    githubId = 35706792;
+  };
   jsusk = {
     email = "joshua@suskalo.org";
     github = "IGJoshua";

--- a/pkgs/development/python-modules/sphinx-immaterial/default.nix
+++ b/pkgs/development/python-modules/sphinx-immaterial/default.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  npmHooks,
+  setuptools-scm,
+  poetry-core,
+  nodejs_18,
+  sphinx,
+  pydantic,
+  pydantic-extra-types,
+  appdirs,
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-immaterial";
+  version = "0.12.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jbms";
+    repo = "sphinx-immaterial";
+    rev = "v${version}";
+    hash = "sha256-d+2xddIXithxMnypfQDqylJXKGMf4mgmN/eD8BPMpt8=";
+  };
+
+  build-system = [
+    poetry-core
+    setuptools-scm
+  ];
+
+  nativeBuildInputs = [
+    nodejs_18
+    npmHooks.npmConfigHook
+  ];
+
+  dependencies = [
+    sphinx
+    pydantic
+    pydantic-extra-types
+    appdirs
+  ];
+
+  env.npmDeps = fetchNpmDeps {
+    name = "sphinx-immaterial-npm-deps";
+    src = "${src}";
+    hash = "sha256-NUKCAsn3Y9/gDkez5NgnCMKoQm45JSvR/oAepChDAJg=";
+  };
+
+  meta = {
+    lib.description = "Adaptation of the popular mkdocs-material theme for the Sphinx documentation tool";
+    lib.longDescription = ''
+      This theme is regularly maintained to stay up to date with the upstream mkdocs-material repository.
+      The HTML templates, JavaScript, and styles from the mkdocs-material theme are incorporated directly
+      with mostly minor modifications.
+
+      Independent of the upstream mkdocs-material theme, this theme integrates with and significantly
+      extends Sphinx’s API documentation functionality.
+
+      This theme is a fork of the sphinx-material theme, which proved the concept of a Sphinx theme based
+      on an earlier version of the mkdocs-material theme, but has now significantly diverged from the
+      upstream mkdocs-material repository.
+    '';
+    lib.homepage = "https://jbms.github.io/sphinx-immaterial/";
+    lib.license = lib.licenses.mit;
+    lib.maintainers = with lib.maintainers; [ jsqu4re ];
+  };
+}


### PR DESCRIPTION
## Description of changes

From readme.md

    This theme is an adaptation of the popular mkdocs-material theme for the Sphinx documentation tool.

    This theme is regularly maintained to stay up to date with the upstream mkdocs-material repository.
    The HTML templates, JavaScript, and styles from the mkdocs-material theme are incorporated directly
    with mostly minor modifications.

    Independent of the upstream mkdocs-material theme, this theme integrates with and significantly
    extends Sphinx’s API documentation functionality.

    This theme is a fork of the sphinx-material theme, which proved the concept of a Sphinx theme based
    on an earlier version of the mkdocs-material theme, but has now significantly diverged from the
    upstream mkdocs-material repository.

It looks pretty good and is used in many places it also is growing continuously.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
