### PR TITLE
customtkinter: build from source

### DIFF
--- a/pkgs/development/python-modules/customtkinter/0001-Add-Missing-Cfg-Packages.patch
+++ b/pkgs/development/python-modules/customtkinter/0001-Add-Missing-Cfg-Packages.patch
@@ -1,0 +1,15 @@
+diff --git a/setup.cfg b/setup.cfg
+index 5f95b7f..9250e4f 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -22,6 +22,10 @@ repository = https://github.com/tomschimansky/customtkinter
+ python_requires = >=3.7
+ packages =
+     customtkinter
++    customtkinter.assets.fonts
++    customtkinter.assets.fonts.Roboto
++    customtkinter.assets.icons
++    customtkinter.assets.themes
+     customtkinter.windows
+     customtkinter.windows.widgets
+     customtkinter.windows.widgets.appearance_mode

--- a/pkgs/development/python-modules/customtkinter/default.nix
+++ b/pkgs/development/python-modules/customtkinter/default.nix
@@ -2,11 +2,12 @@
   lib,
   buildPythonPackage,
   pythonOlder,
-  fetchPypi,
+  fetchFromGitHub,
   setuptools,
-  wheel,
   tkinter,
   darkdetect,
+  packaging,
+  typing-extensions,
 }:
 let
   pname = "customtkinter";
@@ -17,20 +18,26 @@ buildPythonPackage {
   pyproject = true;
   disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-/Y2zuvqWHJgu5gMNuoC0wuJYWGMHVrUTmG2xkRPY0gc=";
+  src = fetchFromGitHub {
+    owner = "TomSchimansky";
+    repo = "CustomTkinter";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-1g2wdXbUv5xNnpflFLXvU39s16kmwvuegKWd91E3qm4=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
-    wheel
+    tkinter
   ];
-  buildInputs = [ tkinter ];
-  propagatedBuildInputs = [ darkdetect ];
 
-  # No tests
-  doCheck = false;
+  dependencies = [
+    darkdetect
+    packaging
+    typing-extensions
+  ];
+
+  patches = [ ./0001-Add-Missing-Cfg-Packages.patch ];
+
   pythonImportsCheck = [ "customtkinter" ];
 
   meta = {


### PR DESCRIPTION
## Description of changes

Build `customtkinter` from source

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc