### PR TITLE
autoPatchelfHook: add keep_libc flag

### DIFF
--- a/pkgs/build-support/setup-hooks/auto-patchelf.py
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.py
@@ -257,20 +257,20 @@ def auto_patchelf_file(path: Path, runtime_deps: list[Path], append_rpaths: list
             # 1. If a candidate is an absolute path, it is already a
             #    valid dependency if that path exists, and nothing needs
             #    to be done. It should be an error if that path does not exist.
-            # 2. If a candidate is found in our library dependencies, that
-            #    dependency should be added to rpath. This search is skipped
-            #    for libc dependencies when keep_libc is False.
-            # 3. If a candidate is found in libc, it will be correctly
-            #    resolved by the dynamic linker automatically.
+            # 2. If a candidate is found within libc, it should be dropped
+            #    and resolved automatically by the dynamic linker, unless
+            #    keep_libc is enabled.
+            # 3. If a candidate is found in our library dependencies, that
+            #    dependency should be added to rpath.
+            # 4. If all of the above fail, libc dependencies should still be
+            #    considered found. This is in contrast to step 2, because
+            #    enabling keep_libc should allow libc to be found in step 3
+            #    if possible to preserve its presence in rpath.
             #
             # These conditions are checked in this order, because #2
             # and #3 may both be true. In that case, we still want to
             # add the dependency to rpath, as the original binary
             # presumably had it and this should be preserved.
-            #
-            # The keep_libc flag affects how libc dependencies are handled. If
-            # it's True, the loop will attempt to search for and relink them.
-            # When it's False, they are removed from the rpath.
 
             is_libc = (libc_lib / candidate).is_file()
 

--- a/pkgs/build-support/setup-hooks/auto-patchelf.py
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.py
@@ -258,7 +258,8 @@ def auto_patchelf_file(path: Path, runtime_deps: list[Path], append_rpaths: list
             #    valid dependency if that path exists, and nothing needs
             #    to be done. It should be an error if that path does not exist.
             # 2. If a candidate is found in our library dependencies, that
-            #    dependency should be added to rpath.
+            #    dependency should be added to rpath. This search is skipped
+            #    for libc dependencies when keep_libc is False.
             # 3. If a candidate is found in libc, it will be correctly
             #    resolved by the dynamic linker automatically.
             #
@@ -266,6 +267,10 @@ def auto_patchelf_file(path: Path, runtime_deps: list[Path], append_rpaths: list
             # and #3 may both be true. In that case, we still want to
             # add the dependency to rpath, as the original binary
             # presumably had it and this should be preserved.
+            #
+            # The keep_libc flag affects how libc dependencies are handled. If
+            # it's True, the loop will attempt to search for and relink them.
+            # When it's False, they are removed from the rpath.
 
             is_libc = (libc_lib / candidate).is_file()
 
@@ -387,7 +392,7 @@ def main() -> None:
         "--keep-libc",
         dest="keep_libc",
         action="store_true",
-        help="Leave libc in the rpath if it's found",
+        help="Attempt to search for and relink libc dependencies.",
     )
     parser.add_argument(
         "--extra-args",

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -58,11 +58,13 @@ autoPatchelf() {
         local appendRunpathsArray=( "${appendRunpaths[@]}" )
         local runtimeDependenciesArray=( "${runtimeDependencies[@]}" )
         local patchelfFlagsArray=( "${patchelfFlags[@]}" )
+        local autoPatchelfFlagsArray=( "${autoPatchelfFlags[@]}" )
     else
         readarray -td' ' ignoreMissingDepsArray < <(echo -n "$autoPatchelfIgnoreMissingDeps")
         local appendRunpathsArray=($appendRunpaths)
         local runtimeDependenciesArray=($runtimeDependencies)
         local patchelfFlagsArray=($patchelfFlags)
+        local autoPatchelfFlagsArray=($autoPatchelfFlags)
     fi
 
     # Check if ignoreMissingDepsArray contains "1" and if so, replace it with
@@ -85,6 +87,7 @@ autoPatchelf() {
                "${extraAutoPatchelfLibs[@]}"                            \
         --runtime-dependencies "${runtimeDependenciesArray[@]/%//lib}"  \
         --append-rpaths "${appendRunpathsArray[@]}"                     \
+        "${autoPatchelfFlagsArray[@]}"                                  \
         --extra-args "${patchelfFlagsArray[@]}"
 }
 

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -342,6 +342,8 @@ stdenv.mkDerivation (finalAttrs: {
     ]
   ;
 
+  autoPatchelfFlags = [ "--keep-libc" ];
+
   buildInputs =
     [
       libxcrypt


### PR DESCRIPTION
## Description of changes
    
- Add keep_libc flag to disable the default libc handling. Intended to be used by systemd.
- Add autoPatchelfFlags to autoPatchelfHook for passing arguments to the autoPatchelf script

This reverts part of the change made in #307068 / 80be926.

Fixes #332533

Relevant: #325126

cc @ElvishJerricco @layus 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
