### PR TITLE
google-chrome: 127.0.6533.89 -> 127.0.6533.100, add darwin support

### DIFF
--- a/pkgs/by-name/go/google-chrome/package.nix
+++ b/pkgs/by-name/go/google-chrome/package.nix
@@ -164,11 +164,11 @@ let
 
   linux = stdenv.mkDerivation (finalAttrs: {
     inherit pname meta passthru;
-    version = "127.0.6533.88";
+    version = "127.0.6533.99";
 
     src = fetchurl {
       url = "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${finalAttrs.version}-1_amd64.deb";
-      hash = "sha256-0l9cidNFO0dcyzWy4nDD/OGFQDBLXx9aPVq6ioDkqK0=";
+      hash = "sha256-pMGLSai4C/XifFkRmUoTRG/3dETGJXWhJbewtb/szVg=";
     };
 
     # With strictDeps on, some shebangs were not being patched correctly
@@ -256,11 +256,11 @@ let
 
   darwin = stdenvNoCC.mkDerivation (finalAttrs: {
     inherit pname meta passthru;
-    version = "127.0.6533.89";
+    version = "127.0.6533.100";
 
     src = fetchurl {
-      url = "http://dl.google.com/release2/chrome/aclo5k72baz7erlbweyjruguwh2a_127.0.6533.89/GoogleChrome-127.0.6533.89.dmg";
-      hash = "sha256-YUHhHyId3MMZFuKlx/xzuGSYLi62QazCLoyl+00+mbA=";
+      url = "http://dl.google.com/release2/chrome/knybzo7stwsgi7z5xw6krwtnym_127.0.6533.100/GoogleChrome-127.0.6533.100.dmg";
+      hash = "sha256-slZ1FHXZqCCgWEStfnVTU4ykQBqa3H35KTVuqTXSHQs=";
     };
 
     dontPatch = true;

--- a/pkgs/by-name/go/google-chrome/package.nix
+++ b/pkgs/by-name/go/google-chrome/package.nix
@@ -4,7 +4,7 @@
   makeWrapper,
   patchelf,
   stdenv,
-  writeScript,
+  stdenvNoCC,
 
   # Linked dynamic libraries.
   alsa-lib,
@@ -91,9 +91,12 @@
 
   # For Vulkan support (--enable-features=Vulkan)
   addDriverRunpath,
+  undmg,
 }:
 
 let
+  pname = "google-chrome";
+
   opusWithCustomModes = libopus.override { withCustomModes = true; };
 
   deps =
@@ -159,116 +162,147 @@ let
       gtk4
     ];
 
-in
-stdenv.mkDerivation (finalAttrs: {
-  pname = "google-chrome";
-  version = "127.0.6533.88";
+  linux = stdenv.mkDerivation (finalAttrs: {
+    inherit pname meta passthru;
+    version = "127.0.6533.88";
 
-  src = fetchurl {
-    url = "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${finalAttrs.version}-1_amd64.deb";
-    hash = "sha256-0l9cidNFO0dcyzWy4nDD/OGFQDBLXx9aPVq6ioDkqK0=";
-  };
+    src = fetchurl {
+      url = "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${finalAttrs.version}-1_amd64.deb";
+      hash = "sha256-0l9cidNFO0dcyzWy4nDD/OGFQDBLXx9aPVq6ioDkqK0=";
+    };
 
-  nativeBuildInputs = [
-    makeWrapper
-    patchelf
-  ];
+    # With strictDeps on, some shebangs were not being patched correctly
+    # ie, $out/share/google/chrome/google-chrome
+    strictDeps = false;
 
-  buildInputs = [
-    # needed for XDG_ICON_DIRS
-    adwaita-icon-theme
-    glib
-    gtk3
-    gtk4
-    # needed for GSETTINGS_SCHEMAS_PATH
-    gsettings-desktop-schemas
-  ];
+    nativeBuildInputs = [
+      makeWrapper
+      patchelf
+    ];
 
-  unpackPhase = ''
-    ar x $src
-    tar xf data.tar.xz
-  '';
+    buildInputs = [
+      # needed for XDG_ICON_DIRS
+      adwaita-icon-theme
+      glib
+      gtk3
+      gtk4
+      # needed for GSETTINGS_SCHEMAS_PATH
+      gsettings-desktop-schemas
+    ];
 
-  rpath = lib.makeLibraryPath deps + ":" + lib.makeSearchPathOutput "lib" "lib64" deps;
-  binpath = lib.makeBinPath deps;
-
-  installPhase = ''
-    runHook preInstall
-
-    appname=chrome
-    dist=stable
-
-    exe=$out/bin/google-chrome-$dist
-
-    mkdir -p $out/bin $out/share
-
-    cp -a opt/* $out/share
-    cp -a usr/share/* $out/share
-
-
-    substituteInPlace $out/share/google/$appname/google-$appname \
-      --replace 'CHROME_WRAPPER' 'WRAPPER'
-    substituteInPlace $out/share/applications/google-$appname.desktop \
-      --replace /usr/bin/google-chrome-$dist $exe
-    substituteInPlace $out/share/gnome-control-center/default-apps/google-$appname.xml \
-      --replace /opt/google/$appname/google-$appname $exe
-    substituteInPlace $out/share/menu/google-$appname.menu \
-      --replace /opt $out/share \
-      --replace $out/share/google/$appname/google-$appname $exe
-
-    for icon_file in $out/share/google/chrome*/product_logo_[0-9]*.png; do
-      num_and_suffix="''${icon_file##*logo_}"
-      if [ $dist = "stable" ]; then
-        icon_size="''${num_and_suffix%.*}"
-      else
-        icon_size="''${num_and_suffix%_*}"
-      fi
-      logo_output_prefix="$out/share/icons/hicolor"
-      logo_output_path="$logo_output_prefix/''${icon_size}x''${icon_size}/apps"
-      mkdir -p "$logo_output_path"
-      mv "$icon_file" "$logo_output_path/google-$appname.png"
-    done
-
-    makeWrapper "$out/share/google/$appname/google-$appname" "$exe" \
-      --prefix LD_LIBRARY_PATH : "$rpath" \
-      --prefix PATH            : "$binpath" \
-      --suffix PATH            : "${lib.makeBinPath [ xdg-utils ]}" \
-      --prefix XDG_DATA_DIRS   : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH:${addDriverRunpath.driverLink}/share" \
-      --set CHROME_WRAPPER  "google-chrome-$dist" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
-      --add-flags ${lib.escapeShellArg commandLineArgs}
-
-    for elf in $out/share/google/$appname/{chrome,chrome-sandbox,chrome_crashpad_handler}; do
-      patchelf --set-rpath $rpath $elf
-      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $elf
-    done
-
-    runHook postInstall
-  '';
-
-  passthru = {
-    updateScript = writeScript "update-google-chrome.sh" ''
-      #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl jq common-updater-scripts
-      set -euo pipefail
-      url="https://versionhistory.googleapis.com/v1/chrome/platforms/linux/channels/stable/versions/all/releases"
-      response="$(curl --silent --fail $url)"
-      version="$(jq ".releases[0].version" --raw-output <<< $response)"
-      update-source-version ${finalAttrs.pname} $version --ignore-same-hash
+    unpackPhase = ''
+      runHook preUnpack
+      ar x $src
+      tar xf data.tar.xz
+      runHook postUnpack
     '';
-  };
+
+    rpath = lib.makeLibraryPath deps + ":" + lib.makeSearchPathOutput "lib" "lib64" deps;
+    binpath = lib.makeBinPath deps;
+
+    installPhase = ''
+      runHook preInstall
+
+      appname=chrome
+      dist=stable
+
+      exe=$out/bin/google-chrome-$dist
+
+      mkdir -p $out/bin $out/share
+
+      cp -a opt/* $out/share
+      cp -a usr/share/* $out/share
+
+      substituteInPlace $out/share/google/$appname/google-$appname \
+        --replace-fail 'CHROME_WRAPPER' 'WRAPPER'
+      substituteInPlace $out/share/applications/google-$appname.desktop \
+        --replace-fail /usr/bin/google-chrome-$dist $exe
+      substituteInPlace $out/share/gnome-control-center/default-apps/google-$appname.xml \
+        --replace-fail /opt/google/$appname/google-$appname $exe
+      substituteInPlace $out/share/menu/google-$appname.menu \
+        --replace-fail /opt $out/share \
+        --replace-fail $out/share/google/$appname/google-$appname $exe
+
+      for icon_file in $out/share/google/chrome*/product_logo_[0-9]*.png; do
+        num_and_suffix="''${icon_file##*logo_}"
+        if [ $dist = "stable" ]; then
+          icon_size="''${num_and_suffix%.*}"
+        else
+          icon_size="''${num_and_suffix%_*}"
+        fi
+        logo_output_prefix="$out/share/icons/hicolor"
+        logo_output_path="$logo_output_prefix/''${icon_size}x''${icon_size}/apps"
+        mkdir -p "$logo_output_path"
+        mv "$icon_file" "$logo_output_path/google-$appname.png"
+      done
+
+      makeWrapper "$out/share/google/$appname/google-$appname" "$exe" \
+        --prefix LD_LIBRARY_PATH : "$rpath" \
+        --prefix PATH            : "$binpath" \
+        --suffix PATH            : "${lib.makeBinPath [ xdg-utils ]}" \
+        --prefix XDG_DATA_DIRS   : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH:${addDriverRunpath.driverLink}/share" \
+        --set CHROME_WRAPPER  "google-chrome-$dist" \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+        --add-flags ${lib.escapeShellArg commandLineArgs}
+
+      for elf in $out/share/google/$appname/{chrome,chrome-sandbox,chrome_crashpad_handler}; do
+        patchelf --set-rpath $rpath $elf
+        patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $elf
+      done
+
+      runHook postInstall
+    '';
+  });
+
+  darwin = stdenvNoCC.mkDerivation (finalAttrs: {
+    inherit pname meta passthru;
+    version = "127.0.6533.89";
+
+    src = fetchurl {
+      url = "http://dl.google.com/release2/chrome/aclo5k72baz7erlbweyjruguwh2a_127.0.6533.89/GoogleChrome-127.0.6533.89.dmg";
+      hash = "sha256-YUHhHyId3MMZFuKlx/xzuGSYLi62QazCLoyl+00+mbA=";
+    };
+
+    dontPatch = true;
+    dontConfigure = true;
+    dontBuild = true;
+    dontFixup = true;
+
+    nativeBuildInputs = [
+      makeWrapper
+      undmg
+    ];
+
+    sourceRoot = ".";
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/Applications
+      cp -r *.app $out/Applications
+
+      mkdir -p $out/bin
+      makeWrapper $out/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome $out/bin/google-chrome-stable \
+        --add-flags ${lib.escapeShellArg commandLineArgs}
+
+      runHook postInstall
+    '';
+  });
+
+  passthru.updateScript = ./update.sh;
 
   meta = {
+    changelog = "https://chromereleases.googleblog.com/";
     description = "Freeware web browser developed by Google";
     homepage = "https://www.google.com/chrome/browser/";
-    changelog = "https://chromereleases.googleblog.com/";
     license = lib.licenses.unfree;
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     maintainers = with lib.maintainers; [
       jnsgruk
       johnrtitor
     ];
-    platforms = [ "x86_64-linux" ];
+    platforms = lib.platforms.darwin ++ [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     mainProgram = "google-chrome-stable";
   };
-})
+in
+if stdenvNoCC.isDarwin then darwin else linux

--- a/pkgs/by-name/go/google-chrome/update.sh
+++ b/pkgs/by-name/go/google-chrome/update.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p curl jq gawk libossp_uuid libxml2 nix
+
+set -euo pipefail
+
+DEFAULT_NIX="$(realpath "./pkgs/by-name/go/google-chrome/package.nix")"
+
+get_version_info() {
+    local platform="$1"
+    local start_pattern="$2"
+    local end_pattern="$3"
+
+    local url="https://versionhistory.googleapis.com/v1/chrome/platforms/${platform}/channels/stable/versions/all/releases"
+    local response
+    local version
+    local current_version
+
+    response="$(curl --silent --fail "$url")"
+    version="$(jq ".releases[0].version" --raw-output <<< "$response")"
+    current_version="$(awk "/${start_pattern}/,/${end_pattern}/ { if (\$0 ~ /version = \"/) { match(\$0, /version = \"([^\"]+)\"/, arr); print arr[1]; exit } }" "$DEFAULT_NIX")"
+
+    echo "$version" "$current_version"
+}
+
+update_linux() {
+    local version_info
+    local version
+    local current_version
+    local new_hash
+    local new_sri_hash
+
+    read -ra version_info <<< "$(get_version_info "linux" "linux = stdenv.mkDerivation" "});")"
+    version="${version_info[0]}"
+    current_version="${version_info[1]}"
+
+    if [[ "$current_version" = "$version" ]]; then
+        echo "[Nix] Linux google chrome: same version"
+        return 0
+    fi
+
+    local download_url="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb"
+    new_hash="$(nix-prefetch-url "$download_url" 2>/dev/null)"
+    new_sri_hash="$(nix hash to-sri --type sha256 "$new_hash")"
+
+    sed -i "/^  linux = stdenv.mkDerivation/,/^  });/s/version = \".*\"/version = \"$version\"/" "$DEFAULT_NIX"
+    sed -i "/^  linux = stdenv.mkDerivation/,/^  });/s|hash = \".*\"|hash = \"$new_sri_hash\"|" "$DEFAULT_NIX"
+
+    echo "[Nix] Linux google-chrome: $current_version -> $version with hash $new_hash"
+}
+
+update_darwin() {
+    local version_info
+    local version
+    local current_version
+    local uuid
+    local url
+    local pkg
+    local manifest_version
+    local new_hash
+    local new_sri_hash
+
+    read -ra version_info <<< "$(get_version_info "mac" "darwin = stdenvNoCC.mkDerivation" "});")"
+    version="${version_info[0]}"
+    current_version="${version_info[1]}"
+    uuid="$(uuidgen)"
+
+    if [[ "$current_version" = "$version" ]]; then
+        echo "[Nix] Darwin google chrome: same version"
+        exit 0
+    fi
+
+    local post_data="<?xml version='1.0' encoding='UTF-8'?>
+    <request protocol='3.0' version='1.3.23.9' shell_version='1.3.21.103' ismachine='1'
+        sessionid='$uuid' installsource='ondemandcheckforupdate'
+        requestid='$uuid' dedup='cr'>
+        <hw sse='1' sse2='1' sse3='1' ssse3='1' sse41='1' sse42='1' avx='1' physmemory='12582912' />
+        <os platform='mac' version='$version' arch='arm64'/>
+        <app appid='com.google.Chrome' ap=' ' version=' ' nextversion=' ' lang=' ' brand='GGLS' client=' '>
+            <updatecheck/>
+        </app>
+    </request>"
+
+    response="$(curl -s -X POST -H "Content-Type: text/xml" --data "$post_data" "https://tools.google.com/service/update2")"
+    url="$(echo "$response" | xmllint --xpath "string(//url[contains(@codebase, 'http://dl.google.com/release2')]/@codebase)" -)"
+    pkg="$(echo "$response" | xmllint --xpath "string(//package/@name)" -)"
+    manifest_version="$(echo "$response" | xmllint --xpath "string(//manifest/@version)" -)"
+
+    local download_url="$url$pkg"
+    new_hash="$(nix hash to-sri --type sha256 "$(nix-prefetch-url "$download_url" 2>/dev/null)")"
+    new_sri_hash="$(nix hash to-sri --type sha256 "$new_hash")"
+
+    sed -i "/^  darwin = stdenvNoCC.mkDerivation/,/^  });/s/version = \".*\"/version = \"$manifest_version\"/" "$DEFAULT_NIX"
+    sed -i "/^  darwin = stdenvNoCC.mkDerivation/,/^  });/s|hash = \".*\"|hash = \"$new_sri_hash\"|" "$DEFAULT_NIX"
+    sed -i "/^  darwin = stdenvNoCC.mkDerivation/,/^  });/s|url = \".*\"|url = \"$download_url\"|" "$DEFAULT_NIX"
+
+    echo "[Nix] Darwin google-chrome: $current_version -> $manifest_version with hash $new_hash"
+}
+
+update_linux
+update_darwin


### PR DESCRIPTION
Closes: https://github.com/NixOS/nixpkgs/pull/162436
Closes: https://github.com/NixOS/nixpkgs/pull/162467

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc