### PR TITLE
singularity-tools: miscellaneous fixes (2nd round)

### DIFF
--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -99,11 +99,11 @@ lib.makeExtensible (final: {
           }
           ''
             rmdir "$out"
-            mkdir disk
+            mkdir workspace
             mkfs -t ext3 -b 4096 /dev/${vmTools.hd}
-            mount /dev/${vmTools.hd} disk
-            mkdir -p disk/img
-            cd disk/img
+            mount /dev/${vmTools.hd} workspace
+            mkdir -p workspace/img
+            cd workspace/img
             mkdir proc sys dev
 
             # Run root script

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -92,11 +92,13 @@ lib.makeExtensible (final: {
             preVM = vmTools.createEmptyImage {
               size = diskSize;
               fullName = "${projectName}-run-disk";
+              # Leaving "$out" for the Singularity/Container image
+              destination = "disk-image";
             };
             inherit memSize;
           }
           ''
-            rm -rf $out
+            rmdir "$out"
             mkdir disk
             mkfs -t ext3 -b 4096 /dev/${vmTools.hd}
             mount /dev/${vmTools.hd} disk

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -116,14 +116,14 @@ lib.makeExtensible (final: {
 
             # Build /bin and copy across closure
             mkdir -p bin ./${builtins.storeDir}
-            for f in $(cat $layerClosure) ; do
-              cp -ar $f ./$f
+            for f in $(cat "$layerClosure") ; do
+              cp -ar "$f" "./$f"
             done
 
             for c in ${toString contents} ; do
-              for f in $c/bin/* ; do
-                if [ ! -e bin/$(basename $f) ] ; then
-                  ln -s $f bin/
+              for f in "$c"/bin/* ; do
+                if [ ! -e "bin/$(basename "$f")" ] ; then
+                  ln -s "$f" bin/
                 fi
               done
             done
@@ -143,7 +143,7 @@ lib.makeExtensible (final: {
             mkdir -p /var/lib/${projectName}/mnt/session
             echo "root:x:0:0:System administrator:/root:/bin/sh" > /etc/passwd
             echo > /etc/resolv.conf
-            TMPDIR=$(pwd -P) ${projectName} build $out ./img
+            TMPDIR="$(pwd -P)" ${projectName} build "$out" ./img
           ''
       );
 

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -82,7 +82,13 @@ rec {
               util-linux
             ];
             strictDeps = true;
-            layerClosure = writeClosure contents;
+            layerClosure = writeClosure (
+              [
+                bashInteractive
+                runScriptFile
+              ]
+              ++ contents
+            );
             preVM = vmTools.createEmptyImage {
               size = diskSize;
               fullName = "${projectName}-run-disk";

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -116,9 +116,10 @@ lib.makeExtensible (final: {
 
             # Build /bin and copy across closure
             mkdir -p bin ./${builtins.storeDir}
-            for f in $(cat "$layerClosure") ; do
+            # Loop over the line-separated paths in $layerClosure
+            while IFS= read -r f; do
               cp -ar "$f" "./$f"
-            done
+            done < "$layerClosure"
 
             # TODO(@ShamrockLee):
             # Once vmTools.runInLinuxVMm works with `__structuredAttrs = true` (#334705),

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -20,7 +20,7 @@
 let
   defaultSingularity = singularity;
 in
-rec {
+lib.makeExtensible (final: {
   # TODO(@ShamrockLee): Remove after Nixpkgs 24.11 branch-off.
   shellScript =
     lib.warn
@@ -147,4 +147,4 @@ rec {
 
     in
     result;
-}
+})

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -120,7 +120,12 @@ lib.makeExtensible (final: {
               cp -ar "$f" "./$f"
             done
 
-            for c in ${toString contents} ; do
+            # TODO(@ShamrockLee):
+            # Once vmTools.runInLinuxVMm works with `__structuredAttrs = true` (#334705),
+            # set __structuredAttrs = true and pass contents as an attribute
+            # so that we could loop with `for c in ''${contents[@]}`
+            # instead of expanding all the paths in contents into the Bash string.
+            for c in ${lib.escapeShellArgs contents} ; do
               for f in "$c"/bin/* ; do
                 if [ ! -e "bin/$(basename "$f")" ] ; then
                   ln -s "$f" bin/

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -118,7 +118,7 @@ lib.makeExtensible (final: {
             mkdir -p bin ./${builtins.storeDir}
             # Loop over the line-separated paths in $layerClosure
             while IFS= read -r f; do
-              cp -ar "$f" "./$f"
+              cp -r "$f" "./$f"
             done < "$layerClosure"
 
             # TODO(@ShamrockLee):


### PR DESCRIPTION
## Description of changes

When rebasing #268199, I found some more minor issues. Here's what I do in this round of fixes:
-   Include `bashInteractive` and `runScriptFile` into `closureInfo` and the resulting container image.
-   Make `singularity-tools` extensible instead of using `rec`. This will be useful for #268199.
-   Tidy up the VM disk image mounting code. Place the disk image outside "$out" instead of removing it.
-   String-interpolate `contents` before copying (instead of `toString`) to ensure that path objects get appropriately included in the resulting image.
-   Don't preserve ownership when copying store contents so that such copying won't require root privileges.
-   Miscellaneous shell linting.

Thank you, @SomeoneSerge, for being so patient in reviewing everything.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
