### PR TITLE
eww: 0.6.0-unstable-2024-04-26 -> 0.6.0-unstable-2024-07-05

### DIFF
--- a/pkgs/by-name/ew/eww/lockfile.patch
+++ b/pkgs/by-name/ew/eww/lockfile.patch
@@ -1,0 +1,37 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 5d94bd4..acd2c8d 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1676,7 +1676,7 @@ dependencies = [
+  "libm",
+  "log",
+  "regex",
+- "time 0.3.34",
++ "time 0.3.36",
+  "urlencoding",
+ ]
+ 
+@@ -2893,9 +2893,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "time"
+-version = "0.3.34"
++version = "0.3.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
++checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+ dependencies = [
+  "deranged",
+  "itoa",
+@@ -2914,9 +2914,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+ 
+ [[package]]
+ name = "time-macros"
+-version = "0.2.17"
++version = "0.2.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
++checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+ dependencies = [
+  "num-conv",
+  "time-core",

--- a/pkgs/by-name/ew/eww/package.nix
+++ b/pkgs/by-name/ew/eww/package.nix
@@ -1,13 +1,14 @@
-{ lib
-, rustPlatform
-, fetchFromGitHub
-, pkg-config
-, wrapGAppsHook3
-, gtk3
-, librsvg
-, gtk-layer-shell
-, stdenv
-, libdbusmenu-gtk3
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  wrapGAppsHook3,
+  gtk3,
+  librsvg,
+  gtk-layer-shell,
+  stdenv,
+  libdbusmenu-gtk3,
 }:
 
 rustPlatform.buildRustPackage rec {

--- a/pkgs/by-name/ew/eww/package.nix
+++ b/pkgs/by-name/ew/eww/package.nix
@@ -9,6 +9,7 @@
   gtk-layer-shell,
   stdenv,
   libdbusmenu-gtk3,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -48,6 +49,8 @@ rustPlatform.buildRustPackage rec {
 
   # requires unstable rust features
   RUSTC_BOOTSTRAP = 1;
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
     description = "Widget system made in Rust to create widgets for any WM";

--- a/pkgs/by-name/ew/eww/package.nix
+++ b/pkgs/by-name/ew/eww/package.nix
@@ -14,7 +14,7 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "eww";
-  version = "0.6.0-unstable-2024-04-26";
+  version = "0.6.0-unstable-2024-07-05";
 
   src = fetchFromGitHub {
     owner = "elkowar";
@@ -22,11 +22,13 @@ rustPlatform.buildRustPackage rec {
     # FIXME: change to a release tag once a new release is available
     # https://github.com/elkowar/eww/pull/1084
     # using the revision to fix string truncation issue in eww config
-    rev = "2c8811512460ce6cc75e021d8d081813647699dc";
-    hash = "sha256-eDOg5Ink3iWT/B1WpD9po5/UxS4DEaVO4NPIRyjSheM=";
+    rev = "4d55e9ad63d1fae887726dffcd25a32def23d34f";
+    hash = "sha256-LTSFlW/46hl1u9SzqnvbtNxswCW05bhwOY6CzVEJC5o=";
   };
 
-  cargoHash = "sha256-ClnIW7HxbQcC85OyoMhBLFjVtdEUCOARuimfS4uRi+E=";
+  # needed to fix build errors with rust 1.80 due to outdated time crate
+  cargoPatches = [ ./lockfile.patch ];
+  cargoHash = "sha256-55lmQl5pJwrEj5RlSG8b0PqtZVrASxTmX4Qdk090DZo=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION

## Description of changes

- **eww: nixfmt**
- **eww: set updateScript**
- **eww: 0.6.0-unstable-2024-04-26 -> 0.6.0-unstable-2024-07-05**

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
