### PR TITLE
nixos/systemd-networkd: add NFTSet related options

### DIFF
--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -745,6 +745,7 @@ let
           "ManageTemporaryAddress"
           "AddPrefixRoute"
           "AutoJoin"
+          "NFTSet"
         ])
         (assertHasField "Address")
         (assertValueOneOf "PreferredLifetime" ["forever" "infinity" "0" 0])
@@ -754,6 +755,7 @@ let
         (assertValueOneOf "ManageTemporaryAddress" boolValues)
         (assertValueOneOf "AddPrefixRoute" boolValues)
         (assertValueOneOf "AutoJoin" boolValues)
+        (assertNftSet "NFTSet")
       ];
 
       sectionRoutingPolicyRule = checkUnitConfigWithLegacyKey "routingPolicyRuleConfig" "RoutingPolicyRule" [
@@ -871,6 +873,7 @@ let
           "FallbackLeaseLifetimeSec"
           "Label"
           "Use6RD"
+          "NFTSet"
         ])
         (assertValueOneOf "UseDNS" boolValues)
         (assertValueOneOf "RoutesToDNS" boolValues)
@@ -896,6 +899,7 @@ let
         (assertValueOneOf "SendDecline" boolValues)
         (assertValueOneOf "FallbackLeaseLifetimeSec" ["forever" "infinity"])
         (assertValueOneOf "Use6RD" boolValues)
+        (assertNftSet "NFTSet")
       ];
 
       sectionDHCPv6 = checkUnitConfig "DHCPv6" [
@@ -920,6 +924,7 @@ let
           "IAID"
           "UseDelegatedPrefix"
           "SendRelease"
+          "NFTSet"
         ])
         (assertValueOneOf "UseAddress" boolValues)
         (assertValueOneOf "UseDNS" boolValues)
@@ -933,6 +938,7 @@ let
         (assertInt "IAID")
         (assertValueOneOf "UseDelegatedPrefix" boolValues)
         (assertValueOneOf "SendRelease" boolValues)
+        (assertNftSet "NFTSet")
       ];
 
       sectionDHCPPrefixDelegation = checkUnitConfig "DHCPPrefixDelegation" [
@@ -944,11 +950,13 @@ let
           "Token"
           "ManageTemporaryAddress"
           "RouteMetric"
+          "NFTSet"
         ])
         (assertValueOneOf "Announce" boolValues)
         (assertValueOneOf "Assign" boolValues)
         (assertValueOneOf "ManageTemporaryAddress" boolValues)
         (assertRange "RouteMetric" 0 4294967295)
+        (assertNftSet "NFTSet")
       ];
 
       sectionIPv6AcceptRA = checkUnitConfig "IPv6AcceptRA" [
@@ -971,6 +979,7 @@ let
           "UseRoutePrefix"
           "Token"
           "UsePREF64"
+          "NFTSet"
         ])
         (assertValueOneOf "UseDNS" boolValues)
         (assertValueOneOf "UseDomains" (boolValues ++ ["route"]))
@@ -982,6 +991,7 @@ let
         (assertValueOneOf "UseGateway" boolValues)
         (assertValueOneOf "UseRoutePrefix" boolValues)
         (assertValueOneOf "UsePREF64" boolValues)
+        (assertNftSet "NFTSet")
       ];
 
       sectionDHCPServer = checkUnitConfig "DHCPServer" [

--- a/nixos/tests/systemd-networkd-nftset.nix
+++ b/nixos/tests/systemd-networkd-nftset.nix
@@ -1,0 +1,132 @@
+# This tests systemd-networkd NFTSet option. The interface's statically
+# configured address is added to an nft set, and the DHCP configured address is
+# added to another. The sets are used by one rule that blocks connections to
+# the static address, and one rule that blocks connections to the DHCP address.
+# It is tested that the expected connections succeed or fail from another host.
+import ./make-test-python.nix (
+  { pkgs, ... }:
+  {
+    name = "systemd-networkd-nftset";
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [ mvnetbiz ];
+    };
+    nodes = {
+      router =
+        { ... }:
+        {
+          virtualisation.vlans = [ 1 ];
+          systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
+          networking = {
+            useNetworkd = true;
+            useDHCP = false;
+            firewall.enable = false;
+          };
+          systemd.network = {
+            networks = {
+              # systemd-networkd will load the first network unit file
+              # that matches, ordered lexiographically by filename.
+              # /etc/systemd/network/{40-eth1,99-main}.network already
+              # exists. This network unit must be loaded for the test,
+              # however, hence why this network is named such.
+              "01-eth1" = {
+                name = "eth1";
+                networkConfig = {
+                  DHCPServer = true;
+                  IPv6AcceptRA = "no";
+                  Address = "10.0.0.1/24";
+                };
+                dhcpServerConfig = {
+                  PoolOffset = 100;
+                  PoolSize = 1;
+                };
+              };
+            };
+          };
+        };
+
+      client =
+        { ... }:
+        {
+          virtualisation.vlans = [ 1 ];
+          systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
+          networking = {
+            useNetworkd = true;
+            useDHCP = false;
+            firewall.enable = false;
+            nftables = {
+              enable = true;
+              flushRuleset = true;
+              ruleset = ''
+                table inet mytable {
+                  set dhcp_set {
+                    type ipv4_addr
+                  }
+                  set static_set {
+                    type ipv4_addr
+                  }
+                  chain input {
+                    type filter hook input priority filter; policy accept;
+                    ip daddr @dhcp_set tcp dport 80 reject with tcp reset
+                    ip daddr @static_set tcp dport 8080 reject with tcp reset
+                  }
+                }
+              '';
+            };
+          };
+          systemd.network.networks."01-eth" = {
+            name = "eth1";
+            networkConfig = {
+              DHCP = "ipv4";
+              IPv6AcceptRA = "no";
+            };
+            addresses = [
+              {
+                Address = "10.0.0.2/24";
+                NFTSet = "address:inet:mytable:static_set";
+              }
+            ];
+            dhcpV4Config = {
+              NFTSet = "address:inet:mytable:dhcp_set";
+            };
+          };
+          services.nginx = {
+            enable = true;
+            virtualHosts.localhost.listen = [
+              {
+                addr = "0.0.0.0";
+                port = 80;
+              }
+              {
+                addr = "0.0.0.0";
+                port = 8080;
+              }
+            ];
+          };
+        };
+    };
+    testScript =
+      { ... }:
+      ''
+        start_all()
+
+        router.systemctl("start network-online.target")
+        client.systemctl("start network-online.target")
+        router.wait_for_unit("systemd-networkd-wait-online.service")
+        client.wait_for_unit("systemd-networkd-wait-online.service")
+
+        # should be able to ping both IPs
+        router.wait_until_succeeds("ping -c 5 10.0.0.2")
+        router.wait_until_succeeds("ping -c 5 10.0.0.100")
+
+        client.wait_for_unit("nginx.service")
+        client.wait_for_unit("nftables.service")
+        # should be able to get static IP, but not the DHCP IP on port 80
+        router.wait_until_succeeds("curl 10.0.0.2")
+        router.wait_until_fails("curl 10.0.0.100");
+
+        # vice versa on port 8080
+        router.wait_until_succeeds("curl 10.0.0.100:8080")
+        router.wait_until_fails("curl 10.0.0.2:8080");
+      '';
+  }
+)


### PR DESCRIPTION
## Description of changes
Allow setting `NFTSet=` option in systemd-netword network files. This option is for automatically adding the interface's address, prefix, or index to a named nftables set. It is valid under `[Address]` for static addresses, as well as the various sections for dynamic configuration (DHCP, etc.)

Added a NixOS test that configures a machine that uses NFTSet on a statically configured address section, as well as a DHCPv4 section, and checks that both nft sets are modified by testing nft rules that match on the sets.
 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Tested that it works on a system with nftables configured.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
