### PR TITLE
bugstalker: 0.1.4 -> 0.2.2

### DIFF
--- a/pkgs/by-name/bu/bugstalker/package.nix
+++ b/pkgs/by-name/bu/bugstalker/package.nix
@@ -7,91 +7,23 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "bugstalker";
-  version = "0.1.4";
+  version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "godzie44";
     repo = "BugStalker";
     rev = "v${version}";
-    hash = "sha256-16bmvz6/t8H8Sx/32l+fp3QqP5lwi0o1Q9KqDHqF22U=";
+    hash = "sha256-JacRt+zNwL7hdpdh5h9Mxztqi47f5eUbcZyx6ct/5Bc=";
   };
 
-  cargoHash = "sha256-kp0GZ0cM57BMpH/8lhxevnBuJhUSH0rtxP4B/9fXYiU=";
+  cargoHash = "sha256-ljT7Dl9553sfZBqTe6gT3iYPH+D1Jp9ZsyGVQGOekxw=";
 
   buildInputs = [ libunwind ];
 
   nativeBuildInputs = [ pkg-config ];
 
-  # Tests which require access to example source code fail in the sandbox. I
-  # haven't managed to figure out how to fix this.
-  checkFlags = [
-    "--skip=breakpoints::test_breakpoint_at_fn_with_monomorphization"
-    "--skip=breakpoints::test_breakpoint_at_line_with_monomorphization"
-    "--skip=breakpoints::test_brkpt_on_function"
-    "--skip=breakpoints::test_brkpt_on_function_name_collision"
-    "--skip=breakpoints::test_brkpt_on_line"
-    "--skip=breakpoints::test_brkpt_on_line2"
-    "--skip=breakpoints::test_brkpt_on_line_collision"
-    "--skip=breakpoints::test_debugee_run"
-    "--skip=breakpoints::test_deferred_breakpoint"
-    "--skip=breakpoints::test_multiple_brkpt_on_addr"
-    "--skip=breakpoints::test_set_breakpoint_idempotence"
-    "--skip=io::test_backtrace"
-    "--skip=io::test_read_register_write"
-    "--skip=io::test_read_value_u64"
-    "--skip=multithreaded::test_multithreaded_app_running"
-    "--skip=multithreaded::test_multithreaded_backtrace"
-    "--skip=multithreaded::test_multithreaded_breakpoints"
-    "--skip=multithreaded::test_multithreaded_trace"
-    "--skip=signal::test_signal_stop_multi_thread"
-    "--skip=signal::test_signal_stop_multi_thread_multiple_signal"
-    "--skip=signal::test_signal_stop_single_thread"
-    "--skip=signal::test_transparent_signals"
-    "--skip=steps::test_step_into"
-    "--skip=steps::test_step_into_recursion"
-    "--skip=steps::test_step_out"
-    "--skip=steps::test_step_over"
-    "--skip=steps::test_step_over_inline_code"
-    "--skip=steps::test_step_over_on_fn_decl"
-    "--skip=symbol::test_symbol"
-    "--skip=test_debugger_disassembler"
-    "--skip=test_debugger_graceful_shutdown"
-    "--skip=test_debugger_graceful_shutdown_multithread"
-    "--skip=test_frame_cfa"
-    "--skip=test_registers"
-    "--skip=variables::test_arguments"
-    "--skip=variables::test_btree_map"
-    "--skip=variables::test_cast_pointers"
-    "--skip=variables::test_cell"
-    "--skip=variables::test_circular_ref_types"
-    "--skip=variables::test_lexical_blocks"
-    "--skip=variables::test_read_array"
-    "--skip=variables::test_read_atomic"
-    "--skip=variables::test_read_btree_set"
-    "--skip=variables::test_read_closures"
-    "--skip=variables::test_read_enum"
-    "--skip=variables::test_read_hashmap"
-    "--skip=variables::test_read_hashset"
-    "--skip=variables::test_read_only_local_variables"
-    "--skip=variables::test_read_pointers"
-    "--skip=variables::test_read_scalar_variables"
-    "--skip=variables::test_read_scalar_variables_at_place"
-    "--skip=variables::test_read_static_in_fn_variable"
-    "--skip=variables::test_read_static_variables"
-    "--skip=variables::test_read_static_variables_different_modules"
-    "--skip=variables::test_read_strings"
-    "--skip=variables::test_read_struct"
-    "--skip=variables::test_read_tls_variables"
-    "--skip=variables::test_read_type_alias"
-    "--skip=variables::test_read_union"
-    "--skip=variables::test_read_uuid"
-    "--skip=variables::test_read_vec_and_slice"
-    "--skip=variables::test_read_vec_deque"
-    "--skip=variables::test_shared_ptr"
-    "--skip=variables::test_slice_operator"
-    "--skip=variables::test_type_parameters"
-    "--skip=variables::test_zst_types"
-  ];
+  # Tests require rustup.
+  doCheck = false;
 
   meta = {
     description = "Rust debugger for Linux x86-64";


### PR DESCRIPTION
## Description of changes

[Required to build with Rust 1.80.](https://github.com/rust-lang/rust/issues/127343)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
