### PR TITLE
python312Packages.ocrmypdf: 16.4.2 -> 16.4.3

### DIFF
--- a/pkgs/development/python-modules/ocrmypdf/default.nix
+++ b/pkgs/development/python-modules/ocrmypdf/default.nix
@@ -28,7 +28,7 @@
 
 buildPythonPackage rec {
   pname = "ocrmypdf";
-  version = "16.4.2";
+  version = "16.4.3";
 
   disabled = pythonOlder "3.10";
 
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     postFetch = ''
       rm "$out/.git_archival.txt"
     '';
-    hash = "sha256-zU3Yzdu5iF6USGj7bpf52+UMyeJuC7LFvR9NOrd8gXE=";
+    hash = "sha256-SHinfAWUqrPnHdDDXa1meVfxsyct17b1ak5U91GEc1w=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/ocrmypdf/paths.patch
+++ b/pkgs/development/python-modules/ocrmypdf/paths.patch
@@ -1,5 +1,5 @@
 diff --git a/src/ocrmypdf/_exec/ghostscript.py b/src/ocrmypdf/_exec/ghostscript.py
-index 94eec244..4bb15db9 100644
+index eaa48117..30201d97 100644
 --- a/src/ocrmypdf/_exec/ghostscript.py
 +++ b/src/ocrmypdf/_exec/ghostscript.py
 @@ -31,7 +31,7 @@ COLOR_CONVERSION_STRATEGIES = frozenset(
@@ -12,19 +12,19 @@ index 94eec244..4bb15db9 100644
  
  log = logging.getLogger(__name__)
 diff --git a/src/ocrmypdf/_exec/jbig2enc.py b/src/ocrmypdf/_exec/jbig2enc.py
-index 5a34a95a..5ee1b333 100644
+index 1c6dd5fe..b689a091 100644
 --- a/src/ocrmypdf/_exec/jbig2enc.py
 +++ b/src/ocrmypdf/_exec/jbig2enc.py
-@@ -14,7 +14,7 @@ from ocrmypdf.subprocess import get_version, run
- 
+@@ -15,7 +15,7 @@ from ocrmypdf.subprocess import get_version, run
  
  def version() -> Version:
--    return Version(get_version('jbig2', regex=r'jbig2enc (\d+(\.\d+)*).*'))
-+    return Version(get_version('@jbig2@', regex=r'jbig2enc (\d+(\.\d+)*).*'))
- 
- 
- def available():
-@@ -27,7 +27,7 @@ def available():
+     try:
+-        version = get_version('jbig2', regex=r'jbig2enc (\d+(\.\d+)*).*')
++        version = get_version('@jbig2@', regex=r'jbig2enc (\d+(\.\d+)*).*')
+     except CalledProcessError as e:
+         # TeX Live for Windows provides an incompatible jbig2.EXE which may
+         # be on the PATH.
+@@ -33,7 +33,7 @@ def available():
  
  def convert_group(cwd, infiles, out_prefix, threshold):
      args = [
@@ -33,7 +33,7 @@ index 5a34a95a..5ee1b333 100644
          '-b',
          out_prefix,
          '--symbol-mode',  # symbol mode (lossy)
-@@ -44,7 +44,7 @@ def convert_group(cwd, infiles, out_prefix, threshold):
+@@ -50,7 +50,7 @@ def convert_group(cwd, infiles, out_prefix, threshold):
  
  
  def convert_single(cwd, infile, outfile, threshold):
@@ -65,7 +65,7 @@ index 5b8600d0..fcad771b 100644
              '--skip-if-larger',
              '--quality',
 diff --git a/src/ocrmypdf/_exec/tesseract.py b/src/ocrmypdf/_exec/tesseract.py
-index fab92bb1..78b634a7 100644
+index 102bdab8..bfef4400 100644
 --- a/src/ocrmypdf/_exec/tesseract.py
 +++ b/src/ocrmypdf/_exec/tesseract.py
 @@ -95,7 +95,7 @@ class TesseractVersion(Version):
@@ -96,10 +96,10 @@ index fab92bb1..78b634a7 100644
          args.extend(['-l', '+'.join(langs)])
      if engine_mode is not None:
 diff --git a/src/ocrmypdf/_exec/unpaper.py b/src/ocrmypdf/_exec/unpaper.py
-index 493d9b3a..578c2dda 100644
+index d1165c46..7c732b15 100644
 --- a/src/ocrmypdf/_exec/unpaper.py
 +++ b/src/ocrmypdf/_exec/unpaper.py
-@@ -70,7 +70,7 @@ class UnpaperImageTooLargeError(Exception):
+@@ -48,7 +48,7 @@ class UnpaperImageTooLargeError(Exception):
  
  
  def version() -> Version:
@@ -108,7 +108,7 @@ index 493d9b3a..578c2dda 100644
  
  
  @contextmanager
-@@ -92,7 +92,7 @@ def _setup_unpaper_io(input_file: Path) -> Iterator[tuple[Path, Path, Path]]:
+@@ -70,7 +70,7 @@ def _setup_unpaper_io(input_file: Path) -> Iterator[tuple[Path, Path, Path]]:
  def run_unpaper(
      input_file: Path, output_file: Path, *, dpi: DecFloat, mode_args: list[str]
  ) -> None:


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/ocrmypdf/OCRmyPDF/compare/v16.4.2...v16.4.3

Changelog: https://github.com/ocrmypdf/OCRmyPDF/blob/v16.4.3/docs/release_notes.rst



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
