### PR TITLE
sx: add desktop file and providedSessions

### DIFF
--- a/nixos/modules/services/x11/display-managers/sx.nix
+++ b/nixos/modules/services/x11/display-managers/sx.nix
@@ -12,7 +12,7 @@ in
 {
   options = {
     services.xserver.displayManager.sx = {
-      enable = lib.mkEnableOption "sx pseudo-display manager" // {
+      enable = lib.mkEnableOption "" // {
         description = ''
           Whether to enable the "sx" pseudo-display manager, which allows users
           to start manually via the "sx" command from a vt shell. The X server
@@ -25,6 +25,14 @@ in
         '';
       };
 
+      addAsSession = lib.mkEnableOption "" // {
+        description = ''
+          Whether to add sx as a display manager session. Keep in mind that sx
+          expects to be run from a TTY, so it may not work in your display
+          manager.
+        '';
+      };
+
       package = lib.mkPackageOption pkgs "sx" { };
     };
   };
@@ -32,9 +40,13 @@ in
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
 
-    services.xserver = {
-      exportConfiguration = true;
-      logFile = lib.mkDefault null;
+    services = {
+      displayManager.sessionPackages = lib.optionals cfg.addAsSession [ cfg.package ];
+
+      xserver = {
+        exportConfiguration = true;
+        logFile = lib.mkDefault null;
+      };
     };
   };
 

--- a/nixos/modules/services/x11/display-managers/sx.nix
+++ b/nixos/modules/services/x11/display-managers/sx.nix
@@ -50,5 +50,8 @@ in
     };
   };
 
-  meta.maintainers = with lib.maintainers; [ figsoda ];
+  meta.maintainers = with lib.maintainers; [
+    figsoda
+    thiagokokada
+  ];
 }

--- a/nixos/modules/services/x11/display-managers/sx.nix
+++ b/nixos/modules/services/x11/display-managers/sx.nix
@@ -24,11 +24,14 @@ in
           dependency.
         '';
       };
+
+      package = lib.mkPackageOption pkgs "sx" { };
     };
   };
 
   config = lib.mkIf cfg.enable {
-    environment.systemPackages = [ pkgs.sx ];
+    environment.systemPackages = [ cfg.package ];
+
     services.xserver = {
       exportConfiguration = true;
       logFile = lib.mkDefault null;

--- a/nixos/modules/services/x11/display-managers/sx.nix
+++ b/nixos/modules/services/x11/display-managers/sx.nix
@@ -1,13 +1,18 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
-with lib;
+let
+  cfg = config.services.xserver.displayManager.sx;
 
-let cfg = config.services.xserver.displayManager.sx;
-
-in {
+in
+{
   options = {
     services.xserver.displayManager.sx = {
-      enable = mkEnableOption "sx pseudo-display manager" // {
+      enable = lib.mkEnableOption "sx pseudo-display manager" // {
         description = ''
           Whether to enable the "sx" pseudo-display manager, which allows users
           to start manually via the "sx" command from a vt shell. The X server
@@ -22,13 +27,13 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     environment.systemPackages = [ pkgs.sx ];
     services.xserver = {
       exportConfiguration = true;
-      logFile = mkDefault null;
+      logFile = lib.mkDefault null;
     };
   };
 
-  meta.maintainers = with maintainers; [ figsoda ];
+  meta.maintainers = with lib.maintainers; [ figsoda ];
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -925,6 +925,7 @@ in {
   swayfx = handleTest ./swayfx.nix {};
   switchTest = handleTest ./switch-test.nix { ng = false; };
   switchTestNg = handleTest ./switch-test.nix { ng = true; };
+  sx = handleTest ./sx.nix {};
   sympa = handleTest ./sympa.nix {};
   syncthing = handleTest ./syncthing.nix {};
   syncthing-no-settings = handleTest ./syncthing-no-settings.nix {};

--- a/nixos/tests/sx.nix
+++ b/nixos/tests/sx.nix
@@ -1,0 +1,63 @@
+import ./make-test-python.nix (
+  { pkgs, lib, ... }:
+  {
+    name = "sx";
+    meta.maintainers = with lib.maintainers; [
+      figsoda
+      thiagokokada
+    ];
+
+    nodes.machine =
+      { ... }:
+      {
+        imports = [ ./common/user-account.nix ];
+
+        environment.systemPackages = with pkgs; [ icewm ];
+
+        services.getty.autologinUser = "alice";
+
+        services.xserver = {
+          enable = true;
+          displayManager.sx.enable = true;
+        };
+
+        # Create sxrc file on login and start sx
+        programs.bash.loginShellInit =
+          # bash
+          ''
+            mkdir -p "$HOME/.config/sx"
+            echo 'exec icewm' > "$HOME/.config/sx/sxrc"
+            chmod +x "$HOME/.config/sx/sxrc"
+
+            sx
+          '';
+      };
+
+    testScript =
+      { nodes, ... }:
+      let
+        user = nodes.machine.users.users.alice;
+      in
+      # python
+      ''
+        start_all()
+
+        machine.wait_for_unit("multi-user.target")
+
+        xauthority = "${user.home}/.local/share/sx/xauthority"
+        machine.wait_for_file(xauthority)
+        machine.succeed(f"xauth merge {xauthority}")
+
+        def icewm_is_visible(_last_try: bool) -> bool:
+            # sx will set DISPLAY as the TTY number we started, in this case
+            # TTY1:
+            # https://github.com/Earnestly/sx/blob/master/sx#L41.
+            # We can't use `machine.wait_for_window` here since we are running
+            # X as alice and not root.
+            return "IceWM" in machine.succeed("DISPLAY=:1 xwininfo -root -tree")
+
+        # Adding a retry logic to increase reliability
+        retry(icewm_is_visible)
+      '';
+  }
+)

--- a/pkgs/by-name/sx/sx/package.nix
+++ b/pkgs/by-name/sx/sx/package.nix
@@ -1,8 +1,9 @@
-{ lib
-, stdenvNoCC
-, fetchFromGitHub
-, patsh
-, xorg
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  patsh,
+  xorg,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -34,7 +35,10 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://github.com/earnestly/sx";
     license = licenses.mit;
     mainProgram = "sx";
-    maintainers = with maintainers; [ figsoda thiagokokada ];
+    maintainers = with maintainers; [
+      figsoda
+      thiagokokada
+    ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/sx/sx/package.nix
+++ b/pkgs/by-name/sx/sx/package.nix
@@ -5,6 +5,7 @@
   makeDesktopItem,
   patsh,
   xorg,
+  nixosTests,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -40,7 +41,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     }/share/applications/sx.desktop
   '';
 
-  passthru.providedSessions = [ "sx" ];
+  passthru = {
+    providedSessions = [ "sx" ];
+    tests = {
+      inherit (nixosTests) sx;
+    };
+  };
 
   meta = {
     description = "Simple alternative to both xinit and startx for starting a Xorg server";

--- a/pkgs/by-name/sx/sx/package.nix
+++ b/pkgs/by-name/sx/sx/package.nix
@@ -7,14 +7,14 @@
   xorg,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "sx";
   version = "3.0";
 
   src = fetchFromGitHub {
     owner = "earnestly";
-    repo = pname;
-    rev = version;
+    repo = "sx";
+    rev = finalAttrs.version;
     hash = "sha256-hKoz7Kuus8Yp7D0F05wCOQs6BvV0NkRM9uUXTntLJxQ=";
   };
 
@@ -42,15 +42,15 @@ stdenvNoCC.mkDerivation rec {
 
   passthru.providedSessions = [ "sx" ];
 
-  meta = with lib; {
+  meta = {
     description = "Simple alternative to both xinit and startx for starting a Xorg server";
     homepage = "https://github.com/earnestly/sx";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "sx";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       figsoda
       thiagokokada
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/sx/sx/package.nix
+++ b/pkgs/by-name/sx/sx/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  makeDesktopItem,
   patsh,
   xorg,
 }:
@@ -28,7 +29,18 @@ stdenvNoCC.mkDerivation rec {
 
   postInstall = ''
     patsh -f $out/bin/sx -s ${builtins.storeDir}
+
+    install -Dm755 -t $out/share/xsessions ${
+      makeDesktopItem {
+        name = "sx";
+        desktopName = "sx";
+        comment = "Start a xorg server";
+        exec = "sx";
+      }
+    }/share/applications/sx.desktop
   '';
+
+  passthru.providedSessions = [ "sx" ];
 
   meta = with lib; {
     description = "Simple alternative to both xinit and startx for starting a Xorg server";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The changes in this PR will allow `sx` to appear as a session in desktop managers, if you set `services.xserver.displayManager.sx.addAsSession = true` (not enabling by default because there are some considerations, see option description). Also:
- add `services.xserver.displayManager.sx.package` option
- format `sx` related files with `nixpkgs-rfc-style`
- add NixOS test

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
