### PR TITLE
quodlibet: fix build; python.senf: init at 1.5.0

### DIFF
--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   fetchFromGitHub,
-  fetchpatch,
   tag ? "",
 
   # build time
@@ -46,9 +45,9 @@
   xvfb-run,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication {
   pname = "quodlibet${tag}";
-  version = "4.6.0";
+  version = "4.6.0-unstable-2024-08-08";
   pyproject = true;
 
   outputs = [
@@ -59,24 +58,11 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "quodlibet";
     repo = "quodlibet";
-    rev = "refs/tags/release-${version}";
-    hash = "sha256-dkO/CFN7Dk72xhtmcSDcwUciOPMeEjQS2mch+jSfiII=";
+    rev = "3dcf31dfc8db9806d1f73a47fdabc950d35ded1d";
+    hash = "sha256-8qWuxTvMF6ksDkbZ6wRLPCJK1cSqgGMPac/ht6qVpnA=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "python-3.12-startup.patch";
-      url = "https://patch-diff.githubusercontent.com/raw/quodlibet/quodlibet/pull/4358.patch";
-      hash = "sha256-3IjtAX2mKO/Xi/iTwT5WBD5CMTRYFED7XMm/cx+29Zc=";
-    })
-    (fetchpatch {
-      name = "more-python-3.12-fixes.patch";
-      url = "https://patch-diff.githubusercontent.com/raw/quodlibet/quodlibet/pull/4364.patch";
-      hash = "sha256-VRIQ+4e+X0kjZYuxV2wEjrFr+x5biwBtIR50K6hSfCY=";
-      excludes = [ "poetry.lock" ];
-    })
-    ./fix-gdist-python-3.12.patch
-  ];
+  patches = [ ./fix-gdist-python-3.12.patch ];
 
   build-system = [ python3.pkgs.setuptools ];
 

--- a/pkgs/development/python-modules/senf/default.nix
+++ b/pkgs/development/python-modules/senf/default.nix
@@ -1,0 +1,37 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+  hypothesis,
+  pytestCheckHook,
+}:
+buildPythonPackage rec {
+  pname = "senf";
+  version = "1.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-kFlFEOqYVBM47YWmwUOPuiCqoqSW+I3y0tNlSFZjjNE=";
+  };
+
+  nativeCheckInputs = [
+    hypothesis
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Both don't work even with HOME specified...
+    "test_getuserdir"
+    "test_expanduser_user"
+  ];
+
+  pythonImportsCheck = [ "senf" ];
+
+  meta = with lib; {
+    description = "Consistent filename handling for all Python versions and platforms";
+    homepage = "https://senf.readthedocs.io/en/latest/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ cab404 ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14167,6 +14167,8 @@ self: super: with self; {
 
   sendgrid = callPackage ../development/python-modules/sendgrid { };
 
+  senf = callPackage ../development/python-modules/senf { };
+
   sense-energy = callPackage ../development/python-modules/sense-energy { };
 
   sensirion-ble = callPackage ../development/python-modules/sensirion-ble { };


### PR DESCRIPTION
Even with all the progress we've made so far, this train moves on, grinding on software left behind by lack of backward compatibility.

A perfectly good thing becomes forgotten, and then reinvented.

Not today though! c:

## Description of changes

Fixed quodlibet build failure (bump to current master, distutils)
senf: init at 1.5.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
