### PR TITLE
rustPlatform.fetchCargoTarball: support pname+version

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -567,8 +567,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit src sourceRoot;
-    name = "${pname}-${version}";
+    inherit pname version src sourceRoot;
     hash = "sha256-miW//pnOmww2i6SOGbkrAIdc/JMDT4FJLqdMFojZeoY=";
   };
 
@@ -611,9 +610,8 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit src;
+    inherit pname version src;
     sourceRoot = "${pname}-${version}/${cargoRoot}";
-    name = "${pname}-${version}";
     hash = "sha256-PS562W4L1NimqDV2H0jl5vYhL08H9est/pbIxSdYVfo=";
   };
 
@@ -652,8 +650,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-heOBK8qi2nuc/Ib+I/vLzZ1fUUD/G/KTw9d7M4Hz5O0=";
   };
 
@@ -697,8 +694,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-8fa3fa+sFi5H+49B5sr2vYPkp9C9s6CcE0zv4xB8gww=";
   };
 

--- a/pkgs/applications/audio/gnome-podcasts/default.nix
+++ b/pkgs/applications/audio/gnome-podcasts/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit pname version src;
+    inherit src;
     hash = "sha256-XTfKqKs7874ak7Lzscxw8E2qcnJOWMZaaol8TpIB6Vw=";
   };
 

--- a/pkgs/build-support/rust/fetch-cargo-tarball/default.nix
+++ b/pkgs/build-support/rust/fetch-cargo-tarball/default.nix
@@ -1,116 +1,143 @@
-{ lib, stdenv, cacert, git, cargo, python3 }:
-let cargo-vendor-normalise = stdenv.mkDerivation {
-  name = "cargo-vendor-normalise";
-  src = ./cargo-vendor-normalise.py;
-  nativeBuildInputs = [ python3.pkgs.wrapPython ];
-  dontUnpack = true;
-  installPhase = "install -D $src $out/bin/cargo-vendor-normalise";
-  pythonPath = [ python3.pkgs.toml ];
-  postFixup = "wrapPythonPrograms";
-  doInstallCheck = true;
-  installCheckPhase = ''
-    # check that ../fetchcargo-default-config.toml is a fix point
-    reference=${../fetchcargo-default-config.toml}
-    < $reference $out/bin/cargo-vendor-normalise > test;
-    cmp test $reference
-  '';
-  preferLocalBuild = true;
-};
+{
+  lib,
+  stdenv,
+  cacert,
+  git,
+  cargo,
+  python3,
+}:
+let
+  cargo-vendor-normalise = stdenv.mkDerivation {
+    name = "cargo-vendor-normalise";
+    src = ./cargo-vendor-normalise.py;
+    nativeBuildInputs = [ python3.pkgs.wrapPython ];
+    dontUnpack = true;
+    installPhase = "install -D $src $out/bin/cargo-vendor-normalise";
+    pythonPath = [ python3.pkgs.toml ];
+    postFixup = "wrapPythonPrograms";
+    doInstallCheck = true;
+    installCheckPhase = ''
+      # check that ../fetchcargo-default-config.toml is a fix point
+      reference=${../fetchcargo-default-config.toml}
+      < $reference $out/bin/cargo-vendor-normalise > test;
+      cmp test $reference
+    '';
+    preferLocalBuild = true;
+  };
 in
-{ name ? "cargo-deps"
-, src ? null
-, srcs ? []
-, patches ? []
-, sourceRoot ? ""
-, cargoUpdateHook ? ""
-, nativeBuildInputs ? []
-, ...
-} @ args:
+{
+  name ? "cargo-deps",
+  src ? null,
+  srcs ? [ ],
+  patches ? [ ],
+  sourceRoot ? "",
+  cargoUpdateHook ? "",
+  nativeBuildInputs ? [ ],
+  ...
+}@args:
 
-let hash_ =
-  if args ? hash then
-    {
-      outputHashAlgo = if args.hash == "" then "sha256" else null;
-      outputHash = args.hash;
-    }
-  else if args ? sha256 then { outputHashAlgo = "sha256"; outputHash = args.sha256; }
-  else throw "fetchCargoTarball requires a hash for ${name}";
-in stdenv.mkDerivation ({
-  name = "${name}-vendor.tar.gz";
-  nativeBuildInputs = [ cacert git cargo-vendor-normalise cargo ] ++ nativeBuildInputs;
+let
+  hash_ =
+    if args ? hash then
+      {
+        outputHashAlgo = if args.hash == "" then "sha256" else null;
+        outputHash = args.hash;
+      }
+    else if args ? sha256 then
+      {
+        outputHashAlgo = "sha256";
+        outputHash = args.sha256;
+      }
+    else
+      throw "fetchCargoTarball requires a hash for ${name}";
+in
+stdenv.mkDerivation (
+  {
+    name = "${name}-vendor.tar.gz";
+    nativeBuildInputs = [
+      cacert
+      git
+      cargo-vendor-normalise
+      cargo
+    ] ++ nativeBuildInputs;
 
-  buildPhase = ''
-    runHook preBuild
+    buildPhase = ''
+      runHook preBuild
 
-    # Ensure deterministic Cargo vendor builds
-    export SOURCE_DATE_EPOCH=1
+      # Ensure deterministic Cargo vendor builds
+      export SOURCE_DATE_EPOCH=1
 
-    if [[ ! -f Cargo.lock ]]; then
-        echo
-        echo "ERROR: The Cargo.lock file doesn't exist"
-        echo
-        echo "Cargo.lock is needed to make sure that cargoHash/cargoSha256 doesn't change"
-        echo "when the registry is updated."
-        echo
+      if [[ ! -f Cargo.lock ]]; then
+          echo
+          echo "ERROR: The Cargo.lock file doesn't exist"
+          echo
+          echo "Cargo.lock is needed to make sure that cargoHash/cargoSha256 doesn't change"
+          echo "when the registry is updated."
+          echo
 
-        exit 1
-    fi
+          exit 1
+      fi
 
-    # Keep the original around for copyLockfile
-    cp Cargo.lock Cargo.lock.orig
+      # Keep the original around for copyLockfile
+      cp Cargo.lock Cargo.lock.orig
 
-    export CARGO_HOME=$(mktemp -d cargo-home.XXX)
-    CARGO_CONFIG=$(mktemp cargo-config.XXXX)
+      export CARGO_HOME=$(mktemp -d cargo-home.XXX)
+      CARGO_CONFIG=$(mktemp cargo-config.XXXX)
 
-    if [[ -n "$NIX_CRATES_INDEX" ]]; then
-    cat >$CARGO_HOME/config.toml <<EOF
-    [source.crates-io]
-    replace-with = 'mirror'
-    [source.mirror]
-    registry = "$NIX_CRATES_INDEX"
-    EOF
-    fi
+      if [[ -n "$NIX_CRATES_INDEX" ]]; then
+      cat >$CARGO_HOME/config.toml <<EOF
+      [source.crates-io]
+      replace-with = 'mirror'
+      [source.mirror]
+      registry = "$NIX_CRATES_INDEX"
+      EOF
+      fi
 
-    ${cargoUpdateHook}
+      ${cargoUpdateHook}
 
-    # Override the `http.cainfo` option usually specified in `.cargo/config`.
-    export CARGO_HTTP_CAINFO=${cacert}/etc/ssl/certs/ca-bundle.crt
+      # Override the `http.cainfo` option usually specified in `.cargo/config`.
+      export CARGO_HTTP_CAINFO=${cacert}/etc/ssl/certs/ca-bundle.crt
 
-    if grep '^source = "git' Cargo.lock; then
-        echo
-        echo "ERROR: The Cargo.lock contains git dependencies"
-        echo
-        echo "This is currently not supported in the fixed-output derivation fetcher."
-        echo "Use cargoLock.lockFile / importCargoLock instead."
-        echo
+      if grep '^source = "git' Cargo.lock; then
+          echo
+          echo "ERROR: The Cargo.lock contains git dependencies"
+          echo
+          echo "This is currently not supported in the fixed-output derivation fetcher."
+          echo "Use cargoLock.lockFile / importCargoLock instead."
+          echo
 
-        exit 1
-    fi
+          exit 1
+      fi
 
-    cargo vendor $name --respect-source-config | cargo-vendor-normalise > $CARGO_CONFIG
+      cargo vendor $name --respect-source-config | cargo-vendor-normalise > $CARGO_CONFIG
 
-    # Create an empty vendor directory when there is no dependency to vendor
-    mkdir -p $name
-    # Add the Cargo.lock to allow hash invalidation
-    cp Cargo.lock.orig $name/Cargo.lock
+      # Create an empty vendor directory when there is no dependency to vendor
+      mkdir -p $name
+      # Add the Cargo.lock to allow hash invalidation
+      cp Cargo.lock.orig $name/Cargo.lock
 
-    # Packages with git dependencies generate non-default cargo configs, so
-    # always install it rather than trying to write a standard default template.
-    install -D $CARGO_CONFIG $name/.cargo/config;
+      # Packages with git dependencies generate non-default cargo configs, so
+      # always install it rather than trying to write a standard default template.
+      install -D $CARGO_CONFIG $name/.cargo/config;
 
-    runHook postBuild
-  '';
+      runHook postBuild
+    '';
 
-  # Build a reproducible tar, per instructions at https://reproducible-builds.org/docs/archives/
-  installPhase = ''
-    tar --owner=0 --group=0 --numeric-owner --format=gnu \
-        --sort=name --mtime="@$SOURCE_DATE_EPOCH" \
-        -czf $out $name
-  '';
+    # Build a reproducible tar, per instructions at https://reproducible-builds.org/docs/archives/
+    installPhase = ''
+      tar --owner=0 --group=0 --numeric-owner --format=gnu \
+          --sort=name --mtime="@$SOURCE_DATE_EPOCH" \
+          -czf $out $name
+    '';
 
-  inherit (hash_) outputHashAlgo outputHash;
+    inherit (hash_) outputHashAlgo outputHash;
 
-  impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [ "NIX_CRATES_INDEX" ];
-} // (builtins.removeAttrs args [
-  "name" "sha256" "cargoUpdateHook" "nativeBuildInputs"
-]))
+    impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [ "NIX_CRATES_INDEX" ];
+  }
+  // (builtins.removeAttrs args [
+    "name"
+    "sha256"
+    "cargoUpdateHook"
+    "nativeBuildInputs"
+  ])
+)

--- a/pkgs/by-name/ch/chance/package.nix
+++ b/pkgs/by-name/ch/chance/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit (finalAttrs) pname version src;
+    inherit (finalAttrs) src;
     hash = "sha256-Q4CfDQxlhspjg7Et+0zHwZ/iSnp0CnwwpW/gT7htlL8=";
   };
 

--- a/pkgs/by-name/ge/geopard/package.nix
+++ b/pkgs/by-name/ge/geopard/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit (finalAttrs) pname version src;
+    inherit (finalAttrs) src;
     hash = "sha256-YVbaXGGwQaqjUkA47ryW1VgJpZTx5ApRGdCcB5aA71M=";
   };
 

--- a/pkgs/by-name/ke/key-rack/package.nix
+++ b/pkgs/by-name/ke/key-rack/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit (finalAttrs) pname version src;
+    inherit (finalAttrs) src;
     hash = "sha256-wCJTm0W+g3+O1t1fR4maqJoxpPM0NeJG7d54MMAH33c=";
   };
 

--- a/pkgs/by-name/mo/mousai/package.nix
+++ b/pkgs/by-name/mo/mousai/package.nix
@@ -32,8 +32,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-FjnRI1vHA9YF/Uw2+hDtMJmeJVa5RcxaYoG4XgXa9Ds=";
   };
 

--- a/pkgs/by-name/su/surrealist/package.nix
+++ b/pkgs/by-name/su/surrealist/package.nix
@@ -111,7 +111,7 @@ in stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit (finalAttrs) patches src sourceRoot version;
+    inherit (finalAttrs) patches src sourceRoot;
     name = "${finalAttrs.pname}-${finalAttrs.version}";
     hash = "sha256-LtQS0kH+2P4odV7BJYiH6T51+iZHAM9W9mV96rNfNWs=";
   };

--- a/pkgs/development/libraries/libkrun/default.nix
+++ b/pkgs/development/libraries/libkrun/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [ "out" "dev" ];
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit (finalAttrs) pname version src;
+    inherit (finalAttrs) src;
     hash = "sha256-33s62iOWYh1a8ETY/fbPRxvnj8dR4/UfG8mjFyWwz5k=";
   };
 

--- a/pkgs/development/python-modules/datafusion/default.nix
+++ b/pkgs/development/python-modules/datafusion/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     name = "datafusion-cargo-deps";
-    inherit src pname version;
+    inherit src;
     hash = "sha256-M2ZNAFWdsnN9C4+YbqFxZVH9fHR10Bimf1Xzrd9oy9E=";
   };
 

--- a/pkgs/development/python-modules/pdoc-pyo3-sample-library/default.nix
+++ b/pkgs/development/python-modules/pdoc-pyo3-sample-library/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit pname version src;
+    inherit src;
     hash = "sha256-KrEBr998AV/bKcIoq0tX72/QwPD9bQplrS0Zw+JiSMQ=";
   };
 

--- a/pkgs/tools/filesystems/stratisd/default.nix
+++ b/pkgs/tools/filesystems/stratisd/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit pname version src;
+    inherit src;
     hash = "sha256-1KzOKo5Q1uBqO3aCBYUJJxla4873AzrwoFPaNpKKFJU=";
   };
 


### PR DESCRIPTION
## Description of changes

- **rustPlatform.fetchCargoTarball: nixfmt**
- **rustPlatform.fetchCargoTarball: support pname, version**
  - tracking issue: #103997
-  doc/rust: prefer pname+version over name in fetchCargoTarball
- **mousai: change name -> pname+version in cargoDeps**
  - simply done as a proof-of-concept, should result in 0 rebuilds
- treewide: remove existing usages of pname+version in fetchCargoTarball, that incorrectly assumed it was supported (prevents hash mismatches)

Ths should result in exactly one rebuild (the manual).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
