### PR TITLE
fetchPypiLegacy: Pass cacert to enable TLS verification when username/password is used

### DIFF
--- a/pkgs/build-support/fetchpypilegacy/default.nix
+++ b/pkgs/build-support/fetchpypilegacy/default.nix
@@ -3,7 +3,8 @@
   runCommand,
   lib,
   python3,
-}:
+  cacert,
+}@pkgs:
 let
   inherit (lib)
     optionalAttrs
@@ -18,45 +19,52 @@ let
 
   impureEnvVars = fetchers.proxyImpureEnvVars ++ optional inPureEvalMode "NETRC";
 in
-{
-  # package name
-  pname,
-  # Package index
-  url ? null,
-  # Multiple package indices to consider
-  urls ? [ ],
-  # filename including extension
-  file,
-  # SRI hash
-  hash,
-  # allow overriding the derivation name
-  name ? null,
-}:
-let
-  urls' = urls ++ optional (url != null) url;
+lib.makeOverridable (
+  {
+    # package name
+    pname,
+    # Package index
+    url ? null,
+    # Multiple package indices to consider
+    urls ? [ ],
+    # filename including extension
+    file,
+    # SRI hash
+    hash,
+    # allow overriding the derivation name
+    name ? null,
+    # allow overriding cacert using src.override { cacert = cacert.override { extraCertificateFiles = [ ./path/to/cert.pem ]; }; }
+    cacert ? pkgs.cacert,
+  }:
+  let
+    urls' = urls ++ optional (url != null) url;
 
-  pathParts = filter ({ prefix, path }: "NETRC" == prefix) builtins.nixPath;
-  netrc_file = if (pathParts != [ ]) then (head pathParts).path else "";
+    pathParts = filter ({ prefix, path }: "NETRC" == prefix) builtins.nixPath;
+    netrc_file = if (pathParts != [ ]) then (head pathParts).path else "";
 
-in
-# Assert that we have at least one URL
-assert urls' != [ ];
-runCommand file
-  (
-    {
-      nativeBuildInputs = [ python3 ];
-      inherit impureEnvVars;
-      outputHashMode = "flat";
-      # if hash is empty select a default algo to let nix propose the actual hash.
-      outputHashAlgo = if hash == "" then "sha256" else null;
-      outputHash = hash;
-    }
-    // optionalAttrs (name != null) { inherit name; }
-    // optionalAttrs (!inPureEvalMode) { env.NETRC = netrc_file; }
-  )
-  ''
-    python ${./fetch-legacy.py} ${
-      concatStringsSep " " (map (url: "--url ${escapeShellArg url}") urls')
-    } --pname ${pname} --filename ${file}
-    mv ${file} $out
-  ''
+  in
+  # Assert that we have at least one URL
+  assert urls' != [ ];
+  runCommand file
+    (
+      {
+        nativeBuildInputs = [
+          python3
+          cacert
+        ];
+        inherit impureEnvVars;
+        outputHashMode = "flat";
+        # if hash is empty select a default algo to let nix propose the actual hash.
+        outputHashAlgo = if hash == "" then "sha256" else null;
+        outputHash = hash;
+      }
+      // optionalAttrs (name != null) { inherit name; }
+      // optionalAttrs (!inPureEvalMode) { env.NETRC = netrc_file; }
+    )
+    ''
+      python ${./fetch-legacy.py} ${
+        concatStringsSep " " (map (url: "--url ${escapeShellArg url}") urls')
+      } --pname ${pname} --filename ${file}
+      mv ${file} $out
+    ''
+)


### PR DESCRIPTION
## Description of changes

The intent was for TLS verification to be enabled when transfering credentials only, and normally disabled for long-term reproducibility.

See https://github.com/nix-community/poetry2nix/issues/1740

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
