### PR TITLE
nsncd: unstable-2024-03-18 -> unstable-2024-08-06

### DIFF
--- a/pkgs/os-specific/linux/nsncd/0001-cargo-bump.patch
+++ b/pkgs/os-specific/linux/nsncd/0001-cargo-bump.patch
@@ -1,0 +1,197 @@
+From b68e8356cf85fa75582237b4bc02f47efc40e8f0 Mon Sep 17 00:00:00 2001
+From: Picnoir <picnoir@alternativebit.fr>
+Date: Tue, 6 Aug 2024 11:43:34 +0200
+Subject: [PATCH] cargo.lock: bump time version
+
+Bumping time to 0.3.36. Fix the build for rustc > 1.80.
+
+Fix https://github.com/twosigma/nsncd/issues/118
+---
+ Cargo.lock | 74 ++++++++++++++++++++++++++++++++++++++++--------------
+ 1 file changed, 55 insertions(+), 19 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index a043bde..f6ce6f4 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -205,6 +205,15 @@ version = "0.8.19"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+ 
++[[package]]
++name = "deranged"
++version = "0.3.11"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
++dependencies = [
++ "powerfmt",
++]
++
+ [[package]]
+ name = "dirs-next"
+ version = "2.0.0"
+@@ -426,6 +435,12 @@ dependencies = [
+  "temp-env",
+ ]
+ 
++[[package]]
++name = "num-conv"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
++
+ [[package]]
+ name = "num-derive"
+ version = "0.3.3"
+@@ -434,7 +449,7 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 1.0.109",
+ ]
+ 
+ [[package]]
+@@ -519,20 +534,26 @@ dependencies = [
+  "plotters-backend",
+ ]
+ 
++[[package]]
++name = "powerfmt"
++version = "0.2.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
++
+ [[package]]
+ name = "proc-macro2"
+-version = "1.0.64"
++version = "1.0.86"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
++checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+ dependencies = [
+  "unicode-ident",
+ ]
+ 
+ [[package]]
+ name = "quote"
+-version = "1.0.23"
++version = "1.0.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
++checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+ dependencies = [
+  "proc-macro2",
+ ]
+@@ -652,22 +673,22 @@ checksum = "621e3680f3e07db4c9c2c3fb07c6223ab2fab2e54bd3c04c3ae037990f428c32"
+ 
+ [[package]]
+ name = "serde"
+-version = "1.0.154"
++version = "1.0.204"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8cdd151213925e7f1ab45a9bbfb129316bd00799784b174b7cc7bcd16961c49e"
++checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+ dependencies = [
+  "serde_derive",
+ ]
+ 
+ [[package]]
+ name = "serde_derive"
+-version = "1.0.154"
++version = "1.0.204"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4fc80d722935453bcafdc2c9a73cd6fac4dc1938f0346035d84bf99fa9e33217"
++checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 2.0.72",
+ ]
+ 
+ [[package]]
+@@ -745,6 +766,17 @@ dependencies = [
+  "unicode-ident",
+ ]
+ 
++[[package]]
++name = "syn"
++version = "2.0.72"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
++dependencies = [
++ "proc-macro2",
++ "quote",
++ "unicode-ident",
++]
++
+ [[package]]
+ name = "take_mut"
+ version = "0.2.2"
+@@ -788,7 +820,7 @@ checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 1.0.109",
+ ]
+ 
+ [[package]]
+@@ -803,11 +835,14 @@ dependencies = [
+ 
+ [[package]]
+ name = "time"
+-version = "0.3.20"
++version = "0.3.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
++checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+ dependencies = [
++ "deranged",
+  "itoa",
++ "num-conv",
++ "powerfmt",
+  "serde",
+  "time-core",
+  "time-macros",
+@@ -815,16 +850,17 @@ dependencies = [
+ 
+ [[package]]
+ name = "time-core"
+-version = "0.1.0"
++version = "0.1.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
++checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+ 
+ [[package]]
+ name = "time-macros"
+-version = "0.2.8"
++version = "0.2.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
++checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+ dependencies = [
++ "num-conv",
+  "time-core",
+ ]
+ 
+@@ -882,7 +918,7 @@ dependencies = [
+  "once_cell",
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 1.0.109",
+  "wasm-bindgen-shared",
+ ]
+ 
+@@ -904,7 +940,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 1.0.109",
+  "wasm-bindgen-backend",
+  "wasm-bindgen-shared",
+ ]

--- a/pkgs/os-specific/linux/nsncd/default.nix
+++ b/pkgs/os-specific/linux/nsncd/default.nix
@@ -2,21 +2,29 @@
 , stdenv
 , fetchFromGitHub
 , rustPlatform
-, nix-gitignore
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage {
   pname = "nsncd";
-  version = "unstable-2024-03-18";
+  version = "1.4.1-unstable-2024-04-10";
 
   src = fetchFromGitHub {
     owner = "twosigma";
     repo = "nsncd";
-    rev =  "7605e330d5a313a8656e6fcaf1c10cd6b5cdd427";
+    rev = "7605e330d5a313a8656e6fcaf1c10cd6b5cdd427";
     hash = "sha256-Bd7qE9MP5coBCkr70TdoJfwYhQpdrn/zmN4KoARcaMI=";
   };
 
-  cargoHash = "sha256-i1rmc5wxtc631hZy2oM4d6r7od0w8GrG7+/pdM6Gqco=";
+  cargoHash = "sha256-N7U9YsyGh8+fLT973GGZTmVXcdnWhpqkeYTxzJ0rzdo=";
+
+  # TOREMOVE when https://github.com/twosigma/nsncd/pull/119 gets merged.
+  cargoPatches = [
+    ./0001-cargo-bump.patch
+  ];
+
+  # TOREMOVE when https://github.com/twosigma/nsncd/pull/119 gets merged.
+  RUSTFLAGS = "-A dead_code";
+
   checkFlags = [
     # Relies on the test environment to be able to resolve "localhost"
     # on IPv4. That's not the case in the Nix sandbox somehow. Works

--- a/pkgs/os-specific/linux/nsncd/default.nix
+++ b/pkgs/os-specific/linux/nsncd/default.nix
@@ -1,7 +1,8 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, rustPlatform
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
 }:
 
 rustPlatform.buildRustPackage {
@@ -18,9 +19,7 @@ rustPlatform.buildRustPackage {
   cargoHash = "sha256-N7U9YsyGh8+fLT973GGZTmVXcdnWhpqkeYTxzJ0rzdo=";
 
   # TOREMOVE when https://github.com/twosigma/nsncd/pull/119 gets merged.
-  cargoPatches = [
-    ./0001-cargo-bump.patch
-  ];
+  cargoPatches = [ ./0001-cargo-bump.patch ];
 
   # TOREMOVE when https://github.com/twosigma/nsncd/pull/119 gets merged.
   RUSTFLAGS = "-A dead_code";
@@ -40,7 +39,10 @@ rustPlatform.buildRustPackage {
     '';
     homepage = "https://github.com/twosigma/nsncd";
     license = licenses.asl20;
-    maintainers = with maintainers; [ flokli picnoir ];
+    maintainers = with maintainers; [
+      flokli
+      picnoir
+    ];
     # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
     broken = stdenv.isDarwin;
   };


### PR DESCRIPTION
## Description of changes

:warning:  Note: this is kind of blocking the next staging merge! We rollbacked by accident Nsncd in staging to a previous version with known bugs.

Continuation of https://github.com/NixOS/nixpkgs/pull/332176#issuecomment-2270824319

Currently picking the commit from a upstream open PR https://github.com/twosigma/nsncd/pull/119. If upstream end up merging the PR fast enough, it'd make sense to wait for it to be merged.

I'll open a subsequent PR to Nixpkgs to point to the merged PR if they're too slow for us.



## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
