### PR TITLE
forgejo: 8.0.0 -> 8.0.1, forgejo-lts: 7.0.6 -> 7.0.7, forgejo,forgejo-lts: fix passthru.updateScript

### DIFF
--- a/pkgs/by-name/fo/forgejo/generic.nix
+++ b/pkgs/by-name/fo/forgejo/generic.nix
@@ -3,6 +3,7 @@
 , hash
 , npmDepsHash
 , vendorHash
+, nixUpdateExtraArgs ? [ ]
 }:
 
 { bash
@@ -154,7 +155,7 @@ buildGoModule rec {
     '';
 
     tests = if lts then nixosTests.forgejo-lts else nixosTests.forgejo;
-    updateScript = nix-update-script { };
+    updateScript = nix-update-script { extraArgs = nixUpdateExtraArgs; };
   };
 
   meta = {

--- a/pkgs/by-name/fo/forgejo/lts.nix
+++ b/pkgs/by-name/fo/forgejo/lts.nix
@@ -4,4 +4,10 @@ import ./generic.nix {
   npmDepsHash = "sha256-OqtYRjftwGxgW1JgMxyWd+9DndpEkd3LdQHSECc40yU=";
   vendorHash = "sha256-hfbNyCQMQzDzJxFc2MPAR4+v/qNcnORiQNbwbbIA4Nw=";
   lts = true;
+  nixUpdateExtraArgs = [
+    "--version-regex"
+    "v(7\.[0-9.]+)"
+    "--override-filename"
+    "pkgs/by-name/fo/forgejo/lts.nix"
+  ];
 }

--- a/pkgs/by-name/fo/forgejo/lts.nix
+++ b/pkgs/by-name/fo/forgejo/lts.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "7.0.6";
-  hash = "sha256-Y8H85HMKnzNSXnrLOxhzOBSfedivGvcQ3MOAp31Kvno=";
+  version = "7.0.7";
+  hash = "sha256-Xk5ElAfTjbz77Jv5VMbSW7q8qJ5vhNd3daNilNzDsY4=";
   npmDepsHash = "sha256-OqtYRjftwGxgW1JgMxyWd+9DndpEkd3LdQHSECc40yU=";
   vendorHash = "sha256-hfbNyCQMQzDzJxFc2MPAR4+v/qNcnORiQNbwbbIA4Nw=";
   lts = true;

--- a/pkgs/by-name/fo/forgejo/package.nix
+++ b/pkgs/by-name/fo/forgejo/package.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "8.0.0";
-  hash = "sha256-ol/2D+zMieERVDHOKlu+wm3WKkQNjbIw0sc0KLUTwzI=";
+  version = "8.0.1";
+  hash = "sha256-0D2ntZVK4k5AwAMg4XnLyabnxAoHx9JjBoFAdkfrdAY=";
   npmDepsHash = "sha256-6AMaZadgcTvOBsIXJjZQB6Q1rkdn+R82pclXdVvtdWY=";
   vendorHash = "sha256-tNb0tCf+gjUmUqrjkzt7Wqqz21hW9WRh8CEdX8rv8Do=";
   lts = false;

--- a/pkgs/by-name/fo/forgejo/package.nix
+++ b/pkgs/by-name/fo/forgejo/package.nix
@@ -4,4 +4,8 @@ import ./generic.nix {
   npmDepsHash = "sha256-6AMaZadgcTvOBsIXJjZQB6Q1rkdn+R82pclXdVvtdWY=";
   vendorHash = "sha256-tNb0tCf+gjUmUqrjkzt7Wqqz21hW9WRh8CEdX8rv8Do=";
   lts = false;
+  nixUpdateExtraArgs = [
+    "--override-filename"
+    "pkgs/by-name/fo/forgejo/package.nix"
+  ];
 }


### PR DESCRIPTION
## Description of changes

https://codeberg.org/forgejo/forgejo/releases/tag/v8.0.1
https://codeberg.org/forgejo/forgejo/milestone/7682
diff: https://codeberg.org/forgejo/forgejo/compare/v8.0.0...v8.0.1

https://codeberg.org/forgejo/forgejo/releases/tag/v7.0.6
https://codeberg.org/forgejo/forgejo/milestone/7682
diff: https://codeberg.org/forgejo/forgejo/compare/v7.0...v7.0.6

Fixes a `XSS` vulnerability. See the respective milestones for more details.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
