### PR TITLE
darwin.moltenvk: Add `enableStatic` option

### DIFF
--- a/pkgs/os-specific/darwin/moltenvk/default.nix
+++ b/pkgs/os-specific/darwin/moltenvk/default.nix
@@ -16,6 +16,7 @@
   Foundation,
   Metal,
   QuartzCore,
+  enableStatic ? stdenv.hostPlatform.isStatic,
   # MoltenVK supports using private APIs to implement some Vulkan functionality.
   # Applications that use private APIs can’t be distributed on the App Store,
   # but that’s not really a concern for nixpkgs, so use them by default.
@@ -23,9 +24,6 @@
   enablePrivateAPIUsage ? true,
 }:
 
-let
-  inherit (stdenv.hostPlatform) isStatic;
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "MoltenVK";
   version = "1.2.9";
@@ -142,7 +140,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postBuild =
-    if isStatic then
+    if enableStatic then
       ''
         mkdir -p Package/Release/MoltenVK/static
         cp Products/Release/libMoltenVK.a Package/Release/MoltenVK/static
@@ -174,8 +172,8 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    libraryExtension=${if isStatic then ".a" else ".dylib"}
-    packagePath=${if isStatic then "static" else "dynamic/dylib"}
+    libraryExtension=${if enableStatic then ".a" else ".dylib"}
+    packagePath=${if enableStatic then "static" else "dynamic/dylib"}
 
     mkdir -p "$out/lib" "$out/share/vulkan/icd.d" "$bin/bin" "$dev"
 


### PR DESCRIPTION
## Description of changes

Added an `enableStatic` option, which enables to build `libMoltenVK.a` without building its dependencies statically. 
A default is set, such that dependent derivations do not have to change.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
