### PR TITLE
katago: 1.14.1 -> 1.15.3

### DIFF
--- a/pkgs/games/katago/default.nix
+++ b/pkgs/games/katago/default.nix
@@ -1,69 +1,40 @@
-{ stdenv
-, boost
-, cmake
-, config
-, cudaPackages
-, eigen
-, fetchFromGitHub
-, gperftools
-, lib
-, libzip
-, makeWrapper
-, mesa
-, ocl-icd
-, opencl-headers
-, openssl
-, writeShellScriptBin
-, enableAVX2 ? stdenv.hostPlatform.avx2Support
+{ stdenv, boost, cmake, config, cudaPackages, eigen, fetchFromGitHub, gperftools
+, lib, libzip, makeWrapper, ocl-icd, opencl-headers, openssl
+, writeShellScriptBin, enableAVX2 ? stdenv.hostPlatform.avx2Support
 , backend ? if config.cudaSupport then "cuda" else "opencl"
-, enableBigBoards ? false
-, enableContrib ? false
-, enableTcmalloc ? true
-, enableTrtPlanCache ? false
-}:
+, enableBigBoards ? false, enableContrib ? false, enableTcmalloc ? true
+, enableTrtPlanCache ? false }:
 
 assert lib.assertOneOf "backend" backend [ "opencl" "cuda" "tensorrt" "eigen" ];
 
 # N.b. older versions of cuda toolkit (e.g. 10) do not support newer versions
 # of gcc.  If you need to use cuda10, please override stdenv with gcc8Stdenv
-stdenv.mkDerivation rec {
+let
+  githash = "cd0ed6c0712088ddb901be68189ba7fa1439a9e7";
+  fakegit = writeShellScriptBin "git" "echo ${githash}";
+in stdenv.mkDerivation rec {
   pname = "katago";
-  version = "1.14.1";
-  githash = "f2dc582f98a79fefeb11b2c37de7db0905318f4f";
+  version = "1.15.3";
 
   src = fetchFromGitHub {
     owner = "lightvector";
     repo = "katago";
     rev = "v${version}";
-    hash = "sha256-ZdvHvrtSLwQ5vFMzLdJSJEiGcSent9iskPgpbL1TfhI=";
+    sha256 = "sha256-hZc8LlOxnVqJqyqOSIWKv3550QOaGr79xgqsAQ8B8SM=";
   };
 
-  fakegit = writeShellScriptBin "git" "echo ${githash}";
+  nativeBuildInputs = [ cmake makeWrapper ];
 
-  nativeBuildInputs = [
-    cmake
-    makeWrapper
-  ];
-
-  buildInputs = [
-    libzip
-    boost
-  ] ++ lib.optionals (backend == "eigen") [
-    eigen
-  ] ++ lib.optionals (backend == "cuda") [
-    cudaPackages.cudnn
-    cudaPackages.cudatoolkit
-  ] ++ lib.optionals (backend == "tensorrt") [
+  buildInputs = [ libzip boost ] ++ lib.optionals (backend == "eigen") [ eigen ]
+    ++ lib.optionals (backend == "cuda") [
+      cudaPackages.cudnn
+      cudaPackages.cudatoolkit
+    ] ++ lib.optionals (backend == "tensorrt") [
       cudaPackages.cudatoolkit
       cudaPackages.tensorrt
-  ] ++ lib.optionals (backend == "opencl") [
-    opencl-headers
-    ocl-icd
-  ] ++ lib.optionals enableContrib [
-    openssl
-  ] ++ lib.optionals enableTcmalloc [
-    gperftools
-  ];
+    ] ++ lib.optionals (backend == "opencl") [ opencl-headers ocl-icd ]
+    ++ lib.optionals enableContrib [ openssl ]
+    ++ lib.optionals enableTcmalloc [ gperftools ];
 
   cmakeFlags = [
     (lib.cmakeFeature "USE_BACKEND" (lib.toUpper backend))
@@ -97,9 +68,9 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Go engine modeled after AlphaGo Zero";
     mainProgram = "katago";
-    homepage    = "https://github.com/lightvector/katago";
-    license     = licenses.mit;
+    homepage = "https://github.com/lightvector/katago";
+    license = licenses.mit;
     maintainers = [ maintainers.omnipotententity ];
-    platforms   = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
## Description of changes

Version update, removed unnecessary dependency, used `nixfmt`, also hoisted the fakegit shell script out of the derivation as suggested in the last update.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
