### PR TITLE
castor: 0.14.0 -> 0.17.1

### DIFF
--- a/pkgs/development/php-packages/castor/default.nix
+++ b/pkgs/development/php-packages/castor/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   fetchFromGitHub,
-  fetchpatch,
   installShellFiles,
   php,
   nix-update-script,
@@ -10,25 +9,16 @@
 
 php.buildComposerProject (finalAttrs: {
   pname = "castor";
-  version = "0.14.0";
+  version = "0.17.1";
 
   src = fetchFromGitHub {
     owner = "jolicode";
     repo = "castor";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-sSIkXNW6RR1mx15dKouQLMaHBr5FEkTTc/0QIkWV8sg=";
+    hash = "sha256-ng32vuGlGffpkzf3hXu0sNbj0PCDu4DpZnMnbDV9pZk=";
   };
 
-  patches = [
-    # Upstream lock is invalid. https://github.com/jolicode/castor/issues/319
-    (fetchpatch {
-      name = "fix-invalid-lock.patch";
-      url = "https://github.com/jolicode/castor/commit/5ff0c3ecbdddad20146adbc2f055b83f5aadba0f.patch";
-      hash = "sha256-1a3Dpk/UXp92Ugw9zSoLPsbWOJEuP2FBWc/pQ/EKwaM=";
-    })
-  ];
-
-  vendorHash = "sha256-HfEjwlkozeuT4LDnYwiCu7T0spcf4GLhkd7Kc1VRnro=";
+  vendorHash = "sha256-E2NMWuUQXQ96NbKrcFnFGlxWR0tkd56MXk1bCL0N/sE=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/development/php-packages/castor/default.nix
+++ b/pkgs/development/php-packages/castor/default.nix
@@ -35,9 +35,9 @@ php.buildComposerProject (finalAttrs: {
   # install shell completions
   postInstall = ''
     installShellCompletion --cmd castor \
-      --bash <($out/bin/castor completion bash) \
-      --fish <($out/bin/castor completion fish) \
-      --zsh <($out/bin/castor completion zsh)
+      --bash <(php $out/bin/castor completion bash) \
+      --fish <(php $out/bin/castor completion fish) \
+      --zsh <(php $out/bin/castor completion zsh)
   '';
 
   passthru = {


### PR DESCRIPTION
## Description of changes
https://github.com/jolicode/castor/releases/tag/v0.15.0
https://github.com/jolicode/castor/releases/tag/v0.16.0
https://github.com/jolicode/castor/releases/tag/v0.17.0
https://github.com/jolicode/castor/releases/tag/v0.17.1

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
