### PR TITLE
qcal: update 0.9.1 -> 0.9.2

### DIFF
--- a/pkgs/tools/networking/qcal/default.nix
+++ b/pkgs/tools/networking/qcal/default.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
   # to that config file in the nix store
   preBuild = ''
     substituteInPlace helpers.go \
-      --replace " config-sample.json " " $out/share/qcal/config-sample.json "
+      --replace-fail " config-sample.json " " $out/share/qcal/config-sample.json "
   '';
 
   postInstall = ''

--- a/pkgs/tools/networking/qcal/default.nix
+++ b/pkgs/tools/networking/qcal/default.nix
@@ -5,14 +5,14 @@
 
 buildGoModule rec {
   pname = "qcal";
-  version = "0.9.1";
+  version = "0.9.2";
   src = fetchFromSourcehut {
     owner = "~psic4t";
     repo = "qcal";
     rev = version;
-    hash = "sha256-Rj806cKCFxWB8X4EiKvyZ5/xACw+VVbo9hv8AJiB0S4=";
+    hash = "sha256-azUN4oYbD0fBZav4ogh/mELV9+IW6aAV7Oom8Wq6sYI=";
   };
-  vendorHash = "sha256-ntpSj3Ze7n1sMIMojaESi4tQtx+mrA0aiv3+MQetjZI=";
+  vendorHash = "sha256-W9g2JzShvm2hJ+fcdwsoD3B6iUU55ufN6FTTl6qK6Oo=";
 
   # Replace "config-sample.json" in error message with the absolute path
   # to that config file in the nix store


### PR DESCRIPTION
## Description of changes

- update 0.9.1 -> 0.9.2 ([release notes](https://git.sr.ht/~psic4t/qcal/refs/0.9.2))
- use `substituteInPlace --replace-fail` instead of deprecated `substituteInPlace --replace` (see https://github.com/NixOS/nixpkgs/pull/260776)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
