### PR TITLE
python312Packages.pytest-spec: 3.2.0-unstable-2023-06-04 -> 4.0.0

### DIFF
--- a/pkgs/development/python-modules/pytest-spec/default.nix
+++ b/pkgs/development/python-modules/pytest-spec/default.nix
@@ -1,34 +1,33 @@
 {
   lib,
   buildPythonPackage,
+  pythonOlder,
   fetchFromGitHub,
-  poetry-core,
+  setuptools,
+  setuptools-scm,
   pytest,
   pytestCheckHook,
   pytest-describe,
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "pytest-spec";
-  version = "3.2.0-unstable-2023-06-04";
+  version = "4.0.0";
   pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "pchomik";
     repo = "pytest-spec";
-    rev = "e16e0550dd6bc557411e4312b7b42d53b26e69ef";
-    hash = "sha256-dyDUdZJU4E4y1yCzunAX2c48Qv6ogu0b60U/5YbJvIU=";
+    rev = "refs/tags/${version}";
+    hash = "sha256-SOu4ucRcLQSk1YOfNifFDezsB+ZeLXTwbJJ93/3EASk=";
   };
 
-  postPatch = ''
-    sed -i '/addopts/d' setup.cfg
-    # TODO: upstream
-    substituteInPlace pyproject.toml \
-        --replace-fail "poetry>=0.12" "poetry-core" \
-        --replace-fail "poetry.masonry.api" "poetry.core.masonry.api"
-  '';
-
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
 
   buildInputs = [ pytest ];
 
@@ -37,11 +36,10 @@ buildPythonPackage {
     pytest-describe
   ];
 
-  pytestFlagsArray = [ "--spec" ];
-
   pythonImportsCheck = [ "pytest_spec" ];
 
   meta = {
+    changelog = "https://github.com/pchomik/pytest-spec/blob/${src.rev}/CHANGES.txt";
     description = "Pytest plugin to display test execution output like a SPECIFICATION";
     homepage = "https://github.com/pchomik/pytest-spec";
     license = lib.licenses.gpl2Plus;


### PR DESCRIPTION
## Description of changes

This PR bumps the `pytest-spec` package to a stable release.

https://github.com/pchomik/pytest-spec/releases/tag/4.0.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
