### PR TITLE
spidermonkey_128: init at 128.1.0

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/128.nix
+++ b/pkgs/development/interpreters/spidermonkey/128.nix
@@ -1,0 +1,4 @@
+import ./common.nix {
+  version = "128.1.0";
+  hash = "sha512-gFWn+DrPDKthJLpYCa/xwILoGg0w/zGOxxn4/T9K+apg4glMGr1smBGT11EHWpVpNwF24g5Q88GVn+J6FVETiA==";
+}

--- a/pkgs/development/interpreters/spidermonkey/allow-system-s-nspr-and-icu-on-bootstrapped-sysroot-128.patch
+++ b/pkgs/development/interpreters/spidermonkey/allow-system-s-nspr-and-icu-on-bootstrapped-sysroot-128.patch
@@ -1,0 +1,37 @@
+From a26bb162d9403138d64b84e8fa4f0471084c45b2 Mon Sep 17 00:00:00 2001
+From: "Kirill A. Korinsky" <kirill@korins.ky>
+Date: Fri, 8 Jul 2022 21:21:25 +0200
+Subject: [PATCH] Allow system's nspr and icu on bootstrapped sysroot
+
+This patch partially reverts https://github.com/mozilla/gecko-dev/commit/9aa3587bbf0416dd2eb5b614f7b301c71c64286b
+---
+ build/moz.configure/nspr.configure | 2 +-
+ js/moz.configure                   | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/build/moz.configure/nspr.configure b/build/moz.configure/nspr.configure
+index bc6d62982b87a..8346f08b86923 100644
+--- a/build/moz.configure/nspr.configure
++++ b/build/moz.configure/nspr.configure
+@@ -19,7 +19,7 @@ def enable_nspr_build(enable):
+         return enable
+ 
+ 
+-system_lib_option(
++option(
+     "--with-system-nspr",
+     help="Use system NSPR",
+     when=use_pkg_config,
+diff --git a/js/moz.configure b/js/moz.configure
+index 8fb51095876fa..7629b29d33c8f 100644
+--- a/js/moz.configure
++++ b/js/moz.configure
+@@ -1296,7 +1296,7 @@ set_define(
+ 
+ # ECMAScript Internationalization API Support (uses ICU)
+ # ======================================================
+-system_lib_option(
++option(
+     "--with-system-icu",
+     help="Use system ICU",
+     when=use_pkg_config,

--- a/pkgs/development/interpreters/spidermonkey/always-check-for-pkg-config-128.patch
+++ b/pkgs/development/interpreters/spidermonkey/always-check-for-pkg-config-128.patch
@@ -1,0 +1,22 @@
+From 9d3f6e9ff5e66af90a5d187d902f7893fb91c24b Mon Sep 17 00:00:00 2001
+From: "Kirill A. Korinsky" <kirill@korins.ky>
+Date: Fri, 1 Jul 2022 12:23:37 +0200
+Subject: [PATCH] Always check for pkg-config
+
+---
+ build/moz.configure/pkg.configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletions(-)
+
+diff --git a/build/moz.configure/pkg.configure b/build/moz.configure/pkg.configure
+index 418331b874f47..09cc40eda03fa 100644
+--- a/build/moz.configure/pkg.configure
++++ b/build/moz.configure/pkg.configure
+@@ -12,7 +12,7 @@ def pkg_config(prefixes):
+ 
+ @depends(compile_environment, target)
+ def use_pkg_config(compile_environment, target):
+-    return compile_environment and target.os not in ("WINNT", "OSX", "Android")
++    return compile_environment
+ 
+ 
+ pkg_config = check_prog(

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17129,6 +17129,9 @@ with pkgs;
   spidermonkey_115 = callPackage ../development/interpreters/spidermonkey/115.nix {
     inherit (darwin) libobjc;
   };
+  spidermonkey_128 = callPackage ../development/interpreters/spidermonkey/128.nix {
+    inherit (darwin) libobjc;
+  };
 
   starlark-rust = callPackage ../development/interpreters/starlark-rust { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17120,18 +17120,26 @@ with pkgs;
 
   sparkleshare = callPackage ../applications/version-management/sparkleshare { };
 
-  spidermonkey_78 = callPackage ../development/interpreters/spidermonkey/78.nix {
-    inherit (darwin) libobjc;
-  };
-  spidermonkey_91 = callPackage ../development/interpreters/spidermonkey/91.nix {
-    inherit (darwin) libobjc;
-  };
-  spidermonkey_115 = callPackage ../development/interpreters/spidermonkey/115.nix {
-    inherit (darwin) libobjc;
-  };
-  spidermonkey_128 = callPackage ../development/interpreters/spidermonkey/128.nix {
-    inherit (darwin) libobjc;
-  };
+  inherit
+    ({
+      spidermonkey_78 = callPackage ../development/interpreters/spidermonkey/78.nix {
+        inherit (darwin) libobjc;
+      };
+      spidermonkey_91 = callPackage ../development/interpreters/spidermonkey/91.nix {
+        inherit (darwin) libobjc;
+      };
+      spidermonkey_115 = callPackage ../development/interpreters/spidermonkey/115.nix {
+        inherit (darwin) libobjc;
+      };
+      spidermonkey_128 = callPackage ../development/interpreters/spidermonkey/128.nix {
+        inherit (darwin) libobjc;
+      };
+    })
+    spidermonkey_78
+    spidermonkey_91
+    spidermonkey_115
+    spidermonkey_128
+    ;
 
   starlark-rust = callPackage ../development/interpreters/starlark-rust { };
 


### PR DESCRIPTION




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

