### PR TITLE
postgresqlPackages.timescaledb_toolkit: fix on macos

### DIFF
--- a/pkgs/development/tools/rust/cargo-pgrx/buildPgrxExtension.nix
+++ b/pkgs/development/tools/rust/cargo-pgrx/buildPgrxExtension.nix
@@ -119,6 +119,7 @@ let
 
       NIX_PGLIBDIR="${postgresql}/lib" \
       PGRX_BUILD_FLAGS="--frozen -j $NIX_BUILD_CORES ${builtins.concatStringsSep " " cargoBuildFlags}" \
+      RUSTFLAGS="${lib.optionalString stdenv.isDarwin "-Clink-args=-Wl,-undefined,dynamic_lookup"}" \
       cargo pgrx package \
         --pg-config ${postgresql}/bin/pg_config \
         ${maybeDebugFlag} \

--- a/pkgs/servers/sql/postgresql/ext/timescaledb_toolkit.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb_toolkit.nix
@@ -5,7 +5,6 @@
 , nixosTests
 , cargo-pgrx_0_10_2
 , nix-update-script
-, stdenv
 }:
 
 (buildPgrxExtension.override { cargo-pgrx = cargo-pgrx_0_10_2; }) rec {

--- a/pkgs/servers/sql/postgresql/ext/timescaledb_toolkit.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb_toolkit.nix
@@ -40,8 +40,5 @@
     maintainers = with maintainers; [ typetetris ];
     platforms = postgresql.meta.platforms;
     license = licenses.tsl;
-
-    # as it needs to be used with timescaledb, simply use the condition from there
-    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
It looks like the macOS linker doesn’t like that some of the symbols are undefined in the extension. They will be provided by the postgres binary, but macOS linker checks that all symbols are defined. Apparently, Linux allows these symbols to be undefined.

The -undefined flag changes this behavior:

> Specifies how undefined symbols are to be treated. Options are:
> error, warning, suppress, or dynamic_lookup. The default is error.

So, setting to dynamic_lookup makes the most sense here, and makes this package work on macOS. I tried to see if pgvecto-rs, which also uses buildPgrxExtension, would build. Unfortunately, it gave other errors.

More information on the bug here: https://github.com/supabase/nix-postgres/issues/10

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant packa4ge/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
