### PR TITLE
Revert "python312Packages.textual: 0.72.0 -> 0.75.0"

### DIFF
--- a/pkgs/development/python-modules/textual/default.nix
+++ b/pkgs/development/python-modules/textual/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "textual";
-  version = "0.75.0";
+  version = "0.72.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -39,7 +39,10 @@ buildPythonPackage rec {
   ] ++ markdown-it-py.optional-dependencies.plugins ++ markdown-it-py.optional-dependencies.linkify;
 
   optional-dependencies = {
-    syntax = [ tree-sitter ] ++ lib.optionals (pythonOlder "3.12") [ tree-sitter-languages ];
+    syntax = [
+      tree-sitter
+      tree-sitter-languages
+    ];
   };
 
   nativeCheckInputs = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#332289

This PR is incomplete, and a hack to optional-dependencies should also be resolved upstream, like https://github.com/NixOS/nixpkgs/pull/332747.

cc @greg-hellings @drupol 