### PR TITLE
blackmagic-desktop-video,decklink: 14.0.1a2 -> 14.1a1

### DIFF
--- a/pkgs/by-name/bl/blackmagic-desktop-video/package.nix
+++ b/pkgs/by-name/bl/blackmagic-desktop-video/package.nix
@@ -10,7 +10,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "blackmagic-desktop-video";
-  version = "14.0.1a2";
+  version = "14.1a1";
 
   buildInputs = [
     autoPatchelfHook
@@ -23,14 +23,16 @@ stdenv.mkDerivation (finalAttrs: {
   # blame blackmagicdesign.
   src =
     let
-    # from the URL that the POST happens to, see browser console
-      DOWNLOADID = "d73a63095b6a4a189916fb2baa5a0ef3";
+      # from the URL the download page where you click the "only download" button is at
+      REFERID = "93b33ad64a244cd5b95ec9d373e8d2e1";
+      # from the URL that the POST happens to, see browser console
+      DOWNLOADID = "0f544a89ce204df6818079a2f18c76a7";
     in
     runCommandLocal "${finalAttrs.pname}-${lib.versions.majorMinor finalAttrs.version}-src.tar.gz"
       {
         outputHashMode = "recursive";
         outputHashAlgo = "sha256";
-        outputHash = "sha256-jkKzUqfirvsVIefjWLx4NlqznXanWDtvhTsIThWFTo4=";
+        outputHash = "sha256-1Cv7VQHhHcM53DKa15lJJVJmdiGUHNTYPTbX+VghQOc=";
 
         impureEnvVars = lib.fetchers.proxyImpureEnvVars;
 
@@ -39,9 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
         # ENV VARS
         SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
-        inherit DOWNLOADID;
-        # from the URL the download page where you click the "only download" button is at
-        REFERID = "76801bc1d84147da9cb1a16e663ac33e";
+        inherit REFERID;
         SITEURL = "https://www.blackmagicdesign.com/api/register/us/download/${DOWNLOADID}";
 
         USERAGENT = builtins.concatStringsSep " " [


### PR DESCRIPTION
## Description of changes

Updating to the latest version.

Desktop Video 14.1 release notes (2024-07-22): https://www.blackmagicdesign.com/support/readme/93b33ad64a244cd5b95ec9d373e8d2e1

I did some basic testing in OBS with my Intensity Pro 4K and everything seems to be working without any issues.

(Apologies if I missed anything as far as contributing etiquette goes. I'm still pretty new to NixOS and this is my first PR.)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
