### PR TITLE
rospo: init at 0.12.1

### DIFF
--- a/pkgs/by-name/ro/rospo/package.nix
+++ b/pkgs/by-name/ro/rospo/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+
+buildGoModule rec {
+  pname = "rospo";
+  version = "0.12.1";
+
+  src = fetchFromGitHub {
+    owner = "ferama";
+    repo = "rospo";
+    rev = "v${version}";
+    hash = "sha256-cUah73wr0fKK9Lw3228r5SITDn5rNlpgQW5rHtbo6jU=";
+  };
+
+  vendorHash = "sha256-KbR8T7KwueQ9fc4AOX26GOTQFXuV9LgfSxgwCzQt4eE=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/ferama/rospo/cmd.Version=${version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  doCheck = false;
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd rospo \
+      --bash <($out/bin/rospo completion bash) \
+      --fish <($out/bin/rospo completion fish) \
+      --zsh <($out/bin/rospo completion zsh)
+  '';
+
+  meta = {
+    description = "Simple, reliable, persistent ssh tunnels with embedded ssh server";
+    homepage = "https://github.com/ferama/rospo";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sikmir ];
+    mainProgram = "rospo";
+  };
+}


### PR DESCRIPTION
## Description of changes
https://github.com/ferama/rospo

> Rospo is a tool meant to create secure and reliable SSH tunnels.

[![Packaging status](https://repology.org/badge/tiny-repos/rospo.svg)](https://repology.org/project/rospo/versions)

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
