### PR TITLE
sherlock: 0-unstable-2024-06-09 -> 0.15.0

### DIFF
--- a/pkgs/by-name/sh/sherlock/package.nix
+++ b/pkgs/by-name/sh/sherlock/package.nix
@@ -1,9 +1,10 @@
-{ lib
-, fetchFromGitHub
-, makeWrapper
-, python3
-, unstableGitUpdater
-, poetry
+{
+  lib,
+  fetchFromGitHub,
+  makeWrapper,
+  python3,
+  unstableGitUpdater,
+  poetry,
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -67,9 +68,7 @@ python3.pkgs.buildPythonApplication rec {
     pythonRelaxDepsHook
   ];
 
-  pythonRelaxDeps = [
-    "stem"
-  ];
+  pythonRelaxDeps = [ "stem" ];
 
   pytestFlagsArray = [
     "-m"

--- a/pkgs/by-name/sh/sherlock/package.nix
+++ b/pkgs/by-name/sh/sherlock/package.nix
@@ -8,14 +8,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "sherlock";
-  version = "0-unstable-2024-06-09";
+  version = "0.15.0";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "sherlock-project";
     repo = "sherlock";
-    rev = "d678908c00f16c7f6c44efc0357cef713fa96739";
-    hash = "sha256-XAXDqbdHQta9OiupbPmmyp3TK1VLtDQ7CadsOei/6rs=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-+fQDvvwsLpiEvy+vC49AzlOA/KaKrhhpS97sZvFbpLA=";
   };
 
   patches = [
@@ -45,7 +45,7 @@ python3.pkgs.buildPythonApplication rec {
     runHook preInstall
 
     mkdir -p $out/bin $out/share
-    cp -R ./sherlock $out/share
+    cp -R ./sherlock_project $out/share
 
     runHook postInstall
   '';
@@ -53,7 +53,7 @@ python3.pkgs.buildPythonApplication rec {
   postFixup = ''
     makeWrapper ${python3.interpreter} $out/bin/sherlock \
       --add-flags "-m" \
-      --add-flags "sherlock" \
+      --add-flags "sherlock_project" \
       --prefix PYTHONPATH : "$PYTHONPATH:$out/share"
   '';
 
@@ -75,10 +75,6 @@ python3.pkgs.buildPythonApplication rec {
     "-m"
     "'not online'"
   ];
-
-  passthru.updateScript = unstableGitUpdater {
-    hardcodeZeroVersion = true;
-  };
 
   meta = with lib; {
     homepage = "https://sherlock-project.github.io/";

--- a/pkgs/by-name/sh/sherlock/package.nix
+++ b/pkgs/by-name/sh/sherlock/package.nix
@@ -3,7 +3,6 @@
   fetchFromGitHub,
   makeWrapper,
   python3,
-  unstableGitUpdater,
   poetry,
 }:
 
@@ -75,11 +74,11 @@ python3.pkgs.buildPythonApplication rec {
     "'not online'"
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://sherlock-project.github.io/";
     description = "Hunt down social media accounts by username across social networks";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "sherlock";
-    maintainers = with maintainers; [ applePrincess ];
+    maintainers = with lib.maintainers; [ applePrincess ];
   };
 }


### PR DESCRIPTION
## Description of changes

https://github.com/sherlock-project/sherlock/releases/tag/v0.15.0

Fixes the project being renamed to sherlock_project.
Closes #333082

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
