### PR TITLE
photoqt: 4.5 -> 4.6

### DIFF
--- a/pkgs/by-name/ph/photoqt/package.nix
+++ b/pkgs/by-name/ph/photoqt/package.nix
@@ -17,11 +17,11 @@
 
 stdenv.mkDerivation rec {
   pname = "photoqt";
-  version = "4.5";
+  version = "4.6";
 
   src = fetchurl {
     url = "https://photoqt.org/pkgs/photoqt-${version}.tar.gz";
-    hash = "sha256-QFziMNRhiM4LaNJ8RkJ0iCq/8J82wn0F594qJeSN3Lw=";
+    hash = "sha256-5VbGMJ1B9yDbTiri7SZ+r+c9LdfG/C1c0/01QBUvbCY=";
   };
 
   nativeBuildInputs = [
@@ -31,30 +31,35 @@ stdenv.mkDerivation rec {
     qt6.wrapQtAppsHook
   ];
 
-  buildInputs = [
-    exiv2
-    graphicsmagick
-    libarchive
-    libraw
-    mpv
-    pugixml
-    qt6.qtbase
-    qt6.qtcharts
-    qt6.qtdeclarative
-    qt6.qtimageformats
-    qt6.qtlocation
-    qt6.qtmultimedia
-    qt6.qtpositioning
-    qt6.qtsvg
-    qt6Packages.poppler
-    zxing-cpp
-  ] ++ lib.optionals stdenv.isLinux [ qt6.qtwayland ];
+  buildInputs =
+    [
+      exiv2
+      graphicsmagick
+      libarchive
+      libraw
+      pugixml
+      qt6.qtbase
+      qt6.qtcharts
+      qt6.qtdeclarative
+      qt6.qtimageformats
+      qt6.qtlocation
+      qt6.qtmultimedia
+      qt6.qtpositioning
+      qt6.qtsvg
+      qt6Packages.poppler
+      zxing-cpp
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      mpv
+      qt6.qtwayland
+    ];
 
   cmakeFlags = [
     (lib.cmakeBool "DEVIL" false)
     (lib.cmakeBool "CHROMECAST" false)
     (lib.cmakeBool "FREEIMAGE" false)
     (lib.cmakeBool "IMAGEMAGICK" false)
+    (lib.cmakeBool "VIDEO_MPV" (!stdenv.isDarwin))
   ];
 
   env.MAGICK_LOCATION = "${graphicsmagick}/include/GraphicsMagick";

--- a/pkgs/by-name/ph/photoqt/package.nix
+++ b/pkgs/by-name/ph/photoqt/package.nix
@@ -1,27 +1,18 @@
-{ lib
-, stdenv
-, fetchurl
-, cmake
-, extra-cmake-modules
-, qttools
-, wrapQtAppsHook
-, exiv2
-, graphicsmagick
-, libarchive
-, libraw
-, mpv
-, poppler
-, pugixml
-, qtbase
-, qtcharts
-, qtdeclarative
-, qtimageformats
-, qtlocation
-, qtmultimedia
-, qtpositioning
-, qtsvg
-, zxing-cpp
-, qtwayland
+{
+  lib,
+  stdenv,
+  fetchurl,
+  cmake,
+  extra-cmake-modules,
+  exiv2,
+  graphicsmagick,
+  libarchive,
+  libraw,
+  mpv,
+  pugixml,
+  qt6,
+  qt6Packages,
+  zxing-cpp,
 }:
 
 stdenv.mkDerivation rec {
@@ -36,8 +27,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     extra-cmake-modules
-    qttools
-    wrapQtAppsHook
+    qt6.qttools
+    qt6.wrapQtAppsHook
   ];
 
   buildInputs = [
@@ -46,20 +37,18 @@ stdenv.mkDerivation rec {
     libarchive
     libraw
     mpv
-    poppler
     pugixml
-    qtbase
-    qtcharts
-    qtdeclarative
-    qtimageformats
-    qtlocation
-    qtmultimedia
-    qtpositioning
-    qtsvg
+    qt6.qtbase
+    qt6.qtcharts
+    qt6.qtdeclarative
+    qt6.qtimageformats
+    qt6.qtlocation
+    qt6.qtmultimedia
+    qt6.qtpositioning
+    qt6.qtsvg
+    qt6Packages.poppler
     zxing-cpp
-  ] ++ lib.optionals stdenv.isLinux [
-    qtwayland
-  ];
+  ] ++ lib.optionals stdenv.isLinux [ qt6.qtwayland ];
 
   cmakeFlags = [
     (lib.cmakeBool "DEVIL" false)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33076,7 +33076,9 @@ with pkgs;
 
   phantomsocks = callPackage ../tools/networking/phantomsocks { };
 
-  photoqt = qt6Packages.callPackage ../applications/graphics/photoqt { };
+  photoqt = callPackage ../by-name/ph/photoqt/package.nix {
+    stdenv = if stdenv.isDarwin then overrideSDK stdenv "11.0" else stdenv;
+  };
 
   photoflare = libsForQt5.callPackage ../applications/graphics/photoflare { };
 


### PR DESCRIPTION
## Description of changes

https://photoqt.org/changelog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
