### PR TITLE
whatsie: init at 4.15.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -725,6 +725,12 @@
     githubId = 45179933;
     name = "Alex Jackson";
   };
+  ajgon = {
+    email = "igor@rzegocki.pl";
+    github = "ajgon";
+    githubId = 150545;
+    name = "Igor Rzegocki";
+  };
   ajgrf = {
     email = "a@ajgrf.com";
     github = "ajgrf";

--- a/pkgs/by-name/wh/whatsie/package.nix
+++ b/pkgs/by-name/wh/whatsie/package.nix
@@ -1,0 +1,58 @@
+{
+  fetchFromGitHub,
+  lib,
+  stdenv,
+  libX11,
+  libxcb,
+  qt5,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "whatsie";
+  version = "4.15.3";
+
+  src = fetchFromGitHub {
+    owner = "keshavbhatt";
+    repo = "whatsie";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-fbbyh8Q1jbKY+4ZEexDvIrhdcP+uCYAnhtUQsSqS0jw=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/src";
+
+  buildInputs = [
+    libX11
+    libxcb
+    qt5.qtwebengine
+  ];
+
+  nativeBuildInputs = [
+    qt5.wrapQtAppsHook
+    qt5.qmake
+  ];
+
+  strictDeps = false;
+
+  enableParallelBuilding = true;
+
+  preBuild = ''
+    export QT_WEBENGINE_ICU_DATA_DIR=${qt5.qtwebengine.out}/resources
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 whatsie -t $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/keshavbhatt/whatsie";
+    description = "Feature rich WhatsApp Client for Desktop Linux";
+    license = lib.licenses.mit;
+    mainProgram = "whatsie";
+    maintainers = with lib.maintainers; [ ajgon ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/wh/whatsie/package.nix
+++ b/pkgs/by-name/wh/whatsie/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "whatsie";
-  version = "4.15.3";
+  version = "4.15.5";
 
   src = fetchFromGitHub {
     owner = "keshavbhatt";
     repo = "whatsie";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-fbbyh8Q1jbKY+4ZEexDvIrhdcP+uCYAnhtUQsSqS0jw=";
+    hash = "sha256-6tczt9oPtcKvA59YqRHGOE2VFQLRNbyHpCJ6b4kzgks=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src";


### PR DESCRIPTION
## Description of changes

Whatsie is a WhatsApp client/webview wrapper written in QT5. Homepage: https://github.com/keshavbhatt/whatsie.git

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
