### PR TITLE
Detangle Python `krb5` dependency mess

### DIFF
--- a/pkgs/development/python-modules/cccolutils/default.nix
+++ b/pkgs/development/python-modules/cccolutils/default.nix
@@ -4,7 +4,7 @@
   fetchPypi,
   git,
   gitpython,
-  krb5,
+  krb5-c, # C krb5 library, not PyPI krb5
   mock,
   pytestCheckHook,
   pythonOlder,
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     hash = "sha256-YzKjG43biRbTZKtzSUHHhtzOfcZfzISHDFolqzrBjL8=";
   };
 
-  buildInputs = [ krb5 ];
+  buildInputs = [ krb5-c ];
 
   propagatedBuildInputs = [
     git

--- a/pkgs/development/python-modules/gssapi/default.nix
+++ b/pkgs/development/python-modules/gssapi/default.nix
@@ -7,7 +7,6 @@
 
   # build-system
   cython,
-  krb5,
   setuptools,
 
   # dependencies
@@ -15,6 +14,7 @@
 
   # native dependencies
   GSS,
+  krb5-c, # C krb5 library, not PyPI krb5
 
   # tests
   parameterized,
@@ -38,7 +38,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace 'get_output(f"{kc} gssapi --prefix")' '"${lib.getDev krb5}"'
+      --replace 'get_output(f"{kc} gssapi --prefix")' '"${lib.getDev krb5-c}"'
   '';
 
   env = lib.optionalAttrs (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) {
@@ -47,7 +47,7 @@ buildPythonPackage rec {
 
   build-system = [
     cython
-    krb5
+    krb5-c
     setuptools
   ];
 

--- a/pkgs/development/python-modules/k5test/default.nix
+++ b/pkgs/development/python-modules/k5test/default.nix
@@ -1,12 +1,12 @@
 {
   lib,
   buildPythonPackage,
-  pythonOlder,
   fetchPypi,
-  substituteAll,
   findutils,
-  krb5,
+  krb5-c,
+  pythonOlder,
   setuptools,
+  substituteAll,
 }:
 
 buildPythonPackage rec {
@@ -24,9 +24,10 @@ buildPythonPackage rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      inherit findutils krb5;
+      inherit findutils;
+      krb5 = krb5-c;
       # krb5-config is in dev output
-      krb5Dev = krb5.dev;
+      krb5Dev = krb5-c.dev;
     })
   ];
 

--- a/pkgs/development/python-modules/krb5/default.nix
+++ b/pkgs/development/python-modules/krb5/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  cython,
+  fetchPypi,
+  k5test,
+  krb5-c, # C krb5 library
+  pytestCheckHook,
+  pythonOlder,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "krb5";
+  version = "0.6.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-cSugkvvjoo7BiCC7Gx7SzBA3t1xccDP5cMaoyXu9Egk=";
+  };
+
+  build-system = [
+    cython
+    setuptools
+  ];
+
+  nativeBuildInputs = [ krb5-c ];
+
+  nativeCheckInputs = [
+    k5test
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "krb5" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/jborean93/pykrb5/blob/v${version}/CHANGELOG.md";
+    description = "Kerberos API bindings for Python";
+    homepage = "https://github.com/jborean93/pykrb5";
+    license = licenses.mit;
+    maintainers = teams.deshaw.members;
+  };
+}

--- a/pkgs/development/python-modules/pykerberos/default.nix
+++ b/pkgs/development/python-modules/pykerberos/default.nix
@@ -2,7 +2,7 @@
   lib,
   fetchPypi,
   buildPythonPackage,
-  pkgs,
+  krb5-c, # C krb5 library, not PyPI krb5
 }:
 
 buildPythonPackage rec {
@@ -15,9 +15,9 @@ buildPythonPackage rec {
     hash = "sha256-nXAevY/FlsmdMVXVukWBO9WQjSbvg7oK3SUO22IqvtQ=";
   };
 
-  nativeBuildInputs = [ pkgs.krb5 ]; # for krb5-config
+  nativeBuildInputs = [ krb5-c ]; # for krb5-config
 
-  buildInputs = [ pkgs.krb5 ];
+  buildInputs = [ krb5-c ];
 
   # there are no tests
   doCheck = false;

--- a/pkgs/development/python-modules/pykerberos/default.nix
+++ b/pkgs/development/python-modules/pykerberos/default.nix
@@ -2,7 +2,7 @@
   lib,
   fetchPypi,
   buildPythonPackage,
-  krb5,
+  pkgs,
 }:
 
 buildPythonPackage rec {
@@ -15,12 +15,13 @@ buildPythonPackage rec {
     hash = "sha256-nXAevY/FlsmdMVXVukWBO9WQjSbvg7oK3SUO22IqvtQ=";
   };
 
-  nativeBuildInputs = [ krb5 ]; # for krb5-config
+  nativeBuildInputs = [ pkgs.krb5 ]; # for krb5-config
 
-  buildInputs = [ krb5 ];
+  buildInputs = [ pkgs.krb5 ];
 
   # there are no tests
   doCheck = false;
+
   pythonImportsCheck = [ "kerberos" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pypsrp/default.nix
+++ b/pkgs/development/python-modules/pypsrp/default.nix
@@ -4,10 +4,8 @@
   buildPythonPackage,
   cryptography,
   fetchFromGitHub,
-  gssapi,
   httpcore,
   httpx,
-  krb5,
   psrpcore,
   psutil,
   pyspnego,
@@ -52,11 +50,7 @@ buildPythonPackage rec {
 
   passthru.optional-dependencies = {
     credssp = [ requests-credssp ];
-    kerberos = [
-      # pyspnego[kerberos] will have those two dependencies
-      gssapi
-      krb5
-    ];
+    kerberos = pyspnego.optional-dependencies.kerberos;
     named_pipe = [ psutil ];
     ssh = [ asyncssh ];
   };

--- a/pkgs/development/python-modules/requests-credssp/default.nix
+++ b/pkgs/development/python-modules/requests-credssp/default.nix
@@ -3,8 +3,6 @@
   buildPythonPackage,
   cryptography,
   fetchFromGitHub,
-  gssapi,
-  krb5,
   pyspnego,
   pytestCheckHook,
   pythonOlder,
@@ -34,11 +32,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   passthru.optional-dependencies = {
-    kerberos = [
-      # pyspnego[kerberos] will have those two dependencies
-      gssapi
-      krb5
-    ];
+    kerberos = pyspnego.optional-dependencies.kerberos;
   };
 
   pythonImportsCheck = [ "requests_credssp" ];

--- a/pkgs/development/python-modules/requests-kerberos/default.nix
+++ b/pkgs/development/python-modules/requests-kerberos/default.nix
@@ -30,18 +30,12 @@ buildPythonPackage rec {
     requests
     pykerberos
     pyspnego
-  ];
+  ] ++ pyspnego.optional-dependencies.kerberos;
 
   nativeCheckInputs = [
     pytestCheckHook
     pytest-mock
   ];
-
-  # avoid needing to package krb5
-  postPatch = ''
-    substituteInPlace setup.py \
-    --replace "pyspnego[kerberos]" "pyspnego"
-  '';
 
   pythonImportsCheck = [ "requests_kerberos" ];
 

--- a/pkgs/development/python-modules/requests-kerberos/default.nix
+++ b/pkgs/development/python-modules/requests-kerberos/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   cryptography,
   fetchFromGitHub,
-  pykerberos,
   pyspnego,
   pytest-mock,
   pytestCheckHook,
@@ -28,7 +27,6 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     cryptography
     requests
-    pykerberos
     pyspnego
   ] ++ pyspnego.optional-dependencies.kerberos;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2031,7 +2031,9 @@ self: super: with self; {
 
   cbor = callPackage ../development/python-modules/cbor { };
 
-  cccolutils = callPackage ../development/python-modules/cccolutils { };
+  cccolutils = callPackage ../development/python-modules/cccolutils {
+    krb5-c = pkgs.krb5;
+  };
 
   cdcs = callPackage ../development/python-modules/cdcs { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5370,8 +5370,8 @@ self: super: with self; {
   gspread = callPackage ../development/python-modules/gspread { };
 
   gssapi = callPackage ../development/python-modules/gssapi {
-    inherit (pkgs) krb5;
     inherit (pkgs.darwin.apple_sdk.frameworks) GSS;
+    krb5-c = pkgs.krb5;
   };
 
   gst-python = callPackage ../development/python-modules/gst-python {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6686,6 +6686,10 @@ self: super: with self; {
 
   krakenex = callPackage ../development/python-modules/krakenex { };
 
+  krb5 = callPackage ../development/python-modules/krb5 {
+    krb5-c = pkgs.krb5;
+  };
+
   krfzf-py = callPackage ../development/python-modules/krfzf-py { };
 
   kserve = callPackage ../development/python-modules/kserve { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6536,7 +6536,8 @@ self: super: with self; {
   k-diffusion = callPackage ../development/python-modules/k-diffusion { };
 
   k5test = callPackage ../development/python-modules/k5test {
-    inherit (pkgs) krb5 findutils;
+    inherit (pkgs) findutils;
+    krb5-c = pkgs.krb5;
   };
 
   kaa-base = callPackage ../development/python-modules/kaa-base { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11603,7 +11603,9 @@ self: super: with self; {
 
   pykeepass = callPackage ../development/python-modules/pykeepass { };
 
-  pykerberos = callPackage ../development/python-modules/pykerberos { };
+  pykerberos = callPackage ../development/python-modules/pykerberos {
+    krb5-c = pkgs.krb5;
+  };
 
   pykeyatome = callPackage ../development/python-modules/pykeyatome { };
 


### PR DESCRIPTION
## Description of changes

PyPI has a package called `krb5` ([here](https://pypi.org/project/krb5/)) that was *not* packaged in Nixpkgs. Nixpkgs also has a top-level system package called `krb5`.

`pyspnego` was adding `krb5` to its optional dependencies, but it was incorrectly referring to the top-level systems `krb5` when it *meant* the PyPI package `krb5`. Several other packages made the same mistake because they use `pyspnego[kerberos]` as optional dependencies as well.

To resolve this, I...
  * Disambiguated Python packages that *mean* the top-level systems `krb5` by having them use `pkgs.krb5` (is there a better way to do this?)
  * Refactored packages that copy/pasted `pyspnego[kerberos]`'s optional dependencies to instead use `pyspnego.optional-dependencies.kerberos` directly. This preserves the intent better and makes the fix apply to those places as well.
  * Added `krb5` the *PyPI* package to `python-modules`.
  * Fixed `requests-kerberos`'s hack to avoid this problem, now that it's solved.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
