### PR TITLE
codecrafters-cli: init at 34

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2637,10 +2637,11 @@
     name = "Roman Gerasimenko";
   };
   builditluc = {
-    email = "builditluc@icloud.com";
+    email = "git@builditluc.eu";
     github = "Builditluc";
     githubId = 37375448;
-    name = "Buildit";
+    name = "Builditluc";
+    keys = [ { fingerprint = "FF16E475723B8C1E57A6B2569374074AE2D6F20E"; } ];
   };
   bwlang = {
     email = "brad@langhorst.com";

--- a/pkgs/by-name/co/codecrafters-cli/package.nix
+++ b/pkgs/by-name/co/codecrafters-cli/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  git,
+}:
+
+buildGoModule rec {
+  pname = "codecrafters-cli";
+  version = "34";
+
+  src = fetchFromGitHub {
+    owner = "codecrafters-io";
+    repo = "cli";
+    rev = "v${version}";
+    hash = "sha256-+daBduhjUt7lrjTdXgm1qpZN1oEHC3Nx+ZiOLoO5+s4=";
+    # A shortened git commit hash is part of the version output, and is
+    # needed at build time. Use the `.git` directory to retrieve the
+    # commit SHA, and remove the directory afterwards since it is not needed
+    # after that.
+    leaveDotGit = true;
+    postFetch = ''
+      git -C $"$out" rev-parse --short=7 HEAD > $out/COMMIT
+      rm -rf $out/.git
+    '';
+  };
+
+  vendorHash = "sha256-TQcxzfiqKeCQZUKLHnPjBa/0WsYJhER3fmr4cRGFknw=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/codecrafters-io/cli/internal/utils.Version=${version}"
+  ];
+
+  # ldflags based on metadata from git
+  preBuild = ''
+    ldflags+=" -X github.com/codecrafters-io/cli/internal/utils.Commit=$(cat COMMIT)"
+  '';
+
+  doCheck = true;
+
+  nativeBuildInputs = [ git ];
+
+  meta = with lib; {
+    description = "CodeCrafters CLI to run tests";
+    mainProgram = "codecrafters";
+    homepage = "https://github.com/codecrafters-io/cli";
+    maintainers = with maintainers; [ builditluc ];
+    license = licenses.mit;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The CodeCrafters CLI, [codecrafters](https://docs.codecrafters.io/cli/installation), is a command-line tool that allows you to run tests & view test results of the current stage from your local machine.

Link to the homepage: https://codecrafters.io/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
