### PR TITLE
youki: 0.3.2 -> 0.3.3

### DIFF
--- a/pkgs/applications/virtualization/youki/default.nix
+++ b/pkgs/applications/virtualization/youki/default.nix
@@ -1,32 +1,38 @@
-{ lib
-, rustPlatform
-, fetchFromGitHub
-, pkg-config
-, installShellFiles
-, dbus
-, libseccomp
-, systemd
-, stdenv
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  installShellFiles,
+  dbus,
+  libseccomp,
+  systemd,
+  stdenv,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "youki";
-  version = "0.3.2";
+  version = "0.3.3";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-/cc+gHnakxC446MxErvgCDvc1gMWNi45h6fZ1Cd1Pj0=";
+    hash = "sha256-lOt+bi9JbHLRUFiSoIfgNH2f9LXcrKk7vSz8fXLFDJE=";
   };
 
-  cargoPatches = [
-    ./fix-cargo-lock.patch
+  cargoPatches = [ ./fix-cargo-lock.patch ];
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
   ];
 
-  nativeBuildInputs = [ pkg-config installShellFiles ];
-
-  buildInputs = [ dbus libseccomp systemd ];
+  buildInputs = [
+    dbus
+    libseccomp
+    systemd
+  ];
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd youki \
@@ -35,17 +41,23 @@ rustPlatform.buildRustPackage rec {
       --zsh <($out/bin/youki completion -s zsh)
   '';
 
-  cargoBuildFlags = [ "-p" "youki" ];
-  cargoTestFlags = [ "-p" "youki" ];
+  cargoBuildFlags = [
+    "-p"
+    "youki"
+  ];
+  cargoTestFlags = [
+    "-p"
+    "youki"
+  ];
 
-  cargoHash = "sha256-PKn448fOCnyMC42NtQnLt8kvZIBautsq4Fw/bRvwmpw=";
+  cargoHash = "sha256-bbKuycv747NKtxhnakASRtlkPqT2Ry6g0z4Zi1EuNzQ=";
 
   meta = with lib; {
     description = "Container runtime written in Rust";
     homepage = "https://containers.github.io/youki/";
     changelog = "https://github.com/containers/youki/releases/tag/v${version}";
     license = licenses.asl20;
-    maintainers = [ ];
+    maintainers = with maintainers; [ builditluc ];
     platforms = platforms.linux;
     mainProgram = "youki";
   };

--- a/pkgs/applications/virtualization/youki/fix-cargo-lock.patch
+++ b/pkgs/applications/virtualization/youki/fix-cargo-lock.patch
@@ -1,40 +1,82 @@
 diff --git a/Cargo.lock b/Cargo.lock
-index cfef78c0..7cad3faa 100644
+index ffbcdc33..62659a4d 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -1879,7 +1879,7 @@ checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+@@ -1915,7 +1915,7 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
  
  [[package]]
  name = "libcgroups"
--version = "0.3.1"
-+version = "0.3.2"
+-version = "0.3.2"
++version = "0.3.3"
  dependencies = [
   "anyhow",
   "clap",
-@@ -1904,7 +1904,7 @@ dependencies = [
+@@ -1940,7 +1940,7 @@ dependencies = [
  
  [[package]]
  name = "libcontainer"
--version = "0.3.1"
-+version = "0.3.2"
+-version = "0.3.2"
++version = "0.3.3"
  dependencies = [
   "anyhow",
-  "bitflags 2.4.2",
-@@ -1947,7 +1947,7 @@ dependencies = [
+  "bitflags 2.5.0",
+@@ -1983,7 +1983,7 @@ dependencies = [
  
  [[package]]
  name = "liboci-cli"
--version = "0.3.1"
-+version = "0.3.2"
+-version = "0.3.2"
++version = "0.3.3"
  dependencies = [
   "clap",
  ]
-@@ -5712,7 +5712,7 @@ dependencies = [
+@@ -3881,9 +3881,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "time"
+-version = "0.3.34"
++version = "0.3.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
++checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+ dependencies = [
+  "deranged",
+  "itoa",
+@@ -3893,7 +3893,7 @@ dependencies = [
+  "powerfmt",
+  "serde",
+  "time-core",
+- "time-macros 0.2.17",
++ "time-macros 0.2.18",
+ ]
+ 
+ [[package]]
+@@ -3914,9 +3914,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "time-macros"
+-version = "0.2.17"
++version = "0.2.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
++checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+ dependencies = [
+  "num-conv",
+  "time-core",
+@@ -4287,7 +4287,7 @@ dependencies = [
+  "anyhow",
+  "cfg-if",
+  "rustversion",
+- "time 0.3.34",
++ "time 0.3.36",
+ ]
+ 
+ [[package]]
+@@ -5678,7 +5678,7 @@ dependencies = [
  
  [[package]]
  name = "youki"
--version = "0.3.1"
-+version = "0.3.2"
+-version = "0.3.2"
++version = "0.3.3"
  dependencies = [
   "anyhow",
   "caps",


### PR DESCRIPTION
## Description of changes

Updates the unmaintained (in nixpkgs) youki to [v0.3.3](https://github.com/containers/youki/releases/tag/v0.3.3).

Also updates the `time` crate in `Cargo.lock` with a patch, because of the build failure with Rust 1.80 (see https://github.com/NixOS/nixpkgs/issues/332957 for more information about the issue). I've already created an issue in youki, so this patch will be removed with the next version update PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
