### PR TITLE
Add aiosonic and onecache dependency

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7370,6 +7370,12 @@
       { fingerprint = "MP2UpIRtJpbFFqyucP431H/FPCfn58UhEUTro4lXtRs"; }
     ];
   };
+  geraldog = {
+    email = "geraldogabriel@gmail.com";
+    github = "geraldog";
+    githubId = 14135816;
+    name = "Geraldo Nascimento";
+  };
   gerg-l = {
     email = "gregleyda@proton.me";
     github = "Gerg-L";

--- a/pkgs/development/python-modules/aiosonic/default.nix
+++ b/pkgs/development/python-modules/aiosonic/default.nix
@@ -1,0 +1,147 @@
+{
+  nodejs,
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  poetry-core,
+  # install_requires
+  charset-normalizer,
+  h2,
+  onecache,
+  # test dependencies
+  asgiref,
+  black,
+  django,
+  click,
+  httpx,
+  proxy-py,
+  pytest-aiohttp,
+  pytest-asyncio,
+  pytest-django,
+  pytest-mock,
+  pytest-sugar,
+  pytest-timeout,
+  uvicorn,
+  httptools,
+  typed-ast,
+  uvloop,
+  requests,
+  aiohttp,
+  aiodns,
+  pytestCheckHook,
+  stdenv,
+}:
+
+buildPythonPackage rec {
+  pname = "aiosonic";
+  version = "0.20.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  __darwinAllowLocalNetworking = true;
+
+  src = fetchFromGitHub {
+    owner = "sonic182";
+    repo = "aiosonic";
+    rev = "refs/tags/${version}";
+    hash = "sha256-RMkmmXUqzt9Nsx8N+f9Xdbgjt1nd5NuJHs9dzarx8IY=";
+  };
+
+  postPatch = ''
+    substituteInPlace pytest.ini --replace-fail \
+      "addopts = --black --cov=aiosonic --cov-report term --cov-report html --doctest-modules" \
+      "addopts = --doctest-modules"
+  '';
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    charset-normalizer
+    onecache
+    h2
+  ];
+
+  nativeCheckInputs = [
+    aiohttp
+    aiodns
+    asgiref
+    black
+    django
+    click
+    httpx
+    proxy-py
+    pytest-aiohttp
+    pytest-asyncio
+    pytest-django
+    pytest-mock
+    pytest-sugar
+    pytest-timeout
+    uvicorn
+    httptools
+    typed-ast
+    uvloop
+    requests
+    pytestCheckHook
+    nodejs
+  ];
+
+  pythonImportsCheck = [ "aiosonic" ];
+
+  disabledTests =
+    lib.optionals stdenv.isLinux [
+      # need network
+      "test_simple_get"
+      "test_get_python"
+      "test_post_http2"
+      "test_get_http2"
+      "test_method_lower"
+      "test_keep_alive_smart_pool"
+      "test_keep_alive_cyclic_pool"
+      "test_get_with_params"
+      "test_get_with_params_in_url"
+      "test_get_with_params_tuple"
+      "test_post_form_urlencoded"
+      "test_post_tuple_form_urlencoded"
+      "test_post_json"
+      "test_put_patch"
+      "test_delete"
+      "test_delete_2"
+      "test_get_keepalive"
+      "test_post_multipart_to_django"
+      "test_connect_timeout"
+      "test_read_timeout"
+      "test_timeouts_overriden"
+      "test_pool_acquire_timeout"
+      "test_simple_get_ssl"
+      "test_simple_get_ssl_ctx"
+      "test_simple_get_ssl_no_valid"
+      "test_get_chunked_response"
+      "test_get_chunked_response_and_not_read_it"
+      "test_read_chunks_by_text_method"
+      "test_get_body_gzip"
+      "test_get_body_deflate"
+      "test_post_chunked"
+      "test_close_connection"
+      "test_close_old_keeped_conn"
+      "test_get_redirect"
+      "test_max_redirects"
+      "test_get_image"
+      "test_get_image_chunked"
+      "test_get_with_cookies"
+      "test_proxy_request"
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      # "FAILED tests/test_proxy.py::test_proxy_request - Exception: port 8865 never got active"
+      "test_proxy_request"
+    ];
+
+  meta = {
+    changelog = "https://github.com/sonic182/aiosonic/blob/${version}/CHANGELOG.md";
+    description = "Very fast Python asyncio http client";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/sonic182/aiosonic";
+    maintainers = with lib.maintainers; [ geraldog ];
+  };
+}

--- a/pkgs/development/python-modules/onecache/default.nix
+++ b/pkgs/development/python-modules/onecache/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  poetry-core,
+  pytestCheckHook,
+  pytest-cov-stub,
+  pytest-asyncio,
+  stdenv,
+}:
+
+buildPythonPackage rec {
+  pname = "onecache";
+  version = "0.7.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "sonic182";
+    repo = "onecache";
+    rev = "refs/tags/${version}";
+    hash = "sha256-go/3HntSLzzTmHS9CxGPHT6mwXl+6LuWFmkGygGIjqU=";
+  };
+
+  build-system = [ poetry-core ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+    pytest-asyncio
+  ];
+
+  disabledTests = lib.optionals stdenv.isDarwin [
+    # test fails due to unknown reason on darwin
+    "test_lru_and_ttl_refresh"
+  ];
+
+  pythonImportsCheck = [ "onecache" ];
+
+  meta = {
+    changelog = "https://github.com/sonic182/onecache/blob/${version}/CHANGELOG.md";
+    description = "Python LRU and TTL cache for sync and async code";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/sonic182/onecache";
+    maintainers = with lib.maintainers; [ geraldog ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -403,6 +403,8 @@ self: super: with self; {
 
   aiosasl = callPackage ../development/python-modules/aiosasl { };
 
+  aiosonic = callPackage ../development/python-modules/aiosonic { };
+
   aiosql = callPackage ../development/python-modules/aiosql { };
 
   aiosenz = callPackage ../development/python-modules/aiosenz { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9373,6 +9373,8 @@ self: super: with self; {
 
   ondilo = callPackage ../development/python-modules/ondilo { };
 
+  onecache = callPackage ../development/python-modules/onecache { };
+
   onetimepass = callPackage ../development/python-modules/onetimepass { };
 
   onigurumacffi = callPackage ../development/python-modules/onigurumacffi { };


### PR DESCRIPTION
## Description of changes

* Added myself as maintainer
* init aiosonic, A very fast Python asyncio http client, see: https://github.com/sonic182/aiosonic
* init onecache, Python LRU and TTL cache for sync and async code, see: https://github.com/sonic182/onecache

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
```
8 packages built:
python311Packages.aiosonic python311Packages.aiosonic.dist python311Packages.onecache python311Packages.onecache.dist python312Packages.aiosonic python312Packages.aiosonic.dist python312Packages.onecache python312Packages.onecache.dist
```
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
