### PR TITLE
tinygo: 0.31.2 -> 0.32.0

### DIFF
--- a/pkgs/development/compilers/tinygo/0001-GNUmakefile.patch
+++ b/pkgs/development/compilers/tinygo/0001-GNUmakefile.patch
@@ -1,7 +1,7 @@
 diff --git a/GNUmakefile b/GNUmakefile
 --- a/GNUmakefile
 +++ b/GNUmakefile
-@@ -14,11 +14,6 @@ LLVM_VERSIONS = 14 13 12 11
+@@ -14,11 +14,6 @@ LLVM_VERSIONS = 18 17 16 15
  errifempty = $(if $(1),$(1),$(error $(2)))
  detect = $(shell which $(call errifempty,$(firstword $(foreach p,$(2),$(shell command -v $(p) 2> /dev/null && echo $(p)))),failed to locate $(1) at any of: $(2)))
  toolSearchPathsVersion = $(1)-$(2)
@@ -13,7 +13,7 @@ diff --git a/GNUmakefile b/GNUmakefile
  # First search for a custom built copy, then move on to explicitly version-tagged binaries, then just see if the tool is in path with its normal name.
  findLLVMTool = $(call detect,$(1),$(abspath llvm-build/bin/$(1)) $(foreach ver,$(LLVM_VERSIONS),$(call toolSearchPathsVersion,$(1),$(ver))) $(1))
  CLANG ?= $(call findLLVMTool,clang)
-@@ -707,9 +702,8 @@ endif
+@@ -816,9 +811,8 @@ endif
  wasmtest:
  	$(GO) test ./tests/wasm
  
@@ -24,26 +24,26 @@ diff --git a/GNUmakefile b/GNUmakefile
  	@mkdir -p build/release/tinygo/lib/CMSIS/CMSIS
  	@mkdir -p build/release/tinygo/lib/macos-minimal-sdk
  	@mkdir -p build/release/tinygo/lib/mingw-w64/mingw-w64-crt/lib-common
-@@ -721,15 +715,8 @@ build/release: tinygo gen-device wasi-libc $(if $(filter 1,$(USE_SYSTEM_BINARYEN
- 	@mkdir -p build/release/tinygo/lib/picolibc/newlib/libc
- 	@mkdir -p build/release/tinygo/lib/picolibc/newlib/libm
- 	@mkdir -p build/release/tinygo/lib/wasi-libc
+@@ -832,15 +826,11 @@ build/release: tinygo gen-device wasi-libc $(if $(filter 1,$(USE_SYSTEM_BINARYEN
+ 	@mkdir -p build/release/tinygo/lib/wasi-libc/libc-bottom-half/headers
+ 	@mkdir -p build/release/tinygo/lib/wasi-libc/libc-top-half/musl/arch
+ 	@mkdir -p build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
 -	@mkdir -p build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0
 -	@mkdir -p build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0plus
 -	@mkdir -p build/release/tinygo/pkg/thumbv7em-unknown-unknown-eabi-cortex-m4
  	@echo copying source files
  	@cp -p  build/tinygo$(EXE)           build/release/tinygo/bin
--ifneq ($(USE_SYSTEM_BINARYEN),1)
--	@cp -p  build/wasm-opt$(EXE)         build/release/tinygo/bin
--endif
+ ifneq ($(USE_SYSTEM_BINARYEN),1)
+ 	@cp -p  build/wasm-opt$(EXE)         build/release/tinygo/bin
+ endif
 -	@cp -p $(abspath $(CLANG_SRC))/lib/Headers/*.h build/release/tinygo/lib/clang/include
  	@cp -rp lib/CMSIS/CMSIS/Include      build/release/tinygo/lib/CMSIS/CMSIS
  	@cp -rp lib/CMSIS/README.md          build/release/tinygo/lib/CMSIS
  	@cp -rp lib/macos-minimal-sdk/*      build/release/tinygo/lib/macos-minimal-sdk
-@@ -768,16 +755,9 @@ endif
- 	@cp -rp lib/picolibc/newlib/libm/common      build/release/tinygo/lib/picolibc/newlib/libm
- 	@cp -rp lib/picolibc-stdio.c         build/release/tinygo/lib
- 	@cp -rp lib/wasi-libc/sysroot        build/release/tinygo/lib/wasi-libc/sysroot
+@@ -891,16 +881,9 @@ endif
+ 	@cp -rp lib/wasi-libc/libc-top-half/musl/src/string             build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
+ 	@cp -rp lib/wasi-libc/libc-top-half/musl/include                build/release/tinygo/lib/wasi-libc/libc-top-half/musl
+ 	@cp -rp lib/wasi-libc/sysroot                                   build/release/tinygo/lib/wasi-libc/sysroot
 -	@cp -rp llvm-project/compiler-rt/lib/builtins build/release/tinygo/lib/compiler-rt-builtins
 -	@cp -rp llvm-project/compiler-rt/LICENSE.TXT  build/release/tinygo/lib/compiler-rt-builtins
 +	@cp -rp lib/compiler-rt-builtins     build/release/tinygo/lib/compiler-rt-builtins

--- a/pkgs/development/compilers/tinygo/default.nix
+++ b/pkgs/development/compilers/tinygo/default.nix
@@ -28,17 +28,17 @@ in
 
 buildGoModule rec {
   pname = "tinygo";
-  version = "0.31.2";
+  version = "0.32.0";
 
   src = fetchFromGitHub {
     owner = "tinygo-org";
     repo = "tinygo";
     rev = "v${version}";
-    hash = "sha256-e0zXxIdAtJZXJdP/S6lHRnPm5Rsf638Fhox8XcqOWrk=";
+    hash = "sha256-zoXruGoWitx6kietF3HKTYCtUrXp5SOrf2FEGgVPzkQ=";
     fetchSubmodules = true;
   };
 
-  vendorHash = "sha256-HZiyAgsTEBQv+Qp0T9RXTV1lkxvIGh7Q45rd45cfvjo=";
+  vendorHash = "sha256-rJ8AfJkIpxDkk+9Tf7ORnn7ueJB1kjJUBiLMDV5tias=";
 
   patches = [
     ./0001-GNUmakefile.patch
@@ -110,7 +110,7 @@ buildGoModule rec {
   installPhase = ''
     runHook preInstall
 
-    make build/release
+    make build/release USE_SYSTEM_BINARYEN=1
 
     wrapProgram $out/bin/tinygo \
       --prefix PATH : ${lib.makeBinPath runtimeDeps }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16529,7 +16529,7 @@ with pkgs;
   tinycc = darwin.apple_sdk_11_0.callPackage ../development/compilers/tinycc { };
 
   tinygo = callPackage ../development/compilers/tinygo {
-    llvmPackages = llvmPackages_17;
+    llvmPackages = llvmPackages_18;
   };
 
   tinyscheme = callPackage ../development/interpreters/tinyscheme { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updated to 0.32.0. See the changelog: https://github.com/tinygo-org/tinygo/blob/v0.32.0/CHANGELOG.md

In addition to that, I've cleaned up the GNUmakefile patch a bit: instead of commenting out a few lines, pass `USE_SYSTEM_BINARYEN=1` explicitly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
