### PR TITLE
Revert "pkgs/top-level/config.nix: nixfmt, declare options"

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -41,13 +41,12 @@ let
 
   # If we're in hydra, we can dispense with the more verbose error
   # messages and make problems easier to spot.
-  inherit (config) inHydra;
-
+  inHydra = config.inHydra or false;
   # Allow the user to opt-into additional warnings, e.g.
   # import <nixpkgs> { config = { showDerivationWarnings = [ "maintainerless" ]; }; }
   showWarnings = config.showDerivationWarnings;
 
-  getNameWithVersion = attrs: attrs.name or "${attrs.pname or "«name-missing»"}-${attrs.version or "«version-missing»"}";
+  getNameWithVersion = attrs: attrs.name or ("${attrs.pname or "«name-missing»"}-${attrs.version or "«version-missing»"}");
 
   allowUnfree = config.allowUnfree
     || builtins.getEnv "NIXPKGS_ALLOW_UNFREE" == "1";
@@ -56,7 +55,7 @@ let
     envVar = builtins.getEnv "NIXPKGS_ALLOW_NONSOURCE";
   in if envVar != ""
      then envVar != "0"
-     else config.allowNonSource;
+     else config.allowNonSource or true;
 
   allowlist = config.allowlistedLicenses or config.whitelistedLicenses or [];
   blocklist = config.blocklistedLicenses or config.blacklistedLicenses or [];
@@ -114,7 +113,7 @@ let
   #   allowUnfree = false;
   #   allowUnfreePredicate = (x: pkgs.lib.hasPrefix "vscode" x.name);
   # }
-  inherit (config) allowUnfreePredicate;
+  allowUnfreePredicate = config.allowUnfreePredicate or (x: false);
 
   # Check whether unfree packages are allowed and if not, whether the
   # package has an unfree license and is not explicitly allowed by the
@@ -124,7 +123,7 @@ let
     !allowUnfree &&
     !allowUnfreePredicate attrs;
 
-  allowInsecureDefaultPredicate = x: elem (getNameWithVersion x) config.permittedInsecurePackages;
+  allowInsecureDefaultPredicate = x: builtins.elem (getNameWithVersion x) (config.permittedInsecurePackages or []);
   allowInsecurePredicate = x: (config.allowInsecurePredicate or allowInsecureDefaultPredicate) x;
 
   hasAllowedInsecure = attrs:
@@ -146,7 +145,7 @@ let
   #   allowNonSource = false;
   #   allowNonSourcePredicate = with pkgs.lib.lists; pkg: !(any (p: !p.isSource && p != lib.sourceTypes.binaryFirmware) pkg.meta.sourceProvenance);
   # }
-  inherit (config) allowNonSourcePredicate;
+  allowNonSourcePredicate = config.allowNonSourcePredicate or (x: false);
 
   # Check whether non-source packages are allowed and if not, whether the
   # package has non-source provenance and is not explicitly allowed by the

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -12,45 +12,37 @@ let
   inherit (lib)
     literalExpression
     mapAttrsToList
-    mkEnableOption
     mkOption
     optionals
     types
     ;
 
-  mkMassRebuild =
-    args:
-    mkOption (
-      builtins.removeAttrs args [ "feature" ]
-      // {
-        type = args.type or (types.uniq types.bool);
-        default = args.default or false;
-        description = (
-          (args.description or ''
-            Whether to ${args.feature} while building nixpkgs packages.
-          ''
-          )
-          + ''
-            Changing the default may cause a mass rebuild.
-          ''
-        );
-      }
-    );
+  mkMassRebuild = args: mkOption (builtins.removeAttrs args [ "feature" ] // {
+    type = args.type or (types.uniq types.bool);
+    default = args.default or false;
+    description = ((args.description or ''
+      Whether to ${args.feature} while building nixpkgs packages.
+    '') + ''
+      Changing the default may cause a mass rebuild.
+    '');
+  });
 
   options = {
 
-    # Internal stuff
+    /* Internal stuff */
 
     # Hide built-in module system options from docs.
-    _module.args = mkOption { internal = true; };
-
-    warnings = mkOption {
-      type = types.listOf types.str;
-      default = [ ];
+    _module.args = mkOption {
       internal = true;
     };
 
-    # Config options
+    warnings = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      internal = true;
+    };
+
+    /* Config options */
 
     warnUndeclaredOptions = mkOption {
       description = "Whether to warn when `config` contains an unrecognized attribute.";
@@ -58,9 +50,13 @@ let
       default = false;
     };
 
-    doCheckByDefault = mkMassRebuild { feature = "run `checkPhase` by default"; };
+    doCheckByDefault = mkMassRebuild {
+      feature = "run `checkPhase` by default";
+    };
 
-    strictDepsByDefault = mkMassRebuild { feature = "set `strictDeps` to true by default"; };
+    strictDepsByDefault = mkMassRebuild {
+      feature = "set `strictDeps` to true by default";
+    };
 
     structuredAttrsByDefault = mkMassRebuild {
       feature = "set `__structuredAttrs` to true by default";
@@ -108,80 +104,6 @@ let
       '';
     };
 
-    allowUnfreePredicate = mkOption {
-      type = types.functionTo types.bool;
-      default = _: false;
-      defaultText = literalExpression ''pkg: false'';
-      example = literalExpression ''pkg: lib.hasPrefix "vscode" pkg.name'';
-      description = ''
-        A function that specifies whether a given unfree package may be permitted.
-        Only takes effect if [`config.allowUnfree`](#opt-allowUnfree) is set to false.
-
-        See [Installing unfree packages](https://nixos.org/manual/nixpkgs/stable/#sec-allow-unfree) in the NixOS manual.
-      '';
-    };
-
-    allowlistedLicenses = mkOption {
-      type = types.listOf (types.lazyAttrsOf types.raw); # list of license attrsets
-      default = [ ];
-      example = literalExpression ''
-        [
-          lib.licenses.cc-by-nc-sa-20
-          ({
-            spdxId = "Abstyles";
-            fullName = "Abstyles License";
-          })
-        ]
-      '';
-      description = ''
-        Permits evaluation of a package, if the package:
-          * only has free licenses or licenses in this allowlist, and
-          * does not fail evaluation for some other reason.
-      '';
-    };
-
-    blocklistedLicenses = mkOption {
-      type = types.listOf (types.lazyAttrsOf types.raw); # list of license attrsets
-      default = [ ];
-      example = literalExpression ''
-        [
-          lib.licenses.cc-by-nc-sa-20
-          ({
-            spdxId = "Abstyles";
-            fullName = "Abstyles License";
-          })
-        ]
-      '';
-      description = ''
-        Disallows evaluation of a package, if the package has a license in this blocklist.
-      '';
-    };
-
-    allowNonSource = mkEnableOption "" // {
-      default = true;
-      defaultText = literalExpression ''true && builtins.getEnv "NIXPKGS_ALLOW_NONSOURCE" != "0"'';
-      description = ''
-        Whether to allow non-source packages.
-        Can be combined with `config.allowNonSourcePredicate`.
-      '';
-    };
-
-    allowNonSourcePredicate = mkOption {
-      type = types.functionTo types.bool;
-      default = _: false;
-      defaultText = literalExpression ''pkg: false'';
-      example = literalExpression ''
-        pkg:
-        (lib.all (
-          prov: prov.isSource || prov == lib.sourceTypes.binaryFirmware
-        ) pkg.meta.sourceProvenance);
-      '';
-      description = ''
-        A function that specifies whether a given non-source package may be permitted.
-        Only takes effect if [`config.allowNonSource`](#opt-allowNonSource) is set to false.
-      '';
-    };
-
     allowBroken = mkOption {
       type = types.bool;
       default = false;
@@ -206,33 +128,6 @@ let
       '';
     };
 
-    permittedInsecurePackages = mkOption {
-      type = types.listOf types.str;
-      default = [ ];
-      description = ''
-        List of insecure package names that are permitted.
-        Only takes effect if [`config.allowInsecurePredicate`](#opt-allowInsecurePredicate) is left as default
-        or is written to use the values in this option.
-
-        See [Installing insecure packages](#sec-allow-insecure).
-      '';
-    };
-
-    allowInsecurePredicate = mkOption {
-      type = types.functionTo types.bool;
-      defaultText = literalExpression ''
-        pkg:
-        builtins.elem (pkg.name
-          or "''${pkg.pname or "«name-missing»"}-''${pkg.version or "«version-missing»"}"
-        ) config.permittedInsecurePackages
-      '';
-      description = ''
-        A function that specifies whether a given insecure package may be permitted.
-
-        See [Installing insecure packages](#sec-allow-insecure).
-      '';
-    };
-
     cudaSupport = mkMassRebuild {
       type = types.bool;
       default = false;
@@ -245,26 +140,9 @@ let
       feature = "build packages with ROCm support by default";
     };
 
-    packageOverrides = mkOption {
-      type = types.functionTo types.raw;
-      default = lib.id;
-      defaultText = literalExpression ''lib.id'';
-      example = literalExpression ''
-        pkgs: rec {
-          foo = pkgs.foo.override { /* ... */ };
-        };
-      '';
-      description = ''
-        A function that takes the current nixpkgs instance (`pkgs`) as an argument
-        and returns a modified set of packages.
-
-        See [Modify packages via `packageOverrides`](#sec-modify-via-packageOverrides).
-      '';
-    };
-
     showDerivationWarnings = mkOption {
       type = types.listOf (types.enum [ "maintainerless" ]);
-      default = [ ];
+      default = [];
       description = ''
         Which warnings to display for potentially dangerous
         or deprecated values passed into `stdenv.mkDerivation`.
@@ -284,48 +162,23 @@ let
         Whether to check that the `meta` attribute of derivations are correct during evaluation time.
       '';
     };
-
-    checkMetaRecursively = mkEnableOption "checking that the `meta` attribute of derivations and their references are correct during evalution";
-
-    handleEvalIssue = mkOption {
-      type = types.functionTo (types.functionTo types.bool);
-      internal = true;
-      description = ''
-        Function to handle evaluation errors and possibly output a more informative message.
-      '';
-    };
-
-    inHydra = mkEnableOption "" // {
-      internal = true;
-      description = ''
-        Whether the current nixpkgs instance is being evauluated by Hydra.
-        If set to true, evaluation checks will produce less verbose error messages.
-      '';
-    };
   };
 
-in
-{
+in {
 
   freeformType =
-    let
-      t = types.lazyAttrsOf types.raw;
-    in
-    t
-    // {
-      merge =
-        loc: defs:
-        let
-          r = t.merge loc defs;
-        in
-        r // { _undeclared = r; };
+    let t = types.lazyAttrsOf types.raw;
+    in t // {
+      merge = loc: defs:
+        let r = t.merge loc defs;
+        in r // { _undeclared = r; };
     };
 
   inherit options;
 
   config = {
     warnings = optionals config.warnUndeclaredOptions (
-      mapAttrsToList (k: v: "undeclared Nixpkgs option set: config.${k}") config._undeclared or { }
+      mapAttrsToList (k: v: "undeclared Nixpkgs option set: config.${k}") config._undeclared or {}
     );
   };
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#330753 due to master breakage; will need a new PR and testing in the future.

CC @philiptaron