### PR TITLE
vscode: improve desktop file handling

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -134,7 +134,6 @@ in
       startupNotify = true;
       startupWMClass = shortName;
       categories = [ "Utility" "TextEditor" "Development" "IDE" ];
-      mimeTypes = [ "text/plain" "inode/directory" ];
       keywords = [ "vscode" ];
       actions.new-empty-window = {
         name = "New Empty Window";

--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -1,5 +1,6 @@
 { stdenv
 , lib
+, copyDesktopItems
 , makeDesktopItem
 , unzip
 , libsecret
@@ -122,38 +123,39 @@ in
     inherit rev vscodeServer;
   };
 
-  desktopItem = makeDesktopItem {
-    name = executableName;
-    desktopName = longName;
-    comment = "Code Editing. Redefined.";
-    genericName = "Text Editor";
-    exec = "${executableName} %F";
-    icon = "vs${executableName}";
-    startupNotify = true;
-    startupWMClass = shortName;
-    categories = [ "Utility" "TextEditor" "Development" "IDE" ];
-    mimeTypes = [ "text/plain" "inode/directory" ];
-    keywords = [ "vscode" ];
-    actions.new-empty-window = {
-      name = "New Empty Window";
-      exec = "${executableName} --new-window %F";
+  desktopItems = [
+    (makeDesktopItem {
+      name = executableName;
+      desktopName = longName;
+      comment = "Code Editing. Redefined.";
+      genericName = "Text Editor";
+      exec = "${executableName} %F";
       icon = "vs${executableName}";
-    };
-  };
-
-  urlHandlerDesktopItem = makeDesktopItem {
-    name = executableName + "-url-handler";
-    desktopName = longName + " - URL Handler";
-    comment = "Code Editing. Redefined.";
-    genericName = "Text Editor";
-    exec = executableName + " --open-url %U";
-    icon = "vs${executableName}";
-    startupNotify = true;
-    categories = [ "Utility" "TextEditor" "Development" "IDE" ];
-    mimeTypes = [ "x-scheme-handler/vs${executableName}" ];
-    keywords = [ "vscode" ];
-    noDisplay = true;
-  };
+      startupNotify = true;
+      startupWMClass = shortName;
+      categories = [ "Utility" "TextEditor" "Development" "IDE" ];
+      mimeTypes = [ "text/plain" "inode/directory" ];
+      keywords = [ "vscode" ];
+      actions.new-empty-window = {
+        name = "New Empty Window";
+        exec = "${executableName} --new-window %F";
+        icon = "vs${executableName}";
+      };
+    })
+    (makeDesktopItem {
+      name = executableName + "-url-handler";
+      desktopName = longName + " - URL Handler";
+      comment = "Code Editing. Redefined.";
+      genericName = "Text Editor";
+      exec = executableName + " --open-url %U";
+      icon = "vs${executableName}";
+      startupNotify = true;
+      categories = [ "Utility" "TextEditor" "Development" "IDE" ];
+      mimeTypes = [ "x-scheme-handler/vs${executableName}" ];
+      keywords = [ "vscode" ];
+      noDisplay = true;
+    })
+  ];
 
   buildInputs = [ libsecret libXScrnSaver libxshmfence ]
     ++ lib.optionals (!stdenv.isDarwin) [ alsa-lib at-spi2-atk libkrb5 mesa nss nspr systemd xorg.libxkbfile ];
@@ -164,6 +166,7 @@ in
     ++ lib.optionals stdenv.isLinux [
     autoPatchelfHook
     asar
+    copyDesktopItems
     # override doesn't preserve splicing https://github.com/NixOS/nixpkgs/issues/132651
     (buildPackages.wrapGAppsHook3.override { inherit (buildPackages) makeWrapper; })
   ];
@@ -183,10 +186,6 @@ in
     cp -r ./* "$out/lib/vscode"
 
     ln -s "$out/lib/vscode/bin/${sourceExecutableName}" "$out/bin/${executableName}"
-
-    mkdir -p "$out/share/applications"
-    ln -s "$desktopItem/share/applications/${executableName}.desktop" "$out/share/applications/${executableName}.desktop"
-    ln -s "$urlHandlerDesktopItem/share/applications/${executableName}-url-handler.desktop" "$out/share/applications/${executableName}-url-handler.desktop"
 
     # These are named vscode.png, vscode-insiders.png, etc to match the name in upstream *.deb packages.
     mkdir -p "$out/share/pixmaps"


### PR DESCRIPTION
## Description of changes

- **vscode: use copyDesktopItems hook instead of manually copying**
- **vscode: remove folder and text mimetype associations**
  - See https://github.com/microsoft/vscode/pull/209510

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
