### PR TITLE
[WIP] qt6.wrapQtAppsHook: propagate qtwayland, qtbase; qt6.wrapQtAppsNoGuiHook: init

### DIFF
--- a/doc/languages-frameworks/qt.section.md
+++ b/doc/languages-frameworks/qt.section.md
@@ -25,12 +25,14 @@ stdenv.mkDerivation {
 
 The same goes for Qt 5 where libraries and tools are under `libsForQt5`.
 
-Any Qt package should include `wrapQtAppsHook` in `nativeBuildInputs`, or explicitly set `dontWrapQtApps` to bypass generating the wrappers.
+Any Qt package should include `wrapQtAppsHook` (or `wrapQtAppsNoGuiHook`) in `nativeBuildInputs`, or explicitly set `dontWrapQtApps` to bypass generating the wrappers.
 
 ::: {.note}
-Qt 6 graphical applications should also include `qtwayland` in `buildInputs` on Linux (but not on platforms e.g. Darwin, where `qtwayland` is not available), to ensure the Wayland platform plugin is available.
 
-This may become default in the future, see [NixOS/nixpkgs#269674](https://github.com/NixOS/nixpkgs/pull/269674).
+`wrapQtAppsHook` will propagate `qtwayland` to ensure the Wayland platform plugin is available, which is useful for graphical applications. On platforms that do not support qtwayland (e.g., Darwin), only `qtbase` will be propagated.
+
+`wrapQtAppsNoGuiHook` will not propagate any qt components to reduce closure size for purely command-line applications.
+
 :::
 
 ## Packages supporting multiple Qt versions {#qt-versions}

--- a/pkgs/applications/graphics/pineapple-pictures/default.nix
+++ b/pkgs/applications/graphics/pineapple-pictures/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , fetchFromGitHub
 , qtsvg
-, qtwayland
 , qttools
 , exiv2
 , wrapQtAppsHook
@@ -28,7 +27,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     qtsvg
-    qtwayland
     exiv2
   ];
 

--- a/pkgs/desktops/deepin/core/dde-application-manager/default.nix
+++ b/pkgs/desktops/deepin/core/dde-application-manager/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-    qt6Packages.wrapQtAppsHook
+    qt6Packages.wrapQtAppsNoGuiHook
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -186,6 +186,14 @@ let
           } ./hooks/wrap-qt-apps-hook.sh)
         { };
 
+      wrapQtAppsNoGuiHook = callPackage
+        ({ makeBinaryWrapper }: makeSetupHook
+          {
+            name = "wrap-qt6-apps-no-gui-hook";
+            propagatedBuildInputs = [ makeBinaryWrapper ];
+          } ./hooks/wrap-qt-apps-hook.sh)
+        { };
+
       qmake = callPackage
         ({ qtbase }: makeSetupHook
           {

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -182,7 +182,7 @@ let
           {
             name = "wrap-qt6-apps-hook";
             propagatedBuildInputs = [ qtbase.dev makeBinaryWrapper ]
-              ++ lib.optional stdenv.isLinux qtwayland.dev;
+              ++ lib.optional (lib.meta.availableOn stdenv.targetPlatform qtwayland) qtwayland.dev;
           } ./hooks/wrap-qt-apps-hook.sh)
         { };
 

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -178,10 +178,11 @@ let
       };
 
       wrapQtAppsHook = callPackage
-        ({ makeBinaryWrapper }: makeSetupHook
+        ({ makeBinaryWrapper, qtbase, qtwayland }: makeSetupHook
           {
             name = "wrap-qt6-apps-hook";
-            propagatedBuildInputs = [ makeBinaryWrapper ];
+            propagatedBuildInputs = [ qtbase.dev makeBinaryWrapper ]
+              ++ lib.optional stdenv.isLinux qtwayland.dev;
           } ./hooks/wrap-qt-apps-hook.sh)
         { };
 

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -182,7 +182,7 @@ let
           {
             name = "wrap-qt6-apps-hook";
             propagatedBuildInputs = [ qtbase.dev makeBinaryWrapper ]
-              ++ lib.optional (lib.meta.availableOn stdenv.targetPlatform qtwayland) qtwayland.dev;
+              ++ lib.optional (lib.meta.availableOn stdenv.hostPlatform qtwayland) qtwayland.dev;
           } ./hooks/wrap-qt-apps-hook.sh)
         { };
 

--- a/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
@@ -75,9 +75,9 @@ else # Only set up Qt once.
     fi
 
     qtPreHook() {
-        # Check that wrapQtAppsHook is used, or it is explicitly disabled.
+        # Check that wrapQtAppsHook/wrapQtAppsNoGuiHook is used, or it is explicitly disabled.
         if [[ -z "$__nix_wrapQtAppsHook" && -z "$dontWrapQtApps" ]]; then
-            echo >&2 "Error: wrapQtAppsHook is not used, and dontWrapQtApps is not set."
+            echo >&2 "Error: wrapQtAppsHook and wrapQtAppsNoGuiHook are not used, and dontWrapQtApps is not set."
             exit 1
         fi
     }

--- a/pkgs/development/libraries/qt-6/modules/qtwayland.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwayland.nix
@@ -1,4 +1,5 @@
-{ qtModule
+{ lib
+, qtModule
 , qtbase
 , qtdeclarative
 , wayland
@@ -36,4 +37,9 @@ qtModule {
       sha256 = "sha256-1EIcMj6+yIpqXAGZB3ZbrwRkl4n1o7TVP2SC1Nu1t78=";
     })
   ];
+
+  meta = {
+    platforms = lib.platforms.unix;
+    badPlatforms = lib.platforms.darwin;
+  };
 }


### PR DESCRIPTION
## Description of changes

Continuation of #269674, with some grammatical corrections and renaming `wrapQtClisHook` to `wrapQtAppsNoGuiHook`
(to be more consistent with the gtk wrappers).

- **qt6.wrapQtAppsHook: add qtbase and qtwayland to propagatedBuildInputs**
  - fixes #332981
  - closes #322067
- **qt6.wrapQtAppsNoGuiHook: init**
  - I didn't look into adding qt5 support for the no-gui hook, per this comment: https://github.com/NixOS/nixpkgs/pull/269674#issuecomment-2011207336
- **qt6.qtwayland: set meta.{platforms,badPlatforms}**
- **doc/qt: mention wrapQtAppsNoGuiHook**
- **qtbase-setup-hook: add wrapQtAppsNoGuiHook to error message**
- **deepin.dde-application-manager: use wrapQtAppsNoGuiHook to avoid propagating qtwayland**
- **pineapple-pictures: let wrapQtAppsHook propagate qtwayland**
- **wrap-qt6-apps-hook: check if qtwayland is available on hostPlatform**
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
