### PR TITLE
pretix: variouss fixes

### DIFF
--- a/nixos/modules/services/web-apps/pretix.nix
+++ b/nixos/modules/services/web-apps/pretix.nix
@@ -538,6 +538,7 @@ in
           TimeoutStartSec = "15min";
           ExecStart = "${getExe' pythonEnv "gunicorn"} --bind unix:/run/pretix/pretix.sock ${cfg.gunicorn.extraArgs} pretix.wsgi";
           RuntimeDirectory = "pretix";
+          Restart = "on-failure";
         };
       };
 
@@ -559,7 +560,10 @@ in
           "postgresql.service"
         ];
         wantedBy = [ "multi-user.target" ];
-        serviceConfig.ExecStart = "${getExe' pythonEnv "celery"} -A pretix.celery_app worker ${cfg.celery.extraArgs}";
+        serviceConfig = {
+          ExecStart = "${getExe' pythonEnv "celery"} -A pretix.celery_app worker ${cfg.celery.extraArgs}";
+          Restart = "on-failure";
+        };
       };
 
       nginx.serviceConfig.SupplementaryGroups = mkIf cfg.nginx.enable [ "pretix" ];

--- a/nixos/tests/web-apps/pretix.nix
+++ b/nixos/tests/web-apps/pretix.nix
@@ -20,6 +20,7 @@
         plugins = with pkgs.pretix.plugins; [
           passbook
           pages
+          zugferd
         ];
         settings = {
           pretix = {

--- a/pkgs/by-name/pr/pretix/package.nix
+++ b/pkgs/by-name/pr/pretix/package.nix
@@ -13,6 +13,16 @@ let
   python = python3.override {
     self = python;
     packageOverrides = self: super: {
+      bleach = super.bleach.overridePythonAttrs (oldAttrs: rec {
+        version = "5.0.1";
+
+        src = fetchPypi {
+          pname = "bleach";
+          inherit version;
+          hash = "sha256-DQMlXEfrm9Lyaqm7fyEHcy5+j+GVyi9kcJ/POwpKCFw=";
+        };
+      });
+
       django = super.django_4;
 
       django-oauth-toolkit = super.django-oauth-toolkit.overridePythonAttrs (oldAttrs: {
@@ -84,7 +94,6 @@ python.pkgs.buildPythonApplication rec {
   ];
 
   pythonRelaxDeps = [
-    "bleach"
     "importlib-metadata"
     "pillow"
     "protobuf"

--- a/pkgs/by-name/pr/pretix/plugins/zugferd.nix
+++ b/pkgs/by-name/pr/pretix/plugins/zugferd.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   pretix-plugin-build,
   setuptools,
+  django,
   drafthorse,
   ghostscript_headless,
 }:
@@ -28,9 +29,14 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "drafthorse" ];
 
   build-system = [
+    django
     pretix-plugin-build
     setuptools
   ];
+
+  postBuild = ''
+    make
+  '';
 
   dependencies = [ drafthorse ];
 


### PR DESCRIPTION
Pin bleach to 5.0.1 otherwise we run into TypeErrors on at least the pages plugin.

```
ERROR 2024-08-05 15:15:33,302 django.request log Internal Server Error: /mrmcd/2019/page/house-rules/
Traceback (most recent call last):
  File "/nix/store/a9hc321pvz664g5022szqkhark1majxg-python3-3.12.4-env/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/a9hc321pvz664g5022szqkhark1majxg-python3-3.12.4-env/lib/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/a9hc321pvz664g5022szqkhark1majxg-python3-3.12.4-env/lib/python3.12/site-packages/pretix/presale/utils.py", line 424, in wrap
    response = func(request=request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/a9hc321pvz664g5022szqkhark1majxg-python3-3.12.4-env/lib/python3.12/site-packages/pretix/presale/utils.py", line 424, in wrap
    response = func(request=request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/a9hc321pvz664g5022szqkhark1majxg-python3-3.12.4-env/lib/python3.12/site-packages/pretix/presale/utils.py", line 424, in wrap
    response = func(request=request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/a9hc321pvz664g5022szqkhark1majxg-python3-3.12.4-env/lib/python3.12/site-packages/django/views/generic/base.py", line 104, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/a9hc321pvz664g5022szqkhark1majxg-python3-3.12.4-env/lib/python3.12/site-packages/django/views/generic/base.py", line 143, in dispatch
    return handler(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/a9hc321pvz664g5022szqkhark1majxg-python3-3.12.4-env/lib/python3.12/site-packages/django/views/generic/base.py", line 226, in get
    context = self.get_context_data(**kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/a9hc321pvz664g5022szqkhark1majxg-python3-3.12.4-env/lib/python3.12/site-packages/pretix_pages/views.py", line 292, in get_context_data
    ctx['content'] = bleach.clean(str(page.text), tags=bleach.ALLOWED_TAGS + [
                                                       ^^^^^^^^^^^^^^^^^^^^^^^
TypeError: unsupported operand type(s) for +: 'frozenset' and 'list'
```

And a failure to restart pretix-worker (celery), when it complained about redis (was a disk full event):

```
Aug 05 14:53:10 srv2 systemd[1]: Started pretalx asynchronous job runner.
Aug 05 14:53:12 srv2 celery[30931]: ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
Aug 05 14:53:12 srv2 celery[30931]: ┃ ┏━━━━━━━━━━┓  pretalx v2024.1.0                                                                                                ┃
Aug 05 14:53:12 srv2 celery[30931]: ┃ ┃  ┌─·──╮  ┃  Settings:                                                                                                        ┃
Aug 05 14:53:12 srv2 celery[30931]: ┃ ┃  │  O │  ┃  Database:  pretalx (postgresql)                                                                                  ┃
Aug 05 14:53:12 srv2 celery[30931]: ┃ ┃  │ ┌──╯  ┃  Logging:   /var/log/pretalx                                                                                      ┃
Aug 05 14:53:12 srv2 celery[30931]: ┃ ┃  └─┘     ┃  Root dir:  /nix/store/7l28675h69s087imm1k0ky3d4k0xjzjx-python3-3.12.4-env/lib/python3.12/site-packages/pretalx   ┃
Aug 05 14:53:12 srv2 celery[30931]: ┃ ┗━━━┯━┯━━━━┛  Python:    /nix/store/7l28675h69s087imm1k0ky3d4k0xjzjx-python3-3.12.4-env/bin/python3.12                         ┃
Aug 05 14:53:12 srv2 celery[30931]: ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
Aug 05 14:53:12 srv2 celery[30931]:  
Aug 05 14:53:12 srv2 celery[30931]:  -------------- celery@srv2 v5.4.0 (opalescent)
Aug 05 14:53:12 srv2 celery[30931]: --- ***** -----
Aug 05 14:53:12 srv2 celery[30931]: -- ******* ---- Linux-6.6.44-aarch64-with-glibc2.39 2024-08-05 14:53:12
Aug 05 14:53:12 srv2 celery[30931]: - *** --- * ---
Aug 05 14:53:12 srv2 celery[30931]: - ** ---------- [config]
Aug 05 14:53:12 srv2 celery[30931]: - ** ---------- .> app:         pretalx:0xffff9fca7980
Aug 05 14:53:12 srv2 celery[30931]: - ** ---------- .> transport:   redis+socket:///run/redis-pretalx/redis.sock
Aug 05 14:53:12 srv2 celery[30931]: - ** ---------- .> results:     socket:///run/redis-pretalx/redis.sock
Aug 05 14:53:12 srv2 celery[30931]: - *** --- * --- .> concurrency: 2 (prefork)
Aug 05 14:53:12 srv2 celery[30931]: -- ******* ---- .> task events: OFF (enable -E to monitor tasks in this worker)
Aug 05 14:53:12 srv2 celery[30931]: --- ***** -----
Aug 05 14:53:12 srv2 celery[30931]:  -------------- [queues]
Aug 05 14:53:12 srv2 celery[30931]:                 .> celery           exchange=celery(direct) key=celery
Aug 05 14:53:12 srv2 celery[30931]:                 
Aug 05 14:53:13 srv2 celery[30931]: [2024-08-05 14:53:13,144: WARNING/MainProcess] /nix/store/7l28675h69s087imm1k0ky3d4k0xjzjx-python3-3.12.4-env/lib/python3.12/site-packages/celery/worker/consumer/consumer.py:508: CPendingDeprecationWarning: The broker_connection_retry configuration setting will no longer determine
Aug 05 14:53:13 srv2 celery[30931]: whether broker connection retries are made during startup in Celery 6.0 and above.
Aug 05 14:53:13 srv2 celery[30931]: If you wish to retain the existing behavior for retrying connections on startup,
Aug 05 14:53:13 srv2 celery[30931]: you should set broker_connection_retry_on_startup to True.
Aug 05 14:53:13 srv2 celery[30931]:   warnings.warn(
Aug 05 14:53:13 srv2 celery[30931]: [2024-08-05 14:53:13,150: WARNING/MainProcess] /nix/store/7l28675h69s087imm1k0ky3d4k0xjzjx-python3-3.12.4-env/lib/python3.12/site-packages/celery/worker/consumer/consumer.py:508: CPendingDeprecationWarning: The broker_connection_retry configuration setting will no longer determine
Aug 05 14:53:13 srv2 celery[30931]: whether broker connection retries are made during startup in Celery 6.0 and above.
Aug 05 14:53:13 srv2 celery[30931]: If you wish to retain the existing behavior for retrying connections on startup,
Aug 05 14:53:13 srv2 celery[30931]: you should set broker_connection_retry_on_startup to True.
Aug 05 14:53:13 srv2 celery[30931]:   warnings.warn(
Aug 05 15:18:03 srv2 celery[30931]: [2024-08-05 15:18:03,709: CRITICAL/MainProcess] Unrecoverable error: ResponseError("MISCONF Redis is configured to save RDB snapshots, but it's currently unable to persist to disk. Commands that may modify the data set are disabled, because this instance is configured to report errors during writes if RDB snapshotting fails (stop-writes-on-bgsave-error option). Please check the Redis logs for details about the RDB error.")
Aug 05 15:18:03 srv2 celery[30931]: Traceback (most recent call last):
Aug 05 15:18:03 srv2 celery[30931]:   File "/nix/store/7l28675h69s087imm1k0ky3d4k0xjzjx-python3-3.12.4-env/lib/python3.12/site-packages/celery/worker/worker.py", line 202, in start
Aug 05 15:18:03 srv2 celery[30931]:     self.blueprint.start(self)
Aug 05 15:18:03 srv2 celery[30931]:   File "/nix/store/7l28675h69s087imm1k0ky3d4k0xjzjx-python3-3.12.4-env/lib/python3.12/site-packages/celery/bootsteps.py", line 116, in start
Aug 05 15:18:03 srv2 celery[30931]:     step.start(parent)
Aug 05 15:18:03 srv2 celery[30931]:   File "/nix/store/7l28675h69s087imm1k0ky3d4k0xjzjx-python3-3.12.4-env/lib/python3.12/site-packages/celery/bootsteps.py", line 365, in start
Aug 05 15:18:03 srv2 celery[30931]:     return self.obj.start()
Aug 05 15:18:03 srv2 celery[30931]:            ^^^^^^^^^^^^^^^^
Aug 05 15:18:03 srv2 celery[30931]:   File "/nix/store/7l28675h69s087imm1k0ky3d4k0xjzjx-python3-3.12.4-env/lib/python3.12/site-packages/celery/worker/consumer/consumer.py", line 340, in start
Aug 05 15:18:03 srv2 celery[30931]:     blueprint.start(self)
Aug 05 15:18:03 srv2 celery[30931]:   File "/nix/store/7l28675h69s087imm1k0ky3d4k0xjzjx-python3-3.12.4-env/lib/python3.12/site-packages/celery/bootsteps.py", line 116, in start
Aug 05 15:18:03 srv2 celery[30931]:     step.start(parent)
Aug 05 15:18:03 srv2 celery[30931]:   File "/nix/store/7l28675h69s087imm1k0ky3d4k0xjzjx-python3-3.12.4-env/lib/python3.12/site-packages/celery/worker/consumer/consumer.py", line 746, in start
Aug 05 15:18:03 srv2 celery[30931]:     c.loop(*c.loop_args())
Aug 05 15:18:03 srv2 celery[30931]:   File "/nix/store/7l28675h69s087imm1k0ky3d4k0xjzjx-python3-3.12.4-env/lib/python3.12/site-packages/celery/worker/loops.py", line 97, in asynloop
Aug 05 15:18:03 srv2 celery[30931]:     next(loop)
Aug 05 15:18:03 srv2 celery[30931]:   File "/nix/store/7l28675h69s087imm1k0ky3d4k0xjzjx-python3-3.12.4-env/lib/python3.12/site-packages/kombu/asynchronous/hub.py", line 373, in create_loop
Aug 05 15:18:03 srv2 celery[30931]:     cb(*cbargs)
Aug 05 15:18:03 srv2 celery[30931]:   File "/nix/store/7l28675h69s087imm1k0ky3d4k0xjzjx-python3-3.12.4-env/lib/python3.12/site-packages/kombu/transport/redis.py", line 1344, in on_readable
Aug 05 15:18:03 srv2 celery[30931]:     self.cycle.on_readable(fileno)
Aug 05 15:18:03 srv2 celery[30931]:   File "/nix/store/7l28675h69s087imm1k0ky3d4k0xjzjx-python3-3.12.4-env/lib/python3.12/site-packages/kombu/transport/redis.py", line 569, in on_readable
Aug 05 15:18:03 srv2 celery[30931]:     chan.handlers[type]()
Aug 05 15:18:03 srv2 celery[30931]:   File "/nix/store/7l28675h69s087imm1k0ky3d4k0xjzjx-python3-3.12.4-env/lib/python3.12/site-packages/kombu/transport/redis.py", line 962, in _brpop_read
Aug 05 15:18:03 srv2 celery[30931]:     dest__item = self.client.parse_response(self.client.connection,
Aug 05 15:18:03 srv2 celery[30931]:                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 05 15:18:03 srv2 celery[30931]:   File "/nix/store/7l28675h69s087imm1k0ky3d4k0xjzjx-python3-3.12.4-env/lib/python3.12/site-packages/redis/client.py", line 562, in parse_response
Aug 05 15:18:03 srv2 celery[30931]:     response = connection.read_response()
Aug 05 15:18:03 srv2 celery[30931]:                ^^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 05 15:18:03 srv2 celery[30931]:   File "/nix/store/7l28675h69s087imm1k0ky3d4k0xjzjx-python3-3.12.4-env/lib/python3.12/site-packages/redis/connection.py", line 536, in read_response
Aug 05 15:18:03 srv2 celery[30931]:     raise response
Aug 05 15:18:03 srv2 celery[30931]: redis.exceptions.ResponseError: MISCONF Redis is configured to save RDB snapshots, but it's currently unable to persist to disk. Commands that may modify the data set are disabled, because this instance is configured to report errors during writes if RDB snapshotting fails (stop-writes-on-bgsave-error option). Please check the Redis logs for details about the RDB error.
Aug 05 15:18:05 srv2 systemd[1]: pretalx-worker.service: Main process exited, code=exited, status=1/FAILURE
Aug 05 15:18:05 srv2 systemd[1]: pretalx-worker.service: Failed with result 'exit-code'.
Aug 05 15:18:05 srv2 systemd[1]: pretalx-worker.service: Consumed 7.012s CPU time, 211.9M memory peak, 21.5M read from disk.
```


## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
