### PR TITLE
canaille: init at 0.0.56, add module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1316,6 +1316,7 @@
   ./services/security/aesmd.nix
   ./services/security/authelia.nix
   ./services/security/bitwarden-directory-connector-cli.nix
+  ./services/security/canaille.nix
   ./services/security/certmgr.nix
   ./services/security/cfssl.nix
   ./services/security/clamav.nix

--- a/nixos/modules/services/security/canaille.nix
+++ b/nixos/modules/services/security/canaille.nix
@@ -1,0 +1,390 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.canaille;
+
+  inherit (lib)
+    mkOption
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    types
+    getExe
+    optional
+    converge
+    filterAttrsRecursive
+    ;
+
+  dataDir = "/var/lib/canaille";
+  secretsDir = "${dataDir}/secrets";
+
+  settingsFormat = pkgs.formats.toml { };
+
+  # Remove null values, so we can document optional/forbidden values that don't end up in the generated TOML file.
+  filterConfig = converge (filterAttrsRecursive (_: v: v != null));
+
+  finalPackage = cfg.package.overridePythonAttrs (old: {
+    dependencies =
+      old.dependencies
+      ++ old.optional-dependencies.front
+      ++ old.optional-dependencies.oidc
+      ++ old.optional-dependencies.ldap
+      ++ old.optional-dependencies.sentry
+      ++ old.optional-dependencies.postgresql;
+    makeWrapperArgs = (old.makeWrapperArgs or [ ]) ++ [
+      "--set CONFIG /etc/canaille/config.toml"
+      "--set SECRETS_DIR \"${secretsDir}\""
+    ];
+  });
+  inherit (finalPackage) python;
+  pythonEnv = python.buildEnv.override {
+    extraLibs = with python.pkgs; [
+      (toPythonModule finalPackage)
+      celery
+    ];
+  };
+
+  commonServiceConfig = {
+    WorkingDirectory = dataDir;
+    User = "canaille";
+    Group = "canaille";
+    StateDirectory = "canaille";
+    StateDirectoryMode = "0750";
+    PrivateTmp = true;
+  };
+
+  postgresqlHost = "postgresql://localhost/canaille?host=/run/postgresql";
+  createLocalPostgresqlDb = cfg.settings.CANAILLE_SQL.DATABASE_URI == postgresqlHost;
+in
+{
+
+  options.services.canaille = {
+    enable = mkEnableOption "Canaille";
+    package = mkPackageOption pkgs "canaille" { };
+    secretKeyFile = mkOption {
+      description = ''
+        File containing the Flask secret key. Its content is going to be
+        provided to Canaille as `SECRET_KEY`. Make sure it has appropriate
+        permissions. For example, copy the output of this to the specified
+        file:
+
+        ```
+        python3 -c 'import secrets; print(secrets.token_hex())'
+        ```
+      '';
+      type = types.path;
+    };
+    smtpPasswordFile = mkOption {
+      description = ''
+        File containing the SMTP password. Make sure it has appropriate permissions.
+      '';
+      default = null;
+      type = types.nullOr types.path;
+    };
+    jwtPrivateKeyFile = mkOption {
+      description = ''
+        File containing the JWT private key. Make sure it has appropriate permissions.
+
+        You can generate one using
+        ```
+        openssl genrsa -out private.pem 4096
+        openssl rsa -in private.pem -pubout -outform PEM -out public.pem
+        ```
+      '';
+      default = null;
+      type = types.nullOr types.path;
+    };
+    ldapBindPasswordFile = mkOption {
+      description = ''
+        File containing the LDAP bind password.
+      '';
+      default = null;
+      type = types.nullOr types.path;
+    };
+    settings = mkOption {
+      default = { };
+      description = "Settings for Canaille. See [the documentation](https://canaille.readthedocs.io/en/latest/references/configuration.html) for details.";
+      type = types.submodule {
+        freeformType = settingsFormat.type;
+        options = {
+          SECRET_KEY = mkOption {
+            readOnly = true;
+            description = ''
+              Flask Secret Key. Can't be set and must be provided through
+              `services.canaille.settings.secretKeyFile`.
+            '';
+            default = null;
+            type = types.nullOr types.str;
+          };
+          SERVER_NAME = mkOption {
+            description = "The domain name on which canaille will be served.";
+            example = "auth.example.org";
+            type = types.str;
+          };
+          PREFERRED_URL_SCHEME = mkOption {
+            description = "The url scheme by which canaille will be served.";
+            default = "https";
+            type = types.enum [
+              "http"
+              "https"
+            ];
+          };
+
+          CANAILLE = {
+            ACL = mkOption {
+              default = null;
+              description = ''
+                Access Control Lists.
+
+                See also [the documentation](https://canaille.readthedocs.io/en/latest/references/configuration.html#canaille.core.configuration.ACLSettings).
+              '';
+              type = types.nullOr (
+                types.submodule {
+                  freeformType = settingsFormat.type;
+                  options = { };
+                }
+              );
+            };
+            SMTP = mkOption {
+              default = null;
+              example = { };
+              description = ''
+                SMTP configuration. By default, sending emails is not enabled.
+
+                Set to an empty attrs to send emails from localhost without
+                authentication.
+
+                See also [the documentation](https://canaille.readthedocs.io/en/latest/references/configuration.html#canaille.core.configuration.SMTPSettings).
+              '';
+              type = types.nullOr (
+                types.submodule {
+                  freeformType = settingsFormat.type;
+                  options = {
+                    PASSWORD = mkOption {
+                      readOnly = true;
+                      description = ''
+                        SMTP Password. Can't be set and has to be provided using
+                        `services.canaille.smtpPasswordFile`.
+                      '';
+                      default = null;
+                      type = types.nullOr types.str;
+                    };
+                  };
+                }
+              );
+            };
+
+          };
+          CANAILLE_OIDC = mkOption {
+            default = null;
+            description = ''
+              OpenID Connect settings. See [the documentation](https://canaille.readthedocs.io/en/latest/references/configuration.html#canaille.oidc.configuration.OIDCSettings).
+            '';
+            type = types.nullOr (
+              types.submodule {
+                freeformType = settingsFormat.type;
+                options = {
+                  JWT.PRIVATE_KEY = mkOption {
+                    readOnly = true;
+                    description = ''
+                      JWT private key. Can't be set and has to be provided using
+                      `services.canaille.jwtPrivateKeyFile`.
+                    '';
+                    default = null;
+                    type = types.nullOr types.str;
+                  };
+                };
+              }
+            );
+          };
+          CANAILLE_LDAP = mkOption {
+            default = null;
+            description = ''
+              Configuration for the LDAP backend. This storage backend is not
+              yet supported by the module, so use at your own risk!
+            '';
+            type = types.nullOr (
+              types.submodule {
+                freeformType = settingsFormat.type;
+                options = {
+                  BIND_PW = mkOption {
+                    readOnly = true;
+                    description = ''
+                      The LDAP bind password. Can't be set and has to be provided using
+                      `services.canaille.ldapBindPasswordFile`.
+                    '';
+                    default = null;
+                    type = types.nullOr types.str;
+                  };
+                };
+              }
+            );
+          };
+          CANAILLE_SQL = {
+            DATABASE_URI = mkOption {
+              description = ''
+                The SQL server URI. Will configure a local PostgreSQL db if
+                left to default. Please note that the NixOS module only really
+                supports PostgreSQL for now. Change at your own risk!
+              '';
+              default = postgresqlHost;
+              type = types.str;
+            };
+          };
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # We can use some kind of fix point for the config anyways, and
+    # /etc/canaille is recommended by upstream. The alternative would be to use
+    # a double wrapped canaille executable, to avoid having to rebuild Canaille
+    # on every config change.
+    environment.etc."canaille/config.toml" = {
+      source = settingsFormat.generate "config.toml" (filterConfig cfg.settings);
+      user = "canaille";
+      group = "canaille";
+    };
+
+    # Secrets management is unfortunately done in a semi stateful way, due to these constraints:
+    # - Canaille uses Pydantic, which currently only accepts an env file or a single
+    #   directory (SECRETS_DIR) for loading settings from files.
+    # - The canaille user needs access to secrets, as it needs to run the CLI
+    #   for e.g. user creation. Therefore specifying the SECRETS_DIR as systemd's
+    #   CREDENTIALS_DIRECTORY is not an option.
+    #
+    # See this for how Pydantic maps file names/env vars to config settings:
+    # https://docs.pydantic.dev/latest/concepts/pydantic_settings/#parsing-environment-variable-values
+    systemd.tmpfiles.rules =
+      [
+        "Z  ${secretsDir} 700 canaille canaille - -"
+        "L+ ${secretsDir}/SECRET_KEY - - - - ${cfg.secretKeyFile}"
+      ]
+      ++ optional (
+        cfg.smtpPasswordFile != null
+      ) "L+ ${secretsDir}/CANAILLE_SMTP__PASSWORD - - - - ${cfg.smtpPasswordFile}"
+      ++ optional (
+        cfg.jwtPrivateKeyFile != null
+      ) "L+ ${secretsDir}/CANAILLE_OIDC__JWT__PRIVATE_KEY - - - - ${cfg.jwtPrivateKeyFile}"
+      ++ optional (
+        cfg.ldapBindPasswordFile != null
+      ) "L+ ${secretsDir}/CANAILLE_LDAP__BIND_PW - - - - ${cfg.ldapBindPasswordFile}";
+
+    # This is not a migration, just an initial setup of schemas
+    systemd.services.canaille-install = {
+      # We want this on boot, not on socket activation
+      wantedBy = [ "multi-user.target" ];
+      after = optional createLocalPostgresqlDb "postgresql.service";
+      serviceConfig = commonServiceConfig // {
+        Type = "oneshot";
+        ExecStart = "${getExe finalPackage} install";
+      };
+    };
+
+    systemd.services.canaille = {
+      description = "Canaille";
+      documentation = [ "https://canaille.readthedocs.io/en/latest/tutorial/deployment.html" ];
+      after = [
+        "network.target"
+        "canaille-install.service"
+      ] ++ optional createLocalPostgresqlDb "postgresql.service";
+      requires = [
+        "canaille-install.service"
+        "canaille.socket"
+      ];
+      environment = {
+        PYTHONPATH = "${pythonEnv}/${python.sitePackages}/";
+        CONFIG = "/etc/canaille/config.toml";
+        SECRETS_DIR = secretsDir;
+      };
+      serviceConfig = commonServiceConfig // {
+        Restart = "on-failure";
+        ExecStart =
+          let
+            gunicorn = python.pkgs.gunicorn.overridePythonAttrs (old: {
+              # Allows Gunicorn to set a meaningful process name
+              dependencies = (old.dependencies or [ ]) ++ old.optional-dependencies.setproctitle;
+            });
+          in
+          ''
+            ${getExe gunicorn} \
+              --name=canaille \
+              --bind='unix:///run/canaille.socket' \
+              'canaille:create_app()'
+          '';
+      };
+      restartTriggers = [ "/etc/canaille/config.toml" ];
+    };
+
+    systemd.sockets.canaille = {
+      before = [ "nginx.service" ];
+      wantedBy = [ "sockets.target" ];
+      socketConfig = {
+        ListenStream = "/run/canaille.socket";
+        SocketUser = "canaille";
+        SocketGroup = "canaille";
+        SocketMode = "770";
+      };
+    };
+
+    services.nginx.enable = true;
+    services.nginx.recommendedGzipSettings = true;
+    services.nginx.recommendedProxySettings = true;
+    services.nginx.virtualHosts."${cfg.settings.SERVER_NAME}" = {
+      forceSSL = true;
+      enableACME = true;
+      # Config from https://canaille.readthedocs.io/en/latest/tutorial/deployment.html#nginx
+      extraConfig = ''
+        charset utf-8;
+        client_max_body_size 10M;
+
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        add_header X-Frame-Options                      "SAMEORIGIN"    always;
+        add_header X-XSS-Protection                     "1; mode=block" always;
+        add_header X-Content-Type-Options               "nosniff"       always;
+        add_header Referrer-Policy                      "same-origin"   always;
+      '';
+      locations = {
+        "/".proxyPass = "http://unix:///run/canaille.socket";
+        "/static" = {
+          root = "${finalPackage}/${python.sitePackages}/canaille";
+        };
+        "~* ^/static/.+\\.(?:css|cur|js|jpe?g|gif|htc|ico|png|html|xml|otf|ttf|eot|woff|woff2|svg)$" = {
+          root = "${finalPackage}/${python.sitePackages}/canaille";
+          extraConfig = ''
+            access_log off;
+            expires 30d;
+            more_set_headers Cache-Control public;
+          '';
+        };
+      };
+    };
+
+    services.postgresql = mkIf createLocalPostgresqlDb {
+      enable = true;
+      ensureUsers = [
+        {
+          name = "canaille";
+          ensureDBOwnership = true;
+        }
+      ];
+      ensureDatabases = [ "canaille" ];
+    };
+
+    users.users.canaille = {
+      isSystemUser = true;
+      group = "canaille";
+      packages = [ finalPackage ];
+    };
+
+    users.groups.canaille.members = [ config.services.nginx.user ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ erictapen ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -184,6 +184,7 @@ in {
   cagebreak = handleTest ./cagebreak.nix {};
   calibre-web = handleTest ./calibre-web.nix {};
   calibre-server = handleTest ./calibre-server.nix {};
+  canaille = handleTest ./canaille.nix {};
   castopod = handleTest ./castopod.nix {};
   cassandra_3_0 = handleTest ./cassandra.nix { testPackage = pkgs.cassandra_3_0; };
   cassandra_3_11 = handleTest ./cassandra.nix { testPackage = pkgs.cassandra_3_11; };

--- a/nixos/tests/canaille.nix
+++ b/nixos/tests/canaille.nix
@@ -1,0 +1,62 @@
+import ./make-test-python.nix (
+  { pkgs, ... }:
+  let
+    certs = import ./common/acme/server/snakeoil-certs.nix;
+    inherit (certs) domain;
+  in
+  {
+    name = "canaille";
+    meta.maintainers = with pkgs.lib.maintainers; [ erictapen ];
+
+    nodes.server =
+      { pkgs, lib, ... }:
+      {
+        services.canaille = {
+          enable = true;
+          secretKeyFile = pkgs.writeText "canaille-secret-key" ''
+            this is not a secret key
+          '';
+          settings = {
+            SERVER_NAME = domain;
+          };
+        };
+
+        services.nginx.virtualHosts."${domain}" = {
+          enableACME = lib.mkForce false;
+          sslCertificate = certs."${domain}".cert;
+          sslCertificateKey = certs."${domain}".key;
+        };
+
+        networking.hosts."::1" = [ "${domain}" ];
+        networking.firewall.allowedTCPPorts = [
+          80
+          443
+        ];
+
+        users.users.canaille.shell = pkgs.bashInteractive;
+
+        security.pki.certificateFiles = [ certs.ca.cert ];
+      };
+
+    nodes.client =
+      { nodes, ... }:
+      {
+        networking.hosts."${nodes.server.networking.primaryIPAddress}" = [ "${domain}" ];
+        security.pki.certificateFiles = [ certs.ca.cert ];
+      };
+
+    testScript =
+      { ... }:
+      ''
+        import json
+
+        start_all()
+        server.wait_for_unit("canaille.socket")
+        server.wait_until_succeeds("curl -f https://${domain}")
+        server.succeed("sudo -iu canaille -- canaille create user --user-name admin --password adminpass --emails admin@${domain}")
+        json_str = server.succeed("sudo -iu canaille -- canaille get user")
+        assert json.loads(json_str)[0]["user_name"] == "admin"
+        server.succeed("sudo -iu canaille -- canaille check")
+      '';
+  }
+)

--- a/pkgs/by-name/ca/canaille/package.nix
+++ b/pkgs/by-name/ca/canaille/package.nix
@@ -1,0 +1,118 @@
+{
+  lib,
+  python3,
+  fetchFromGitLab,
+  openldap,
+  nixosTests,
+}:
+
+let
+  python = python3;
+in
+python.pkgs.buildPythonApplication rec {
+  pname = "canaille";
+  version = "0.0.56";
+  pyproject = true;
+
+  disabled = python.pythonOlder "3.10";
+
+  src = fetchFromGitLab {
+    owner = "yaal";
+    repo = "canaille";
+    rev = "refs/tags/${version}";
+    hash = "sha256-cLsLwttUDxMKVqtVDCY5A22m1YY1UezeZQh1j74WzgU=";
+  };
+
+  build-system = with python.pkgs; [
+    hatchling
+    babel
+    setuptools
+  ];
+
+  dependencies =
+    with python.pkgs;
+    [
+      flask
+      flask-wtf
+      pydantic-settings
+      wtforms
+    ]
+    ++ sentry-sdk.optional-dependencies.flask;
+
+  nativeCheckInputs =
+    with python.pkgs;
+    [
+      pytestCheckHook
+      coverage
+      flask-webtest
+      pyquery
+      pytest-cov
+      pytest-httpserver
+      pytest-lazy-fixtures
+      pytest-smtpd
+      pytest-xdist
+      slapd
+      toml
+      faker
+      time-machine
+    ]
+    ++ optional-dependencies.front
+    ++ optional-dependencies.oidc
+    ++ optional-dependencies.ldap
+    ++ optional-dependencies.postgresql;
+
+  postInstall = ''
+    mkdir -p $out/etc/schema
+    cp $out/${python.sitePackages}/canaille/backends/ldap/schemas/* $out/etc/schema/
+  '';
+
+  preCheck = ''
+    # Needed by tests to setup a mockup ldap server.
+    export BIN="${openldap}/bin"
+    export SBIN="${openldap}/bin"
+    export SLAPD="${openldap}/libexec/slapd"
+    export SCHEMA="${openldap}/etc/schema"
+
+    # Just use their example config for testing
+    export CONFIG=canaille/config.sample.toml
+  '';
+
+  optional-dependencies = with python.pkgs; {
+    front = [
+      email-validator
+      flask-babel
+      flask-themer
+      pycountry
+      pytz
+      toml
+      zxcvbn-rs-py
+    ];
+    oidc = [ authlib ];
+    ldap = [ python-ldap ];
+    sentry = [ sentry-sdk ];
+    postgresql = [
+      passlib
+      sqlalchemy
+      sqlalchemy-json
+      sqlalchemy-utils
+    ] ++ sqlalchemy.optional-dependencies.postgresql;
+  };
+
+  passthru = {
+    inherit python;
+    tests = {
+      inherit (nixosTests) canaille;
+    };
+  };
+
+  meta = with lib; {
+    description = "Lightweight Identity and Authorization Management";
+    homepage = "https://canaille.readthedocs.io/en/latest/index.html";
+    changelog = "https://gitlab.com/yaal/canaille/-/blob/${src.rev}/CHANGES.rst";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ erictapen ];
+    mainProgram = "canaille";
+  };
+
+}

--- a/pkgs/development/python-modules/flask-themer/default.nix
+++ b/pkgs/development/python-modules/flask-themer/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  flask,
+  pytestCheckHook,
+  pytest-cov-stub,
+}:
+
+buildPythonPackage rec {
+  pname = "flask-themer";
+  version = "2.0.0";
+  pyproject = true;
+
+  # Pypi tarball doesn't contain tests/
+  src = fetchFromGitHub {
+    owner = "TkTech";
+    repo = "flask-themer";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-2Zw+gKKN0kfjYuruuLQ+3dIFF0X07DTy0Ypc22Ih66w=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ flask ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
+
+  pythonImportsCheck = [ "flask_themer" ];
+
+  meta = with lib; {
+    description = "Simple theming support for Flask apps";
+    homepage = "https://github.com/TkTech/flask-themer";
+    changelog = "https://github.com/TkTech/flask-themer/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ erictapen ];
+  };
+}

--- a/pkgs/development/python-modules/flask-webtest/default.nix
+++ b/pkgs/development/python-modules/flask-webtest/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  flask,
+  webtest,
+  blinker,
+  flask-sqlalchemy,
+  greenlet,
+}:
+
+buildPythonPackage rec {
+  pname = "flask-webtest";
+  version = "0.1.4";
+  pyproject = true;
+
+  # Pypi tarball doesn't include version.py
+  src = fetchFromGitHub {
+    owner = "level12";
+    repo = "flask-webtest";
+    rev = "refs/tags/${version}";
+    hash = "sha256-4USNT6HYh49v+euCePYkL1gR6Ul8C0+/xanuYGxKpfM=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    flask
+    webtest
+    blinker
+  ];
+
+  nativeCheckInputs = [
+    flask-sqlalchemy
+    greenlet
+  ];
+
+  pythonImportsCheck = [ "flask_webtest" ];
+
+  meta = with lib; {
+    description = "Utilities for testing Flask applications with WebTest";
+    homepage = "https://github.com/level12/flask-webtest";
+    changelog = "https://github.com/level12/flask-webtest/blob/${src.rev}/changelog.rst";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ erictapen ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-smtpd/default.nix
+++ b/pkgs/development/python-modules/pytest-smtpd/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  hatchling,
+  pytest,
+  smtpdfix,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-smtpd";
+  version = "0.1.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  # Pypi tarball doesn't include tests/
+  src = fetchFromGitHub {
+    owner = "bebleo";
+    repo = "pytest-smtpd";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-Vu2D2hfxBYxgXQ4Gjr+jFpac9fjpLL2FftBhnqrcQaA=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    smtpdfix
+  ];
+
+  buildInputs = [ pytest ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pytest_smtpd" ];
+
+  meta = with lib; {
+    description = "Pytest fixture that creates an SMTP server";
+    homepage = "https://github.com/bebleo/pytest-smtpd";
+    license = licenses.mit;
+    maintainers = with maintainers; [ erictapen ];
+  };
+}

--- a/pkgs/development/python-modules/slapd/default.nix
+++ b/pkgs/development/python-modules/slapd/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  poetry-core,
+  openldap,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "slapd";
+  version = "0.1.5";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  # Pypi tarball doesn't include tests/
+  src = fetchFromGitHub {
+    owner = "python-ldap";
+    repo = "python-slapd";
+    rev = "refs/tags/${version}";
+    hash = "sha256-AiJvhgJ62vCj75m6l5kuIEb7k2qCh/QJybS0uqw2vBY=";
+  };
+
+  build-system = [ poetry-core ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  preCheck = ''
+    # Needed by tests to setup a mockup ldap server
+    export BIN="${openldap}/bin"
+    export SBIN="${openldap}/bin"
+    export SLAPD="${openldap}/libexec/slapd"
+    export SCHEMA="${openldap}/etc/schema"
+  '';
+
+  pythonImportsCheck = [ "slapd" ];
+
+  meta = with lib; {
+    description = "Controls a slapd process in a pythonic way";
+    homepage = "https://github.com/python-ldap/python-slapd";
+    changelog = "https://github.com/python-ldap/python-slapd/blob/${src.rev}/CHANGES.rst";
+    license = licenses.mit;
+    maintainers = with maintainers; [ erictapen ];
+  };
+
+}

--- a/pkgs/development/python-modules/sqlalchemy-json/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy-json/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  pythonOlder,
+  sqlalchemy,
+}:
+
+let
+  version = "0.7.0";
+in
+buildPythonPackage {
+  pname = "sqlalchemy-json";
+  inherit version;
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "edelooff";
+    repo = "sqlalchemy-json";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-Is3DznojvpWYFSDutzCxRLceQMIiS3ZIg0c//MIOF+s=";
+  };
+
+  propagatedBuildInputs = [ sqlalchemy ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "Full-featured JSON type with mutation tracking for SQLAlchemy";
+    homepage = "https://github.com/edelooff/sqlalchemy-json";
+    changelog = "https://github.com/edelooff/sqlalchemy-json/tree/v${version}#changelog";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ augustebaum ];
+  };
+}

--- a/pkgs/development/python-modules/zxcvbn-rs-py/default.nix
+++ b/pkgs/development/python-modules/zxcvbn-rs-py/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  pythonAtLeast,
+  fetchPypi,
+  rustPlatform,
+}:
+
+buildPythonPackage rec {
+  pname = "zxcvbn-rs-py";
+  version = "0.1.1";
+
+  pyproject = true;
+
+  disabled = pythonOlder "3.9" || pythonAtLeast "3.13";
+
+  src = fetchPypi {
+    pname = "zxcvbn_rs_py";
+    inherit version;
+    hash = "sha256-7EZJ/WGekfsnisqTs9dwwbQia6OlDEx3MR9mkqSI+gA=";
+  };
+
+  build-system = [
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    name = "${pname}-${version}";
+    inherit src;
+    hash = "sha256-OA6iyojBMAG9GtjHaIQ9cM0SEMwMa2bKFRIXmqp4OBE=";
+  };
+
+  pythonImportsCheck = [ "zxcvbn_rs_py" ];
+
+  meta = with lib; {
+    description = "Python bindings for zxcvbn-rs, the Rust implementation of zxcvbn";
+    homepage = "https://github.com/fief-dev/zxcvbn-rs-py/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ erictapen ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12792,6 +12792,8 @@ self: super: with self; {
 
   pytest-shutil = callPackage ../development/python-modules/pytest-shutil { };
 
+  pytest-smtpd = callPackage ../development/python-modules/pytest-smtpd { };
+
   pytest-spec = callPackage ../development/python-modules/pytest-spec { };
 
   python-status = callPackage ../development/python-modules/python-status { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18301,6 +18301,8 @@ self: super: with self; {
 
   zxcvbn = callPackage ../development/python-modules/zxcvbn { };
 
+  zxcvbn-rs-py = callPackage ../development/python-modules/zxcvbn-rs-py { };
+
   zxing-cpp = callPackage ../development/python-modules/zxing-cpp {
     libzxing-cpp = pkgs.zxing-cpp;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14681,6 +14681,8 @@ self: super: with self; {
 
   slack-sdk = callPackage ../development/python-modules/slack-sdk { };
 
+  slapd = callPackage ../development/python-modules/slapd { };
+
   sleekxmpp = callPackage ../development/python-modules/sleekxmpp { };
 
   sleekxmppfs = callPackage ../development/python-modules/sleekxmppfs { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15152,6 +15152,8 @@ self: super: with self; {
 
   sqlalchemy-i18n = callPackage ../development/python-modules/sqlalchemy-i18n { };
 
+  sqlalchemy-json = callPackage ../development/python-modules/sqlalchemy-json { };
+
   sqlalchemy-jsonfield = callPackage ../development/python-modules/sqlalchemy-jsonfield { };
 
   sqlalchemy-mixins = callPackage ../development/python-modules/sqlalchemy-mixins { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4700,6 +4700,8 @@ self: super: with self; {
 
   flask-testing = callPackage ../development/python-modules/flask-testing { };
 
+  flask-themer = callPackage ../development/python-modules/flask-themer { };
+
   flask-themes2 = callPackage ../development/python-modules/flask-themes2 { };
 
   flask-versioned = callPackage ../development/python-modules/flask-versioned { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4704,6 +4704,8 @@ self: super: with self; {
 
   flask-versioned = callPackage ../development/python-modules/flask-versioned { };
 
+  flask-webtest = callPackage ../development/python-modules/flask-webtest { };
+
   flask-wtf = callPackage ../development/python-modules/flask-wtf { };
 
   flatbuffers = callPackage ../development/python-modules/flatbuffers {


### PR DESCRIPTION
## Description of changes

The module is already usable and can be deployed as can be seen here: https://canaille.erictapen.name

~~Most of the options are missing currently, and it would be nice to have a working deployment check in the NixOS test.~~

Addresses:
- https://github.com/ngi-nix/projects/issues/2121
- https://gitlab.com/yaal/canaille/-/issues/190

~~I'll plan to get this into reviewable shape beginning next week.~~ :heavy_check_mark: 

Pinging people involved so far: @azmeuk @Janik-Haag @fricklerhandwerk (@soupglasses because I used parts of your package definition and you seem to be involved)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
