### PR TITLE
Improve assertions for `etc.overlay` and `systemd-sysusers`

### DIFF
--- a/nixos/modules/system/boot/systemd/sysusers.nix
+++ b/nixos/modules/system/boot/systemd/sysusers.nix
@@ -73,9 +73,9 @@ in
         message = "config.users.mutableUsers requires config.system.etc.overlay.enable.";
       }
     ] ++ (lib.mapAttrsToList
-      (_username: opts: {
+      (username: opts: {
         assertion = !opts.isNormalUser;
-        message = "systemd-sysusers doesn't create normal users. You can currently only use it to create system users.";
+        message = "${username} is a normal user. systemd-sysusers doesn't create normal users, only system users.";
       })
       userCfg.users)
     ++ lib.mapAttrsToList

--- a/nixos/modules/system/boot/systemd/sysusers.nix
+++ b/nixos/modules/system/boot/systemd/sysusers.nix
@@ -68,10 +68,6 @@ in
         assertion = config.system.activationScripts.users == "";
         message = "system.activationScripts.users has to be empty to use systemd-sysusers";
       }
-      {
-        assertion = config.users.mutableUsers -> config.system.etc.overlay.enable;
-        message = "config.users.mutableUsers requires config.system.etc.overlay.enable.";
-      }
     ] ++ (lib.mapAttrsToList
       (username: opts: {
         assertion = !opts.isNormalUser;

--- a/nixos/modules/system/etc/etc-activation.nix
+++ b/nixos/modules/system/etc/etc-activation.nix
@@ -26,13 +26,6 @@
           assertion = lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.6";
           message = "`system.etc.overlay.enable requires a newer kernel, at least version 6.6";
         }
-        {
-          assertion = config.systemd.sysusers.enable -> (config.users.mutableUsers == config.system.etc.overlay.mutable);
-          message = ''
-            When using systemd-sysusers and mounting `/etc` via an overlay, users
-            can only be mutable when `/etc` is mutable and vice versa.
-          '';
-        }
       ];
 
       boot.initrd.availableKernelModules = [ "loop" "erofs" "overlay" ];


### PR DESCRIPTION
## Description of changes

Fixes https://github.com/NixOS/nixpkgs/pull/328926#issuecomment-2264266648

Remove unneeded/wrong assertions

Closes #311665

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
