### PR TITLE
duff: 2014-07-03 -> 2024-02-16

### DIFF
--- a/pkgs/tools/filesystems/duff/default.nix
+++ b/pkgs/tools/filesystems/duff/default.nix
@@ -2,13 +2,11 @@
 
 stdenv.mkDerivation {
   pname = "duff";
-  # The last release (0.5.2) is more than 2 years old and lacks features like -D,
-  # limiting its usefulness. Upstream appears comatose if not dead.
-  version = "2014-07-03";
+  version = "2024-02-16";
 
   src = fetchFromGitHub {
-    sha256 = "1k2dx38pjzc5d624vw1cs5ipj9fprsm5vqv55agksc29m63lswnx";
-    rev = "f26d4837768b062a3f98fa075c791d9c8a0bb75c";
+    sha256 = "9lS4th+qeglsoA+1s45uEE2UGmlE3YtSy4/uGqWKU/k=";
+    rev = "c1baefa4f4d5cefbbbc7bfefc0c18356752c8a1b";
     repo = "duff";
     owner = "elmindreda";
   };
@@ -23,6 +21,8 @@ stdenv.mkDerivation {
     ./gettextize
     sed 's@po/Makefile.in\( .*\)po/Makefile.in@po/Makefile.in \1@' \
       -i configure.ac
+    # src/main.c is utf8, not ascii
+    sed '/^XGETTEXT_OPTIONS =/ s,$, --from-code=utf-8,' -i po/Makevars
   '';
 
   enableParallelBuilding = true;
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
       Duff is a Unix command-line utility for quickly finding duplicates in
       a given set of files.
     '';
-    homepage = "https://duff.dreda.org/";
+    homepage = "https://github.com/elmindreda/duff";
     license = licenses.zlib;
     platforms = platforms.all;
   };


### PR DESCRIPTION
This updates duff to the latest commit, removing links to a now hostile domain.

The old homepage link is blocked by ublock origin ("badware"). Due to the security risk, the change should be backported to 24.05.

## Description of changes

See https://github.com/elmindreda/duff/issues/14
and https://github.com/elmindreda/duff/commit/c1baefa4f4d5cefbbbc7bfefc0c18356752c8a1b

Further, it seems the author's name changed, and now contains an Umlaut, 
in https://github.com/elmindreda/duff/commit/d7828fb6d110708b9a1180f64e5f55db47623262
This requires an additional xgettest arg --from-code=utf-8 .

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
