### PR TITLE
Added openmw-dev package for the latest development build of openmw

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19154,6 +19154,11 @@
     githubId = 9720532;
     name = "Sergei K";
   };
+  sonjiku = {
+    email = "50nj1ku@proton.me";
+    github = "sonjiku";
+    githubId = 57968409;
+  };
   sontek = {
     email = "sontek@gmail.com";
     github = "sontek";

--- a/pkgs/games/openmw/openmw-dev.nix
+++ b/pkgs/games/openmw/openmw-dev.nix
@@ -1,0 +1,136 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, fetchpatch
+, cmake
+, pkg-config
+, wrapQtAppsHook
+, SDL2
+, CoreMedia
+, VideoToolbox
+, VideoDecodeAcceleration
+, boost
+, bullet
+, ffmpeg
+, libXt
+, luajit
+, lz4
+, mygui
+, openal
+, openscenegraph
+, recastnavigation
+, unshield
+, yaml-cpp
+}:
+
+let
+  GL = "GLVND"; # or "LEGACY";
+
+    mygui' = pkgs.mygui.overrideAttrs (finalAttrs: previousAttrs: {
+        pname = "mygui";
+        version = "3.4.3";
+
+        src = pkgs.fetchFromGitHub {
+            owner = "MyGUI";
+            repo = "mygui";
+            rev = "MyGUI${finalAttrs.version}";
+            hash = "sha256-qif9trHgtWpYiDVXY3cjRsXypjjjgStX8tSWCnXhXlk=";
+        };
+
+        patches = [];
+
+        cmakeFlags = previousAttrs.cmakeFlags ++ [
+            "-DMYGUI_RENDERSYSTEM=1"
+            "-DMYGUI_BUILD_DEMOS=OFF"
+            "-DMYGUI_BUILD_TOOLS=OFF"
+            "-DMYGUI_BUILD_PLUGINS=OFF"
+            "-DMYGUI_DONT_USE_OBSOLETE=ON"
+        ];
+    });
+
+    osg' = (openscenegraph.override { colladaSupport = true; }).overrideDerivation (old: {
+      patches = [
+        (fetchpatch {
+          # Darwin: Without this patch, OSG won't build osgdb_png.so, which is required by OpenMW.
+          name = "darwin-osg-plugins-fix.patch";
+          url = "https://gitlab.com/OpenMW/openmw-dep/-/raw/0abe3c9c3858211028d881d7706813d606335f72/macos/osg.patch";
+          sha256 = "sha256-/CLRZofZHot8juH78VG1/qhTHPhy5DoPMN+oH8hC58U=";
+        })
+      ];
+
+      cmakeFlags = (old.cmakeFlags or [ ]) ++ [
+        "-Wno-dev"
+        "-DOpenGL_GL_PREFERENCE=${GL}"
+        "-DBUILD_OSG_PLUGINS_BY_DEFAULT=0"
+        "-DBUILD_OSG_DEPRECATED_SERIALIZERS=0"
+      ] ++ (map (e: "-DBUILD_OSG_PLUGIN_${e}=1") [ "BMP" "DAE" "DDS" "FREETYPE" "JPEG" "OSG" "PNG" "TGA" ]);
+    });
+
+  bullet' = bullet.overrideDerivation (old: {
+    cmakeFlags = (old.cmakeFlags or [ ]) ++ [
+      "-Wno-dev"
+      "-DOpenGL_GL_PREFERENCE=${GL}"
+      "-DUSE_DOUBLE_PRECISION=ON"
+      "-DBULLET2_MULTITHREADING=ON"
+    ];
+  });
+
+in
+stdenv.mkDerivation rec {
+  pname = "openmw-dev";
+  version = "4.8.0";
+
+  src = fetchFromGitLab {
+    owner = "OpenMW";
+    repo = "openmw";
+    rev = "488a05d14cdd7ed21c0c7d6433fcb607df7538ae";
+    hash = "sha256-zkjVt3GfQZsFXl2Ht3lCuQtDMYQWxhdFO4aGSb3rsyo=";
+  };
+
+  postPatch = ''
+    sed '1i#include <memory>' -i components/myguiplatform/myguidatamanager.cpp # gcc12
+  '' + lib.optionalString stdenv.isDarwin ''
+    # Don't fix Darwin app bundle
+    sed -i '/fixup_bundle/d' CMakeLists.txt
+  '';
+
+  nativeBuildInputs = [ cmake pkg-config wrapQtAppsHook ];
+
+  # If not set, OSG plugin .so files become shell scripts on Darwin.
+  dontWrapQtApps = stdenv.isDarwin;
+
+  buildInputs = [
+    SDL2
+    boost
+    bullet'
+    ffmpeg
+    libXt
+    luajit
+    lz4
+    mygui'
+    openal
+    osg'
+    recastnavigation
+    unshield
+    yaml-cpp
+  ] ++ lib.optionals stdenv.isDarwin [
+    CoreMedia
+    VideoDecodeAcceleration
+    VideoToolbox
+  ];
+
+  cmakeFlags = [
+    "-DOpenGL_GL_PREFERENCE=${GL}"
+    "-DOPENMW_USE_SYSTEM_RECASTNAVIGATION=1"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "-DOPENMW_OSX_DEPLOYMENT=ON"
+  ];
+
+  meta = with lib; {
+    description = "Unofficial open source engine reimplementation of the game Morrowind";
+    homepage = "https://openmw.org";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ abbradar marius851000 ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36366,6 +36366,10 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreMedia VideoDecodeAcceleration VideoToolbox;
   };
 
+  openmw-dev = libsForQt5.callPackage ../games/openmw/openmw-dev.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreMedia VideoDecodeAcceleration VideoToolbox;
+  };
+
   openmw-tes3mp = libsForQt5.callPackage ../games/openmw/tes3mp.nix { };
 
   opensoldat = callPackage ../games/opensoldat { };


### PR DESCRIPTION
## Description of changes

Added a separate package for the latest dev build of OpenMW

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
