### PR TITLE
nixos/k3s: add containerdConfigTemplate option

### DIFF
--- a/nixos/tests/k3s/containerd-config.nix
+++ b/nixos/tests/k3s/containerd-config.nix
@@ -1,0 +1,52 @@
+# A test that containerdConfigTemplate settings get written to containerd/config.toml
+import ../make-test-python.nix (
+  { lib, k3s, ... }:
+  let
+    nodeName = "test";
+  in
+  {
+    name = "${k3s.name}-containerd-config";
+    nodes.machine =
+      { ... }:
+      {
+        # k3s uses enough resources the default vm fails.
+        virtualisation.memorySize = 1536;
+        virtualisation.diskSize = 4096;
+
+        services.k3s = {
+          enable = true;
+          package = k3s;
+          # Slightly reduce resource usage
+          extraFlags = [
+            "--disable coredns"
+            "--disable local-storage"
+            "--disable metrics-server"
+            "--disable servicelb"
+            "--disable traefik"
+            "--node-name ${nodeName}"
+          ];
+          containerdConfigTemplate = ''
+            # Base K3s config
+            {{ template "base" . }}
+
+            # MAGIC COMMENT
+          '';
+        };
+      };
+
+    testScript = ''
+      start_all()
+      machine.wait_for_unit("k3s")
+      # wait until the node is ready
+      machine.wait_until_succeeds(r"""kubectl wait --for='jsonpath={.status.conditions[?(@.type=="Ready")].status}=True' nodes/${nodeName}""")
+      # test whether the config template file contains the magic comment
+      out=machine.succeed("cat /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl")
+      assert "MAGIC COMMENT" in out, "the containerd config template does not contain the magic comment"
+      # test whether the config file contains the magic comment
+      out=machine.succeed("cat /var/lib/rancher/k3s/agent/etc/containerd/config.toml")
+      assert "MAGIC COMMENT" in out, "the containerd config does not contain the magic comment"
+    '';
+
+    meta.maintainers = lib.teams.k3s.members;
+  }
+)

--- a/nixos/tests/k3s/default.nix
+++ b/nixos/tests/k3s/default.nix
@@ -11,6 +11,9 @@ in
     _: k3s: import ./airgap-images.nix { inherit system pkgs k3s; }
   ) allK3s;
   auto-deploy = lib.mapAttrs (_: k3s: import ./auto-deploy.nix { inherit system pkgs k3s; }) allK3s;
+  containerd-config = lib.mapAttrs (
+    _: k3s: import ./containerd-config.nix { inherit system pkgs k3s; }
+  ) allK3s;
   etcd = lib.mapAttrs (
     _: k3s:
     import ./etcd.nix {


### PR DESCRIPTION
## Description of changes

K3S provides the ability to configure containerd, described [here](https://docs.k3s.io/advanced#configuring-containerd). This PR adds the option `containerdConfigTemplate` to expose this.

You can use it to add any containerd config. In my case, I wanted to add extra runtimes in order to enable [Kata containers](https://github.com/kata-containers/kata-containers).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
