### PR TITLE
nixos/kubernetes: ipv6 support

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/kubelet.nix
+++ b/nixos/modules/services/cluster/kubernetes/kubelet.nix
@@ -61,11 +61,13 @@ let
     containerRuntimeEndpoint = cfg.containerRuntimeEndpoint;
     healthzPort = cfg.healthz.port;
     healthzBindAddress = cfg.healthz.bind;
+    failSwapOn = cfg.failSwapOn;
   } // lib.optionalAttrs (cfg.tlsCertFile != null)  { tlsCertFile = cfg.tlsCertFile; }
     // lib.optionalAttrs (cfg.tlsKeyFile != null)   { tlsPrivateKeyFile = cfg.tlsKeyFile; }
     // lib.optionalAttrs (cfg.clusterDomain != "")  { clusterDomain = cfg.clusterDomain; }
-    // lib.optionalAttrs (cfg.clusterDns != "")     { clusterDNS = [ cfg.clusterDns ] ; }
+    // lib.optionalAttrs (cfg.clusterDns != "")     { clusterDNS = [ cfg.clusterDns ]; }
     // lib.optionalAttrs (cfg.featureGates != [])   { featureGates = cfg.featureGates; }
+    // cfg.extraConfig
   ));
 
   manifestPath = "kubernetes/manifests";
@@ -178,6 +180,12 @@ in
 
     enable = mkEnableOption "Kubernetes kubelet";
 
+    extraConfig = mkOption {
+      description = "Kubernetes kubelet extra config file options.";
+      default = {};
+      type = attrs;
+    };
+
     extraOpts = mkOption {
       description = "Kubernetes kubelet extra command line options.";
       default = "";
@@ -223,6 +231,13 @@ in
       description = "IP address of the node. If set, kubelet will use this IP address for the node.";
       default = null;
       type = nullOr str;
+    };
+
+    failSwapOn = mkOption {
+      description = "Needed to be false if you use swap";
+      default = true;
+      type = bool;
+      example = false;
     };
 
     registerNode = mkOption {
@@ -334,7 +349,6 @@ in
             --kubeconfig=${kubeconfig} \
             ${optionalString (cfg.nodeIp != null)
               "--node-ip=${cfg.nodeIp}"} \
-            --pod-infra-container-image=pause \
             ${optionalString (cfg.manifests != {})
               "--pod-manifest-path=/etc/${manifestPath}"} \
             ${optionalString (taints != "")

--- a/nixos/modules/services/networking/flannel.nix
+++ b/nixos/modules/services/networking/flannel.nix
@@ -6,10 +6,15 @@ let
   cfg = config.services.flannel;
 
   networkConfig = filterAttrs (n: v: v != null) {
+    EnableIPv6 = cfg.ipv6Network != null;
     Network = cfg.network;
+    IPv6Network = cfg.ipv6Network;
     SubnetLen = cfg.subnetLen;
     SubnetMin = cfg.subnetMin;
     SubnetMax = cfg.subnetMax;
+    Ipv6SubnetLen = cfg.ipv6SubnetLen;
+    Ipv6SubnetMin = cfg.ipv6SubnetMin;
+    Ipv6SubnetMax = cfg.ipv6SubnetMax;
     Backend = cfg.backend;
   };
 in {
@@ -82,6 +87,11 @@ in {
       type = types.str;
     };
 
+    ipv6Network = mkOption {
+      description = " IPv6 network in CIDR format to use for the entire flannel network.";
+      type = types.nullOr types.str;
+    };
+
     nodeName = mkOption {
       description = ''
         Needed when running with Kubernetes as backend as this cannot be auto-detected";
@@ -121,6 +131,34 @@ in {
       description = ''
         The end of IP range which the subnet allocation should start with.
         Defaults to the last subnet of Network.
+      '';
+      type = types.nullOr types.str;
+      default = null;
+    };
+
+    ipv6SubnetLen = mkOption {
+      description = ''
+        The size of the ipv6 subnet allocated to each host. Defaults to 64 (i.e. /64)
+        unless Ipv6Network was configured to be smaller than a /62 in which case
+        it is two less than the network.
+      '';
+      type = types.int;
+      default = 24;
+    };
+
+    ipv6SubnetMin = mkOption {
+      description = ''
+        The beginning of IPv6 range which the subnet allocation should start with.
+        Defaults to the second subnet of Ipv6Network.
+      '';
+      type = types.nullOr types.str;
+      default = null;
+    };
+
+    ipv6SubnetMax = mkOption {
+      description = ''
+        The end of the IPv6 range at which the subnet allocation should end with.
+        Defaults to the last subnet of Ipv6Network.
       '';
       type = types.nullOr types.str;
       default = null;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

1. Some of the arg options in kubelet will be deprecated and should be merged into the config file.
2. Flannel service should be modified to support IPv6.

## Things done

1. Add `failSwapOn`, `extraConfig` options in `services.kubernetes.kubelet`.
2. Patch flannel service to support IPv6 via something like `services.kubernetes.clusterCidr = "10.42.0.0/16,2001:cafe:42::/56";`.
3. Tested on my homelab.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
