### PR TITLE
vapoursynth-{eedi3,nnedi3cl,nnedi3,znedi3}: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19070,6 +19070,13 @@
     githubId = 602439;
     name = "Serguei Narojnyi";
   };
+  snaki = {
+    email = "ek@kyouma.net";
+    matrix = "@snaki:kescher.at";
+    name = "emily";
+    github = "snaakey";
+    githubId = 38018554;
+  };
   snapdgn = {
     email = "snapdgn@proton.me";
     name = "Nitish Kumar";

--- a/pkgs/by-name/va/vapoursynth-eedi3/package.nix
+++ b/pkgs/by-name/va/vapoursynth-eedi3/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  boost,
+  vapoursynth,
+  opencl-headers,
+  ocl-icd,
+  openclSupport ? true,
+}:
+
+stdenv.mkDerivation {
+  pname = "vapoursynth-eedi3";
+  version = "unstable-2019-09-30";
+
+  src = fetchFromGitHub {
+    owner = "HomeOfVapourSynthEvolution";
+    repo = "VapourSynth-EEDI3";
+    rev = "d11bdb37c7a7118cd095b53d9f8fbbac02a06ac0";
+    hash = "sha256-MIUf6sOnJ2uqGw3ixEHy1ijzlLFkQauwtm1vfgmYmcg=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs =
+    [
+      boost
+      vapoursynth
+    ]
+    ++ lib.optionals openclSupport [
+      ocl-icd
+      opencl-headers
+    ];
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail "vapoursynth_dep.get_pkgconfig_variable('libdir')" "get_option('libdir')"
+  '';
+
+  mesonFlags = [ (lib.mesonBool "opencl" openclSupport) ];
+
+  meta = {
+    description = "Filter for VapourSynth";
+    homepage = "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-EEDI3";
+    license = with lib.licenses; [ gpl2Plus ];
+    maintainers = with lib.maintainers; [ snaki ];
+    platforms = lib.platforms.x86_64;
+  };
+}

--- a/pkgs/by-name/va/vapoursynth-nnedi3/package.nix
+++ b/pkgs/by-name/va/vapoursynth-nnedi3/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  vapoursynth,
+  yasm,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vapoursynth-nnedi3";
+  version = "12";
+
+  src = fetchFromGitHub {
+    owner = "dubhater";
+    repo = "vapoursynth-nnedi3";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-jd/PCXhbCZGMsoXjekbeqMSRVBJAy4INdpkTbZFjVO0=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    vapoursynth
+    yasm
+  ];
+
+  configureFlags = [ "--libdir=$(out)/lib/vapoursynth" ];
+
+  postInstall = ''
+    rm -f $out/lib/vapoursynth/*.la
+  '';
+
+  meta = {
+    description = "Filter for VapourSynth";
+    homepage = "https://github.com/dubhater/vapoursynth-nnedi3";
+    license = with lib.licenses; [ gpl2Plus ];
+    maintainers = with lib.maintainers; [ snaki ];
+    platforms = with lib.platforms; x86_64 ++ aarch64;
+  };
+})

--- a/pkgs/by-name/va/vapoursynth-nnedi3cl/package.nix
+++ b/pkgs/by-name/va/vapoursynth-nnedi3cl/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  boost,
+  vapoursynth,
+  opencl-headers,
+  ocl-icd,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vapoursynth-nnedi3cl";
+  version = "8";
+
+  src = fetchFromGitHub {
+    owner = "HomeOfVapourSynthEvolution";
+    repo = "VapourSynth-NNEDI3CL";
+    rev = "refs/tags/r${finalAttrs.version}";
+    hash = "sha256-zW/qEtZTDJOTarXbXhv+nks25eePutLDpLck4TuMKUk=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    boost
+    vapoursynth
+    ocl-icd
+    opencl-headers
+  ];
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail "vapoursynth_dep.get_pkgconfig_variable('libdir')" "get_option('libdir')"
+  '';
+
+  meta = {
+    description = "Filter for VapourSynth";
+    homepage = "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-NNEDI3CL";
+    license = with lib.licenses; [ gpl2Plus ];
+    maintainers = with lib.maintainers; [ snaki ];
+    platforms = lib.platforms.x86_64;
+  };
+})

--- a/pkgs/by-name/va/vapoursynth-znedi3/package.nix
+++ b/pkgs/by-name/va/vapoursynth-znedi3/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  vapoursynth,
+}:
+
+stdenv.mkDerivation {
+  pname = "vapoursynth-znedi3";
+  version = "unstable-2023-07-09";
+
+  src = fetchFromGitHub {
+    fetchSubmodules = true;
+    owner = "sekrit-twc";
+    repo = "znedi3";
+    rev = "68dc130bc37615fd912d1dc1068261f00f54b146";
+    hash = "sha256-QC+hMMfp6XwW4PqsN6sip1Y7ttiYn/xuxq/pUg/trog=";
+  };
+
+  buildInputs = [ vapoursynth ];
+
+  postPatch = ''
+    rm -rf vsxx/vapoursynth
+    ln -s ${vapoursynth}/include/vapoursynth vsxx/vapoursynth
+  '';
+
+  makeFlags =
+    [ "CPPFLAGS=-DNNEDI3_WEIGHTS_PATH='\"$(out)/share/nnedi3/nnedi3_weights.bin\"'" ]
+    ++ lib.optionals stdenv.hostPlatform.isx86 [
+      "X86=1"
+      "X86_AVX512=1"
+    ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -t $out/lib/vapoursynth vsznedi3${stdenv.hostPlatform.extensions.sharedLibrary}
+    install -D -m644 -t $out/share/nnedi3 nnedi3_weights.bin
+
+    runHook postInstall
+  '';
+
+  meta = {
+    inherit (vapoursynth.meta) platforms;
+    description = "Filter for VapourSynth";
+    homepage = "https://github.com/sekrit-twc/znedi3";
+    license = with lib.licenses; [
+      gpl2Plus
+      wtfpl
+      lgpl21
+    ];
+    maintainers = with lib.maintainers; [ snaki ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Addition of vapoursynth deinterlacing plugins:
- eedi3: unstable-2019-09-30
- nnedi3cl: 8
- nnedi3: 12
- znedi3: unstable-2023-07-09

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
