### PR TITLE
nixpkgs-manual: Document `runCommandWith`, refactor `runCommand{,CC,Local}`

### DIFF
--- a/doc/build-helpers/trivial-build-helpers.chapter.md
+++ b/doc/build-helpers/trivial-build-helpers.chapter.md
@@ -8,9 +8,13 @@ Like [`stdenv.mkDerivation`](#sec-using-stdenv), each of these build helpers cre
 
 The function `runCommandWith` returns a derivation built using the specified command(s), in a specified environment.
 
-It is the underlying base function of  all `runCommand*` variants. 
-The general behavior is controlled via a single attribute set passed 
+It is the underlying base function of  all [`runCommand*` variants].
+The general behavior is controlled via a single attribute set passed
 as the first argument, and allows specifying `stdenv` freely.
+
+The following [`runCommand*` variants] exist: `runCommand`, `runCommandCC`, and `runCommandLocal`.
+
+[`runCommand*` variants]: #trivial-builder-runCommand
 
 ### Type {#trivial-builder-runCommandWith-Type}
 

--- a/doc/build-helpers/trivial-build-helpers.chapter.md
+++ b/doc/build-helpers/trivial-build-helpers.chapter.md
@@ -29,11 +29,12 @@ runCommandWith :: {
 :   The derivation's name, which Nix will append to the store path; see [`mkDerivation`](#sec-using-stdenv).
 
 `runLocal` (Boolean)
-:   If set to `true` this forces the derivation to be built locally. Remote substitutes and distributed builds, won't be used.
+:   If set to `true` this forces the derivation to be built locally, not using [substitutes] nor remote builds.
+    This is intended for very cheap commands (<1s execution time) which can be sped up by avoiding the network round-trip(s).
     Its effect is to set [`preferLocalBuild = true`][preferLocalBuild] and [`allowSubstitutes = false`][allowSubstitutes].
 
    ::: {.note}
-   This prevents the use of substitutors, so only set `runLocal` (or use `runCommandLocal`) when certain the user will
+   This prevents the use of [substituters][substituter], so only set `runLocal` (or use `runCommandLocal`) when certain the user will
    always have a builder for the `system` of the derivation. This should be true for most trivial use cases
    (e.g., just copying some files to a different location or adding symlinks) because there the `system`
    is usually the same as `builtins.currentSystem`.
@@ -54,6 +55,8 @@ runCommandWith :: {
 
 [allowSubstitutes]: https://nixos.org/nix/manual/#adv-attr-allowSubstitutes
 [preferLocalBuild]: https://nixos.org/nix/manual/#adv-attr-preferLocalBuild
+[substituter]: https://nix.dev/manual/nix/latest/glossary#gloss-substituter
+[substitutes]: https://nix.dev/manual/nix/2.23/glossary#gloss-substitute
 
 ::: {.example #ex-runcommandwith}
 # Invocation of `runCommandWith`
@@ -80,16 +83,22 @@ The function `runCommand` returns a derivation built using the specified command
 `runCommandCC` is similar but uses the default compiler environment. To minimize dependencies, `runCommandCC`
 should only be used when the build command needs a C compiler.
 
+`runCommandLocal` is also similar to `runCommand`, but forces the derivation to be built locally.
+See the note on [`runCommandWith`] about `runLocal`.
+
+[`runCommandWith`]: #trivial-builder-runCommandWith
+
 ### Type {#trivial-builder-runCommand-Type}
 
 ```
-runCommand   :: String -> AttrSet -> String -> Derivation
-runCommandCC :: String -> AttrSet -> String -> Derivation
+runCommand      :: String -> AttrSet -> String -> Derivation
+runCommandCC    :: String -> AttrSet -> String -> Derivation
+runCommandLocal :: String -> AttrSet -> String -> Derivation
 ```
 
 ### Input {#trivial-builder-runCommand-Input}
 
-While the type signature(s) differ from `runCommandWith`, individual arguments with the same name will have the same type and meaning:
+While the type signature(s) differ from [`runCommandWith`], individual arguments with the same name will have the same type and meaning:
 
 `name` (String)
 :   The derivation's name
@@ -143,14 +152,6 @@ runCommandWith {
 ```
 :::
 
-
-## `runCommandLocal` {#trivial-builder-runCommandLocal}
-
-Variant of `runCommand` that forces the derivation to be built locally, it is not substituted. This is intended for very cheap commands (<1s execution time). It saves on the network round-trip and can speed up a build.
-
-::: {.note}
-This sets [`allowSubstitutes` to `false`][allowSubstitutes], so only use `runCommandLocal` if you are certain the user will always have a builder for the `system` of the derivation. This should be true for most trivial use cases (e.g., just copying some files to a different location or adding symlinks) because there the `system` is usually the same as `builtins.currentSystem`.
-:::
 
 ## Writing text files {#trivial-builder-text-writing}
 

--- a/doc/build-helpers/trivial-build-helpers.chapter.md
+++ b/doc/build-helpers/trivial-build-helpers.chapter.md
@@ -73,32 +73,39 @@ runCommandWith {
 :::
 
 
-## `runCommand` {#trivial-builder-runCommand}
+## `runCommand` and `runCommandCC` {#trivial-builder-runCommand}
 
-`runCommand :: String -> AttrSet -> String -> Derivation`
+The function `runCommand` returns a derivation built using the specified command(s), in the `stdenvNoCC` environment.
 
-The result of `runCommand name drvAttrs buildCommand` is a derivation that is built by running the specified shell commands.
+`runCommandCC` is similar but uses the default compiler environment. To minimize dependencies, `runCommandCC`
+should only be used when the build command needs a C compiler.
 
-By default `runCommand` runs in a stdenv with no compiler environment, whereas [`runCommandCC`](#trivial-builder-runCommandCC) uses the default stdenv, `pkgs.stdenv`.
+### Type {#trivial-builder-runCommand-Type}
 
-`name :: String`
-:   The name that Nix will append to the store path in the same way that `stdenv.mkDerivation` uses its `name` attribute.
+```
+runCommand   :: String -> AttrSet -> String -> Derivation
+runCommandCC :: String -> AttrSet -> String -> Derivation
+```
 
-`drvAttr :: AttrSet`
-:   Attributes to pass to the underlying call to [`stdenv.mkDerivation`](#chap-stdenv).
+### Input {#trivial-builder-runCommand-Input}
 
-`buildCommand :: String`
-:   Shell commands to run in the derivation builder.
+While the type signature(s) differ from `runCommandWith`, individual arguments with the same name will have the same type and meaning:
 
-    ::: {.note}
-    You have to create a file or directory `$out` for Nix to be able to run the builder successfully.
-    :::
+`name` (String)
+:   The derivation's name
+
+`derivationArgs` (Attribute set)
+:   Additional parameters passed to [`mkDerivation`]
+
+`buildCommand` (String)
+:   The command(s) run to build the derivation.
+
 
 ::: {.example #ex-runcommand-simple}
 # Invocation of `runCommand`
 
 ```nix
-(import <nixpkgs> {}).runCommand "my-example" {} ''
+runCommand "my-example" {} ''
   echo My example command is running
 
   mkdir $out
@@ -118,10 +125,6 @@ By default `runCommand` runs in a stdenv with no compiler environment, whereas [
 ''
 ```
 :::
-
-## `runCommandCC` {#trivial-builder-runCommandCC}
-
-This works just like `runCommand`. The only difference is that it also provides a C compiler in `buildCommand`'s environment. To minimize your dependencies, you should only use this if you are sure you will need a C compiler as part of running your command.
 
 ## `runCommandLocal` {#trivial-builder-runCommandLocal}
 

--- a/doc/build-helpers/trivial-build-helpers.chapter.md
+++ b/doc/build-helpers/trivial-build-helpers.chapter.md
@@ -126,6 +126,24 @@ runCommand "my-example" {} ''
 ```
 :::
 
+::: {.note}
+`runCommand name derivationArgs buildCommand` is equivalent to
+```nix
+runCommandWith {
+  inherit name derivationArgs;
+  stdenv = stdenvNoCC;
+} buildCommand
+```
+
+Likewise, `runCommandCC name derivationArgs buildCommand` is equivalent to
+```nix
+runCommandWith {
+  inherit name derivationArgs;
+} buildCommand
+```
+:::
+
+
 ## `runCommandLocal` {#trivial-builder-runCommandLocal}
 
 Variant of `runCommand` that forces the derivation to be built locally, it is not substituted. This is intended for very cheap commands (<1s execution time). It saves on the network round-trip and can speed up a build.

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -36,17 +36,8 @@ rec {
   # `runCommandCCLocal` left out on purpose.
   # We shouldn’t force the user to have a cc in scope.
 
-  # TODO: Move documentation for runCommandWith to the Nixpkgs manual
-  /*
-    Generalized version of the `runCommand`-variants
-    which does customized behavior via a single
-    attribute set passed as the first argument
-    instead of having a lot of variants like
-    `runCommand*`. Additionally it allows changing
-    the used `stdenv` freely and has a more explicit
-    approach to changing the arguments passed to
-    `stdenv.mkDerivation`.
-   */
+  # Docs in doc/build-helpers/trivial-build-helpers.chapter.md
+  # See https://nixos.org/manual/nixpkgs/unstable/#trivial-builder-runCommandWith
   runCommandWith =
     let
       # prevent infinite recursion for the default stdenv value


### PR DESCRIPTION
## Description of changes

- [x] Document `runCommandWith`
- [x] Refactor the documentation of `runCommand{,CC,Local}` to refer back to the generalized version
- [x] Add note describing how to express `runCommand{,CC}` in terms of `runCommandWith`

## Things done

- `nixpkgs-manual` built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
