### PR TITLE
[Backport release-24.05] grafana-agent: 0.40.5 -> 0.42.0

### DIFF
--- a/pkgs/servers/monitoring/grafana-agent/default.nix
+++ b/pkgs/servers/monitoring/grafana-agent/default.nix
@@ -15,28 +15,28 @@
 
 buildGoModule rec {
   pname = "grafana-agent";
-  version = "0.40.5";
+  version = "0.41.0";
 
   src = fetchFromGitHub {
     owner = "grafana";
     repo = "agent";
     rev = "v${version}";
-    hash = "sha256-Ctv/s9lgZQ9uCXx+xwJlNVe1ycQnQHtziVNafdYVBig=";
+    hash = "sha256-I763iHBMWnfGzh6KyGGzZekafseEIetnflnVVvro/cE=";
   };
 
-  vendorHash = "sha256-pI2hk91wqMVaZ5/6uegoQOh94p4zb7Tvn2CtOMRhZME=";
+  vendorHash = "sha256-ueU9n57KUiUe2kXcxDsxpidjwmDLN8eoFO9nQRkZyKY=";
   proxyVendor = true; # darwin/linux hash mismatch
 
   frontendYarnOfflineCache = fetchYarnDeps {
-    yarnLock = src + "/web/ui/yarn.lock";
+    yarnLock = src + "/internal/web/ui/yarn.lock";
     hash = "sha256-WqbIg18qUNcs9O2wh7DAzwXKb60iEuPL8zFCIgScqI0=";
   };
 
   ldflags = let
-    prefix = "github.com/grafana/agent/pkg/build";
+    prefix = "github.com/grafana/agent/internal/build";
   in [
     "-s" "-w"
-    # https://github.com/grafana/agent/blob/d672eba4ca8cb010ad8a9caef4f8b66ea6ee3ef2/Makefile#L125
+    # https://github.com/grafana/agent/blob/v0.41.0/Makefile#L132-L137
     "-X ${prefix}.Version=${version}"
     "-X ${prefix}.Branch=v${version}"
     "-X ${prefix}.Revision=v${version}"
@@ -56,13 +56,13 @@ buildGoModule rec {
   subPackages = [
     "cmd/grafana-agent"
     "cmd/grafana-agentctl"
-    "web/ui"
+    "internal/web/ui"
   ];
 
   preBuild = ''
     export HOME="$TMPDIR"
 
-    pushd web/ui
+    pushd internal/web/ui
     fixup-yarn-lock yarn.lock
     yarn config --offline set yarn-offline-mirror $frontendYarnOfflineCache
     yarn install --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive

--- a/pkgs/servers/monitoring/grafana-agent/default.nix
+++ b/pkgs/servers/monitoring/grafana-agent/default.nix
@@ -15,16 +15,16 @@
 
 buildGoModule rec {
   pname = "grafana-agent";
-  version = "0.41.0";
+  version = "0.41.1";
 
   src = fetchFromGitHub {
     owner = "grafana";
     repo = "agent";
     rev = "v${version}";
-    hash = "sha256-I763iHBMWnfGzh6KyGGzZekafseEIetnflnVVvro/cE=";
+    hash = "sha256-A/h8Mwtor4VUT7e7TsNiE/0OOXCSq38GAf9j7c8ZDKk=";
   };
 
-  vendorHash = "sha256-ueU9n57KUiUe2kXcxDsxpidjwmDLN8eoFO9nQRkZyKY=";
+  vendorHash = "sha256-W29GZoZfgjdSwGiFz4udGA9gXgmM0xIDEGld7ZE1ycQ=";
   proxyVendor = true; # darwin/linux hash mismatch
 
   frontendYarnOfflineCache = fetchYarnDeps {

--- a/pkgs/servers/monitoring/grafana-agent/default.nix
+++ b/pkgs/servers/monitoring/grafana-agent/default.nix
@@ -15,21 +15,21 @@
 
 buildGoModule rec {
   pname = "grafana-agent";
-  version = "0.41.1";
+  version = "0.42.0";
 
   src = fetchFromGitHub {
     owner = "grafana";
     repo = "agent";
     rev = "v${version}";
-    hash = "sha256-A/h8Mwtor4VUT7e7TsNiE/0OOXCSq38GAf9j7c8ZDKk=";
+    hash = "sha256-qSxm00zC1Ms9C5R077Zn5FKluEqFs8KYUPnDUaMvMs8=";
   };
 
-  vendorHash = "sha256-W29GZoZfgjdSwGiFz4udGA9gXgmM0xIDEGld7ZE1ycQ=";
+  vendorHash = "sha256-rC8iqCZ6tzXVCOHNqH+jAMDh2yTAR88zj45HcgJ2lSg=";
   proxyVendor = true; # darwin/linux hash mismatch
 
   frontendYarnOfflineCache = fetchYarnDeps {
     yarnLock = src + "/internal/web/ui/yarn.lock";
-    hash = "sha256-WqbIg18qUNcs9O2wh7DAzwXKb60iEuPL8zFCIgScqI0=";
+    hash = "sha256-FvrfWcuKld242YfZ8CixF5GGFRp8iFWZ3Vkef3Kf4ag=";
   };
 
   ldflags = let


### PR DESCRIPTION
## Description of changes

Backport of:
- #316736
- #318063
- #331906

All cherry-picks applied cleanly. Meaning the GitHub backport action would have worked, but also would have opened 3 PR instead of 1.

Note that both https://github.com/grafana/agent/releases/tag/v0.41.0 and https://github.com/grafana/agent/releases/tag/v0.41.1 had minor breaking changes.

- @tamara-schmitz requested the bump to `0.42.0` (#331906) to be backported due to the various security fixes in https://github.com/NixOS/nixpkgs/pull/331906#issuecomment-2269609378.
- @katexochen added the backport label to the bump to `0.41.1` (#318063).

Given how minor the breaking changes are in combination with the multiple requests to backport the many included security fixes, backporting should be fine.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
