### PR TITLE
nixos/localsend: add package option & allow udp port

### DIFF
--- a/nixos/modules/programs/localsend.nix
+++ b/nixos/modules/programs/localsend.nix
@@ -12,13 +12,17 @@ in
   options.programs.localsend = {
     enable = lib.mkEnableOption "localsend, an open source cross-platform alternative to AirDrop";
 
-    openFirewall = lib.mkEnableOption "opening the firewall port ${toString firewallPort} for receiving files" // {
-      default = true;
-    };
+    package = lib.mkPackageOption pkgs "localsend" { };
+
+    openFirewall =
+      lib.mkEnableOption "opening the firewall port ${toString firewallPort} for receiving files"
+      // {
+        default = true;
+      };
   };
 
   config = lib.mkIf cfg.enable {
-    environment.systemPackages = [ pkgs.localsend ];
+    environment.systemPackages = [ cfg.package ];
     networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [ firewallPort ];
   };
 

--- a/nixos/modules/programs/localsend.nix
+++ b/nixos/modules/programs/localsend.nix
@@ -24,6 +24,7 @@ in
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
     networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [ firewallPort ];
+    networking.firewall.allowedUDPPorts = lib.optionals cfg.openFirewall [ firewallPort ];
   };
 
   meta.maintainers = with lib.maintainers; [ pandapip1 ];

--- a/nixos/tests/localsend.nix
+++ b/nixos/tests/localsend.nix
@@ -16,6 +16,7 @@ import ./make-test-python.nix (
       machine.wait_for_open_port(53317)
       machine.wait_for_window("LocalSend", 10)
       machine.succeed("netstat --listening --program --tcp | grep -P 'tcp.*53317.*localsend'")
+      machine.succeed("netstat --listening --program --udp | grep -P 'udp.*53317.*localsend'")
     '';
   }
 )


### PR DESCRIPTION
## Description of changes

It seems to be using UDP
https://github.com/localsend/protocol?tab=readme-ov-file#31-multicast-udp-default

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
