### PR TITLE
stats: build from source

### DIFF
--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -1,29 +1,334 @@
 {
   lib,
-  stdenvNoCC,
-  fetchurl,
-  undmg,
+  swiftPackages,
+  fetchFromGitHub,
+  darwin,
+  leveldb,
+  perl,
+  actool,
+  makeWrapper,
   nix-update-script,
 }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
-  pname = "stats";
-  version = "2.12.1";
+let
+  inherit (swiftPackages) stdenv swift;
 
-  src = fetchurl {
-    url = "https://github.com/exelban/stats/releases/download/v${finalAttrs.version}/Stats.dmg";
-    hash = "sha256-li4pCrwt37Wmmk3VAJT9XTcqPQ4HywQObUVSSgzARsE=";
+  frameworks = [
+    "Kit"
+    "CPU"
+    "GPU"
+    "RAM"
+    "Disk"
+    "Net"
+    "Battery"
+    "Bluetooth"
+    "Sensors"
+    "Clock"
+  ];
+  modules = lib.tail frameworks;
+
+  toPlist = lib.generators.toPlist { escape = true; };
+
+  frameworkPlist =
+    name:
+    toPlist {
+      CFBundleExecutable = name;
+      CFBundleIdentifier = "eu.exelban.Stats.${name}";
+      CFBundleInfoDictionaryVersion = "6.0";
+      CFBundleName = name;
+      CFBundlePackageType = "FMWK";
+      CFBundleVersion = "1";
+    };
+
+  mainInfoPlist =
+    version:
+    toPlist {
+      CFBundleDevelopmentRegion = "en";
+      CFBundleExecutable = "Stats";
+      CFBundleIdentifier = "eu.exelban.Stats";
+      CFBundleInfoDictionaryVersion = "6.0";
+      CFBundleName = "Stats";
+      CFBundlePackageType = "APPL";
+      CFBundleShortVersionString = version;
+      # CFBundleVersion is extracted from upstream's Info.plist at build time
+      Description = "Simple macOS system monitor in your menu bar";
+      LSApplicationCategoryType = "public.app-category.utilities";
+      LSMinimumSystemVersion = "11.0";
+      LSUIElement = true;
+      NSAppTransportSecurity = {
+        NSAllowsArbitraryLoads = true;
+      };
+      NSBluetoothAlwaysUsageDescription = "This permission allows obtaining battery level of Bluetooth devices";
+      NSHumanReadableCopyright = "Copyright © 2020 Serhiy Mytrovtsiy. All rights reserved.";
+      NSPrincipalClass = "NSApplication";
+      NSUserNotificationAlertStyle = "alert";
+      TeamId = "RP2S87B72W";
+    };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "stats";
+  version = "2.12.7";
+
+  src = fetchFromGitHub {
+    owner = "exelban";
+    repo = "Stats";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qx4FI+MnFknIrTOPP+8wyy1wqFMWyaunmags023ay6A=";
   };
 
-  sourceRoot = ".";
+  nativeBuildInputs = [
+    swift
+    perl
+    actool
+    darwin.autoSignDarwinBinariesHook
+    makeWrapper
+  ];
 
-  nativeBuildInputs = [ undmg ];
+  buildInputs = [ leveldb ];
+
+  # Stats uses IOReport private API symbols declared in bridging headers
+  env.NIX_LDFLAGS = "-lIOReport";
+
+  # Swift 5.10 doesn't support trailing commas in argument lists (Swift 6 feature)
+  # Remove them from all Swift source files
+  postPatch = ''
+    find . -name '*.swift' -exec perl -0777 -pi -e '
+      s/,(\s*\))/$1/g;
+      s/\@retroactive //g;
+    ' {} +
+
+    # CWPHYMode.mode11be (WiFi 7) requires macOS 15+ SDK; @unknown default covers it
+    sed -i '/mode11be/d' Modules/Net/readers.swift
+
+  '';
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    buildDir="$PWD/build"
+    mkdir -p "$buildDir"
+
+    commonSwiftFlags=(
+      -O
+      -Xcc -IKit/lldb
+      -Xcc -IKit/lldb/include
+      -Xcc -I${leveldb.dev}/include/leveldb
+      -disable-bridging-pch
+      # Stamp binaries with macOS 26 SDK version so the system applies Liquid Glass UI
+      # The Swift compiler in nixpkgs uses SDK 14 headers (which compile fine), but without
+      # this flag the linker records SDK 14 and macOS withholds it (Liquid Glass)
+      -Xlinker -platform_version -Xlinker macos -Xlinker 14.0 -Xlinker 26.0
+    )
+
+    buildFramework() {
+      local name="$1"
+      shift
+      local bridgingHeader="$1"
+      shift
+      local extraFlags=("$@")
+
+      echo "Building framework: $name"
+
+      local swiftFiles=()
+      while IFS= read -r -d "" f; do
+        swiftFiles+=("$f")
+      done < <(find "$name" -name '*.swift' -print0 2>/dev/null)
+
+      # For modules in Modules/ subdirectory
+      if [ ''${#swiftFiles[@]} -eq 0 ]; then
+        while IFS= read -r -d "" f; do
+          swiftFiles+=("$f")
+        done < <(find "Modules/$name" -name '*.swift' -print0 2>/dev/null)
+      fi
+
+      local bridgeFlags=()
+      if [ -n "$bridgingHeader" ]; then
+        bridgeFlags=(-import-objc-header "$bridgingHeader")
+      fi
+
+      swiftc \
+        "''${commonSwiftFlags[@]}" \
+        -emit-module \
+        -emit-library \
+        -module-name "$name" \
+        -module-link-name "$name" \
+        -emit-module-path "$buildDir/$name.swiftmodule" \
+        "''${bridgeFlags[@]}" \
+        -I "$buildDir" \
+        -L "$buildDir" \
+        -Xlinker -install_name -Xlinker "@rpath/$name.framework/$name" \
+        "''${extraFlags[@]}" \
+        "''${swiftFiles[@]}" \
+        -o "$buildDir/lib$name.dylib"
+    }
+
+    echo "=== Building Kit ==="
+
+    # Compile lldb.m (Objective-C++ with LevelDB)
+    clang++ -x objective-c++ \
+      -I Kit/lldb/include \
+      -I Kit/lldb \
+      -I ${leveldb.dev}/include/leveldb \
+      -fobjc-arc \
+      -O2 \
+      -c Kit/lldb/lldb.m \
+      -o "$buildDir/lldb.o"
+
+    kitSwiftFiles=()
+    while IFS= read -r -d "" f; do
+      kitSwiftFiles+=("$f")
+    done < <(find Kit -name '*.swift' -print0)
+    # Kit also compiles shared SMC source files (protocol.swift, smc.swift)
+    kitSwiftFiles+=("SMC/Helper/protocol.swift" "SMC/smc.swift")
+
+    swiftc \
+      "''${commonSwiftFlags[@]}" \
+      -emit-module \
+      -emit-library \
+      -module-name Kit \
+      -module-link-name Kit \
+      -emit-module-path "$buildDir/Kit.swiftmodule" \
+      -import-objc-header "Kit/Supporting Files/Kit.h" \
+      -Xcc -IKit/lldb \
+      -Xcc -IKit/lldb/include \
+      -Xcc -I${leveldb.dev}/include/leveldb \
+      -Xlinker -install_name -Xlinker "@rpath/Kit.framework/Kit" \
+      "$buildDir/lldb.o" \
+      -L ${leveldb}/lib -lleveldb \
+      -lstdc++ \
+      "''${kitSwiftFiles[@]}" \
+      -o "$buildDir/libKit.dylib"
+
+    buildFramework CPU "Modules/CPU/bridge.h" \
+      -lKit -framework IOKit
+
+    buildFramework GPU "" \
+      -lKit -framework IOKit -framework Metal
+
+    buildFramework RAM "" \
+      -lKit -framework IOKit
+
+    buildFramework Disk "Modules/Disk/header.h" \
+      -lKit -framework IOKit -framework DiskArbitration
+
+    buildFramework Net "" \
+      -lKit -framework IOKit -framework CoreWLAN -framework SystemConfiguration
+
+    buildFramework Battery "" \
+      -lKit -framework IOKit
+
+    buildFramework Bluetooth "" \
+      -lKit -framework IOKit -framework IOBluetooth -framework CoreBluetooth
+
+    # Build Sensors - needs ObjC file too
+    echo "Building framework: Sensors"
+
+    # Compile reader.m (ObjC)
+    clang -x objective-c \
+      -I "Modules/Sensors" \
+      -fobjc-arc \
+      -O2 \
+      -c Modules/Sensors/reader.m \
+      -o "$buildDir/sensors_reader.o"
+
+    sensorsSwiftFiles=()
+    while IFS= read -r -d "" f; do
+      sensorsSwiftFiles+=("$f")
+    done < <(find Modules/Sensors -name '*.swift' -print0)
+
+    swiftc \
+      "''${commonSwiftFlags[@]}" \
+      -emit-module \
+      -emit-library \
+      -module-name Sensors \
+      -module-link-name Sensors \
+      -emit-module-path "$buildDir/Sensors.swiftmodule" \
+      -import-objc-header "Modules/Sensors/bridge.h" \
+      -I "$buildDir" \
+      -L "$buildDir" \
+      -lKit \
+      -framework IOKit \
+      -Xlinker -install_name -Xlinker "@rpath/Sensors.framework/Sensors" \
+      "$buildDir/sensors_reader.o" \
+      "''${sensorsSwiftFiles[@]}" \
+      -o "$buildDir/libSensors.dylib"
+
+    buildFramework Clock "" \
+      -lKit
+
+    echo "=== Building Stats app ==="
+
+    statsSwiftFiles=()
+    while IFS= read -r -d "" f; do
+      statsSwiftFiles+=("$f")
+    done < <(find Stats -name '*.swift' -print0)
+
+    swiftc \
+      "''${commonSwiftFlags[@]}" \
+      -emit-executable \
+      -module-name Stats \
+      -I "$buildDir" \
+      -L "$buildDir" \
+      ${lib.concatMapStringsSep " " (fw: "-l${fw}") frameworks} \
+      -Xlinker -rpath -Xlinker "@executable_path/../Frameworks" \
+      "''${statsSwiftFiles[@]}" \
+      -o "$buildDir/Stats"
+
+    runHook postBuild
+  '';
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p "$out/Applications"
-    cp -r *.app "$out/Applications"
+    app="$out/Applications/Stats.app"
+    mkdir -p "$app/Contents/"{MacOS,Frameworks,Resources}
+
+    cp "$buildDir/Stats" "$app/Contents/MacOS/Stats"
+
+    # Install frameworks with generated Info.plists
+    ${lib.concatMapStrings (fw: ''
+      fwDir="$app/Contents/Frameworks/${fw}.framework"
+      mkdir -p "$fwDir/Resources"
+      cp "$buildDir/lib${fw}.dylib" "$fwDir/${fw}"
+      printf '%s' ${lib.escapeShellArg (frameworkPlist fw)} > "$fwDir/Resources/Info.plist"
+    '') frameworks}
+
+    printf '%s' ${lib.escapeShellArg (mainInfoPlist finalAttrs.version)} > "$app/Contents/Info.plist"
+    # Splice CFBundleVersion from upstream's checked-in Info.plist so it stays
+    # in sync automatically — nix-update-script bumps the tag & hash, and the
+    # new source tree carries the correct build number
+    bundleVersion=$(sed -n '/<key>CFBundleVersion<\/key>/{n;s/.*<string>\(.*\)<\/string>.*/\1/p;}' \
+      "Stats/Supporting Files/Info.plist")
+    sed -i "s|</dict>|<key>CFBundleVersion</key><string>$bundleVersion</string></dict>|" \
+      "$app/Contents/Info.plist"
+
+    # Compile asset catalogs
+    actool \
+      --compile "$app/Contents/Resources" \
+      --platform macosx \
+      --minimum-deployment-target 14.0 \
+      --app-icon AppIcon \
+      "Stats/Supporting Files/Assets.xcassets"
+
+    actool \
+      --compile "$app/Contents/Frameworks/Kit.framework/Resources" \
+      --platform macosx \
+      --minimum-deployment-target 14.0 \
+      "Kit/Supporting Files/Assets.xcassets"
+
+    # Copy localization files
+    find "Stats/Supporting Files" -name '*.lproj' -type d -exec cp -r {} "$app/Contents/Resources/" \;
+
+    # Copy module config plists into each framework's Resources
+    for mod in ${lib.concatStringsSep " " modules}; do
+      if [ -f "Modules/$mod/config.plist" ]; then
+        cp "Modules/$mod/config.plist" "$app/Contents/Frameworks/$mod.framework/Resources/config.plist"
+      fi
+    done
+
+    makeWrapper "$app/Contents/MacOS/Stats" "$out/bin/stats"
 
     runHook postInstall
   '';
@@ -40,6 +345,5 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       emilytrau
     ];
     platforms = lib.platforms.darwin;
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 })


### PR DESCRIPTION
## Description of changes

@NixOS/darwin-maintainers Hey folks! I need a bit of helping hand, I think I *almost* have everything done for `stats` to be build from source but I'm struggling with an error that I have no idea how to fix

<details>
  <summary>Build log:</summary>
  <ul>
<li>

```console
$ nix-build -A stats
...
Running phase: unpackPhase
unpacking source archive /nix/store/az200p1ssqh25k1flyfrvcsfxq5sgh9d-source
calling 'unpackCmd' function hook '_defaultUnpack' /nix/store/az200p1ssqh25k1flyfrvcsfxq5sgh9d-source
source root is source
calling 'postUnpack' function hook '_updateSourceDateEpochFromSourceRoot'
Running phase: patchPhase
applying patch /nix/store/1f188qaadrz743a65n5y7lkfxhms81gc-0001-Fixup-Makefile.patch
patching file Makefile
evaling implicit 'postPatch' string hook
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
calling 'preConfigure' function hook '_multioutConfig'
no configure script, doing nothing
Running phase: buildPhase
build flags: SHELL=/nix/store/fyjay93q3dq2hx3dhx7zhr8kyjnkh9m8-bash-5.2p26/bin/bash
Actual version is: 582
Next version is: 583
Exporting application archive...
warning: destination option not implemented
warning: object version 54 may be unsupported
warning: unhandled Project key packageReferences
warning: unhandled ShellScriptBuildPhase key alwaysOutOfDate
warning: unhandled ShellScriptBuildPhase key inputFileListPaths
warning: unhandled ShellScriptBuildPhase key outputFileListPaths
warning: unhandled ShellScriptBuildPhase key alwaysOutOfDate
warning: unhandled ShellScriptBuildPhase key inputFileListPaths
warning: unhandled ShellScriptBuildPhase key outputFileListPaths
warning: unhandled NativeTarget key packageProductDependencies
warning: unhandled NativeTarget key packageProductDependencies
warning: unhandled NativeTarget key packageProductDependencies
Build settings from the command line:
    DERIVED_DATA_DIR=.
    SDKROOT=MacOSX11.0

=== BUILD TARGET Kit OF PROJECT Stats WITH CONFIGURATION Release ===

Check dependencies
warning: unable to find Swift libraries

Write auxiliary files
/bin/mkdir -p ./Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Intermediates/Stats.build/Release/Kit.build
write-file ./Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Intermediates/Stats.build/Release/Kit.build/Kit.hmap
write-file ./Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Intermediates/Stats.build/Release/Kit.build/Kit-own-target-headers.hmap
write-file ./Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Intermediates/Stats.build/Release/Kit.build/Kit-all-target-headers.hmap
write-file ./Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Intermediates/Stats.build/Release/Kit.build/Kit-all-non-framework-target-headers.hmap
write-file ./Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Intermediates/Stats.build/Release/Kit.build/Kit-generated-files.hmap
write-file ./Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Intermediates/Stats.build/Release/Kit.build/Kit-project-headers.hmap
write-file ./Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Intermediates/Stats.build/Release/Kit.build/module.modulemap
/bin/mkdir -p ./Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Intermediates/Stats.build/Release/Kit.build/Objects-normal/arm64
write-file ./Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Intermediates/Stats.build/Release/Kit.build/Objects-normal/arm64/Kit-OutputFileMap.json
write-file ./Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Intermediates/Stats.build/Release/Kit.build/unextended-module.modulemap
write-file ./Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Intermediates/Stats.build/Release/Kit.build/unextended-module-overlay.yaml
write-file ./Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Intermediates/Stats.build/Release/Kit.build/Objects-normal/arm64/Kit.LinkFileList

Create product structure

CpHeader ./Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Products/Release/Kit.bundle/Contents/PrivateHeaders/Kit.h '/private/tmp/nix-build-stats-2.11.5.drv-0/source/Kit/Supporting Files/Kit.h'
    cd /private/tmp/nix-build-stats-2.11.5.drv-0/source
    export DEVELOPER_DIR=/nix/store/60n185lykh89xmvmjl4nd6difsfa4bi3-xcodebuild-0.1.2-pre
    export PATH=/nix/store/kdiiaab1y56f0a6q3417wvb9ypl0wv2w-Platforms/MacOSX.platform/Developer/usr/bin:/nix/store/kdiiaab1y56f0a6q3417wvb9ypl0wv2w-Platforms/MacOSX.platform/usr/local/bin:/nix/store/kdiiaab1y56f0a6q3417wvb9ypl0wv2w-Platforms/MacOSX.platform/usr/bin:/nix/store/kdiiaab1y56f0a6q3417wvb9ypl0wv2w-Platforms/MacOSX.platform/usr/local/bin:/nix/store/3lbn1q3bbyxmfa59zwxk8g8952nl132p-Toolchains/XcodeDefault.xctoolchain/usr/bin:/nix/store/3lbn1q3bbyxmfa59zwxk8g8952nl132p-Toolchains/XcodeDefault.xctoolchain/usr/libexec:/nix/store/60n185lykh89xmvmjl4nd6difsfa4bi3-xcodebuild-0.1.2-pre/usr/bin:/nix/store/60n185lykh89xmvmjl4nd6difsfa4bi3-xcodebuild-0.1.2-pre/usr/local/bin:/nix/store/60n185lykh89xmvmjl4nd6difsfa4bi3-xcodebuild-0.1.2-pre/Tools:/nix/store/ncswzgmmm16xfckcrj9k57jx1yfp326y-ditto-impure-darwin/bin:/nix/store/ajjyja98l3xa05w6rvrzi14arj23g4sd-create-dmg-1.2.2/bin:/nix/store/60n185lykh89xmvmjl4nd6difsfa4bi3-xcodebuild-0.1.2-pre/bin:/nix/store/3lbn1q3bbyxmfa59zwxk8g8952nl132p-Toolchains/XcodeDefault.xctoolchain/bin:/nix/store/wsgvg07q93xmaqp6ln58kzr75rg6jm40-clang-wrapper-16.0.6/bin:/nix/store/xdw9w5y9xdjways9xzs7r02zdmky4bim-clang-16.0.6/bin:/nix/store/7k0qi2r54imwjfs2bklg7fv0mn5jglil-coreutils-9.5/bin:/nix/store/58jqw1w9kj3xm10jfgpr7n9rkvx3p2cy-cctools-binutils-darwin-wrapper-1010.6/bin:/nix/store/5nwhbvfxfhdz9192ihsjpqbsr5vvhbsk-cctools-binutils-darwin-1010.6/bin:/nix/store/y01yv3ylb4zyadnh8cmpv3h8j0vw9slx-findutils-4.10.0/bin:/nix/store/pj9qh3y52knawg34qfnk9nq1kk12lh48-diffutils-3.10/bin:/nix/store/0x1mwb2bl2mjm658kcciwyg7n5avzvfp-gnused-4.9/bin:/nix/store/5g9xsw7dyihfh1kcf73nqqrla3zyy3r0-gnugrep-3.11/bin:/nix/store/ssprxb26mz01akbhlswdb7nbc30iyjjh-gawk-5.2.2/bin:/nix/store/lzndf97akrpmd3vjdq06xzwk8fnjc4j7-gnutar-1.35/bin:/nix/store/ynhzyabgbx6fz49sy944ws9wnskangxc-gzip-1.13/bin:/nix/store/ci1mxirfvn961zh3m4w9mr513ii7s2lz-bzip2-1.0.8-bin/bin:/nix/store/6gylp4vygmsm12rafhzvklrfkbhwwq40-gnumake-4.4.1/bin:/nix/store/fyjay93q3dq2hx3dhx7zhr8kyjnkh9m8-bash-5.2p26/bin:/nix/store/ga67f01j6g0qq7y9flgf3fzr1lbdi58y-patch-2.7.6/bin:/nix/store/6rk472mwpc5zwfhh6siyycl28y2baqrf-xz-5.6.2-bin/bin:/nix/store/apqqsrdg6xsz9icx04siw3l4z9yrxws3-file-5.45/bin
    builtin-copy -resolve-src-symlinks -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg /private/tmp/nix-build-stats-2.11.5.drv-0/source/Kit/Supporting Files/Kit.h ./Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Products/Release/Kit.bundle/Contents/PrivateHeaders

Ditto ./Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Products/Release/Kit.bundle/Contents/Modules/Kit.swiftmodule/arm64.swiftmodule ./Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Intermediates/Stats.build/Release/Kit.build/Objects-normal/arm64/Kit.swiftmodule
    cd /private/tmp/nix-build-stats-2.11.5.drv-0/source
    /usr/bin/ditto -rsrc ./Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Intermediates/Stats.build/Release/Kit.build/Objects-normal/arm64/Kit.swiftmodule ./Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Products/Release/Kit.bundle/Contents/Modules/Kit.swiftmodule/arm64.swiftmodule
ditto: Cannot get the real path for source './Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Intermediates/Stats.build/Release/Kit.build/Objects-normal/arm64/Kit.swiftmodule'

** BUILD FAILED **

The following build commands failed:
    Ditto ./Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Products/Release/Kit.bundle/Contents/Modules/Kit.swiftmodule/arm64.swiftmodule ./Stats-bkfkssqxiuvzqubnwpwicsycxaul/Build/Intermediates/Stats.build/Release/Kit.build/Objects-normal/arm64/Kit.swiftmodule
(1 failure)
make: *** [Makefile:17: archive] Error 1
```
</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc