### PR TITLE
python312Packages.behave: 1.2.7.dev2 -> 1.2.7.dev5

### DIFF
--- a/pkgs/development/python-modules/behave/default.nix
+++ b/pkgs/development/python-modules/behave/default.nix
@@ -4,46 +4,49 @@
   fetchFromGitHub,
   buildPythonPackage,
   python,
+  pythonOlder,
   pytestCheckHook,
+  assertpy,
   mock,
   path,
   pyhamcrest,
   pytest-html,
-  glibcLocales,
   colorama,
   cucumber-tag-expressions,
   parse,
   parse-type,
+  setuptools,
   six,
 }:
 
 buildPythonPackage rec {
   pname = "behave";
-  version = "1.2.7.dev2";
-  format = "setuptools";
+  version = "1.2.7.dev5";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "behave";
-    repo = pname;
+    repo = "behave";
     rev = "v${version}";
-    hash = "sha256-B8PUN1Q4UAsDWrHjPZDlpaPjCKjI/pAogCSI+BQnaWs=";
+    hash = "sha256-G1o0a57MRczwjGLl/tEYC+yx3nxpk6+E58RvR9kVJpA=";
   };
+
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [
     pytestCheckHook
+    assertpy
     mock
     path
     pyhamcrest
     pytest-html
   ];
 
-  # upstream tests are failing, so instead we only check if we can import it
-  doCheck = false;
+  doCheck = pythonOlder "3.12";
 
   pythonImportsCheck = [ "behave" ];
 
-  buildInputs = [ glibcLocales ];
-  propagatedBuildInputs = [
+  dependencies = [
     colorama
     cucumber-tag-expressions
     parse
@@ -60,15 +63,13 @@ buildPythonPackage rec {
   disabledTests = lib.optionals stdenv.isDarwin [ "test_step_decorator_async_run_until_complete" ];
 
   postCheck = ''
-    export LANG="en_US.UTF-8"
-    export LC_ALL="en_US.UTF-8"
-
     ${python.interpreter} bin/behave -f progress3 --stop --tags='~@xfail' features/
     ${python.interpreter} bin/behave -f progress3 --stop --tags='~@xfail' tools/test-features/
     ${python.interpreter} bin/behave -f progress3 --stop --tags='~@xfail' issue.features/
   '';
 
   meta = with lib; {
+    changelog = "https://github.com/behave/behave/blob/${src.rev}/CHANGES.rst";
     homepage = "https://github.com/behave/behave";
     description = "behaviour-driven development, Python style";
     mainProgram = "behave";


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/behave/behave/compare/v1.2.7.dev2...v1.2.7.dev5

Changelog: https://github.com/behave/behave/blob/v1.2.7.dev5/CHANGES.rst



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
