### PR TITLE
ente-auth: init at 3.1.1

### DIFF
--- a/pkgs/by-name/en/ente-auth/package.nix
+++ b/pkgs/by-name/en/ente-auth/package.nix
@@ -1,0 +1,42 @@
+{
+  appimageTools,
+  fetchurl,
+  lib,
+}:
+let
+  pname = "ente-auth";
+  version = "3.1.1";
+
+  src = fetchurl {
+    url = "https://github.com/ente-io/ente/releases/download/auth-v${version}/ente-auth-v${version}-x86_64.AppImage";
+    hash = "sha256-RcH+1YM6gPneVbv158LejClkrCNnAwr6K5hKbcyvTMI=";
+  };
+
+  appimageContents = appimageTools.extractType1 { inherit pname version src; };
+in
+
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/ente_auth.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/ente_auth.desktop \
+      --replace-fail 'Exec=LD_LIBRARY_PATH=usr/lib ente_auth' 'Exec=ente-auth'
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
+
+  extraPkgs = pkgs: [
+    pkgs.libepoxy
+    pkgs.brotli
+  ];
+
+  meta = {
+    description = "An end-to-end encrypted, cross platform and free app for storing your 2FA codes with cloud backups.";
+    homepage = "https://ente.io/auth";
+    changelog = "https://github.com/ente-io/ente/releases/tag/auth-v${version}";
+    license = lib.licenses.agpl3Only;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "ente-auth";
+    maintainers = with lib.maintainers; [ schnow265 ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
An end-to-end encrypted, cross platform and free app for storing your 2FA codes with cloud backups. Works offline. You can even use it without signing up for an account if you don't want the cloud backups or multi-device sync.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
