### PR TITLE
python3.apt-repo: init at 0-unstable-2023-09-27

### DIFF
--- a/pkgs/development/python-modules/apt-repo/default.nix
+++ b/pkgs/development/python-modules/apt-repo/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  fetchFromGitHub,
+  unstableGitUpdater,
+
+  buildPythonPackage,
+  pytestCheckHook,
+  pythonOlder,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "apt-repo";
+  version = "0-unstable-2023-09-27";
+  pyproject = true;
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "brennerm";
+    repo = "python-apt-repo";
+    rev = "0287c59317f9ec8e8edbf7c228665a7010f758e7";
+    hash = "sha256-9PA6AIeMXpaDc9g+rYpzwhf4ts3Xb31rvAUgDebTG4A=";
+  };
+  passthru.updateScript = unstableGitUpdater {};
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "apt_repo" ];
+
+  meta = with lib; {
+    description = "Python library to query APT repositories";
+    homepage = "https://github.com/brennerm/python-apt-repo";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nicoo ];
+  };
+}

--- a/pkgs/development/python-modules/apt-repo/default.nix
+++ b/pkgs/development/python-modules/apt-repo/default.nix
@@ -24,6 +24,7 @@ buildPythonPackage rec {
   passthru.updateScript = unstableGitUpdater {};
 
   build-system = [ setuptools ];
+  nativeBuildInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "apt_repo" ];
 

--- a/pkgs/development/python-modules/apt-repo/default.nix
+++ b/pkgs/development/python-modules/apt-repo/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "apt-repo";
-  version = "0-unstable-2023-09-27";
+  version = "0.5-unstable-2023-09-27";
   pyproject = true;
   disabled = pythonOlder "3.5";
 

--- a/pkgs/development/python-modules/apt-repo/default.nix
+++ b/pkgs/development/python-modules/apt-repo/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     rev = "0287c59317f9ec8e8edbf7c228665a7010f758e7";
     hash = "sha256-9PA6AIeMXpaDc9g+rYpzwhf4ts3Xb31rvAUgDebTG4A=";
   };
-  passthru.updateScript = unstableGitUpdater {};
+  passthru.updateScript = unstableGitUpdater { };
 
   build-system = [ setuptools ];
   nativeBuildInputs = [ pytestCheckHook ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -711,6 +711,8 @@ self: super: with self; {
 
   apsw = callPackage ../development/python-modules/apsw { };
 
+  apt-repo = callPackage ../development/python-modules/apt-repo { };
+
   apycula = callPackage ../development/python-modules/apycula { };
 
   aqipy-atmotech = callPackage ../development/python-modules/aqipy-atmotech { };


### PR DESCRIPTION
## Description of changes

Add new Python module `apt-repo`, used for parsing APT repositories.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
