### PR TITLE
nushellPlugins.dbus: init at 0.10.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4560,6 +4560,13 @@
     github = "dariof4";
     githubId = 9992814;
   };
+  darkkronicle = {
+    name = "DarkKronicle";
+    email = "darkkronicle@gmail.com";
+    matrix = "@darkkronicle:jpxs.io";
+    github = "DarkKronicle";
+    githubId = 38167691;
+  };
   darkonion0 = {
     name = "Alexandre Peruggia";
     email = "darkgenius1@protonmail.com";

--- a/pkgs/shells/nushell/plugins/dbus.nix
+++ b/pkgs/shells/nushell/plugins/dbus.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  gitUpdater,
+  pkg-config,
+  dbus,
+  IOKit,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nu-plugin-dbus";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "devyn";
+    repo = "nu_plugin_dbus";
+    rev = version;
+    hash = "sha256-XVLX0tCgpf5Vfr00kbQZPWMolzHpkMVYKoBHYylpz48=";
+  };
+
+  passthru.updateScript = gitUpdater { };
+
+  cargoHash = "sha256-6/oG274QG8qq+rgtVtHlBkvaWYvzxuoPGCrHZNMwKzw=";
+
+  nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
+
+  buildInputs =
+    [ dbus ]
+    ++ lib.optionals stdenv.isDarwin [
+      IOKit
+    ];
+
+  meta = with lib; {
+    description = "Nushell plugin for interacting with D-Bus";
+    homepage = "https://github.com/devyn/nu_plugin_dbus";
+    license = licenses.mit;
+    maintainers = with lib.maintainers; [ darkkronicle ];
+    mainProgram = "nu_plugin_dbus";
+    platforms = with platforms; all;
+  };
+}

--- a/pkgs/shells/nushell/plugins/default.nix
+++ b/pkgs/shells/nushell/plugins/default.nix
@@ -1,10 +1,18 @@
-{ lib, newScope, IOKit, CoreFoundation, Foundation, Security }:
-
-lib.makeScope newScope (self: with self; {
+{
+  lib,
+  callPackage,
+  newScope,
+  IOKit,
+  CoreFoundation,
+  Foundation,
+  Security,
+}:
+lib.makeScope newScope (self: {
   gstat = callPackage ./gstat.nix { inherit Security; };
   formats = callPackage ./formats.nix { inherit IOKit Foundation; };
   polars = callPackage ./polars.nix { inherit IOKit Foundation; };
   query = callPackage ./query.nix { inherit IOKit CoreFoundation; };
   regex = throw "`nu_plugin_regex` is no longer compatible with the current Nushell release.";
   net = callPackage ./net.nix { inherit IOKit CoreFoundation; };
+  dbus = callPackage ./dbus.nix { inherit IOKit; };
 })


### PR DESCRIPTION
## Description of changes

Add [nu_plugin_dbus](https://github.com/devyn/nu_plugin_dbus)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
