### PR TITLE
perplexica: init at 1.9.3

### DIFF
--- a/pkgs/by-name/pe/perplexica/package.json
+++ b/pkgs/by-name/pe/perplexica/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "perplexica-backend",
+  "version": "1.10.0-rc2",
+  "license": "MIT",
+  "author": "ItzCrazyKns",
+  "scripts": {
+    "start": "npm run db:push && node dist/app.js",
+    "build": "tsc",
+    "dev": "nodemon --ignore uploads/ src/app.ts ",
+    "db:push": "drizzle-kit push sqlite",
+    "format": "prettier . --check",
+    "format:write": "prettier . --write"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.10",
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/html-to-text": "^9.0.4",
+    "@types/multer": "^1.4.12",
+    "@types/pdf-parse": "^1.1.4",
+    "@types/readable-stream": "^4.0.11",
+    "@types/ws": "^8.5.12",
+    "drizzle-kit": "^0.22.7",
+    "nodemon": "^3.1.0",
+    "prettier": "^3.2.5",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.3"
+  },
+  "dependencies": {
+    "@iarna/toml": "^2.2.5",
+    "@langchain/anthropic": "^0.2.3",
+    "@langchain/community": "^0.2.16",
+    "@langchain/openai": "^0.0.25",
+    "@langchain/google-genai": "^0.0.23",
+    "@xenova/transformers": "^2.17.1",
+    "axios": "^1.6.8",
+    "better-sqlite3": "^11.0.0",
+    "compute-cosine-similarity": "^1.1.0",
+    "compute-dot": "^1.1.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "drizzle-orm": "^0.31.2",
+    "express": "^4.19.2",
+    "html-to-text": "^9.0.5",
+    "langchain": "^0.1.30",
+    "mammoth": "^1.8.0",
+    "multer": "^1.4.5-lts.1",
+    "pdf-parse": "^1.1.1",
+    "winston": "^3.13.0",
+    "ws": "^8.17.1",
+    "zod": "^3.22.4"
+  }
+}

--- a/pkgs/by-name/pe/perplexica/package.nix
+++ b/pkgs/by-name/pe/perplexica/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  mkYarnPackage,
+  fetchYarnDeps,
+  fetchFromGitHub,
+  makeWrapper,
+  nodejs_22,
+  patchelf,
+  srcOnly,
+  python3,
+  removeReferencesTo,
+  stdenv,
+  cctools,
+}:
+
+let
+  pin = lib.importJSON ./pin.json;
+  version = pin.version;
+  pname = "perplexica-backend";
+  nodeSources = srcOnly nodejs_22;
+
+  src = fetchFromGitHub {
+    owner = "ItzCrazyKns";
+    repo = "Perplexica";
+    rev = "v${version}";
+    hash = pin.srcHash;
+  };
+
+  passthru = {
+    nodeAppDir = "libexec/${pname}/deps/${pname}";
+    updateScript = ./update.sh;
+  };
+in
+mkYarnPackage {
+  inherit
+    version
+    pname
+    src
+    passthru
+    ;
+
+  packageJSON = ./package.json;
+  offlineCache = fetchYarnDeps {
+    yarnLock = "${src}/yarn.lock";
+    sha256 = pin.yarnSha256;
+  };
+
+  nodejs = nodejs_22;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    yarn --offline build
+
+    runHook postBuild
+  '';
+
+  pkgConfig = {
+    better-sqlite3 = {
+      nativeBuildInputs = [
+        python3
+        patchelf
+        nodejs_22
+      ] ++ lib.optionals stdenv.isDarwin [ cctools ];
+      postInstall = ''
+        # build native sqlite bindings
+        npm run build-release --offline --nodedir="${nodeSources}"
+        find build -type f -exec \
+          ${removeReferencesTo}/bin/remove-references-to \
+          -t "${nodeSources}" {} \;
+      '';
+    };
+  };
+
+  doCheck = false;
+
+  postInstall = ''
+    OUT_JS_DIR="$out/${passthru.nodeAppDir}/dist"
+
+    # server wrapper
+    makeWrapper '${nodejs_22}/bin/node' "$out/bin/${pname}" \
+      --add-flags "$OUT_JS_DIR/app.js"
+  '';
+
+  # don't generate the dist tarball
+  doDist = false;
+
+  meta = {
+    description = "Perplexica is an AI-powered search engine. It is an Open source alternative to Perplexity AI";
+    homepage = "https://github.com/ItzCrazyKns/Perplexica";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ happysalada ];
+    platforms = lib.platforms.all;
+    mainProgram = pname;
+  };
+}

--- a/pkgs/by-name/pe/perplexica/pin.json
+++ b/pkgs/by-name/pe/perplexica/pin.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.10.0",
+  "srcHash": "sha256-VGTB1Od1NL8/WRN3ZqgY7sB2OMTl8/BscV/dMPQCIVM=",
+  "yarnSha256": "0srmp8dvssf76inlkz7j2qc4x4ayh10k06xgi6vkdnzfi3w936pb"
+}

--- a/pkgs/by-name/pe/perplexica/update.sh
+++ b/pkgs/by-name/pe/perplexica/update.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=../../../.. -i bash -p nix curl jq prefetch-yarn-deps nix-prefetch-github
+
+ORG="ItzCrazyKns"
+PROJ="Perplexica"
+
+if [ "$#" -gt 1 ] || [[ "$1" == -* ]]; then
+  echo "Regenerates packaging data for $PROJ."
+  echo "Usage: $0 [git release tag]"
+  exit 1
+fi
+
+tag="$1"
+
+set -euox pipefail
+
+if [ -z "$tag" ]; then
+  tag="$(
+    curl "https://api.github.com/repos/$ORG/$PROJ/releases?per_page=1" |
+    jq -r '.[0].tag_name'
+  )"
+fi
+
+src="https://raw.githubusercontent.com/$ORG/$PROJ/$tag"
+src_hash=$(nix-prefetch-github $ORG $PROJ --rev ${tag} | jq -r .hash)
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+pushd $tmpdir
+curl -O "$src/yarn.lock"
+yarn_sha256=$(prefetch-yarn-deps yarn.lock)
+popd
+
+curl -O "$src/package.json"
+cat > pin.json << EOF
+{
+  "version": "$(echo $tag | grep -P '(\d|\.)+' -o)",
+  "srcHash": "$src_hash",
+  "yarnSha256": "$yarn_sha256"
+}
+EOF


### PR DESCRIPTION
## Description of changes

Very small PR to package perplexica. This only contains the backend so far, but this is to start the process. I'll likely do the frontend in another PR.
I'm not 100% settled on putting the module in perplexica vs perplexica-backend.
Just opening this early in case someone else is interested in this package and has opinions.
Most likely this won't be merged until this is properly updated with the 1.9.0 release.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
