### PR TITLE
stm32loader: fix build with python 3.12

### DIFF
--- a/pkgs/development/python-modules/stm32loader/default.nix
+++ b/pkgs/development/python-modules/stm32loader/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  fetchpatch2,
 
   # build-system
   flit-core,
@@ -26,6 +27,15 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-QTLSEjdJtDH4GCamnKHN5pEjW41rRtAMXxyZZMM5K3w=";
   };
+
+  patches = [
+    # fix build with python 3.12
+    # https://github.com/florisla/stm32loader/pull/79
+    (fetchpatch2 {
+      url = "https://github.com/florisla/stm32loader/commit/96f59b2984b0d0371b2da0360d6e8d94d0b39a68.patch?full_index=1";
+      hash = "sha256-JUEjQWOnzeMA1OELS214OR7+MYUkCKN5lxwsmRoFbfo=";
+    })
+  ];
 
   nativeBuildInputs = [ flit-core ];
 


### PR DESCRIPTION
## Description of changes

- add patch from upstream PR fixing assert that became error on python 3.12:
https://github.com/florisla/stm32loader/pull/79

Fixes #332715 (Build failure: stm32loader)
Hydra build falure:
https://hydra.nixos.org/build/267612095
<details>
<summary>Build failure logs</summary>

```text
============================= test session starts ==============================
platform linux -- Python 3.12.4, pytest-8.2.2, pluggy-1.5.0
rootdir: /build/stm32loader-0.7.1
configfile: pyproject.toml
collected 49 items                                                             

tests/unit/test_arguments.py .....                                       [ 10%]
tests/unit/test_bootloader.py ..............................FFF......... [ 95%]
.                                                                        [ 97%]
tests/unit/test_hexfile.py .                                             [100%]

=================================== FAILURES ===================================
__________ test_get_uid_for_known_family_reads_at_correct_address[F1] __________

connection = <MagicMock id='140737318300720'>, family = 'F1'

    @pytest.mark.parametrize(
        "family", ["F1", "F3", "F7"],
    )
    def test_get_uid_for_known_family_reads_at_correct_address(connection, family):
        bootloader = Stm32Bootloader(connection, device_family=family)
        bootloader.read_memory = MagicMock()
        bootloader.get_uid()
        uid_address = bootloader.UID_ADDRESS[family]
>       assert bootloader.read_memory.called_once_with(uid_address)

tests/unit/test_bootloader.py:216: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <MagicMock id='140737318289632'>, name = 'called_once_with'

    def __getattr__(self, name):
        if name in {'_mock_methods', '_mock_unsafe'}:
            raise AttributeError(name)
        elif self._mock_methods is not None:
            if name not in self._mock_methods or name in _all_magics:
                raise AttributeError("Mock object has no attribute %r" % name)
        elif _is_magic(name):
            raise AttributeError(name)
        if not self._mock_unsafe and (not self._mock_methods or name not in self._mock_methods):
            if name.startswith(('assert', 'assret', 'asert', 'aseert', 'assrt')) or name in _ATTRIB_DENY_LIST:
>               raise AttributeError(
                    f"{name!r} is not a valid assertion. Use a spec "
                    f"for the mock if {name!r} is meant to be an attribute.")
E               AttributeError: 'called_once_with' is not a valid assertion. Use a spec for the mock if 'called_once_with' is meant to be an attribute.. Did you mean: 'assert_called_once_with'?

/nix/store/l014xp1qxdl6gim3zc0jv3mpxhbp346s-python3-3.12.4/lib/python3.12/unittest/mock.py:663: AttributeError
__________ test_get_uid_for_known_family_reads_at_correct_address[F3] __________

connection = <MagicMock id='140737324790560'>, family = 'F3'

    @pytest.mark.parametrize(
        "family", ["F1", "F3", "F7"],
    )
    def test_get_uid_for_known_family_reads_at_correct_address(connection, family):
        bootloader = Stm32Bootloader(connection, device_family=family)
        bootloader.read_memory = MagicMock()
        bootloader.get_uid()
        uid_address = bootloader.UID_ADDRESS[family]
>       assert bootloader.read_memory.called_once_with(uid_address)

tests/unit/test_bootloader.py:216: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <MagicMock id='140737318384608'>, name = 'called_once_with'

    def __getattr__(self, name):
        if name in {'_mock_methods', '_mock_unsafe'}:
            raise AttributeError(name)
        elif self._mock_methods is not None:
            if name not in self._mock_methods or name in _all_magics:
                raise AttributeError("Mock object has no attribute %r" % name)
        elif _is_magic(name):
            raise AttributeError(name)
        if not self._mock_unsafe and (not self._mock_methods or name not in self._mock_methods):
            if name.startswith(('assert', 'assret', 'asert', 'aseert', 'assrt')) or name in _ATTRIB_DENY_LIST:
>               raise AttributeError(
                    f"{name!r} is not a valid assertion. Use a spec "
                    f"for the mock if {name!r} is meant to be an attribute.")
E               AttributeError: 'called_once_with' is not a valid assertion. Use a spec for the mock if 'called_once_with' is meant to be an attribute.. Did you mean: 'assert_called_once_with'?

/nix/store/l014xp1qxdl6gim3zc0jv3mpxhbp346s-python3-3.12.4/lib/python3.12/unittest/mock.py:663: AttributeError
__________ test_get_uid_for_known_family_reads_at_correct_address[F7] __________

connection = <MagicMock id='140737318373664'>, family = 'F7'

    @pytest.mark.parametrize(
        "family", ["F1", "F3", "F7"],
    )
    def test_get_uid_for_known_family_reads_at_correct_address(connection, family):
        bootloader = Stm32Bootloader(connection, device_family=family)
        bootloader.read_memory = MagicMock()
        bootloader.get_uid()
        uid_address = bootloader.UID_ADDRESS[family]
>       assert bootloader.read_memory.called_once_with(uid_address)

tests/unit/test_bootloader.py:216: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <MagicMock id='140737318299712'>, name = 'called_once_with'

    def __getattr__(self, name):
        if name in {'_mock_methods', '_mock_unsafe'}:
            raise AttributeError(name)
        elif self._mock_methods is not None:
            if name not in self._mock_methods or name in _all_magics:
                raise AttributeError("Mock object has no attribute %r" % name)
        elif _is_magic(name):
            raise AttributeError(name)
        if not self._mock_unsafe and (not self._mock_methods or name not in self._mock_methods):
            if name.startswith(('assert', 'assret', 'asert', 'aseert', 'assrt')) or name in _ATTRIB_DENY_LIST:
>               raise AttributeError(
                    f"{name!r} is not a valid assertion. Use a spec "
                    f"for the mock if {name!r} is meant to be an attribute.")
E               AttributeError: 'called_once_with' is not a valid assertion. Use a spec for the mock if 'called_once_with' is meant to be an attribute.. Did you mean: 'assert_called_once_with'?

/nix/store/l014xp1qxdl6gim3zc0jv3mpxhbp346s-python3-3.12.4/lib/python3.12/unittest/mock.py:663: AttributeError
=========================== short test summary info ============================
FAILED tests/unit/test_bootloader.py::test_get_uid_for_known_family_reads_at_correct_address[F1] - AttributeError: 'called_once_with' is not a valid assertion. Use a spec for...
FAILED tests/unit/test_bootloader.py::test_get_uid_for_known_family_reads_at_correct_address[F3] - AttributeError: 'called_once_with' is not a valid assertion. Use a spec for...
FAILED tests/unit/test_bootloader.py::test_get_uid_for_known_family_reads_at_correct_address[F7] - AttributeError: 'called_once_with' is not a valid assertion. Use a spec for...
========================= 3 failed, 46 passed in 0.88s =========================
/nix/store/1r32fki5z5ivgaikgh8pq0r6vz3b0jpj-stdenv-linux/setup: line 1655: pop_var_context: head of shell_variables not a function context
```

</details>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
