### PR TITLE
Minor LLVM improvements

### DIFF
--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -89,9 +89,7 @@ let
         }
       );
     in
-    {
-      llef = callPackage ./lldb-plugins/llef.nix { };
-    }
+    lib.recurseIntoAttrs { llef = callPackage ./lldb-plugins/llef.nix { }; }
   );
 
   tools = lib.makeExtensible (

--- a/pkgs/development/compilers/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/default.nix
@@ -7,6 +7,7 @@
   stdenv,
   gcc12Stdenv,
   pkgs,
+  recurseIntoAttrs,
   # This is the default binutils, but with *this* version of LLD rather
   # than the default LLVM version's, if LLD is the choice. We use these for
   # the `useLLVM` bootstrapping below.
@@ -51,25 +52,27 @@ let
         args.name or (if (gitRelease != null) then "git" else lib.versions.major release_version);
     in
     lib.nameValuePair attrName (
-      callPackage ./common {
-        inherit (stdenvAdapters) overrideCC;
-        buildLlvmTools = buildPackages."llvmPackages_${attrName}".tools;
-        targetLlvmLibraries =
-          targetPackages."llvmPackages_${attrName}".libraries or llvmPackages."${attrName}".libraries;
-        targetLlvm = targetPackages."llvmPackages_${attrName}".llvm or llvmPackages."${attrName}".llvm;
-        stdenv =
-          if (lib.versions.major release_version == "13" && stdenv.cc.cc.isGNU or false) then
-            gcc12Stdenv
-          else
-            stdenv; # does not build with gcc13
-        inherit bootBintoolsNoLibc bootBintools;
-        inherit
-          officialRelease
-          gitRelease
-          monorepoSrc
-          version
-          ;
-      }
+      recurseIntoAttrs (
+        callPackage ./common {
+          inherit (stdenvAdapters) overrideCC;
+          buildLlvmTools = buildPackages."llvmPackages_${attrName}".tools;
+          targetLlvmLibraries =
+            targetPackages."llvmPackages_${attrName}".libraries or llvmPackages."${attrName}".libraries;
+          targetLlvm = targetPackages."llvmPackages_${attrName}".llvm or llvmPackages."${attrName}".llvm;
+          stdenv =
+            if (lib.versions.major release_version == "13" && stdenv.cc.cc.isGNU or false) then
+              gcc12Stdenv
+            else
+              stdenv; # does not build with gcc13
+          inherit bootBintoolsNoLibc bootBintools;
+          inherit
+            officialRelease
+            gitRelease
+            monorepoSrc
+            version
+            ;
+        }
+      )
     );
 
   llvmPackages = lib.mapAttrs' (version: args: mkPackage (args // { inherit version; })) versions;

--- a/pkgs/development/compilers/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/default.nix
@@ -77,4 +77,4 @@ let
 
   llvmPackages = lib.mapAttrs' (version: args: mkPackage (args // { inherit version; })) versions;
 in
-llvmPackages
+llvmPackages // { inherit mkPackage; }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -877,7 +877,7 @@ mapAliases ({
   linuxPackages_testing_bcachefs = throw "'linuxPackages_testing_bcachefs' has been removed, please use 'linuxPackages_latest', any kernel version at least 6.7, or any other linux kernel with bcachefs support";
   linux_testing_bcachefs = throw "'linux_testing_bcachefs' has been removed, please use 'linux_latest', any kernel version at least 6.7, or any other linux kernel with bcachefs support";
 
-  llvmPackages_git = (recurseIntoAttrs (callPackages ../development/compilers/llvm { })).git;
+  llvmPackages_git = (callPackages ../development/compilers/llvm { }).git;
 
   lld_6 = throw "lld_6 has been removed from nixpkgs"; # Added 2024-01-08
   lld_7 = throw "lld_7 has been removed from nixpkgs"; # Added 2023-11-19


### PR DESCRIPTION
## Description of changes

Make a few improvements / changes, doesn't make any rebuilds.

- As brought up by @philiptaron on Matrix, `llvmPackages_git` uses `recurseIntoAttrs` after `callPackage`. Since this isn't necessary, remove it.
- Expose `mkPackage` in `llvmPackagesSets` so other packages / libraries could "import" an unpackaged LLVM version.
- Add `recurseIntoAttrs` into each LLVM version attr sets for Hydra / NixOS Search.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
