### PR TITLE
smc-fuzzer: init at 0-unstable-2020-12-23

### DIFF
--- a/pkgs/by-name/sm/smc-fuzzer/package.nix
+++ b/pkgs/by-name/sm/smc-fuzzer/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  swiftPackages,
+  fetchFromGitHub,
+  stdenv,
+}:
+
+stdenv.mkDerivation {
+  pname = "smc-fuzzer";
+  version = "0-unstable-2020-12-23";
+
+  src = fetchFromGitHub {
+    repo = "smc-fuzzer";
+    owner = "theopolis";
+    rev = "ed60c4efeddea8a9778a976c49c650eee3840eac";
+    hash = "sha256-FyiFSVeO46UnBrpC8AhSuGe7alo37pT8J1qQWGPqV2U=";
+  };
+
+  buildInputs = [ swiftPackages.apple_sdk.frameworks.AppKit ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm 755 smc -t $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Apple SMC (System Management Controller) API fuzzer";
+    longDescription = ''
+      smc-fuzzer uses the AppleSMC IOKit interface and a userland API for
+      interacting with the System Management Controller (Mac embedded
+      controllers). The tool focuses on the SMC key/value API.
+
+      smc-fuzzer is not just useful for fuzzing the SMC itself: it can also be
+      used to explicitly control or query the SMC.  That makes it useful in
+      system management, e.g. controlling and querying the charge status of an
+      Apple laptop.
+    '';
+    homepage = "https://github.com/theopolis/smc-fuzzer";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ hraban ];
+    mainProgram = "smc";
+    platforms = lib.platforms.darwin;
+  };
+}


### PR DESCRIPTION
## Description of changes
smc-fuzzer "https://github.com/theopolis/smc-fuzzer/" is originally written to fuzz the SMC chip on apple laptops, but it's actually quite useful if you just want to have bona fide interaction with the SMC.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
