### PR TITLE
treewide: Remove ineffective capability grants.

### DIFF
--- a/nixos/modules/services/misc/mollysocket.nix
+++ b/nixos/modules/services/misc/mollysocket.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) getExe mkIf mkOption mkEnableOption optionals types;
+  inherit (lib) getExe mkIf mkOption mkEnableOption types;
 
   cfg = config.services.mollysocket;
   configuration = format.generate "mollysocket.conf" cfg.settings;
@@ -85,9 +85,7 @@ in {
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
       environment.RUST_LOG = cfg.logLevel;
-      serviceConfig = let
-        capabilities = [ "" ] ++ optionals (cfg.settings.port < 1024) [ "CAP_NET_BIND_SERVICE" ];
-      in {
+      serviceConfig = {
         EnvironmentFile = cfg.environmentFile;
         ExecStart = "${getExe package} server";
         KillSignal = "SIGINT";
@@ -97,8 +95,6 @@ in {
         WorkingDirectory = "/var/lib/mollysocket";
 
         # hardening
-        AmbientCapabilities = capabilities;
-        CapabilityBoundingSet = capabilities;
         DevicePolicy = "closed";
         DynamicUser = true;
         LockPersonality = true;

--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -364,9 +364,6 @@ in
         SystemCallFilter = defaultServiceConfig.SystemCallFilter ++ [ "@setuid mbind" ];
         # Needs to serve web page
         PrivateNetwork = false;
-      } // lib.optionalAttrs (cfg.port < 1024) {
-        AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
-        CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
       };
       environment = env // {
         PYTHONPATH = "${cfg.package.python.pkgs.makePythonPath cfg.package.propagatedBuildInputs}:${cfg.package}/lib/paperless-ngx/src";

--- a/nixos/modules/services/misc/tandoor-recipes.nix
+++ b/nixos/modules/services/misc/tandoor-recipes.nix
@@ -119,9 +119,6 @@ in
         # gunicorn needs setuid
         SystemCallFilter = [ "@system-service" "~@privileged" "@resources" "@setuid" "@keyring" ];
         UMask = "0066";
-      } // lib.optionalAttrs (cfg.port < 1024) {
-        AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
-        CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
       };
 
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/misc/transfer-sh.nix
+++ b/nixos/modules/services/misc/transfer-sh.nix
@@ -69,7 +69,6 @@ in
           wantedBy = [ "multi-user.target" ];
           environment = mapAttrs (_: v: if isBool v then boolToString v else toString v) cfg.settings;
           serviceConfig = {
-            CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
             DevicePolicy = "closed";
             DynamicUser = true;
             ExecStart = "${getExe cfg.package} --provider ${cfg.provider}";

--- a/nixos/modules/services/misc/wastebin.nix
+++ b/nixos/modules/services/misc/wastebin.nix
@@ -126,7 +126,6 @@ in
         wantedBy = [ "multi-user.target" ];
         environment = mapAttrs (_: v: if isBool v then boolToString v else toString v) cfg.settings;
         serviceConfig = {
-          CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
           DevicePolicy = "closed";
           DynamicUser = true;
           ExecStart = "${getExe cfg.package}";

--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -1811,8 +1811,6 @@ in
         StateDirectory = cfg.stateDir;
         StateDirectoryMode = "0700";
         # Hardening
-        AmbientCapabilities = lib.mkIf (cfg.port < 1024) [ "CAP_NET_BIND_SERVICE" ];
-        CapabilityBoundingSet = if (cfg.port < 1024) then [ "CAP_NET_BIND_SERVICE" ] else [ "" ];
         DeviceAllow = [ "/dev/null rw" ];
         DevicePolicy = "strict";
         LockPersonality = true;

--- a/nixos/modules/services/web-apps/dex.nix
+++ b/nixos/modules/services/web-apps/dex.nix
@@ -80,7 +80,6 @@ in
         ];
 
         RuntimeDirectory = "dex";
-        AmbientCapabilities = "CAP_NET_BIND_SERVICE";
         BindReadOnlyPaths = [
           "/nix/store"
           "-/etc/dex"
@@ -91,7 +90,6 @@ in
           "-/etc/ssl/certs/ca-certificates.crt"
         ];
         BindPaths = optional (cfg.settings.storage.type == "postgres") "/var/run/postgresql";
-        CapabilityBoundingSet = "CAP_NET_BIND_SERVICE";
         # ProtectClock= adds DeviceAllow=char-rtc r
         DeviceAllow = "";
         DynamicUser = true;

--- a/nixos/modules/services/web-apps/freshrss.nix
+++ b/nixos/modules/services/web-apps/freshrss.nix
@@ -164,7 +164,6 @@ in
     let
       defaultServiceConfig = {
         ReadWritePaths = "${cfg.dataDir}";
-        CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
         DeviceAllow = "";
         LockPersonality = true;
         NoNewPrivileges = true;

--- a/nixos/modules/services/web-apps/microbin.nix
+++ b/nixos/modules/services/web-apps/microbin.nix
@@ -61,7 +61,6 @@ in
       wantedBy = [ "multi-user.target" ];
       environment = lib.mapAttrs (_: v: if lib.isBool v then lib.boolToString v else toString v) cfg.settings;
       serviceConfig = {
-        CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
         DevicePolicy = "closed";
         DynamicUser = true;
         EnvironmentFile = lib.optional (cfg.passwordFile != null) cfg.passwordFile;

--- a/nixos/modules/services/web-apps/photoprism.nix
+++ b/nixos/modules/services/web-apps/photoprism.nix
@@ -109,7 +109,6 @@ in
         LoadCredential = lib.optionalString (cfg.passwordFile != null)
           "PHOTOPRISM_ADMIN_PASSWORD:${cfg.passwordFile}";
 
-        CapabilityBoundingSet = "";
         LockPersonality = true;
         PrivateDevices = true;
         PrivateUsers = true;
@@ -126,9 +125,6 @@ in
         SystemCallArchitectures = "native";
         SystemCallFilter = [ "@system-service" "~@setuid @keyring" ];
         UMask = "0066";
-      } // lib.optionalAttrs (cfg.port < 1024) {
-        AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
-        CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
       };
 
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/web-apps/powerdns-admin.nix
+++ b/nixos/modules/services/web-apps/powerdns-admin.nix
@@ -87,7 +87,6 @@ in
         User = "powerdnsadmin";
         Group = "powerdnsadmin";
 
-        AmbientCapabilities = "CAP_NET_BIND_SERVICE";
         BindReadOnlyPaths = [
           "/nix/store"
           "-/etc/resolv.conf"
@@ -97,7 +96,6 @@ in
         ]
         ++ (optional (cfg.secretKeyFile != null) cfg.secretKeyFile)
         ++ (optional (cfg.saltFile != null) cfg.saltFile);
-        CapabilityBoundingSet = "CAP_NET_BIND_SERVICE";
         # ProtectClock= adds DeviceAllow=char-rtc r
         DeviceAllow = "";
         # Implies ProtectSystem=strict, which re-mounts all paths

--- a/nixos/modules/services/web-apps/shiori.nix
+++ b/nixos/modules/services/web-apps/shiori.nix
@@ -90,7 +90,6 @@ in {
             "/var/run/mysqld";
 
         CapabilityBoundingSet = "";
-        AmbientCapabilities = "CAP_NET_BIND_SERVICE";
 
         DeviceAllow = "";
 


### PR DESCRIPTION
Systemd units with `PrivateUsers` set get their capabilities within the user namespace only [1].
As a result they do cannot bind to privileged ports even though they *appear* like they should be able to.

The units in this commit [2] set `PrivateUsers` unconditionally so binding to privileged ports is currently impossible.
Granting them CAP_NET_BIND_SERVICE is useless and misleading any reader of those modules.
Technically, this commit also hardens these modules ever so slightly.

(There are corner cases where this could make sense (e.g. across units, using `JoinsNamspaceOf`) but this is arcane enough to not to be present in nixpkgs.)

[1]: systemd.exec(5): PrivateUsers
[2]: found using `rg -e 'PrivateUsers.?=\s+[^f][^a]' -l | xargs rg -e '\bCAP_' -l`

## Description of changes

See commit message above.

Decisions taken:
* err on side of caution: disable caps instead of missing with `PrivateUsers` value
* remove empty capability settings: they do not add any value unless they are acting as overrides

Observations:
* many of the services that work around this disable PrivateUsers conditionally. This is not explicitly exposed and typically a result of setting that service's `.port` to a privileged value. Having the port number control 2 hardening settings is clearly not the right UX. But out of scope for this PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
