### PR TITLE
zfs_2_2: 2.2.4 -> 2.2.5

### DIFF
--- a/pkgs/os-specific/linux/zfs/2_2.nix
+++ b/pkgs/os-specific/linux/zfs/2_2.nix
@@ -15,12 +15,12 @@ callPackage ./generic.nix args {
   # this attribute is the correct one for this package.
   kernelModuleAttribute = "zfs_2_2";
   # check the release notes for compatible kernels
-  kernelCompatible = kernel.kernelOlder "6.9";
+  kernelCompatible = kernel.kernelOlder "6.10";
 
-  latestCompatibleLinuxPackages = linuxKernel.packages.linux_6_8;
+  latestCompatibleLinuxPackages = linuxKernel.packages.linux_6_9;
 
   # this package should point to the latest release.
-  version = "2.2.4";
+  version = "2.2.5";
 
   tests = [
     nixosTests.zfs.installer
@@ -29,5 +29,5 @@ callPackage ./generic.nix args {
 
   maintainers = with lib.maintainers; [ adamcstephens amarshall ];
 
-  hash = "sha256-SSp/1Tu1iGx5UDcG4j0k2fnYxK05cdE8gzfSn8DU5Z4=";
+  hash = "sha256-BkwcNPk+jX8CXp5xEVrg4THof7o/5j8RY2SY6+IPNTg=";
 }

--- a/pkgs/os-specific/linux/zfs/unstable.nix
+++ b/pkgs/os-specific/linux/zfs/unstable.nix
@@ -23,31 +23,13 @@ callPackage ./generic.nix args {
   # IMPORTANT: Always use a tagged release candidate or commits from the
   # zfs-<version>-staging branch, because this is tested by the OpenZFS
   # maintainers.
-  version = "2.2.4-unstable-2024-07-15";
-  rev = "/54ef0fdf60a8e7633c38cb46e1f5bcfcec792f4e";
+  version = "2.2.5";
+  # rev = "";
 
   isUnstable = true;
   tests = [
     nixosTests.zfs.unstable
   ];
 
-  # 6.10 patches approved+merged to the default branch, not in staging yet
-  # https://github.com/openzfs/zfs/pull/16250
-  extraPatches = [
-    (fetchpatch {
-      url = "https://github.com/openzfs/zfs/commit/7ca7bb7fd723a91366ce767aea53c4f5c2d65afb.patch";
-      hash = "sha256-vUX4lgywh5ox6DjtIfeC90KjbLoW3Ol0rK/L65jOENo=";
-    })
-    (fetchpatch {
-      url = "https://github.com/openzfs/zfs/commit/e951dba48a6330aca9c161c50189f6974e6877f0.patch";
-      hash = "sha256-A1h0ZLY+nlReBMTlEm3O9kwBqto1cgsZdnJsHpR6hw0=";
-    })
-    (fetchpatch {
-      url = "https://github.com/openzfs/zfs/commit/b409892ae5028965a6fe98dde1346594807e6e45.patch";
-      hash = "sha256-pW1b8ktglFhwVRapTB5th9UCyjyrPmCVPg53nMENax8=";
-    })
-
-  ];
-
-  hash = "sha256-7vZeIzA2yDW/gSCcS2AM3+C9qbRIbA9XbCRUxikW2+M=";
+  hash = "sha256-BkwcNPk+jX8CXp5xEVrg4THof7o/5j8RY2SY6+IPNTg=";
 }


### PR DESCRIPTION
## Description of changes

Update zfs_unstable to match as well.

## Things done

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>8 packages marked as broken and skipped:</summary>
  <ul>
    <li>libvmi</li>
    <li>linuxKernel.packages.linux_6_10.zfs</li>
    <li>linuxKernel.packages.linux_latest_libre.zfs</li>
    <li>linuxKernel.packages.linux_zen.zfs</li>
    <li>nixops_unstablePlugins.nixops-libvirtd</li>
    <li>nixops_unstablePlugins.nixops-libvirtd.dist</li>
    <li>nixops_unstable_full</li>
    <li>nixops_unstable_full.dist</li>
  </ul>
</details>
<details>
  <summary>15 packages failed to build:</summary>
  <ul>
    <li>ceph</li>
    <li>ceph-client</li>
    <li>ceph-csi</li>
    <li>ceph.dev</li>
    <li>ceph.doc</li>
    <li>libceph (ceph.lib ,libceph.dev ,libceph.doc ,libceph.lib ,libceph.man)</li>
    <li>ceph.man</li>
    <li>qemu_full</li>
    <li>qemu_full.debug</li>
    <li>qemu_full.ga</li>
    <li>quickemu</li>
    <li>quickgui</li>
    <li>samba4Full</li>
    <li>samba4Full.dev</li>
    <li>samba4Full.man</li>
  </ul>
</details>
<details>
  <summary>87 packages built:</summary>
  <ul>
    <li>appvm</li>
    <li>booster</li>
    <li>check_zfs</li>
    <li>collectd</li>
    <li>diffoscope</li>
    <li>diffoscope.dist</li>
    <li>diffoscope.man</li>
    <li>docker-machine-kvm2</li>
    <li>easysnap</li>
    <li>facter</li>
    <li>gnome.gnome-boxes</li>
    <li>guestfs-tools</li>
    <li>htcondor</li>
    <li>kdePackages.kpmcore</li>
    <li>kdePackages.kpmcore.debug</li>
    <li>kdePackages.kpmcore.dev</li>
    <li>kdePackages.kpmcore.devtools</li>
    <li>kdePackages.partitionmanager</li>
    <li>kdePackages.partitionmanager.debug</li>
    <li>kdePackages.partitionmanager.dev</li>
    <li>kdePackages.partitionmanager.devtools</li>
    <li>libguestfs</li>
    <li>libguestfs-with-appliance</li>
    <li>librenms</li>
    <li>libsForQt5.partitionmanager</li>
    <li>libvirt</li>
    <li>libvirt-glib</li>
    <li>libvirt-glib.dev</li>
    <li>libvirt-glib.devdoc</li>
    <li>linuxKernel.packages.linux_4_19.zfs (linuxKernel.packages.linux_4_19.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_4_19_hardened.zfs (linuxKernel.packages.linux_4_19_hardened.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_5_10.zfs (linuxKernel.packages.linux_5_10.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_5_10_hardened.zfs (linuxKernel.packages.linux_5_10_hardened.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_5_15.zfs (linuxKernel.packages.linux_5_15.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_5_15_hardened.zfs (linuxKernel.packages.linux_5_15_hardened.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_5_4.zfs (linuxKernel.packages.linux_5_4.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_5_4_hardened.zfs (linuxKernel.packages.linux_5_4_hardened.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_6_1.zfs (linuxKernel.packages.linux_6_1.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_6_10.zfs_unstable</li>
    <li>linuxKernel.packages.linux_6_1_hardened.zfs (linuxKernel.packages.linux_6_1_hardened.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_6_6.zfs (linuxKernel.packages.linux_6_6.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_hardened.zfs (linuxKernel.packages.linux_6_6_hardened.zfs ,linuxKernel.packages.linux_hardened.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_6_8.zfs (linuxKernel.packages.linux_6_8.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_6_8_hardened.zfs (linuxKernel.packages.linux_6_8_hardened.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_6_9.zfs (linuxKernel.packages.linux_6_9.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_6_9_hardened.zfs (linuxKernel.packages.linux_6_9_hardened.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_latest_libre.zfs_unstable</li>
    <li>linuxKernel.packages.linux_libre.zfs (linuxKernel.packages.linux_libre.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_lqx.zfs (linuxKernel.packages.linux_lqx.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_xanmod.zfs (linuxKernel.packages.linux_xanmod.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_xanmod_latest.zfs (linuxKernel.packages.linux_xanmod_latest.zfs_unstable ,linuxKernel.packages.linux_xanmod_stable.zfs ,linuxKernel.packages.linux_xanmod_stable.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_zen.zfs_unstable</li>
    <li>mgmt</li>
    <li>minikube</li>
    <li>multipass</li>
    <li>ocamlPackages.ocaml_libvirt</li>
    <li>perl536Packages.SysVirt</li>
    <li>perl536Packages.SysVirt.devdoc</li>
    <li>perl538Packages.SysVirt</li>
    <li>perl538Packages.SysVirt.devdoc</li>
    <li>python311Packages.guestfs</li>
    <li>python311Packages.guestfs.dist</li>
    <li>python311Packages.libvirt</li>
    <li>python311Packages.libvirt.dist</li>
    <li>python311Packages.py-libzfs</li>
    <li>python311Packages.py-libzfs.dist</li>
    <li>python312Packages.guestfs</li>
    <li>python312Packages.guestfs.dist</li>
    <li>python312Packages.libvirt</li>
    <li>python312Packages.libvirt.dist</li>
    <li>python312Packages.py-libzfs</li>
    <li>python312Packages.py-libzfs.dist</li>
    <li>rubyPackages.ruby-libvirt</li>
    <li>rubyPackages_3_2.ruby-libvirt</li>
    <li>rubyPackages_3_3.ruby-libvirt</li>
    <li>sanoid</li>
    <li>vagrant</li>
    <li>virt-manager</li>
    <li>virt-manager-qt</li>
    <li>virt-manager.dist</li>
    <li>virt-top</li>
    <li>virt-viewer</li>
    <li>zfs (zfs_unstable)</li>
    <li>zfs.dev (zfs_unstable.dev)</li>
    <li>zfstools</li>
    <li>zpool-auto-expand-partitions</li>
    <li>zxfer</li>
  </ul>
</details>

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
