### PR TITLE
ada-url: init at 2.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1430,6 +1430,12 @@
     githubId = 29845794;
     name = "Duncan Russell";
   };
+  anonrig = {
+    email = "yagiz@nizipli.com";
+    github = "anonrig";
+    githubId = 1935246;
+    name = "Yagiz Nizipli";
+  };
   anpin = {
     email = "pavel@anpin.fyi";
     github = "anpin";

--- a/pkgs/by-name/ad/ada-url/conditional-dl.patch
+++ b/pkgs/by-name/ad/ada-url/conditional-dl.patch
@@ -1,0 +1,21 @@
+diff --git a/cmake/CPM.cmake b/cmake/CPM.cmake
+index ad6b74a8..079eed46 100644
+--- a/cmake/CPM.cmake
++++ b/cmake/CPM.cmake
+@@ -16,9 +16,11 @@ endif()
+ # Expand relative path. This is important if the provided path contains a tilde (~)
+ get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
+ 
+-file(DOWNLOAD
+-     https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+-     ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
+-)
++if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
++  file(DOWNLOAD
++       https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
++       ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
++  )
++endif()
+ 
+ include(${CPM_DOWNLOAD_LOCATION})
+ 

--- a/pkgs/by-name/ad/ada-url/package.nix
+++ b/pkgs/by-name/ad/ada-url/package.nix
@@ -1,0 +1,55 @@
+{ lib, fetchFromGitHub, stdenv, cpm-cmake, simdjson, cmake, cxxopts, }:
+
+let
+  googletest = fetchFromGitHub {
+    owner = "google";
+    repo = "googletest";
+    rev = "v1.14.0";
+    hash = "sha256-t0RchAHTJbuI5YW4uyBPykTvcjy90JW9AOPNjIhwh6U=";
+  };
+  googlebenchmark = fetchFromGitHub {
+    owner = "google";
+    repo = "benchmark";
+    rev = "v1.6.0";
+    hash = "sha256-EAJk3JhLdkuGKRMtspTLejck8doWPd7Z0Lv/Mvf3KFY=";
+  };
+  pname = "ada-url";
+  version = "2.9.0";
+in stdenv.mkDerivation {
+  inherit pname version;
+  src = fetchFromGitHub {
+    owner = "ada-url";
+    repo = "ada";
+    rev = "v${version}";
+    hash = "sha256-eh/tOwU+sU/8FYYuRE7DL1v1Fp6bNFWneLtGG0wsWgA=";
+  };
+
+  patches = [ ./conditional-dl.patch ];
+
+  preConfigure = ''
+    mkdir -p ${placeholder "out"}/share/cpm
+    cp ${cpm-cmake}/share/cpm/CPM.cmake ${
+      placeholder "out"
+    }/share/cpm/CPM_0.38.6.cmake
+  '';
+
+  cmakeFlags = [
+    "-DCPM_SOURCE_CACHE=${placeholder "out"}/share"
+    "-DFETCHCONTENT_SOURCE_DIR_SIMDJSON=${simdjson.src}"
+    "-DFETCHCONTENT_SOURCE_DIR_GTEST=${googletest}"
+    "-DFETCHCONTENT_SOURCE_DIR_BENCHMARK=${googlebenchmark}"
+    "-DBUILD_SHARED_LIBS=ON"
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ cxxopts ];
+
+  meta = with lib; {
+    homepage = "https://www.ada-url.com/";
+    description = "WHATWG-compliant and fast URL parser written in modern C++";
+    license = with licenses; [ asl20 mit ];
+    platforms = platforms.all;
+    maintainers = with maintainers; [ anonrig ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Based on https://github.com/NixOS/nixpkgs/pull/297294

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
