### PR TITLE
nixos/mailman: add option to expand the uwsgi settings

### DIFF
--- a/nixos/modules/services/mail/mailman.nix
+++ b/nixos/modules/services/mail/mailman.nix
@@ -263,6 +263,15 @@ in {
       serve = {
         enable = lib.mkEnableOption "automatic nginx and uwsgi setup for mailman-web";
 
+        uwsgiSettings = lib.mkOption {
+          default = { };
+          example = { uwsgi.buffer-size = 8192; };
+          inherit (pkgs.formats.json {}) type;
+          description = ''
+            Extra configuration to merge into uwsgi config.
+          '';
+        };
+
         virtualRoot = lib.mkOption {
           default = "/";
           example = lib.literalExpression "/lists";
@@ -570,18 +579,20 @@ in {
       };
 
       mailman-uwsgi = lib.mkIf cfg.serve.enable (let
-        uwsgiConfig.uwsgi = {
-          type = "normal";
-          plugins = ["python3"];
-          home = webEnv;
-          http = "127.0.0.1:18507";
-        }
-        // (if cfg.serve.virtualRoot == "/"
-          then { module = "mailman_web.wsgi:application"; }
-          else {
-            mount = "${cfg.serve.virtualRoot}=mailman_web.wsgi:application";
-            manage-script-name = true;
+        uwsgiConfig = lib.recursiveUpdate {
+          uwsgi = {
+            type = "normal";
+            plugins = ["python3"];
+            home = webEnv;
+            http = "127.0.0.1:18507";
+          }
+          // (if cfg.serve.virtualRoot == "/"
+            then { module = "mailman_web.wsgi:application"; }
+            else {
+              mount = "${cfg.serve.virtualRoot}=mailman_web.wsgi:application";
+              manage-script-name = true;
           });
+        } cfg.serve.uwsgiSettings;
         uwsgiConfigFile = pkgs.writeText "uwsgi-mailman.json" (builtins.toJSON uwsgiConfig);
       in {
         wantedBy = ["multi-user.target"];


### PR DESCRIPTION
## Description of changes

I needed to expand the uwsgi buffer-size because a cookie from oauth2-proxy I am sending with the request was to big.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
