### PR TITLE
lib/attrsets: add `filterAttrsRecursiveCond`

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -651,6 +651,10 @@ rec {
     Filter an attribute set recursively by removing all attributes for
     which the given predicate return false.
 
+    Note: the attrset is filtered top-down, first testing the predicate on "branch" attrs
+    before recursing towards leaf values.
+    This is different to `mapAttrsRecursive` and `mapAttrsRecursiveCond`, which only apply the mapping function to leaf nodes.
+
 
     # Inputs
 
@@ -675,6 +679,13 @@ rec {
     ```nix
     filterAttrsRecursive (n: v: v != null) { foo = { bar = null; }; }
     => { foo = {}; }
+    ```
+    :::{.example}
+    ## `lib.attrsets.filterAttrsRecursive` removing branch nodes
+
+    ```nix
+    filterAttrsRecursive (n: v: n != "foo") { foo = { bar = null; }; hello = { world = "Hello, world!"; }; }
+    => { hello = { world = "Hello, world!"; }; }
     ```
 
     :::

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -82,7 +82,7 @@ let
       composeManyExtensions makeExtensible makeExtensibleWithCustomName;
     inherit (self.attrsets) attrByPath hasAttrByPath setAttrByPath
       getAttrFromPath attrVals attrNames attrValues getAttrs catAttrs filterAttrs
-      filterAttrsRecursive foldlAttrs foldAttrs collect nameValuePair mapAttrs
+      filterAttrsRecursive filterAttrsRecursiveCond foldlAttrs foldAttrs collect nameValuePair mapAttrs
       mapAttrs' mapAttrsToList attrsToList concatMapAttrs mapAttrsRecursive
       mapAttrsRecursiveCond genAttrs isDerivation toDerivation optionalAttrs
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -46,6 +46,7 @@ let
     escapeXML
     evalModules
     filter
+    filterAttrsRecursive
     fix
     fold
     foldAttrs
@@ -1116,6 +1117,24 @@ runTests {
     };
   };
 
+  testFilterAttrsRecursiveExample1 = {
+    expr = filterAttrsRecursive (n: v: v != null) {
+      foo.bar = null;
+    };
+    expected = {
+      foo = { };
+    };
+  };
+
+  testFilterAttrsRecursiveExample2 = {
+    expr = filterAttrsRecursive (n: v: n != "foo") {
+      foo.bar = null;
+      hello.world = "Hello, world!";
+    };
+    expected = {
+      hello.world = "Hello, world!";
+    };
+  };
 
   testMergeAttrsListExample1 = {
     expr = attrsets.mergeAttrsList [ { a = 0; b = 1; } { c = 2; d = 3; } ];

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -47,6 +47,7 @@ let
     evalModules
     filter
     filterAttrsRecursive
+    filterAttrsRecursiveCond
     fix
     fold
     foldAttrs
@@ -1133,6 +1134,46 @@ runTests {
     };
     expected = {
       hello.world = "Hello, world!";
+    };
+  };
+
+  # The example filters for derivations named "hello"
+  testFilterAttrsRecursiveCondExample = {
+    expr =
+      filterAttrsRecursiveCond
+      (as: ! lib.isDerivation as)
+      (_: v: lib.isDerivation v -> v.name == "hello")
+      {
+        foo = {
+          type = "derivation";
+          name = "hello";
+        };
+        bar = {
+          type = "derivation";
+          name = "bar";
+        };
+        hello.world = {
+          type = "derivation";
+          name = "hello";
+          nester.attr = null;
+        };
+        foobar.baz = {
+          type = "derivation";
+          name = "baz";
+          nester.attr = null;
+        };
+      };
+    expected = {
+      foo = {
+        type = "derivation";
+        name = "hello";
+      };
+      hello.world = {
+        type = "derivation";
+        name = "hello";
+        nester.attr = null;
+      };
+      foobar = { };
     };
   };
 


### PR DESCRIPTION
## Description of changes

Adds a filtering equivalent to `mapAttrsrecursiveCond`. Like `filterAttrsRecursive`, but allows specifying a condition for whether to continue recursing deeper.

### Name vs path
In an ideal world, `filterAttrsRecursive` and this new function would both take an attr `path` instead of or in addition to an attr `name` in the filter function, like `mapAttrsRecursive` does in its mapper function. However that'd be a breaking change for `filterAttrsRecursive`, and it makes sense for `filterAttrsRecursive` and `filterAttrsRecursiveCond` to use the same signature.

### Test
Added a test to verify the documented example works correctly, this was checked by building `nix-build ./lib/tests/misc.nix`.

### Motivation
I've been experimenting with adding a `definedConfig` output to `lib.evalModules` and was reaching for something like this, to do something like:

```nix
definedOptions =
  filterAttrsRecursiveCond
  (v: ! isOption v)
  (_: opt: opt.isDefined)
  options;
```

Note: the current implementation doesn't fully solve my needs, see [Recurse top-down vs bottom-up](#Recurse-top-down-vs-bottom-up).

I was surprised that it wasn't already in nixpkgs lib, so I figured I'd open a PR.

## Recurse top-down vs bottom-up

`mapAttrsRecursive` only touches the _leaf nodes_ of the attrset. However `filterAttrsRecursive` tests _all_ nodes of the attrset, top-down (walking from the roots/branches down to the leafs).

For my use-case, I really need a bottom-up filter, that also removes empty attrs on the way up. Perhaps this would better be served with a `filterAttrsWith` function that takes a configuration attrset as an argument?

e.g.
```nix
filterAttrsWith =
  {
    recursive ? false,
    topDown ? !bottomUp,
    bottomUp ? false,
    recurseInto ? (as: true),
    predicate ? (n: v: true),
    leafPredicate ? predicate,
    branchPredicate ? predicate,
  }:
  assert assertMsg (!topDown || !bottomUp) "Cannot enable both topDown and bottomUp!";
  # implementation
```

Or, instead of `topDown` and `bottomUp`, we could have an `inPredicate`, `leafPredicate` and `outPredicate`; the "in" and "out" predicates being tested on branch nodes while recursing into and out-of the attrset respectively.
We could probably optimize the eval time by making these predicates nullable.

#### Draft

A draft implementation, optimized for clarity not performance:

```nix
filterAttrsRecursiveWith =
  # TODO: make predicates nullable
  # null predicates will not be tested and are equivalent to (_: _: true)
  {
    # Whether to treat this value as a branch node
    # and recurse into it
    # Attrset -> Bool
    continueRecursing ? _: true,

    # Predicate tested on leaf nodes
    # String -> Any -> Bool
    leafPredicate ? _: _: true,

    # Predicate tested on all nodes before any other filtering
    # String -> Attrset -> Bool
    inPredicate ? _: _: true,

    # Predicate tested on branch nodes after filtering their content
    # String -> Attrset -> Bool
    outPredicate ? _: _: true,
  } @ args:
  set:
  lib.pipe set [
    attrNames
    (lib.concatMap (name:
      let
        value = set.${name};
        filtered = filterAttrsRecursiveWith args value;
      in
      # FIXME: should inPredicate only run on branches or leaves too?
      lib.optional (inPredicate name value) (
        if isAttrs value && continueRecursing value then
          lib.optional (outPredicate name filtered) {
            inherit name;
            value = filtered;
          }
        else
          lib.optional (leafPredicate name value) {
            inherit name value;
          }
      )
    ))
    lib.listToAttrs
  ];
``` 

cc @infinisil

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
