### PR TITLE
Update leptosfmt v0.1.18 -> v0.1.30

### DIFF
--- a/pkgs/development/tools/rust/leptosfmt/default.nix
+++ b/pkgs/development/tools/rust/leptosfmt/default.nix
@@ -5,16 +5,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "leptosfmt";
-  version = "0.1.18";
+  version = "0.1.30";
 
   src = fetchFromGitHub {
     owner = "bram209";
     repo = "leptosfmt";
-    rev = version;
-    hash = "sha256-bNfTZgcru7PJR/9AcaOmW0E8QwdiXcuP7MWXcDPXGso=";
+    rev = "85b06b9a8bb0616b6a03ba43517245c79e1dd4cf";
+    hash = "sha256-PiVPnni7W8SIhO6L9698RSMTD4VVTB+klLrqMzEtWWo=";
+    fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-NQYIq9Wc2mtUGeS3Iv2e0nfQkvcX6hOxZ6FHVcHD5cs=";
+  cargoHash = "sha256-zj81fXjDM648Y8mIb6QMmAh/ck9GGEypzuJIBWZ32r8=";
 
   meta = with lib; {
     description = "Formatter for the leptos view! macro";


### PR DESCRIPTION
## Description of changes
Updates the leptosfmt package to v0.1.30. Changelog is at https://github.com/bram209/leptosfmt/blob/main/CHANGELOG.md

(NOTE, switched to using the git hash as the rev instead of the version number because the upstream repo did not check the `Cargo.lock` file into the commit creating the release tag. This rev points to a later commit that does include the correct `Cargo.lock`)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
