### PR TITLE
Doc: pkgs{compressDrv,compressDrvWeb} improve clarity

### DIFF
--- a/pkgs/build-support/compress-drv/default.nix
+++ b/pkgs/build-support/compress-drv/default.nix
@@ -4,36 +4,51 @@
   runCommand,
 }:
 /**
-  #  compressDrv compresses files in a given derivation.
+  Compresses files of a given derivation, and returns a new derivation with
+  compressed files
 
-  ## Inputs:
+  # Inputs
 
   `formats` ([String])
 
   : List of file extensions to compress. Example: `["txt" "svg" "xml"]`.
 
-  `compressors` (String -> String)
+  `compressors` ( { ${fileExtension} :: String })
 
   : Map a desired extension (e.g. `gz`) to a compress program.
 
-  The compressor program that will be executed to get the `COMPRESSOR` extension.
-  The program should have a single " {}", which will be the replaced with the
-  target filename.
+    The compressor program that will be executed to get the `COMPRESSOR` extension.
+    The program should have a single " {}", which will be the replaced with the
+    target filename.
 
-  Compressor must:
-  - read symlinks (thus --force is needed to gzip, zstd, xz).
-  - keep the original file in place (--keep).
+    Compressor must:
 
-  Example:
+    - read symlinks (thus --force is needed to gzip, zstd, xz).
+    - keep the original file in place (--keep).
+
+  # Type
 
   ```
-  {
-    xz = "${xz}/bin/xz --force --keep {}";
+  compressDrv :: Derivation -> { formats :: [ String ]; compressors :: { ${fileExtension} :: String; } } -> Derivation
+  ```
+
+  # Examples
+  :::{.example}
+  ## `pkgs.compressDrv` usage example
+  ```
+  compressDrv pkgs.spdx-license-list-data.json {
+    formats = ["json"];
+    compressors = {
+      "json" = "${zopfli}/bin/zopfli --keep {}";
+    };
   }
+  =>
+  «derivation /nix/store/...-spdx-license-list-data-3.24.0-compressed.drv»
   ```
 
-  See compressDrvWeb, which is a wrapper on top of compressDrv, for broader use
+  See also pkgs.compressDrvWeb, which is a wrapper on top of compressDrv, for broader usage
   examples.
+  :::
 */
 drv:
 { formats, compressors, ... }:

--- a/pkgs/build-support/compress-drv/web.nix
+++ b/pkgs/build-support/compress-drv/web.nix
@@ -4,76 +4,105 @@
   compressDrv,
 }:
 /**
-  # compressDrvWeb compresses a derivation for common web server use.
+  compressDrvWeb compresses a derivation for common web server use.
 
   Useful when one wants to pre-compress certain static assets and pass them to
-  the web server. For example, `pkgs.gamja` creates this derivation:
+  the web server.
 
-      /nix/store/2wn1qbk8gp4y2m8xvafxv1b2dcdqj8fz-gamja-1.0.0-beta.9/
-      ├── index.2fd01148.js
-      ├── index.2fd01148.js.map
-      ├── index.37aa9a8a.css
-      ├── index.37aa9a8a.css.map
-      ├── index.html
-      └── manifest.webmanifest
+  # Inputs
 
-  `pkgs.compressDrvWeb pkgs.gamja`:
+  `formats` ([String])
 
-      /nix/store/f5ryid7zrw2hid7h9kil5g5j29q5r2f7-gamja-1.0.0-beta.9-compressed
-      ├── index.2fd01148.js -> /nix/store/2wn1qbk8gp4y2m8xvafxv1b2dcdqj8fz-gamja-1.0.0-beta.9/index.2fd01148.js
-      ├── index.2fd01148.js.br
-      ├── index.2fd01148.js.gz
-      ├── index.2fd01148.js.map -> /nix/store/2wn1qbk8gp4y2m8xvafxv1b2dcdqj8fz-gamja-1.0.0-beta.9/index.2fd01148.js.map
-      ├── index.2fd01148.js.map.br
-      ├── index.2fd01148.js.map.gz
-      ├── index.37aa9a8a.css -> /nix/store/2wn1qbk8gp4y2m8xvafxv1b2dcdqj8fz-gamja-1.0.0-beta.9/index.37aa9a8a.css
-      ├── index.37aa9a8a.css.br
-      ├── index.37aa9a8a.css.gz
-      ├── index.37aa9a8a.css.map -> /nix/store/2wn1qbk8gp4y2m8xvafxv1b2dcdqj8fz-gamja-1.0.0-beta.9/index.37aa9a8a.css.map
-      ├── index.37aa9a8a.css.map.br
-      ├── index.37aa9a8a.css.map.gz
-      ├── index.html -> /nix/store/2wn1qbk8gp4y2m8xvafxv1b2dcdqj8fz-gamja-1.0.0-beta.9/index.html
-      ├── index.html.br
-      ├── index.html.gz
-      ├── manifest.webmanifest -> /nix/store/2wn1qbk8gp4y2m8xvafxv1b2dcdqj8fz-gamja-1.0.0-beta.9/manifest.webmanifest
-      ├── manifest.webmanifest.br
-      └── manifest.webmanifest.gz
+  : List of file extensions to compress.
 
-  When this `-compressed` directory is passed to a properly configured web
-  server, it will serve those pre-compressed files:
+    Defaults to common formats that compress well.
 
-      $ curl -I -H 'Accept-Encoding: br' https://irc.example.org/
-      <...>
-      content-encoding: br
-      <...>
+  `extraFormats` ([ String ])
+
+  : Extra extensions to compress in addition to `formats`.
+
+  `compressors` ( { ${fileExtension} :: String })
+
+  : Map a desired extension (e.g. `gz`) to a compress program.
+
+  # Type
+
+  ```
+  compressDrvWeb :: Derivation -> { formats :: [ String ]; extraFormats :: [ String ]; compressors :: { ${fileExtension} :: String; } } -> Derivation
+  ```
+
+  # Examples
+  :::{.example}
+  ## `pkgs.compressDrvWeb` full usage example with `pkgs.gamja` and a webserver
+  ```nix
+
+  For example, building `pkgs.gamja` produces the following output:
+
+    /nix/store/2wn1qbk8gp4y2m8xvafxv1b2dcdqj8fz-gamja-1.0.0-beta.9/
+    ├── index.2fd01148.js
+    ├── index.2fd01148.js.map
+    ├── index.37aa9a8a.css
+    ├── index.37aa9a8a.css.map
+    ├── index.html
+    └── manifest.webmanifest
+
+  With `pkgs.compressDrvWeb`, one can compress these files:
+
+  ```nix
+  pkgs.compressDrvWeb pkgs.gamja {}
+  =>
+  «derivation /nix/store/...-gamja-compressed.drv»
+  ```
+
+  ```bash
+  /nix/store/f5ryid7zrw2hid7h9kil5g5j29q5r2f7-gamja-1.0.0-beta.9-compressed
+  ├── index.2fd01148.js -> /nix/store/2wn1qbk8gp4y2m8xvafxv1b2dcdqj8fz-gamja-1.0.0-beta.9/index.2fd01148.js
+  ├── index.2fd01148.js.br
+  ├── index.2fd01148.js.gz
+  ├── index.2fd01148.js.map -> /nix/store/2wn1qbk8gp4y2m8xvafxv1b2dcdqj8fz-gamja-1.0.0-beta.9/index.2fd01148.js.map
+  ├── index.2fd01148.js.map.br
+  ├── index.2fd01148.js.map.gz
+  ├── index.37aa9a8a.css -> /nix/store/2wn1qbk8gp4y2m8xvafxv1b2dcdqj8fz-gamja-1.0.0-beta.9/index.37aa9a8a.css
+  ├── index.37aa9a8a.css.br
+  ├── index.37aa9a8a.css.gz
+  ├── index.37aa9a8a.css.map -> /nix/store/2wn1qbk8gp4y2m8xvafxv1b2dcdqj8fz-gamja-1.0.0-beta.9/index.37aa9a8a.css.map
+  ├── index.37aa9a8a.css.map.br
+  ├── index.37aa9a8a.css.map.gz
+  ├── index.html -> /nix/store/2wn1qbk8gp4y2m8xvafxv1b2dcdqj8fz-gamja-1.0.0-beta.9/index.html
+  ├── index.html.br
+  ├── index.html.gz
+  ├── manifest.webmanifest -> /nix/store/2wn1qbk8gp4y2m8xvafxv1b2dcdqj8fz-gamja-1.0.0-beta.9/manifest.webmanifest
+  ├── manifest.webmanifest.br
+  └── manifest.webmanifest.gz
+  ```
+
+  When the `-compressed` derivation is passed to a properly configured web server,
+  it enables direct serving of the pre-compressed files.
+
+  ```shell-session
+  $ curl -I -H 'Accept-Encoding: br' https://irc.example.org/
+  <...>
+  content-encoding: br
+  <...>
+  ```
 
   For example, a caddy configuration snippet for gamja to serve
   the static assets (JS, CSS files) pre-compressed:
 
-      virtualHosts."irc.example.org".extraConfig = ''
-        root * ${pkgs.compressDrvWeb pkgs.gamja {}}
-        file_server browse {
-            precompressed br gzip
-        }
-      '';
+  ```nix
+  {
+    virtualHosts."irc.example.org".extraConfig = ''
+      root * ${pkgs.compressDrvWeb pkgs.gamja {}}
+      file_server browse {
+          precompressed br gzip
+      }
+    '';
+  }
+  ```
 
   This feature is also available in nginx via `ngx_brotli` and
   `ngx_http_gzip_static_module`.
-
-  ## Inputs
-
-  `formats` ([String])
-
-  : List of file extensions to compress. Default is common formats that compress
-  well. The list may be expanded.
-
-  `extraFormats` ([String])
-
-  : Extra extensions to compress in addition to `formats`.
-
-  `compressors` (String -> String)
-
-  : See parameter `compressors` of compressDrv.
+  :::
 */
 drv:
 {


### PR DESCRIPTION
## Description of changes

> Note: This doesnt get rendered into any of the manuals:
> The only place where people can discover it currently is the code and https://noogle.dev/f/pkgs/compressDrv

- Improves clarity
- More consistent with the other docs.
- Move the extensive example into an example block, which can be collapsed / is collapsed by default in nixpkgs manual.

cc: @motiejus @Ma27 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
