### PR TITLE
python3Packages.ffmpeg-python: 0.2.0 -> 0.2.0-unstable-2022-07-11; patch out future dependency; add patches for FFmpeg 7

### DIFF
--- a/pkgs/development/python-modules/ffmpeg-python/default.nix
+++ b/pkgs/development/python-modules/ffmpeg-python/default.nix
@@ -52,6 +52,6 @@ buildPythonPackage rec {
     description = "Python bindings for FFmpeg - with complex filtering support";
     homepage = "https://github.com/kkroening/ffmpeg-python";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.emily ];
   };
 }

--- a/pkgs/development/python-modules/ffmpeg-python/default.nix
+++ b/pkgs/development/python-modules/ffmpeg-python/default.nix
@@ -7,7 +7,7 @@
   setuptools,
   pytestCheckHook,
   pytest-mock,
-  ffmpeg_4,
+  ffmpeg_7,
 }:
 
 buildPythonPackage {
@@ -25,7 +25,7 @@ buildPythonPackage {
   patches = [
     (substituteAll {
       src = ./ffmpeg-location.patch;
-      ffmpeg = ffmpeg_4;
+      ffmpeg = ffmpeg_7;
     })
 
     # Remove dependency on `future`
@@ -33,6 +33,20 @@ buildPythonPackage {
     (fetchpatch2 {
       url = "https://github.com/kkroening/ffmpeg-python/commit/dce459d39ace25f03edbabdad1735064787568f7.patch?full_index=1";
       hash = "sha256-ZptCFplL88d0p2s741ymHiwyDsDGVFylBJ8FTrZDGMc=";
+    })
+
+    # Fix ffmpeg/tests/test_ffmpeg.py: test_pipe() (v1: ignore duplicate frames)
+    # https://github.com/kkroening/ffmpeg-python/pull/726
+    (fetchpatch2 {
+      url = "https://github.com/kkroening/ffmpeg-python/commit/557ed8e81ff48c5931c9249ec4aae525347ecf85.patch?full_index=1";
+      hash = "sha256-XrL9yLaBg1tu63OYZauEb/4Ghp2zHtiF6vB+1YYbv1Y=";
+    })
+
+    # Fix `test__probe` on FFmpeg 7
+    # https://github.com/kkroening/ffmpeg-python/pull/848
+    (fetchpatch2 {
+      url = "https://github.com/kkroening/ffmpeg-python/commit/eeaa83398ba1d4e5b470196f7d4c7ca4ba9e8ddf.patch?full_index=1";
+      hash = "sha256-/qxez4RF/RPRr9nA+wp+XB49L3VNgnMwMQhFD2NwijU=";
     })
   ];
 

--- a/pkgs/development/python-modules/ffmpeg-python/default.nix
+++ b/pkgs/development/python-modules/ffmpeg-python/default.nix
@@ -8,19 +8,18 @@
   pytestCheckHook,
   pytest-mock,
   ffmpeg_4,
-  pythonAtLeast,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "ffmpeg-python";
-  version = "0.2.0";
+  version = "0.2.0-unstable-2022-07-11";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "kkroening";
     repo = "ffmpeg-python";
-    rev = version;
-    hash = "sha256-Dk3nHuYVlIiFF6nORZ5TVFkBXdoZUxLfoiz68V1tvlY=";
+    rev = "df129c7ba30aaa9ffffb81a48f53aa7253b0b4e6";
+    hash = "sha256-jPiFhYRwfuS+vo6LsLw0+65NWy2A+B+EdC8SewZTRP4=";
   };
 
   patches = [
@@ -39,14 +38,7 @@ buildPythonPackage rec {
     pytest-mock
   ];
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "'pytest-runner'" ""
-  '';
-
   pythonImportsCheck = [ "ffmpeg" ];
-
-  disabledTests = lib.optionals (pythonAtLeast "3.10") [ "test__output__video_size" ];
 
   meta = {
     description = "Python bindings for FFmpeg - with complex filtering support";

--- a/pkgs/development/python-modules/ffmpeg-python/default.nix
+++ b/pkgs/development/python-modules/ffmpeg-python/default.nix
@@ -3,8 +3,8 @@
   buildPythonPackage,
   fetchFromGitHub,
   substituteAll,
+  fetchpatch2,
   setuptools,
-  future,
   pytestCheckHook,
   pytest-mock,
   ffmpeg_4,
@@ -27,11 +27,16 @@ buildPythonPackage {
       src = ./ffmpeg-location.patch;
       ffmpeg = ffmpeg_4;
     })
+
+    # Remove dependency on `future`
+    # https://github.com/kkroening/ffmpeg-python/pull/795
+    (fetchpatch2 {
+      url = "https://github.com/kkroening/ffmpeg-python/commit/dce459d39ace25f03edbabdad1735064787568f7.patch?full_index=1";
+      hash = "sha256-ZptCFplL88d0p2s741ymHiwyDsDGVFylBJ8FTrZDGMc=";
+    })
   ];
 
   build-system = [ setuptools ];
-
-  dependencies = [ future ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/ffmpeg-python/default.nix
+++ b/pkgs/development/python-modules/ffmpeg-python/default.nix
@@ -2,21 +2,19 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  ffmpeg_4,
-  future,
-  pytest-mock,
-  pytestCheckHook,
-  pythonAtLeast,
-  pythonOlder,
   substituteAll,
+  setuptools,
+  future,
+  pytestCheckHook,
+  pytest-mock,
+  ffmpeg_4,
+  pythonAtLeast,
 }:
 
 buildPythonPackage rec {
   pname = "ffmpeg-python";
   version = "0.2.0";
-  format = "setuptools";
-
-  disabled = pythonOlder "3.7";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "kkroening";
@@ -25,18 +23,20 @@ buildPythonPackage rec {
     hash = "sha256-Dk3nHuYVlIiFF6nORZ5TVFkBXdoZUxLfoiz68V1tvlY=";
   };
 
-  propagatedBuildInputs = [ future ];
-
-  nativeCheckInputs = [
-    pytestCheckHook
-    pytest-mock
-  ];
-
   patches = [
     (substituteAll {
       src = ./ffmpeg-location.patch;
       ffmpeg = ffmpeg_4;
     })
+  ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [ future ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-mock
   ];
 
   postPatch = ''
@@ -48,10 +48,10 @@ buildPythonPackage rec {
 
   disabledTests = lib.optionals (pythonAtLeast "3.10") [ "test__output__video_size" ];
 
-  meta = with lib; {
+  meta = {
     description = "Python bindings for FFmpeg - with complex filtering support";
     homepage = "https://github.com/kkroening/ffmpeg-python";
-    license = licenses.asl20;
+    license = lib.licenses.asl20;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ffmpeg-python/ffmpeg-location.patch
+++ b/pkgs/development/python-modules/ffmpeg-python/ffmpeg-location.patch
@@ -1,21 +1,21 @@
-diff --git i/ffmpeg/_probe.py w/ffmpeg/_probe.py
-index 41e8168..eb83b54 100644
---- i/ffmpeg/_probe.py
-+++ w/ffmpeg/_probe.py
-@@ -4,7 +4,7 @@ from ._run import Error
+diff --git a/ffmpeg/_probe.py b/ffmpeg/_probe.py
+index 090d7abf9e..07fb4d9459 100644
+--- a/ffmpeg/_probe.py
++++ b/ffmpeg/_probe.py
+@@ -4,7 +4,7 @@
  from ._utils import convert_kwargs_to_cmd_line_args
  
  
--def probe(filename, cmd='ffprobe', **kwargs):
-+def probe(filename, cmd='@ffmpeg@/bin/ffprobe', **kwargs):
+-def probe(filename, cmd='ffprobe', timeout=None, **kwargs):
++def probe(filename, cmd='@ffmpeg@/bin/ffprobe', timeout=None, **kwargs):
      """Run ffprobe on the specified file and return a JSON representation of the output.
  
      Raises:
-diff --git i/ffmpeg/_run.py w/ffmpeg/_run.py
-index afc504d..9445cca 100644
---- i/ffmpeg/_run.py
-+++ w/ffmpeg/_run.py
-@@ -172,7 +172,7 @@ def get_args(stream_spec, overwrite_output=False):
+diff --git a/ffmpeg/_run.py b/ffmpeg/_run.py
+index f42d1d7309..d3e1df9c80 100644
+--- a/ffmpeg/_run.py
++++ b/ffmpeg/_run.py
+@@ -174,7 +174,7 @@
  
  
  @output_operator()
@@ -23,8 +23,8 @@ index afc504d..9445cca 100644
 +def compile(stream_spec, cmd='@ffmpeg@/bin/ffmpeg', overwrite_output=False):
      """Build command-line for invoking ffmpeg.
  
-     The :meth:`run` function uses this to build the commnad line
-@@ -193,7 +193,7 @@ def compile(stream_spec, cmd='ffmpeg', overwrite_output=False):
+     The :meth:`run` function uses this to build the command line
+@@ -195,7 +195,7 @@
  @output_operator()
  def run_async(
      stream_spec,
@@ -33,7 +33,7 @@ index afc504d..9445cca 100644
      pipe_stdin=False,
      pipe_stdout=False,
      pipe_stderr=False,
-@@ -289,7 +289,7 @@ def run_async(
+@@ -299,7 +299,7 @@
  @output_operator()
  def run(
      stream_spec,
@@ -42,11 +42,11 @@ index afc504d..9445cca 100644
      capture_stdout=False,
      capture_stderr=False,
      input=None,
-diff --git i/ffmpeg/tests/test_ffmpeg.py w/ffmpeg/tests/test_ffmpeg.py
-index 279a323..8d3b35c 100644
---- i/ffmpeg/tests/test_ffmpeg.py
-+++ w/ffmpeg/tests/test_ffmpeg.py
-@@ -24,7 +24,7 @@ TEST_OUTPUT_FILE2 = os.path.join(SAMPLE_DATA_DIR, 'out2.mp4')
+diff --git a/ffmpeg/tests/test_ffmpeg.py b/ffmpeg/tests/test_ffmpeg.py
+index 8dbc271a79..168e662e8d 100644
+--- a/ffmpeg/tests/test_ffmpeg.py
++++ b/ffmpeg/tests/test_ffmpeg.py
+@@ -26,7 +26,7 @@
  BOGUS_INPUT_FILE = os.path.join(SAMPLE_DATA_DIR, 'bogus')
  
  
@@ -55,7 +55,13 @@ index 279a323..8d3b35c 100644
  
  
  def test_escape_chars():
-@@ -423,7 +423,7 @@ def test_filter_text_arg_str_escape():
+@@ -450,12 +450,12 @@
+ 
+ 
+ # def test_version():
+-#    subprocess.check_call(['ffmpeg', '-version'])
++#    subprocess.check_call(['@ffmpeg@/bin/ffmpeg', '-version'])
+ 
  
  def test__compile():
      out_file = ffmpeg.input('dummy.mp4').output('dummy2.mp4')
@@ -64,7 +70,7 @@ index 279a323..8d3b35c 100644
      assert out_file.compile(cmd='ffmpeg.old') == [
          'ffmpeg.old',
          '-i',
-@@ -490,7 +490,7 @@ def test__run__input_output(mocker):
+@@ -530,7 +530,7 @@
  @pytest.mark.parametrize('capture_stdout', [True, False])
  @pytest.mark.parametrize('capture_stderr', [True, False])
  def test__run__error(mocker, capture_stdout, capture_stderr):
@@ -73,12 +79,12 @@ index 279a323..8d3b35c 100644
      stream = _get_complex_filter_example()
      with pytest.raises(ffmpeg.Error) as excinfo:
          out, err = ffmpeg.run(
-@@ -684,7 +684,7 @@ def test_pipe():
+@@ -724,7 +724,7 @@
          'pipe:1',
      ]
  
 -    cmd = ['ffmpeg'] + args
 +    cmd = ['@ffmpeg@/bin/ffmpeg'] + args
      p = subprocess.Popen(
-         cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-     )
+         cmd,
+         stdin=subprocess.PIPE,


### PR DESCRIPTION
## Description of changes

I think it’s cool when the number of things that depend on FFmpeg 4 goes down.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
