### PR TITLE
jedit: 5.6.0-unstable-2023-11-19 -> 5.7.0

### DIFF
--- a/pkgs/by-name/je/jedit/package.nix
+++ b/pkgs/by-name/je/jedit/package.nix
@@ -12,13 +12,16 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "jedit";
-  version = "5.6.0-unstable-2023-11-19";
+  version = "5.7.0";
 
-  src = fetchsvn {
-    url = "https://svn.code.sf.net/p/jedit/svn/jEdit/trunk";
-    rev = "25703";
-    hash = "sha256-z1KTZqKl6Dlqayw/3h/JvHQK3kSfio02R8V6aCb4g4Q=";
-  };
+  src =
+    let
+      versionWithDashes = lib.replaceStrings [ "." ] [ "-" ] finalAttrs.version;
+    in
+    fetchsvn {
+      url = "https://svn.code.sf.net/p/jedit/svn/jEdit/tags/jedit-${versionWithDashes}";
+      hash = "sha256-XfYK2C0QZrg4b//1eQcUNViRthBbXV+cbcYetzw2RG8=";
+    };
 
   ivyDeps = stdenv.mkDerivation {
     name = "${finalAttrs.pname}-${finalAttrs.version}-ivy-deps";
@@ -58,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
-    outputHash = "sha256-J5i5IhXlXw84y/4K6Vt84au4eVXVLupmtfscO+y1Fi0=";
+    outputHash = "sha256-NGSBGB7q0HpOpajJV68K0rqCOqFYNrZHsnUHW+1GSLs=";
   };
 
   # ignore a test failing because of the build environment
@@ -104,8 +107,9 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
+    changelog = "${finalAttrs.src.url}/doc/CHANGES.txt";
     description = "Programmer's text editor written in Java";
-    homepage = "http://www.jedit.org";
+    homepage = "https://www.jedit.org";
     license = lib.licenses.gpl2Only;
     mainProgram = "jedit";
     maintainers = with lib.maintainers; [ tomasajt ];


### PR DESCRIPTION
## Description of changes

Changelog (changes since 5.6.0): https://svn.code.sf.net/p/jedit/svn/jEdit/tags/jedit-5-7-0/doc/CHANGES.txt

This PR bumps the version of the `jedit` package to a recently released stable version.

I also set `meta.changelog`, though I reused the `src.url` as part of the link. Not sure if that's fine.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
