### PR TITLE
testers.runCommand: init

### DIFF
--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -339,6 +339,39 @@ once to get a derivation hash, and again to produce the final fixed output deriv
 
 :::
 
+## `runCommand` {#tester-runCommand}
+
+This is a wrapper around `pkgs.runCommandWith`, which
+- produces a fixed-output derivation, enabling the command(s) to access the network ;
+- salts the derivation's name based on its inputs, ensuring the command is re-run whenever the inputs changes.
+
+It accepts the following attributes:
+- the derivation's `name` ;
+- the `script` to be executed ;
+- `stdenv`, the environment to use, defaulting to `stdenvNoCC` ;
+- the derivation's output `hash`, defaulting to the empty file's.
+  The derivation's `outputHashMode` is set by default to recursive, so the `script` can output a directory as well.
+
+All other attributes are passed through to [`mkDerivation`](#sec-using-stdenv),
+including `nativeBuildInputs` to specify dependencies available to the `script`.
+
+:::{.example #ex-tester-runCommand-nix}
+
+# Run a command with network access
+
+```nix
+testers.runCommand {
+  name = "access-the-internet";
+  command = ''
+    curl -o /dev/null https://example.com
+    touch $out
+  '';
+  nativeBuildInputs = with pkgs; [ cacert curl ];
+}
+```
+
+:::
+
 ## `runNixOSTest` {#tester-runNixOSTest}
 
 A helper function that behaves exactly like the NixOS `runTest`, except it also assigns this Nixpkgs package set as the `pkgs` of the test and makes the `nixpkgs.*` options read-only.

--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -341,6 +341,8 @@ once to get a derivation hash, and again to produce the final fixed output deriv
 
 ## `runCommand` {#tester-runCommand}
 
+`runCommand :: { name, script, stdenv ? stdenvNoCC, hash ? "...", ... } -> Derivation`
+
 This is a wrapper around `pkgs.runCommandWith`, which
 - produces a fixed-output derivation, enabling the command(s) to access the network ;
 - salts the derivation's name based on its inputs, ensuring the command is re-run whenever the inputs changes.

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -1,4 +1,16 @@
-{ pkgs, pkgsLinux, buildPackages, diffoscopeMinimal, lib, callPackage, runCommand, stdenv, substituteAll, testers }:
+{
+  lib,
+  buildPackages,
+  callPackage,
+  pkgs,
+  pkgsLinux,
+
+  diffoscopeMinimal,
+  runCommand,
+  stdenv,
+  substituteAll,
+  testers,
+}:
 # Documentation is in doc/build-helpers/testers.chapter.md
 {
   # See https://nixos.org/manual/nixpkgs/unstable/#tester-lycheeLinkCheck

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -104,7 +104,7 @@
   # See https://nixos.org/manual/nixpkgs/unstable/#tester-runCommand
   runCommand = testers.invalidateFetcherByDrvHash (
     {
-      hash ? "sha256-d6xi4mKdjkX2JFicDIv5niSzpyI0m/Hnm8GGAIU04kY=", # hash value of empty file
+      hash ? pkgs.emptyFile.outputHash,
       name,
       script,
       stdenv ? stdenvNoCC,

--- a/pkgs/build-support/testers/test/default.nix
+++ b/pkgs/build-support/testers/test/default.nix
@@ -18,6 +18,27 @@ lib.recurseIntoAttrs {
 
   shellcheck = pkgs.callPackage ../shellcheck/tests.nix { };
 
+  runCommand = lib.recurseIntoAttrs {
+    dns-resolution = testers.runCommand {
+      name = "runCommand-dns-resolution-test";
+      nativeBuildInputs = [ pkgs.ldns ];
+      script = ''
+        drill example.com
+        touch $out
+      '';
+    };
+
+    nonDefault-hash = testers.runCommand {
+      name = "runCommand-nonDefaultHash-test";
+      script = ''
+        mkdir $out
+        touch $out/empty
+        echo aaaaaaaaaaicjnrkeflncmrlk > $out/keymash
+      '';
+      hash = "sha256-eMy+6bkG+KS75u7Zt4PM3APhtdVd60NxmBRN5GKJrHs=";
+    };
+  };
+
   runNixOSTest-example = pkgs-with-overlay.testers.runNixOSTest ({ lib, ... }: {
     name = "runNixOSTest-test";
     nodes.machine = { pkgs, ... }: {

--- a/pkgs/build-support/testers/test/default.nix
+++ b/pkgs/build-support/testers/test/default.nix
@@ -19,6 +19,8 @@ lib.recurseIntoAttrs {
   shellcheck = pkgs.callPackage ../shellcheck/tests.nix { };
 
   runCommand = lib.recurseIntoAttrs {
+    bork = pkgs.python3Packages.bork.tests.pytest-network;
+
     dns-resolution = testers.runCommand {
       name = "runCommand-dns-resolution-test";
       nativeBuildInputs = [ pkgs.ldns ];

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -887,9 +887,8 @@ rec {
   /* An immutable file in the store with a length of 0 bytes. */
   emptyFile = runCommand "empty-file"
     {
-      outputHashAlgo = "sha256";
+      outputHash = "sha256-d6xi4mKdjkX2JFicDIv5niSzpyI0m/Hnm8GGAIU04kY=";
       outputHashMode = "recursive";
-      outputHash = "0ip26j2h11n1kgkz36rl4akv694yz65hr72q4kv4b3lxcbi65b3p";
       preferLocalBuild = true;
     } "touch $out";
 

--- a/pkgs/development/python-modules/bork/default.nix
+++ b/pkgs/development/python-modules/bork/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildPythonPackage,
+  callPackage,
   fetchFromGitHub,
   pytestCheckHook,
   pythonOlder,
@@ -60,6 +61,8 @@ buildPythonPackage rec {
     # tries to call python -m bork
     "test_repo"
   ];
+
+  passthru.tests = callPackage ./tests.nix { };
 
   meta = with lib; {
     description = "Python build and release management tool";

--- a/pkgs/development/python-modules/bork/tests.nix
+++ b/pkgs/development/python-modules/bork/tests.nix
@@ -1,0 +1,28 @@
+{
+  testers,
+
+  bork,
+  cacert,
+  git,
+  pytest,
+}:
+{
+  # a.k.a. `tests.testers.runCommand.bork`
+  pytest-network = testers.runCommand {
+    name = "bork-pytest-network";
+    nativeBuildInputs = [
+      bork
+      cacert
+      git
+      pytest
+    ];
+    script = ''
+      # Copy the source tree over, and make it writeable
+      cp -r ${bork.src} bork/
+      find -type d -exec chmod 0755 '{}' '+'
+
+      pytest -v -m network bork/
+      touch $out
+    '';
+  };
+}


### PR DESCRIPTION
## Description of changes

- [x] `testers`: add `runCommand` wrapper, for tests requiring network access
- [x] `tests.testers`: add `runCommand` attrset
- [x] `doc`: add `runCommand` to the `testers` chapter
- [x] `python3Packages.bork`: add test using `testers.runCommand`
  a “real world” usecase, and linked as an additional test of `runCommand`


## Rationale

It is not uncommon for package tests to need network access, especially when packaging software whose functionality fundamentaly requires it.

There is currently no obvious and ergonomic way to do it, meaning contributors either do not add tests, or duplicate effort when doing so and risk introducing bugs which are not immediately obvious: for instance, naively adding `outputHash` to the test's derivation will prevent a rebuild when inputs change.

The intent is to provide a correct, easy, and well-documented way of doing so.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Built `tests.testers.runCommand`
- [x] Tested basic functionality
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
