### PR TITLE
python312Packages.homf: 1.0.0 → 1.1.1

### DIFF
--- a/pkgs/development/python-modules/homf/default.nix
+++ b/pkgs/development/python-modules/homf/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "homf";
-  version = "1.0.0";
+  version = "1.1.1";
   pyproject = true;
   disabled = pythonOlder "3.8";
 
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "duckinator";
     repo = "homf";
     rev = "refs/tags/v${version}";
-    hash = "sha256-PU5VjBIVSMupTBh/qvVuZSFWpBbJOylCR02lONn9/qw=";
+    hash = "sha256-fDH6uJ2d/Jsnuudv+Qlv1tr3slxOJWh7b4smGS32n9A=";
   };
 
   build-system = [ hatchling ];

--- a/pkgs/development/python-modules/homf/default.nix
+++ b/pkgs/development/python-modules/homf/default.nix
@@ -1,9 +1,11 @@
 {
   lib,
   buildPythonPackage,
+  callPackage,
   fetchFromGitHub,
   # pytestCheckHook,
   pythonOlder,
+  versionCheckHook,
 
   hatchling,
   packaging,
@@ -25,7 +27,6 @@ buildPythonPackage rec {
   build-system = [ hatchling ];
 
   pythonRelaxDeps = [ "packaging" ];
-
   dependencies = [ packaging ];
 
   pythonImportsCheck = [
@@ -38,6 +39,11 @@ buildPythonPackage rec {
   # There are currently no checks which do not require network access, which breaks the check hook somehow?
   # nativeCheckInputs = [ pytestCheckHook ];
   # pytestFlagsArray = [ "-m 'not network'" ];
+
+  nativeBuildInputs = [ versionCheckHook ];
+
+  # (Ab)using `callPackage` as a fix-point operator, so tests can use the `homf` drv
+  passthru.tests = callPackage ./tests.nix { };
 
   meta = with lib; {
     description = "Asset download tool for GitHub Releases, PyPi, etc.";

--- a/pkgs/development/python-modules/homf/tests.nix
+++ b/pkgs/development/python-modules/homf/tests.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  runCommand,
+  testers,
+
+  cacert,
+  homf,
+}:
+let
+  # runs homf, putting the fetched artefacts in the drv output
+  Homf =
+    subcommand:
+    {
+      pkgName,
+      version,
+      hash,
+    }:
+    # testers.runCommand ensures we have an FOD, so the command has network access,
+    #  yet the test is rerun whenever one of its inputs changes.
+    testers.runCommand {
+      name = "homf-${subcommand}-${pkgName}";
+      script = "homf ${subcommand} --directory $out ${pkgName} ${version}";
+      nativeBuildInputs = [
+        cacert
+        homf
+      ];
+      inherit hash;
+    };
+in
+
+lib.mapAttrs Homf {
+  pypi = {
+    pkgName = "homf";
+    version = "1.1.1"; # pinned so updating homf won't invalidate hashes
+    hash = "sha256-zpdt7+zTaGkLG6xYoTZVw/kUek0/MrCqvljfLxNB94A=";
+  };
+
+  github = {
+    pkgName = "duckinator/homf";
+    version = "v1.1.1";
+    hash = "sha256-NeEz8wZqDWYUnrgsknXWHzhWdk8cPW8mknKS3+/dngQ=";
+  };
+}


### PR DESCRIPTION
## Description of changes

- [x] Update `python3.pkgs.homf` from v1.0.0 to v1.1.1, released 9h ago:
  - minor documentation fixes ;
  - API extended for feature-parity with `bork`, whose next release will stub its `download` command out to `homf`.
- [x] Add version check
- [x] Add package tests

[Upstream changes]: https://github.com/duckinator/homf/compare/v1.0.0...v1.1.1

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested compilation of all affected packages using `nixpkgs-review`
- [x] Added (and ran) package tests
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
