### PR TITLE
python312Packages.pygatt: 4.0.5 -> 5.0.0, python312Packages.meshtastic: 2.3.11 -> 2.3.14 

### DIFF
--- a/pkgs/development/python-modules/meshtastic/default.nix
+++ b/pkgs/development/python-modules/meshtastic/default.nix
@@ -4,10 +4,16 @@
   buildPythonPackage,
   dotmap,
   fetchFromGitHub,
+  hypothesis,
   packaging,
+  parse,
   pexpect,
+  platformdirs,
+  ppk2-api,
+  print-color,
   protobuf,
-  pygatt,
+  pyarrow,
+  pyparsing,
   pypubsub,
   pyqrcode,
   pyserial,
@@ -19,6 +25,7 @@
   setuptools,
   tabulate,
   timeago,
+  webencodings,
 }:
 
 buildPythonPackage rec {
@@ -35,15 +42,22 @@ buildPythonPackage rec {
     hash = "sha256-s56apVx7+EXkdw3FUjyGKGFjP+IVbO0/VDB4urXEtXQ=";
   };
 
+  pythonRelaxDeps = [ "protobuf" ];
+
   build-system = [ setuptools ];
 
   dependencies = [
     bleak
     dotmap
     packaging
+    parse
     pexpect
+    platformdirs
+    ppk2-api
+    print-color
     protobuf
-    pygatt
+    pyarrow
+    pyparsing
     pypubsub
     pyqrcode
     pyserial
@@ -52,6 +66,7 @@ buildPythonPackage rec {
     setuptools
     tabulate
     timeago
+    webencodings
   ];
 
   passthru.optional-dependencies = {
@@ -59,9 +74,9 @@ buildPythonPackage rec {
   };
 
   nativeCheckInputs = [
-    pytap2
+    hypothesis
     pytestCheckHook
-  ];
+  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
 
   preCheck = ''
     export PATH="$PATH:$out/bin";
@@ -79,6 +94,7 @@ buildPythonPackage rec {
     "test_main_support"
     "test_MeshInterface"
     "test_message_to_json_shows_all"
+    "test_node"
     "test_SerialInterface_single_port"
     "test_support_info"
     "test_TCPInterface"

--- a/pkgs/development/python-modules/modbus-tk/default.nix
+++ b/pkgs/development/python-modules/modbus-tk/default.nix
@@ -1,36 +1,33 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
+  fetchPypi,
   setuptools,
   pythonOlder,
   pyserial,
-  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "modbus-tk";
-  version = "1.1.1";
+  version = "1.1.3";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
 
-  src = fetchFromGitHub {
-    owner = "ljean";
-    repo = "modbus-tk";
-    rev = "refs/tags/${version}";
-    hash = "sha256-zikfVMFdlOJvuKVQGEsK03i58X6BGFsGWGrGOJZGC0g=";
+  src = fetchPypi {
+    pname = "modbus_tk";
+    inherit version;
+    hash = "sha256-aQ+nu4bql4mSRl0tYci1rMY5zg6LgzoKqW1N0XLFZEo=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [ pyserial ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  # Source no tagged anymore and PyPI doesn't ship tests
+  doCheck = false;
 
   pythonImportsCheck = [ "modbus_tk" ];
-
-  pytestFlagsArray = [ "tests/unittest_*.py" ];
 
   meta = with lib; {
     description = "Module for simple Modbus interactions";

--- a/pkgs/development/python-modules/pygatt/default.nix
+++ b/pkgs/development/python-modules/pygatt/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   mock,
-  nose,
   pexpect,
   pyserial,
   pytestCheckHook,
@@ -13,27 +12,24 @@
 
 buildPythonPackage rec {
   pname = "pygatt";
-  version = "4.0.5";
+  version = "5.0.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.5";
+  disabled = pythonOlder "3.10";
 
   src = fetchFromGitHub {
     owner = "peplin";
     repo = "pygatt";
     rev = "refs/tags/v${version}";
-    hash = "sha256-DUZGsztZViVNZwmhXoRN5FOQ7BgUeI0SsYgCHlvsrv0=";
+    hash = "sha256-TMIqC+JvNOLU38a9jkacRAbdmAAd4UekFUDRoAWhHFo=";
   };
 
   postPatch = ''
-    # Not support for Python < 3.4
     substituteInPlace setup.py \
-      --replace-fail "'enum-compat'" "" \
-      --replace-fail "'coverage >= 3.7.1'," "" \
-      --replace-fail "'nose >= 1.3.7'" ""
-    substituteInPlace tests/bgapi/test_bgapi.py \
-       --replace-fail "assertEquals" "assertEqual"
+      --replace-fail "setup_requires" "test_requires"
   '';
+
+  pythonRemoveDeps = [ "enum-compat" ];
 
   build-system = [ setuptools ];
 
@@ -41,12 +37,8 @@ buildPythonPackage rec {
 
   optional-dependencies.GATTTOOL = [ pexpect ];
 
-  # tests require nose
-  doCheck = pythonOlder "3.12";
-
   nativeCheckInputs = [
     mock
-    nose
     pytestCheckHook
   ] ++ optional-dependencies.GATTTOOL;
 

--- a/pkgs/development/python-modules/riden/default.nix
+++ b/pkgs/development/python-modules/riden/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  click,
+  fetchFromGitHub,
+  modbus-tk,
+  poetry-core,
+  pyserial,
+  pythonOlder,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "riden";
+  version = "1.2.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "geeksville";
+    repo = "riden";
+    rev = "refs/tags/${version}";
+    hash = "sha256-uR1CsVsGn/QC4krHaxl6GqRnTPbFdRaqyMEl2RVMHPU=";
+  };
+
+  build-system = [
+    poetry-core
+    setuptools
+  ];
+
+  dependencies = [
+    click
+    modbus-tk
+    pyserial
+  ];
+
+  # Module has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "riden" ];
+
+  meta = with lib; {
+    description = "Module for Riden RD power supplies";
+    homepage = "https://github.com/geeksville/riden";
+    changelog = "https://github.com/geeksville/Riden/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13682,6 +13682,8 @@ self: super: with self; {
 
   rich-theme-manager = callPackage ../development/python-modules/rich-theme-manager { };
 
+  riden = callPackage ../development/python-modules/riden { };
+
   ring-doorbell = callPackage ../development/python-modules/ring-doorbell { };
 
   rio-tiler = callPackage ../development/python-modules/rio-tiler { };


### PR DESCRIPTION
Diff: https://github.com/peplin/pygatt/compare/refs/tags/v4.0.5...v5.0.0

Changelog: https://github.com/peplin/pygatt/blob/v5.0.0/CHANGELOG.rst

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
