### PR TITLE
[staging] perl: 5.38.2 -> 5.40.0

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1055,6 +1055,7 @@ in {
   unbound = handleTest ./unbound.nix {};
   unifi = handleTest ./unifi.nix {};
   unit-php = handleTest ./web-servers/unit-php.nix {};
+  unit-perl = handleTest ./web-servers/unit-perl.nix {};
   upnp.iptables = handleTest ./upnp.nix { useNftables = false; };
   upnp.nftables = handleTest ./upnp.nix { useNftables = true; };
   uptermd = handleTest ./uptermd.nix {};

--- a/nixos/tests/web-servers/unit-perl.nix
+++ b/nixos/tests/web-servers/unit-perl.nix
@@ -1,0 +1,46 @@
+import ../make-test-python.nix (
+  { pkgs, ... }:
+  let
+    testdir = pkgs.writeTextDir "www/app.psgi" ''
+      my $app = sub {
+          return [
+              "200",
+              [ "Content-Type" => "text/plain" ],
+              [ "Hello, Perl on Unit!" ],
+          ];
+      };
+    '';
+
+  in
+  {
+    name = "unit-perl-test";
+    meta.maintainers = with pkgs.lib.maintainers; [ sgo ];
+
+    nodes.machine =
+      {
+        config,
+        lib,
+        pkgs,
+        ...
+      }:
+      {
+        services.unit = {
+          enable = true;
+          config = pkgs.lib.strings.toJSON {
+            listeners."*:8080".application = "perl";
+            applications.perl = {
+              type = "perl";
+              script = "${testdir}/www/app.psgi";
+            };
+          };
+        };
+      };
+    testScript = ''
+      machine.wait_for_unit("unit.service")
+      machine.wait_for_open_port(8080)
+
+      response = machine.succeed("curl -f -vvv -s http://127.0.0.1:8080/")
+      assert "Hello, Perl on Unit!" in response, "Hello world"
+    '';
+  }
+)

--- a/pkgs/applications/editors/vim/macvim.nix
+++ b/pkgs/applications/editors/vim/macvim.nix
@@ -8,7 +8,7 @@
 , cscope
 , ruby_3_2
 , tcl
-, perl536
+, perl540
 , luajit
 , darwin
 , libiconv
@@ -17,8 +17,7 @@
 
 # Try to match MacVim's documented script interface compatibility
 let
-  # Perl 5.30 - closest we get is 5.36. 5.38 is currently failing
-  perl = perl536;
+  perl = perl540;
   # Ruby 3.2
   ruby = ruby_3_2;
 
@@ -35,13 +34,13 @@ in
 stdenv.mkDerivation (finalAttrs: {
   pname = "macvim";
 
-  version = "178";
+  version = "179";
 
   src = fetchFromGitHub {
     owner = "macvim-dev";
     repo = "macvim";
     rev = "release-${finalAttrs.version}";
-    hash = "sha256-JYh5fyaYuME/Lk67vrf1hYOIcAkEbwtslcnI9KRzHa8=";
+    hash = "sha256-L9LVXyeA09aMtNf+b/Oo+eLpeVEKTD1/oNWCiFn5FbU=";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/interpreters/perl/cross540.patch
+++ b/pkgs/development/interpreters/perl/cross540.patch
@@ -1,0 +1,224 @@
+From: =?UTF-8?q?Christian=20K=C3=B6gler?= <ck3d@gmx.de>
+Date: Mon, 10 Apr 2023 22:12:24 +0200
+Subject: [PATCH] miniperl compatible modules
+
+CPAN::Meta
+ExtUtils::MakeMaker
+JSON::PP
+Data::Dumper
+
+Updated for perl v5.40.0 by marcus@means.no
+
+---
+
+ # safe if given an unblessed reference
+diff --git a/cpan/CPAN-Meta-YAML/lib/CPAN/Meta/YAML.pm b/cpan/CPAN-Meta-YAML/lib/CPAN/Meta/YAML.pm
+index 746abd63bc..c55d7cd2d0 100644
+--- a/cpan/CPAN-Meta-YAML/lib/CPAN/Meta/YAML.pm
++++ b/cpan/CPAN-Meta-YAML/lib/CPAN/Meta/YAML.pm
+@@ -1,6 +1,7 @@
+ use 5.008001; # sane UTF-8 support
+ use strict;
+ use warnings;
++no warnings 'experimental::builtin';
+ package CPAN::Meta::YAML; # git description: v1.68-2-gcc5324e
+ # XXX-INGY is 5.8.1 too old/broken for utf8?
+ # XXX-XDG Lancaster consensus was that it was sufficient until
+@@ -650,27 +651,29 @@ sub _dump_string {
+     join '', map { "$_\n" } @lines;
+ }
+ 
+-sub _has_internal_string_value {
++# taken from cpan/JSON-PP/lib/JSON/PP.pm
++sub _looks_like_number {
+     my $value = shift;
+-    my $b_obj = B::svref_2object(\$value);  # for round trip problem
+-    return $b_obj->FLAGS & B::SVf_POK();
++    no warnings 'numeric';
++    # if the utf8 flag is on, it almost certainly started as a string
++    return if utf8::is_utf8($value);
++    # detect numbers
++    # string & "" -> ""
++    # number & "" -> 0 (with warning)
++    # nan and inf can detect as numbers, so check with * 0
++    return unless length((my $dummy = "") & $value);
++    return unless 0 + $value eq $value;
++    return 1 if $value * 0 == 0;
++    return -1; # inf/nan
+ }
+ 
+ sub _dump_scalar {
+     my $string = $_[1];
+     my $is_key = $_[2];
+-    # Check this before checking length or it winds up looking like a string!
+-    my $has_string_flag = _has_internal_string_value($string);
+     return '~'  unless defined $string;
+     return "''" unless length  $string;
+-    if (Scalar::Util::looks_like_number($string)) {
+-        # keys and values that have been used as strings get quoted
+-        if ( $is_key || $has_string_flag ) {
+-            return qq['$string'];
+-        }
+-        else {
+-            return $string;
+-        }
++    if (_looks_like_number($string)) {
++        return qq['$string'];
+     }
+     if ( $string =~ /[\x00-\x09\x0b-\x0d\x0e-\x1f\x7f-\x9f\'\n]/ ) {
+         $string =~ s/\\/\\\\/g;
+@@ -800,9 +803,6 @@ sub errstr {
+ # Helper functions. Possibly not needed.
+ 
+ 
+-# Use to detect nv or iv
+-use B;
+-
+ # XXX-INGY Is flock CPAN::Meta::YAML's responsibility?
+ # Some platforms can't flock :-(
+ # XXX-XDG I think it is.  When reading and writing files, we ought
+@@ -822,35 +822,8 @@ sub _can_flock {
+     }
+ }
+ 
+-
+-# XXX-INGY Is this core in 5.8.1? Can we remove this?
+-# XXX-XDG Scalar::Util 1.18 didn't land until 5.8.8, so we need this
+-#####################################################################
+-# Use Scalar::Util if possible, otherwise emulate it
+-
+-use Scalar::Util ();
+ BEGIN {
+-    local $@;
+-    if ( eval { Scalar::Util->VERSION(1.18); } ) {
+-        *refaddr = *Scalar::Util::refaddr;
+-    }
+-    else {
+-        eval <<'END_PERL';
+-# Scalar::Util failed to load or too old
+-sub refaddr {
+-    my $pkg = ref($_[0]) or return undef;
+-    if ( !! UNIVERSAL::can($_[0], 'can') ) {
+-        bless $_[0], 'Scalar::Util::Fake';
+-    } else {
+-        $pkg = undef;
+-    }
+-    "$_[0]" =~ /0x(\w+)/;
+-    my $i = do { no warnings 'portable'; hex $1 };
+-    bless $_[0], $pkg if defined $pkg;
+-    $i;
+-}
+-END_PERL
+-    }
++    *refaddr = *builtin::refaddr;
+ }
+ 
+ delete $CPAN::Meta::YAML::{refaddr};
+diff --git a/cpan/CPAN-Meta/lib/CPAN/Meta/Merge.pm b/cpan/CPAN-Meta/lib/CPAN/Meta/Merge.pm
+index 3604eae402..991f69d275 100644
+--- a/cpan/CPAN-Meta/lib/CPAN/Meta/Merge.pm
++++ b/cpan/CPAN-Meta/lib/CPAN/Meta/Merge.pm
+@@ -1,12 +1,13 @@
+ use strict;
+ use warnings;
++no warnings 'experimental::builtin';
+ 
+ package CPAN::Meta::Merge;
+ 
+ our $VERSION = '2.150010';
+ 
+ use Carp qw/croak/;
+-use Scalar::Util qw/blessed/;
++use builtin qw/blessed/;
+ use CPAN::Meta::Converter 2.141170;
+ 
+ sub _is_identical {
+diff --git a/cpan/CPAN-Meta/lib/CPAN/Meta/Prereqs.pm b/cpan/CPAN-Meta/lib/CPAN/Meta/Prereqs.pm
+index d4e93fd8a5..809da68d02 100644
+--- a/cpan/CPAN-Meta/lib/CPAN/Meta/Prereqs.pm
++++ b/cpan/CPAN-Meta/lib/CPAN/Meta/Prereqs.pm
+@@ -1,6 +1,7 @@
+ use 5.006;
+ use strict;
+ use warnings;
++no warnings 'experimental::builtin';
+ package CPAN::Meta::Prereqs;
+ 
+ our $VERSION = '2.150010';
+@@ -14,7 +15,6 @@ our $VERSION = '2.150010';
+ #pod =cut
+ 
+ use Carp qw(confess);
+-use Scalar::Util qw(blessed);
+ use CPAN::Meta::Requirements 2.121;
+ 
+ #pod =method new
+@@ -168,7 +168,12 @@ sub types_in {
+ sub with_merged_prereqs {
+   my ($self, $other) = @_;
+ 
+-  my @other = blessed($other) ? $other : @$other;
++  eval 'require Scalar::Util';
++  my @other = unless($@){
++    Scalar::Util::blessed($other) ? $other : @$other;
++  }else{
++    builtin::blessed($other) ? $other : @$other;
++  }
+ 
+   my @prereq_objs = ($self, @other);
+ 
+diff --git a/cpan/JSON-PP/lib/JSON/PP.pm b/cpan/JSON-PP/lib/JSON/PP.pm
+index fc8fcbc8f0..cda7b90c65 100644
+--- a/cpan/JSON-PP/lib/JSON/PP.pm
++++ b/cpan/JSON-PP/lib/JSON/PP.pm
+@@ -4,6 +4,7 @@ package JSON::PP;
+ 
+ use 5.008;
+ use strict;
++no warnings 'experimental::builtin';
+ 
+ use Exporter ();
+ BEGIN { our @ISA = ('Exporter') }
+diff --git a/dist/Data-Dumper/Dumper.pm b/dist/Data-Dumper/Dumper.pm
+index bb6d3caedb..0c2fde4743 100644
+--- a/dist/Data-Dumper/Dumper.pm
++++ b/dist/Data-Dumper/Dumper.pm
+@@ -11,6 +11,7 @@ package Data::Dumper;
+ 
+ use strict;
+ use warnings;
++no warnings 'experimental::builtin';
+ 
+ #$| = 1;
+ 
+@@ -125,8 +126,7 @@ sub new {
+ # Packed numeric addresses take less memory. Plus pack is faster than sprintf
+ 
+ sub format_refaddr {
+-    require Scalar::Util;
+-    pack "J", Scalar::Util::refaddr(shift);
++    pack "J", builtin::refaddr(shift);
+ };
+ 
+ #
+@@ -282,9 +282,8 @@ sub _dump {
+       warn "WARNING(Freezer method call failed): $@" if $@;
+     }
+ 
+-    require Scalar::Util;
+-    my $realpack = Scalar::Util::blessed($val);
+-    my $realtype = $realpack ? Scalar::Util::reftype($val) : ref $val;
++    my $realpack = builtin::blessed($val);
++    my $realtype = $realpack ? builtin::reftype($val) : ref $val;
+     $id = format_refaddr($val);
+ 
+     # Note: By this point $name is always defined and of non-zero length.
+@@ -576,7 +575,7 @@ sub _dump {
+     # here generates a different result. So there are actually "three" different
+     # implementations of Data::Dumper (kind of sort of) but we only test two.
+     elsif (!defined &_vstring
+-       and ref $ref eq 'VSTRING' || eval{Scalar::Util::isvstring($val)}) {
++       and ref $ref eq 'VSTRING') {
+       $out .= sprintf "v%vd", $val;
+     }
+     # \d here would treat "1\x{660}" as a safe decimal number

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -69,4 +69,12 @@ in rec {
     sha256 = "sha256-oKMVNEUet7g8fWWUpJdUOlTUiLyQygD140diV39AZV4=";
     inherit passthruFun;
   };
+
+  # Maint version
+  perl540 = callPackage ./interpreter.nix {
+    self = perl540;
+    version = "5.40.0";
+    sha256 = "sha256-x0A0jzVzljJ6l5XT6DI7r9D+ilx4NfwcuroMyN/nFh8=";
+    inherit passthruFun;
+  };
 }

--- a/pkgs/development/interpreters/perl/interpreter.nix
+++ b/pkgs/development/interpreters/perl/interpreter.nix
@@ -28,7 +28,7 @@
 assert (enableCrypt -> (libxcrypt != null));
 
 let
-  crossCompiling = stdenv.buildPlatform != stdenv.hostPlatform;
+  crossCompiling = !(stdenv.buildPlatform.canExecute stdenv.hostPlatform);
   libc = if stdenv.cc.libc or null != null then stdenv.cc.libc else "/usr";
   libcInc = lib.getDev libc;
   libcLib = lib.getLib libc;
@@ -99,12 +99,31 @@ stdenv.mkDerivation (rec {
   # Miniperl needs -lm. perl needs -lrt.
   configureFlags =
     (if crossCompiling
-    then [ "-Dlibpth=\"\"" "-Dglibpth=\"\"" "-Ddefault_inc_excludes_dot" ]
-    else [ "-de" "-Dcc=cc" ])
+    then [
+      "-Dlibpth=\"\""
+      "-Dglibpth=\"\""
+      "-Ddefault_inc_excludes_dot"
+    ]
+    else ([
+      "-de"
+      "-Dprefix=${placeholder "out"}"
+      "-Dman1dir=${placeholder "out"}/share/man/man1"
+      "-Dman3dir=${placeholder "out"}/share/man/man3"
+    ] ++
+    (if stdenv.hostPlatform.isStatic
+    then [
+      "-Dcc=${stdenv.cc.targetPrefix}cc"
+      "-Dnm=${stdenv.cc.targetPrefix}nm"
+      "-Dar=${stdenv.cc.targetPrefix}ar"
+      "-Uusedl"
+    ]
+    else [
+      "-Dcc=cc"
+      "-Duseshrplib"
+    ])))
     ++ [
       "-Uinstallusrbinperl"
       "-Dinstallstyle=lib/perl5"
-    ] ++ lib.optional (!crossCompiling) "-Duseshrplib" ++ [
       "-Dlocincpth=${libcInc}/include"
       "-Dloclibpth=${libcLib}/lib"
     ]
@@ -112,12 +131,6 @@ stdenv.mkDerivation (rec {
     ++ lib.optional stdenv.isSunOS "-Dcc=gcc"
     ++ lib.optional enableThreading "-Dusethreads"
     ++ lib.optional (!enableCrypt) "-A clear:d_crypt_r"
-    ++ lib.optional stdenv.hostPlatform.isStatic "--all-static"
-    ++ lib.optionals (!crossCompiling) [
-      "-Dprefix=${placeholder "out"}"
-      "-Dman1dir=${placeholder "out"}/share/man/man1"
-      "-Dman3dir=${placeholder "out"}/share/man/man3"
-    ]
     ++ lib.optionals (stdenv.isFreeBSD && crossCompiling && enableCrypt) [
       # https://github.com/Perl/perl5/issues/22295
       # configure cannot figure out that we have crypt automatically, but we really do
@@ -125,6 +138,11 @@ stdenv.mkDerivation (rec {
     ];
 
   configureScript = lib.optionalString (!crossCompiling) "${stdenv.shell} ./Configure";
+
+  postConfigure = lib.optionalString stdenv.hostPlatform.isStatic ''
+    substituteInPlace Makefile \
+      --replace-fail "AR = ar" "AR = ${stdenv.cc.targetPrefix}ar"
+  '';
 
   dontAddStaticConfigureFlags = true;
 
@@ -246,7 +264,7 @@ stdenv.mkDerivation (rec {
     priority = 6; # in `buildEnv' (including the one inside `perl.withPackages') the library files will have priority over files in `perl`
     mainProgram = "perl";
   };
-} // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) rec {
+} // lib.optionalAttrs crossCompiling rec {
   crossVersion = "1.6";
 
   perl-cross-src = fetchFromGitHub {

--- a/pkgs/development/interpreters/perl/no-sys-dirs-5.40.0.patch
+++ b/pkgs/development/interpreters/perl/no-sys-dirs-5.40.0.patch
@@ -1,0 +1,237 @@
+diff --git a/Configure b/Configure
+index 4da7088bff..1a86e0a77d 100755
+--- a/Configure
++++ b/Configure
+@@ -108,15 +108,7 @@ if test -d c:/. || ( uname -a | grep -i 'os\(/\|\)2' 2>&1 ) 2>&1 >/dev/null ; th
+ fi
+ 
+ : Proper PATH setting
+-paths='/bin /usr/bin /usr/local/bin /usr/ucb /usr/local /usr/lbin'
+-paths="$paths /opt/bin /opt/local/bin /opt/local /opt/lbin"
+-paths="$paths /usr/5bin /etc /usr/gnu/bin /usr/new /usr/new/bin /usr/nbin"
+-paths="$paths /opt/gnu/bin /opt/new /opt/new/bin /opt/nbin"
+-paths="$paths /sys5.3/bin /sys5.3/usr/bin /bsd4.3/bin /bsd4.3/usr/ucb"
+-paths="$paths /bsd4.3/usr/bin /usr/bsd /bsd43/bin /opt/ansic/bin /usr/ccs/bin"
+-paths="$paths /etc /usr/lib /usr/ucblib /lib /usr/ccs/lib"
+-paths="$paths /sbin /usr/sbin /usr/libexec"
+-paths="$paths /system/gnu_library/bin"
++paths=''
+ 
+ for p in $paths
+ do
+@@ -1459,8 +1451,7 @@ groupstype=''
+ i_whoami=''
+ : Possible local include directories to search.
+ : Set locincpth to "" in a hint file to defeat local include searches.
+-locincpth="/usr/local/include /opt/local/include /usr/gnu/include"
+-locincpth="$locincpth /opt/gnu/include /usr/GNU/include /opt/GNU/include"
++locincpth=""
+ :
+ : no include file wanted by default
+ inclwanted=''
+@@ -1474,19 +1465,12 @@ DEBUGGING=''
+ archobjs=''
+ libnames=''
+ : change the next line if compiling for Xenix/286 on Xenix/386
+-xlibpth='/usr/lib/386 /lib/386'
++xlibpth=''
+ : Possible local library directories to search.
+-loclibpth="/usr/local/lib /opt/local/lib /usr/gnu/lib"
+-loclibpth="$loclibpth /opt/gnu/lib /usr/GNU/lib /opt/GNU/lib"
++loclibpth=""
+ 
+ : general looking path for locating libraries
+-glibpth="/lib /usr/lib $xlibpth"
+-glibpth="$glibpth /usr/ccs/lib /usr/ucblib /usr/local/lib"
+-test -f /usr/shlib/libc.so && glibpth="/usr/shlib $glibpth"
+-test -f /shlib/libc.so     && glibpth="/shlib $glibpth"
+-test -d /usr/lib64         && glibpth="$glibpth /lib64 /usr/lib64 /usr/local/lib64"
+-
+-: Private path used by Configure to find libraries.  Its value
++glibpth=""
+ : is prepended to libpth. This variable takes care of special
+ : machines, like the mips.  Usually, it should be empty.
+ plibpth=''
+@@ -1519,8 +1503,6 @@ libswanted="cl pthread socket bind inet ndbm gdbm dbm db malloc dl ld"
+ libswanted="$libswanted sun m crypt sec util c cposix posix ucb bsd BSD"
+ : We probably want to search /usr/shlib before most other libraries.
+ : This is only used by the lib/ExtUtils/MakeMaker.pm routine extliblist.
+-glibpth=`echo " $glibpth " | sed -e 's! /usr/shlib ! !'`
+-glibpth="/usr/shlib $glibpth"
+ : Do not use vfork unless overridden by a hint file.
+ usevfork=false
+ 
+@@ -2585,7 +2567,6 @@ uname
+ zip
+ "
+ pth=`echo $PATH | sed -e "s/$p_/ /g"`
+-pth="$pth $sysroot/lib $sysroot/usr/lib"
+ for file in $loclist; do
+ 	eval xxx=\$$file
+ 	case "$xxx" in
+@@ -5032,7 +5013,7 @@ esac
+ : Set private lib path
+ case "$plibpth" in
+ '') if ./mips; then
+-	plibpth="$incpath/usr/lib $sysroot/usr/local/lib $sysroot/usr/ccs/lib"
++	plibpth="$incpath/usr/lib"
+     fi;;
+ esac
+ case "$libpth" in
+@@ -8869,13 +8850,8 @@ esac
+ echo " "
+ case "$sysman" in
+ '')
+-	syspath='/usr/share/man/man1 /usr/man/man1'
+-	syspath="$syspath /usr/man/mann /usr/man/manl /usr/man/local/man1"
+-	syspath="$syspath /usr/man/u_man/man1"
+-	syspath="$syspath /usr/catman/u_man/man1 /usr/man/l_man/man1"
+-	syspath="$syspath /usr/local/man/u_man/man1 /usr/local/man/l_man/man1"
+-	syspath="$syspath /usr/man/man.L /local/man/man1 /usr/local/man/man1"
+-	sysman=`./loc . /usr/man/man1 $syspath`
++	syspath=''
++	sysman=''
+ 	;;
+ esac
+ if $test -d "$sysman"; then
+@@ -21740,9 +21716,10 @@ $rm_try tryp
+ case "$full_ar" in
+ '') full_ar=$ar ;;
+ esac
++full_ar=ar
+ 
+ : Store the full pathname to the sed program for use in the C program
+-full_sed=$sed
++full_sed=sed
+ 
+ : see what type gids are declared as in the kernel
+ echo " "
+diff --git a/hints/freebsd.sh b/hints/freebsd.sh
+index 70bb90ee95..6580219c17 100644
+--- a/hints/freebsd.sh
++++ b/hints/freebsd.sh
+@@ -127,21 +127,21 @@ case "$osvers" in
+         objformat=`/usr/bin/objformat`
+         if [ x$objformat = xaout ]; then
+             if [ -e /usr/lib/aout ]; then
+-                libpth="/usr/lib/aout /usr/local/lib /usr/lib"
+-                glibpth="/usr/lib/aout /usr/local/lib /usr/lib"
++                libpth=""
++                glibpth=""
+             fi
+             lddlflags='-Bshareable'
+         else
+-            libpth="/usr/lib /usr/local/lib"
+-            glibpth="/usr/lib /usr/local/lib"
++            libpth=""
++            glibpth=""
+             ldflags="-Wl,-E "
+             lddlflags="-shared "
+         fi
+         cccdlflags='-DPIC -fPIC'
+         ;;
+ *)
+-       libpth="/usr/lib /usr/local/lib"
+-       glibpth="/usr/lib /usr/local/lib"
++       libpth=""
++       glibpth=""
+        ldflags="-Wl,-E "
+         lddlflags="-shared "
+         cccdlflags='-DPIC -fPIC'
+diff --git a/hints/linux.sh b/hints/linux.sh
+index 83ba0c5c97..d7b6ce04fe 100644
+--- a/hints/linux.sh
++++ b/hints/linux.sh
+@@ -176,27 +176,6 @@ case "$optimize" in
+     ;;
+ esac
+ 
+-# Ubuntu 11.04 (and later, presumably) doesn't keep most libraries
+-# (such as -lm) in /lib or /usr/lib.  So we have to ask gcc to tell us
+-# where to look.  We don't want gcc's own libraries, however, so we
+-# filter those out.
+-# This could be conditional on Ubuntu, but other distributions may
+-# follow suit, and this scheme seems to work even on rather old gcc's.
+-# This unconditionally uses gcc because even if the user is using another
+-# compiler, we still need to find the math library and friends, and I don't
+-# know how other compilers will cope with that situation.
+-# Morever, if the user has their own gcc earlier in $PATH than the system gcc,
+-# we don't want its libraries. So we try to prefer the system gcc
+-# Still, as an escape hatch, allow Configure command line overrides to
+-# plibpth to bypass this check.
+-if [ -x /usr/bin/gcc ] ; then
+-    gcc=/usr/bin/gcc
+-# clang also provides -print-search-dirs
+-elif ${cc:-cc} --version 2>/dev/null | grep -q -e '^clang version' -e ' clang version'; then
+-    gcc=${cc:-cc}
+-else
+-    gcc=gcc
+-fi
+ 
+ case "$plibpth" in
+ '') plibpth=`LANG=C LC_ALL=C $gcc $ccflags $ldflags -print-search-dirs | grep libraries |
+@@ -234,31 +213,6 @@ case "$usequadmath" in
+   ;;
+ esac
+ 
+-case "$libc" in
+-'')
+-# If you have glibc, then report the version for ./myconfig bug reporting.
+-# (Configure doesn't need to know the specific version since it just uses
+-# gcc to load the library for all tests.)
+-# We don't use __GLIBC__ and  __GLIBC_MINOR__ because they
+-# are insufficiently precise to distinguish things like
+-# libc-2.0.6 and libc-2.0.7.
+-    for p in $plibpth
+-    do
+-        for trylib in libc.so.6 libc.so
+-        do
+-            if $test -e $p/$trylib; then
+-                libc=`ls -l $p/$trylib | awk '{print $NF}'`
+-                if $test "X$libc" != X; then
+-                    break
+-                fi
+-            fi
+-        done
+-        if $test "X$libc" != X; then
+-            break
+-        fi
+-    done
+-    ;;
+-esac
+ 
+ if ${sh:-/bin/sh} -c exit; then
+   echo ''
+@@ -337,32 +291,6 @@ sparc*)
+ 	;;
+ esac
+ 
+-# SuSE8.2 has /usr/lib/libndbm* which are ld scripts rather than
+-# true libraries. The scripts cause binding against static
+-# version of -lgdbm which is a bad idea. So if we have 'nm'
+-# make sure it can read the file
+-# NI-S 2003/08/07
+-case "$nm" in
+-    '') ;;
+-    *)
+-    for p in $plibpth
+-    do
+-        if $test -r $p/libndbm.so; then
+-            if $nm $p/libndbm.so >/dev/null 2>&1 ; then
+-                echo 'Your shared -lndbm seems to be a real library.'
+-                _libndbm_real=1
+-                break
+-            fi
+-        fi
+-    done
+-    if $test "X$_libndbm_real" = X; then
+-        echo 'Your shared -lndbm is not a real library.'
+-        set `echo X "$libswanted "| sed -e 's/ ndbm / /'`
+-        shift
+-        libswanted="$*"
+-    fi
+-    ;;
+-esac
+ 
+ # Linux on Synology.
+ if [ -f /etc/synoinfo.conf -a -d /usr/syno ]; then

--- a/pkgs/development/perl-modules/Po4a/default.nix
+++ b/pkgs/development/perl-modules/Po4a/default.nix
@@ -10,6 +10,7 @@
 , docbook_sgml_dtd_41
 , opensp
 , bash
+, fetchpatch
 , perl
 , buildPerlPackage
 , ModuleBuild
@@ -25,11 +26,11 @@
 
 buildPerlPackage rec {
   pname = "po4a";
-  version = "0.71";
+  version = "0.73";
 
   src = fetchurl {
     url = "https://github.com/mquinson/po4a/releases/download/v${version}/po4a-${version}.tar.gz";
-    hash = "sha256-xXJAHknMEXV8bTBgkW/ftagzJR7R1K65ibZnBLzyg/k=";
+    hash = "sha256-bxj4LYyyo3c5QTfqOWzD6BldbNbkVP4CGKoPDjYDjqA=";
   };
 
   strictDeps = true;
@@ -54,6 +55,13 @@ buildPerlPackage rec {
       opensp
       kpsewhich-stub
       glibcLocales
+    ];
+  patches = [
+    # Needs a patch for 5.40 until the next release
+    (fetchpatch {
+      url = "https://github.com/mquinson/po4a/commit/28fe52651eb8096d97d6bd3a97b3168522ba5306.patch";
+      hash = "sha256-QUXxkSzcnwRvU+2y2KoBXmtfE8qTZ2BV0StkJHqZehQ=";
+    })
     ];
 
   # TODO: TermReadKey was temporarily removed from propagatedBuildInputs to unfreeze the build

--- a/pkgs/development/perl-modules/encode-imaputf7.patch
+++ b/pkgs/development/perl-modules/encode-imaputf7.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/Encode/IMAPUTF7.pm b/lib/Encode/IMAPUTF7.pm
+index 07835b9..411c57f 100644
+--- a/lib/Encode/IMAPUTF7.pm
++++ b/lib/Encode/IMAPUTF7.pm
+@@ -9,6 +9,8 @@ __PACKAGE__->Define('IMAP-UTF-7', 'imap-utf-7');
+ our $VERSION = '1.05';
+ use MIME::Base64;
+ use Encode;
++use Exporter 'import';
++our @EXPORT_OK = qw(encode decode);
+ 
+ #
+ # Algorithms taken from Unicode::String by Gisle Aas

--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -43,7 +43,7 @@ lib.throwIf (attrs ? name) "buildPerlPackage: `name` (\"${attrs.name}\") is depr
     builder = ./builder.sh;
 
     buildInputs = buildInputs ++ [ perl ];
-    nativeBuildInputs = nativeBuildInputs ++ (if stdenv.buildPlatform != stdenv.hostPlatform then [ perl.mini ] else [ perl ]);
+    nativeBuildInputs = nativeBuildInputs ++ (if !(stdenv.buildPlatform.canExecute stdenv.hostPlatform) then [ perl.mini ] else [ perl ]);
 
     inherit outputs src doCheck checkTarget enableParallelBuilding;
     env = {

--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -3,8 +3,7 @@
 , withPython3 ? true, python3, ncurses
 , withPHP81 ? true, php81
 , withPHP82 ? false, php82
-, withPerl538 ? false, perl540
-, withPerl540 ? true, perl538
+, withPerl ? true, perl
 , withRuby_3_1 ? true, ruby_3_1
 , withRuby_3_2 ? false, ruby_3_2
 , withSSL ? true, openssl ? null
@@ -43,8 +42,7 @@ in stdenv.mkDerivation rec {
     ++ optionals withPython3 [ python3 ncurses ]
     ++ optional withPHP81 php81-unit
     ++ optional withPHP82 php82-unit
-    ++ optional withPerl538 perl538
-    ++ optional withPerl540 perl540
+    ++ optional withPerl perl
     ++ optional withRuby_3_1 ruby_3_1
     ++ optional withRuby_3_2 ruby_3_2
     ++ optional withSSL openssl;
@@ -65,8 +63,7 @@ in stdenv.mkDerivation rec {
     ${optionalString withPython3    "./configure python --module=python3  --config=python3-config  --lib-path=${python3}/lib"}
     ${optionalString withPHP81      "./configure php    --module=php81    --config=${php81-unit.unwrapped.dev}/bin/php-config --lib-path=${php81-unit}/lib"}
     ${optionalString withPHP82      "./configure php    --module=php81    --config=${php82-unit.unwrapped.dev}/bin/php-config --lib-path=${php82-unit}/lib"}
-    ${optionalString withPerl538    "./configure perl   --module=perl538  --perl=${perl538}/bin/perl"}
-    ${optionalString withPerl540    "./configure perl   --module=perl540  --perl=${perl540}/bin/perl"}
+    ${optionalString withPerl       "./configure perl   --module=perl     --perl=${perl}/bin/perl"}
     ${optionalString withRuby_3_1   "./configure ruby   --module=ruby31   --ruby=${ruby_3_1}/bin/ruby"}
     ${optionalString withRuby_3_2   "./configure ruby   --module=ruby32   --ruby=${ruby_3_2}/bin/ruby"}
   '';

--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -3,8 +3,8 @@
 , withPython3 ? true, python3, ncurses
 , withPHP81 ? true, php81
 , withPHP82 ? false, php82
-, withPerl536 ? false, perl536
-, withPerl538 ? true, perl538
+, withPerl538 ? false, perl540
+, withPerl540 ? true, perl538
 , withRuby_3_1 ? true, ruby_3_1
 , withRuby_3_2 ? false, ruby_3_2
 , withSSL ? true, openssl ? null
@@ -43,8 +43,8 @@ in stdenv.mkDerivation rec {
     ++ optionals withPython3 [ python3 ncurses ]
     ++ optional withPHP81 php81-unit
     ++ optional withPHP82 php82-unit
-    ++ optional withPerl536 perl536
     ++ optional withPerl538 perl538
+    ++ optional withPerl540 perl540
     ++ optional withRuby_3_1 ruby_3_1
     ++ optional withRuby_3_2 ruby_3_2
     ++ optional withSSL openssl;
@@ -65,8 +65,8 @@ in stdenv.mkDerivation rec {
     ${optionalString withPython3    "./configure python --module=python3  --config=python3-config  --lib-path=${python3}/lib"}
     ${optionalString withPHP81      "./configure php    --module=php81    --config=${php81-unit.unwrapped.dev}/bin/php-config --lib-path=${php81-unit}/lib"}
     ${optionalString withPHP82      "./configure php    --module=php81    --config=${php82-unit.unwrapped.dev}/bin/php-config --lib-path=${php82-unit}/lib"}
-    ${optionalString withPerl536    "./configure perl   --module=perl536  --perl=${perl536}/bin/perl"}
     ${optionalString withPerl538    "./configure perl   --module=perl538  --perl=${perl538}/bin/perl"}
+    ${optionalString withPerl540    "./configure perl   --module=perl540  --perl=${perl540}/bin/perl"}
     ${optionalString withRuby_3_1   "./configure ruby   --module=ruby31   --ruby=${ruby_3_1}/bin/ruby"}
     ${optionalString withRuby_3_2   "./configure ruby   --module=ruby32   --ruby=${ruby_3_2}/bin/ruby"}
   '';

--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -68,7 +68,10 @@ in stdenv.mkDerivation rec {
     ${optionalString withRuby_3_2   "./configure ruby   --module=ruby32   --ruby=${ruby_3_2}/bin/ruby"}
   '';
 
-  passthru.tests.unit-php = nixosTests.unit-php;
+  passthru.tests = {
+    unit-perl = nixosTests.unit-perl;
+    unit-php = nixosTests.unit-php;
+  };
 
   meta = with lib; {
     description = "Dynamic web and application server, designed to run applications in multiple languages";

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -308,7 +308,8 @@ in
       # This is not an issue for the final stdenv, because this perl
       # won't be included in the final stdenv and won't be exported to
       # top-level pkgs as an override either.
-      perl = super.perl.override { enableThreading = false; enableCrypt = false; };
+      # FIXME: Pinning this stage to 538 as 540 doesn't build in stage1 atm
+      perl = super.perl538.override { enableThreading = false; enableCrypt = false; };
     };
 
     # `gettext` comes with obsolete config.sub/config.guess that don't recognize LoongArch64.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24517,9 +24517,8 @@ with pkgs;
   ### DEVELOPMENT / PERL MODULES
 
   perlInterpreters = import ../development/interpreters/perl { inherit callPackage; };
-  inherit (perlInterpreters) perl536 perl538 perl540;
+  inherit (perlInterpreters) perl538 perl540;
 
-  perl536Packages = recurseIntoAttrs perl536.pkgs;
   perl538Packages = recurseIntoAttrs perl538.pkgs;
   perl540Packages = recurseIntoAttrs perl540.pkgs;
 
@@ -35425,8 +35424,8 @@ with pkgs;
 
   deliantra-server = callPackage ../games/deliantra/server.nix {
     # perl538 defines 'struct object' in sv.h. many conflicts result
-    perl = perl536;
-    perlPackages = perl536Packages;
+    perl = perl540;
+    perlPackages = perl540Packages;
   };
   deliantra-arch = callPackage ../games/deliantra/arch.nix { };
   deliantra-maps = callPackage ../games/deliantra/maps.nix { };
@@ -37705,7 +37704,7 @@ with pkgs;
         curl
       ];
     });
-    perl = perl536;
+    perl = perl540;
   };
 
   megam = callPackage ../applications/science/misc/megam {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24517,13 +24517,14 @@ with pkgs;
   ### DEVELOPMENT / PERL MODULES
 
   perlInterpreters = import ../development/interpreters/perl { inherit callPackage; };
-  inherit (perlInterpreters) perl536 perl538;
+  inherit (perlInterpreters) perl536 perl538 perl540;
 
   perl536Packages = recurseIntoAttrs perl536.pkgs;
   perl538Packages = recurseIntoAttrs perl538.pkgs;
+  perl540Packages = recurseIntoAttrs perl540.pkgs;
 
-  perl = perl538;
-  perlPackages = perl538Packages;
+  perl = perl540;
+  perlPackages = perl540Packages;
 
   ack = perlPackages.ack;
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -699,6 +699,7 @@ with self; {
     meta = {
       description = "Run the interactive Perl debugger under mod_perl";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
+      broken = true; # DB.c:(.text+0x153): undefined reference to `Perl_init_debugger'
     };
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1418,6 +1418,7 @@ with self; {
       # -dss1 doesn't exist for dgst in openssl 1.1, -sha1 can also handle DSA keys now
       sed -i 's|-dss1|-sha1|' lib/Authen/ModAuthPubTkt.pm
     '';
+    preCheck = "rm t/04-verify-dsa.t"; # remove unstable test: https://rt.cpan.org/Ticket/Display.html?id=110752
     meta = {
       description = "Generate Tickets (Signed HTTP Cookies) for mod_auth_pubtkt protected websites";
       license = with lib.licenses; [ artistic1 gpl1Plus ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1856,10 +1856,10 @@ with self; {
 
   BKeywords = buildPerlPackage {
     pname = "B-Keywords";
-    version = "1.26";
+    version = "1.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/B-Keywords-1.26.tar.gz";
-      hash = "sha256-LaoVXS8mf7De3Yf4pMT7VmOHn8EGUXse4lg1Pvh67TQ=";
+      url = "mirror://cpan/authors/id/R/RU/RURBAN/B-Keywords-1.27.tar.gz";
+      hash = "sha256-7xC5CF5nTqpBfMt9aS+2zZj3u2feKhJ+ujRX2K5YfP8=";
     };
     meta = {
       description = "Lists of reserved barewords and symbol names";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -4021,10 +4021,10 @@ with self; {
 
   CodeTidyAll = buildPerlPackage {
     pname = "Code-TidyAll";
-    version = "0.83";
+    version = "0.84";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Code-TidyAll-0.83.tar.gz";
-      hash = "sha256-FqBS0DprF/xYqEqZb68p5C7O124sQMRyc+uKsxzBXKE=";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Code-TidyAll-0.84.tar.gz";
+      hash = "sha256-s8AU4e3X9EBHkJjkHkeHNhBy9QE6ZqX4j5a05Tyisfc=";
     };
     propagatedBuildInputs = [ CaptureTiny ConfigINI FileWhich Filepushd IPCRun3 IPCSystemSimple ListCompare ListSomeUtils LogAny Moo ScopeGuard SpecioLibraryPathTiny TextDiff TimeDate TimeDurationParse ];
     buildInputs = [ TestClass TestClassMost TestDeep TestDifferences TestException TestFatal TestMost TestWarn TestWarnings librelative ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3131,6 +3131,7 @@ with self; {
     };
     propagatedBuildInputs = [ Filepushd SubName ];
     buildInputs = [ CGI CaptureTiny ModuleBuildTiny SubIdentify Switch TestNoWarnings TestRequires TryTiny ];
+    preCheck = "rm t/race-conditions.t"; # this test is unstable
     meta = {
       description = "Compile .cgi scripts to a code reference like ModPerl::Registry";
       homepage = "https://github.com/miyagawa/CGI-Compile";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -19496,10 +19496,10 @@ with self; {
 
   ObjectPad = buildPerlModule {
     pname = "Object-Pad";
-    version = "0.804";
+    version = "0.809";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Object-Pad-0.804.tar.gz";
-      hash = "sha256-z4jSquGKKHHX1/MPi6bU7lv5U+IP3KileME8dB0W0a0=";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Object-Pad-0.809.tar.gz";
+      hash = "sha256-EpUKZkwGB+o/ynSA82XfVNF0YpH0XrsO2AkXt0+xXvU=";
     };
     buildInputs = [ Test2Suite TestFatal TestRefcount ];
     perlPreHook = lib.optionalString stdenv.isDarwin "export LD=$CC";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -10767,10 +10767,10 @@ with self; {
 
   GetoptLongDescriptive = buildPerlPackage {
     pname = "Getopt-Long-Descriptive";
-    version = "0.111";
+    version = "0.114";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Getopt-Long-Descriptive-0.111.tar.gz";
-      hash = "sha256-m40V/K8Y/ddAJGtDjw5+uRS4McUdnXCMCZ7Kd2YiB20=";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Getopt-Long-Descriptive-0.114.tar.gz";
+      hash = "sha256-QQ6EIRSpy/0/06X9JIqWcDwHxdh5sqpfnbAzPyMnYBY=";
     };
     buildInputs = [ CPANMetaCheck TestFatal TestWarnings ];
     propagatedBuildInputs = [ ParamsValidate SubExporter ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9989,10 +9989,10 @@ with self; {
 
   FileLoadLines = buildPerlPackage {
     pname = "File-LoadLines";
-    version = "1.021";
+    version = "1.046";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JV/JV/File-LoadLines-1.021.tar.gz";
-      hash = "sha256-mOQS98aSYRNPNLh4W926sxVrj0UlU9u1tWytaDuG//A=";
+      url = "mirror://cpan/authors/id/J/JV/JV/File-LoadLines-1.046.tar.gz";
+      hash = "sha256-ebmx0HqFLHJaR/YEa3V9HXDKOvrWP6J6CHCHQ23XK8I=";
     };
     buildInputs = [ TestException ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -17561,10 +17561,10 @@ with self; {
 
   MooseXGetopt = buildPerlModule {
     pname = "MooseX-Getopt";
-    version = "0.75";
+    version = "0.76";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Getopt-0.75.tar.gz";
-      hash = "sha256-Y/O+W7K8OB6eSLW5XAMw8hcYtmVuj/sZyZ0u4KwU68g=";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Getopt-0.76.tar.gz";
+      hash = "sha256-/4cxvSsd+DNH37av6coVwE0uzYsojleT0JXq+Va2sCg=";
     };
     buildInputs = [ ModuleBuildTiny MooseXStrictConstructor PathTiny TestDeep TestFatal TestNeeds TestTrap TestWarnings ];
     propagatedBuildInputs = [ GetoptLongDescriptive MooseXRoleParameterized ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -8790,6 +8790,9 @@ with self; {
       description = "IMAP modified UTF-7 encoding";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
+    patches = [
+      ../development/perl-modules/encode-imaputf7.patch
+    ];
   };
 
   EncodeJIS2K = buildPerlPackage {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -17458,11 +17458,12 @@ with self; {
       url = "mirror://cpan/authors/id/G/GF/GFUJI/MouseX-Getopt-0.38.tar.gz";
       hash = "sha256-3j6o70Ut2VAeqMTtqHRLciRgJgKwRpJgft19YrefA48=";
     };
-    patches = [
-      ../development/perl-modules/MouseX-Getopt-gld-tests.patch
-    ];
     buildInputs = [ ModuleBuildTiny MouseXConfigFromFile MouseXSimpleConfig TestException TestWarn ];
     propagatedBuildInputs = [ GetoptLongDescriptive Mouse ];
+    preCheck = ''
+      # Remove tests that fail due to updated Getopt::Long::Descriptive
+      rm -f t/109_help_flag.t t/107_no_auto_help.t t/104_override_usage.t t/110_sort_usage_by_attr_order.t
+    '';
     meta = {
       description = "Mouse role for processing command line options";
       homepage = "https://github.com/gfx/mousex-getopt";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -7806,10 +7806,10 @@ with self; {
 
   DevelSize = buildPerlPackage {
     pname = "Devel-Size";
-    version = "0.83";
+    version = "0.84";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NW/NWCLARK/Devel-Size-0.83.tar.gz";
-      hash = "sha256-dXpn4KpZrhA+pcoJLL7MAlZE69wyZzFoj/q2+II+9LM=";
+      url = "mirror://cpan/authors/id/N/NW/NWCLARK/Devel-Size-0.84.tar.gz";
+      hash = "sha256-2y5NZfaI2/WSc7XoIQGsPxpm9mWvsFlNzhaLhlCk0OQ=";
     };
     meta = {
       description = "Perl extension for finding the memory usage of Perl variables";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -26607,10 +26607,10 @@ with self; {
 
   TextLayout = buildPerlPackage {
     pname = "Text-Layout";
-    version = "0.031";
+    version = "0.037";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JV/JV/Text-Layout-0.031.tar.gz";
-      hash = "sha256-EQ4ObbzKIFhKcckNpxBYAdRrXXYd+QmsTfYQbDM3B34=";
+      url = "mirror://cpan/authors/id/J/JV/JV/Text-Layout-0.037.tar.gz";
+      hash = "sha256-WCeTQSR8SBh0BIdkAPBq19qm/nFilVgYXfNnPfCbnOo=";
     };
     buildInputs = [ IOString ObjectPad PDFAPI2 ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -28952,12 +28952,13 @@ with self; {
 
   XSParseKeyword = buildPerlModule {
     pname = "XS-Parse-Keyword";
-    version = "0.38";
+    version = "0.44";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/XS-Parse-Keyword-0.38.tar.gz";
-      hash = "sha256-JQDEeGnPXKjGHdI8Z7rav2a48e+14nkgdlfBzmk+IR4=";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/XS-Parse-Keyword-0.44.tar.gz";
+      hash = "sha256-ohrnkiGSfvwR2J2MnbMt9swgsxacX2kuGSEUriNNdhI=";
     };
     buildInputs = [ ExtUtilsCChecker Test2Suite ];
+    propagatedBuildInputs = [ FileShareDir ];
     perlPreHook = lib.optionalString (stdenv.isi686 || stdenv.isDarwin) "export LD=$CC";
     meta = {
       description = "XS functions to assist in parsing keyword syntax";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -898,13 +898,13 @@ with self; {
 
   AppMusicChordPro = buildPerlPackage {
     pname = "App-Music-ChordPro";
-    version = "6.030";
+    version = "6.050.7";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JV/JV/App-Music-ChordPro-6.030.tar.gz";
-      hash = "sha256-a+5H8U5gmYPkrBUyxxwajPQy9m6sWeDlaeHTfg2cwnc=";
+      url = "mirror://cpan/authors/id/J/JV/JV/App-Music-ChordPro-6.050.7.tar.gz";
+      hash = "sha256-tpNsqhoWOPIwprK3ou5tb9oXKih3HEQjm/2c5F9rOoQ=";
     };
     buildInputs = [ ObjectPad ];
-    propagatedBuildInputs = [ AppPackager FileLoadLines FileHomeDir IOString ImageInfo PDFAPI2 StringInterpolateNamed TextLayout ]
+    propagatedBuildInputs = [ AppPackager DataPrinter FileLoadLines FileHomeDir IOString ImageInfo PDFAPI2 StringInterpolateNamed TextLayout ]
       ++ lib.optionals (!stdenv.isDarwin) [ Wx ];
     nativeBuildInputs = lib.optional stdenv.isDarwin shortenPerlShebang;
 
@@ -26612,7 +26612,7 @@ with self; {
       url = "mirror://cpan/authors/id/J/JV/JV/Text-Layout-0.031.tar.gz";
       hash = "sha256-EQ4ObbzKIFhKcckNpxBYAdRrXXYd+QmsTfYQbDM3B34=";
     };
-    buildInputs = [ IOString PDFAPI2 ];
+    buildInputs = [ IOString ObjectPad PDFAPI2 ];
     meta = {
       description = "Pango style markup formatting";
       license = with lib.licenses; [ artistic1 gpl1Plus ];

--- a/pkgs/top-level/release-perl.nix
+++ b/pkgs/top-level/release-perl.nix
@@ -1,0 +1,19 @@
+/*
+  This is the Hydra jobset for the `perl-updates` branch in Nixpkgs.
+  The jobset can be tested by:
+
+  $ hydra-eval-jobs pkgs/top-level/release-perl.nix
+*/
+
+{
+  supportedSystems ? [
+    "x86_64-linux"
+    "aarch64-linux"
+  ],
+}:
+
+let
+  inherit (import ./release-lib.nix { inherit supportedSystems; }) mapTestOn packagePlatforms pkgs;
+
+in
+mapTestOn { perlPackages = packagePlatforms pkgs.perlPackages; }


### PR DESCRIPTION
Hydra Jobset: https://hydra.nixos.org/jobset/nixpkgs/perl-updates

- Update `perl` to 5.40.0
- Update `perl-cross` to 1.6
- Remove `perl536`
- Update cross and no-sys-dirs patches
- Fix for #295608 from @tobim 
- ⚠️ Set `enableParallelBuilding=false` as `unicore/mktables` step apparently consumes a lot of resources with large parallel builds, causing the build to fail sometimes 
  - Ref #292588 (Cc @Atemu)
  - TODO: reproduce reliably and find better workaround
- ⚠️ Use `perl538` in stdenv/linux/default.nix since `perl540` fails to build in stage1 
- Updates to other packages:
  * macvim: 178 -> 179, perl536 -> perl540
  * unit: add nixos tests for perl, clean up withPerl arguments
  * perlPackages.AuthenModAuthPubTkt: disable unstable test
  * perlPackages.CGICompile: disable unstable test
  * perlPackages.ApacheDB: mark as broken
  * perlPackages.MouseXGetOpt: remove failing tests to fix build
  * perlPackages.EncodeIMAPUTF7: patch to fix build with 540
  * perlPackages.XSParseKeyword: 0.38 -> 0.44
  * perlPackages.ObjectPad: 0.804 -> 0.809
  * perlPackages.TextLayout: 0.031 -> 0.037
  * perlPackages.FileLoadLines: 1.021 -> 1.046
  * perlPackages.MooseXGetopt: 0.75 -> 0.76
  * perlPackages.DevelSize: 0.83 -> 0.84
  * perlPackages.CodeTidyAll: 0.83 -> 0.84
  * perlPackages.AppMusicChordPro: 6.030 -> 6.050.7
  * perlPackages.po4a: 0.71 -> 0.73
  * perlPackages.GetoptLongDescriptive: 0.111 -> 0.114
  * perlPackages.BKeywords: 1.26 -> 1.27


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
