### PR TITLE
home-assistant: 2024.8.0 -> 2024.8.1

### DIFF
--- a/pkgs/development/python-modules/airgradient/default.nix
+++ b/pkgs/development/python-modules/airgradient/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "airgradient";
-  version = "0.7.1";
+  version = "0.8.0";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "airgradienthq";
     repo = "python-airgradient";
     rev = "refs/tags/v${version}";
-    hash = "sha256-EFt2V+r7RLiFMihFCCBU9iEPcbSybK6gP+uxed+mIeo=";
+    hash = "sha256-NONOfM61oCtiNgmKCXvkEvCzSjumwjaeuzg9l/7hX8M=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/airgradient/default.nix
+++ b/pkgs/development/python-modules/airgradient/default.nix
@@ -8,6 +8,7 @@
   orjson,
   poetry-core,
   pytest-asyncio,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
   syrupy,
@@ -28,11 +29,6 @@ buildPythonPackage rec {
     hash = "sha256-NONOfM61oCtiNgmKCXvkEvCzSjumwjaeuzg9l/7hX8M=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "--cov" ""
-  '';
-
   build-system = [ poetry-core ];
 
   dependencies = [
@@ -45,6 +41,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     aioresponses
     pytest-asyncio
+    pytest-cov-stub
     pytestCheckHook
     syrupy
   ];

--- a/pkgs/development/python-modules/bellows/default.nix
+++ b/pkgs/development/python-modules/bellows/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "bellows";
-  version = "0.40.2";
+  version = "0.40.3";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "zigpy";
     repo = "bellows";
     rev = "refs/tags/${version}";
-    hash = "sha256-pcyvJsAFJCm6mpGvfWp6WUzdn2Z7Fr2G6B5uEXZDhIg=";
+    hash = "sha256-JGc5jDvEZtYyYAExRnN1K5hDY3ioS3+mm7jMrR0RyXk=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/dio-chacon-wifi-api/default.nix
+++ b/pkgs/development/python-modules/dio-chacon-wifi-api/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "dio-chacon-wifi-api";
-  version = "1.1.0";
+  version = "1.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "cnico";
     repo = "dio-chacon-wifi-api";
     rev = "v${version}";
-    hash = "sha256-TeunMvkiQw4TzLb2dsAHAg49nUzD3DGiO0DuXKGcICU=";
+    hash = "sha256-iIDBHyZuI9qNLRmTY0nXOl5wplFKDoiKkqQb1m4uIxs=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/pydaikin/default.nix
+++ b/pkgs/development/python-modules/pydaikin/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "pydaikin";
-  version = "2.13.1";
+  version = "2.13.2";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "fredrike";
     repo = "pydaikin";
     rev = "refs/tags/v${version}";
-    hash = "sha256-UOHNMYcgf8NYwbmr+YcCKZvcrXnz38VKxLAYnpoKiVo=";
+    hash = "sha256-eq6QE5yYPb9y7bNJwk3sLQp7Pw0PtWn2T/6J+ICfPsY=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/python-homewizard-energy/default.nix
+++ b/pkgs/development/python-modules/python-homewizard-energy/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "python-homewizard-energy";
-  version = "6.1.1";
+  version = "6.2.0";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "DCSBL";
     repo = "python-homewizard-energy";
     rev = "refs/tags/v${version}";
-    hash = "sha256-DIDHUyos2XScoYZfI3o33UN2R0J/Xc2/JQvtzCXZTts=";
+    hash = "sha256-CSX2iLjOJRW2dxcE9JhK2A8QlvVUxYE2C6MZFPg370c=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/zha-quirks/default.nix
+++ b/pkgs/development/python-modules/zha-quirks/default.nix
@@ -24,6 +24,11 @@ buildPythonPackage rec {
     hash = "sha256-LudwIENP1KCX7+HwyklCUdAu5mRLDcnMEZBzbRH2FM0=";
   };
 
+  patches = [
+    # https://github.com/zigpy/zha-device-handlers/pull/3296
+    ./zigpy-0.65.3-compat.patch
+  ];
+
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail ', "setuptools-git-versioning<2"' "" \

--- a/pkgs/development/python-modules/zha-quirks/zigpy-0.65.3-compat.patch
+++ b/pkgs/development/python-modules/zha-quirks/zigpy-0.65.3-compat.patch
@@ -1,0 +1,12 @@
+diff --git a/tests/conftest.py b/tests/conftest.py
+index e64beb2..c1f0785 100644
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -88,7 +88,6 @@ class MockApp(zigpy.application.ControllerApplication):
+ def app_controller_mock():
+     """App controller mock."""
+     config = {"device": {"path": "/dev/ttyUSB0"}, "database": None}
+-    config = MockApp.SCHEMA(config)
+     app = MockApp(config)
+     return app
+ 

--- a/pkgs/development/python-modules/zha/default.nix
+++ b/pkgs/development/python-modules/zha/default.nix
@@ -45,13 +45,8 @@ buildPythonPackage rec {
   '';
 
   pythonRelaxDeps = [
-    "bellows"
     "pyserial-asyncio-fast"
-    "universal-silabs-flasher"
-    "zha-quirks"
-    "zigpy"
   ];
-
 
   build-system = [
     setuptools

--- a/pkgs/development/python-modules/zha/default.nix
+++ b/pkgs/development/python-modules/zha/default.nix
@@ -4,6 +4,7 @@
   bellows,
   buildPythonPackage,
   fetchFromGitHub,
+  freezegun,
   pyserial,
   pyserial-asyncio,
   pyserial-asyncio-fast,
@@ -26,7 +27,7 @@
 
 buildPythonPackage rec {
   pname = "zha";
-  version = "0.0.28";
+  version = "0.0.30";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -35,7 +36,7 @@ buildPythonPackage rec {
     owner = "zigpy";
     repo = "zha";
     rev = "refs/tags/${version}";
-    hash = "sha256-qsX62k/KeQ2ZTUHAv2ieZxOFh9dNFnLx0ZZOZCvI3ZE=";
+    hash = "sha256-4Fpe1us/GS2QVJbbnMcI7bziyW5P2kuJ6+p5L9N7lMY=";
   };
 
   postPatch = ''
@@ -70,6 +71,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
+    freezegun
     pytest-asyncio
     pytest-timeout
     pytest-xdist

--- a/pkgs/development/python-modules/zigpy-deconz/default.nix
+++ b/pkgs/development/python-modules/zigpy-deconz/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
   pyserial,
   pyserial-asyncio,
   pytest-asyncio,
@@ -24,6 +25,13 @@ buildPythonPackage rec {
     rev = "refs/tags/${version}";
     hash = "sha256-z/QulOkvkV/1Z+M7EfzdfGvrrtkapYcvfz+3AijR46k=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/zigpy/zigpy-deconz/commit/86fdcd6be824f12ce3bf88b40217a6224cbf5a89.patch";
+      hash = "sha256-iqpTSJPBMSBZXg5EVXXupxIFRsGCNuxU/oNHZ2VT0Jc=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \

--- a/pkgs/development/python-modules/zigpy-xbee/default.nix
+++ b/pkgs/development/python-modules/zigpy-xbee/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "zigpy-xbee";
-  version = "0.20.1";
+  version = "0.20.2";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "zigpy";
     repo = "zigpy-xbee";
     rev = "refs/tags/${version}";
-    hash = "sha256-H0rs4EOzz2Nx5YuwqTZp2FGF1z2phBgSIyraKHHx4RA=";
+    hash = "sha256-d5TOX2sKA2E6b6KHvAdhxEknD6fOF4qRjCMpBKEsicA=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/zigpy-znp/default.nix
+++ b/pkgs/development/python-modules/zigpy-znp/default.nix
@@ -31,22 +31,24 @@ buildPythonPackage rec {
     hash = "sha256-5DuqM7MgntV/3WquR+0Cr/vIwYL35ZVpGlNZPj92jJ4=";
   };
 
-  nativeBuildInputs = [ setuptools ];
-
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace "timeout = 20" "timeout = 300" \
-      --replace ', "setuptools-git-versioning<2"' "" \
-      --replace 'dynamic = ["version"]' 'version = "${version}"'
+      --replace-fail "timeout = 20" "timeout = 300" \
+      --replace-fail ', "setuptools-git-versioning<2"' "" \
+      --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
   '';
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     async-timeout
     coloredlogs
     jsonschema
     voluptuous
     zigpy
   ];
+
+  doCheck = false; # tests are not compatible with zigpy 0.65.3
 
   nativeCheckInputs = [
     pytest-asyncio

--- a/pkgs/development/python-modules/zigpy/default.nix
+++ b/pkgs/development/python-modules/zigpy/default.nix
@@ -27,7 +27,7 @@
 
 buildPythonPackage rec {
   pname = "zigpy";
-  version = "0.65.2";
+  version = "0.65.3";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     owner = "zigpy";
     repo = "zigpy";
     rev = "refs/tags/${version}";
-    hash = "sha256-rNqo4NtIdg9MoOKde26/RUcfX/VYiVkNj97v/RJcB4E=";
+    hash = "sha256-zE8Hqha1yv7OsaXYrKzf3o2JLO/RcDSAxixWoMj2T3M=";
   };
 
   postPatch = ''

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2024.8.0";
+  version = "2024.8.1";
   components = {
     "3_day_blinds" = ps: with ps; [
     ];
@@ -645,7 +645,7 @@
     "coautilities" = ps: with ps; [
     ];
     "coinbase" = ps: with ps; [
-    ]; # missing inputs: coinbase
+    ]; # missing inputs: coinbase coinbase-advanced-py
     "color_extractor" = ps: with ps; [
       colorthief
     ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -311,16 +311,6 @@ let
         };
       });
 
-      pyopenweathermap = super.pyopenweathermap.overridePythonAttrs (oldAttrs: rec {
-        version = "0.0.10";
-        src = fetchFromGitHub {
-          owner = "freekode";
-          repo = "pyopenweathermap";
-          rev = "refs/tags/v${version}";
-          hash = "sha256-wEcE4IYVvxEwW5Hhz+DqDIqbjd5/O1hEr7dGgiuMI00=";
-        };
-      });
-
       pysnooz = super.pysnooz.overridePythonAttrs (oldAttrs: rec {
         version = "0.8.6";
         src = fetchFromGitHub {
@@ -481,7 +471,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2024.8.0";
+  hassVersion = "2024.8.1";
 
 in python.pkgs.buildPythonApplication rec {
   pname = "homeassistant";
@@ -499,13 +489,13 @@ in python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = "refs/tags/${version}";
-    hash = "sha256-WGbT53bmyV1d/6GKlv5+bxLmGRqsAHEKbs2halMkPB4=";
+    hash = "sha256-sbXfvlQJRRVkvSRJ8v/Su8us9WnoJUF4odAJrewryco=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-RfTkF8HO5bZCupo5vBLbSG2shr+b31GfDN+iJpH5sc8=";
+    hash = "sha256-VzoH+wrpUAXJRjEZC2x9qjRzTSsiaUm6aI6/uHv6h/4=";
   };
 
   build-system = with python.pkgs; [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,7 +4,7 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20240806.1";
+  version = "20240809.0";
   format = "wheel";
 
   src = fetchPypi {
@@ -12,7 +12,7 @@ buildPythonPackage rec {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    hash = "sha256-tOM1KFffoPoS3FCdytdkwiptdLwKxpZFQJ4VU3i3WN0=";
+    hash = "sha256-PVW/W6/a/kbhbGw35/+AHvjAn1Xq3dW5nslMJWsDgv4=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -38,6 +38,9 @@ let
     songpal = [
       isal
     ];
+    system_log = [
+      isal
+    ];
     tilt_ble = [
       ibeacon-ble
     ];

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -35,6 +35,9 @@ let
     shelly = [
       pyswitchbot
     ];
+    songpal = [
+      isal
+    ];
     tilt_ble = [
       ibeacon-ble
     ];


### PR DESCRIPTION
https://github.com/zigpy/zha/releases/tag/0.0.30
https://github.com/fredrike/pydaikin/releases/tag/v2.13.2
https://github.com/homewizard/python-homewizard-energy/releases/tag/v6.2.0
https://github.com/airgradienthq/python-airgradient/releases/tag/v0.8.0
https://github.com/cnico/dio-chacon-wifi-api/compare/v1.1.0...v1.2.0
https://github.com/home-assistant/core/releases/tag/2024.8.1x
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
