### PR TITLE
python312Packages.aioswitcher: 3.4.3 -> 4.0.3

### DIFF
--- a/pkgs/development/python-modules/aioswitcher/default.nix
+++ b/pkgs/development/python-modules/aioswitcher/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  aiohttp,
   assertpy,
   buildPythonPackage,
   fetchFromGitHub,
@@ -9,18 +10,15 @@
   pytest-asyncio,
   pytest-mockservers,
   pytest-resource-path,
-  pytest-sugar,
   pytestCheckHook,
   pythonAtLeast,
   pythonOlder,
-  requests,
   time-machine,
-  types-requests,
 }:
 
 buildPythonPackage rec {
   pname = "aioswitcher";
-  version = "4.0.0";
+  version = "4.0.3";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -29,17 +27,18 @@ buildPythonPackage rec {
     owner = "TomerFi";
     repo = "aioswitcher";
     rev = "refs/tags/${version}";
-    hash = "sha256-a6Sl36X+r6mVqRAcO0C2f4CT/FDPF7r3VHnQp3328qo=";
+    hash = "sha256-QSnroxVHlfZd6QDaqUTMyoctiEsxWmGmFxzql1YIAD0=";
   };
 
   __darwinAllowLocalNetworking = true;
 
   build-system = [ poetry-core ];
 
+  pythonRelaxDeps = [ "aiohttp" ];
+
   dependencies = [
+    aiohttp
     pycryptodome
-    requests
-    types-requests
   ];
 
   preCheck = ''
@@ -52,7 +51,6 @@ buildPythonPackage rec {
     pytest-asyncio
     pytest-mockservers
     pytest-resource-path
-    pytest-sugar
     pytestCheckHook
     time-machine
   ];

--- a/pkgs/development/python-modules/aioswitcher/default.nix
+++ b/pkgs/development/python-modules/aioswitcher/default.nix
@@ -75,7 +75,7 @@ buildPythonPackage rec {
     description = "Python module to interact with Switcher water heater";
     homepage = "https://github.com/TomerFi/aioswitcher";
     changelog = "https://github.com/TomerFi/aioswitcher/releases/tag/${version}";
-    license = with licenses; [ mit ];
+    license = licenses.asl20;
     maintainers = with maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/aioswitcher/default.nix
+++ b/pkgs/development/python-modules/aioswitcher/default.nix
@@ -3,7 +3,9 @@
   assertpy,
   buildPythonPackage,
   fetchFromGitHub,
+  freezegun,
   poetry-core,
+  pycryptodome,
   pytest-asyncio,
   pytest-mockservers,
   pytest-resource-path,
@@ -11,26 +13,34 @@
   pytestCheckHook,
   pythonAtLeast,
   pythonOlder,
+  requests,
   time-machine,
+  types-requests,
 }:
 
 buildPythonPackage rec {
   pname = "aioswitcher";
-  version = "3.4.3";
+  version = "4.0.0";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "TomerFi";
-    repo = pname;
+    repo = "aioswitcher";
     rev = "refs/tags/${version}";
-    hash = "sha256-yKHSExtnO9m8Tc3BmCqV8tJs59ynKOqUmekaOatGRTc=";
+    hash = "sha256-a6Sl36X+r6mVqRAcO0C2f4CT/FDPF7r3VHnQp3328qo=";
   };
 
   __darwinAllowLocalNetworking = true;
 
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    pycryptodome
+    requests
+    types-requests
+  ];
 
   preCheck = ''
     export TZ=Asia/Jerusalem
@@ -38,6 +48,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     assertpy
+    freezegun
     pytest-asyncio
     pytest-mockservers
     pytest-resource-path


### PR DESCRIPTION
Changelog: https://github.com/TomerFi/aioswitcher/releases/tag/4.0.0
Changelog: https://github.com/TomerFi/aioswitcher/releases/tag/4.0.3

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
