### PR TITLE
nixos-rebuild: Support `system.nix` by default

### DIFF
--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -454,7 +454,7 @@ trap cleanup EXIT
 # Re-execute nixos-rebuild from the Nixpkgs tree.
 if [[ -z $_NIXOS_REBUILD_REEXEC && -n $canRun && -z $fast ]]; then
     if [[ -n $buildingAttribute ]]; then
-        p=$(runCmd nix-build --no-out-link $buildFile -A "${attr:+$attr.}config.system.build.nixos-rebuild" "${extraBuildFlags[@]}")
+        p=$(runCmd nix-build --no-out-link "$buildFile" -A "${attr:+$attr.}config.system.build.nixos-rebuild" "${extraBuildFlags[@]}")
         SHOULD_REEXEC=1
     elif [[ -z $flake ]]; then
         if p=$(runCmd nix-build --no-out-link --expr 'with import <nixpkgs/nixos> {}; config.system.build.nixos-rebuild' "${extraBuildFlags[@]}"); then
@@ -527,7 +527,7 @@ getNixDrv() {
     nixDrv=
 
     if [[ -n $buildingAttribute ]]; then
-        if nixDrv="$(runCmd nix-instantiate $buildFile --add-root "$tmpDir/nix.drv" --indirect -A ${attr:+$attr.}config.nix.package.out "${extraBuildFlags[@]}")"; then return; fi
+        if nixDrv="$(runCmd nix-instantiate "$buildFile" --add-root "$tmpDir/nix.drv" --indirect -A ${attr:+$attr.}config.nix.package.out "${extraBuildFlags[@]}")"; then return; fi
     fi
     if nixDrv="$(runCmd nix-instantiate '<nixpkgs/nixos>' --add-root "$tmpDir/nix.drv" --indirect -A config.nix.package.out "${extraBuildFlags[@]}")"; then return; fi
     if nixDrv="$(runCmd nix-instantiate '<nixpkgs>' --add-root "$tmpDir/nix.drv" --indirect -A nix "${extraBuildFlags[@]}")"; then return; fi
@@ -590,7 +590,7 @@ if [ "$action" = repl ]; then
     # You should feel free to improve its behavior, as well as resolve tech
     # debt in "breaking" ways. Humans adapt quite well.
     if [[ -n $buildingAttribute ]]; then
-        exec nix repl --file $buildFile $attr "${extraBuildFlags[@]}"
+        exec nix repl --file "$buildFile" "$attr" "${extraBuildFlags[@]}"
     elif [[ -z $flake ]]; then
         exec nix repl '<nixpkgs/nixos>' "${extraBuildFlags[@]}"
     else
@@ -745,7 +745,7 @@ if [ -z "$rollback" ]; then
     log "building the system configuration..."
     if [[ "$action" = switch || "$action" = boot ]]; then
         if [[ -n $buildingAttribute ]]; then
-            pathToConfig="$(nixBuild $buildFile -A "${attr:+$attr.}config.system.build.toplevel" "${extraBuildFlags[@]}")"
+            pathToConfig="$(nixBuild "$buildFile" -A "${attr:+$attr.}config.system.build.toplevel" "${extraBuildFlags[@]}")"
         elif [[ -z $flake ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' --no-out-link -A system "${extraBuildFlags[@]}")"
         else
@@ -755,7 +755,7 @@ if [ -z "$rollback" ]; then
         targetHostSudoCmd nix-env -p "$profile" --set "$pathToConfig"
     elif [[ "$action" = test || "$action" = build || "$action" = dry-build || "$action" = dry-activate ]]; then
         if [[ -n $buildingAttribute ]]; then
-            pathToConfig="$(nixBuild $buildFile -A "${attr:+$attr.}config.system.build.toplevel" "${extraBuildFlags[@]}")"
+            pathToConfig="$(nixBuild "$buildFile" -A "${attr:+$attr.}config.system.build.toplevel" "${extraBuildFlags[@]}")"
         elif [[ -z $flake ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' -A system -k "${extraBuildFlags[@]}")"
         else
@@ -763,7 +763,7 @@ if [ -z "$rollback" ]; then
         fi
     elif [ "$action" = build-vm ]; then
         if [[ -n $buildingAttribute ]]; then
-            pathToConfig="$(nixBuild $buildFile -A "${attr:+$attr.}config.system.build.vm" "${extraBuildFlags[@]}")"
+            pathToConfig="$(nixBuild "$buildFile" -A "${attr:+$attr.}config.system.build.vm" "${extraBuildFlags[@]}")"
         elif [[ -z $flake ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' -A vm -k "${extraBuildFlags[@]}")"
         else
@@ -771,7 +771,7 @@ if [ -z "$rollback" ]; then
         fi
     elif [ "$action" = build-vm-with-bootloader ]; then
         if [[ -n $buildingAttribute ]]; then
-            pathToConfig="$(nixBuild $buildFile -A "${attr:+$attr.}config.system.build.vmWithBootLoader" "${extraBuildFlags[@]}")"
+            pathToConfig="$(nixBuild "$buildFile" -A "${attr:+$attr.}config.system.build.vmWithBootLoader" "${extraBuildFlags[@]}")"
         elif [[ -z $flake ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' -A vmWithBootLoader -k "${extraBuildFlags[@]}")"
         else

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -36,7 +36,7 @@ verboseScript=
 noFlake=
 attr=
 buildFile=default.nix
-buildingAttribute=
+buildingFile=
 installBootloader=
 json=
 
@@ -67,7 +67,7 @@ while [ "$#" -gt 0 ]; do
             exit 1
         fi
         buildFile="$1"
-        buildingAttribute=1
+        buildingFile=1
         shift 1
         ;;
       --attr|-A)
@@ -76,7 +76,7 @@ while [ "$#" -gt 0 ]; do
             exit 1
         fi
         attr="$1"
-        buildingAttribute=1
+        buildingFile=1
         shift 1
         ;;
       --install-grub)
@@ -368,7 +368,7 @@ fi
 
 # Verify that user is not trying to use attribute building and flake
 # at the same time
-if [[ -n $buildingAttribute && -n $flake ]]; then
+if [[ -n $buildingFile && -n $flake ]]; then
     log "error: '--flake' cannot be used with '--file' or '--attr'"
     exit 1
 fi
@@ -453,7 +453,7 @@ trap cleanup EXIT
 
 # Re-execute nixos-rebuild from the Nixpkgs tree.
 if [[ -z $_NIXOS_REBUILD_REEXEC && -n $canRun && -z $fast ]]; then
-    if [[ -n $buildingAttribute ]]; then
+    if [[ -n $buildingFile ]]; then
         p=$(runCmd nix-build --no-out-link "$buildFile" -A "${attr:+$attr.}config.system.build.nixos-rebuild" "${extraBuildFlags[@]}")
         SHOULD_REEXEC=1
     elif [[ -z $flake ]]; then
@@ -478,7 +478,7 @@ fi
 
 # Find configuration.nix and open editor instead of building.
 if [ "$action" = edit ]; then
-    if [[ -n $buildingAttribute ]]; then
+    if [[ -n $buildingFile ]]; then
         log "error: '--file' and '--attr' are not supported with 'edit'"
         exit 1
     elif [[ -z $flake ]]; then
@@ -526,7 +526,7 @@ prebuiltNix() {
 getNixDrv() {
     nixDrv=
 
-    if [[ -n $buildingAttribute ]]; then
+    if [[ -n $buildingFile ]]; then
         if nixDrv="$(runCmd nix-instantiate "$buildFile" --add-root "$tmpDir/nix.drv" --indirect -A ${attr:+$attr.}config.nix.package.out "${extraBuildFlags[@]}")"; then return; fi
     fi
     if nixDrv="$(runCmd nix-instantiate '<nixpkgs/nixos>' --add-root "$tmpDir/nix.drv" --indirect -A config.nix.package.out "${extraBuildFlags[@]}")"; then return; fi
@@ -589,7 +589,7 @@ if [ "$action" = repl ]; then
     # This is a very end user command, implemented using sub-optimal means.
     # You should feel free to improve its behavior, as well as resolve tech
     # debt in "breaking" ways. Humans adapt quite well.
-    if [[ -n $buildingAttribute ]]; then
+    if [[ -n $buildingFile ]]; then
         exec nix repl --file "$buildFile" "$attr" "${extraBuildFlags[@]}"
     elif [[ -z $flake ]]; then
         exec nix repl '<nixpkgs/nixos>' "${extraBuildFlags[@]}"
@@ -744,7 +744,7 @@ fi
 if [ -z "$rollback" ]; then
     log "building the system configuration..."
     if [[ "$action" = switch || "$action" = boot ]]; then
-        if [[ -n $buildingAttribute ]]; then
+        if [[ -n $buildingFile ]]; then
             pathToConfig="$(nixBuild "$buildFile" -A "${attr:+$attr.}config.system.build.toplevel" "${extraBuildFlags[@]}")"
         elif [[ -z $flake ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' --no-out-link -A system "${extraBuildFlags[@]}")"
@@ -754,7 +754,7 @@ if [ -z "$rollback" ]; then
         copyToTarget "$pathToConfig"
         targetHostSudoCmd nix-env -p "$profile" --set "$pathToConfig"
     elif [[ "$action" = test || "$action" = build || "$action" = dry-build || "$action" = dry-activate ]]; then
-        if [[ -n $buildingAttribute ]]; then
+        if [[ -n $buildingFile ]]; then
             pathToConfig="$(nixBuild "$buildFile" -A "${attr:+$attr.}config.system.build.toplevel" "${extraBuildFlags[@]}")"
         elif [[ -z $flake ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' -A system -k "${extraBuildFlags[@]}")"
@@ -762,7 +762,7 @@ if [ -z "$rollback" ]; then
             pathToConfig="$(nixFlakeBuild "$flake#$flakeAttr.config.system.build.toplevel" "${extraBuildFlags[@]}" "${lockFlags[@]}")"
         fi
     elif [ "$action" = build-vm ]; then
-        if [[ -n $buildingAttribute ]]; then
+        if [[ -n $buildingFile ]]; then
             pathToConfig="$(nixBuild "$buildFile" -A "${attr:+$attr.}config.system.build.vm" "${extraBuildFlags[@]}")"
         elif [[ -z $flake ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' -A vm -k "${extraBuildFlags[@]}")"
@@ -770,7 +770,7 @@ if [ -z "$rollback" ]; then
             pathToConfig="$(nixFlakeBuild "$flake#$flakeAttr.config.system.build.vm" "${extraBuildFlags[@]}" "${lockFlags[@]}")"
         fi
     elif [ "$action" = build-vm-with-bootloader ]; then
-        if [[ -n $buildingAttribute ]]; then
+        if [[ -n $buildingFile ]]; then
             pathToConfig="$(nixBuild "$buildFile" -A "${attr:+$attr.}config.system.build.vmWithBootLoader" "${extraBuildFlags[@]}")"
         elif [[ -z $flake ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' -A vmWithBootLoader -k "${extraBuildFlags[@]}")"

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -479,8 +479,7 @@ fi
 # Find configuration.nix and open editor instead of building.
 if [ "$action" = edit ]; then
     if [[ -n $buildingFile ]]; then
-        log "error: '--file' and '--attr' are not supported with 'edit'"
-        exit 1
+        runCmd exec ${EDITOR:-nano} "$buildFile"
     elif [[ -z $flake ]]; then
         NIXOS_CONFIG=${NIXOS_CONFIG:-$(runCmd nix-instantiate --find-file nixos-config)}
         if [[ -d $NIXOS_CONFIG ]]; then


### PR DESCRIPTION
## Description of changes

(in addition to various minor improvements)

Previously, `nixos-rebuild -A foo` would build the `default.nix` in the current directory, while `nixos-rebuild` without `-A` would not use file-based building at all.

This difference compared to what `nix-build` would do is confusing. Furthermore, using `default.nix` is not great, because there's many of those files all around, and they're almost never for NixOS.

This PR fixes those two issues by:
- Removing support for using `default.nix` as a default when using `--attr`, **this is a breaking change**, but support for this has not made it to a stable branch
- Using the `<nixos-system>` entry in NIX_PATH as the default if it exists
- Otherwise, use the `system.nix` file in the current directory or any of its parents, if it exists, as a default
- Otherwise, use `/etc/nixos/system.nix` as a default

While `system.nix` could be conflated with the `system` Nixpkgs argument, there's no practical way for this to cause problems, because `system` is never specified in a file.

Having this finally allows using `nixos-rebuild` without any arguments and without any `NIX_PATH` entries, effectively a way to declaratively use NixOS without `nix-channel`!

I think it's important to get this for the next release, so that we don't bake in stability for the `default.nix` behavior.

Unfortunately I'm a bit low on time, but if @amozeo (who pioneered the file-based building with https://github.com/NixOS/nixpkgs/pull/320462) could take this PR to its conclusion I'd be very grateful!

## Things done
- [ ] Tests
- [ ] Documentation

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
