### PR TITLE
python31{1,2}Packages.subliminal: 2.1.0 -> 2.2.1, python31{1,2}Packages.enzyme: 0.4.1 -> 0.5.2, python31{1,2}Packages.pysubs2: 1.6.1 -> 1.7.3

### DIFF
--- a/pkgs/by-name/ff/ffsubsync/package.nix
+++ b/pkgs/by-name/ff/ffsubsync/package.nix
@@ -1,6 +1,7 @@
-{ lib
-, fetchFromGitHub
-, python3
+{
+  lib,
+  fetchFromGitHub,
+  python3,
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -15,9 +16,7 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-ZdKZeKfAUe/FXLOur9Btb5RgXewmy3EHunQphqlxpIc=";
   };
 
-  nativeBuildInputs = with python3.pkgs; [
-    setuptools
-  ];
+  nativeBuildInputs = with python3.pkgs; [ setuptools ];
 
   propagatedBuildInputs = with python3.pkgs; [
     auditok
@@ -36,13 +35,9 @@ python3.pkgs.buildPythonApplication rec {
     webrtcvad
   ];
 
-  nativeCheckInputs = with python3.pkgs; [
-    pytestCheckHook
-  ];
+  nativeCheckInputs = with python3.pkgs; [ pytestCheckHook ];
 
-  pythonImportsCheck = [
-    "ffsubsync"
-  ];
+  pythonImportsCheck = [ "ffsubsync" ];
 
   meta = with lib; {
     homepage = "https://github.com/smacke/ffsubsync";

--- a/pkgs/by-name/ff/ffsubsync/package.nix
+++ b/pkgs/by-name/ff/ffsubsync/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch,
   python3,
 }:
 
@@ -15,6 +16,14 @@ python3.pkgs.buildPythonApplication rec {
     rev = "refs/tags/${version}";
     hash = "sha256-ZdKZeKfAUe/FXLOur9Btb5RgXewmy3EHunQphqlxpIc=";
   };
+
+  patches = [
+    # updates for python 3.12 (not currently included in a release)
+    (fetchpatch {
+      url = "https://github.com/smacke/ffsubsync/commit/de75bdbfe846b3376f8c0bcfe2e5e5db82d7ff20.patch";
+      hash = "sha256-JN7F9H9G8HK2aLOlm/Ec+GsWnU+65f1P658nq8FbAjo=";
+    })
+  ];
 
   nativeBuildInputs = with python3.pkgs; [ setuptools ];
 

--- a/pkgs/development/python-modules/enzyme/default.nix
+++ b/pkgs/development/python-modules/enzyme/default.nix
@@ -2,24 +2,27 @@
   lib,
   fetchPypi,
   buildPythonPackage,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "enzyme";
-  version = "0.4.1";
-  format = "setuptools";
+  version = "0.5.2";
+  pyproject = true;
 
   # Tests rely on files obtained over the network
   doCheck = false;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1fv2kh2v4lwj0hhrhj9pib1pdjh01yr4xgyljhx11l94gjlpy5pj";
+    hash = "sha256-fPd5FI2eZusoOGA+rOFAxTw878i4/l1NWgOl+11Xs8E=";
   };
+
+  nativeBuildInputs = [ setuptools ];
 
   meta = with lib; {
     homepage = "https://github.com/Diaoul/enzyme";
-    license = licenses.asl20;
+    license = licenses.mit;
     description = "Python video metadata parser";
   };
 }

--- a/pkgs/development/python-modules/pysubs2/default.nix
+++ b/pkgs/development/python-modules/pysubs2/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "pysubs2";
-  version = "1.6.1";
+  version = "1.7.3";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "tkarabela";
     repo = pname;
     rev = version;
-    hash = "sha256-0bW9aB6ERRQK3psqeU0Siyi/8drEGisAp8UtTfOKlp0=";
+    hash = "sha256-PrpN+w/gCi7S9OmD6kbbvL9VlZEfy1DbehFTwjxsibA=";
   };
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/subliminal/default.nix
+++ b/pkgs/development/python-modules/subliminal/default.nix
@@ -1,23 +1,25 @@
 {
   lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+
   appdirs,
   babelfish,
   beautifulsoup4,
-  buildPythonPackage,
   chardet,
   click,
   dogpile-cache,
   enzyme,
-  fetchFromGitHub,
   guessit,
   pysrt,
-  pytestCheckHook,
-  pythonOlder,
   pytz,
   rarfile,
   requests,
   six,
   stevedore,
+
+  pytestCheckHook,
   sympy,
   vcrpy,
 }:
@@ -31,7 +33,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Diaoul";
-    repo = pname;
+    repo = "subliminal";
     rev = "refs/tags/${version}";
     hash = "sha256-P4gVxKKCGKS3MC4F3yTAaOSv36TtdoYfrf61tBHg8VY=";
   };
@@ -59,15 +61,15 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
+    pytestCheckHook
     sympy
     vcrpy
-    pytestCheckHook
   ];
 
   pythonImportsCheck = [ "subliminal" ];
 
   disabledTests = [
-    # Tests rewuire network access
+    # Tests require network access
     "test_refine_video_metadata"
     "test_scan"
     "test_hash"
@@ -84,12 +86,12 @@ buildPythonPackage rec {
     "tests/test_legendastv.py"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Python library to search and download subtitles";
     homepage = "https://github.com/Diaoul/subliminal";
     changelog = "https://github.com/Diaoul/subliminal/blob/${version}/HISTORY.rst";
-    license = licenses.mit;
-    maintainers = with maintainers; [ doronbehar ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ doronbehar ];
     # Too many tests fail ever since a certain python-updates merge, see:
     # https://github.com/Diaoul/subliminal/issues/1062 . Disabling tests
     # alltogether may produce a not completly failing executable, but that

--- a/pkgs/development/python-modules/subliminal/default.nix
+++ b/pkgs/development/python-modules/subliminal/default.nix
@@ -4,64 +4,67 @@
   fetchFromGitHub,
   pythonOlder,
 
-  appdirs,
   babelfish,
   beautifulsoup4,
   chardet,
   click,
+  click-option-group,
   dogpile-cache,
   enzyme,
   guessit,
-  pysrt,
-  pytz,
+  srt,
+  pysubs2,
   rarfile,
   requests,
-  six,
+  platformdirs,
   stevedore,
+  tomli,
 
   pytestCheckHook,
+  pytest-cov,
+  pytest-xdist,
+  mypy,
   sympy,
   vcrpy,
 }:
 
 buildPythonPackage rec {
   pname = "subliminal";
-  version = "2.1.0";
-  format = "setuptools";
+  version = "2.2.1";
+  pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "Diaoul";
     repo = "subliminal";
     rev = "refs/tags/${version}";
-    hash = "sha256-P4gVxKKCGKS3MC4F3yTAaOSv36TtdoYfrf61tBHg8VY=";
+    hash = "sha256-g7gg2qdLKl7bg/nNXRWN9wZaNShOOc38sVASZrIycMU=";
   };
 
-  postPatch = ''
-    substituteInPlace pytest.ini \
-      --replace " --pep8 --flakes" ""
-  '';
-
   propagatedBuildInputs = [
-    appdirs
     babelfish
     beautifulsoup4
     chardet
     click
+    click-option-group
     dogpile-cache
     enzyme
     guessit
-    pysrt
-    pytz
+    srt
+    pysubs2
     rarfile
     requests
-    six
+    platformdirs
     stevedore
+    tomli
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
+    pytest-cov
+    pytest-xdist
+    mypy
     sympy
     vcrpy
   ];
@@ -70,20 +73,9 @@ buildPythonPackage rec {
 
   disabledTests = [
     # Tests require network access
-    "test_refine_video_metadata"
+    "test_refine"
     "test_scan"
     "test_hash"
-    "test_provider_pool_list_subtitles"
-    "test_async_provider_pool_list_subtitles"
-    "test_list_subtitles"
-    "test_download_bad_subtitle"
-    # Not implemented
-    "test_save_subtitles"
-  ];
-
-  disabledTestPaths = [
-    # AttributeError: module 'rarfile' has no attribute 'custom_check'
-    "tests/test_legendastv.py"
   ];
 
   meta = {


### PR DESCRIPTION
## Description of changes

Updates subliminal from 2.1.0 to 2.2.1 ([changelog](https://github.com/Diaoul/subliminal/releases)), unbreaking it in the process (the JSON decoder errors mentioned in the derivation's comments are no longer present, and I successfully downloads subtitles with it).
This update changes the supported providers (added `opensubtitlescom`, `gestdown`, `tmdb`; removed `thesubdb`, `argenteam`, `shooter`, `legendastv`).
I don't think it warrants inclusion in the release notes because I expect most people to just use the default option of searching all available providers to find subtitles and the removed providers were removed due to going down.

Additionally, this update required updating some dependencies. Thus, this PR also updates:
- enzyme from 0.4.1 to 0.5.2 ([changelog](https://github.com/Diaoul/enzyme/releases)), which seems to only change the supported Python versions (drops support for Python <3.8, adds support for Python 3.12)
- pysubs2 from 1.6.1 to 1.7.3 ([changelog](https://github.com/tkarabela/pysubs2/blob/1.7.3/docs/release-notes.rst)), which seems to not have any breaking changes apart from dropping support for Python <3.8

Furthermore, the new `pysubs2` broke `ffsubsync`: it used an old `versioneer.py` that prevented it from detecting its dependencies properly. The fix is applied in this PR: it was [already available upstream](https://github.com/smacke/ffsubsync/commit/de75bdbfe846b3376f8c0bcfe2e5e5db82d7ff20) but unreleased, so this PR applies that patch, which is meant to provide Python 3.12 support.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- **N/A(?)** Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- Tested basic functionality of all binary files (usually in `./result/bin/`)
  * [x] pysubs2
  * [x] subliminal
  * [ ] ffsubsync -- not tested, but not expected to break (minimal dependency update, minimal changes to build process)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - **N/A(?)** (Package updates) Added a release notes entry if the change is major or breaking
  - **N/A** (Module updates) Added a release notes entry if the change is significant
  - **N/A** (Module addition) Added a release notes entry if adding a new NixOS module
- [?] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
