### PR TITLE
lib.composeExtensions: unify the api to use overlays

### DIFF
--- a/lib/fixed-points.nix
+++ b/lib/fixed-points.nix
@@ -1,4 +1,13 @@
 { lib, ... }:
+let
+  # Internal helper function to compose two overlay functions
+  # The public API is `composeManyExtensions` which uses this operation in a fold manner
+  _composeExtensions =
+    f: g: final: prev:
+      let fApplied = f final prev;
+          prev' = prev // fApplied;
+      in fApplied // g final prev';
+in
 rec {
   /**
     `fix f` computes the fixed point of the given function `f`. In other words, the return value is `x` in `x = f x`.
@@ -334,11 +343,7 @@ rec {
 
     : 4\. Function argument
   */
-  composeExtensions =
-    f: g: final: prev:
-      let fApplied = f final prev;
-          prev' = prev // fApplied;
-      in fApplied // g final prev';
+  composeExtensions = lib.warn "'composeManyExtensions a b' is deprecated. Use 'composeManyExtensions [a b]' instead." _composeExtensions;
 
   /**
     Compose several extending functions of the type expected by 'extends' into
@@ -351,7 +356,8 @@ rec {
     ```
   */
   composeManyExtensions =
-    lib.foldr (x: y: composeExtensions x y) (final: prev: {});
+    lib.foldr (x: y: _composeExtensions x y) (final: prev: {});
+
 
   /**
     Create an overridable, recursive attribute set. For example:

--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -16,7 +16,7 @@ let
 
   py = python3.override {
     self = py;
-    packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) ([
+    packageOverrides = lib.composeManyExtensions [
       (
         # Due to flask > 2.3 the login will not work
         self: super: {
@@ -271,7 +271,7 @@ let
       })
       (callPackage ./plugins.nix { })
       packageOverrides
-    ]);
+    ];
   };
 in
 with py.pkgs;

--- a/pkgs/applications/networking/cluster/nixops/default.nix
+++ b/pkgs/applications/networking/cluster/nixops/default.nix
@@ -89,7 +89,7 @@ let
        * them with the `withPlugins` method.
        */
       addAvailablePlugins = newPlugins: this.extend (finalThis: oldThis: {
-        plugins = lib.composeExtensions oldThis.plugins newPlugins;
+        plugins = lib.composeManyExtensions [oldThis.plugins newPlugins];
       });
 
       # For those who need or dare.

--- a/pkgs/development/compilers/ghcjs/8.10/default.nix
+++ b/pkgs/development/compilers/ghcjs/8.10/default.nix
@@ -29,7 +29,7 @@ let
       inherit (bootGhcjs) version;
       happy = bootPkgs.happy_1_19_12;
     };
-    bootPkgs = bootPkgs.extend (lib.foldr lib.composeExtensions (_:_:{}) [
+    bootPkgs = bootPkgs.extend (lib.composeManyExtensions [
       (self: _: import stage0 {
         inherit (passthru) configuredSrc;
         inherit (self) callPackage;

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -273,9 +273,12 @@ in package-set { inherit pkgs lib callPackage; } self // {
       , cabal2nixOptions ? "" }:
       let drv =
         (extensible-self.extend
-           (pkgs.lib.composeExtensions
-              (self.packageSourceOverrides source-overrides)
-              overrides))
+           (pkgs.lib.composeManyExtensions
+              [
+                (self.packageSourceOverrides source-overrides)
+                overrides
+              ]
+           ))
         .callCabal2nixWithOptions name root cabal2nixOptions {};
       in if returnShellEnv
            then (modifier drv).envFunc {inherit withHoogle;}

--- a/pkgs/development/interpreters/python/passthrufun.nix
+++ b/pkgs/development/interpreters/python/passthrufun.nix
@@ -51,18 +51,18 @@
       optionalExtensions = cond: as: lib.optionals cond as;
       pythonExtension = import ../../../top-level/python-packages.nix;
       python2Extension = import ../../../top-level/python2-packages.nix;
-      extensions = lib.composeManyExtensions ([
+      extensions = [
         hooks
         pythonExtension
       ] ++ (optionalExtensions (!self.isPy3k) [
         python2Extension
       ]) ++ pythonPackagesExtensions ++ [
         overrides
-      ]);
+      ];
       aliases = self: super: lib.optionalAttrs config.allowAliases (import ../../../top-level/python-aliases.nix lib self super);
     in makeScopeWithSplicing' {
       inherit otherSplices keep;
-      f = lib.extends (lib.composeExtensions aliases extensions) pythonPackagesFun;
+      f = lib.extends (lib.composeManyExtensions ([aliases] ++ extensions)) pythonPackagesFun;
     }) {
       overrides = packageOverrides;
       python = self;

--- a/pkgs/servers/mail/mailman/python.nix
+++ b/pkgs/servers/mail/mailman/python.nix
@@ -2,8 +2,9 @@
 
 lib.fix (self: python3.override {
   inherit self;
-  packageOverrides = lib.composeExtensions
-    (self: super: {
+  packageOverrides = lib.composeManyExtensions
+    [
+      (self: super: {
       /*
         This overlay can be used whenever we need to override
         dependencies specific to the mailman ecosystem: in the past
@@ -29,7 +30,7 @@ lib.fix (self: python3.override {
           hash = "sha256-WF3FFrnrBCphnvCjnD19Vf6BvbTfCaUsnN3g0Hvxqn0=";
         };
       });
-    })
-
-    overlay;
+      })
+      overlay
+    ];
 })

--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -31,12 +31,15 @@ let
 
   addEntangled = origOverrideAttrs: f:
     origOverrideAttrs (
-      lib.composeExtensions f (self: super: {
-        passthru = super.passthru // {
-          entangled = super.passthru.entangled.overrideAttrs f;
-          overrideAttrs = addEntangled self.overrideAttrs;
-        };
-      })
+      lib.composeManyExtensions [
+        f
+        (self: super: {
+          passthru = super.passthru // {
+            entangled = super.passthru.entangled.overrideAttrs f;
+            overrideAttrs = addEntangled self.overrideAttrs;
+          };
+        })
+      ]
     );
 
   entangle = pkg1: pkg2: pkg1.overrideAttrs (self: super: {

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -595,9 +595,10 @@ in {
             ghc = bh.compiler.integer-simple.${name};
             buildHaskellPackages = bh.packages.integer-simple.${name};
             overrides =
-              pkgs.lib.composeExtensions
+              pkgs.lib.composeManyExtensions [
                 (oldAttrs.overrides or (_: _: {}))
-                (_: _: { integer-simple = null; });
+                (_: _: { integer-simple = null; })
+              ];
           })
         );
 


### PR DESCRIPTION
## Description of changes

This PR tries to unify the API to use and apply overlays.

`composeExtensions a b` is equivalent to:
`composeManyExtensions [a b]`

But composeManyExtensions is more generic since it can be extended `composeManyExtensions [a b ...]`

Due to lacking documentation and inherent API for overlays some package set maintainers re-implemented `composeManyExtensions` as:

```
lib.foldr  (composeExtensions [ ... ] (final: prev: {});
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
