### PR TITLE
pdm: 2.15.4 -> 2.17.3

### DIFF
--- a/pkgs/development/python-modules/pdm-build-locked/default.nix
+++ b/pkgs/development/python-modules/pdm-build-locked/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  pdm-backend,
+  tomli,
+  build,
+  hatchling,
+  pkginfo,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pdm-build-locked";
+  version = "0.3.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pdm-project";
+    repo = "pdm-build-locked";
+    rev = "refs/tags/${version}";
+    hash = "sha256-tgLC1tUgmyX7QvlLpNb/SMQRTDZ+DNFV3o0JELAZEeo=";
+  };
+
+  postPatch = ''
+    substituteInPlace tests/conftest.py \
+      --replace-fail '"pdm.pytest"' ""
+    sed -i "/addopts/d" pyproject.toml
+  '';
+
+  build-system = [ pdm-backend ];
+
+  dependencies = lib.optionals (pythonOlder "3.11") [ tomli ];
+
+  pythonImportsCheck = [ "pdm_build_locked" ];
+
+  nativeCheckInputs = [
+    build
+    hatchling
+    pkginfo
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # circular import of pdm
+    "tests/unit/test_build_command.py"
+  ];
+
+  meta = {
+    description = "Pdm-build-locked is a pdm plugin to publish locked dependencies as optional-dependencies";
+    homepage = "https://github.com/pdm-project/pdm-build-locked";
+    changelog = "https://github.com/pdm-project/pdm-build-locked/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ natsukium ];
+  };
+}

--- a/pkgs/tools/package-management/pdm/default.nix
+++ b/pkgs/tools/package-management/pdm/default.nix
@@ -11,14 +11,14 @@
 with python3.pkgs;
 buildPythonApplication rec {
   pname = "pdm";
-  version = "2.15.4";
+  version = "2.17.3";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-WOIlhQVn3K3OQkGNtGOJlt8rE3jNCDDNSK/aG0VdnHI=";
+    hash = "sha256-9JIg8iXscSWMv3FIsUp2yurGEnRb7atn+QYjmOpWp6U=";
   };
 
   nativeBuildInputs = [
@@ -27,6 +27,7 @@ buildPythonApplication rec {
 
   build-system = [
     pdm-backend
+    pdm-build-locked
   ];
 
   dependencies = [
@@ -102,11 +103,14 @@ buildPythonApplication rec {
     "test_convert_setup_py_project"
     # pythonfinder isn't aware of nix's python infrastructure
     "test_use_wrapper_python"
+    "test_build_with_no_isolation"
+    "test_run_script_with_inline_metadata"
 
     # touches the network
     "test_find_candidates_from_find_links"
     "test_lock_all_with_excluded_groups"
     "test_find_interpreters_with_PDM_IGNORE_ACTIVE_VENV"
+    "test_build_distributions"
   ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9892,6 +9892,8 @@ self: super: with self; {
 
   pdm-backend = callPackage ../development/python-modules/pdm-backend { };
 
+  pdm-build-locked = callPackage ../development/python-modules/pdm-build-locked { };
+
   pdm-pep517 = callPackage ../development/python-modules/pdm-pep517 { };
 
   pdoc = callPackage ../development/python-modules/pdoc { };


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/pdm-project/pdm/releases/tag/2.17.3

add dependencies, python312Packages.pdm-build-locked
https://github.com/pdm-project/pdm-build-locked

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
