### PR TITLE
python3.pkgs.nose: Fix nosetests distutils command

### DIFF
--- a/pkgs/development/python-modules/nose/inspect-args.patch
+++ b/pkgs/development/python-modules/nose/inspect-args.patch
@@ -1,0 +1,56 @@
+diff --git a/nose/plugins/manager.py b/nose/plugins/manager.py
+index 04593f56..c7d882c7 100644
+--- a/nose/plugins/manager.py
++++ b/nose/plugins/manager.py
+@@ -104,8 +104,16 @@ def addPlugin(self, plugin, call):
+         """
+         meth = getattr(plugin, call, None)
+         if meth is not None:
+-            if call == 'loadTestsFromModule' and \
+-                    len(inspect.getargspec(meth)[0]) == 2:
++            sig = inspect.signature(meth)
++            bl = set([inspect.Parameter.VAR_KEYWORD,
++                      inspect.Parameter.VAR_POSITIONAL,
++                      inspect.Parameter.KEYWORD_ONLY])
++            args = [k for k, v in sig.parameters.items()
++                    if v.kind not in bl]
++            arg_len = len(args)
++            if hasattr(meth, '__self__'):
++                arg_len += 1
++            if call == 'loadTestsFromModule' and arg_len == 2:
+                 orig_meth = meth
+                 meth = lambda module, path, **kwargs: orig_meth(module)
+             self.plugins.append((plugin, meth))
+diff --git a/nose/util.py b/nose/util.py
+index bfe16589..9ec9c3ed 100644
+--- a/nose/util.py
++++ b/nose/util.py
+@@ -449,16 +449,23 @@ def try_run(obj, names):
+             if type(obj) == types.ModuleType:
+                 # py.test compatibility
+                 if isinstance(func, types.FunctionType):
+-                    args, varargs, varkw, defaults = \
+-                        inspect.getargspec(func)
++                    sig = inspect.signature(func)
++                    bl = set([inspect.Parameter.VAR_KEYWORD,
++                              inspect.Parameter.VAR_POSITIONAL,
++                              inspect.Parameter.KEYWORD_ONLY])
++                    args = [k for k, v in sig.parameters.items()
++                            if v.kind not in bl]
+                 else:
+                     # Not a function. If it's callable, call it anyway
+                     if hasattr(func, '__call__') and not inspect.ismethod(func):
+                         func = func.__call__
+                     try:
+-                        args, varargs, varkw, defaults = \
+-                            inspect.getargspec(func)
+-                        args.pop(0) # pop the self off
++                        sig = inspect.signature(func)
++                        bl = set([inspect.Parameter.VAR_KEYWORD,
++                                  inspect.Parameter.VAR_POSITIONAL,
++                                  inspect.Parameter.KEYWORD_ONLY])
++                        args = [k for k, v in sig.parameters.items()
++                                if v.kind not in bl]
+                     except TypeError:
+                         raise TypeError("Attribute %s of %r is not a python "
+                                         "function. Only functions or callables"


### PR DESCRIPTION
## Description of changes

For some reason, entry-points were not installed breaking `setup.py nosetests`. Since this is a dead project and I only need it to migrate away from it, let’s write the entry points manually.

Additionally, it was using `inspect.getargspec`, which was removed in Python 3.6.1. Let’s apply an umerged upstream patch to use `inspect.signature` from Python 3.3 instead. I have removed the fallback branches from the patch since we do not need to support Python < 3.3.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
