### PR TITLE
cp2k: 24.1 -> 24.2

### DIFF
--- a/pkgs/applications/science/chemistry/cp2k/default.nix
+++ b/pkgs/applications/science/chemistry/cp2k/default.nix
@@ -10,6 +10,10 @@
 , libint
 , libvori
 , libxc
+, dftd4
+, mctc-lib
+, mstore
+, multicharge
 , mpi
 , gsl
 , scalapack
@@ -80,6 +84,10 @@ stdenv.mkDerivation rec {
     libint
     libvori
     libxc
+    dftd4
+    mctc-lib
+    mstore
+    multicharge
     libxsmm
     mpi
     spglib
@@ -154,6 +162,7 @@ stdenv.mkDerivation rec {
                  -D__MPI_VERSION=3 -D__F2008 -D__LIBXSMM -D__SPGLIB \
                  -D__MAX_CONTR=4 -D__LIBVORI ${lib.optionalString enableElpa "-D__ELPA"} \
                  -D__PLUMED2 -D__HDF5 -D__GSL -D__SIRIUS -D__LIBVDWXC -D__SPFFT -D__SPLA \
+                 -D__DFTD4 \
                  ${lib.strings.optionalString (gpuBackend == "cuda") "-D__OFFLOAD_CUDA -D__ACC -D__DBCSR_ACC -D__NO_OFFLOAD_PW"} \
                  ${lib.strings.optionalString (gpuBackend == "rocm") "-D__OFFLOAD_HIP -D__DBCSR_ACC -D__NO_OFFLOAD_PW"}
     CFLAGS    = -fopenmp
@@ -165,6 +174,7 @@ stdenv.mkDerivation rec {
                  -I${lib.getDev libint}/include  \
                  -I${lib.getDev sirius}/include/sirius \
                  -I${lib.getDev libxc}/include \
+                 -I${lib.getDev dftd4}/include/dftd4 \
                  -I${lib.getDev libxsmm}/include \
                  -I${lib.getDev hdf5-fortran}/include \
                  -fallow-argument-mismatch
@@ -176,6 +186,7 @@ stdenv.mkDerivation rec {
                  -fopenmp ${lib.optionalString enableElpa "$(pkg-config --libs elpa)"} \
                  -lz -ldl ${lib.optionalString (mpi.pname == "openmpi") "$(mpicxx --showme:link)"} \
                  -lplumed -lhdf5_fortran -lhdf5_hl -lhdf5 -lgsl -lsirius -lspla -lspfft -lvdwxc \
+                 -ldftd4 -lmstore -lmulticharge -lmctc-lib \
                  ${lib.strings.optionalString (gpuBackend == "cuda") ''
                    -L${cudaPackages.cuda_cudart}/lib/stubs/ \
                    -lcudart -lnvrtc -lcuda -lcublas

--- a/pkgs/applications/science/chemistry/cp2k/default.nix
+++ b/pkgs/applications/science/chemistry/cp2k/default.nix
@@ -54,13 +54,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "cp2k";
-  version = "2024.1";
+  version = "2024.2";
 
   src = fetchFromGitHub {
     owner = "cp2k";
     repo = "cp2k";
     rev = "v${version}";
-    hash = "sha256-6PB6wjdTOa55dXV7QIsjxI77hhc95WFEjNePfupBUJQ=";
+    hash = "sha256-KXxqzapdPZggFlxX1rkNcxEYb2+aQIPFclFspxII7aE=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/libraries/science/chemistry/dftd4/default.nix
+++ b/pkgs/development/libraries/science/chemistry/dftd4/default.nix
@@ -26,6 +26,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-VIV9953hx0MZupOARdH+P1h7JtZeJmTlqtO8si+lwdU=";
   };
 
+  patches = [
+    # Make sure fortran headers are installed directly in /include
+    ./fortran-module-dir.patch
+  ];
+
   nativeBuildInputs = [ gfortran meson ninja pkg-config python3 ];
 
   buildInputs = [ blas lapack mctc-lib mstore multicharge ];

--- a/pkgs/development/libraries/science/chemistry/dftd4/fortran-module-dir.patch
+++ b/pkgs/development/libraries/science/chemistry/dftd4/fortran-module-dir.patch
@@ -1,0 +1,56 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f222aab..262b505 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -89,7 +89,6 @@ target_include_directories(
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${module-dir}>
+ )
+ target_include_directories(
+   "${PROJECT_NAME}-lib"
+@@ -132,7 +131,7 @@ install(
+ install(
+   DIRECTORY
+   "${CMAKE_CURRENT_BINARY_DIR}/include/"
+-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${module-dir}"
++  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/"
+ )
+ if(WITH_API)
+   enable_language("C")
+diff --git a/config/template.cmake b/config/template.cmake
+index 8b5141d..8f94d66 100644
+--- a/config/template.cmake
++++ b/config/template.cmake
+@@ -6,7 +6,6 @@ set("@PROJECT_NAME@_WITH_OpenMP" @WITH_OpenMP@)
+ set(
+   "@PROJECT_NAME@_INCLUDE_DIRS"
+   "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@"
+-  "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@/@module-dir@"
+ )
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+ 
+diff --git a/config/template.pc b/config/template.pc
+index 3d6efbb..fea69e4 100644
+--- a/config/template.pc
++++ b/config/template.pc
+@@ -6,4 +6,4 @@ Name: @PROJECT_NAME@
+ Description: @PROJECT_DESCRIPTION@
+ Version: @PROJECT_VERSION@
+ Libs: -L${libdir} -l@PROJECT_NAME@
+-Cflags: -I${includedir} -I${includedir}/@module-dir@
++Cflags: -I${includedir} -I${includedir}/
+diff --git a/meson.build b/meson.build
+index c9e9c58..ac8f0bd 100644
+--- a/meson.build
++++ b/meson.build
+@@ -83,7 +83,7 @@ if install
+     )
+   endif
+ 
+-  module_id = meson.project_name() / fc_id + '-' + fc.version()
++  module_id = meson.project_name()
+   meson.add_install_script(
+     find_program(files('config'/'install-mod.py')),
+     get_option('includedir') / module_id,


### PR DESCRIPTION
## Description of changes

Release notes https://github.com/cp2k/cp2k/releases
Added support for DFTd4 dispersion corrections (+ fixing dftd4 for Fotran header locations).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
