### PR TITLE
treewide: migrate to pytest-cov-stub

### DIFF
--- a/pkgs/development/python-modules/aionotion/default.nix
+++ b/pkgs/development/python-modules/aionotion/default.nix
@@ -13,7 +13,7 @@
   pytest-aiohttp,
   pytest-asyncio,
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
   pythonOlder,
   yarl,
 }:
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     aresponses
     pytest-aiohttp
     pytest-asyncio
-    pytest-cov
+    pytest-cov-stub
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/binance-connector/default.nix
+++ b/pkgs/development/python-modules/binance-connector/default.nix
@@ -7,7 +7,7 @@
   requests,
   websocket-client,
   # dependencies for tests
-  pytest-cov,
+  pytest-cov-stub,
   pytest,
   sure,
   responses,
@@ -35,7 +35,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    pytest-cov
+    pytest-cov-stub
     pytest
     sure
     responses

--- a/pkgs/development/python-modules/brottsplatskartan/default.nix
+++ b/pkgs/development/python-modules/brottsplatskartan/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pytest-cov,
+  pytest-cov-stub,
   pytestCheckHook,
   requests,
 }:
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ requests ];
 
   nativeCheckInputs = [
-    pytest-cov
+    pytest-cov-stub
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/cashews/default.nix
+++ b/pkgs/development/python-modules/cashews/default.nix
@@ -9,7 +9,7 @@
   lib,
   pytest,
   pytest-asyncio,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-rerunfailures,
   pytestCheckHook,
   redis,
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     hypothesis
     pytest
     pytest-asyncio
-    pytest-cov
+    pytest-cov-stub
     pytest-rerunfailures
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/cffconvert/default.nix
+++ b/pkgs/development/python-modules/cffconvert/default.nix
@@ -9,7 +9,7 @@
   pykwalify,
   jsonschema,
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
 }:
 
 buildPythonPackage rec {
@@ -34,11 +34,9 @@ buildPythonPackage rec {
     jsonschema
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
-
-  checkInputs = [
-    # addopts uses --no-cov
-    pytest-cov
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/hydrawiser/default.nix
+++ b/pkgs/development/python-modules/hydrawiser/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   pytest-asyncio,
-  pytest-cov,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
   requests,
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytest-asyncio
-    pytest-cov
+    pytest-cov-stub
     pytestCheckHook
     requests
     requests-mock

--- a/pkgs/development/python-modules/ipydatawidgets/default.nix
+++ b/pkgs/development/python-modules/ipydatawidgets/default.nix
@@ -4,7 +4,7 @@
   fetchPypi,
   isPy27,
   pytest,
-  pytest-cov,
+  pytest-cov-stub,
   nbval,
   jupyter-packaging,
   ipywidgets,
@@ -38,7 +38,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytest
-    pytest-cov
+    pytest-cov-stub
     nbval
   ];
 

--- a/pkgs/development/python-modules/ndindex/default.nix
+++ b/pkgs/development/python-modules/ndindex/default.nix
@@ -11,7 +11,7 @@
 
   # tests
   hypothesis,
-  pytest-cov,
+  pytest-cov-stub,
   pytestCheckHook,
 }:
 
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pytest.ini \
-      --replace "--cov=ndindex/ --cov-report=term-missing --flakes" ""
+      --replace "--flakes" ""
   '';
 
   passthru.optional-dependencies.arrays = [ numpy ];
@@ -40,7 +40,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     hypothesis
-    pytest-cov # uses cov markers
+    pytest-cov-stub
     pytestCheckHook
   ] ++ passthru.optional-dependencies.arrays;
 

--- a/pkgs/development/python-modules/pure-protobuf/default.nix
+++ b/pkgs/development/python-modules/pure-protobuf/default.nix
@@ -8,7 +8,7 @@
   typing-extensions,
   pytestCheckHook,
   pytest-benchmark,
-  pytest-cov,
+  pytest-cov-stub,
   pydantic,
 }:
 
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     pydantic
     pytestCheckHook
     pytest-benchmark
-    pytest-cov
+    pytest-cov-stub
   ];
 
   pytestFlagsArray = [ "--benchmark-disable" ];

--- a/pkgs/development/python-modules/pyexcel-ods/default.nix
+++ b/pkgs/development/python-modules/pyexcel-ods/default.nix
@@ -9,7 +9,7 @@
   pyexcel-xls,
   psutil,
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
   setuptools,
 }:
 
@@ -43,7 +43,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
     pyexcel
     pyexcel-xls
     psutil

--- a/pkgs/development/python-modules/pynws/default.nix
+++ b/pkgs/development/python-modules/pynws/default.nix
@@ -7,7 +7,7 @@
   metar,
   pytest-aiohttp,
   pytest-asyncio,
-  pytest-cov,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
   setuptools,
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     freezegun
     pytest-aiohttp
     pytest-asyncio
-    pytest-cov
+    pytest-cov-stub
     pytestCheckHook
   ] ++ lib.flatten (lib.attrValues optional-dependencies);
 

--- a/pkgs/development/python-modules/pytest-cov-stub/default.nix
+++ b/pkgs/development/python-modules/pytest-cov-stub/default.nix
@@ -6,6 +6,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-cov-stub";
+  # please use pythonRemoveDeps rather than change this version
   version = (lib.importTOML ./src/pyproject.toml).project.version;
   pyproject = true;
 

--- a/pkgs/development/python-modules/pyvera/default.nix
+++ b/pkgs/development/python-modules/pyvera/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   poetry-core,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-asyncio,
   pytest-timeout,
   responses,
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytest-asyncio
     pytest-timeout
-    pytest-cov
+    pytest-cov-stub
     pytestCheckHook
     responses
   ];


### PR DESCRIPTION
## Description of changes

This time i grepped for `\bpytest-cov[^-]\b` to see if any new issues would come up. I discovered that some packages that use `pytest` rather than `pytestCheckHook` will try to `pip install pytest-cov` if it is not present in the sandbox, even if i try to `pythonRemoveDeps` it. I decided to try and deal with those cases in a different PR

EDIT: addressed in https://github.com/NixOS/nixpkgs/pull/332842

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
