### PR TITLE
visp: init at 3.6.0

### DIFF
--- a/pkgs/by-name/vi/visp/package.nix
+++ b/pkgs/by-name/vi/visp/package.nix
@@ -1,0 +1,104 @@
+{
+  cmake,
+  coin3d,
+  darwin,
+  doxygen,
+  eigen,
+  fetchFromGitHub,
+  fetchpatch,
+  lapack,
+  lib,
+  libdc1394,
+  libdmtx,
+  libglvnd,
+  libjpeg, # this is libjpeg-turbo
+  libpng,
+  librealsense,
+  libxml2,
+  libX11,
+  nlohmann_json,
+  #ogre,
+  openblas,
+  opencv,
+  pkg-config,
+  python3Packages,
+  stdenv,
+  texliveSmall,
+  v4l-utils,
+  xorg,
+  zbar,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "visp";
+  version = "3.6.0";
+
+  src = fetchFromGitHub {
+    owner = "lagadic";
+    repo = "visp";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-m5Tmr+cZab7eSjmbXb8HpJpFHb0UYFTyimY+CkfBIAo=";
+  };
+
+  patches = [
+    # fix for absolute install paths
+    # this was merged upstream, and can be removed on next release
+    (fetchpatch {
+      url = "https://github.com/lagadic/visp/pull/1416/commits/fdda5620389badee998fe1926ddd3b46f7a6bcd8.patch";
+      hash = "sha256-W3vvBdQdp59WAMjuucNoWI0eCyPHjWerl7VCNcPVvzI=";
+    })
+
+    # fix for opencv new Universal Intrinsic API
+    # this was merged upstream, and can be removed on next release
+    (fetchpatch {
+      url = "https://github.com/lagadic/visp/pull/1310/commits/9ed0300507e13dddd83fd62a799f5039025ea44e.patch";
+      hash = "sha256-xrJ7B/8mEfi9dM/ToMr6vCAwX/FMw+GA/W0zFYgT32s=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    pkg-config
+    texliveSmall
+  ];
+
+  buildInputs =
+    [
+      eigen
+      lapack
+      libdc1394
+      libdmtx
+      libglvnd
+      libjpeg
+      libpng
+      librealsense
+      libX11
+      libxml2
+      nlohmann_json
+      #ogre
+      openblas
+      opencv
+      python3Packages.numpy
+      xorg.libpthreadstubs
+      zbar
+      zlib
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      coin3d
+      v4l-utils
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.IOKit ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Open Source Visual Servoing Platform";
+    homepage = "https://visp.inria.fr";
+    changelog = "https://github.com/lagadic/visp/blob/v${finalAttrs.version}/ChangeLog.txt";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ nim65s ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description of changes

Visp is an open source visual servoing library: https://visp.inria.fr/

Nix support & CI was added upstream in https://github.com/lagadic/visp/pull/1416.
This PR is based on that work, plus darwin fixes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
