### PR TITLE
shopify-cli: Build using importNpmLock

### DIFF
--- a/pkgs/by-name/sh/shopify-cli/package.nix
+++ b/pkgs/by-name/sh/shopify-cli/package.nix
@@ -1,4 +1,4 @@
-{ buildNpmPackage, lib, makeWrapper, bundlerEnv, testers, shopify-cli }:
+{ buildNpmPackage, lib, importNpmLock, makeWrapper, bundlerEnv, testers, shopify-cli }:
 let
   version = "3.63.2";
 
@@ -20,8 +20,11 @@ buildNpmPackage {
     ];
   };
 
-  npmDepsHash = "sha256-6CEDcWXZXYHFrT2xpbj5NwMrbDZXH6HclgTGkfKDlJs=";
+  npmDeps = importNpmLock {
+    npmRoot = ./.;
+  };
   dontNpmBuild = true;
+  npmConfigHook = importNpmLock.npmConfigHook;
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/by-name/sh/shopify-cli/update.sh
+++ b/pkgs/by-name/sh/shopify-cli/update.sh
@@ -24,8 +24,6 @@ sed -i "s|$UPDATE_NIX_OLD_VERSION|$version|g" package.json
 # Update the package-lock.json
 rm -f package-lock.json
 npm i --package-lock-only
-npm_hash=$(prefetch-npm-deps package-lock.json)
-sed -i "s|npmDepsHash = \".*\";|npmDepsHash = \"$npm_hash\";|" package.nix
 
 # Update the Gemfile
 curl -sf "https://raw.githubusercontent.com/Shopify/cli/$version/packages/cli-kit/src/public/node/ruby.ts" > $tmp/ruby.ts


### PR DESCRIPTION
## Description of changes

This package has both a `package.json` & a `package-lock.json` file vendored, meaning we can use `importNpmLock` instead of implicitly using `fetchNpmDeps`. Instead of one gigantic fixed-output derivation `importNpmLock` generates one derivation per dependency.
This is a much more efficient fetching approach, but it can only be done for the handful of packages where we have both `package.json` & `package-lock.json`.

For full disclosure: My main motivation is to have at least one `importNpmLock` usage example in-tree. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
