### PR TITLE
python312Packages.tree-sitter_0_21: remove from propagated dependencies

### DIFF
--- a/pkgs/by-name/au/autotools-language-server/package.nix
+++ b/pkgs/by-name/au/autotools-language-server/package.nix
@@ -5,7 +5,10 @@
 }:
 
 let
-  python3 = python311;
+  python3 = python311.override {
+    self = python3;
+    packageOverrides = _: super: { tree-sitter = super.tree-sitter_0_21; };
+  };
 in
 python3.pkgs.buildPythonApplication rec {
   pname = "autotools-language-server";

--- a/pkgs/development/python-modules/lsp-tree-sitter/default.nix
+++ b/pkgs/development/python-modules/lsp-tree-sitter/default.nix
@@ -1,14 +1,15 @@
-{ lib
-, buildPythonPackage
-, fetchFromGitHub
-, setuptools-generate
-, setuptools-scm
-, colorama
-, jinja2
-, jsonschema
-, pygls
-, tree-sitter0_21
-, pytestCheckHook
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools-generate,
+  setuptools-scm,
+  colorama,
+  jinja2,
+  jsonschema,
+  pygls,
+  tree-sitter0_21,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -40,9 +41,7 @@ buildPythonPackage rec {
     # mismatch by defaulting here to this lower version.
     tree-sitter0_21
   ];
-  nativeCheckInputs = [
-    pytestCheckHook
-  ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "lsp_tree_sitter" ];
 

--- a/pkgs/development/python-modules/lsp-tree-sitter/default.nix
+++ b/pkgs/development/python-modules/lsp-tree-sitter/default.nix
@@ -8,7 +8,7 @@
   jinja2,
   jsonschema,
   pygls,
-  tree-sitter0_21,
+  tree-sitter,
   pytestCheckHook,
 }:
 
@@ -34,12 +34,7 @@ buildPythonPackage rec {
     jinja2
     jsonschema
     pygls
-    # The build won't fail if we had used tree-sitter (version > 0.21), but
-    # this package is only a dependency of autotools-language-server which also
-    # depends on tree-sitter-languages which must use tree-sitter0_21 and not
-    # tree-sitter. Hence we avoid different tree-sitter versions dependency
-    # mismatch by defaulting here to this lower version.
-    tree-sitter0_21
+    tree-sitter
   ];
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/textual/default.nix
+++ b/pkgs/development/python-modules/textual/default.nix
@@ -51,7 +51,8 @@ buildPythonPackage rec {
     pytestCheckHook
     syrupy
     time-machine
-  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
+    tree-sitter
+  ];
 
   disabledTestPaths = [
     # Snapshot tests require syrupy<4

--- a/pkgs/development/python-modules/tree-sitter-languages/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-languages/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
-  wheel,
   cython,
   tree-sitter0_21,
   pytestCheckHook,
@@ -35,7 +34,6 @@ buildPythonPackage rec {
 
   build-system = [
     setuptools
-    wheel
     cython
   ];
   dependencies = [

--- a/pkgs/development/python-modules/tree-sitter-languages/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-languages/default.nix
@@ -1,12 +1,13 @@
-{ lib
-, buildPythonPackage
-, fetchFromGitHub
-, setuptools
-, wheel
-, cython
-, tree-sitter0_21
-, pytestCheckHook
-, python
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  wheel,
+  cython,
+  tree-sitter0_21,
+  pytestCheckHook,
+  python,
 }:
 
 buildPythonPackage rec {
@@ -45,9 +46,7 @@ buildPythonPackage rec {
   preBuild = ''
     ${python.pythonOnBuildForHost.interpreter} build.py
   '';
-  nativeCheckInputs = [
-    pytestCheckHook
-  ];
+  nativeCheckInputs = [ pytestCheckHook ];
   # Without cd $out, tests fail to import the compiled cython extensions.
   # Without copying the ./tests/ directory to $out, pytest won't detect the
   # tests and run them. See also:

--- a/pkgs/development/python-modules/tree-sitter-languages/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-languages/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   setuptools,
   cython,
-  tree-sitter0_21,
+  tree-sitter,
   pytestCheckHook,
   python,
 }:
@@ -36,10 +36,7 @@ buildPythonPackage rec {
     setuptools
     cython
   ];
-  dependencies = [
-    # https://github.com/grantjenks/py-tree-sitter-languages/issues/67
-    tree-sitter0_21
-  ];
+  dependencies = [ tree-sitter ];
   # Generate languages.so file (build won't fail without this, but tests will).
   preBuild = ''
     ${python.pythonOnBuildForHost.interpreter} build.py
@@ -61,5 +58,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/grantjenks/py-tree-sitter-languages";
     license = licenses.asl20;
     maintainers = with maintainers; [ doronbehar ];
+    # https://github.com/grantjenks/py-tree-sitter-languages/issues/67
+    broken = versionAtLeast tree-sitter.version "0.22";
   };
 }

--- a/pkgs/development/python-modules/tree-sitter/0_21.nix
+++ b/pkgs/development/python-modules/tree-sitter/0_21.nix
@@ -10,7 +10,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "tree-sitter0_21";
+  pname = "tree-sitter";
   version = "0.21.3";
   pyproject = true;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15814,7 +15814,7 @@ self: super: with self; {
 
   tree-sitter = callPackage ../development/python-modules/tree-sitter { };
 
-  tree-sitter0_21 = callPackage ../development/python-modules/tree-sitter0_21 { };
+  tree-sitter_0_21 = callPackage ../development/python-modules/tree-sitter/0_21.nix { };
 
   tree-sitter-html = callPackage ../development/python-modules/tree-sitter-html { };
 


### PR DESCRIPTION
## Description of changes

Python packages must not propagate such versioned packages due to PYTHONPATH conflicts.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
