### PR TITLE
miniflux: fix panic on youtube channel feed discovery

### DIFF
--- a/pkgs/servers/miniflux/default.nix
+++ b/pkgs/servers/miniflux/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, installShellFiles, nixosTests }:
+{ lib, buildGoModule, fetchFromGitHub, fetchpatch2, installShellFiles, nixosTests }:
 
 buildGoModule rec {
   pname = "miniflux";
@@ -10,6 +10,15 @@ buildGoModule rec {
     rev = "refs/tags/${version}";
     hash = "sha256-1EH8KtKdAssxLk0IyhJsbrFU1obDTvmaGtFyLVlnOdQ=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      # Fix panic during YouTube channel feed discovery
+      name = "miniflux-pr2742.patch";
+      url = "https://github.com/miniflux/v2/commit/79ea9e28b5a8c09f4d1dcbf31b661fb5f8e85e6a.patch";
+      hash = "sha256-BZPv83QsJ6iJs12FLALfTN//VZL/BfGkXs3Pzn9cGeU=";
+    })
+  ];
 
   vendorHash = "sha256-kr2qCKuwp6Fpr0zEjggqk4Mff3V9pxGLU71lRhdRrW8=";
 


### PR DESCRIPTION
## Description of changes

I'm running into a panic when adding a youtube channel as a feed. This was fixed upstream and I'm pulling the patch.

```
http: panic serving 127.0.0.1:59792: runtime error: invalid memory address or nil pointer dereference
goroutine 826812 [running]:
net/http.(*conn).serve.func1()
	net/http/server.go:1903 +0xbe
panic({0xd219c0?, 0x17285c0?})
	runtime/panic.go:770 +0x132
miniflux.app/v2/internal/ui.(*handler).submitSubscription(0xc000f55660, {0x10c2ea0, 0xc0012041c0}, 0xc0012a3680)
	miniflux.app/v2/internal/ui/subscription_submit.go:121 +0x8ca
net/http.HandlerFunc.ServeHTTP(0xc0012a3560?, {0x10c2ea0?, 0xc0012041c0?}, 0x10b8260?)
	net/http/server.go:2171 +0x29
miniflux.app/v2/internal/ui.(*middleware).handleAppSession-fm.(*middleware).handleAppSession.func1({0x10c2ea0, 0xc0012041c0}, 0xc0012a3560)
	miniflux.app/v2/internal/ui/middleware.go:125 +0x9b4
net/http.HandlerFunc.ServeHTTP(0xc0012a3440?, {0x10c2ea0?, 0xc0012041c0?}, 0x10bb3b8?)
	net/http/server.go:2171 +0x29
miniflux.app/v2/internal/ui.(*middleware).handleUserSession-fm.(*middleware).handleUserSession.func1({0x10c2ea0, 0xc0012041c0}, 0xc0012a3440)
	miniflux.app/v2/internal/ui/middleware.go:59 +0x385
net/http.HandlerFunc.ServeHTTP(0xc001c841e0?, {0x10c2ea0?, 0xc0012041c0?}, 0x10bb3c8?)
	net/http/server.go:2171 +0x29
miniflux.app/v2/internal/http/server.middleware.func1({0x10c2ea0, 0xc0012041c0}, 0xc0012a3320)
	miniflux.app/v2/internal/http/server/middleware.go:43 +0x351
net/http.HandlerFunc.ServeHTTP(0xc0012a3200?, {0x10c2ea0?, 0xc0012041c0?}, 0x1?)
	net/http/server.go:2171 +0x29
github.com/gorilla/mux.(*Router).ServeHTTP(0xc00067c000, {0x10c2ea0, 0xc0012041c0}, 0xc0012a30e0)
	github.com/gorilla/mux@v1.8.1/mux.go:212 +0x1e2
net/http.serverHandler.ServeHTTP({0x10c0e20?}, {0x10c2ea0?, 0xc0012041c0?}, 0x6?)
	net/http/server.go:3142 +0x8e
net/http.(*conn).serve(0xc0012b2480, {0x10c4bf0, 0xc001280090})
	net/http/server.go:2044 +0x5e8
created by net/http.(*Server).Serve in goroutine 82
	net/http/server.go:3290 +0x4b4
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
