### PR TITLE
mongodb-7_0: init at 7.0.12

### DIFF
--- a/pkgs/servers/nosql/mongodb/7.0.nix
+++ b/pkgs/servers/nosql/mongodb/7.0.nix
@@ -1,0 +1,29 @@
+{
+  stdenv,
+  callPackage,
+  sasl,
+  boost,
+  Security,
+  CoreFoundation,
+  cctools,
+  avxSupport ? stdenv.hostPlatform.avxSupport,
+}:
+
+let
+  buildMongoDB = callPackage ./mongodb.nix {
+    inherit
+      sasl
+      boost
+      Security
+      CoreFoundation
+      cctools
+      stdenv
+      ;
+  };
+in
+buildMongoDB {
+  inherit avxSupport;
+  version = "7.0.12";
+  sha256 = "sha256-kB1Q0dcxB7G/usGs44GTST4766Mb3cCsZRG9Dd+RfRk=";
+  patches = [ ./SConstruct-disable-mongo-tooling-metrics.patch ];
+}

--- a/pkgs/servers/nosql/mongodb/7.0.nix
+++ b/pkgs/servers/nosql/mongodb/7.0.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   stdenv,
   callPackage,
   sasl,
@@ -26,4 +27,5 @@ buildMongoDB {
   version = "7.0.12";
   sha256 = "sha256-kB1Q0dcxB7G/usGs44GTST4766Mb3cCsZRG9Dd+RfRk=";
   patches = [ ./SConstruct-disable-mongo-tooling-metrics.patch ];
+  license = lib.licenses.asl20; # Temporarily switch the license to build on Github
 }

--- a/pkgs/servers/nosql/mongodb/SConstruct-disable-mongo-tooling-metrics.patch
+++ b/pkgs/servers/nosql/mongodb/SConstruct-disable-mongo-tooling-metrics.patch
@@ -1,6 +1,8 @@
---- a/SConstruct	2024-06-19 03:26:19 UTC
-+++ a/SConstruct
-@@ -23,7 +23,6 @@ import SCons.Script
+diff --git a/SConstruct b/SConstruct
+index 92d557b..80ee9e8 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -23,7 +23,6 @@ from pkg_resources import parse_version
 
  import SCons
  import SCons.Script
@@ -8,12 +10,10 @@
  from site_scons.mongo import build_profiles
 
  # This must be first, even before EnsureSConsVersion, if
-@@ -1653,16 +1652,6 @@ env.AddMethod(lambda env, name, **kwargs: add_option(n
- del envDict
- env.AddMethod(lambda env, name, **kwargs: add_option(name, **kwargs), 'AddOption')
+@@ -1649,13 +1648,6 @@ env.AddMethod(lambda env, name, **kwargs: add_option(name, **kwargs), 'AddOption
 
--# The placement of this is intentional. Here we setup an atexit method to store tooling metrics.
--# We should only register this function after env, env_vars and the parser have been properly initialized.
+ # The placement of this is intentional. Here we setup an atexit method to store tooling metrics.
+ # We should only register this function after env, env_vars and the parser have been properly initialized.
 -SConsToolingMetrics.register_metrics(
 -    utc_starttime=datetime.utcnow(),
 -    artifact_dir=env.Dir('$BUILD_DIR').get_abspath(),
@@ -21,19 +21,120 @@
 -    env=env,
 -    parser=_parser,
 -)
--
+
  if get_option('build-metrics'):
      env['BUILD_METRICS_ARTIFACTS_DIR'] = '$BUILD_ROOT/$VARIANT_DIR'
-     env.Tool('build_metrics')
-@@ -1799,9 +1788,9 @@ if has_option('variables-help'):
-     print(env_vars.GenerateHelpText(env))
-     Exit(0)
+@@ -3026,7 +3018,6 @@ if env.TargetOSIs('posix'):
+     env.Append(
+         CCFLAGS=[
+             "-fasynchronous-unwind-tables",
+-            "-g2" if not env.TargetOSIs('emscripten') else "-g",
+             "-Wall",
+             "-Wsign-compare",
+             "-Wno-unknown-pragmas",
+@@ -3143,7 +3136,7 @@ if env.TargetOSIs('posix'):
+         ], )
 
--unknown_vars = env_vars.UnknownVariables()
--if unknown_vars:
--    env.FatalError("Unknown variables specified: {0}", ", ".join(list(unknown_vars.keys())))
-+#unknown_vars = env_vars.UnknownVariables()
-+#if unknown_vars:
-+#    env.FatalError("Unknown variables specified: {0}", ", ".join(list(unknown_vars.keys())))
+     #make scons colorgcc friendly
+-    for key in ('HOME', 'TERM'):
++    for key in ('HOME', 'TERM', 'PATH'):
+         try:
+             env['ENV'][key] = os.environ[key]
+         except KeyError:
+@@ -3543,33 +3536,6 @@ def doConfigure(myenv):
+         myenv.AddMethod(
+             functools.partial(var_func, var=var, func=CheckFlag), f"Check{var}Supported")
 
- install_actions.setup(env, get_option('install-action'))
+-    if myenv.ToolchainIs('gcc', 'clang'):
+-        # This tells clang/gcc to use the gold linker if it is available - we prefer the gold linker
+-        # because it is much faster. Don't use it if the user has already configured another linker
+-        # selection manually.
+-        if any(flag.startswith('-fuse-ld=') for flag in env['LINKFLAGS']):
+-            myenv.FatalError(
+-                f"Use the '--linker' option instead of modifying the LINKFLAGS directly.")
+-
+-        linker_ld = get_option('linker')
+-        if linker_ld == 'auto':
+-            if not env.TargetOSIs('darwin', 'macOS'):
+-                if not myenv.AddToLINKFLAGSIfSupported('-fuse-ld=lld'):
+-                    myenv.FatalError(
+-                        f"The recommended linker 'lld' is not supported with the current compiler configuration, you can try the 'gold' linker with '--linker=gold'."
+-                    )
+-        elif link_model.startswith("dynamic") and linker_ld == 'bfd':
+-            # BFD is not supported due to issues with it causing warnings from some of
+-            # the third party libraries that mongodb is linked with:
+-            # https://jira.mongodb.org/browse/SERVER-49465
+-            myenv.FatalError(f"Linker {linker_ld} is not supported with dynamic link model builds.")
+-        else:
+-            if not myenv.AddToLINKFLAGSIfSupported(f'-fuse-ld={linker_ld}'):
+-                myenv.FatalError(f"Linker {linker_ld} could not be configured.")
+-
+-        if has_option('gcov') and myenv.AddToCCFLAGSIfSupported('-fprofile-update=single'):
+-            myenv.AppendUnique(LINKFLAGS=['-fprofile-update=single'])
+-
+     detectCompiler = Configure(
+         myenv,
+         help=False,
+@@ -4621,43 +4587,6 @@ def doConfigure(myenv):
+     if optBuild == "off" and myenv.ToolchainIs('clang') and env.TargetOSIs('darwin'):
+         myenv.AddToLINKFLAGSIfSupported("-Wl,-no_deduplicate")
+
+-    # Apply any link time optimization settings as selected by the 'lto' option.
+-    if has_option('lto'):
+-        if myenv.ToolchainIs('msvc'):
+-            # Note that this is actually more aggressive than LTO, it is whole program
+-            # optimization due to /GL. However, this is historically what we have done for
+-            # windows, so we are keeping it.
+-            #
+-            # /GL implies /LTCG, so no need to say it in CCFLAGS, but we do need /LTCG on the
+-            # link flags.
+-            myenv.Append(CCFLAGS=['/GL'])
+-            myenv.Append(LINKFLAGS=['/LTCG'])
+-            myenv.Append(ARFLAGS=['/LTCG'])
+-        elif myenv.ToolchainIs('gcc', 'clang'):
+-            # For GCC and clang, the flag is -flto, and we need to pass it both on the compile
+-            # and link lines.
+-            if not myenv.AddToCCFLAGSIfSupported('-flto') or \
+-                    not myenv.AddToLINKFLAGSIfSupported('-flto'):
+-                myenv.ConfError("Link time optimization requested, "
+-                                "but selected compiler does not honor -flto")
+-
+-            if myenv.TargetOSIs('darwin'):
+-                myenv.AddToLINKFLAGSIfSupported('-Wl,-object_path_lto,${TARGET}.lto')
+-            else:
+-                # According to intel benchmarks -fno-plt increases perf
+-                # See PM-2215
+-                if linker_ld != "gold":
+-                    myenv.ConfError("lto compilation currently only works with the --linker=gold")
+-                if link_model != "object":
+-                    myenv.ConfError(
+-                        "lto compilation currently only works with the --link-model=object")
+-                if not myenv.AddToCCFLAGSIfSupported('-fno-plt') or \
+-                    not myenv.AddToLINKFLAGSIfSupported('-fno-plt'):
+-                    myenv.ConfError("-fno-plt is not supported by the compiler")
+-
+-        else:
+-            myenv.ConfError("Don't know how to enable --lto on current toolchain")
+-
+     if get_option('runtime-hardening') == "on" and optBuild != "off":
+         # Older glibc doesn't work well with _FORTIFY_SOURCE=2. Selecting 2.11 as the minimum was an
+         # emperical decision, as that is the oldest non-broken glibc we seem to require. It is possible
+@@ -5120,17 +5049,13 @@ def doConfigure(myenv):
+         "BOOST_LOG_NO_SHORTHAND_NAMES",
+         "BOOST_LOG_USE_NATIVE_SYSLOG",
+         "BOOST_LOG_WITHOUT_THREAD_ATTR",
++        "BOOST_LOG_DYN_LINK",
+         "BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS",
+         "BOOST_SYSTEM_NO_DEPRECATED",
+         "BOOST_THREAD_USES_DATETIME",
+         ("BOOST_THREAD_VERSION", "5"),
+     ])
+
+-    if link_model.startswith("dynamic") and not link_model == 'dynamic-sdk':
+-        conf.env.AppendUnique(CPPDEFINES=[
+-            "BOOST_LOG_DYN_LINK",
+-        ])
+-
+     if use_system_version_of_library("boost"):
+         if not conf.CheckCXXHeader("boost/filesystem/operations.hpp"):
+             myenv.ConfError("can't find boost headers")

--- a/pkgs/servers/nosql/mongodb/SConstruct-disable-mongo-tooling-metrics.patch
+++ b/pkgs/servers/nosql/mongodb/SConstruct-disable-mongo-tooling-metrics.patch
@@ -1,0 +1,39 @@
+--- a/SConstruct	2024-06-19 03:26:19 UTC
++++ a/SConstruct
+@@ -23,7 +23,6 @@ import SCons.Script
+
+ import SCons
+ import SCons.Script
+-from mongo_tooling_metrics.lib.top_level_metrics import SConsToolingMetrics
+ from site_scons.mongo import build_profiles
+
+ # This must be first, even before EnsureSConsVersion, if
+@@ -1653,16 +1652,6 @@ env.AddMethod(lambda env, name, **kwargs: add_option(n
+ del envDict
+ env.AddMethod(lambda env, name, **kwargs: add_option(name, **kwargs), 'AddOption')
+
+-# The placement of this is intentional. Here we setup an atexit method to store tooling metrics.
+-# We should only register this function after env, env_vars and the parser have been properly initialized.
+-SConsToolingMetrics.register_metrics(
+-    utc_starttime=datetime.utcnow(),
+-    artifact_dir=env.Dir('$BUILD_DIR').get_abspath(),
+-    env_vars=env_vars,
+-    env=env,
+-    parser=_parser,
+-)
+-
+ if get_option('build-metrics'):
+     env['BUILD_METRICS_ARTIFACTS_DIR'] = '$BUILD_ROOT/$VARIANT_DIR'
+     env.Tool('build_metrics')
+@@ -1799,9 +1788,9 @@ if has_option('variables-help'):
+     print(env_vars.GenerateHelpText(env))
+     Exit(0)
+
+-unknown_vars = env_vars.UnknownVariables()
+-if unknown_vars:
+-    env.FatalError("Unknown variables specified: {0}", ", ".join(list(unknown_vars.keys())))
++#unknown_vars = env_vars.UnknownVariables()
++#if unknown_vars:
++#    env.FatalError("Unknown variables specified: {0}", ", ".join(list(unknown_vars.keys())))
+
+ install_actions.setup(env, get_option('install-action'))

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -4,6 +4,7 @@
 , buildPackages
 , boost
 , gperftools
+, pcre2
 , pcre-cpp
 , snappy
 , zlib
@@ -13,6 +14,9 @@
 , openldap
 , openssl
 , libpcap
+, libunwind
+, libstemmer
+, pkg-config
 , python311Packages
 , curl
 , Security
@@ -57,7 +61,8 @@ let
   ] ++ lib.optionals stdenv.isLinux [
     "tcmalloc"
   ] ++ lib.optionals (lib.versionOlder version "7.0") [
-    "pcre"
+    "pcre2"
+    "libstemmer"
   ];
   inherit (lib) systems subtractLists;
 
@@ -74,6 +79,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     scons
+    pkg-config
     python
   ] ++ lib.optionals stdenv.isLinux [
     net-snmp
@@ -84,9 +90,12 @@ in stdenv.mkDerivation rec {
     curl
     gperftools
     libpcap
+    libunwind
+    libstemmer
     yaml-cpp
     openssl
     openldap
+    pcre2.dev
     pcre-cpp
     sasl
     snappy
@@ -132,7 +141,6 @@ in stdenv.mkDerivation rec {
     "-Wno-unused-command-line-argument";
 
   sconsFlags = [
-    "--linker=gold"
     "--release"
     "--ssl"
     #"--rocksdb" # Don't have this packaged yet
@@ -143,6 +151,14 @@ in stdenv.mkDerivation rec {
     "VARIANT_DIR=nixos" # Needed so we don't produce argument lists that are too long for gcc / ld
     "--link-model=static"
     "MONGO_VERSION=${version}"
+    "--use-system-boost"
+    "--use-system-yaml"
+    "--use-system-zlib"
+    "--use-system-zstd"
+    "--use-system-tcmalloc"
+    "--use-system-stemmer"
+    "--use-system-libunwind"
+    "--runtime-hardening=off"
   ]
   ++ map (lib: "--use-system-${lib}") system-libraries;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25596,7 +25596,7 @@ with pkgs;
         buildPlatform = old.buildPlatform // { darwinMinVersion = "10.14"; };
         targetPlatform = old.targetPlatform // { darwinMinVersion = "10.14"; };
       }) else
-      if stdenv.cc.isClang then llvmPackages.stdenv else gcc11Stdenv;
+      if stdenv.cc.isClang then llvmPackages.stdenv else gcc12Stdenv;
   };
 
   immudb = callPackage ../servers/nosql/immudb { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25586,6 +25586,19 @@ with pkgs;
       if stdenv.cc.isClang then llvmPackages.stdenv else stdenv;
   };
 
+  mongodb-7_0 = darwin.apple_sdk_11_0.callPackage ../servers/nosql/mongodb/7.0.nix {
+    sasl = cyrus_sasl;
+    boost = boost.override { enableShared = false; };
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+    stdenv = if stdenv.isDarwin then
+      darwin.apple_sdk_11_0.stdenv.override (old: {
+        hostPlatform = old.hostPlatform // { darwinMinVersion = "10.14"; };
+        buildPlatform = old.buildPlatform // { darwinMinVersion = "10.14"; };
+        targetPlatform = old.targetPlatform // { darwinMinVersion = "10.14"; };
+      }) else
+      if stdenv.cc.isClang then llvmPackages.stdenv else gcc11Stdenv;
+  };
+
   immudb = callPackage ../servers/nosql/immudb { };
 
   influxdb = callPackage ../servers/nosql/influxdb { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25596,7 +25596,7 @@ with pkgs;
         buildPlatform = old.buildPlatform // { darwinMinVersion = "10.14"; };
         targetPlatform = old.targetPlatform // { darwinMinVersion = "10.14"; };
       }) else
-      if stdenv.cc.isClang then llvmPackages.stdenv else gcc12Stdenv;
+      if stdenv.cc.isClang then llvmPackages.stdenv else gcc14Stdenv;
   };
 
   immudb = callPackage ../servers/nosql/immudb { };


### PR DESCRIPTION
Work in progress:

Trying to use stuff from Arch AUR: https://aur.archlinux.org/cgit/aur.git/tree/?h=mongodb

No luck so far.

build currently broken:

```
Compiling build/nixos/third_party/libmongocrypt/dist/src/mc-efc.o
Compiling build/nixos/mongo/db/commands/fle2_compact_gen.o
In file included from src/mongo/db/catalog/util/partitioned.h:43,
                 from src/mongo/db/query/partitioned_cache.h:32,
                 from src/mongo/db/query/query_stats/query_stats_on_parameter_change.h:34,
                 from build/nixos/mongo/db/query/query_knobs_gen.h:29,
                 from src/mongo/db/pipeline/javascript_execution.h:36,
                 from src/mongo/db/pipeline/expression_context.h:45,
                 from src/mongo/db/pipeline/expression.h:50,
                 from src/mongo/db/pipeline/group_from_first_document_transformation.h:32,
                 from src/mongo/db/pipeline/group_from_first_document_transformation.cpp:30:
src/mongo/util/aligned.h:170:88: warning: use of ‘std::hardware_destructive_interference_size’ [-Winterference-size]
  170 |             aligned_detail::roundUpByStep<stdx::hardware_destructive_interference_size>(sizeof(T))>;
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
src/mongo/util/aligned.h:170:88: note: its value can vary between compiler versions or with different ‘-mtune’ or ‘-mcpu’ flags
src/mongo/util/aligned.h:170:88: note: if this use is part of a public ABI, change it to instead use a constant variable you define
src/mongo/util/aligned.h:170:88: note: the default value for the current CPU tuning is 64 bytes
src/mongo/util/aligned.h:170:88: note: you can stabilize this value with ‘--param hardware_destructive_interference_size=64’, or disable this warning with ‘-Wno-interference-size’
src/mongo/util/aligned.h:170:99: warning: use of ‘std::hardware_destructive_interference_size’ [-Winterference-size]
  170 |             aligned_detail::roundUpByStep<stdx::hardware_destructive_interference_size>(sizeof(T))>;
      |                                                                                                   ^
src/mongo/util/aligned.h:205:85: warning: use of ‘std::hardware_destructive_interference_size’ [-Winterference-size]
  205 |                                        stdx::hardware_constructive_interference_size>;
      |                                                                                     ^
src/mongo/util/aligned.h:205:85: warning: use of ‘std::hardware_destructive_interference_size’ [-Winterference-size]
Compiling build/nixos/mongo/db/geo/geometry_container.o
Compiling build/nixos/mongo/client/connpool.o
In file included from src/third_party/s2/s2.h:19,
                 from src/third_party/s2/s2region.h:6,
                 from src/third_party/s2/s2regionunion.h:12,
                 from src/mongo/db/geo/geometry_container.h:32,
                 from src/mongo/db/geo/geometry_container.cpp:31:
src/third_party/s2/hash.h:8:23: error: invalid use of template-name ‘std::unordered_set’ without an argument list
    8 | #define hash_set std::unordered_set
      |                       ^~~~~~~~~~~~~
In file included from /nix/store/zw4dkm2hl72kfz7j2ci4qbc0avgxzz75-gcc-13.3.0/include/c++/13.3.0/unordered_set:41,
                 from src/third_party/s2/hash.h:7:
/nix/store/zw4dkm2hl72kfz7j2ci4qbc0avgxzz75-gcc-13.3.0/include/c++/13.3.0/bits/unordered_set.h:104:11: note: ‘template<class _Value, class _Hash, class _Pred, class _Alloc> class std::unordered_set’ declared here
  104 |     class unordered_set
      |           ^~~~~~~~~~~~~
src/third_party/s2/hash.h:5:23: error: invalid use of template-name ‘std::unordered_map’ without an argument list
    5 | #define hash_map std::unordered_map
      |                       ^~~~~~~~~~~~~
In file included from /nix/store/zw4dkm2hl72kfz7j2ci4qbc0avgxzz75-gcc-13.3.0/include/c++/13.3.0/unordered_map:41,
                 from src/third_party/s2/hash.h:4:
/nix/store/zw4dkm2hl72kfz7j2ci4qbc0avgxzz75-gcc-13.3.0/include/c++/13.3.0/bits/unordered_map.h:109:11: note: ‘template<class _Key, class _Tp, class _Hash, class _Pred, class _Alloc> class std::unordered_map’ declared here
  109 |     class unordered_map
      |           ^~~~~~~~~~~~~
In file included from src/mongo/crypto/fle_crypto.h:40:
src/mongo/base/data_range.h: In substitution of ‘template<class T> struct mongo::ConstDataRange::ContiguousContainerOfByteLike<T, std::void_t<decltype (declval<T>().data()), typename std::enable_if<(isByteV<typename T::value_type> && mongo::ConstDataRange::HasDataSize>
src/mongo/base/data_range.h:112:97:   required by substitution of ‘template<class Container, typename std::enable_if<mongo::ConstDataRange::ContiguousContainerOfByteLike<Container>::value, int>::type <anonymous> > mongo::ConstDataRange::ConstDataRange(const Container&>
src/mongo/db/query/fle/encrypted_predicate.h:71:76:   required from ‘T mongo::fle::parseFindPayload(BSONValue) [with T = mongo::ParsedFindEqualityPayload; BSONValue = mpark::variant<mongo::BSONElement, std::reference_wrapper<mongo::Value> >]’
src/mongo/db/query/fle/equality_predicate.cpp:49:83:   required from here
src/mongo/base/data_range.h:69:48: note: field ‘const char* mongo::BSONElement::data’ can be accessed via ‘const char* mongo::BSONElement::rawdata() const’
   69 |         std::void_t<decltype(std::declval<T>().data()),
      |                              ~~~~~~~~~~~~~~~~~~^~~~
      |                              rawdata()
scons: *** [build/nixos/mongo/db/geo/geometry_container.o] Error 1
scons: building terminated because of errors.
build/nixos/mongo/db/geo/geometry_container.o failed: Error 1
```

Same error with GCC 11:

```
mongodb> Compiling build/nixos/mongo/util/net/ocsp/ocsp_manager.o
mongodb> In file included from src/third_party/s2/s2.h:19,
mongodb>                  from src/third_party/s2/s2region.h:6,
mongodb>                  from src/third_party/s2/s2regionunion.h:12,
mongodb>                  from src/mongo/db/geo/geometry_container.h:32,
mongodb>                  from src/mongo/db/matcher/expression_geo.h:34,
mongodb>                  from src/mongo/db/matcher/expression_geo.cpp:31:
mongodb> src/third_party/s2/hash.h:8:23: error: invalid use of template-name ‘std::unordered_set’ without an argument list
mongodb>     8 | #define hash_set std::unordered_set
mongodb>       |                       ^~~~~~~~~~~~~
mongodb> In file included from /nix/store/z2hfvpgziara1vfijksjr3adgjl9307y-gcc-11.4.0/include/c++/11.4.0/unordered_set:47,
mongodb>                  from src/third_party/s2/hash.h:7,
mongodb>                  from src/third_party/s2/s2.h:19,
mongodb>                  from src/third_party/s2/s2region.h:6,
mongodb>                  from src/third_party/s2/s2regionunion.h:12,
mongodb>                  from src/mongo/db/geo/geometry_container.h:32,
mongodb>                  from src/mongo/db/matcher/expression_geo.h:34,
mongodb>                  from src/mongo/db/matcher/expression_geo.cpp:31:
mongodb> /nix/store/z2hfvpgziara1vfijksjr3adgjl9307y-gcc-11.4.0/include/c++/11.4.0/bits/unordered_set.h:97:11: note: ‘template<class _Value, class _Hash, class _Pred, class _Alloc> class std::unordered_set’ declared here
mongodb>    97 |     class unordered_set
mongodb>       |           ^~~~~~~~~~~~~
mongodb> In file included from src/third_party/s2/s2.h:19,
mongodb>                  from src/third_party/s2/s2region.h:6,
mongodb>                  from src/third_party/s2/s2regionunion.h:12,
mongodb>                  from src/mongo/db/geo/geometry_container.h:32,
mongodb>                  from src/mongo/db/matcher/expression_geo.h:34,
mongodb>                  from src/mongo/db/matcher/expression_geo.cpp:31:
mongodb> src/third_party/s2/hash.h:5:23: error: invalid use of template-name ‘std::unordered_map’ without an argument list
mongodb>     5 | #define hash_map std::unordered_map
mongodb>       |                       ^~~~~~~~~~~~~
mongodb> In file included from /nix/store/z2hfvpgziara1vfijksjr3adgjl9307y-gcc-11.4.0/include/c++/11.4.0/unordered_map:47,
mongodb>                  from /nix/store/z2hfvpgziara1vfijksjr3adgjl9307y-gcc-11.4.0/include/c++/11.4.0/functional:61,
mongodb>                  from /nix/store/z2hfvpgziara1vfijksjr3adgjl9307y-gcc-11.4.0/include/c++/11.4.0/pstl/glue_algorithm_defs.h:13,
mongodb>                  from /nix/store/z2hfvpgziara1vfijksjr3adgjl9307y-gcc-11.4.0/include/c++/11.4.0/algorithm:74,
mongodb>                  from src/third_party/s2/s2.h:6,
mongodb>                  from src/third_party/s2/s2region.h:6,
mongodb>                  from src/third_party/s2/s2regionunion.h:12,
mongodb>                  from src/mongo/db/geo/geometry_container.h:32,
mongodb>                  from src/mongo/db/matcher/expression_geo.h:34,
mongodb>                  from src/mongo/db/matcher/expression_geo.cpp:31:
mongodb> /nix/store/z2hfvpgziara1vfijksjr3adgjl9307y-gcc-11.4.0/include/c++/11.4.0/bits/unordered_map.h:102:11: note: ‘template<class _Key, class _Tp, class _Hash, class _Pred, class _Alloc> class std::unordered_map’ declared here
mongodb>   102 |     class unordered_map
mongodb>       |           ^~~~~~~~~~~~~
mongodb> Compiling build/nixos/third_party/mozjs/platform/x86_64/linux/build/gc/Unified_cpp_js_src_gc1.o
mongodb> Compiling build/nixos/mongo/util/signal_handlers_synchronous.o
mongodb> In file included from src/third_party/mozjs/extract/js/src/vm/Caches.h:17,
mongodb>                  from src/third_party/mozjs/extract/js/src/vm/Runtime.h:49,
mongodb>                  from src/third_party/mozjs/extract/js/src/gc/PublicIterators.h:19,
mongodb>                  from src/third_party/mozjs/extract/js/src/gc/GCAPI.cpp:17,
mongodb>                  from src/third_party/mozjs/platform/x86_64/linux/build/gc/Unified_cpp_js_src_gc1.cpp:2:
mongodb> src/third_party/mozjs/extract/js/src/frontend/ScopeBindingCache.h:190:32: warning: ‘virtual js::frontend::BindingMap<JSAtom*>* js::frontend::ScopeBindingCache::lookupScope(js::Scope*, js::frontend::ScopeBindingCache::CacheGeneration)’ was hidden [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Woverloaded-virtual-Woverloaded-virtual8;;]
mongodb>   190 |   virtual BindingMap<JSAtom*>* lookupScope(Scope* ptr, CacheGeneration gen);
mongodb>       |                                ^~~~~~~~~~~
mongodb> src/third_party/mozjs/extract/js/src/frontend/ScopeBindingCache.h:238:38: note:   by ‘virtual js::frontend::BindingMap<js::frontend::TaggedParserAtomIndex>* js::frontend::StencilScopeBindingCache::lookupScope(js::frontend::ScopeStencilRef, js::frontend::ScopeBindingCache::CacheGeneration)’
mongodb>   238 |   BindingMap<TaggedParserAtomIndex>* lookupScope(ScopeStencilRef ref,
mongodb>       |                                      ^~~~~~~~~~~
mongodb> src/third_party/mozjs/extract/js/src/frontend/ScopeBindingCache.h:183:32: warning: ‘virtual js::frontend::BindingMap<JSAtom*>* js::frontend::ScopeBindingCache::createCacheFor(js::Scope*)’ was hidden [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Woverloaded-virtual-Woverloaded-virtual8;;]
mongodb>   183 |   virtual BindingMap<JSAtom*>* createCacheFor(Scope* ptr);
mongodb>       |                                ^~~~~~~~~~~~~~
mongodb> src/third_party/mozjs/extract/js/src/frontend/ScopeBindingCache.h:236:38: note:   by ‘virtual js::frontend::BindingMap<js::frontend::TaggedParserAtomIndex>* js::frontend::StencilScopeBindingCache::createCacheFor(js::frontend::ScopeStencilRef)’
mongodb>   236 |   BindingMap<TaggedParserAtomIndex>* createCacheFor(
mongodb>       |                                      ^~~~~~~~~~~~~~
mongodb> src/third_party/mozjs/extract/js/src/frontend/ScopeBindingCache.h:178:16: warning: ‘virtual bool js::frontend::ScopeBindingCache::canCacheFor(js::Scope*)’ was hidden [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Woverloaded-virtual-Woverloaded-virtual8;;]
mongodb>   178 |   virtual bool canCacheFor(Scope* ptr);
mongodb>       |                ^~~~~~~~~~~
mongodb> src/third_party/mozjs/extract/js/src/frontend/ScopeBindingCache.h:235:8: note:   by ‘virtual bool js::frontend::StencilScopeBindingCache::canCacheFor(js::frontend::ScopeStencilRef)’
mongodb>   235 |   bool canCacheFor(ScopeStencilRef ref) override;
mongodb>       |        ^~~~~~~~~~~
mongodb> src/third_party/mozjs/extract/js/src/frontend/ScopeBindingCache.h:191:46: warning: ‘virtual js::frontend::BindingMap<js::frontend::TaggedParserAtomIndex>* js::frontend::ScopeBindingCache::lookupScope(js::frontend::ScopeStencilRef, js::frontend::ScopeBindingCache::CacheGeneration)’ was hidden [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Woverloaded-virtual-Woverloaded-virtual8;;]
mongodb>   191 |   virtual BindingMap<TaggedParserAtomIndex>* lookupScope(ScopeStencilRef ref,
mongodb>       |                                              ^~~~~~~~~~~
mongodb> src/third_party/mozjs/extract/js/src/frontend/ScopeBindingCache.h:266:24: note:   by ‘virtual js::frontend::BindingMap<JSAtom*>* js::frontend::RuntimeScopeBindingCache::lookupScope(js::Scope*, js::frontend::ScopeBindingCache::CacheGeneration)’
mongodb>   266 |   BindingMap<JSAtom*>* lookupScope(Scope* ptr, CacheGeneration gen) override;
mongodb>       |                        ^~~~~~~~~~~
mongodb> src/third_party/mozjs/extract/js/src/frontend/ScopeBindingCache.h:184:46: warning: ‘virtual js::frontend::BindingMap<js::frontend::TaggedParserAtomIndex>* js::frontend::ScopeBindingCache::createCacheFor(js::frontend::ScopeStencilRef)’ was hidden [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Woverloaded-virtual-Woverloaded-virtual8;;]
mongodb>   184 |   virtual BindingMap<TaggedParserAtomIndex>* createCacheFor(
mongodb>       |                                              ^~~~~~~~~~~~~~
mongodb> src/third_party/mozjs/extract/js/src/frontend/ScopeBindingCache.h:265:24: note:   by ‘virtual js::frontend::BindingMap<JSAtom*>* js::frontend::RuntimeScopeBindingCache::createCacheFor(js::Scope*)’
mongodb>   265 |   BindingMap<JSAtom*>* createCacheFor(Scope* ptr) override;
mongodb>       |                        ^~~~~~~~~~~~~~
mongodb> src/third_party/mozjs/extract/js/src/frontend/ScopeBindingCache.h:179:16: warning: ‘virtual bool js::frontend::ScopeBindingCache::canCacheFor(js::frontend::ScopeStencilRef)’ was hidden [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Woverloaded-virtual-Woverloaded-virtual8;;]
mongodb>   179 |   virtual bool canCacheFor(ScopeStencilRef ref);
mongodb>       |                ^~~~~~~~~~~
mongodb> src/third_party/mozjs/extract/js/src/frontend/ScopeBindingCache.h:264:8: note:   by ‘virtual bool js::frontend::RuntimeScopeBindingCache::canCacheFor(js::Scope*)’
mongodb>   264 |   bool canCacheFor(Scope* ptr) override;
mongodb>       |        ^~~~~~~~~~~
mongodb> Compiling build/nixos/mongo/db/log_process_details.o
mongodb> scons: *** [build/nixos/mongo/db/matcher/expression_geo.o] Error 1
mongodb> scons: building terminated because of errors.
mongodb> build/nixos/mongo/db/matcher/expression_geo.o failed: Error 1
```

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
