### PR TITLE
home-assistant-custom-components.somweb: init at 1.1.0

### DIFF
--- a/pkgs/development/python-modules/somweb/default.nix
+++ b/pkgs/development/python-modules/somweb/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  aiohttp,
+  buildPythonPackage,
+  fetchFromGitHub,
+  requests,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "somweb";
+  version = "1.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "taarskog";
+    repo = "pySOMweb";
+    rev = "v${version}";
+    hash = "sha256-cLKEKDCMK7lCtbmj2KbhgJUCZpPnPI5tZvO5L+ey8qI=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiohttp
+    requests
+  ];
+
+  pythonImportsCheck = [ "somweb" ];
+
+  doCheck = false; # no tests
+
+  meta = with lib; {
+    changelog = "https://github.com/taarskog/pySOMweb/releases/tag/v${version}";
+    description = "A client library to control garage door operators produced by SOMMER through their SOMweb device";
+    homepage = "https://github.com/taarskog/pysomweb";
+    license = licenses.mit;
+    maintainers = with maintainers; [ uvnikita ];
+    mainProgram = "somweb";
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -56,6 +56,8 @@
 
   smartthinq-sensors = callPackage ./smartthinq-sensors {};
 
+  somweb = callPackage ./somweb {};
+
   spook = callPackage ./spook {};
 
   tuya_local = callPackage ./tuya_local {};

--- a/pkgs/servers/home-assistant/custom-components/somweb/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/somweb/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildHomeAssistantComponent,
+  somweb,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "taarskog";
+  domain = "somweb";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "home-assistant-component-somweb";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-anOcpaGeblFVaP2EFVuxx1EuXnNgxy/QoYqvYJMv1Fo=";
+  };
+
+  dependencies = [ somweb ];
+
+  meta = with lib; {
+    changelog = "https://github.com/taarskog/home-assistant-component-somweb/releases/tag/v${version}";
+    description = "Custom component for Home Assistant to manage garage doors and gates by Sommer through SOMweb";
+    homepage = "https://github.com/taarskog/home-assistant-component-somweb";
+    maintainers = with maintainers; [ uvnikita ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14584,6 +14584,8 @@ self: super: with self; {
 
   somfy-mylink-synergy = callPackage ../development/python-modules/somfy-mylink-synergy { };
 
+  somweb = callPackage ../development/python-modules/somweb { };
+
   sonarr = callPackage ../development/python-modules/sonarr { };
 
   sonos-websocket = callPackage ../development/python-modules/sonos-websocket { };


### PR DESCRIPTION
## Description of changes

- home-assistant-custom-components.somweb: init at 1.1.0
- python3Packages.somweb: init at 1.2.1

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
