### PR TITLE
python311Packages.stups-*: migrate to pytestCheckHook

### DIFF
--- a/pkgs/development/python-modules/ipydatawidgets/default.nix
+++ b/pkgs/development/python-modules/ipydatawidgets/default.nix
@@ -3,8 +3,7 @@
   buildPythonPackage,
   fetchPypi,
   isPy27,
-  pytest,
-  pytest-cov-stub,
+  pytestCheckHook,
   nbval,
   jupyter-packaging,
   ipywidgets,
@@ -37,12 +36,9 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    pytest
-    pytest-cov-stub
+    pytestCheckHook
     nbval
   ];
-
-  checkPhase = "pytest ipydatawidgets/tests";
 
   meta = {
     description = "Widgets to help facilitate reuse of large datasets across different widgets";

--- a/pkgs/development/python-modules/stups-cli-support/default.nix
+++ b/pkgs/development/python-modules/stups-cli-support/default.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
+  setuptools,
   clickclick,
   dnspython,
   requests,
@@ -12,7 +13,7 @@
 buildPythonPackage rec {
   pname = "stups-cli-support";
   version = "1.1.20";
-  format = "setuptools";
+  pyproject = true;
   disabled = !isPy3k;
 
   src = fetchFromGitHub {
@@ -22,7 +23,9 @@ buildPythonPackage rec {
     sha256 = "1r6g29gd009p87m8a6wv4rzx7f0564zdv67qz5xys4wsgvc95bx0";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     clickclick
     dnspython
     requests

--- a/pkgs/development/python-modules/stups-cli-support/default.nix
+++ b/pkgs/development/python-modules/stups-cli-support/default.nix
@@ -5,8 +5,7 @@
   clickclick,
   dnspython,
   requests,
-  pytest,
-  pytest-cov,
+  pytestCheckHook,
   isPy3k,
 }:
 
@@ -31,10 +30,7 @@ buildPythonPackage rec {
 
   preCheck = "export HOME=$TEMPDIR";
 
-  nativeCheckInputs = [
-    pytest
-    pytest-cov
-  ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     description = "Helper library for all STUPS command line tools";

--- a/pkgs/development/python-modules/stups-fullstop/default.nix
+++ b/pkgs/development/python-modules/stups-fullstop/default.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
+  pythonAtLeast,
   requests,
   stups-cli-support,
   stups-zign,
@@ -43,5 +44,8 @@ buildPythonPackage rec {
     homepage = "https://github.com/zalando-stups/stups-fullstop-cli";
     license = licenses.asl20;
     maintainers = [ maintainers.mschuwalow ];
+    # Uses regex patterns deprecated in 3.9:
+    #     re.error: global flags not at the start of the expression at ...
+    broken = pythonAtLeast "3.11";
   };
 }

--- a/pkgs/development/python-modules/stups-pierone/default.nix
+++ b/pkgs/development/python-modules/stups-pierone/default.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
+  setuptools,
   requests,
   stups-cli-support,
   stups-zign,
@@ -13,7 +14,7 @@
 buildPythonPackage rec {
   pname = "stups-pierone";
   version = "1.1.51";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -24,7 +25,11 @@ buildPythonPackage rec {
     hash = "sha256-OypGYHfiFUfcUndylM2N2WfPnfXXJ4gvWypUbltYAYE=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  pythonRelaxDeps = [ "stups-zign" ];
+
+  dependencies = [
     requests
     stups-cli-support
     stups-zign

--- a/pkgs/development/python-modules/stups-pierone/default.nix
+++ b/pkgs/development/python-modules/stups-pierone/default.nix
@@ -5,8 +5,7 @@
   requests,
   stups-cli-support,
   stups-zign,
-  pytest,
-  pytest-cov,
+  pytestCheckHook,
   hypothesis,
   pythonOlder,
 }:
@@ -36,8 +35,7 @@ buildPythonPackage rec {
   '';
 
   nativeCheckInputs = [
-    pytest
-    pytest-cov
+    pytestCheckHook
     hypothesis
   ];
 

--- a/pkgs/development/python-modules/stups-tokens/default.nix
+++ b/pkgs/development/python-modules/stups-tokens/default.nix
@@ -4,8 +4,7 @@
   buildPythonPackage,
   requests,
   mock,
-  pytest,
-  pytest-cov,
+  pytestCheckHook,
   isPy3k,
 }:
 
@@ -26,8 +25,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     mock
-    pytest
-    pytest-cov
+    pytestCheckHook
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/stups-tokens/default.nix
+++ b/pkgs/development/python-modules/stups-tokens/default.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
+  setuptools,
   requests,
   mock,
   pytestCheckHook,
@@ -11,7 +12,7 @@
 buildPythonPackage rec {
   pname = "stups-tokens";
   version = "1.1.19";
-  format = "setuptools";
+  pyproject = true;
   disabled = !isPy3k;
 
   src = fetchFromGitHub {
@@ -21,7 +22,9 @@ buildPythonPackage rec {
     sha256 = "09z3l3xzdlwpivbi141gk1k0zd9m75mjwbdy81zc386rr9k8s0im";
   };
 
-  propagatedBuildInputs = [ requests ];
+  build-system = [ setuptools ];
+
+  dependencies = [ requests ];
 
   nativeCheckInputs = [
     mock

--- a/pkgs/development/python-modules/stups-zign/default.nix
+++ b/pkgs/development/python-modules/stups-zign/default.nix
@@ -5,8 +5,7 @@
   fetchpatch,
   stups-tokens,
   stups-cli-support,
-  pytest,
-  pytest-cov,
+  pytestCheckHook,
   isPy3k,
 }:
 
@@ -40,10 +39,7 @@ buildPythonPackage rec {
     export HOME=$TEMPDIR
   ";
 
-  nativeCheckInputs = [
-    pytest
-    pytest-cov
-  ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     description = "OAuth2 token management command line utility";

--- a/pkgs/development/python-modules/stups-zign/default.nix
+++ b/pkgs/development/python-modules/stups-zign/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
+  setuptools,
   stups-tokens,
   stups-cli-support,
   pytestCheckHook,
@@ -12,7 +13,7 @@
 buildPythonPackage rec {
   pname = "stups-zign";
   version = "1.2";
-  format = "setuptools";
+  pyproject = true;
   disabled = !isPy3k;
 
   src = fetchFromGitHub {
@@ -30,7 +31,9 @@ buildPythonPackage rec {
     })
   ];
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     stups-tokens
     stups-cli-support
   ];

--- a/pkgs/development/python-modules/typesentry/default.nix
+++ b/pkgs/development/python-modules/typesentry/default.nix
@@ -3,8 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   colorama,
-  pytest,
-  pytest-cov,
+  pytestCheckHook,
 }:
 
 buildPythonPackage {
@@ -21,13 +20,7 @@ buildPythonPackage {
   };
 
   propagatedBuildInputs = [ colorama ];
-  nativeCheckInputs = [
-    pytest
-    pytest-cov
-  ];
-  checkPhase = ''
-    pytest
-  '';
+  nativeCheckInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     description = "Python 2.7 & 3.5+ runtime type-checker";


### PR DESCRIPTION
## Description of changes

I discovered in https://github.com/NixOS/nixpkgs/pull/332821 a bunch of packages that used `pytest-cov` because `pytest` via `setuptools test` otherwise would try to `pip install` it. This PR fixes those cases.

Migrating to `pytestCheckHook` removed the need for `pytest-cov` entirely, not even needing the new stub. I migrated the packages to `pyproject` for good measure.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
