### PR TITLE
yeahconsole: init at 0.1.3

### DIFF
--- a/pkgs/by-name/ye/yeahconsole/package.nix
+++ b/pkgs/by-name/ye/yeahconsole/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  libX11,
+  libXrandr,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "yeahconsole";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "jceb";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-Ea6erNF9hEhDHlWLctu1SHFVoXXXsPeWUbvCBSZwn4s=";
+  };
+
+  buildInputs = [
+    libX11
+    libXrandr
+  ];
+
+  preConfigure = ''
+    sed -i "s@PREFIX = /usr/local@PREFIX = $out@g" Makefile
+  '';
+
+  meta = {
+    description = "Turns an xterm into a gamelike console";
+    homepage = "https://github.com/jceb/yeahconsole";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ jceb ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add yeahconsole, a wrapper to turn terminal emulators into a quake terminal.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- [x] Tested, as applicable:
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)