### PR TITLE
nixos/smokeping: do homedir management with systemd.tmpfiles

### DIFF
--- a/nixos/modules/services/networking/smokeping.nix
+++ b/nixos/modules/services/networking/smokeping.nix
@@ -313,11 +313,16 @@ in
       group = cfg.user;
       description = "smokeping daemon user";
       home = smokepingHome;
-      createHome = true;
-      # When `cfg.webService` is enabled, `nginx` requires read permissions on the home directory.
-      homeMode = "711";
     };
+
+    users.users.${config.services.nginx.user} = mkIf cfg.webService {
+      extraGroups = [
+        cfg.user ## user == group in this module
+      ];
+    };
+
     users.groups.${cfg.user} = { };
+
     systemd.services.smokeping = {
       reloadTriggers = [ configPath ];
       requiredBy = [ "multi-user.target" ];
@@ -327,14 +332,22 @@ in
         ExecStart = "${cfg.package}/bin/smokeping --config=/etc/smokeping.conf --nodaemon";
       };
       preStart = ''
-        mkdir -m 0755 -p ${smokepingHome}/cache ${smokepingHome}/data
-        ln -snf ${cfg.package}/htdocs/css ${smokepingHome}/css
-        ln -snf ${cfg.package}/htdocs/js ${smokepingHome}/js
-        ln -snf ${cgiHome} ${smokepingHome}/smokeping.fcgi
         ${cfg.package}/bin/smokeping --check --config=${configPath}
         ${cfg.package}/bin/smokeping --static --config=${configPath}
       '';
     };
+
+    systemd.tmpfiles.rules = [
+      # create cache and data directories
+      "d ${smokepingHome}/cache 0750 ${cfg.user} ${cfg.user}"
+      "d ${smokepingHome}/data 0750 ${cfg.user} ${cfg.user}"
+      # create symlings
+      "L+ ${smokepingHome}/css - - - - ${cfg.package}/htdocs/css"
+      "L+ ${smokepingHome}/js - - - - ${cfg.package}/htdocs/js"
+      "L+ ${smokepingHome}/smokeping.fcgi - - - - ${cgiHome}"
+      # recursively adjust access mode and ownership (in case config change)
+      "Z ${smokepingHome} 0750 ${cfg.user} ${cfg.user}"
+    ];
 
     # use nginx to serve the smokeping web service
     services.fcgiwrap.instances.smokeping = mkIf cfg.webService {
@@ -367,4 +380,3 @@ in
     nh2
   ];
 }
-


### PR DESCRIPTION
## Description of changes

There was a fix as part of https://github.com/NixOS/nixpkgs/pull/331465/files#diff-5dc9e8441124c077c1f7b0b5fd2a123f4633c6f55e448d007b2438afaf9793d8R331 to adapt smokeping state directory owners, in case of changes.

This "forward port" does this with `systemd.tmpfiles`, as well as tightens up security somewhat.

- ensures that everything in /var/lib/smokeping belongs to the service
- add nginx user to smokeping group, instead of allowing world to cd into somkeping homedir

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
