### PR TITLE
Stockfish update: 16 -> 16.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20464,6 +20464,12 @@
     name = "Thiago K. Okada";
     matrix = "@k0kada:matrix.org";
   };
+  thibaultd = {
+    email = "t@lichess.org";
+    github = "ornicar";
+    githubId = 140370;
+    name = "Thibault D";
+  };
   thibaultlemaire = {
     email = "thibault.lemaire@protonmail.com";
     github = "ThibaultLemaire";

--- a/pkgs/games/stockfish/default.nix
+++ b/pkgs/games/stockfish/default.nix
@@ -11,29 +11,36 @@ let
            if stdenv.isAarch64 then "armv8" else
            "unknown";
 
-    nnueFile = "nn-5af11540bbfe.nnue";
-    nnue = fetchurl {
-      name = nnueFile;
-      url = "https://tests.stockfishchess.org/api/nn/${nnueFile}";
-      sha256 = "sha256-WvEVQLv+/LVOOMXdAAyrS0ad+nWZodVb5dJyLCCokps=";
+    # These files can be found in src/evaluate.h
+    nnueBigFile = "nn-b1a57edbea57.nnue";
+    nnueBig = fetchurl {
+      name = nnueBigFile;
+      url = "https://tests.stockfishchess.org/api/nn/${nnueBigFile}";
+      sha256 = "sha256-saV+2+pXTKi4jWg3RzhFeRvrU9iF+H+G1czdVln787I=";
+    };
+    nnueSmallFile = "nn-baff1ede1f90.nnue";
+    nnueSmall = fetchurl {
+      name = nnueSmallFile;
+      url = "https://tests.stockfishchess.org/api/nn/${nnueSmallFile}";
+      sha256 = "sha256-uv8e3h+Qwd0bT3cvHv8phIghgB6BhjRdp/DrQSG9b2M=";
     };
 in
 
 stdenv.mkDerivation rec {
   pname = "stockfish";
-  version = "16";
+  version = "16.1";
 
   src = fetchFromGitHub {
     owner = "official-stockfish";
     repo = "Stockfish";
     rev = "sf_${version}";
-    sha256 = "sha256-ASy2vIP94lnSKgxixK1GoC84yAysaJpxeyuggV4MrP4=";
+    sha256 = "sha256-xTtjfJgEHF0SQT9Fw/9RLZA0Quh00jrIbihr7IYCm2U=";
   };
 
   postUnpack = ''
     sourceRoot+=/src
-    echo ${nnue}
-    cp "${nnue}" "$sourceRoot/${nnueFile}"
+    cp "${nnueBig}" "$sourceRoot/${nnueBigFile}"
+    cp "${nnueSmall}" "$sourceRoot/${nnueSmallFile}"
   '';
 
   makeFlags = [ "PREFIX=$(out)" "ARCH=${arch}" "CXX=${stdenv.cc.targetPrefix}c++" ];


### PR DESCRIPTION
## Description of changes

Upgrades stockfish to 16.1. It now uses 2 NNUE files:
https://stockfishchess.org/blog/2024/stockfish-16-1/

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
