### PR TITLE
maintainers: add phanirithvij, init distrobox-tui, gh-i, gitcs, go-mtree, gup

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15879,6 +15879,13 @@
     githubId = 101753;
     keys = [ { fingerprint = "5D69 CF04 B7BC 2BC1 A567  9267 00BC F29B 3208 0700"; } ];
   };
+  phanirithvij = {
+    name = "Phani Rithvij";
+    email = "phanirithvij2000@gmail.com";
+    github = "phanirithvij";
+    githubId = 29627898;
+    matrix = "@phanirithvij:matrix.org";
+  };
   phdcybersec = {
     name = "Léo Lavaur";
     email = "phdcybersec@pm.me";

--- a/pkgs/by-name/di/distrobox-tui/package.nix
+++ b/pkgs/by-name/di/distrobox-tui/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "distrobox-tui";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "phanirithvij";
+    repo = "distrobox-tui";
+    rev = "v${version}";
+    hash = "sha256-J5stvhUNaU9YMczE56vC5bw2g67zsdVWiCi8k6KV/pU=";
+  };
+
+  vendorHash = "sha256-F7X3FBM/F0uPxbM3en0sk9a58O/meKnVsASgIlL7FCo=";
+
+  ldflags = [ "-s" ];
+
+  meta = with lib; {
+    description = "A TUI for DistroBox";
+    changelog = "https://github.com/phanirithvij/distrobox-tui/releases/tag/v${version}";
+    homepage = "https://github.com/phanirithvij/distrobox-tui";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ phanirithvij ];
+    mainProgram = "distrobox-tui";
+  };
+}

--- a/pkgs/by-name/gh/gh-i/package.nix
+++ b/pkgs/by-name/gh/gh-i/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "gh-i";
+  version = "0.0.7";
+
+  src = fetchFromGitHub {
+    owner = "gennaro-tedesco";
+    repo = "gh-i";
+    rev = "v${version}";
+    hash = "sha256-nVMWeXssSpfWsD20+qLvQp6Wlrp/DiVNLBR6qnvuD2M=";
+  };
+
+  vendorHash = "sha256-TSl+7N3W3BeW8UWxUdTv3cob2P7eLvO+80BLqcbhanQ=";
+
+  ldflags = [ "-s" ];
+
+  meta = with lib; {
+    description = "Search github issues interactively";
+    changelog = "https://github.com/gennaro-tedesco/gh-i/releases/tag/v${version}";
+    homepage = "https://github.com/gennaro-tedesco/gh-i";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ phanirithvij ];
+    mainProgram = "gh-i";
+  };
+}

--- a/pkgs/by-name/gi/gitcs/package.nix
+++ b/pkgs/by-name/gi/gitcs/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "gitcs";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "knbr13";
+    repo = "gitcs";
+    rev = "v${version}";
+    hash = "sha256-IyhVVRTKftZIzqMH5pBUMLPIk8bk0rVAxPKD6bABP68=";
+  };
+
+  vendorHash = "sha256-8yzPdVljnODOeI5yWh19BHsF4Pa9BWc49IwenMCVGZo=";
+
+  ldflags = [ "-s" ];
+
+  meta = with lib; {
+    description = "Scan local git repositories and generate a visual contributions graph";
+    changelog = "https://github.com/knbr13/gitcs/releases/tag/v${version}";
+    homepage = "https://github.com/knbr13/gitcs";
+    license = licenses.mit;
+    maintainers = with maintainers; [ phanirithvij ];
+    mainProgram = "gitcs";
+  };
+}

--- a/pkgs/by-name/go/gogup/package.nix
+++ b/pkgs/by-name/go/gogup/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "gogup";
+  version = "0.27.3";
+
+  src = fetchFromGitHub {
+    owner = "nao1215";
+    repo = "gup";
+    rev = "v${version}";
+    hash = "sha256-8DtD22kvGez2iX0VqoZ1zSydcNYnDz3r698nXEwtoZE=";
+  };
+
+  vendorHash = "sha256-yqCmo33ihkaPK8iL5cnCIGbOLkdXjuIWLwtgAa+KB8Y=";
+  doCheck = false;
+
+  ldflags = [
+    "-s"
+    "-X github.com/nao1215/gup/internal/cmdinfo.Version=v${version}"
+  ];
+
+  meta = with lib; {
+    description = "Update binaries installed by 'go install' with goroutines";
+    changelog = "https://github.com/nao1215/gup/blob/v${version}/CHANGELOG.md";
+    homepage = "https://github.com/nao1215/gup";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ phanirithvij ];
+    mainProgram = "gup";
+  };
+}

--- a/pkgs/by-name/go/gomtree/package.nix
+++ b/pkgs/by-name/go/gomtree/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "gomtree";
+  version = "0.5.4";
+
+  src = fetchFromGitHub {
+    owner = "vbatts";
+    repo = "go-mtree";
+    rev = "v${version}";
+    hash = "sha256-MDX16z4H1fyuV5atEsZHReJyvC+MRdeA54DORCFtpqI=";
+  };
+
+  vendorHash = null;
+
+  # test fails with nix due to ro file system
+  checkFlags = [ "-skip=^TestXattr$" ];
+
+  subPackages = [ "cmd/gomtree" ];
+
+  ldflags = [
+    "-s"
+    "-X main.Version=${version}"
+  ];
+
+  meta = with lib; {
+    description = "File systems verification utility and library, in likeness of mtree(8)";
+    changelog = "https://github.com/vbatts/go-mtree/releases/tag/v${version}";
+    homepage = "https://github.com/vbatts/go-mtree";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ phanirithvij ];
+    mainProgram = "gomtree";
+  };
+}


### PR DESCRIPTION
## Description of changes

- added myself as a maintainer
- init [distrobox-tui](https://github.com/phanirithvij/distrobox-tui)
  - original at https://github.com/hyperreal64/distrobox-tui, succeeded by my fork.
- init [gitcs](https://github.com/knbr13/gitcs)
- init [gh-i](https://github.com/gennaro-tedesco/gh-i)
- init [gogup](https://github.com/nao1215/gup)
  - named gup as gogup since a package named gup [already exisits](https://search.nixos.org/packages?channel=unstable&show=gup&from=0&size=50&sort=relevance&type=packages&query=gup) in nixpkgs.
- init [go-mtree](https://github.com/vbatts/go-mtree)
  - disabled checks due to `Setxattr` syscall not working with nix since it is read-only
  - tested normally `go test ./...` on nixos and it passes, v0.5.4 tag of go-mtree.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  ```
  5 packages built:
  distrobox-tui gh-i gitcs go-mtree gogup
  ```
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
