### PR TITLE
sysdig-cli-scanner: init at 1.13.2

### DIFF
--- a/pkgs/by-name/sy/sysdig-cli-scanner/package.nix
+++ b/pkgs/by-name/sy/sysdig-cli-scanner/package.nix
@@ -1,0 +1,55 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  makeWrapper,
+}:
+let
+  versionMetadata = import ./sysdig-cli-scanner.versions.nix;
+  fetchForSystem = versionMetadata.${stdenv.system} or (throw "unsupported system ${stdenv.system}");
+in
+stdenv.mkDerivation {
+  pname = "sysdig-cli-scanner";
+  version = versionMetadata.version;
+
+  src = fetchurl { inherit (fetchForSystem) url hash; };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 -T $src $out/bin/sysdig-cli-scanner
+
+    wrapProgram $out/bin/sysdig-cli-scanner \
+      --add-flags --dbpath="\$HOME/.cache/sysdig-cli-scanner/"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = with lib; {
+    description = "Tool for scanning container images and directories using Sysdig";
+    longDescription = ''
+      The Sysdig Vulnerability CLI Scanner, sysdig-cli-scanner, is a versatile tool designed to
+      manually scan container images and directories, whether they are located locally or remotely.
+      Depending on your specific use case, you have the flexibility to execute sysdig-cli-scanner
+      in Vulnerability Management (VM) mode for image scanning or Infrastructure as Code (IaC) mode
+      for scanning directories.
+    '';
+    homepage = "https://docs.sysdig.com/en/docs/installation/sysdig-secure/install-vulnerability-cli-scanner/";
+    mainProgram = "sysdig-cli-scanner";
+    license = licenses.unfreeRedistributable;
+    maintainers = with maintainers; [ tembleking ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/sy/sysdig-cli-scanner/sysdig-cli-scanner.versions.nix
+++ b/pkgs/by-name/sy/sysdig-cli-scanner/sysdig-cli-scanner.versions.nix
@@ -1,0 +1,23 @@
+{
+  version = "1.13.2";
+
+  x86_64-linux = {
+    url = "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/1.13.2/linux/amd64/sysdig-cli-scanner";
+    hash = "sha256-nFQ+xDiB7CA9mfQlRiTH/FvyZMKZ0YH8Gzn4ZuZ/Ucc=";
+  };
+
+  aarch64-linux = {
+    url = "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/1.13.2/linux/arm64/sysdig-cli-scanner";
+    hash = "sha256-IscMTVzEbWImFZa7uXNp2K6Gplnq2LZoVPoAo5oIZ1U=";
+  };
+
+  x86_64-darwin = {
+    url = "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/1.13.2/darwin/amd64/sysdig-cli-scanner";
+    hash = "sha256-Xgip9cquafpRuYcXnnCF5ptFi774EocBZ535b/LzXUQ=";
+  };
+
+  aarch64-darwin = {
+    url = "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/1.13.2/darwin/arm64/sysdig-cli-scanner";
+    hash = "sha256-l/u8UV9O5/mFrNHpyIaKvXbVCQ+Fh6binJLv7MCHrtM=";
+  };
+}

--- a/pkgs/by-name/sy/sysdig-cli-scanner/update.sh
+++ b/pkgs/by-name/sy/sysdig-cli-scanner/update.sh
@@ -1,0 +1,56 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p bash curl jq
+
+set -euo pipefail
+
+LATEST_VERSION=$(curl -L -s https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)
+SUPPORTED_OPERATING_SYSTEMS=("linux" "darwin")
+SUPPORTED_ARCHITECTURES=("x86_64" "aarch64")
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+VERSIONS_FILE="${SCRIPT_DIR}/sysdig-cli-scanner.versions.nix"
+
+main() {
+  echo "{" > "$VERSIONS_FILE"
+  echo "  version = \"${LATEST_VERSION}\";" >> "$VERSIONS_FILE"
+  for os in "${SUPPORTED_OPERATING_SYSTEMS[@]}"; do
+    for arch in "${SUPPORTED_ARCHITECTURES[@]}"; do
+      formatted_arch=$(formatArchitectureForURL "$arch")
+      download_url="https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/${LATEST_VERSION}/${os}/${formatted_arch}/sysdig-cli-scanner"
+      file_hash=$(fetchFileHash "$download_url")
+      appendToVersionsFile "$VERSIONS_FILE" "$arch" "$os" "$download_url" "$file_hash"
+    done
+  done
+  echo "}" >> "$VERSIONS_FILE"
+}
+
+formatArchitectureForURL() {
+  local architecture="$1"
+  case "$architecture" in
+    x86_64) echo "amd64" ;;
+    aarch64) echo "arm64" ;;
+    *) echo "Unsupported architecture: $architecture" >&2; return 1 ;;
+  esac
+}
+
+fetchFileHash() {
+  local url="$1"
+  nix store prefetch-file --json "$url" | jq -r .hash
+}
+
+appendToVersionsFile() {
+  local file="$1"
+  local architecture="$2"
+  local operating_system="$3"
+  local url="$4"
+  local hash="$5"
+  cat >> "$file" << EOF
+
+  ${architecture}-${operating_system} = {
+    url = "$url";
+    hash = "$hash";
+  };
+EOF
+}
+
+main
+


### PR DESCRIPTION
## Description of changes

The Sysdig Vulnerability CLI Scanner, [sysdig-cli-scanner](https://docs.sysdig.com/en/docs/installation/sysdig-secure/install-vulnerability-cli-scanner/), is a versatile tool designed to manually scan container images and directories, whether they are located locally or remotely. Depending on your specific use case, you have the flexibility to execute sysdig-cli-scanner in Vulnerability Management (VM) mode for image scanning or Infrastructure as Code (IaC) mode for scanning directories

Latest version: 1.13.2 (Can be checked at: https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
