### PR TITLE
unixODBCDrivers.psql: replace with pkgs.psqlodbc, fix qtbase build

### DIFF
--- a/pkgs/development/libraries/psqlodbc/default.nix
+++ b/pkgs/development/libraries/psqlodbc/default.nix
@@ -1,4 +1,9 @@
-{ lib, stdenv, fetchurl, libiodbc, postgresql, openssl }:
+{ lib, stdenv, fetchurl, postgresql, openssl
+, withLibiodbc ? false, libiodbc
+, withUnixODBC ? true, unixODBC
+}:
+
+assert lib.xor withLibiodbc withUnixODBC;
 
 stdenv.mkDerivation rec {
   pname = "psqlodbc";
@@ -9,18 +14,28 @@ stdenv.mkDerivation rec {
     hash = "sha256-r9iS+J0uzujT87IxTxvVvy0CIBhyxuNDHlwxCW7KTIs=";
   };
 
-  buildInputs = [ libiodbc postgresql openssl ];
+  buildInputs = [
+    postgresql
+    openssl
+  ]
+  ++ lib.optional withLibiodbc libiodbc
+  ++ lib.optional withUnixODBC unixODBC;
+
+  passthru = lib.optionalAttrs withUnixODBC {
+    fancyName = "PostgreSQL";
+    driver = "lib/psqlodbcw.so";
+  };
 
   configureFlags = [
-    "--with-iodbc=${libiodbc}"
     "--with-libpq=${lib.getDev postgresql}/bin/pg_config"
-  ];
+  ]
+  ++ lib.optional withLibiodbc "--with-iodbc=${libiodbc}";
 
   meta = with lib; {
     homepage = "https://odbc.postgresql.org/";
     description = "ODBC driver for PostgreSQL";
     license = licenses.lgpl2;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, unixODBC, cmake, postgresql, mariadb, sqlite, zlib, libxml2, dpkg, lib, openssl, libkrb5, libuuid, patchelf, libiconv, fixDarwinDylibNames, fetchFromGitHub }:
+{ fetchurl, stdenv, unixODBC, cmake, mariadb, sqlite, zlib, libxml2, dpkg, lib, openssl, libkrb5, libuuid, patchelf, libiconv, fixDarwinDylibNames, fetchFromGitHub, psqlodbc }:
 
 # Each of these ODBC drivers can be configured in your odbcinst.ini file using
 # the various passthru and meta values. Of note are:
@@ -16,30 +16,7 @@
 # ''
 
 {
-  psql = stdenv.mkDerivation rec {
-    pname = "psqlodbc";
-    version = "10.01.0000";
-
-    src = fetchurl {
-      url = "mirror://postgresql/odbc/versions/src/${pname}-${version}.tar.gz";
-      sha256 = "1cyams7157f3gry86x64xrplqi2vyqrq3rqka59gv4lb4rpl7jl7";
-    };
-
-    buildInputs = [ unixODBC postgresql ];
-
-    # see the top of the file for an explanation
-    passthru = {
-      fancyName = "PostgreSQL";
-      driver = "lib/psqlodbcw.so";
-    };
-
-    meta = with lib; {
-      description = "Official PostgreSQL ODBC Driver";
-      homepage = "https://odbc.postgresql.org/";
-      license = licenses.lgpl2;
-      platforms = platforms.unix;
-    };
-  };
+  psql = psqlodbc.override { withUnixODBC = true; withLibiodbc = false; };
 
   mariadb = stdenv.mkDerivation rec {
     pname = "mariadb-connector-odbc";


### PR DESCRIPTION

## Description of changes
The former hasn't been updated in years and broke with the upgrade of `pkgs.postgresql` to v16 subsequently breaking `qtbase`[1].

There's already `pkgs.psqlodbc` which seems to be the same, but kept up-to-date.

[1] https://github.com/NixOS/nixpkgs/pull/329611#issuecomment-2267513284

cc @alyssais 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
