### PR TITLE
anki: 24.06.2 -> 24.06.3, rust 1.80 fix

### DIFF
--- a/pkgs/games/anki/Cargo.lock
+++ b/pkgs/games/anki/Cargo.lock
@@ -5581,9 +5581,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -5602,9 +5602,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -1,29 +1,30 @@
-{ lib
-, stdenv
+{
+  lib,
+  stdenv,
 
-, buildEnv
-, cargo
-, fetchFromGitHub
-, fetchYarnDeps
-, installShellFiles
-, lame
-, mpv-unwrapped
-, ninja
-, nixosTests
-, nodejs
-, nodejs-slim
-, fixup-yarn-lock
-, protobuf
-, python3
-, qt6
-, rsync
-, rustPlatform
-, writeShellScriptBin
-, yarn
+  buildEnv,
+  cargo,
+  fetchFromGitHub,
+  fetchYarnDeps,
+  installShellFiles,
+  lame,
+  mpv-unwrapped,
+  ninja,
+  nixosTests,
+  nodejs,
+  nodejs-slim,
+  fixup-yarn-lock,
+  protobuf,
+  python3,
+  qt6,
+  rsync,
+  rustPlatform,
+  writeShellScriptBin,
+  yarn,
 
-, AVKit
-, CoreAudio
-, swift
+  AVKit,
+  CoreAudio,
+  swift,
 }:
 
 let
@@ -53,9 +54,7 @@ let
     hash = "sha256-Dbd7RtE0td7li7oqPPfBmAsbXPM8ed9NTAhM5gytpG8=";
   };
 
-  anki-build-python = python3.withPackages (ps: with ps; [
-    mypy-protobuf
-  ]);
+  anki-build-python = python3.withPackages (ps: with ps; [ mypy-protobuf ]);
 
   # anki shells out to git to check its revision, and also to update submodules
   # We don't actually need the submodules, so we stub that out
@@ -122,7 +121,11 @@ in
 python3.pkgs.buildPythonApplication {
   inherit pname version;
 
-  outputs = [ "out" "doc" "man" ];
+  outputs = [
+    "out"
+    "doc"
+    "man"
+  ];
 
   inherit src;
 
@@ -154,63 +157,70 @@ python3.pkgs.buildPythonApplication {
     qt6.qtsvg
   ] ++ lib.optional stdenv.isLinux qt6.qtwayland;
 
-  propagatedBuildInputs = with python3.pkgs; [
-    # This rather long list came from running:
-    #    grep --no-filename -oE "^[^ =]*" python/{requirements.base.txt,requirements.bundle.txt,requirements.qt6_lin.txt} | \
-    #      sort | uniq | grep -v "^#$"
-    # in their repo at the git tag for this version
-    # There's probably a more elegant way, but the above extracted all the
-    # names, without version numbers, of their python dependencies. The hope is
-    # that nixpkgs versions are "close enough"
-    # I then removed the ones the check phase failed on (pythonCatchConflictsPhase)
-    attrs
-    beautifulsoup4
-    blinker
-    build
-    certifi
-    charset-normalizer
-    click
-    colorama
-    decorator
-    flask
-    flask-cors
-    google-api-python-client
-    idna
-    importlib-metadata
-    itsdangerous
-    jinja2
-    jsonschema
-    markdown
-    markupsafe
-    orjson
-    packaging
-    pip
-    pip-system-certs
-    pip-tools
-    protobuf
-    pyproject-hooks
-    pyqt6
-    pyqt6-sip
-    pyqt6-webengine
-    pyrsistent
-    pysocks
-    requests
-    send2trash
-    setuptools
-    soupsieve
-    tomli
-    urllib3
-    waitress
-    werkzeug
-    wheel
-    wrapt
-    zipp
-  ] ++ lib.optionals stdenv.isDarwin [
-    AVKit
-    CoreAudio
-  ];
+  propagatedBuildInputs =
+    with python3.pkgs;
+    [
+      # This rather long list came from running:
+      #    grep --no-filename -oE "^[^ =]*" python/{requirements.base.txt,requirements.bundle.txt,requirements.qt6_lin.txt} | \
+      #      sort | uniq | grep -v "^#$"
+      # in their repo at the git tag for this version
+      # There's probably a more elegant way, but the above extracted all the
+      # names, without version numbers, of their python dependencies. The hope is
+      # that nixpkgs versions are "close enough"
+      # I then removed the ones the check phase failed on (pythonCatchConflictsPhase)
+      attrs
+      beautifulsoup4
+      blinker
+      build
+      certifi
+      charset-normalizer
+      click
+      colorama
+      decorator
+      flask
+      flask-cors
+      google-api-python-client
+      idna
+      importlib-metadata
+      itsdangerous
+      jinja2
+      jsonschema
+      markdown
+      markupsafe
+      orjson
+      packaging
+      pip
+      pip-system-certs
+      pip-tools
+      protobuf
+      pyproject-hooks
+      pyqt6
+      pyqt6-sip
+      pyqt6-webengine
+      pyrsistent
+      pysocks
+      requests
+      send2trash
+      setuptools
+      soupsieve
+      tomli
+      urllib3
+      waitress
+      werkzeug
+      wheel
+      wrapt
+      zipp
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      AVKit
+      CoreAudio
+    ];
 
-  nativeCheckInputs = with python3.pkgs; [ pytest mock astroid ];
+  nativeCheckInputs = with python3.pkgs; [
+    pytest
+    mock
+    astroid
+  ];
 
   # tests fail with to many open files
   # TODO: verify if this is still true (I can't, no mac)
@@ -252,25 +262,29 @@ python3.pkgs.buildPythonApplication {
   '';
 
   # mimic https://github.com/ankitects/anki/blob/76d8807315fcc2675e7fa44d9ddf3d4608efc487/build/ninja_gen/src/python.rs#L232-L250
-  checkPhase = let
-    disabledTestsString = lib.pipe [
-      # assumes / is not writeable, somehow fails on nix-portable brwap
-      "test_create_open"
-    ] [
-      (lib.map (test: "not ${test}"))
-      (lib.concatStringsSep " and ")
-      lib.escapeShellArg
-    ];
+  checkPhase =
+    let
+      disabledTestsString =
+        lib.pipe
+          [
+            # assumes / is not writeable, somehow fails on nix-portable brwap
+            "test_create_open"
+          ]
+          [
+            (lib.map (test: "not ${test}"))
+            (lib.concatStringsSep " and ")
+            lib.escapeShellArg
+          ];
 
-  in ''
-    runHook preCheck
-    HOME=$TMP ANKI_TEST_MODE=1 PYTHONPATH=$PYTHONPATH:$PWD/out/pylib \
-      pytest -p no:cacheprovider pylib/tests -k ${disabledTestsString}
-    HOME=$TMP ANKI_TEST_MODE=1 PYTHONPATH=$PYTHONPATH:$PWD/out/pylib:$PWD/pylib:$PWD/out/qt \
-      pytest -p no:cacheprovider qt/tests -k ${disabledTestsString}
-    runHook postCheck
-  '';
-
+    in
+    ''
+      runHook preCheck
+      HOME=$TMP ANKI_TEST_MODE=1 PYTHONPATH=$PYTHONPATH:$PWD/out/pylib \
+        pytest -p no:cacheprovider pylib/tests -k ${disabledTestsString}
+      HOME=$TMP ANKI_TEST_MODE=1 PYTHONPATH=$PYTHONPATH:$PWD/out/pylib:$PWD/pylib:$PWD/out/qt \
+        pytest -p no:cacheprovider qt/tests -k ${disabledTestsString}
+      runHook postCheck
+    '';
 
   preInstall = ''
     mkdir dist
@@ -316,7 +330,10 @@ python3.pkgs.buildPythonApplication {
     homepage = "https://apps.ankiweb.net";
     license = licenses.agpl3Plus;
     platforms = platforms.mesaPlatforms;
-    maintainers = with maintainers; [ euank oxij ];
+    maintainers = with maintainers; [
+      euank
+      oxij
+    ];
     # Reported to crash at launch on darwin (as of 2.1.65)
     broken = stdenv.isDarwin;
   };

--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -28,14 +28,14 @@
 
 let
   pname = "anki";
-  version = "24.06.2";
-  rev = "33a923797afc9655c3b4f79847e1705a1f998d03";
+  version = "24.06.3";
+  rev = "d678e39350a2d243242a69f4e22f5192b04398f2";
 
   src = fetchFromGitHub {
     owner = "ankitects";
     repo = "anki";
     rev = version;
-    hash = "sha256-jn8MxyDPVk36neHyiuvwOQQ+x7x4JPOR8BnNutTRmnY=";
+    hash = "sha256-ap8WFDDSGonk5kgXXIsADwAwd7o6Nsy6Wxsa7r1iUIM=";
     fetchSubmodules = true;
   };
 
@@ -50,7 +50,7 @@ let
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = "${src}/yarn.lock";
-    hash = "sha256-wyrVoaDdCkSe5z6C7EAw04G87s6tQ1cfc2d6ygGU0DM=";
+    hash = "sha256-Dbd7RtE0td7li7oqPPfBmAsbXPM8ed9NTAhM5gytpG8=";
   };
 
   anki-build-python = python3.withPackages (ps: with ps; [

--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -130,6 +130,8 @@ python3.pkgs.buildPythonApplication {
     ./patches/disable-auto-update.patch
     ./patches/remove-the-gl-library-workaround.patch
     ./patches/skip-formatting-python-code.patch
+    # Also remove from anki/sync-server.nix on next update
+    ./patches/Cargo.lock-update-time-for-rust-1.80.patch
   ];
 
   inherit cargoDeps yarnOfflineCache;

--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -226,6 +226,13 @@ python3.pkgs.buildPythonApplication {
   # TODO: verify if this is still true (I can't, no mac)
   doCheck = !stdenv.isDarwin;
 
+  checkFlags = [
+    # these two tests are flaky, see https://github.com/ankitects/anki/issues/3353
+    # Also removed from anki-sync-server when removing this.
+    "--skip=media::check::test::unicode_normalization"
+    "--skip=scheduler::answering::test::state_application"
+  ];
+
   dontUseNinjaInstall = false;
   dontWrapQtApps = true;
 

--- a/pkgs/games/anki/patches/Cargo.lock-update-time-for-rust-1.80.patch
+++ b/pkgs/games/anki/patches/Cargo.lock-update-time-for-rust-1.80.patch
@@ -1,0 +1,40 @@
+From 66d9c405bfe7cb431cc52a7aec038068b364f034 Mon Sep 17 00:00:00 2001
+From: Dominique Martinet <asmadeus@codewreck.org>
+Date: Sat, 10 Aug 2024 13:05:26 +0900
+Subject: [PATCH] Cargo.lock: update time for rust 1.80
+
+---
+ Cargo.lock | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 9219317f2cea..17fb6f4a894c 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -5581,9 +5581,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "time"
+-version = "0.3.34"
++version = "0.3.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
++checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+ dependencies = [
+  "deranged",
+  "itoa",
+@@ -5602,9 +5602,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+ 
+ [[package]]
+ name = "time-macros"
+-version = "0.2.17"
++version = "0.2.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
++checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+ dependencies = [
+  "num-conv",
+  "time-core",
+-- 
+2.45.2
+

--- a/pkgs/games/anki/sync-server.nix
+++ b/pkgs/games/anki/sync-server.nix
@@ -23,6 +23,13 @@ rustPlatform.buildRustPackage {
     "anki-sync-server"
   ];
 
+  checkFlags = [
+    # these two tests are flaky, see https://github.com/ankitects/anki/issues/3353
+    # Also removed from anki when removing this.
+    "--skip=media::check::test::unicode_normalization"
+    "--skip=scheduler::answering::test::state_application"
+  ];
+
   nativeBuildInputs = [ protobuf pkg-config ];
 
   buildInputs = [

--- a/pkgs/games/anki/sync-server.nix
+++ b/pkgs/games/anki/sync-server.nix
@@ -13,6 +13,10 @@ rustPlatform.buildRustPackage {
   pname = "anki-sync-server";
   inherit (anki) version src cargoLock;
 
+  patches = [
+    ./patches/Cargo.lock-update-time-for-rust-1.80.patch
+  ];
+
   # only build sync server
   cargoBuildFlags = [
     "--bin"


### PR DESCRIPTION
## Description of changes

- update the `time` dependency to fix rust 1.80 build (not easily testable, but build with 1.79 passes) ; see #332957
- while here also update anki itself to the latest release, see release notes https://github.com/ankitects/anki/releases -- nothing stands out to me, but if we're going to rebuild it anyway might as well update.
- my new vim config automatically runs rustfmt so I've included it as a separate commit last; happy to remove it if you're rather not have it but if it's going to become the official style I guess there's no harm? No opinion on that; I don't particularly like churn so will drop the commit without discussing if requested.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
