### PR TITLE
gensort: init at 1.5

### DIFF
--- a/pkgs/by-name/ge/gensort/package.nix
+++ b/pkgs/by-name/ge/gensort/package.nix
@@ -1,0 +1,45 @@
+{
+  fetchurl,
+  lib,
+  zlib,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  name = "gensort";
+  version = "1.5";
+
+  src = fetchurl {
+    url = "https://www.ordinal.com/try.cgi/gensort-${finalAttrs.version}.tar.gz";
+    hash = "sha256-f3VzeD2CmM7z3Uqh24IlyRTeGgz+0oOWXqILaYOKZ60=";
+  };
+
+  buildInputs = [
+    zlib
+  ];
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=format-security";
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 gensort $out/bin/gensort
+    install -Dm755 valsort $out/bin/valsort
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Generate and validate records for the sorting benchmark";
+    longDescription = ''
+      The gensort program can be used to generate input records for the sort
+      benchmarks presented on www.sortbenchmark.org.
+
+      The valsort program can be used to validate the sort output file is
+      correct.
+    '';
+    homepage = "https://www.ordinal.com/gensort.html";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ zimeg ];
+    mainProgram = "gensort";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

This package contains the `gensort` and `valsort` programs that generate random records and validate a sorted order for https://sortbenchmark.org. Package details can be found here: https://www.ordinal.com/gensort.html.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
