### PR TITLE
darwin.shell_cmds: restore missing /bin/[

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/shell_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/shell_cmds/default.nix
@@ -12,18 +12,18 @@ appleDerivation {
     # - w (Undefined symbol '_res_9_init')
     # - expr
     substituteInPlace shell_cmds.xcodeproj/project.pbxproj \
-      --replace "FCBA168714A146D000AA698B /* PBXTargetDependency */," "" \
-      --replace "FCBA165914A146D000AA698B /* PBXTargetDependency */," "" \
-      --replace "FCBA169514A146D000AA698B /* PBXTargetDependency */," "" \
-      --replace "FCBA165514A146D000AA698B /* PBXTargetDependency */," ""
+      --replace-fail "FCBA168714A146D000AA698B /* PBXTargetDependency */," "" \
+      --replace-fail "FCBA165914A146D000AA698B /* PBXTargetDependency */," "" \
+      --replace-fail "FCBA169514A146D000AA698B /* PBXTargetDependency */," "" \
+      --replace-fail "FCBA165514A146D000AA698B /* PBXTargetDependency */," ""
 
     # disable w, test install
     # get rid of permission stuff
     substituteInPlace xcodescripts/install-files.sh \
-      --replace 'ln -f "$BINDIR/w" "$BINDIR/uptime"' "" \
-      --replace 'ln -f "$DSTROOT/bin/test" "$DSTROOT/bin/["' "" \
-      --replace "-o root -g wheel -m 0755" "" \
-      --replace "-o root -g wheel -m 0644" ""
+      --replace-fail 'ln -f "$BINDIR/w" "$BINDIR/uptime"' "" \
+      --replace-fail 'ln -f "$DSTROOT/bin/test" "$DSTROOT/bin/["' "" \
+      --replace-fail "-o root -g wheel -m 0755" "" \
+      --replace-fail "-o root -g wheel -m 0644" ""
   '';
 
   # temporary install phase until xcodebuild has "install" support

--- a/pkgs/os-specific/darwin/apple-source-releases/shell_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/shell_cmds/default.nix
@@ -20,8 +20,8 @@ appleDerivation {
     # disable w, test install
     # get rid of permission stuff
     substituteInPlace xcodescripts/install-files.sh \
+      --replace-fail '/usr/' '/' \
       --replace-fail 'ln -f "$BINDIR/w" "$BINDIR/uptime"' "" \
-      --replace-fail 'ln -f "$DSTROOT/bin/test" "$DSTROOT/bin/["' "" \
       --replace-fail "-o root -g wheel -m 0755" "" \
       --replace-fail "-o root -g wheel -m 0644" ""
   '';
@@ -34,11 +34,12 @@ appleDerivation {
       fi
     done
 
+    mv $out/usr/* $out
+
     export DSTROOT=$out
     export SRCROOT=$PWD
     . xcodescripts/install-files.sh
 
-    mv $out/usr/* $out
     mv $out/private/etc $out
     rmdir $out/usr $out/private
   '';


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Tested that files present is the same except `bin/[` is added, and that the latter works as expected.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
