### PR TITLE
libgit2: introduce libgit2_1_8 attribute and init at 1.8.1; cargo-generate: 0.21.1 -> 0.21.3

### DIFF
--- a/pkgs/development/libraries/libgit2/1-7-2.nix
+++ b/pkgs/development/libraries/libgit2/1-7-2.nix
@@ -1,0 +1,5 @@
+(import ./build-version.nix) {
+  # also check the following packages for updates: python3Packages.pygit2 and libgit2-glib
+  version = "1.7.2";
+  hash = "sha256-fVPY/byE2/rxmv/bUykcAbmUFMlF3UZogVuTzjOXJUU=";
+}

--- a/pkgs/development/libraries/libgit2/1-8-1.nix
+++ b/pkgs/development/libraries/libgit2/1-8-1.nix
@@ -1,0 +1,5 @@
+(import ./build-version.nix) {
+  # also check the following packages for updates: python3Packages.pygit2 and libgit2-glib
+  version = "1.8.1";
+  hash = "sha256-J2rCxTecyLbbDdsyBWn9w7r3pbKRMkI9E7RvRgAqBdY=";
+}

--- a/pkgs/development/libraries/libgit2/build-version.nix
+++ b/pkgs/development/libraries/libgit2/build-version.nix
@@ -1,3 +1,6 @@
+{ version
+, hash
+}:
 { lib
 , stdenv
 , fetchFromGitHub
@@ -20,8 +23,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libgit2";
-  version = "1.7.2";
-  # also check the following packages for updates: python3Packages.pygit2 and libgit2-glib
+  inherit version;
 
   outputs = ["lib" "dev" "out"];
 
@@ -29,7 +31,7 @@ stdenv.mkDerivation rec {
     owner = "libgit2";
     repo = "libgit2";
     rev = "v${version}";
-    hash = "sha256-fVPY/byE2/rxmv/bUykcAbmUFMlF3UZogVuTzjOXJUU=";
+    inherit hash;
   };
 
   cmakeFlags = [

--- a/pkgs/development/tools/rust/cargo-generate/default.nix
+++ b/pkgs/development/tools/rust/cargo-generate/default.nix
@@ -2,7 +2,7 @@
 , rustPlatform
 , fetchFromGitHub
 , pkg-config
-, libgit2
+, libgit2_1_8
 , openssl
 , stdenv
 , darwin
@@ -11,20 +11,20 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-generate";
-  version = "0.21.1";
+  version = "0.21.3";
 
   src = fetchFromGitHub {
     owner = "cargo-generate";
     repo = "cargo-generate";
     rev = "v${version}";
-    sha256 = "sha256-Pza1MK5yWpuNfaaFAJy5/Pf+t0TN1Hzc5wKcpmMpEf0=";
+    sha256 = "sha256-1F/865UgdqwfpITFhXCuL7CmducL7w0lVDyfui9UzjU=";
   };
 
-  cargoHash = "sha256-b6WfsDTAZgxA977JhdlafE+POPvMLl8Z7CzEf+L2+Us=";
+  cargoHash = "sha256-szPO1V09EThpo2N03Ll+ZJUpvjp2b+/C/sviOzFfG+k=";
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ libgit2 openssl ] ++ lib.optionals stdenv.isDarwin [
+  buildInputs = [ libgit2_1_8 openssl ] ++ lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.Security
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20372,7 +20372,13 @@ with pkgs;
 
   icon-lang = callPackage ../development/interpreters/icon-lang { };
 
-  libgit2 = callPackage ../development/libraries/libgit2 {
+  # Should be flipped for version 1.8.x soon
+  libgit2 = callPackage ../development/libraries/libgit2/1-7-2.nix {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
+  # Future default version
+  libgit2_1_8 = callPackage ../development/libraries/libgit2/1-8-1.nix {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 


### PR DESCRIPTION
Introduce new attribute for new version of libgit2 (1.8.1) to allow for incremental update of downstream dependencies & Update cargo-generate.

Related to https://github.com/NixOS/nixpkgs/issues/332957#issuecomment-2278578158

### Outdated

<details>
Update of libgit2 to most recent stable version.

Blocks https://github.com/NixOS/nixpkgs/pull/333488

There will be a lot of packages depending on libgit2 so this will cause huge rebuilds. I'm currently running nixpkgs-review on my side to see the impact.

requires review from @SuperSandro2000

Another approach might be to introduce new version of libgit2 along side the existing one.
</details>

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
