### PR TITLE
erlang-language-platform: init at 2024-07-16

### DIFF
--- a/pkgs/by-name/er/erlang-language-platform/package.nix
+++ b/pkgs/by-name/er/erlang-language-platform/package.nix
@@ -1,0 +1,55 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  autoPatchelfHook,
+}:
+let
+  arch = if stdenv.isAarch64 then "aarch64" else "x86_64";
+  release =
+    if stdenv.isDarwin then "macos-${arch}-apple-darwin" else "linux-${arch}-unknown-linux-gnu";
+
+  hashes = {
+    linux-aarch64-unknown-linux-gnu = "sha256-vWMrq/uFU/uyuDnsxZK0ZyvtraVCZwvGjzO1a5QjR8g=";
+    linux-x86_64-unknown-linux-gnu = "sha256-iE/zH6M51C6sFZrsUMwZTQ0+hzfpRFJtiKh3MS9bDto=";
+    macos-aarch64-apple-darwin = "sha256-55LSChvO0wRHGL0H29MLy/JW8V52GFr3z/qoxdIPun0=";
+    macos-x86_64-apple-darwin = "sha256-l9bzQ5z9hQ/N2dOkAjPAU4OfRbLCUoRt1eQB6EZE0NI=";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "erlang-language-platform";
+  version = "2024-07-16";
+
+  src = fetchurl {
+    url = "https://github.com/WhatsApp/erlang-language-platform/releases/download/${version}/elp-${release}-otp-26.2.tar.gz";
+    hash = hashes.${release};
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [ stdenv.cc.cc.lib ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+    install -m755 -D elp $out/bin/elp
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "An IDE-first library for the semantic analysis of Erlang code, including LSP server, linting and refactoring tools.";
+    homepage = "https://github.com/WhatsApp/erlang-language-platform/";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+    maintainers = with lib.maintainers; [ offsetcyan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16806,6 +16806,8 @@ with pkgs;
     lfe lfe_2_1;
   beamPackages = beam.packages.erlang // { __attrsFailEvaluation = true; };
 
+  erlang_language_platform = callPackage ../by-name/er/erlang-language-platform/package.nix { };
+
   expr = callPackage ../development/interpreters/expr { };
 
   genemichaels = callPackage ../development/tools/rust/genemichaels { };


### PR DESCRIPTION
## Description of changes

Adds the Erlang development tool [Erlang Language Platform](https://github.com/WhatsApp/erlang-language-platform) to nixpkgs, which involves patching the latest release binary.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
