### PR TITLE
openmpi & pmix: fix build & evaluation on Darwin

### DIFF
--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -263,7 +263,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.open-mpi.org/";
     description = "Open source MPI-3 implementation";
     longDescription = "The Open MPI Project is an open source MPI-3 implementation that is developed and maintained by a consortium of academic, research, and industry partners. Open MPI is therefore able to combine the expertise, technologies, and resources from all across the High Performance Computing community in order to build the best MPI library available. Open MPI offers advantages for system and software vendors, application developers and computer science researchers.";
-    maintainers = with lib.maintainers; [ markuskowa ];
+    maintainers = with lib.maintainers; [
+      markuskowa
+      doronbehar
+    ];
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -40,11 +40,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "openmpi";
-  version = "5.0.3";
+  version = "5.0.5";
 
   src = fetchurl {
     url = "https://www.open-mpi.org/software/ompi/v${lib.versions.majorMinor finalAttrs.version}/downloads/openmpi-${finalAttrs.version}.tar.bz2";
-    sha256 = "sha256-mQWC8gazqzLpOKoxu/B8Y5No5EBdyhlvq+fw927tqQs=";
+    sha256 = "sha256-ZYjVfApL0pmiQQP04ZYFGynotV+9pJ4R1bPTIDCjJ3Y=";
   };
 
   postPatch = ''

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -116,8 +116,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.enableFeature cudaSupport "mca-dso")
     (lib.enableFeature fortranSupport "mpi-fortran")
     (lib.withFeatureAs stdenv.isLinux "libnl" (lib.getDev libnl))
-    "--with-pmix=${if stdenv.isLinux then (lib.getDev pmix) else "internal"}"
-    (lib.withFeatureAs stdenv.isLinux "pmix-libdir" "${lib.getLib pmix}/lib")
+    "--with-pmix=${lib.getDev pmix}"
+    "--with-pmix-libdir=${lib.getLib pmix}/lib"
     # Puts a "default OMPI_PRTERUN" value to mpirun / mpiexec executables
     (lib.withFeatureAs stdenv.isLinux "prrte" (lib.getBin prrte))
     (lib.withFeature enableSGE "sge")

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -212,7 +212,12 @@ stdenv.mkDerivation (finalAttrs: {
       ${lib.pipe wrapperDataFileNames [
         (lib.mapCartesianProduct (
           { part1, part2 }:
-          ''
+          # From some reason the Darwin build doesn't include some of these
+          # wrapperDataSubstitutions strings and even some of the files. Hence
+          # we currently don't perform these substitutions on other platforms,
+          # until a Darwin user will care enough about this cross platform
+          # related substitution.
+          lib.optionalString stdenv.isLinux ''
             substituteInPlace "''${!outputDev}/share/openmpi/${part1}${part2}-wrapper-data.txt" \
               --replace-fail \
                 compiler=${lib.elemAt wrapperDataSubstitutions.${part2} 0} \

--- a/pkgs/development/libraries/pmix/default.nix
+++ b/pkgs/development/libraries/pmix/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [
     "out"
+  ] ++ lib.optionals stdenv.isLinux [
     "dev"
   ];
 
@@ -80,6 +81,11 @@ stdenv.mkDerivation (finalAttrs: {
     moveToOutput "bin/pmixcc" "''${!outputDev}"
     moveToOutput "share/pmix/pmixcc-wrapper-data.txt" "''${!outputDev}"
 
+    ''
+    # From some reason the Darwin build doesn't include this file, so we
+    # currently disable this substitution for any non-Linux platform, until a
+    # Darwin user will care enough about this cross platform fix.
+    + lib.optionalString stdenv.isLinux ''
     # Pin the compiler to the current version in a cross compiler friendly way.
     # Same pattern as for openmpi (see https://github.com/NixOS/nixpkgs/pull/58964#discussion_r275059427).
     substituteInPlace "''${!outputDev}"/share/pmix/pmixcc-wrapper-data.txt \
@@ -88,6 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postFixup = ''
+  '' + lib.optionalString (lib.elem "dev" finalAttrs.outputs) ''
     # The build info (parameters to ./configure) are hardcoded
     # into the library. This clears all references to $dev/include.
     remove-references-to -t "''${!outputDev}" $(readlink -f $out/lib/libpmix.so)
@@ -109,6 +116,5 @@ stdenv.mkDerivation (finalAttrs: {
       markuskowa
       doronbehar
     ];
-    platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/development/libraries/pmix/default.nix
+++ b/pkgs/development/libraries/pmix/default.nix
@@ -80,11 +80,11 @@ stdenv.mkDerivation (finalAttrs: {
     moveToOutput "bin/pmixcc" "''${!outputDev}"
     moveToOutput "share/pmix/pmixcc-wrapper-data.txt" "''${!outputDev}"
 
-    # The path to the pmixcc-wrapper-data.txt is hard coded and
-    # points to $out instead of dev. Use wrapper to fix paths.
-    wrapProgram "''${!outputDev}"/bin/pmixcc \
-      --set PMIX_INCLUDEDIR "''${!outputDev}"/include \
-      --set PMIX_PKGDATADIR "''${!outputDev}"/share/pmix
+    # Pin the compiler to the current version in a cross compiler friendly way.
+    # Same pattern as for openmpi (see https://github.com/NixOS/nixpkgs/pull/58964#discussion_r275059427).
+    substituteInPlace "''${!outputDev}"/share/pmix/pmixcc-wrapper-data.txt \
+      --replace-fail compiler=gcc \
+        compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc
   '';
 
   postFixup = ''
@@ -92,11 +92,11 @@ stdenv.mkDerivation (finalAttrs: {
     # into the library. This clears all references to $dev/include.
     remove-references-to -t "''${!outputDev}" $(readlink -f $out/lib/libpmix.so)
 
-    # Pin the compiler to the current version in a cross compiler friendly way.
-    # Same pattern as for openmpi (see https://github.com/NixOS/nixpkgs/pull/58964#discussion_r275059427).
-    substituteInPlace "''${!outputDev}"/share/pmix/pmixcc-wrapper-data.txt \
-      --replace-fail compiler=gcc \
-        compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc
+    # The path to the pmixcc-wrapper-data.txt is hard coded and
+    # points to $out instead of dev. Use wrapper to fix paths.
+    wrapProgram "''${!outputDev}"/bin/pmixcc \
+      --set PMIX_INCLUDEDIR "''${!outputDev}"/include \
+      --set PMIX_PKGDATADIR "''${!outputDev}"/share/pmix
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/pmix/default.nix
+++ b/pkgs/development/libraries/pmix/default.nix
@@ -82,19 +82,19 @@ stdenv.mkDerivation (finalAttrs: {
 
     # The path to the pmixcc-wrapper-data.txt is hard coded and
     # points to $out instead of dev. Use wrapper to fix paths.
-    wrapProgram $dev/bin/pmixcc \
-      --set PMIX_INCLUDEDIR $dev/include \
-      --set PMIX_PKGDATADIR $dev/share/pmix
+    wrapProgram "''${!outputDev}"/bin/pmixcc \
+      --set PMIX_INCLUDEDIR "''${!outputDev}"/include \
+      --set PMIX_PKGDATADIR "''${!outputDev}"/share/pmix
   '';
 
   postFixup = ''
     # The build info (parameters to ./configure) are hardcoded
     # into the library. This clears all references to $dev/include.
-    remove-references-to -t $dev $(readlink -f $out/lib/libpmix.so)
+    remove-references-to -t "''${!outputDev}" $(readlink -f $out/lib/libpmix.so)
 
     # Pin the compiler to the current version in a cross compiler friendly way.
     # Same pattern as for openmpi (see https://github.com/NixOS/nixpkgs/pull/58964#discussion_r275059427).
-    substituteInPlace $dev/share/pmix/pmixcc-wrapper-data.txt \
+    substituteInPlace "''${!outputDev}"/share/pmix/pmixcc-wrapper-data.txt \
       --replace-fail compiler=gcc \
         compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc
   '';

--- a/pkgs/development/libraries/pmix/default.nix
+++ b/pkgs/development/libraries/pmix/default.nix
@@ -78,12 +78,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  meta = {
     description = "Process Management Interface for HPC environments";
     homepage = "https://openpmix.github.io/";
-    license = licenses.bsd3;
-    maintainers = [ maintainers.markuskowa ];
-    platforms = platforms.linux;
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ markuskowa ];
+    platforms = lib.platforms.linux;
   };
 })
 

--- a/pkgs/development/libraries/pmix/default.nix
+++ b/pkgs/development/libraries/pmix/default.nix
@@ -4,14 +4,14 @@
 , hwloc, munge, zlib, pandoc, gitMinimal
 } :
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pmix";
   version = "5.0.3";
 
   src = fetchFromGitHub {
     repo = "openpmix";
     owner = "openpmix";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-5qBZj4L0Qu/RvNj8meL0OlLCdfGvBP0D916Mr+0XOCQ=";
     fetchSubmodules = true;
   };
@@ -85,5 +85,5 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.markuskowa ];
     platforms = platforms.linux;
   };
-}
+})
 

--- a/pkgs/development/libraries/pmix/default.nix
+++ b/pkgs/development/libraries/pmix/default.nix
@@ -31,11 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
   };
 
-  outputs = [
-    "out"
-  ] ++ lib.optionals stdenv.isLinux [
-    "dev"
-  ];
+  outputs = [ "out" ] ++ lib.optionals stdenv.isLinux [ "dev" ];
 
   postPatch = ''
     patchShebangs ./autogen.pl
@@ -74,27 +70,27 @@ stdenv.mkDerivation (finalAttrs: {
     ./autogen.pl
   '';
 
-  postInstall = ''
-    find $out/lib/ -name "*.la" -exec rm -f \{} \;
+  postInstall =
+    ''
+      find $out/lib/ -name "*.la" -exec rm -f \{} \;
 
-    moveToOutput "bin/pmix_info" "''${!outputDev}"
-    moveToOutput "bin/pmixcc" "''${!outputDev}"
-    moveToOutput "share/pmix/pmixcc-wrapper-data.txt" "''${!outputDev}"
+      moveToOutput "bin/pmix_info" "''${!outputDev}"
+      moveToOutput "bin/pmixcc" "''${!outputDev}"
+      moveToOutput "share/pmix/pmixcc-wrapper-data.txt" "''${!outputDev}"
 
     ''
     # From some reason the Darwin build doesn't include this file, so we
     # currently disable this substitution for any non-Linux platform, until a
     # Darwin user will care enough about this cross platform fix.
     + lib.optionalString stdenv.isLinux ''
-    # Pin the compiler to the current version in a cross compiler friendly way.
-    # Same pattern as for openmpi (see https://github.com/NixOS/nixpkgs/pull/58964#discussion_r275059427).
-    substituteInPlace "''${!outputDev}"/share/pmix/pmixcc-wrapper-data.txt \
-      --replace-fail compiler=gcc \
-        compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc
-  '';
+      # Pin the compiler to the current version in a cross compiler friendly way.
+      # Same pattern as for openmpi (see https://github.com/NixOS/nixpkgs/pull/58964#discussion_r275059427).
+      substituteInPlace "''${!outputDev}"/share/pmix/pmixcc-wrapper-data.txt \
+        --replace-fail compiler=gcc \
+          compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc
+    '';
 
-  postFixup = ''
-  '' + lib.optionalString (lib.elem "dev" finalAttrs.outputs) ''
+  postFixup = lib.optionalString (lib.elem "dev" finalAttrs.outputs) ''
     # The build info (parameters to ./configure) are hardcoded
     # into the library. This clears all references to $dev/include.
     remove-references-to -t "''${!outputDev}" $(readlink -f $out/lib/libpmix.so)

--- a/pkgs/development/libraries/pmix/default.nix
+++ b/pkgs/development/libraries/pmix/default.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Process Management Interface for HPC environments";
     homepage = "https://openpmix.github.io/";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ markuskowa ];
+    maintainers = with lib.maintainers; [ markuskowa doronbehar ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/development/libraries/pmix/default.nix
+++ b/pkgs/development/libraries/pmix/default.nix
@@ -1,8 +1,23 @@
-{ lib, stdenv, fetchFromGitHub, perl, autoconf, automake
-, removeReferencesTo, libtool, python3, flex, libevent
-, targetPackages, makeWrapper
-, hwloc, munge, zlib, pandoc, gitMinimal
-} :
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  perl,
+  autoconf,
+  automake,
+  removeReferencesTo,
+  libtool,
+  python3,
+  flex,
+  libevent,
+  targetPackages,
+  makeWrapper,
+  hwloc,
+  munge,
+  zlib,
+  pandoc,
+  gitMinimal,
+}:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pmix";
@@ -16,7 +31,10 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
   };
 
-  outputs = [ "out" "dev" ];
+  outputs = [
+    "out"
+    "dev"
+  ];
 
   postPatch = ''
     patchShebangs ./autogen.pl
@@ -36,7 +54,12 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
   ];
 
-  buildInputs = [ libevent hwloc munge zlib ];
+  buildInputs = [
+    libevent
+    hwloc
+    munge
+    zlib
+  ];
 
   configureFlags = [
     "--with-libevent=${lib.getDev libevent}"
@@ -82,8 +105,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Process Management Interface for HPC environments";
     homepage = "https://openpmix.github.io/";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ markuskowa doronbehar ];
+    maintainers = with lib.maintainers; [
+      markuskowa
+      doronbehar
+    ];
     platforms = lib.platforms.linux;
   };
 })
-


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
