### PR TITLE
haskellPackages.doctest: Skip failing cabal-doctest tests

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -169,7 +169,7 @@ self: super: {
   };
 
   # 2024-07-09: rhine 1.4.* needs newer monad-schedule than stackage (and is only consumer)
-  monad-schedule = assert super.monad-schedule.version == "0.1.2.2"; doDistribute self.monad-schedule_0_2;
+  monad-schedule = assert super.monad-schedule.version == "0.1.2.2"; doDistribute self.monad-schedule_0_2_0_1;
 
   aeson =
     # aeson's test suite includes some tests with big numbers that fail on 32bit

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2854,27 +2854,6 @@ self: super: {
   # https://github.com/brandonchinn178/tasty-autocollect/issues/54
   tasty-autocollect = dontCheck super.tasty-autocollect;
 
-  # https://github.com/UnkindPartition/tasty/pull/420#issuecomment-2187406691
-  # Note also 1.5.1 was faux-revoked because of this. See
-  # https://github.com/UnkindPartition/tasty/issues/426
-  tasty_1_5_1 = lib.pipe super.tasty_1_5_1 [
-    (appendPatch
-      (fetchpatch2 {
-        name = "tasty-1.5.1-revert-cr-sufficient-to-clear-line";
-        url = "https://github.com/UnkindPartition/tasty/commit/b152a0bc63166a4592e1f3639ef09e78a43f2b57.diff";
-        hash = "sha256-tlFCyEnIp8geNlJSkye32tUOaPMwkdqLHBMzpAwSDVQ=";
-        revert = true;
-        stripLen = 1;
-      })
-    )
-    (overrideCabal
-      (drv: assert drv.revision == "1"; {
-          revision = null;
-          editedCabalFile = null;
-      })
-    )
-  ];
-
   postgrest = lib.pipe super.postgrest [
     # 2023-12-20: New version needs extra dependencies
     (addBuildDepends [ self.extra self.fuzzyset_0_2_4 self.cache self.timeit ])
@@ -3079,7 +3058,7 @@ self: super: {
   cornelis = dontCheck super.cornelis;
 
   lzma = doJailbreak (super.lzma.overrideScope (self: super: {
-    tasty = super.tasty_1_5_1;
+    tasty = super.tasty_1_5;
   }));
 
   # Fixes build on some platforms: https://github.com/obsidiansystems/commutative-semigroups/pull/18

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -627,7 +627,6 @@ dont-distribute-packages:
  - beam-automigrate
  - beam-postgres
  - beam-th
- - bearriver
  - beautifHOL
  - bech32-th
  - bein
@@ -804,7 +803,7 @@ dont-distribute-packages:
  - chart-cli
  - chart-svg
  - chart-svg-various
- - chart-svg_0_6_0_0
+ - chart-svg_0_6_1_0
  - chart-unit
  - chassis
  - chatty
@@ -826,6 +825,7 @@ dont-distribute-packages:
  - chu2
  - chuchu
  - chunks
+ - circuit-notation
  - citation-resolve
  - citeproc-hs-pandoc-filter
  - clac
@@ -1207,7 +1207,6 @@ dont-distribute-packages:
  - dsh-sql
  - dsmc-tools
  - dtd
- - dunai-test
  - dvda
  - dynamic-cabal
  - dynamic-pipeline
@@ -1348,7 +1347,6 @@ dont-distribute-packages:
  - feature-flipper-postgres
  - fedora-composes
  - fedora-img-dl
- - fedora-repoquery
  - feed-gipeda
  - feed-translator
  - feed2lj
@@ -1972,7 +1970,7 @@ dont-distribute-packages:
  - hasloGUI
  - hasmtlib
  - hasql-cursor-query
- - hasql-interpolate_1_0_0_0
+ - hasql-interpolate_1_0_1_0
  - hasql-postgres
  - hasql-postgres-options
  - hasql-queue
@@ -2024,8 +2022,6 @@ dont-distribute-packages:
  - hedgehog-checkers-lens
  - hedgehog-gen-json
  - hedis-pile
- - heftia
- - heftia-effects
  - heist-aeson
  - helic
  - helics
@@ -2463,6 +2459,7 @@ dont-distribute-packages:
  - knit-haskell
  - koji-install
  - koji-tool
+ - koji-tool_1_2
  - korfu
  - ks-test
  - kubernetes-client
@@ -2911,7 +2908,7 @@ dont-distribute-packages:
  - nonlinear-optimization-backprop
  - not-gloss
  - not-gloss-examples
- - nothunks_0_2_1_0
+ - nothunks_0_2_1_1
  - notmuch-web
  - now-haskell
  - nri-env-parser

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1408,4 +1408,13 @@ self: super: builtins.intersectAttrs super {
   kmonad = enableSeparateBinOutput super.kmonad;
 
   xmobar = enableSeparateBinOutput super.xmobar;
+
+  # 2024-08-09: Disable some cabal-doctest tests pending further investigation.
+  doctest = overrideCabal (drv: {
+    testFlags = drv.testFlags or [] ++ [
+      # These tests require cabal-install
+      "--skip=/Cabal.Options"
+      "--skip=/Cabal.Paths/paths"
+    ];
+  }) super.doctest;
 }


### PR DESCRIPTION
This is for merging into `haskell-updates` (PR #331380).

- Fixes eval of `tasty`, now that [tasty-1.5.1](https://hackage.haskell.org/package/tasty-1.5.1) is deprecated on Hackage.
- Fix eval of `monad-schedule`
- Disable some failing test cases in `doctest-0.22.6`. They want to execute commands such as `cabal path`. I'm not sure whether that is possible.
- Regenerate `hackage-packages.nix` and `transitive-broken.yaml`.
