### PR TITLE
vapoursynth-{bm3d,bm3dcuda,bm3dcpu,bm3dhip,dfttest,hqdn3d,knlmeanscl,wnnm},vs-{dfttest2,dfttest2cuda,dfttest2gcc,dfttest2hip,nlm-cuda,nlm-ispc},neo_{dfttest,f3kdb}: init

### DIFF
--- a/pkgs/by-name/ne/neo_dfttest/package.nix
+++ b/pkgs/by-name/ne/neo_dfttest/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  hostPlatform,
+  cmake,
+  pkg-config,
+  vapoursynth,
+  tbb,
+  zimg,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "neo_dfttest";
+  version = "8";
+
+  src = fetchFromGitHub {
+    owner = "HomeOfAviSynthPlusEvolution";
+    repo = "neo_dfttest";
+    rev = "refs/tags/r${finalAttrs.version}";
+    hash = "sha256-qlgg57Ysr/iwZz6RjJcLEYN/eRaG/LB3dIExY9FyXls=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    vapoursynth
+    tbb
+    zimg
+  ];
+
+  cmakeFlags = [ (lib.cmakeFeature "VERSION" "r${finalAttrs.version}") ];
+
+  postPatch = ''
+    sed -E -i '/^find_package\(Git /,+2d' CMakeLists.txt
+    rm -rf include/vapoursynth
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -t "$out/lib/vapoursynth" libneo-dfttest${hostPlatform.extensions.sharedLibrary}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Plugin for VapourSynth: neo_dfttest";
+    homepage = "https://github.com/HomeOfAviSynthPlusEvolution/neo_dfttest";
+    license = with lib.licenses; [
+      gpl3Plus
+      gpl2Plus
+    ];
+    maintainers = with lib.maintainers; [ snaki ];
+    platforms = lib.platforms.x86_64;
+  };
+})

--- a/pkgs/by-name/ne/neo_f3kdb/package.nix
+++ b/pkgs/by-name/ne/neo_f3kdb/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  hostPlatform,
+  cmake,
+  pkg-config,
+  vapoursynth,
+  tbb,
+  zimg,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "neo_f3kdb";
+  version = "9";
+
+  src = fetchFromGitHub {
+    owner = "HomeOfAviSynthPlusEvolution";
+    repo = "neo_f3kdb";
+    rev = "refs/tags/r${finalAttrs.version}";
+    hash = "sha256-MIvKjsemDeyv9qonuJbns0Dau8BjFQ1REppccs7s9JU=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    vapoursynth
+    tbb
+    zimg
+  ];
+
+  cmakeFlags = [ (lib.cmakeFeature "VERSION" "r${finalAttrs.version}") ];
+
+  postPatch = ''
+    sed -E -i '/^find_package\(Git /,+2d' CMakeLists.txt
+    rm -rf include/vapoursynth
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -t "$out/lib/vapoursynth" libneo-f3kdb${hostPlatform.extensions.sharedLibrary}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Plugin for VapourSynth: neo_f3kdb";
+    homepage = "https://github.com/HomeOfAviSynthPlusEvolution/neo_f3kdb";
+    license = with lib.licenses; [
+      gpl3Plus
+      gpl2Plus
+    ];
+    maintainers = with lib.maintainers; [ snaki ];
+    platforms = lib.platforms.x86_64;
+  };
+})

--- a/pkgs/by-name/va/vapoursynth-bm3d/package.nix
+++ b/pkgs/by-name/va/vapoursynth-bm3d/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  vapoursynth,
+  fftwSinglePrec,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vapoursynth-bm3d";
+  version = "9";
+
+  src = fetchFromGitHub {
+    owner = "HomeOfVapourSynthEvolution";
+    repo = "VapourSynth-BM3D";
+    rev = "refs/tags/r${finalAttrs.version}";
+    hash = "sha256-i7Kk7uFt2Wo/EWpVkGyuYgGZxBuQgOT3JM+WCFPHVrc=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    vapoursynth
+    fftwSinglePrec
+  ];
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail "vapoursynth_dep.get_pkgconfig_variable('libdir')" "get_option('libdir')"
+  '';
+
+  meta = {
+    inherit (vapoursynth.meta) platforms;
+    description = "Plugin for VapourSynth: bm3d";
+    homepage = "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-BM3D";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ snaki ];
+  };
+})

--- a/pkgs/by-name/va/vapoursynth-bm3dcuda/package.nix
+++ b/pkgs/by-name/va/vapoursynth-bm3dcuda/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  gcc12Stdenv,
+  fetchFromGitHub,
+  cmake,
+  cudaPackages_12_3,
+  vapoursynth,
+  cudaSupport ? true,
+  cpuSupport ? false,
+}:
+
+# gcc13 producdes weird artifacts
+gcc12Stdenv.mkDerivation (finalAttrs: {
+  pname = "vapoursynth-bm3dcuda";
+  version = "2.14";
+
+  src = fetchFromGitHub {
+    owner = "WolframRhodium";
+    repo = "VapourSynth-BM3DCUDA";
+    rev = "refs/tags/R${finalAttrs.version}";
+    hash = "sha256-Vcg1RaV0lOMAK0LCAJBMMeeSC0HoKigHwebzH/AcH2g=";
+  };
+
+  nativeBuildInputs =
+    [ cmake ]
+    ++ lib.optionals cudaSupport [
+      cudaPackages_12_3.cuda_nvcc
+      cudaPackages_12_3.cuda_nvrtc
+    ];
+
+  buildInputs = lib.optionals cudaSupport [ cudaPackages_12_3.cuda_cudart ];
+
+  # Taken from https://github.com/WolframRhodium/VapourSynth-BM3DCUDA/blob/main/.github/workflows/linux.yml
+  preConfigure =
+    ''
+      cmakeFlagsArray+=(${lib.escapeShellArg (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-ffast-math${lib.optionalString cpuSupport " -march=x86-64-v3"}")})
+    ''
+    + lib.optionalString cudaSupport ''
+      cmakeFlagsArray+=(${lib.escapeShellArg (lib.cmakeFeature "CMAKE_CUDA_FLAGS" "--use_fast_math -Wno-deprecated-gpu-targets")})
+    '';
+
+  cmakeFlags = [
+    (lib.cmakeFeature "VAPOURSYNTH_INCLUDE_DIRECTORY" "${vapoursynth}/include/vapoursynth")
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib/vapoursynth")
+    (lib.cmakeBool "ENABLE_CUDA" cudaSupport)
+    (lib.cmakeBool "ENABLE_CPU" cpuSupport)
+  ];
+
+  meta = {
+    description = "Plugin for VapourSynth: bm3dcuda bm3dcpu";
+    homepage = "https://github.com/WolframRhodium/VapourSynth-BM3DCUDA";
+    license = with lib.licenses; [ gpl2Plus ];
+    maintainers = with lib.maintainers; [ snaki ];
+    platforms = with lib.platforms; if cpuSupport then x86_64 else all;
+  };
+})

--- a/pkgs/by-name/va/vapoursynth-bm3dhip/package.nix
+++ b/pkgs/by-name/va/vapoursynth-bm3dhip/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  rocmPackages,
+  vapoursynth,
+  gpuTargets ? [
+    "gfx1010"
+    "gfx1011"
+    "gfx1012"
+    "gfx1030"
+    "gfx1031"
+    "gfx1032"
+    "gfx1033"
+    "gfx1034"
+    "gfx1035"
+    "gfx1036"
+    "gfx1100"
+    "gfx1101"
+    "gfx1102"
+    "gfx1103"
+  ],
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vapoursynth-bm3dhip";
+  version = "2.14";
+
+  src = fetchFromGitHub {
+    owner = "WolframRhodium";
+    repo = "VapourSynth-BM3DCUDA";
+    rev = "refs/tags/R${finalAttrs.version}";
+    hash = "sha256-Vcg1RaV0lOMAK0LCAJBMMeeSC0HoKigHwebzH/AcH2g=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    rocmPackages.clr
+  ];
+
+  buildInputs = [ rocmPackages.clr ];
+
+  # Taken from https://github.com/WolframRhodium/VapourSynth-BM3DCUDA/blob/main/.github/workflows/linux.yml
+  preConfigure = ''
+    cmakeFlagsArray=(
+      ${lib.escapeShellArg (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-ffast-math -munsafe-fp-atomics")}
+    )
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeFeature "VAPOURSYNTH_INCLUDE_DIRECTORY" "${vapoursynth}/include/vapoursynth")
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib/vapoursynth")
+    (lib.cmakeFeature "CMAKE_CXX_COMPILER" "hipcc")
+    (lib.cmakeFeature "GPU_TARGETS" (lib.concatStringsSep ";" gpuTargets))
+    (lib.cmakeBool "ENABLE_CUDA" false)
+    (lib.cmakeBool "ENABLE_CPU" false)
+    (lib.cmakeBool "ENABLE_HIP" true)
+  ];
+
+  meta = {
+    description = "Plugin for VapourSynth: bm3dhip";
+    homepage = "https://github.com/WolframRhodium/VapourSynth-BM3DCUDA";
+    license = with lib.licenses; [ gpl2Plus ];
+    maintainers = with lib.maintainers; [ snaki ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/va/vapoursynth-dfttest/package.nix
+++ b/pkgs/by-name/va/vapoursynth-dfttest/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  vapoursynth,
+  fftwSinglePrec,
+}:
+
+stdenv.mkDerivation {
+  pname = "vapoursynth-dfttest";
+  version = "unstable-2022-04-15";
+
+  src = fetchFromGitHub {
+    owner = "HomeOfVapourSynthEvolution";
+    repo = "VapourSynth-DFTTest";
+    rev = "bc5e0186a7f309556f20a8e9502f2238e39179b8";
+    hash = "sha256-HGk9yrs6T3LAP0I5GPt9b4LwldXtQDG277ffX6xMr/4=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    vapoursynth
+    fftwSinglePrec
+  ];
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail "vapoursynth_dep.get_pkgconfig_variable('libdir')" "get_option('libdir')"
+  '';
+
+  meta = {
+    description = "Plugin for VapourSynth: dfttest";
+    homepage = "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-DFTTest";
+    license = with lib.licenses; [
+      gpl3Plus
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ snaki ];
+    platforms = lib.platforms.x86_64;
+  };
+}

--- a/pkgs/by-name/va/vapoursynth-hqdn3d/package.nix
+++ b/pkgs/by-name/va/vapoursynth-hqdn3d/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  vapoursynth,
+}:
+
+stdenv.mkDerivation {
+  pname = "vapoursynth-hqdn3d";
+  version = "unstable-2023-07-09";
+
+  src = fetchFromGitHub {
+    owner = "Hinterwaeldlers";
+    repo = "vapoursynth-hqdn3d";
+    rev = "eb820cb23f7dc47eb67ea95def8a09ab69251d30";
+    hash = "sha256-BObHZs7GQW6UFUwohII1MXHtk5ooGh/LfZ3ZsqoPQBU=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [ vapoursynth ];
+
+  configureFlags = [ "--libdir=$(out)/lib/vapoursynth" ];
+
+  postInstall = ''
+    rm -f $out/lib/vapoursynth/*.la
+  '';
+
+  meta = {
+    inherit (vapoursynth.meta) platforms;
+    description = "Plugin for VapourSynth: hqdn3d";
+    homepage = "https://github.com/Hinterwaeldlers/vapoursynth-hqdn3d";
+    license = with lib.licenses; [ gpl2Plus ];
+    maintainers = with lib.maintainers; [ snaki ];
+  };
+}

--- a/pkgs/by-name/va/vapoursynth-knlmeanscl/package.nix
+++ b/pkgs/by-name/va/vapoursynth-knlmeanscl/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  boost,
+  vapoursynth,
+  opencl-headers,
+  ocl-icd,
+}:
+
+stdenv.mkDerivation {
+  pname = "vapoursynth-knlmeanscl";
+  version = "unstable-2023-06-05";
+
+  src = fetchFromGitHub {
+    owner = "Khanattila";
+    repo = "KNLMeansCL";
+    rev = "ca424fa91d1e16ec011f7db9c3ba0d1e76ed7850";
+    hash = "sha256-co8Jaup3bvvJaKw830CqCkAKHRsT5rx/xAYMbGhrMRk=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    boost
+    vapoursynth
+    ocl-icd
+    opencl-headers
+  ];
+
+  postPatch = ''
+    rm -rf KNLMeansCL/{avi,vapour}synth
+    sed -E -i '/NLMAvisynth\.(h|cpp)/d' meson.build
+  '';
+
+  meta = {
+    description = "Plugin for VapourSynth: knlmeanscl";
+    homepage = "https://github.com/Khanattila/KNLMeansCL";
+    license = with lib.licenses; [ gpl3Plus ];
+    maintainers = with lib.maintainers; [ snaki ];
+    platforms = lib.platforms.x86_64;
+  };
+}

--- a/pkgs/by-name/va/vapoursynth-wnnm/package.nix
+++ b/pkgs/by-name/va/vapoursynth-wnnm/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  mkl,
+  vapoursynth,
+  zimg,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vapoursynth-wnnm";
+  version = "unstable-2023-07-07";
+
+  srcs = [
+    (fetchFromGitHub {
+      owner = "WolframRhodium";
+      repo = "VapourSynth-WNNM";
+      rev = "a8977b4365841bb27c232383cd9a306f70ef9f99";
+      name = "${finalAttrs.pname}-source";
+      hash = "sha256-B4jvl+Lu724QofDbKQObdcpQdlb8KQ2szAp780J9SUY=";
+    })
+    (fetchFromGitHub {
+      owner = "vectorclass";
+      repo = "version2";
+      rev = "refs/tags/v2.02.01";
+      name = "vectorclass";
+      hash = "sha256-45qt0vGz6ibEmcoPZDOeroSivoVnFkvMEihjXJXa8lU=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    (mkl.override { enableStatic = true; })
+    vapoursynth
+    zimg
+  ];
+
+  sourceRoot = "${finalAttrs.pname}-source";
+
+  preConfigure = ''
+    cmakeFlagsArray=(${lib.escapeShellArg (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-ffast-math -mavx2 -mfma")})
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeFeature "VCL_HOME" (toString (lib.last finalAttrs.srcs)))
+    (lib.cmakeFeature "MKL_LINK" "static")
+    (lib.cmakeFeature "MKL_INTERFACE" "lp64")
+    (lib.cmakeFeature "MKL_THREADING" "sequential")
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "\''${VS_LIBDIR}" "lib"
+  '';
+
+  meta = {
+    description = "Plugin for VapourSynth: wnnm";
+    homepage = "https://github.com/WolframRhodium/VapourSynth-WNNM";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ snaki ];
+    platforms = lib.platforms.x86_64;
+  };
+})

--- a/pkgs/by-name/vs/vs-dfttest2/package.nix
+++ b/pkgs/by-name/vs/vs-dfttest2/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  gcc12Stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  cudaPackages_11_8,
+  rocmPackages,
+  vapoursynth,
+  zimg,
+  cudaSupport ? false,
+  rocmSupport ? false,
+  genericVector ? false,
+}:
+
+# Based on project's CI
+gcc12Stdenv.mkDerivation (finalAttrs: {
+  pname = "vs-dfttest2";
+  version = "7";
+
+  src = fetchFromGitHub {
+    fetchSubmodules = true;
+    owner = "AmusementClub";
+    repo = "vs-dfttest2";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-6VFUVdCKSbdhjKBUacQXEN5IyB4crngglAM99h+hGxU=";
+  };
+
+  nativeBuildInputs =
+    [
+      cmake
+      pkg-config
+    ]
+    ++ lib.optionals cudaSupport [
+      cudaPackages_11_8.cuda_nvcc
+      cudaPackages_11_8.cuda_nvrtc
+    ]
+    ++ lib.optionals rocmSupport [ rocmPackages.clr ];
+
+  buildInputs =
+    [
+      vapoursynth
+      zimg
+    ]
+    ++ lib.optionals cudaSupport [
+      cudaPackages_11_8.cuda_cudart
+      cudaPackages_11_8.libcufft
+    ]
+    ++ lib.optionals rocmSupport [
+      rocmPackages.clr
+      rocmPackages.hipfft
+    ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-ffast-math")
+    (lib.cmakeBool "ENABLE_CUDA" cudaSupport)
+    (lib.cmakeBool "ENABLE_HIP" rocmSupport)
+    (lib.cmakeBool "ENABLE_CPU" (!genericVector))
+    (lib.cmakeBool "ENABLE_GCC" genericVector)
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "\''${VS_LIBDIR}" "lib"
+  '';
+
+  meta = {
+    description = "Plugin for VapourSynth: dfttest2";
+    homepage = "https://github.com/AmusementClub/vs-dfttest2";
+    license = with lib.licenses; [
+      gpl3
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ snaki ];
+    platforms = with lib.platforms; if genericVector then all else x86_64;
+  };
+})

--- a/pkgs/by-name/vs/vs-nlm-cuda/package.nix
+++ b/pkgs/by-name/vs/vs-nlm-cuda/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  gcc12Stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  cudaPackages_11_8,
+  vapoursynth,
+  zimg,
+}:
+
+gcc12Stdenv.mkDerivation (finalAttrs: {
+  pname = "vs-nlm-cuda";
+  version = "1";
+
+  src = fetchFromGitHub {
+    owner = "AmusementClub";
+    repo = "vs-nlm-cuda";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-VxIe3ec0Hxgcd6HTDbZ9zx6Ss0H2eOtRVLq1ftIwRPY=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    cudaPackages_11_8.cuda_nvcc
+    cudaPackages_11_8.cuda_nvrtc
+  ];
+
+  buildInputs = [
+    cudaPackages_11_8.cuda_cudart
+    vapoursynth
+    zimg
+  ];
+
+  preConfigure = ''
+    cmakeFlagsArray=(${lib.escapeShellArg (lib.cmakeFeature "CMAKE_CUDA_FLAGS" "--use_fast_math -Wno-deprecated-gpu-targets")})
+  '';
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "\''${VS_LIBDIR}" "lib"
+  '';
+
+  meta = {
+    description = "Plugin for VapourSynth: vs-nlm-cuda";
+    homepage = "https://github.com/AmusementClub/vs-nlm-cuda";
+    license = with lib.licenses; [ gpl3 ];
+    maintainers = with lib.maintainers; [ snaki ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/vs/vs-nlm-ispc/package.nix
+++ b/pkgs/by-name/vs/vs-nlm-ispc/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  hostPlatform,
+  cmake,
+  pkg-config,
+  ispc,
+  vapoursynth,
+  zimg,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vs-nlm-ispc";
+  version = "2";
+
+  src = fetchFromGitHub {
+    owner = "AmusementClub";
+    repo = "vs-nlm-ispc";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-lP/6a83Sy+R4umt2GiZnB/to/x6jjGOChgUFQZQUwz4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    ispc
+  ];
+
+  buildInputs = [
+    vapoursynth
+    zimg
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_ISPC_INSTRUCTION_SETS" (
+      if hostPlatform.isx86_64 then "sse2-i32x4;avx1-i32x4;avx2-i32x8" else "neon-i32x4"
+    ))
+    (lib.cmakeFeature "CMAKE_ISPC_FLAGS" "--opt=fast-math")
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "\''${VS_LIBDIR}" "lib"
+  '';
+
+  meta = {
+    description = "Plugin for VapourSynth: vs-nlm-ispc";
+    homepage = "https://github.com/AmusementClub/vs-nlm-ispc";
+    license = with lib.licenses; [ gpl3 ];
+    maintainers = with lib.maintainers; [ snaki ];
+    platforms = with lib.platforms; x86_64 ++ aarch64;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20020,6 +20020,11 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) ApplicationServices;
   };
 
+  vapoursynth-bm3dcpu = callPackage ../by-name/va/vapoursynth-bm3dcuda/package.nix {
+    cudaSupport = false;
+    cpuSupport = true;
+  };
+
   vapoursynth-editor = libsForQt5.callPackage ../by-name/va/vapoursynth/editor.nix { };
 
   vapoursynth-mvtools = callPackage ../development/libraries/vapoursynth-mvtools { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20029,6 +20029,18 @@ with pkgs;
 
   vapoursynth-mvtools = callPackage ../development/libraries/vapoursynth-mvtools { };
 
+  vs-dfttest2cuda = callPackage ../by-name/vs/vs-dfttest2/package.nix {
+    cudaSupport = true;
+  };
+
+  vs-dfttest2gcc = callPackage ../by-name/vs/vs-dfttest2/package.nix {
+    genericVector = true;
+  };
+
+  vs-dfttest2hip = callPackage ../by-name/vs/vs-dfttest2/package.nix {
+    rocmSupport = true;
+  };
+
   vmmlib = callPackage ../development/libraries/vmmlib {
     inherit (darwin.apple_sdk.frameworks) Accelerate CoreGraphics CoreVideo;
   };


### PR DESCRIPTION
## Description of changes

Added a bunch of vapoursynth plugins
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
