### PR TITLE
nixos/borgbackup: fix extraArgs shell expansion

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -144,6 +144,12 @@
   ```
   This changed follows a deprecation period of one year started in NixOS 24.05 (see [PR #283818](https://github.com/NixOS/nixpkgs/pull/283818)).
 
+- The values of `services.borgbackup.jobs.*.extraArgs` and other `extra*Args` options are now represented as Bash arrays. If these arguments were modified using `services.borgbackup.jobs.*.preHook`, they will need to be adjusted to append to these arrays, i.e.
+  ```diff
+  -extraCreateArgs="$extraCreateArgs --exclude /some/path"
+  +extraCreateArgs+=("--exclude" "/some/path")
+  ```
+
 - `nodePackages.ganache` has been removed, as the package has been deprecated by upstream.
 
 - `virtualisation.azure.agent` option provided by `azure-agent.nix` is replaced by `services.waagent`, and will be removed in a future release.

--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -246,7 +246,7 @@ let
   };
 
 in {
-  meta.maintainers = with lib.maintainers; [ dotlambda ];
+  meta.maintainers = with lib.maintainers; [ dotlambda Scrumplex ];
   meta.doc = ./borgbackup.md;
 
   ###### interface

--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -20,8 +20,19 @@ let
     lib.concatStringsSep " "
       (lib.mapAttrsToList (x: y: "--keep-${x}=${toString y}") cfg.prune.keep);
 
+  mkExtraArgs = cfg:
+    # Create BASH arrays of extra args
+    lib.concatLines
+      (lib.mapAttrsToList (name: values: ''
+        ${name}=(${values})
+      '')
+  { inherit (cfg) extraArgs extraInitArgs extraCreateArgs extraPruneArgs extraCompactArgs; });
+
   mkBackupScript = name: cfg: pkgs.writeShellScript "${name}-script" (''
     set -e
+
+    ${mkExtraArgs cfg}
+
     on_exit()
     {
       exitStatus=$?
@@ -46,35 +57,35 @@ let
     ${cfg.preHook}
   '' + lib.optionalString cfg.doInit ''
     # Run borg init if the repo doesn't exist yet
-    if ! borgWrapper list $extraArgs > /dev/null; then
-      borgWrapper init $extraArgs \
+    if ! borgWrapper list "''${extraArgs[@]}" > /dev/null; then
+      borgWrapper init "''${extraArgs[@]}" \
         --encryption ${cfg.encryption.mode} \
-        $extraInitArgs
+        "''${extraInitArgs[@]}"
       ${cfg.postInit}
     fi
   '' + ''
     (
       set -o pipefail
       ${lib.optionalString (cfg.dumpCommand != null) ''${lib.escapeShellArg cfg.dumpCommand} | \''}
-      borgWrapper create $extraArgs \
+      borgWrapper create "''${extraArgs[@]}" \
         --compression ${cfg.compression} \
         --exclude-from ${mkExcludeFile cfg} \
         --patterns-from ${mkPatternsFile cfg} \
-        $extraCreateArgs \
+        "''${extraCreateArgs[@]}" \
         "::$archiveName$archiveSuffix" \
         ${if cfg.paths == null then "-" else lib.escapeShellArgs cfg.paths}
     )
   '' + lib.optionalString cfg.appendFailedSuffix ''
-    borgWrapper rename $extraArgs \
+    borgWrapper rename "''${extraArgs[@]}" \
       "::$archiveName$archiveSuffix" "$archiveName"
   '' + ''
     ${cfg.postCreate}
   '' + lib.optionalString (cfg.prune.keep != { }) ''
-    borgWrapper prune $extraArgs \
+    borgWrapper prune "''${extraArgs[@]}" \
       ${mkKeepArgs cfg} \
       ${lib.optionalString (cfg.prune.prefix != null) "--glob-archives ${lib.escapeShellArg "${cfg.prune.prefix}*"}"} \
-      $extraPruneArgs
-    borgWrapper compact $extraArgs $extraCompactArgs
+      "''${extraPruneArgs[@]}"
+    borgWrapper compact "''${extraArgs[@]}" "''${extraCompactArgs[@]}"
     ${cfg.postPrune}
   '');
 
@@ -120,7 +131,6 @@ let
       };
       environment = {
         BORG_REPO = cfg.repo;
-        inherit (cfg) extraArgs extraInitArgs extraCreateArgs extraPruneArgs extraCompactArgs;
       } // (mkPassEnv cfg) // cfg.environment;
     };
 
@@ -581,7 +591,7 @@ in {
             default = "";
             example = ''
               # To add excluded paths at runtime
-              extraCreateArgs="$extraCreateArgs --exclude /some/path"
+              extraCreateArgs+=("--exclude" "/some/path")
             '';
           };
 


### PR DESCRIPTION
## Description of changes

Fixes #323262

### Notes for reviewers

The first commit does some general refactoring of the code. The `borgbackup` NixOS test derivation produced by this commit is identical to its parent commit.

The second commit contains the actual fixes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
