### PR TITLE
botan3: fix Darwin build by passing libSystem

### DIFF
--- a/pkgs/development/libraries/botan/generic.nix
+++ b/pkgs/development/libraries/botan/generic.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, python3, bzip2, zlib, gmp, boost
+{ lib, stdenv, fetchurl, python3, bzip2, zlib, gmp, boost, libcxx
 # Passed by version specific builders
 , baseVersion, revision, hash
 , sourceExtension ? "tar.xz"
@@ -9,6 +9,7 @@
 , knownVulnerabilities ? [ ]
 , CoreServices ? null
 , Security ? null
+, Libsystem ? null
 , ...
 }:
 
@@ -31,7 +32,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ python3 ];
   buildInputs = [ bzip2 zlib gmp boost ]
-    ++ lib.optionals stdenv.isDarwin [ CoreServices Security ];
+  ++ lib.optionals stdenv.isDarwin [
+    # Trying to do something about libcxx losing priority for stdint.h
+    libcxx
+    CoreServices Security Libsystem
+    libcxx
+  ];
 
   configurePhase = ''
     runHook preConfigure

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19642,6 +19642,7 @@ with pkgs;
 
   botan3 = callPackage ../development/libraries/botan/3.0.nix {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;
+    inherit (darwin.apple_sdk) Libsystem;
   };
 
   box2d = callPackage ../development/libraries/box2d {


### PR DESCRIPTION
## Description of changes

Fixes #333114 (hopefully)

Should be no-op on Linux.

Will self-merge if CI confirms my hopes…

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
