### PR TITLE
python3Packages.cxxheaderparser: init at 1.3.3

### DIFF
--- a/pkgs/development/python-modules/cxxheaderparser/default.nix
+++ b/pkgs/development/python-modules/cxxheaderparser/default.nix
@@ -1,0 +1,39 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  pcpp,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "cxxheaderparser";
+  version = "1.3.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "robotpy";
+    repo = "cxxheaderparser";
+    rev = version;
+    hash = "sha256-dc+MsSJFeRho6DG21QQZSAq4PmRZl7OlWhIQNisicZo=";
+  };
+
+  postPatch = ''
+    # version.py is generated based on latest git tag
+    echo "__version__ = '${version}'" > cxxheaderparser/version.py
+  '';
+
+  build-system = [ setuptools ];
+
+  checkInputs = [ pcpp ];
+  nativeCheckInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [ "cxxheaderparser" ];
+
+  meta = {
+    description = "Modern pure python C++ header parser";
+    homepage = "https://github.com/robotpy/cxxheaderparser";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2733,6 +2733,8 @@ self: super: with self; {
 
   cxxfilt = callPackage ../development/python-modules/cxxfilt { };
 
+  cxxheaderparser = callPackage ../development/python-modules/cxxheaderparser { };
+
   cycler = callPackage ../development/python-modules/cycler { };
 
   cyclonedx-python-lib = callPackage ../development/python-modules/cyclonedx-python-lib { };


### PR DESCRIPTION
## Description of changes

Add https://github.com/robotpy/cxxheaderparser, a Modern pure python C++ header parser 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
