### PR TITLE
singularity-tools: miscellaneous fixes

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -126,6 +126,8 @@
 
 - `singularity-tools` have the `storeDir` argument removed from its override interface and use `builtins.storeDir` instead.
 
+- Two build helpers in `singularity-tools`, i.e., `mkLayer` and `shellScript`, are deprecated, as they are no longer involved in image-building. Maintainers will remove them in future releases.
+
 - The `budgie` and `budgiePlugins` scope have been removed and their packages
   moved into the top level scope (i.e., `budgie.budgie-desktop` is now
   `budgie-desktop`)

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -124,6 +124,8 @@
   Processes also now run as a dynamically allocated user by default instead of
   root.
 
+- `singularity-tools` have the `storeDir` argument removed from its override interface and use `builtins.storeDir` instead.
+
 - The `budgie` and `budgiePlugins` scope have been removed and their packages
   moved into the top level scope (i.e., `budgie.budgie-desktop` is now
   `budgie-desktop`)

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -57,7 +57,7 @@ rec {
       runAsRootFile = shellScript "run-as-root.sh" runAsRoot;
       runScriptFile = shellScript "run-script.sh" runScript;
       result = vmTools.runInLinuxVM (
-        runCommand "${projectName}-image-${name}.img"
+        runCommand "${projectName}-image-${name}.sif"
           {
             buildInputs = [
               singularity

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -8,7 +8,6 @@
   writeScript,
   # Native build inputs
   e2fsprogs,
-  gawk,
   util-linux,
   # Build inputs
   bash,
@@ -63,7 +62,6 @@ rec {
               singularity
               e2fsprogs
               util-linux
-              gawk
             ];
             strictDeps = true;
             layerClosure = writeClosure contents;

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -59,12 +59,13 @@ rec {
       result = vmTools.runInLinuxVM (
         runCommand "${projectName}-image-${name}.sif"
           {
-            buildInputs = [
+            nativeBuildInputs = [
               singularity
               e2fsprogs
               util-linux
               gawk
             ];
+            strictDeps = true;
             layerClosure = writeClosure contents;
             preVM = vmTools.createEmptyImage {
               size = diskSize;

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -15,6 +15,10 @@
   singularity,
   storeDir ? builtins.storeDir,
 }:
+
+let
+  defaultSingularity = singularity;
+in
 rec {
   shellScript =
     name: text:
@@ -39,9 +43,6 @@ rec {
     '';
 
   buildImage =
-    let
-      defaultSingularity = singularity;
-    in
     {
       name,
       contents ? [ ],

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -107,12 +107,12 @@ rec {
             if [ ! -e bin/sh ]; then
               ln -s ${runtimeShell} bin/sh
             fi
-            mkdir -p .${projectName}.d
-            ln -s ${runScriptFile} .${projectName}.d/runscript
+            mkdir -p .singularity.d
+            ln -s ${runScriptFile} .singularity.d/runscript
 
-            # Fill out .${projectName}.d
-            mkdir -p .${projectName}.d/env
-            touch .${projectName}.d/env/94-appsbase.sh
+            # Fill out .singularity.d
+            mkdir -p .singularity.d/env
+            touch .singularity.d/env/94-appsbase.sh
 
             cd ..
             mkdir -p /var/lib/${projectName}/mnt/session

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -13,7 +13,6 @@
   bashInteractive,
   runtimeShell,
   singularity,
-  storeDir ? builtins.storeDir,
 }:
 
 let
@@ -83,10 +82,10 @@ rec {
 
             # Run root script
             ${lib.optionalString (runAsRoot != null) ''
-              mkdir -p ./${storeDir}
-              mount --rbind ${storeDir} ./${storeDir}
+              mkdir -p ./${builtins.storeDir}
+              mount --rbind "${builtins.storeDir}" ./${builtins.storeDir}
               unshare -imnpuf --mount-proc chroot ./ ${runAsRootFile}
-              umount -R ./${storeDir}
+              umount -R ./${builtins.storeDir}
             ''}
 
             # Build /bin and copy across closure

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -10,7 +10,7 @@
   e2fsprogs,
   util-linux,
   # Build inputs
-  bash,
+  bashInteractive,
   runtimeShell,
   singularity,
   storeDir ? builtins.storeDir,
@@ -105,7 +105,7 @@ rec {
 
             # Create runScript and link shell
             if [ ! -e bin/sh ]; then
-              ln -s ${runtimeShell} bin/sh
+              ln -s ${lib.getExe bashInteractive} bin/sh
             fi
             mkdir -p .singularity.d
             ln -s ${runScriptFile} .singularity.d/runscript


### PR DESCRIPTION
## Description of changes

This pull request introduces fixes targeting the `singularity-tools` build helper set.

Two backward-incompatible changes include:
-   Removing the `storeDir` argument from the `override` interface of `singularity-tools`.
    -   In the current implementation, `storeDir` is used interchangeably with `builtins.storeDir`. Besides, `storeDir` will be naturally reflected by `builtins.storeDir`. We could only configure the store path inside the container, which is not covered by the current implementation.
-   Remove two build helpers, `shellScript` and `mkLayer`.
    -   These two build helpers are no longer involved in image-building.

Split from #268199

Cc: @SomeoneSerge

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable: (tested `apptainer.tests.image-hello-cowsay` and `singularity.tests.image-hello-cowsay`)
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`) (tested the execution of the produced images.)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
