### PR TITLE
spasm-ng: 2020-08-03 -> 2022-07-03

### DIFF
--- a/pkgs/development/compilers/spasm-ng/default.nix
+++ b/pkgs/development/compilers/spasm-ng/default.nix
@@ -8,8 +8,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "alberthdev";
     repo = "spasm-ng";
-    rev = "221898beff2442f459b80ab89c8e1035db97868e";
-    sha256 = "0xspxmp2fir604b4xsk4hi1gjv61rnq2ypppr7cj981jlhicmvjj";
+    rev = "5f0786d38f064835be674d4b7df42969967bb73c";
+    sha256 = "sha256-j7Z3oI+J0wZF4EG5OMMjuDe2o69KKGuJvfyHNPTLrXM=";
   };
 
   nativeBuildInputs = [ gcc ];

--- a/pkgs/development/compilers/spasm-ng/default.nix
+++ b/pkgs/development/compilers/spasm-ng/default.nix
@@ -1,9 +1,9 @@
-{ lib, stdenv, fetchFromGitHub, gcc, gmp, openssl, zlib }:
+{ lib, stdenv, fetchFromGitHub, makeWrapper, gmp, gcc, openssl, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "spasm-ng";
 
-  version = "unstable-2020-08-03";
+  version = "unstable-2022-07-05";
 
   src = fetchFromGitHub {
     owner = "alberthdev";
@@ -12,14 +12,23 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-j7Z3oI+J0wZF4EG5OMMjuDe2o69KKGuJvfyHNPTLrXM=";
   };
 
-  nativeBuildInputs = [ gcc ];
-
+  # GCC is needed for Darwin
+  nativeBuildInputs = [ makeWrapper gcc ];
   buildInputs = [ gmp openssl zlib ];
 
   enableParallelBuilding = true;
 
   installPhase = ''
+    runHook preInstall
+
     install -Dm755 spasm -t $out/bin
+    install -Dm555 inc/*.inc -t $out/include
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/spasm --add-flags "-I $out/include"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Add header files that are automatically included in the SPASM-ng repo into the include directory. Also, update spasm-ng itself.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
 - The Git command took so long I gave up and stopped execution. I searched the Nixpkgs repo for references to spasm-ng, and there were no other references.
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Things that can be improved further, but will not be implemented in this PR:
- Add `passthru.tests`, which requires patchShebangs in the tests.
- There is a bug introduced in this PR where running `spasm` without any arguments results in an error instead of the help message. This can be resolved by creating `spasm-ng-unwrapped` and making a custom wrapper in `spasm`. This is not a big issue because users can run `spasm -h` to get the help options anyway.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
