### PR TITLE
Extended frigate

### DIFF
--- a/nixos/modules/services/video/frigate.nix
+++ b/nixos/modules/services/video/frigate.nix
@@ -7,7 +7,6 @@
 let
   inherit (lib)
     literalExpression
-    mkDefault
     mkEnableOption
     mkPackageOption
     mkIf

--- a/nixos/modules/services/video/frigate.nix
+++ b/nixos/modules/services/video/frigate.nix
@@ -137,7 +137,7 @@ in
         secure-token
         rtmp
         vod
-      ];      
+      ];
       upstreams = {
         frigate-api.servers = {
           "127.0.0.1:5001" = { };
@@ -395,8 +395,8 @@ in
     networking.firewall = mkIf cfg.openFirewall {
       allowedTCPPorts = [
         5000 # Internal unauthenticated UI and API access.
-        5001 
-        5002 
+        5001
+        5002
         8002
         8554 # RTSP feeds
         8555 # WebRTC over tcp

--- a/nixos/modules/services/video/frigate.nix
+++ b/nixos/modules/services/video/frigate.nix
@@ -400,7 +400,7 @@ in
         8554 # RTSP feeds
         8555 # WebRTC over tcp
         8971 # Authenticated UI and API access without TLS.
-        1984 
+        1984
       ];
       allowedUDPPorts = [
         8555 # WebRTC over udp

--- a/pkgs/applications/video/frigate/default.nix
+++ b/pkgs/applications/video/frigate/default.nix
@@ -95,8 +95,7 @@ python.pkgs.buildPythonApplication rec {
 
     substituteInPlace frigate/events/audio.py \
       --replace-warn "/cpu_audio_model.tflite" "${audio_model}" \
-      --replace-warn "/audio-labelmap.txt" "${placeholder "out"}/share/frigate/audio-labelmap.txt"      
-
+      --replace-warn "/audio-labelmap.txt" "${placeholder "out"}/share/frigate/audio-labelmap.txt"
 
     substituteInPlace frigate/app.py \
       --replace-warn "Router(migrate_db)" 'Router(migrate_db, "${placeholder "out"}/share/frigate/migrations")'


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR improves the Fritgate package:
* Added support for audio-recognition role
* Removes some settings which broke other installed packages ([issue](https://github.com/NixOS/nixpkgs/issues/320512)) 
* Added some missing tmpfiles config
* Added openFirewall option
* Resolved some replace-deprecation warnings

I'm a newbie contributor..

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
