### PR TITLE
lib/modules: add `definedOptionsOnly` option to `evalModules`

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -321,6 +321,11 @@ checkConfigError 'is not of type `boolean' config.submodule.config ./declare-sub
 checkConfigError "In module ..*define-submoduleWith-shorthand.nix., you're trying to define a value of type \`bool'\n\s*rather than an attribute set for the option" config.submodule.config ./declare-submoduleWith-noshorthand.nix ./define-submoduleWith-shorthand.nix
 checkConfigOutput '^true$' config.submodule.config ./declare-submoduleWith-noshorthand.nix ./define-submoduleWith-noshorthand.nix
 
+## definedOptionsOnly should behave as expected
+checkConfigOutput '^false$' config.submodule.defined ./definedOptionsOnly-submodule.nix
+checkConfigOutput '^false$' config.submodule.hasDefault ./definedOptionsOnly-submodule.nix
+checkConfigError "^error: attribute 'undefined' in selection path 'config.submodule.undefined' not found" config.submodule.undefined ./definedOptionsOnly-submodule.nix
+
 ## submoduleWith should merge all modules in one swoop
 checkConfigOutput '^true$' config.submodule.inner ./declare-submoduleWith-modules.nix
 checkConfigOutput '^true$' config.submodule.outer ./declare-submoduleWith-modules.nix

--- a/lib/tests/modules/definedOptionsOnly-submodule.nix
+++ b/lib/tests/modules/definedOptionsOnly-submodule.nix
@@ -1,0 +1,20 @@
+{ lib, ... }:
+{
+  options.submodule = lib.mkOption {
+    type = lib.types.submoduleWith {
+      definedOptionsOnly = true;
+      modules = [
+        {
+          options.defined = lib.mkOption { type = lib.types.bool; };
+          options.hasDefault = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+          };
+          options.undefined = lib.mkOption { type = lib.types.bool; };
+        }
+      ];
+    };
+  };
+
+  config.submodule.defined = false;
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -839,6 +839,7 @@ rec {
       { modules
       , specialArgs ? {}
       , shorthandOnlyDefinesConfig ? false
+      , definedOptionsOnly ? false
       , description ? null
       , class ? null
       }@attrs:
@@ -852,7 +853,7 @@ rec {
         ) defs;
 
         base = evalModules {
-          inherit class specialArgs;
+          inherit class definedOptionsOnly specialArgs;
           modules = [{
             # This is a work-around for the fact that some sub-modules,
             # such as the one included in an attribute set, expects an "args"


### PR DESCRIPTION
## Description of changes

Adds a new _`definedOptionsOnly`_ argument to `evalModules` and `types.submoduleWith`, defaulting to false. When set to true _undefined_ options are filtered from the final merged config instead of being present as stubs that throw "used but not defined" when evaluated.

Fixes #158598

See also: #158594, #257511

### Motivation

In [Nixvim](https://github.com/nix-community/nixvim), we have a number of freeform ([rfc42](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md)-style) `settings` options. Most of these have a number of sub-options declared, however we only want these to show up in the generated lua tables when actually defined.

To clarify, nixvim has a philosophy of only generating lua config when explicitly enabled via its nix options. Up until now, we've been using sub-options that default to `null` and filtering out null values, however this has some issues:

- Filtering null values isn't enough when dealing with _nested_ sub-options, we also need to filter empty attrs
- Filtering empty attrs is problematic if users wish to define an empty lua table
- Filtering null also isn't ideal, because users may wish to define `null` to represent lua's `nil`

Instead, I would like for nixvim to use sub-options _without_ a default, but only include them in the resulting config when defined.

This was originally discussed in [this matrix thread](https://matrix.to/#/!wfudwzqQUiJYJnqfSY:nixos.org/$mVuETvj4dPJNF6ZUdVEVvWmp07L5G3X-6y0bk-NmCP4?via=nixos.org&via=matrix.org&via=nixos.dev).

I'm sure this would also be useful for some nixos and home-manager submodules.

### Can it be a `_module` option?

Currently, I expose the configured value via a **read-only** option `_module.definedOptionsOnly`, however due to infinite recursion we cannot _use_ this as a read-write option that **actually decides** which behaviour to use.

Having this as an `evalModules` arg is kinda ugly, but I can't think of a way we could define it as a module option without running into infinite recursion.

More specifically, because `config` changes its actual _shape_ (which attrs are present) based on whether we're filtering out undefined options, we cannot use it recursively to evaluate options from modules that depend on `config`.

### Custom attr filtering

Additionally, I had to write a custom filtering function, as `filterAttrsRecursive` wasn't powerful enough to filter out option leaf-nodes based on `isDefined` and branch-nodes that are empty _after_ filtering the leaves. Should I create a PR to offer a `filterAttrsWith` function in the public lib?


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
