### PR TITLE
 nixos/opendkim: modernize, add expandable settings option, put config file under standard location

### DIFF
--- a/nixos/modules/services/mail/opendkim.nix
+++ b/nixos/modules/services/mail/opendkim.nix
@@ -1,16 +1,14 @@
 { config, lib, pkgs, ... }:
-let
 
+let
   cfg = config.services.opendkim;
 
   defaultSock = "local:/run/opendkim/opendkim.sock";
 
-  keyFile = "${cfg.keyPath}/${cfg.selector}.private";
-
   args = [ "-f" "-l"
            "-p" cfg.socket
            "-d" cfg.domains
-           "-k" keyFile
+           "-k" "${cfg.keyPath}/${cfg.selector}.private"
            "-s" cfg.selector
          ] ++ lib.optionals (cfg.configFile != null) [ "-x" cfg.configFile ];
 
@@ -19,17 +17,9 @@ in {
     (lib.mkRenamedOptionModule [ "services" "opendkim" "keyFile" ] [ "services" "opendkim" "keyPath" ])
   ];
 
-  ###### interface
-
   options = {
-
     services.opendkim = {
-
-      enable = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = "Whether to enable the OpenDKIM sender authentication system.";
-      };
+      enable = lib.mkEnableOption "OpenDKIM sender authentication system";
 
       socket = lib.mkOption {
         type = lib.types.str;
@@ -79,16 +69,10 @@ in {
         default = null;
         description = "Additional opendkim configuration.";
       };
-
     };
-
   };
 
-
-  ###### implementation
-
   config = lib.mkIf cfg.enable {
-
     users.users = lib.optionalAttrs (cfg.user == "opendkim") {
       opendkim = {
         group = cfg.group;
@@ -159,6 +143,5 @@ in {
         UMask = "0077";
       };
     };
-
   };
 }

--- a/nixos/modules/services/mail/opendkim.nix
+++ b/nixos/modules/services/mail/opendkim.nix
@@ -64,10 +64,19 @@ in {
         description = "Selector to use when signing.";
       };
 
+      # TODO: deprecate this?
       configFile = lib.mkOption {
         type = lib.types.nullOr lib.types.path;
         default = null;
-        description = "Additional opendkim configuration.";
+        description = "Additional opendkim configuration as a file.";
+      };
+
+      settings = lib.mkOption {
+        type = with lib.types; submodule {
+          freeformType = attrsOf str;
+        };
+        default = { };
+        description = "Additional opendkim configuration";
       };
     };
   };
@@ -85,6 +94,9 @@ in {
     };
 
     environment.systemPackages = [ pkgs.opendkim ];
+
+    services.opendkim.configFile = lib.mkIf (cfg.settings != { }) (pkgs.writeText "opendkim.conf"
+      (lib.concatStringsSep "\n" (lib.mapAttrsToList (name: value: "${name} ${value}") cfg.settings)));
 
     systemd.tmpfiles.rules = [
       "d '${cfg.keyPath}' - ${cfg.user} ${cfg.group} - -"


### PR DESCRIPTION
## Description of changes

This is mainly for simple-nixos-mailserver to allow users setting additional opendkim settings without hackery.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
