### PR TITLE
everforest-gtk-theme: 0-unstable-2023-03-20 -> 0-unstable-2025-04-11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11548,10 +11548,12 @@
     name = "Joël Miramon";
   };
   jn-sena = {
-    email = "jn-sena@proton.me";
+    email = "contact@sena.pink";
+    matrix = "@sena:tchncs.de";
     github = "jn-sena";
     githubId = 45771313;
     name = "Sena";
+    keys = [ { fingerprint = "41DE CBC3 93E7 DB28 759F 6245 D014 7D14 A6B4 F0C5"; } ];
   };
   jnsgruk = {
     email = "jon@sgrs.uk";

--- a/pkgs/by-name/ev/everforest-gtk-theme/package.nix
+++ b/pkgs/by-name/ev/everforest-gtk-theme/package.nix
@@ -2,12 +2,60 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  gnome-shell,
+  sassc,
   gnome-themes-extra,
   gtk-engine-murrine,
+  colorVariants ? [ ],
+  sizeVariants ? [ ],
+  themeVariants ? [ ],
+  tweakVariants ? [ ],
+  iconVariants ? [ ],
 }:
 
-stdenvNoCC.mkDerivation {
+let
   pname = "everforest-gtk-theme";
+  colorVariantList = [
+    "dark"
+    "light"
+  ];
+  sizeVariantList = [
+    "compact"
+    "standard"
+  ];
+  themeVariantList = [
+    "default"
+    "green"
+    "grey"
+    "orange"
+    "pink"
+    "purple"
+    "red"
+    "teal"
+    "yellow"
+    "all"
+  ];
+  tweakVariantList = [
+    "medium"
+    "soft"
+    "black"
+    "float"
+    "outline"
+    "macos"
+  ];
+  iconVariantList = [
+    "Dark"
+    "Light"
+  ];
+in
+lib.checkListOfEnum "${pname}: colorVariants" colorVariantList colorVariants
+lib.checkListOfEnum "${pname}: sizeVariants" sizeVariantList sizeVariants
+lib.checkListOfEnum "${pname}: themeVariants" themeVariantList themeVariants
+lib.checkListOfEnum "${pname}: tweakVariants" tweakVariantList tweakVariants
+lib.checkListOfEnum "${pname}: iconVariants" iconVariantList iconVariants
+
+stdenvNoCC.mkDerivation {
+  inherit pname;
   version = "0-unstable-2023-03-20";
 
   src = fetchFromGitHub {
@@ -21,17 +69,38 @@ stdenvNoCC.mkDerivation {
     gtk-engine-murrine
   ];
 
+  nativeBuildInputs = [
+    gnome-shell
+    sassc
+  ];
   buildInputs = [
     gnome-themes-extra
   ];
 
   dontBuild = true;
 
+  postPatch = ''
+    patchShebangs themes/install.sh
+  '';
+
   installPhase = ''
     runHook preInstall
-    mkdir -p "$out/share/"{themes,icons}
-    cp -a icons/* "$out/share/icons/"
-    cp -a themes/* "$out/share/themes/"
+
+    cd themes
+    mkdir -p "$out/share/themes"
+    ./install.sh -n Everforest \
+      ${lib.optionalString (colorVariants != [ ]) "-c" + toString colorVariants} \
+      ${lib.optionalString (sizeVariants != [ ]) "-s" + toString sizeVariants} \
+      ${lib.optionalString (themeVariants != [ ]) "-t" + toString themeVariants} \
+      ${lib.optionalString (tweakVariants != [ ]) "--tweaks" + toString tweakVariants} \
+      -d "$out/share/themes"
+
+    cd ../icons
+    ${lib.optionalString (iconVariants != [ ]) ''
+      mkdir -p "$out/share/icons"
+      cp -a ${toString (map (v: "Everforest-${v}") iconVariants)} "$out/share/icons"
+    ''}
+
     runHook postInstall
   '';
 

--- a/pkgs/by-name/ev/everforest-gtk-theme/package.nix
+++ b/pkgs/by-name/ev/everforest-gtk-theme/package.nix
@@ -49,69 +49,81 @@ let
     "Light"
   ];
 in
-lib.checkListOfEnum "${pname}: colorVariants" colorVariantList colorVariants
-lib.checkListOfEnum "${pname}: sizeVariants" sizeVariantList sizeVariants
-lib.checkListOfEnum "${pname}: themeVariants" themeVariantList themeVariants
-lib.checkListOfEnum "${pname}: tweakVariants" tweakVariantList tweakVariants
-lib.checkListOfEnum "${pname}: iconVariants" iconVariantList iconVariants
+lib.checkListOfEnum "${pname}: colorVariants" colorVariantList colorVariants lib.checkListOfEnum
+  "${pname}: sizeVariants"
+  sizeVariantList
+  sizeVariants
+  lib.checkListOfEnum
+  "${pname}: themeVariants"
+  themeVariantList
+  themeVariants
+  lib.checkListOfEnum
+  "${pname}: tweakVariants"
+  tweakVariantList
+  tweakVariants
+  lib.checkListOfEnum
+  "${pname}: iconVariants"
+  iconVariantList
+  iconVariants
 
-stdenvNoCC.mkDerivation {
-  inherit pname;
-  version = "0-unstable-2025-04-11";
+  stdenvNoCC.mkDerivation
+  {
+    inherit pname;
+    version = "0-unstable-2025-04-11";
 
-  src = fetchFromGitHub {
-    owner = "Fausto-Korpsvart";
-    repo = "Everforest-GTK-Theme";
-    rev = "dbd1014f4f3b66d5258bf81e9135e0e75cea084d";
-    hash = "sha256-QfawNkstj3cdIEN60dLrk3a1U4lNTclF7NLB++PrnHE=";
-  };
+    src = fetchFromGitHub {
+      owner = "Fausto-Korpsvart";
+      repo = "Everforest-GTK-Theme";
+      rev = "dbd1014f4f3b66d5258bf81e9135e0e75cea084d";
+      hash = "sha256-QfawNkstj3cdIEN60dLrk3a1U4lNTclF7NLB++PrnHE=";
+    };
 
-  propagatedUserEnvPkgs = [
-    gtk-engine-murrine
-  ];
+    propagatedUserEnvPkgs = [
+      gtk-engine-murrine
+    ];
 
-  nativeBuildInputs = [
-    gnome-shell
-    sassc
-  ];
-  buildInputs = [
-    gnome-themes-extra
-  ];
+    nativeBuildInputs = [
+      gnome-shell
+      sassc
+    ];
+    buildInputs = [
+      gnome-themes-extra
+    ];
 
-  dontBuild = true;
+    dontBuild = true;
 
-  passthru.updateScript = unstableGitUpdater { };
+    passthru.updateScript = unstableGitUpdater { };
 
-  postPatch = ''
-    patchShebangs themes/install.sh
-  '';
+    postPatch = ''
+      patchShebangs themes/install.sh
+    '';
 
-  installPhase = ''
-    runHook preInstall
+    installPhase = ''
+      runHook preInstall
 
-    cd themes
-    mkdir -p "$out/share/themes"
-    ./install.sh -n Everforest \
-      ${lib.optionalString (colorVariants != [ ]) "-c " + toString colorVariants} \
-      ${lib.optionalString (sizeVariants != [ ]) "-s " + toString sizeVariants} \
-      ${lib.optionalString (themeVariants != [ ]) "-t " + toString themeVariants} \
-      ${lib.optionalString (tweakVariants != [ ]) "--tweaks " + toString tweakVariants} \
-      -d "$out/share/themes"
+      cd themes
+      mkdir -p "$out/share/themes"
+      ./install.sh -n Everforest \
+        ${lib.optionalString (colorVariants != [ ]) "-c " + toString colorVariants} \
+        ${lib.optionalString (sizeVariants != [ ]) "-s " + toString sizeVariants} \
+        ${lib.optionalString (themeVariants != [ ]) "-t " + toString themeVariants} \
+        ${lib.optionalString (tweakVariants != [ ]) "--tweaks " + toString tweakVariants} \
+        -d "$out/share/themes"
 
-    cd ../icons
-    ${lib.optionalString (iconVariants != [ ]) ''
-      mkdir -p "$out/share/icons"
-      cp -a ${toString (map (v: "Everforest-${v}") iconVariants)} "$out/share/icons"
-    ''}
+      cd ../icons
+      ${lib.optionalString (iconVariants != [ ]) ''
+        mkdir -p "$out/share/icons"
+        cp -a ${toString (map (v: "Everforest-${v}") iconVariants)} "$out/share/icons"
+      ''}
 
-    runHook postInstall
-  '';
+      runHook postInstall
+    '';
 
-  meta = {
-    description = "Everforest colour palette for GTK";
-    homepage = "https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme";
-    license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ jn-sena ];
-    platforms = lib.platforms.unix;
-  };
-}
+    meta = {
+      description = "Everforest colour palette for GTK";
+      homepage = "https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme";
+      license = lib.licenses.gpl3Plus;
+      maintainers = with lib.maintainers; [ jn-sena ];
+      platforms = lib.platforms.unix;
+    };
+  }

--- a/pkgs/by-name/ev/everforest-gtk-theme/package.nix
+++ b/pkgs/by-name/ev/everforest-gtk-theme/package.nix
@@ -6,6 +6,7 @@
   sassc,
   gnome-themes-extra,
   gtk-engine-murrine,
+  unstableGitUpdater,
   colorVariants ? [ ],
   sizeVariants ? [ ],
   themeVariants ? [ ],
@@ -56,13 +57,13 @@ lib.checkListOfEnum "${pname}: iconVariants" iconVariantList iconVariants
 
 stdenvNoCC.mkDerivation {
   inherit pname;
-  version = "0-unstable-2023-03-20";
+  version = "0-unstable-2025-04-11";
 
   src = fetchFromGitHub {
     owner = "Fausto-Korpsvart";
     repo = "Everforest-GTK-Theme";
-    rev = "8481714cf9ed5148694f1916ceba8fe21e14937b";
-    hash = "sha256-NO12ku8wnW/qMHKxi5TL/dqBxH0+cZbe+fU0iicb9JU=";
+    rev = "dbd1014f4f3b66d5258bf81e9135e0e75cea084d";
+    hash = "sha256-QfawNkstj3cdIEN60dLrk3a1U4lNTclF7NLB++PrnHE=";
   };
 
   propagatedUserEnvPkgs = [
@@ -79,6 +80,8 @@ stdenvNoCC.mkDerivation {
 
   dontBuild = true;
 
+  passthru.updateScript = unstableGitUpdater { };
+
   postPatch = ''
     patchShebangs themes/install.sh
   '';
@@ -89,10 +92,10 @@ stdenvNoCC.mkDerivation {
     cd themes
     mkdir -p "$out/share/themes"
     ./install.sh -n Everforest \
-      ${lib.optionalString (colorVariants != [ ]) "-c" + toString colorVariants} \
-      ${lib.optionalString (sizeVariants != [ ]) "-s" + toString sizeVariants} \
-      ${lib.optionalString (themeVariants != [ ]) "-t" + toString themeVariants} \
-      ${lib.optionalString (tweakVariants != [ ]) "--tweaks" + toString tweakVariants} \
+      ${lib.optionalString (colorVariants != [ ]) "-c " + toString colorVariants} \
+      ${lib.optionalString (sizeVariants != [ ]) "-s " + toString sizeVariants} \
+      ${lib.optionalString (themeVariants != [ ]) "-t " + toString themeVariants} \
+      ${lib.optionalString (tweakVariants != [ ]) "--tweaks " + toString tweakVariants} \
       -d "$out/share/themes"
 
     cd ../icons
@@ -104,11 +107,11 @@ stdenvNoCC.mkDerivation {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Everforest colour palette for GTK";
     homepage = "https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ jn-sena ];
-    platforms = platforms.unix;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ jn-sena ];
+    platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
The outline from #326675, as the install script is the same in this theme as well.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
