### PR TITLE
compose2nix: init at 0.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -828,6 +828,12 @@
     githubId = 20405311;
     name = "Aksh Gupta";
   };
+  aksiksi = {
+    email = "assil@ksiksi.net";
+    github = "aksiksi";
+    githubId = 916621;
+    name = "Assil Ksiksi";
+  };
   akssri = {
     email = "akssri@vakra.xyz";
     github = "akssri";

--- a/pkgs/by-name/co/compose2nix/package.nix
+++ b/pkgs/by-name/co/compose2nix/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  testers,
+  compose2nix,
+}:
+
+buildGoModule rec {
+  pname = "compose2nix";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "aksiksi";
+    repo = "compose2nix";
+    rev = "v${version}";
+    hash = "sha256-+rvjQzfh8lYdJEYwODaRS7fA7Tm/G2ONFvDa1kVG++8";
+  };
+
+  vendorHash = "sha256-5DTPG4FiSWguTmcVmys64Y1fXJHlSI/1qj1VEBJomNk=";
+
+  passthru.tests = {
+    version = testers.testVersion {
+      package = compose2nix;
+      version = "compose2nix v${version}";
+    };
+  };
+
+  meta = {
+    homepage = "https://github.com/aksiksi/compose2nix";
+    changelog = "https://github.com/aksiksi/compose2nix/releases/tag/${src.rev}";
+    description = "Generate a NixOS config from a Docker Compose project";
+    license = lib.licenses.mit;
+    mainProgram = "compose2nix";
+    maintainers = with lib.maintainers; [ aksiksi ];
+  };
+}


### PR DESCRIPTION
## Description of changes

A CLI tool that automatically generates a NixOS config from a Docker Compose project.

Homepage: https://github.com/aksiksi/compose2nix

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).