### PR TITLE
brscan5: remove deprecated SYSFS udev rule

### DIFF
--- a/nixos/tests/brscan5.nix
+++ b/nixos/tests/brscan5.nix
@@ -48,6 +48,10 @@ import ./make-test-python.nix (
       print(scanimage)
       assert """device `brother5:net1;dev0' is a Brother b ADS-1200""" in scanimage
       assert """device `brother5:net1;dev1' is a Brother a ADS-1200""" in scanimage
+
+      # Confirm systemd-udevd no longer logs errors about SYSFS
+      logs = machine.succeed('journalctl --unit systemd-udevd')
+      assert "Invalid key 'SYSFS'" not in logs
     '';
   }
 )

--- a/pkgs/by-name/br/brscan5/package.nix
+++ b/pkgs/by-name/br/brscan5/package.nix
@@ -79,6 +79,9 @@ stdenv.mkDerivation rec {
       # driver is hardcoded to look in /opt/brother/scanner/brscan5/models for model metadata.
       # patch it to look in /etc/opt/brother/scanner/models instead, so nixos environment.etc can make it available
       printf '/etc/opt/brother/scanner/models\x00' | dd of=opt/brother/scanner/brscan5/libsane-brother5.so.1.0.7 bs=1 seek=${toString patchOffsetBytes} conv=notrunc
+
+      # remove deprecated SYSFS udev rule
+      sed -i -e '/^SYSFS/d' opt/brother/scanner/brscan5/udev-rules/*.rules
     '';
 
   installPhase = ''


### PR DESCRIPTION
## Description of changes
This patch resolves an issue where systemd-udevd outputs events like:

```
/nix/store/jm9paymkapbi6pzwbjgmi634vaf2y5va-udev-rules/49-brother-mfp-brscan5-1.0.2-2.rules:17 Invalid key 'SYSFS'.
```

Fixes #332307
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
