### PR TITLE
importNpmLock.buildNodeModules: init

### DIFF
--- a/doc/languages-frameworks/javascript.section.md
+++ b/doc/languages-frameworks/javascript.section.md
@@ -287,6 +287,43 @@ buildNpmPackage {
 }
 ```
 
+#### importNpmLock.buildNodeModules {#javascript-buildNpmPackage-importNpmLock.buildNodeModules}
+
+`importNpmLock.buildNodeModules` returns a derivation with a pre-built `node_modules` directory, as imported by `importNpmLock`.
+
+This is to be used together with `importNpmLock.hooks.linkNodeModulesHook` to facilitate `nix-shell`/`nix develop` based development workflows.
+
+It accepts an argument with the following attributes:
+
+`npmRoot` (Path; optional)
+: Path to package directory containing the source tree. If not specified, the `package` and `packageLock` arguments must both be specified.
+
+`package` (Attrset; optional)
+: Parsed contents of `package.json`, as returned by `lib.importJSON ./my-package.json`. If not specified, the `package.json` in `npmRoot` is used.
+
+`packageLock` (Attrset; optional)
+: Parsed contents of `package-lock.json`, as returned `lib.importJSON ./my-package-lock.json`. If not specified, the `package-lock.json` in `npmRoot` is used.
+
+`derivationArgs` (`mkDerivation` attrset; optional)
+: Arguments passed to `stdenv.mkDerivation`
+
+For example:
+
+```nix
+pkgs.mkShell {
+  packages = [
+    importNpmLock.hooks.linkNodeModulesHook
+    nodejs
+  ];
+
+  npmDeps = importNpmLock.buildNodeModules {
+    npmRoot = ./.;
+    inherit nodejs;
+  };
+}
+```
+will create a development shell where a `node_modules` directory is created & packages symlinked to the Nix store when activated.
+
 ### corepack {#javascript-corepack}
 
 This package puts the corepack wrappers for pnpm and yarn in your PATH, and they will honor the `packageManager` setting in the `package.json`.

--- a/pkgs/build-support/node/import-npm-lock/hooks/default.nix
+++ b/pkgs/build-support/node/import-npm-lock/hooks/default.nix
@@ -10,4 +10,14 @@
         storePrefix = builtins.storeDir;
       };
     } ./npm-config-hook.sh;
+
+  linkNodeModulesHook = makeSetupHook
+    {
+      name = "node-modules-hook.sh";
+      substitutions = {
+        nodejs = lib.getExe nodejs;
+        script = ./link-node-modules.js;
+        storePrefix = builtins.storeDir;
+      };
+    } ./link-node-modules-hook.sh;
 }

--- a/pkgs/build-support/node/import-npm-lock/hooks/link-node-modules-hook.sh
+++ b/pkgs/build-support/node/import-npm-lock/hooks/link-node-modules-hook.sh
@@ -1,0 +1,31 @@
+linkNodeModulesHook() {
+    echo "Executing linkNodeModulesHook"
+    runHook preShellHook
+
+    if [ -n "${npmRoot-}" ]; then
+      pushd "$npmRoot"
+    fi
+
+    @nodejs@ @script@ @storePrefix@ "${npmDeps}/node_modules"
+    if test -f node_modules/.bin; then
+        export PATH=$(readlink -f node_modules/.bin):$PATH
+    fi
+
+    if [ -n "${npmRoot-}" ]; then
+      popd
+    fi
+
+    runHook postShellHook
+    echo "Finished executing linkNodeModulesShellHook"
+}
+
+if [ -z "${dontLinkNodeModules:-}" ] && [ -z "${shellHook-}" ]; then
+    echo "Using linkNodeModulesHook shell hook"
+    shellHook=linkNodeModulesHook
+fi
+
+
+if [ -z "${dontLinkNodeModules:-}" ]; then
+    echo "Using linkNodeModulesHook preConfigure hook"
+    preConfigureHooks+=(linkNodeModulesHook)
+fi

--- a/pkgs/build-support/node/import-npm-lock/hooks/link-node-modules.js
+++ b/pkgs/build-support/node/import-npm-lock/hooks/link-node-modules.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+
+async function asyncFilter(arr, pred) {
+  const filtered = [];
+  for (const elem of arr) {
+    if (await pred(elem)) {
+      filtered.push(elem);
+    }
+  }
+  return filtered;
+}
+
+// Get a list of all _unmanaged_ files in node_modules.
+// This means every file in node_modules that is _not_ a symlink to the Nix store.
+async function getUnmanagedFiles(storePrefix, files) {
+  return await asyncFilter(files, async (file) => {
+    const filePath = path.join("node_modules", file);
+
+    // Is file a symlink
+    const stat = await fs.promises.lstat(filePath);
+    if (!stat.isSymbolicLink()) {
+      return true;
+    }
+
+    // Is file in the store
+    const linkTarget = await fs.promises.readlink(filePath);
+    return !linkTarget.startsWith(storePrefix);
+  });
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const storePrefix = args[0];
+  const sourceModules = args[1];
+
+  // Ensure node_modules exists
+  try {
+    await fs.promises.mkdir("node_modules");
+  } catch (err) {
+    if (err.code !== "EEXIST") {
+      throw err;
+    }
+  }
+
+  const files = await fs.promises.readdir("node_modules");
+
+  // Get deny list of files that we don't manage.
+  // We do manage nix store symlinks, but not other files.
+  // For example: If a .vite was present in both our
+  // source node_modules and the non-store node_modules we don't want to overwrite
+  // the non-store one.
+  const unmanaged = await getUnmanagedFiles(storePrefix, files);
+  const managed = new Set(files.filter((file) => ! unmanaged.includes(file)));
+
+  const sourceFiles = await fs.promises.readdir(sourceModules);
+  await Promise.all(
+    sourceFiles.map(async (file) => {
+      const sourcePath = path.join(sourceModules, file);
+      const targetPath = path.join("node_modules", file);
+
+      // Skip file if it's not a symlink to a store path
+      if (unmanaged.includes(file)) {
+        console.log(`'${targetPath}' exists, cowardly refusing to link.`);
+        return;
+      }
+
+      // Don't unlink this file, we just wrote it.
+      managed.delete(file);
+
+      // Link to a temporary dummy path and rename.
+      // This is to get some degree of atomicity.
+      try {
+        await fs.promises.symlink(sourcePath, targetPath + "-nix-hook-temp");
+      } catch (err) {
+        if (err.code !== "EEXIST") {
+          throw err;
+        }
+
+        await fs.promises.unlink(targetPath + "-nix-hook-temp");
+        await fs.promises.symlink(sourcePath, targetPath + "-nix-hook-temp");
+      }
+      await fs.promises.rename(targetPath + "-nix-hook-temp", targetPath);
+    })
+  );
+
+  // Clean up store symlinks not included in this generation of node_modules
+  await Promise.all(
+    Array.from(managed).map((file) =>
+      fs.promises.unlink(path.join("node_modules", file)),
+    )
+  );
+}
+
+main();


### PR DESCRIPTION
## Description of changes

`importNpmLock.buildNodeModules` returns a derivation with a pre-built `node_modules` directory, as imported by `importNpmLock`. This is to be used together with `importNpmLock.hooks.linkNodeModulesHook` to facilitate `nix-shell`/`nix develop` based development workflows:

```nix
pkgs.mkShell {
  packages = [
    importNpmLock.hooks.linkNodeModulesHook
    nodejs
  ];

  npmDeps = importNpmLock.buildNodeModules {
    npmRoot = ./.;
    inherit nodejs;
  };
}
```
will create a development shell where a `node_modules` directory is created & packages symlinked to the Nix store when activated.

This code is adapted from https://github.com/adisbladis/buildNodeModules (this upstream will be archived shortly after merge).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
