### PR TITLE
sonar-scanner-cli: 4.7.0.2747 -> 6.1.0.4477

### DIFF
--- a/pkgs/tools/security/sonar-scanner-cli/default.nix
+++ b/pkgs/tools/security/sonar-scanner-cli/default.nix
@@ -1,27 +1,17 @@
-{ stdenv, lib, fetchurl, unzip, jre }:
+{ stdenv, lib, fetchzip, unzip, jre }:
 
-let
+stdenv.mkDerivation rec {
+  pname = "sonar-scanner-cli";
+  version = "6.1.0.4477";
 
-  version = "4.7.0.2747";
-
-  sonarScannerArchPackage = {
-    "x86_64-linux" = {
-      url = "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${version}-linux.zip";
-      sha256 = "0qy97lcn9nfwg0x32v9x5kh5jswnjyw3wpvxj45z7cddlj2is4iy";
-    };
-    "x86_64-darwin" = {
-      url = "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${version}-macosx.zip";
-      sha256 = "0f8km7wqkw09g01l03kcrjgvq7b6xclzpvb5r64ymsmrc39p0ylp";
-    };
+  src = fetchzip {
+    url = "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${version}.zip";
+    sha256 = "sha256-af5B5YUS0qph+ZyVYzbI4GBFNweg2xOoZvfjd3Bmrag=";
   };
 
-in stdenv.mkDerivation rec {
-  inherit version;
-  pname = "sonar-scanner-cli";
-
-  src = fetchurl sonarScannerArchPackage.${stdenv.hostPlatform.system} or (throw "unsupported system ${stdenv.hostPlatform.system}");
-
   nativeBuildInputs = [ unzip ];
+
+  env.JAVA_HOME = lib.getBin jre;
 
   installPhase = ''
     mkdir -p $out/lib
@@ -32,16 +22,12 @@ in stdenv.mkDerivation rec {
     cp conf/* $out/conf/
   '';
 
-  fixupPhase = ''
-    substituteInPlace $out/bin/sonar-scanner \
-      --replace "\$sonar_scanner_home/jre" "${lib.getBin jre}"
-  '';
-
   meta = with lib; {
     homepage = "https://github.com/SonarSource/sonar-scanner-cli";
     description = "SonarQube Scanner used to start code analysis";
     license = licenses.gpl3Plus;
+    mainProgram = "sonar-scanner";
     maintainers = with maintainers; [ peterromfeldhk ];
-    platforms = builtins.attrNames sonarScannerArchPackage;
+    platforms = [ "aarch64-darwin" "aarch64-linux" "x86_64-darwin" "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
## Description of changes

Update sonar-scanner-cli package to 6.1.0.4477 (2024-06-27).

Switch to use the jre-less platform-agnostic binary.

- Page w/ download links and brief changelog: https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/scanners/sonarscanner/
- Full Changelog: https://github.com/SonarSource/sonar-scanner-cli/compare/4.7.0.2747...6.1.0.4477

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
