### PR TITLE
aws-lc: init at 1.37.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20412,6 +20412,12 @@
     githubId = 71843723;
     keys = [ { fingerprint = "EEFB CC3A C529 CFD1 943D  A75C BDD5 7BE9 9D55 5965"; } ];
   };
+  theoparis = {
+    email = "theo@tinted.dev";
+    github = "theparis";
+    githubId = 11761863;
+    name = "Theo Paris";
+  };
   thepuzzlemaker = {
     name = "ThePuzzlemaker";
     email = "tpzker@thepuzzlemaker.info";

--- a/pkgs/by-name/aw/aws-lc/package.nix
+++ b/pkgs/by-name/aw/aws-lc/package.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  stdenv,
+  overrideSDK,
+  cmakeMinimal,
+  fetchFromGitHub,
+  ninja,
+  testers,
+  aws-lc,
+  useSharedLibraries ? !stdenv.targetPlatform.isStatic,
+  ...
+}:
+let
+  awsStdenv = if stdenv.hostPlatform.isDarwin then overrideSDK stdenv "11.0" else stdenv;
+in
+awsStdenv.mkDerivation (finalAttrs: {
+  pname = "aws-lc";
+  version = "1.37.0";
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = "aws-lc";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-jgzUre8hjj689YycZZAsNO0KraLB5HuCR/JEfczn0h8=";
+  };
+
+  outputs = [
+    "out"
+    "bin"
+    "dev"
+  ];
+
+  nativeBuildInputs = [
+    cmakeMinimal
+    ninja
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" useSharedLibraries)
+    "-GNinja"
+    "-DDISABLE_GO=ON"
+    "-DDISABLE_PERL=ON"
+    "-DBUILD_TESTING=ON"
+  ];
+
+  doCheck = true;
+
+  checkPhase = ''
+    ninja run_minimal_tests
+  '';
+
+  env.NIX_CFLAGS_COMPILE = toString (
+    lib.optionals stdenv.cc.isGNU [
+      # Needed with GCC 12 but breaks on darwin (with clang)
+      "-Wno-error=stringop-overflow"
+    ]
+  );
+
+  postFixup = ''
+    for f in $out/lib/crypto/cmake/*/crypto-targets.cmake; do
+      substituteInPlace "$f" \
+        --replace-fail 'INTERFACE_INCLUDE_DIRECTORIES "''${_IMPORT_PREFIX}/include"' 'INTERFACE_INCLUDE_DIRECTORIES ""'
+    done
+  '';
+
+  passthru.tests = {
+    version = testers.testVersion {
+      package = aws-lc;
+      command = "bssl version";
+    };
+    pkg-config = testers.hasPkgConfigModules {
+      package = aws-lc;
+      moduleNames = [
+        "libcrypto"
+        "libssl"
+        "openssl"
+      ];
+    };
+  };
+
+  meta = {
+    description = "General-purpose cryptographic library maintained by the AWS Cryptography team for AWS and their customers";
+    homepage = "https://github.com/aws/aws-lc";
+    license = [
+      lib.licenses.asl20 # or
+      lib.licenses.isc
+    ];
+    maintainers = [ lib.maintainers.theoparis ];
+    platforms = lib.platforms.all;
+    mainProgram = "bssl";
+  };
+})


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

I have marked this as a draft because `pkgsStatic.aws-lc` fails to build and I'm yet to figure out the "no such file or directory" errors.

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
