### PR TITLE
lib.cli.escapeShellArg{,s}: Only escape when necessary

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -103,7 +103,7 @@ let
       concatImapStringsSep concatLines makeSearchPath makeSearchPathOutput
       makeLibraryPath makeIncludePath makeBinPath optionalString
       hasInfix hasPrefix hasSuffix stringToCharacters stringAsChars escape
-      escapeBashArg escapeBashArgs escapeShellArg escapeShellArgs
+      escapeShellArg escapeShellArgs
       isStorePath isStringLike
       isValidPosixName toShellVar toShellVars trim trimWith
       escapeRegex escapeURL escapeXML replaceChars lowerChars

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -103,7 +103,7 @@ let
       concatImapStringsSep concatLines makeSearchPath makeSearchPathOutput
       makeLibraryPath makeIncludePath makeBinPath optionalString
       hasInfix hasPrefix hasSuffix stringToCharacters stringAsChars escape
-      escapeShellArg escapeShellArgs
+      escapeBashArg escapeBashArgs escapeShellArg escapeShellArgs
       isStorePath isStringLike
       isValidPosixName toShellVar toShellVars trim trimWith
       escapeRegex escapeURL escapeXML replaceChars lowerChars

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1081,6 +1081,67 @@ rec {
   escapeShellArgs = concatMapStringsSep " " escapeShellArg;
 
   /**
+    This is like `escapeShellArg` except it won't quote the argument if not
+    necessary.
+
+    # Inputs
+
+    `string`
+    : 1\. Function argument
+
+    # Type
+
+    ```
+    escapeBashArg :: string -> string
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.strings.escapeBashArg` usage example
+
+    ```nix
+    escapeBashArg "foo'bar"
+    => "'foo'\\''bar'"
+    escapeBashArg "foobar"
+    => "foobar"
+    ```
+
+    :::
+  */
+  escapeBashArg = arg:
+    if match ".*[]\\[\"'[:space:]\\\\#$&(){}<>|;*?=!~].*" arg == null
+    then arg
+    else escapeShellArg arg;
+
+  /**
+    This is like `escapeShellArg` except it won't quote the arguments if not
+    necessary.
+
+    # Inputs
+
+    `args`
+    : 1\. Function argument
+
+    # Type
+
+    ```
+    escapeBashArgs :: [string] -> string
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.strings.escapeBashArgs` usage example
+
+    ```nix
+    escapeBashArgs ["one" "two three" "four'five"]
+    => "one 'two three' 'four'\\''five'"
+    ```
+
+    :::
+  */
+  escapeBashArgs = concatMapStringsSep " " escapeBashArg;
+
+  /**
     Test whether the given `name` is a valid POSIX shell variable name.
 
 

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1056,7 +1056,7 @@ rec {
     let
       string = toString arg;
     in
-      if match "[[:alnum:],._+:@%/-]*" string == null
+      if match "[[:alnum:],._+:@%/-]+" string == null
       then "'${replaceStrings ["'"] ["'\\''"] string}'"
       else string;
 

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1056,9 +1056,9 @@ rec {
     let
       string = toString arg;
     in
-      if match ".*[]\\[\"'[:space:]\\\\#$&(){}<>|;*?=!~].*" string == null
-      then string
-      else "'${replaceStrings ["'"] ["'\\''"] string}'";
+      if match "[[:alnum:],._+:@%/-]*" string == null
+      then "'${replaceStrings ["'"] ["'\\''"] string}'"
+      else string;
 
   /**
     Quote all arguments that have special characters to be safely passed to the

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -477,21 +477,6 @@ runTests {
 
   testEscapeShellArgs = {
     expr = strings.escapeShellArgs ["one" "two three" "four'five"];
-    expected = "'one' 'two three' 'four'\\''five'";
-  };
-
-  testEscapeBashArgQuote = {
-    expr = strings.escapeBashArg "foo'bar";
-    expected = "'foo'\\''bar'";
-  };
-
-  testEscapeBashArgPlain = {
-    expr = strings.escapeBashArg "foobar";
-    expected = "foobar";
-  };
-
-  testEscapeBashArgs = {
-    expr = strings.escapeBashArgs ["one" "two three" "four'five"];
     expected = "one 'two three' 'four'\\''five'";
   };
 
@@ -594,12 +579,12 @@ runTests {
     '';
     expected = ''
       STRing01='just a '\'''string'\''''
-      declare -a _array_=('with' 'more strings')
+      declare -a _array_=(with 'more strings')
       declare -A assoc=(['with some']='strings
       possibly newlines
       ')
-      drv='/drv'
-      path='/path'
+      drv=/drv
+      path=/path
       stringable='hello toString'
     '';
   };
@@ -1779,7 +1764,7 @@ runTests {
       verbose = true;
     };
 
-    expected = "'-X' 'PUT' '--data' '{\"id\":0}' '--retry' '3' '--url' 'https://example.com/foo' '--url' 'https://example.com/bar' '--verbose'";
+    expected = "-X PUT --data '{\"id\":0}' --retry 3 --url https://example.com/foo --url https://example.com/bar --verbose";
   };
 
   testSanitizeDerivationNameLeadingDots = testSanitizeDerivationName {

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -480,6 +480,11 @@ runTests {
     expected = "one 'two three' 'four'\\''five'";
   };
 
+  testEscapeShellArgsUnicode = {
+    expr = strings.escapeShellArg "á";
+    expected = "'á'";
+  };
+
   testSplitStringsDerivation = {
     expr = take 3  (strings.splitString "/" (derivation {
       name = "name";

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -475,6 +475,11 @@ runTests {
     expected = "'esc'\\''ape\nme'";
   };
 
+  testEscapeShellArgEmpty = {
+    expr = strings.escapeShellArg "";
+    expected = "''";
+  };
+
   testEscapeShellArgs = {
     expr = strings.escapeShellArgs ["one" "two three" "four'five"];
     expected = "one 'two three' 'four'\\''five'";

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -470,6 +470,31 @@ runTests {
     expected = [ "A" "B" ];
   };
 
+  testEscapeShellArg = {
+    expr = strings.escapeShellArg "esc'ape\nme";
+    expected = "'esc'\\''ape\nme'";
+  };
+
+  testEscapeShellArgs = {
+    expr = strings.escapeShellArgs ["one" "two three" "four'five"];
+    expected = "'one' 'two three' 'four'\\''five'";
+  };
+
+  testEscapeBashArgQuote = {
+    expr = strings.escapeBashArg "foo'bar";
+    expected = "'foo'\\''bar'";
+  };
+
+  testEscapeBashArgPlain = {
+    expr = strings.escapeBashArg "foobar";
+    expected = "foobar";
+  };
+
+  testEscapeBashArgs = {
+    expr = strings.escapeBashArgs ["one" "two three" "four'five"];
+    expected = "one 'two three' 'four'\\''five'";
+  };
+
   testSplitStringsDerivation = {
     expr = take 3  (strings.splitString "/" (derivation {
       name = "name";


### PR DESCRIPTION
These utilities will now leave the string undisturbed if it doesn't need to be quoted (because it doesn't have any special characters).  This can help generate nicer-looking command lines.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Built on platform(s)
  - [x] aarch64-darwin
- [x] Tested, as applicable:
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
