### PR TITLE
python312Packages.x-transformers: init at 1.32.2

### DIFF
--- a/pkgs/development/python-modules/x-transformers/default.nix
+++ b/pkgs/development/python-modules/x-transformers/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  einops,
+  torch,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "x-transformers";
+  version = "1.32.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "x_transformers";
+    inherit version;
+    hash = "sha256-NUIlJ+N2/6kz3rI0oc7bfYVWnMkZhvfljQ6zSwBPkWo=";
+  };
+
+  postPatch = ''
+    sed -i '/setup_requires=\[/,/\],/d' setup.py
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    einops
+    torch
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "x_transformers" ];
+
+  meta = {
+    description = "Concise but fully-featured transformer";
+    longDescription = ''
+      A simple but complete full-attention transformer with a set of promising experimental features from various papers
+    '';
+    homepage = "https://github.com/lucidrains/x-transformers";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ByteSudoer ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17479,6 +17479,8 @@ self: super: with self; {
 
   wyoming = callPackage ../development/python-modules/wyoming { };
 
+  x-transformers = callPackage ../development/python-modules/x-transformers { };
+
   x-wr-timezone = callPackage ../development/python-modules/x-wr-timezone { };
 
   x11-hash = callPackage ../development/python-modules/x11-hash { };


### PR DESCRIPTION
## Description of changes


A concise but fully-featured transformer, complete with a set of promising experimental features from various papers.

Metadata
- homepage URL: https://github.com/lucidrains/x-transformers
- source URL: https://github.com/lucidrains/x-transformers
- license: mit

Closes https://github.com/NixOS/nixpkgs/issues/332704

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
