### PR TITLE
python312Packages.python-escpos: init at 3.1

### DIFF
--- a/pkgs/development/python-modules/python-escpos/default.nix
+++ b/pkgs/development/python-modules/python-escpos/default.nix
@@ -1,0 +1,101 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  setuptools,
+  setuptools-scm,
+
+  pillow,
+  qrcode,
+  python-barcode,
+  six,
+  appdirs,
+  pyyaml,
+  argcomplete,
+  importlib-resources,
+
+  pyusb,
+  pyserial,
+  pycups,
+
+  jaconv,
+  pytestCheckHook,
+  pytest-mock,
+  scripttest,
+  mock,
+  hypothesis,
+}:
+
+buildPythonPackage rec {
+  pname = "python-escpos";
+  version = "3.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "python-escpos";
+    repo = "python-escpos";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-f7qA1+8PwnXS526jjULEoyn0ejnvsneuWDt863p4J2g=";
+    fetchSubmodules = true;
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    pillow
+    qrcode
+    python-barcode
+    six
+    appdirs
+    pyyaml
+    argcomplete
+    importlib-resources
+  ];
+
+  optional-dependencies = {
+    usb = [ pyusb ];
+    serial = [ pyserial ];
+    cups = [ pycups ];
+    all = [
+      pyusb
+      pyserial
+      pycups
+    ];
+  };
+
+  preCheck = ''
+    # force the tests to use the module in $out
+    rm -r src
+
+    # disable checking coverage
+    substituteInPlace pyproject.toml \
+        --replace-fail "--cov escpos --cov-report=xml" ""
+
+    # allow tests to find the cli executable
+    export PATH="$out/bin:$PATH"
+  '';
+
+  nativeCheckInputs = [
+    jaconv
+    pytestCheckHook
+    pytest-mock
+    scripttest
+    mock
+    hypothesis
+  ] ++ optional-dependencies.all;
+
+  pythonImportsCheck = [ "escpos" ];
+
+  meta = {
+    changelog = "https://github.com/python-escpos/python-escpos/blob/${src.rev}/CHANGELOG.rst";
+    description = "Python library to manipulate ESC/POS printers";
+    homepage = "https://python-escpos.readthedocs.io/";
+    license = lib.licenses.mit;
+    mainProgram = "python-escpos";
+    maintainers = with lib.maintainers; [ tomasajt ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10397,6 +10397,8 @@ self: super: with self; {
 
   python-ecobee-api = callPackage ../development/python-modules/python-ecobee-api { };
 
+  python-escpos = callPackage ../development/python-modules/python-escpos { };
+
   python-ffmpeg = callPackage ../development/python-modules/python-ffmpeg { };
 
   python-flirt = callPackage ../development/python-modules/python-flirt { };


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/332224

This PR adds 1 new python package: `python-escpos`
Repo: https://github.com/python-escpos/python-escpos

The tests do seem to pass, however I'm only able to test it on actual ESC/POS printers tomorrow.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
