### PR TITLE
xen: add patch to fix hydra failure

### DIFF
--- a/pkgs/applications/virtualization/xen/4.16/0001-xen-fig-geneneration-4.16.patch
+++ b/pkgs/applications/virtualization/xen/4.16/0001-xen-fig-geneneration-4.16.patch
@@ -1,0 +1,16 @@
+Remove a pipe that was causing SIGPIPE
+issues on overloaded Hydra machines.
+
+diff --git a/docs/figs/Makefile b/docs/figs/Makefile
+index e128a4364f..943f745dda 100644
+--- a/docs/figs/Makefile
++++ b/docs/figs/Makefile
+@@ -8,7 +8,7 @@ TARGETS= network-bridge.png network-basic.png
+ all: $(TARGETS)
+ 
+ %.png:	%.fig
+-	$(FIG2DEV) -L png $< >$@.tmp
++	$(FIG2DEV) -L png $< $@.tmp
+ 	mv -f $@.tmp $@
+ 
+ clean:

--- a/pkgs/applications/virtualization/xen/4.16/default.nix
+++ b/pkgs/applications/virtualization/xen/4.16/default.nix
@@ -23,7 +23,10 @@ callPackage (import ../generic.nix {
     xen = {
       rev = "4b33780de790bd438dd7cbb6143b410d94f0f049";
       hash = "sha256-2kcmfKwBo3w1U5CSxLSYSteqvzcJaB+cA7keVb3amyA=";
-      patches = [ ./0000-xen-ipxe-src-4.16.patch ] ++ upstreamPatchList;
+      patches = [
+        ./0000-xen-ipxe-src-4.16.patch
+        ./0001-xen-fig-geneneration-4.16.patch
+      ] ++ upstreamPatchList;
     };
     qemu = {
       rev = "c02cb236b5e4a76cf74e641cc35a0e3ebd3e52f3";

--- a/pkgs/applications/virtualization/xen/4.17/0001-xen-fig-geneneration-4.17.patch
+++ b/pkgs/applications/virtualization/xen/4.17/0001-xen-fig-geneneration-4.17.patch
@@ -1,0 +1,16 @@
+Remove a pipe that was causing SIGPIPE
+issues on overloaded Hydra machines.
+
+diff --git a/docs/figs/Makefile b/docs/figs/Makefile
+index e128a4364f..943f745dda 100644
+--- a/docs/figs/Makefile
++++ b/docs/figs/Makefile
+@@ -8,7 +8,7 @@ TARGETS= network-bridge.png network-basic.png
+ all: $(TARGETS)
+ 
+ %.png:	%.fig
+-	$(FIG2DEV) -L png $< >$@.tmp
++	$(FIG2DEV) -L png $< $@.tmp
+ 	mv -f $@.tmp $@
+ 
+ clean:

--- a/pkgs/applications/virtualization/xen/4.17/default.nix
+++ b/pkgs/applications/virtualization/xen/4.17/default.nix
@@ -26,7 +26,10 @@ callPackage (import ../generic.nix {
     xen = {
       rev = "d530627aaa9b6e03c7f911434bb342fca3d13300";
       hash = "sha256-4ltQUzo4XPzGT/7fGt1hnNMqBQBVF7VP+WXD9ZaJcGo=";
-      patches = [ ./0000-xen-ipxe-src-4.17.patch ] ++ upstreamPatchList;
+      patches = [
+        ./0000-xen-ipxe-src-4.17.patch
+        ./0001-xen-fig-geneneration-4.17.patch
+      ] ++ upstreamPatchList;
     };
     qemu = {
       rev = "ffb451126550b22b43b62fb8731a0d78e3376c03";

--- a/pkgs/applications/virtualization/xen/4.18/0001-xen-fig-geneneration-4.18.patch
+++ b/pkgs/applications/virtualization/xen/4.18/0001-xen-fig-geneneration-4.18.patch
@@ -1,0 +1,16 @@
+Remove a pipe that was causing SIGPIPE
+issues on overloaded Hydra machines.
+
+diff --git a/docs/figs/Makefile b/docs/figs/Makefile
+index e128a4364f..943f745dda 100644
+--- a/docs/figs/Makefile
++++ b/docs/figs/Makefile
+@@ -8,7 +8,7 @@ TARGETS= network-bridge.png network-basic.png
+ all: $(TARGETS)
+ 
+ %.png:	%.fig
+-	$(FIG2DEV) -L png $< >$@.tmp
++	$(FIG2DEV) -L png $< $@.tmp
+ 	mv -f $@.tmp $@
+ 
+ clean:

--- a/pkgs/applications/virtualization/xen/4.18/default.nix
+++ b/pkgs/applications/virtualization/xen/4.18/default.nix
@@ -26,7 +26,10 @@ callPackage (import ../generic.nix {
     xen = {
       rev = "d152a0424677d8b78e00ed1270a583c5dafff16f";
       hash = "sha256-pHCjj+Bcy4xQfB9xHU9fccFwVdP2DXrUhdszwGvrdmY=";
-      patches = [ ./0000-xen-ipxe-src-4.18.patch ] ++ upstreamPatchList;
+      patches = [
+        ./0000-xen-ipxe-src-4.18.patch
+        ./0001-xen-fig-geneneration-4.18.patch
+      ] ++ upstreamPatchList;
     };
     qemu = {
       rev = "0df9387c8983e1b1e72d8c574356f572342c03e6";

--- a/pkgs/applications/virtualization/xen/4.19/0001-xen-fig-geneneration-4.19.patch
+++ b/pkgs/applications/virtualization/xen/4.19/0001-xen-fig-geneneration-4.19.patch
@@ -1,0 +1,16 @@
+Remove a pipe that was causing SIGPIPE
+issues on overloaded Hydra machines.
+
+diff --git a/docs/figs/Makefile b/docs/figs/Makefile
+index e128a4364f..943f745dda 100644
+--- a/docs/figs/Makefile
++++ b/docs/figs/Makefile
+@@ -8,7 +8,7 @@ TARGETS= network-bridge.png network-basic.png
+ all: $(TARGETS)
+ 
+ %.png:	%.fig
+-	$(FIG2DEV) -L png $< >$@.tmp
++	$(FIG2DEV) -L png $< $@.tmp
+ 	mv -f $@.tmp $@
+ 
+ clean:

--- a/pkgs/applications/virtualization/xen/4.19/default.nix
+++ b/pkgs/applications/virtualization/xen/4.19/default.nix
@@ -23,7 +23,10 @@ callPackage (import ../generic.nix {
     xen = {
       rev = "026c9fa29716b0ff0f8b7c687908e71ba29cf239";
       hash = "sha256-Q6x+2fZ4ITBz6sKICI0NHGx773Rc919cl+wzI89UY+Q=";
-      patches = [ ./0000-xen-ipxe-src-4.19.patch ] ++ upstreamPatchList;
+      patches = [
+        ./0000-xen-ipxe-src-4.19.patch
+        ./0001-xen-fig-geneneration-4.19.patch
+      ] ++ upstreamPatchList;
     };
     qemu = {
       rev = "0df9387c8983e1b1e72d8c574356f572342c03e6";


### PR DESCRIPTION
## Description of changes

- Adds a patch to fix [Xen Hydra builds](https://hydra.nixos.org/build/269060526) by removing the redirection in the Figs Makefile.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - `pkg-config` test passes.
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 333764"`.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - No release notes: change is minor.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
