### PR TITLE
nixos/tests/librenms: Using services.snmpd module for tests to fix timeouts

### DIFF
--- a/nixos/tests/librenms.nix
+++ b/nixos/tests/librenms.nix
@@ -3,7 +3,8 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
 let
   api_token = "f87f42114e44b63ad1b9e3c3d33d6fbe"; # random md5 hash
   wrong_api_token = "e68ba041fcf1eab923a7a6de3af5f726"; # another random md5 hash
-in {
+in
+{
   name = "librenms";
   meta.maintainers = lib.teams.wdz.members;
 
@@ -60,37 +61,29 @@ in {
   };
 
   nodes.snmphost = {
-    networking.firewall.allowedUDPPorts = [ 161 ];
 
-    systemd.services.snmpd = {
-      description = "snmpd";
-      after = [ "network-online.target" ];
-      wants = [ "network-online.target" ];
-      wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
-        Type = "forking";
-        User = "root";
-        Group = "root";
-        ExecStart = let
-          snmpd-config = pkgs.writeText "snmpd-config" ''
-            com2sec readonly default public
+    services.snmpd = {
+      enable = true;
+      openFirewall = true;
 
-            group MyROGroup v2c        readonly
-            view all    included  .1                               80
-            access MyROGroup ""      any       noauth    exact  all    none   none
+      configText = ''
+        com2sec readonly default public
 
-            syslocation Testcity, Testcountry
-            syscontact Testi mc Test <test@example.com>
-          '';
-        in "${pkgs.net-snmp}/bin/snmpd -c ${snmpd-config} -C";
-      };
+        group MyROGroup v2c        readonly
+        view all    included  .1                               80
+        access MyROGroup ""      any       noauth    exact  all    none   none
+
+        syslocation Testcity, Testcountry
+        syscontact Testi mc Test <test@example.com>
+      '';
+
     };
   };
 
   testScript = ''
     start_all()
 
-    snmphost.wait_until_succeeds("pgrep snmpd")
+    snmphost.wait_for_unit("snmpd.service")
 
     librenms.wait_for_unit("lnms-api-init.service")
     librenms.wait_for_open_port(80)


### PR DESCRIPTION
This fixes some test timeouts which appeared in #315390 and #312805.

We introduced this test before snmpd was a module in nixpkgs, this PR uses the existing module and so fixes start up issues of the initial implementation provided by us.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
