### PR TITLE
bpftrace: Source from "bpftrace" instead of "iovisor"

### DIFF
--- a/pkgs/by-name/bp/bpftrace/package.nix
+++ b/pkgs/by-name/bp/bpftrace/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   version = "0.21.2";
 
   src = fetchFromGitHub {
-    owner = "iovisor";
+    owner = "bpftrace";
     repo  = "bpftrace";
     rev   = "v${version}";
     hash  = "sha256-/2m+5iFE7R+ZEc/VcgWAhkLD/jEK88roUUOUyYODi0U=";
@@ -35,8 +35,8 @@ stdenv.mkDerivation rec {
 
   # tests aren't built, due to gtest shenanigans. see:
   #
-  #     https://github.com/iovisor/bpftrace/issues/161#issuecomment-453606728
-  #     https://github.com/iovisor/bpftrace/pull/363
+  #     https://github.com/bpftrace/bpftrace/issues/161#issuecomment-453606728
+  #     https://github.com/bpftrace/bpftrace/pull/363
   #
   cmakeFlags = [
     "-DBUILD_TESTING=FALSE"
@@ -76,8 +76,8 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "High-level tracing language for Linux eBPF";
-    homepage    = "https://github.com/iovisor/bpftrace";
-    changelog   = "https://github.com/iovisor/bpftrace/releases/tag/v${version}";
+    homepage    = "https://github.com/bpftrace/bpftrace";
+    changelog   = "https://github.com/bpftrace/bpftrace/releases/tag/v${version}";
     mainProgram = "bpftrace";
     license     = licenses.asl20;
     maintainers = with maintainers; [ rvl thoughtpolice martinetd mfrw ];


### PR DESCRIPTION

## Description of changes

The bpftrace repository moved to its own GitHub organisation earlier in the year. The old iovisor links (https://github.com/iovisor/bpftrace) redirect to the new org (https://github.com/bpftrace/bpftrace), so nothing was broken - this change is just cosmetic.

Links were updated in the bpftrace repository already: https://github.com/bpftrace/bpftrace/pull/2980

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
