### PR TITLE
git-gamble: init at 2.9.0

### DIFF
--- a/pkgs/by-name/gi/git-gamble/package.nix
+++ b/pkgs/by-name/gi/git-gamble/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitLab,
+  gitMinimal,
+  installShellFiles,
+  makeWrapper,
+  nix-update-script,
+}:
+
+let
+  version = "2.9.0";
+
+  src = fetchFromGitLab {
+    owner = "pinage404";
+    repo = "git-gamble";
+    rev = "version/${version}";
+    hash = "sha256-hMP5mBKXcO+Ws04G3OxdYuB5JoaSjlYtlkerRQ6+bXw=";
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = "git-gamble";
+  inherit version src;
+
+  cargoHash = "sha256-vrzcNdLY2PkyZ1eLwOiONRHVAolbTDxytEgi09WkDZQ=";
+
+  nativeCheckInputs = [ gitMinimal ];
+  preCheck = ''
+    patchShebangs tests/editor/fake_editor.sh
+  '';
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ];
+  postInstall = ''
+    wrapProgram $out/bin/git-gamble \
+      --prefix PATH : "${lib.makeBinPath [ gitMinimal ]}"
+
+    export PATH="$PATH:$out/bin/"
+
+    sh ./script/generate_completion.sh target/release/shell_completions/
+    installShellCompletion --cmd git-gamble \
+      --bash target/release/shell_completions/git-gamble.bash \
+      --fish target/release/shell_completions/git-gamble.fish \
+      --zsh target/release/shell_completions/_git-gamble
+
+    sh ./script/usage.sh > git-gamble.1
+    installManPage git-gamble.1
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool that blends TDD (Test Driven Development) + TCR (`test && commit || revert`)";
+    homepage = "https://git-gamble.is-cool.dev";
+    changelog = "https://gitlab.com/pinage404/git-gamble/-/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.isc;
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+    maintainers = [ lib.maintainers.pinage404 ];
+    mainProgram = "git-gamble";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

~~I updated / improved some packages i maintain, then~~ i added a package, if i have to split, just tell me =)

Tool that blends [TDD (Test Driven Development)](https://en.wikipedia.org/wiki/Test-driven_development) + [TCR (`test && commit || revert`)](https://medium.com/@kentbeck_7670/test-commit-revert-870bbd756864) to make sure to **develop** the **right** thing 😌, **baby step by baby step** 👶🦶
https://git-gamble.is-cool.dev/

When a package already have a `flake.nix` which expose `packages.<system>.<package-name>`, what is the recommended way of packaging ? Do there is a way to reuse the flake output in `nixpkgs` ?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
