### PR TITLE
add ypbind-mt package

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2249,6 +2249,11 @@
     github = "barinov274";
     githubId = 54442153;
   };
+  BarrOff = {
+    name = "BarrOff";
+    github = "BarrOff";
+    githubId = 58253563;
+  };
   barrucadu = {
     email = "mike@barrucadu.co.uk";
     github = "barrucadu";

--- a/pkgs/by-name/yp/ypbind-mt/package.nix
+++ b/pkgs/by-name/yp/ypbind-mt/package.nix
@@ -1,0 +1,45 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  autoreconfHook,
+  libnsl,
+  libtirpc,
+  libxcrypt,
+  pkg-config,
+  rpcbind,
+  systemdLibs,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ypbind-mt";
+  version = "2.7.2";
+
+  src = fetchurl {
+    url = "https://github.com/thkukuk/ypbind-mt/releases/download/v${version}/ypbind-mt-${version}.tar.xz";
+    hash = "sha256-Bk8vGFZzxUk9+D9kALeZ86NZ3lYRi2ujfEMnER8vzYs=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    libnsl
+    libtirpc
+    libxcrypt
+    rpcbind
+    systemdLibs
+  ];
+
+  meta = {
+    description = "Multithreaded daemon maintaining the NIS binding informations.";
+    homepage = "https://github.com/thkukuk/ypbind-mt";
+    changelog = "https://github.com/thkukuk/ypbind-mt/blob/master/NEWS";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "ypbind";
+    maintainers = with lib.maintainers; [ BarrOff ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
This is the first time I submit a pull request to nixpkgs.
I read and tried to adhere to the contributing guidelines on a best effort basis.
If there is still something wrong/missing or needs change I will gladly update the PR.

## Description of changes

This pull request adds the package *ypbind-mt* which contains the `ypbind` binary needed for [NIS](https://en.wikipedia.org/wiki/Network_Information_Service) clients to bind to NIS servers.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)

## Misc

The company I work at is using NIS/YP and the necessary tools are still missing in nixpkgs.
This is intended to be the first in a series of packages needed to create usable NIS clients (yp-tools and libnss_nis will follow).
This deviation was created and successfully built/used on a NixOS machine.

A few changes to the Makefile for manpages are necessary.
 I did not find a way to prevent xmllint from trying to access the network.
Maybe there is a better way than commenting out the respective lines using `sed`?

Best regards
BarrOff