### PR TITLE
maintainers: add pbsbot

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15684,6 +15684,12 @@
     githubId = 434254;
     name = "Pavel Borzenkov";
   };
+  pbsbot = {
+    name = "pbsds bot";
+    email = "pbsbot@pbsds.net";
+    github = "pbsbot";
+    githubId = 11412567;
+  };
   pbsds = {
     name = "Peder Bergebakken Sundt";
     email = "pbsds@hotmail.com";


### PR DESCRIPTION
## Description of changes

I want to experiment with a bot that is able to change labels on github.
However I do not want to put a commit bit access key in `/run/secrets`, hence why i am reviving this old bot account @pbsbot i made a long time ago.

How to and whether to differentiate this entry as a bot and not a human is discussable. I've considered adding a team:

```patch
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -94,6 +94,14 @@ with lib.maintainers;
     shortName = "Blockchains";
   };
 
+  bot-accounts = {
+    members = [
+      pbsbot
+    ];
+    scope = "Bot accounts that interact with nixpkgs, may be user-run.";
+    shortName = "Bots";
+  };
+
   budgie = {
     members = [
       bobby285271
```

or extending the `lib.maintainers` schema

```patch
--- a/lib/tests/maintainer-module.nix
+++ b/lib/tests/maintainer-module.nix
@@ -22,6 +22,10 @@ in {
       type = types.nullOr types.ints.unsigned;
       default = null;
     };
+    isBot = lib.mkOption {
+      type = types.bool;
+      default = false;
+    };
     keys = lib.mkOption {
       type = types.listOf (types.submodule {
         options.fingerprint = lib.mkOption { type = types.str; };
```

But feel like doing neither for such a silly thing.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
