### PR TITLE
treewide: retire late maintainer AluisioASG

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1053,13 +1053,6 @@
     githubId = 45176912;
     name = "Tomasz Hołubowicz";
   };
-  AluisioASG = {
-    name = "Aluísio Augusto Silva Gonçalves";
-    email = "aluisio@aasg.name";
-    github = "AluisioASG";
-    githubId = 1904165;
-    keys = [ { fingerprint = "7FDB 17B3 C29B 5BA6 E5A9  8BB2 9FAA 63E0 9750 6D9D"; } ];
-  };
   alunduil = {
     email = "alunduil@gmail.com";
     github = "alunduil";

--- a/pkgs/applications/audio/r128gain/default.nix
+++ b/pkgs/applications/audio/r128gain/default.nix
@@ -39,7 +39,7 @@ python3Packages.buildPythonApplication rec {
     mainProgram = "r128gain";
     homepage = "https://github.com/desbma/r128gain";
     license = licenses.lgpl2Plus;
-    maintainers = [ maintainers.AluisioASG ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/networking/dyndns/dyndnsc/default.nix
+++ b/pkgs/applications/networking/dyndns/dyndnsc/default.nix
@@ -75,7 +75,7 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/infothrill/python-dyndnsc";
     changelog = "https://github.com/infothrill/python-dyndnsc/releases/tag/${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ AluisioASG ];
+    maintainers = [ ];
     mainProgram = "dyndnsc";
     platforms = platforms.unix;
   };

--- a/pkgs/by-name/ha/haunt/package.nix
+++ b/pkgs/by-name/ha/haunt/package.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
       to do things that aren't provided out-of-the-box.
     '';
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ AndersonTorres AluisioASG ];
+    maintainers = with lib.maintainers; [ AndersonTorres ];
     inherit (guile.meta) platforms;
   };
 })

--- a/pkgs/data/fonts/iosevka/default.nix
+++ b/pkgs/data/fonts/iosevka/default.nix
@@ -138,7 +138,6 @@ buildNpmPackage rec {
     maintainers = with maintainers; [
       ttuegel
       rileyinman
-      AluisioASG
       lunik1
     ];
   };

--- a/pkgs/development/python-modules/daemonocle/default.nix
+++ b/pkgs/development/python-modules/daemonocle/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
     '';
     homepage = "https://github.com/jnrbsn/daemonocle";
     license = licenses.mit;
-    maintainers = with maintainers; [ AluisioASG ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/ffmpeg-python/default.nix
+++ b/pkgs/development/python-modules/ffmpeg-python/default.nix
@@ -52,6 +52,6 @@ buildPythonPackage rec {
     description = "Python bindings for FFmpeg - with complex filtering support";
     homepage = "https://github.com/kkroening/ffmpeg-python";
     license = licenses.asl20;
-    maintainers = with maintainers; [ AluisioASG ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/json-logging/default.nix
+++ b/pkgs/development/python-modules/json-logging/default.nix
@@ -69,6 +69,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/bobbui/json-logging-python";
     changelog = "https://github.com/bobbui/json-logging-python/releases/tag/${version}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ AluisioASG ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/linkify-it-py/default.nix
+++ b/pkgs/development/python-modules/linkify-it-py/default.nix
@@ -34,6 +34,6 @@ buildPythonPackage rec {
     description = "Links recognition library with full unicode support";
     homepage = "https://github.com/tsutsu3/linkify-it-py";
     license = licenses.mit;
-    maintainers = with maintainers; [ AluisioASG ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/mdit-py-plugins/default.nix
+++ b/pkgs/development/python-modules/mdit-py-plugins/default.nix
@@ -39,6 +39,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/executablebooks/mdit-py-plugins";
     changelog = "https://github.com/executablebooks/mdit-py-plugins/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ AluisioASG ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/openapi-schema-validator/default.nix
+++ b/pkgs/development/python-modules/openapi-schema-validator/default.nix
@@ -58,6 +58,6 @@ buildPythonPackage rec {
     description = "Validates OpenAPI schema against the OpenAPI Schema Specification v3.0";
     homepage = "https://github.com/python-openapi/openapi-schema-validator";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ AluisioASG ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pytest-console-scripts/default.nix
+++ b/pkgs/development/python-modules/pytest-console-scripts/default.nix
@@ -47,6 +47,6 @@ buildPythonPackage rec {
     '';
     homepage = "https://github.com/kvas-it/pytest-console-scripts";
     license = licenses.mit;
-    maintainers = with maintainers; [ AluisioASG ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pytest-regressions/default.nix
+++ b/pkgs/development/python-modules/pytest-regressions/default.nix
@@ -76,6 +76,6 @@ buildPythonPackage rec {
     '';
     homepage = "https://github.com/ESSS/pytest-regressions";
     license = licenses.mit;
-    maintainers = with maintainers; [ AluisioASG ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/rfc3339-validator/default.nix
+++ b/pkgs/development/python-modules/rfc3339-validator/default.nix
@@ -32,6 +32,6 @@ buildPythonPackage rec {
     description = "RFC 3339 validator for Python";
     homepage = "https://github.com/naimetti/rfc3339-validator";
     license = licenses.mit;
-    maintainers = with maintainers; [ AluisioASG ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/sanic-routing/default.nix
+++ b/pkgs/development/python-modules/sanic-routing/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/sanic-org/sanic-routing";
     changelog = "https://github.com/sanic-org/sanic-routing/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ AluisioASG ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/sanic-testing/default.nix
+++ b/pkgs/development/python-modules/sanic-testing/default.nix
@@ -53,6 +53,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/sanic-org/sanic-testing";
     changelog = "https://github.com/sanic-org/sanic-testing/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ AluisioASG ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/sanic/default.nix
+++ b/pkgs/development/python-modules/sanic/default.nix
@@ -168,6 +168,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/sanic-org/sanic/";
     changelog = "https://github.com/sanic-org/sanic/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ AluisioASG ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/uc-micro-py/default.nix
+++ b/pkgs/development/python-modules/uc-micro-py/default.nix
@@ -31,6 +31,6 @@ buildPythonPackage rec {
     description = "Micro subset of unicode data files for linkify-it-py";
     homepage = "https://github.com/tsutsu3/uc.micro-py";
     license = licenses.mit;
-    maintainers = with maintainers; [ AluisioASG ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
I’ve sadly become aware that Aluísio Augusto Silva Gonçalves (@AluisioASG), a contributor to Nixpkgs until 2021, tragically [passed away that year] at the age of only 25 from complications caused by COVID‐19.

[passed away that year]: https://ufpr.br/ufpr-lamenta-a-morte-do-estudante-aluisio-augusto-silva-goncalves-25-anos/

It doesn’t feel respectful of this loss to have a bot ping his account every time Iosevka gets an update, or to have people expect reviews or support for the packages he maintained, so let’s retire his maintainer list entry.

I’ll adopt ffmpeg-python in my concurrent pull request, but there are a lot of other packages that could use new maintainers. I encourage people to consider continuing his work on Nixpkgs if any of them are of interest.

On the off chance that any of his family or friends ever see this message, I wish I could say more than that I’m sorry for your loss.