### PR TITLE
firedragon: init at 11.20.0-1

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -330,6 +330,7 @@ in {
   ferretdb = handleTest ./ferretdb.nix {};
   filesender = handleTest ./filesender.nix {};
   filesystems-overlayfs = runTest ./filesystems-overlayfs.nix;
+  firedragon = handleTest ./firefox.nix { firefoxPackage = pkgs.firedragon; };
   firefly-iii = handleTest ./firefly-iii.nix {};
   firefly-iii-data-importer = handleTest ./firefly-iii-data-importer.nix {};
   firefox = handleTest ./firefox.nix { firefoxPackage = pkgs.firefox; };

--- a/pkgs/applications/networking/browsers/firedragon/default.nix
+++ b/pkgs/applications/networking/browsers/firedragon/default.nix
@@ -1,0 +1,109 @@
+{
+  buildMozillaMach,
+  callPackage,
+  fetchFromGitLab,
+  fetchurl,
+  lib,
+  nixosTests,
+  pkgs,
+  python311,
+  stdenv,
+}:
+let
+  current = lib.trivial.importJSON ./version.json;
+  packageVersion = current.firedragonSource.version;
+  version = current.firefoxVersion;
+
+  settings = fetchFromGitLab {
+    owner = "garuda-linux/firedragon";
+    repo = "settings";
+    fetchSubmodules = false;
+    inherit (current.firedragonSettings) rev hash;
+  };
+in
+(
+  (buildMozillaMach rec {
+    pname = "firedragon";
+    applicationName = "FireDragon";
+    binaryName = "firedragon";
+    branding = "browser/branding/firedragon";
+    requireSigning = false;
+    allowAddonSideload = true;
+
+    inherit packageVersion version;
+
+    src = fetchurl {
+      url = "https://gitlab.com/api/v4/projects/55893651/packages/generic/firedragon/${packageVersion}/firedragon-v${packageVersion}.source.tar.zst";
+      inherit (current.firedragonSource) hash;
+    };
+
+    updateScript = callPackage ./update.nix { };
+
+    tests = {
+      inherit (nixosTests) firedragon;
+    };
+
+    extraConfigureFlags = [
+      "--disable-debug-js-modules"
+      "--disable-debug-symbols"
+      "--disable-default-browser-agent"
+      "--disable-gpsd"
+      "--disable-rust-tests"
+      "--disable-warnings-as-errors"
+      "--disable-webspeech"
+      "--enable-bundled-fonts"
+      "--enable-jxl"
+      "--enable-private-components"
+      "--enable-proxy-bypass-protection"
+      "--with-app-name=${pname}"
+      "--with-app-basename=${applicationName}"
+      "--with-unsigned-addon-scopes=app,system"
+    ];
+
+    extraNativeBuildInputs = [ pkgs.zstd ];
+
+    extraPassthru = {
+      extraPrefsFiles = [ "${settings}/firedragon.cfg" ];
+      extraPoliciesFiles = [ "${settings}/distribution/policies.json" ];
+    };
+
+    meta = {
+      badPlatforms = lib.platforms.darwin;
+      description = "Floorp fork build using custom branding & settings";
+      homepage = "https://gitlab.com/garuda-linux/firedragon";
+      license = lib.licenses.mpl20;
+      maintainers = with lib; [ maintainers.dr460nf1r3 ];
+      broken = stdenv.buildPlatform.is32bit;
+      # since Firefox 60, build on 32-bit platforms fails with "out of memory".
+      # not in `badPlatforms` because cross-compilation on 64-bit machine might work.
+      maxSilent = 14400; # 4h, double the default of 7200s (c.f. #129212, #129115)
+      platforms = lib.platforms.unix;
+      mainProgram = "firedragon";
+    };
+  }).override
+  {
+    crashreporterSupport = false;
+    enableOfficialBranding = false;
+    pgoSupport = true;
+    privacySupport = true;
+    python3 = python311;
+    webrtcSupport = true;
+  }
+).overrideAttrs
+  {
+    MOZ_APP_REMOTINGNAME = "firedragon";
+    MOZ_CRASHREPORTER = "";
+    MOZ_DATA_REPORTING = "";
+    MOZ_SERVICES_HEALTHREPORT = "";
+    MOZ_TELEMETRY_REPORTING = "";
+    OPT_LEVEL = "3";
+    RUSTC_OPT_LEVEL = "3";
+
+    # Upstream already includes some of the bugfix patches that are applied by
+    # `buildMozillaMach`. Pick out only the relevant ones for Floorp and override
+    # the list here.
+    patches = [
+      ../firefox/env_var_for_system_dir-ff111.patch
+      ../firefox/no-buildconfig-ffx121.patch
+    ];
+  }

--- a/pkgs/applications/networking/browsers/firedragon/update.nix
+++ b/pkgs/applications/networking/browsers/firedragon/update.nix
@@ -1,0 +1,64 @@
+{
+  coreutils,
+  curl,
+  findutils,
+  git,
+  gnugrep,
+  gnused,
+  jq,
+  lib,
+  moreutils,
+  nix,
+  nix-prefetch-git,
+  writeShellScript,
+  ...
+}:
+let
+  path = lib.makeBinPath [
+    coreutils
+    curl
+    findutils
+    git
+    gnugrep
+    gnused
+    jq
+    moreutils
+    nix
+    nix-prefetch-git
+  ];
+in
+writeShellScript "update-firedragon" ''
+  set -euo pipefail
+  PATH=${path}
+
+  srcJson=pkgs/firedragon/version.json
+  localVer=$(jq -r .firedragonSource.version <$srcJson)
+
+  latestVer=$(curl -s https://gitlab.com/api/v4/projects/55893651/releases/ | jq '.[0].tag_name' -r | sed 's/v//g')
+
+  if [ "$localVer" == "$latestVer" ]; then
+    exit 0
+  fi
+
+  # FireDragon doesn't expose this information, instead writing its own version to this file
+  firefoxVersion=$(curl -s https://raw.githubusercontent.com/Floorp-Projects/Floorp/ESR128/browser/config/version.txt)
+
+  latestSha256=$(nix-prefetch-url --type sha256 "https://gitlab.com/api/v4/projects/55893651/packages/generic/firedragon/$latestVer/firedragon-v$latestVer.source.tar.zst")
+  latestHash=$(nix-hash --to-sri --type sha256 "$latestSha256")
+
+  firedragonRepo=$(nix-prefetch-git --fetch-submodules --quiet 'https://gitlab.com/garuda-linux/firedragon/settings.git')
+  firedragonRev=$(echo "$firedragonRepo" | jq -r .rev)
+  firedragonHash=$(echo "$firedragonRepo" | jq -r .hash)
+
+  jq \
+    --arg firefoxVersion "$firefoxVersion" \
+    --arg latestVer "$latestVer" --arg latestHash "$latestHash" \
+    --arg firedragonRev "$firedragonRev" --arg firedragonHash "$firedragonHash" \
+    ".firefoxVersion = \$firefoxVersion |\
+    .firedragonSource.version = \$latestVer | .firedragonSource.hash = \$latestHash |\
+    .firedragonSettings.rev = \$firedragonRev | .firedragonSettings.hash = \$firedragonHash" \
+    "$srcJson" | sponge $srcJson
+
+  git add $srcJson
+  git commit -m "firedragon: $localVer -> $latestVer"
+''

--- a/pkgs/applications/networking/browsers/firedragon/version.json
+++ b/pkgs/applications/networking/browsers/firedragon/version.json
@@ -1,0 +1,11 @@
+{
+  "firefoxVersion": "128.5.0",
+  "firedragonSource": {
+    "version": "11.20.0-1",
+    "hash": "sha256-8u5H8ZmcABDQmaS1acmEohD7RM5icrGXnthm7bMHZeo="
+  },
+  "firedragonSettings": {
+    "rev": "a7dd838657e800be0cba9b2c63296717cb5da2b3",
+    "hash": "sha256-1SpS9McvbpYSQc8eyhzTMY+5CJQ3stzYtTOeQV4rVW4="
+  }
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29218,6 +29218,13 @@ with pkgs;
     libName = "librewolf";
   };
 
+  firedragon-unwrapped = callPackage ../applications/networking/browsers/firedragon {};
+
+  firedragon = wrapFirefox firedragon-unwrapped {
+    inherit (firedragon-unwrapped) extraPrefsFiles extraPoliciesFiles;
+    libName = "firedragon";
+  };
+
   firefox_decrypt = python3Packages.callPackage ../tools/security/firefox_decrypt { };
 
   flac = callPackage ../applications/audio/flac { };


### PR DESCRIPTION
## Description of changes

This PR adds `firedragon` to Nixpkgs. It is a fork of the Floorp browser, with custom branding and opinionated settings.

Source: [https://gitlab.com/garuda-linux/firedragon/settings](https://gitlab.com/garuda-linux/firedragon/settings)

## Todo

- [x] Get it to build (current error: `wasm-ld: error: unknown argument: --undefined-version`), [full build logs](https://bin.garudalinux.org/?f17768a1cc4e5db2#3V2sMTPhq5tCMtHfbsPrtPhrog6HtdftStaDnPU7JrTA) - this error originated in using `pkgs/by-name/fi/firedragon-unwrapped` as way to build `firedragon-unwrapped` (CI complained about using `callPackage` in `all-packages.nix`, doing it the "traditional" way gets rid of the error. I don't understand this enough to make it work the other way - does anyone else know whats going on here?

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
