### PR TITLE
gaucheBootstrap: 0.9.12 -> 0.9.15, gauche: 0.9.13 -> 0.9.15

### DIFF
--- a/pkgs/development/interpreters/gauche/boot.nix
+++ b/pkgs/development/interpreters/gauche/boot.nix
@@ -1,18 +1,41 @@
-{ stdenv, lib, fetchurl, pkg-config, texinfo, libiconv, gdbm, openssl, zlib
-, mbedtls, cacert }:
+{
+  stdenv,
+  lib,
+  fetchurl,
+  pkg-config,
+  texinfo,
+  libiconv,
+  gdbm,
+  openssl,
+  zlib,
+  mbedtls,
+  cacert,
+}:
 
 stdenv.mkDerivation rec {
   pname = "gauche-bootstrap";
-  version = "0.9.12";
+  version = "0.9.15";
 
   src = fetchurl {
-    url = "https://github.com/shirok/Gauche/releases/download/release${lib.replaceStrings ["."] ["_"] version}/Gauche-${version}.tgz";
-    hash = "sha256-tK5kkhsHqWZhaV69WqwN7IE9GmjlRqYWCRE9eEP1thc=";
+    url = "https://github.com/shirok/Gauche/releases/download/release${
+      lib.replaceStrings [ "." ] [ "_" ] version
+    }/Gauche-${version}.tgz";
+    hash = "sha256-NkPie8fIgiz9b7KJLbGF9ljo42STi8LM/O2yOeNa94M=";
   };
 
-  nativeBuildInputs = [ pkg-config texinfo ];
+  nativeBuildInputs = [
+    pkg-config
+    texinfo
+  ];
 
-  buildInputs = [ libiconv gdbm openssl zlib mbedtls cacert ];
+  buildInputs = [
+    libiconv
+    gdbm
+    openssl
+    zlib
+    mbedtls
+    cacert
+  ];
 
   postPatch = ''
     patchShebangs .
@@ -34,8 +57,9 @@ stdenv.mkDerivation rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "R7RS Scheme scripting engine";
+    description = "R7RS Scheme scripting engine (released version)";
     homepage = "https://practical-scheme.net/gauche/";
+    mainProgram = "gosh";
     maintainers = with maintainers; [ mnacamura ];
     license = licenses.bsd3;
     platforms = platforms.unix;

--- a/pkgs/development/interpreters/gauche/default.nix
+++ b/pkgs/development/interpreters/gauche/default.nix
@@ -1,20 +1,46 @@
-{ stdenv, lib, fetchFromGitHub, autoreconfHook, gaucheBootstrap, pkg-config, texinfo
-, libiconv, gdbm, openssl, zlib, mbedtls, cacert, CoreServices }:
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  autoreconfHook,
+  gaucheBootstrap,
+  pkg-config,
+  texinfo,
+  libiconv,
+  gdbm,
+  openssl,
+  zlib,
+  mbedtls,
+  cacert,
+  CoreServices,
+}:
 
 stdenv.mkDerivation rec {
   pname = "gauche";
-  version = "0.9.13";
+  version = "0.9.15";
 
   src = fetchFromGitHub {
     owner = "shirok";
     repo = pname;
     rev = "release${lib.replaceStrings [ "." ] [ "_" ] version}";
-    hash = "sha256-XD4zJzCktGi/E9sA6BVm9JVQBVrG5119EjZNbP1pVJU=";
+    hash = "sha256-M2vZqTMkob+WxUnCo4NDxS4pCVNleVBqkiiRp9nG/KA=";
   };
 
-  nativeBuildInputs = [ gaucheBootstrap pkg-config texinfo autoreconfHook ];
+  nativeBuildInputs = [
+    gaucheBootstrap
+    pkg-config
+    texinfo
+    autoreconfHook
+  ];
 
-  buildInputs = [ libiconv gdbm openssl zlib mbedtls cacert ] ++ lib.optionals stdenv.isDarwin [ CoreServices ];
+  buildInputs = [
+    libiconv
+    gdbm
+    openssl
+    zlib
+    mbedtls
+    cacert
+  ] ++ lib.optionals stdenv.isDarwin [ CoreServices ];
 
   autoreconfPhase = ''
     ./DIST gen


### PR DESCRIPTION
## Description of changes

Update Gauche, a Scheme implementation, from 0.9.12 (released or "bootstrapped" version) and 0.9.13 (built from the source tree) to 0.9.15.

Mark `gaucheBootstrap` as "released version" in its description, and specify `gosh` as the main program.

Format the files with `nixfmt`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
