### PR TITLE
openmpi: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -112,29 +112,31 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals cudaSupport [ cudaPackages.cuda_nvcc ]
     ++ lib.optionals fortranSupport [ gfortran ];
 
-  configureFlags = [
-    (lib.enableFeature cudaSupport "mca-dso")
-    (lib.enableFeature fortranSupport "mpi-fortran")
-    (lib.withFeatureAs stdenv.isLinux "libnl" (lib.getDev libnl))
-    # Puts a "default OMPI_PRTERUN" value to mpirun / mpiexec executables
-    (lib.withFeatureAs stdenv.isLinux "prrte" (lib.getBin prrte))
-    (lib.withFeature enableSGE "sge")
-    (lib.enableFeature enablePrefix "mpirun-prefix-by-default")
-    # TODO: add UCX support, which is recommended to use with cuda for the most robust OpenMPI build
-    # https://github.com/openucx/ucx
-    # https://www.open-mpi.org/faq/?category=buildcuda
-    (lib.withFeatureAs cudaSupport "cuda" (lib.getDev cudaPackages.cuda_cudart))
-    (lib.enableFeature cudaSupport "dlopen")
-    (lib.withFeatureAs fabricSupport "psm2" (lib.getDev libpsm2))
-    (lib.withFeatureAs fabricSupport "ofi" (lib.getDev libfabric))
-    # The flag --without-ofi-libdir is not supported from some reason, so we
-    # don't use lib.withFeatureAs
-  ] ++ lib.optional fabricSupport "--with-ofi-libdir=${lib.getLib libfabric}/lib"
+  configureFlags =
+    [
+      (lib.enableFeature cudaSupport "mca-dso")
+      (lib.enableFeature fortranSupport "mpi-fortran")
+      (lib.withFeatureAs stdenv.isLinux "libnl" (lib.getDev libnl))
+      # Puts a "default OMPI_PRTERUN" value to mpirun / mpiexec executables
+      (lib.withFeatureAs stdenv.isLinux "prrte" (lib.getBin prrte))
+      (lib.withFeature enableSGE "sge")
+      (lib.enableFeature enablePrefix "mpirun-prefix-by-default")
+      # TODO: add UCX support, which is recommended to use with cuda for the most robust OpenMPI build
+      # https://github.com/openucx/ucx
+      # https://www.open-mpi.org/faq/?category=buildcuda
+      (lib.withFeatureAs cudaSupport "cuda" (lib.getDev cudaPackages.cuda_cudart))
+      (lib.enableFeature cudaSupport "dlopen")
+      (lib.withFeatureAs fabricSupport "psm2" (lib.getDev libpsm2))
+      (lib.withFeatureAs fabricSupport "ofi" (lib.getDev libfabric))
+      # The flag --without-ofi-libdir is not supported from some reason, so we
+      # don't use lib.withFeatureAs
+    ]
+    ++ lib.optional fabricSupport "--with-ofi-libdir=${lib.getLib libfabric}/lib"
     # The pmix flags should only be set when pmix is used
     ++ lib.optionals stdenv.isLinux [
-    "--with-pmix=${lib.getDev pmix}"
-    "--with-pmix-libdir=${lib.getLib pmix}/lib"
-  ];
+      "--with-pmix=${lib.getDev pmix}"
+      "--with-pmix-libdir=${lib.getLib pmix}/lib"
+    ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -221,7 +221,7 @@ stdenv.mkDerivation (finalAttrs: {
         ))
         (lib.concatStringsSep "\n")
       ]}
-      # A symlink to ${lib.getDev pmix}/bin/pmixcc upstreeam puts here as well
+      # A symlink to ''${lib.getDev pmix}/bin/pmixcc upstream puts here as well
       # from some reason.
       moveToOutput "bin/pcc" "''${!outputDev}"
 

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -193,8 +193,8 @@ stdenv.mkDerivation (finalAttrs: {
         ];
         part2 = builtins.attrNames wrapperDataSubstitutions;
       };
-    in lib.optionalString stdenv.isLinux
-    ''
+    in
+    lib.optionalString stdenv.isLinux ''
       find $out/lib/ -name "*.la" -exec rm -f \{} \;
 
       # The main wrapper that all the rest of the commonly used binaries are

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -193,7 +193,7 @@ stdenv.mkDerivation (finalAttrs: {
         ];
         part2 = builtins.attrNames wrapperDataSubstitutions;
       };
-    in
+    in lib.optionalString stdenv.isLinux
     ''
       find $out/lib/ -name "*.la" -exec rm -f \{} \;
 

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -116,8 +116,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.enableFeature cudaSupport "mca-dso")
     (lib.enableFeature fortranSupport "mpi-fortran")
     (lib.withFeatureAs stdenv.isLinux "libnl" (lib.getDev libnl))
-    "--with-pmix=${if stdenv.isLinux then (lib.getDev pmix) else "internal"}"
-    (lib.withFeatureAs stdenv.isLinux "pmix-libdir" "${lib.getLib pmix}/lib")
     # Puts a "default OMPI_PRTERUN" value to mpirun / mpiexec executables
     (lib.withFeatureAs stdenv.isLinux "prrte" (lib.getBin prrte))
     (lib.withFeature enableSGE "sge")
@@ -131,7 +129,12 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.withFeatureAs fabricSupport "ofi" (lib.getDev libfabric))
     # The flag --without-ofi-libdir is not supported from some reason, so we
     # don't use lib.withFeatureAs
-  ] ++ lib.optionals fabricSupport [ "--with-ofi-libdir=${lib.getLib libfabric}/lib" ];
+  ] ++ lib.optional fabricSupport "--with-ofi-libdir=${lib.getLib libfabric}/lib"
+    # The pmix flags should only be set when pmix is used
+    ++ lib.optionals stdenv.isLinux [
+    "--with-pmix=${lib.getDev pmix}"
+    "--with-pmix-libdir=${lib.getLib pmix}/lib"
+  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
## Description of changes

This pulled in pmix unconditionally as a dependency and effectively disabled openmpi on darwin.
Fix for https://github.com/NixOS/nixpkgs/pull/327438

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
