### PR TITLE
tigerbeetle: 0.15.3 -> 0.15.5

### DIFF
--- a/pkgs/by-name/ti/tigerbeetle/package.nix
+++ b/pkgs/by-name/ti/tigerbeetle/package.nix
@@ -10,14 +10,14 @@ let
   platform =
     if stdenvNoCC.hostPlatform.isDarwin then "universal-macos" else stdenvNoCC.hostPlatform.system;
   hash = builtins.getAttr platform {
-    "universal-macos" = "sha256-6aZB6RjSsJf8suweaSdKSq16fRb7PGWuYMNg9twuWN4=";
-    "x86_64-linux" = "sha256-d8V/SS6vzzPHRkxZNShi1r+QFVFDwqrVaESMb0kPWDQ=";
-    "aarch64-linux" = "sha256-nEYGJOWR7OEiEamiwiFpU2bOdtQLvV5O+onNhFKKqZQ=";
+    "universal-macos" = "sha256-ls2QFCiPkXMTiCHo8AXb5bFl118zjtuQAGl26c4huwU=";
+    "x86_64-linux" = "sha256-QjQjP5p2fpOLWNGiU2aMMs2bUEFOWfBZrbPGLTOFozg=";
+    "aarch64-linux" = "sha256-DMxGakZBJhLTgZp7B9lwxilr6yhDVDe/GQCMFaRTWe4=";
   };
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "tigerbeetle";
-  version = "0.15.4";
+  version = "0.15.5";
 
   src = fetchzip {
     url = "https://github.com/tigerbeetle/tigerbeetle/releases/download/${finalAttrs.version}/tigerbeetle-${platform}.zip";

--- a/pkgs/by-name/ti/tigerbeetle/package.nix
+++ b/pkgs/by-name/ti/tigerbeetle/package.nix
@@ -1,36 +1,41 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, zig_0_11
-, testers
-, tigerbeetle
-, nix-update-script
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  testers,
+  tigerbeetle,
+  nix-update-script,
 }:
 let
-  # Read [these comments](pkgs/development/compilers/zig/hook.nix#L12-L30) on the default Zig flags, and the associated links. tigerbeetle stopped exposing the `-Doptimize` build flag, so we can't use the default Nixpkgs zig hook as-is. tigerbeetle only exposes a boolean `-Drelease` flag which we'll add in the tigerbeetle derivation in this file.
-  custom_zig_hook = zig_0_11.hook.overrideAttrs (previousAttrs: {
-    zig_default_flags = builtins.filter (flag: builtins.match "-Doptimize.*" flag == null) previousAttrs.zig_default_flags;
-  });
+  platform =
+    if stdenvNoCC.hostPlatform.isDarwin then "universal-macos" else stdenvNoCC.hostPlatform.system;
+  hash = builtins.getAttr platform {
+    "universal-macos" = "sha256-6aZB6RjSsJf8suweaSdKSq16fRb7PGWuYMNg9twuWN4=";
+    "x86_64-linux" = "sha256-d8V/SS6vzzPHRkxZNShi1r+QFVFDwqrVaESMb0kPWDQ=";
+    "aarch64-linux" = "sha256-nEYGJOWR7OEiEamiwiFpU2bOdtQLvV5O+onNhFKKqZQ=";
+  };
 in
-stdenv.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "tigerbeetle";
-  version = "0.15.3";
+  version = "0.15.4";
 
-  src = fetchFromGitHub {
-    owner = "tigerbeetle";
-    repo = "tigerbeetle";
-    rev = "refs/tags/${finalAttrs.version}";
-    hash = "sha256-3+uCMoOnyvI//ltEaqTIXytUxxgJrfMnFly11WCh66Q=";
+  src = fetchzip {
+    url = "https://github.com/tigerbeetle/tigerbeetle/releases/download/${finalAttrs.version}/tigerbeetle-${platform}.zip";
+    inherit hash;
   };
 
-  env.TIGERBEETLE_RELEASE = finalAttrs.version;
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
 
-  nativeBuildInputs = [ custom_zig_hook ];
+  installPhase = ''
+    runHook preInstall
 
-  zigBuildFlags = [
-    "-Drelease"
-    "-Dgit-commit=0000000000000000000000000000000000000000"
-  ];
+    mkdir -p $out/bin
+    cp $src/tigerbeetle $out/bin/tigerbeetle
+
+    runHook postInstall
+  '';
 
   passthru = {
     tests.version = testers.testVersion {
@@ -45,7 +50,11 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Financial accounting database designed to be distributed and fast";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ danielsidhion ];
-    platforms = lib.platforms.linux;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ] ++ lib.platforms.darwin;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
     mainProgram = "tigerbeetle";
   };
 })


### PR DESCRIPTION
## Description of changes

- Now only providing the binaries as released on GitHub (see the Notes subsection for details).
- Nix code formatted with nixfmt-rfc-style.

I'd appreciate someone with Apple hardware testing this package as well. Should work in theory given that the package just grabs the binaries from GitHub.

### Notes

After introducing forward upgradeability between 0.15.3 and 0.15.4, tigerbeetle's build process got complicated enough to port to Nixpkgs. They're essentially building two binaries (the binary for the previous version and the one for the new version) and packing the two binaries in the same ELF file to allow seamless transition between versions without even requiring an explicit process restart.

It's a neat idea, but their build process hardcodes the use of `git` to get the previous version's code, and assumes Internet access. All of the build code is written in Zig and there's a bunch of it, making it prohibitive for me to maintain a "build from source" process in Nixpkgs as well. Because of this, I'm now just providing on Nixpkgs the binaries they build and release on GitHub.

I've talked to the TB folks about this, and there may be a chance of making their build process a bit more modular to allow building from source without requiring `git` or Internet access.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
