### PR TITLE
quickfix: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/quickfix/default.nix
+++ b/pkgs/development/libraries/quickfix/default.nix
@@ -1,13 +1,21 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, autoconf, automake, libtool }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  autoconf,
+  automake,
+  libtool,
+}:
 
 stdenv.mkDerivation rec {
   pname = "quickfix";
   version = "1.15.1";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
-    rev =  "v${version}";
+    owner = "quickfix";
+    repo = "quickfix";
+    rev = "v${version}";
     sha256 = "1fgpwgvyw992mbiawgza34427aakn5zrik3sjld0i924a9d17qwg";
   };
 
@@ -21,7 +29,11 @@ stdenv.mkDerivation rec {
   ];
 
   # autoreconfHook does not work
-  nativeBuildInputs = [ autoconf automake libtool ];
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/quickfix/default.nix
+++ b/pkgs/development/libraries/quickfix/default.nix
@@ -37,6 +37,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  postPatch = ''
+    substituteInPlace bootstrap --replace-fail glibtoolize libtoolize
+  '';
+
   preConfigure = ''
     ./bootstrap
   '';

--- a/pkgs/development/libraries/quickfix/default.nix
+++ b/pkgs/development/libraries/quickfix/default.nix
@@ -55,5 +55,6 @@ stdenv.mkDerivation rec {
     homepage = "http://www.quickfixengine.org";
     license = licenses.free; # similar to BSD 4-clause
     maintainers = with maintainers; [ bhipple ];
+    broken = stdenv.isAarch64;
   };
 }


### PR DESCRIPTION
## Description of changes

added a patch that falls back on libtoolize tool if glibtoolize tool is not available. 
glibtoolize tool is a rename libtoolize on macos due to name conflict. 
nix has original name in the path.

fixes #333096

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
