### PR TITLE
python312Packages.blis: 0.7.11 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/blis/default.nix
+++ b/pkgs/development/python-modules/blis/default.nix
@@ -3,33 +3,41 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
-  cython_0,
+  cython,
   hypothesis,
   numpy,
   pytestCheckHook,
   pythonOlder,
+  blis,
+  numpy_2,
   gitUpdater,
 }:
 
 buildPythonPackage rec {
   pname = "blis";
-  version = "0.7.11";
+  version = "1.0.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "explosion";
     repo = "cython-blis";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-p8pzGZc5OiiGTvXULDgzsBC3jIhovTKUq3RtPnQ/+to=";
+    rev = "refs/tags/release-v${version}";
+    hash = "sha256-XS6h2c+8BJ9pAvIX8340C4vRZEBRmEZc6/6tH7ooqNU=";
   };
 
   postPatch = ''
+    # The commit pinning numpy to version 2 doesn't have any functional changes:
+    # https://github.com/explosion/cython-blis/pull/108
+    # BLIS should thus work with numpy and numpy_2.
+    substituteInPlace pyproject.toml setup.py \
+      --replace-fail "numpy>=2.0.0,<3.0.0" numpy
+
     # See https://github.com/numpy/numpy/issues/21079
     # has no functional difference as the name is only used in log output
     substituteInPlace blis/benchmark.py \
-      --replace 'numpy.__config__.blas_ilp64_opt_info["libraries"]' '["dummy"]'
+      --replace-fail 'numpy.__config__.blas_ilp64_opt_info["libraries"]' '["dummy"]'
   '';
 
   preCheck = ''
@@ -37,12 +45,13 @@ buildPythonPackage rec {
     rm -rf ./blis
   '';
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
-    cython_0
+    cython
+    numpy
   ];
 
-  propagatedBuildInputs = [ numpy ];
+  dependencies = [ numpy ];
 
   nativeCheckInputs = [
     hypothesis
@@ -52,16 +61,18 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "blis" ];
 
   passthru = {
-    # Do not update to BLIS 0.9.x until the following issue is resolved:
-    # https://github.com/explosion/thinc/issues/771#issuecomment-1255825935
-    skipBulkUpdate = true;
+    tests = {
+      numpy_2 = blis.overridePythonAttrs (old: {
+        numpy = numpy_2;
+      });
+    };
     updateScript = gitUpdater {
-      rev-prefix = "v";
-      ignoredVersions = "0\.9\..*";
+      rev-prefix = "release-v";
     };
   };
 
   meta = with lib; {
+    changelog = "https://github.com/explosion/cython-blis/releases/tag/release-v${version}";
     description = "BLAS-like linear algebra library";
     homepage = "https://github.com/explosion/cython-blis";
     license = licenses.bsd3;

--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -50,6 +50,13 @@ buildPythonPackage rec {
     hash = "sha256-pkjGy/Ksx6Vaae6ef6TyK99pqoKKWHobxc//CM88LdM=";
   };
 
+  postPatch = ''
+    # thinc version 8.3.0 had no functional changes
+    # also see https://github.com/explosion/spaCy/issues/13607
+    substituteInPlace pyproject.toml setup.cfg \
+      --replace-fail "thinc>=8.2.2,<8.3.0" "thinc>=8.2.2,<8.4.0"
+  '';
+
   pythonRelaxDeps = [
     "smart-open"
     "typer"

--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -10,13 +10,11 @@
   fetchPypi,
   hypothesis,
   jinja2,
-  jsonschema,
   langcodes,
   mock,
   murmurhash,
   numpy,
   packaging,
-  pathy,
   preshed,
   pydantic,
   pytestCheckHook,
@@ -29,7 +27,6 @@
   thinc,
   tqdm,
   typer,
-  typing-extensions,
   wasabi,
   weasel,
   writeScript,
@@ -40,14 +37,14 @@
 
 buildPythonPackage rec {
   pname = "spacy";
-  version = "3.7.5";
+  version = "3.7.6";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-pkjGy/Ksx6Vaae6ef6TyK99pqoKKWHobxc//CM88LdM=";
+    hash = "sha256-9AZcCqxcSLv7L/4ZHVXMszv7AFN2r71MzW1ek0FRTjQ=";
   };
 
   postPatch = ''
@@ -57,26 +54,22 @@ buildPythonPackage rec {
       --replace-fail "thinc>=8.2.2,<8.3.0" "thinc>=8.2.2,<8.4.0"
   '';
 
-  pythonRelaxDeps = [
-    "smart-open"
-    "typer"
-  ];
-
-  nativeBuildInputs = [
+  build-system = [
+    cymem
     cython_0
+    murmurhash
+    numpy
+    thinc
   ];
 
-  propagatedBuildInputs = [
-    blis
+  dependencies = [
     catalogue
     cymem
     jinja2
-    jsonschema
     langcodes
     murmurhash
     numpy
     packaging
-    pathy
     preshed
     pydantic
     requests
@@ -89,15 +82,13 @@ buildPythonPackage rec {
     typer
     wasabi
     weasel
-  ] ++ lib.optionals (pythonOlder "3.8") [ typing-extensions ];
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook
     hypothesis
     mock
   ];
-
-  doCheck = true;
 
   # Fixes ModuleNotFoundError when running tests on Cythonized code. See #255262
   preCheck = ''
@@ -139,7 +130,7 @@ buildPythonPackage rec {
     description = "Industrial-strength Natural Language Processing (NLP)";
     mainProgram = "spacy";
     homepage = "https://github.com/explosion/spaCy";
-    changelog = "https://github.com/explosion/spaCy/releases/tag/v${version}";
+    changelog = "https://github.com/explosion/spaCy/releases/tag/release-v${version}";
     license = licenses.mit;
     maintainers = [ ];
   };


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/explosion/cython-blis/compare/v0.7.11...release-v1.0.0

Changelog: https://github.com/explosion/cython-blis/releases/tag/release-v1.0.0

Version 1.0 depends on numpy 2.0. C.f. https://github.com/NixOS/nixpkgs/pull/327437.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
