### PR TITLE
nixos/systemd-boot-builder: fix specialisations with special characters

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -65,7 +65,7 @@ class Entry:
         # Matching nixos*-generation-$number*.conf
         rex_generation = re.compile(r"^nixos.*-generation-([0-9]+).*\.conf$")
         # Matching nixos*-generation-$number-specialisation-$specialisation_name*.conf
-        rex_specialisation = re.compile(r"^nixos.*-generation-([0-9]+)-specialisation-([a-zA-Z0-9]+).*\.conf$")
+        rex_specialisation = re.compile(r"^nixos.*-generation-([0-9]+)-specialisation-(.*)\.conf$")
         profile = rex_profile.sub(r"\1", filename) if rex_profile.match(filename) else None
         specialisation = rex_specialisation.sub(r"\2", filename) if rex_specialisation.match(filename) else None
         try:
@@ -114,6 +114,7 @@ class DiskEntry:
             sort_key=entry_map.get("sort_key", "nixos"),
             devicetree=entry_map.get("devicetree"),
         )
+        assert disk_entry.path.samefile(path)
         return disk_entry
 
     def write(self, sorted_first: str) -> None:


### PR DESCRIPTION
Specilisation names can contain non-alphanumberic characters, for example if they have - as a seperator.
In this situation, the path for a specialisation will have its name at the end, and the old regex only checked for alphanumeric names, resulting in the rest of the code using a cut-off version of the full path, and erroring when it cannot find the file.

This also includes an additional check to make sure path parsing doesn't mess up.

For me specifically, this fixes an issue where a have a specialisation named `nvidia-beta`, that makes `nixos-rebuild` error out when installing a new boot entry, because it tries to remove the old boot entry named `nvidia-beta`, but the path is truncated to `...-specialisaion-nvidia.conf`:

```py
Traceback (most recent call last):
  File "/nix/store/38547vyyicbrldi0jiz2k0gr6h4hvm13-systemd-boot", line 546, in <module>
    main()
  File "/nix/store/38547vyyicbrldi0jiz2k0gr6h4hvm13-systemd-boot", line 529, in main
    install_bootloader(args)
  File "/nix/store/38547vyyicbrldi0jiz2k0gr6h4hvm13-systemd-boot", line 462, in install_bootloader
    remove_old_entries(gens, entries)
  File "/nix/store/38547vyyicbrldi0jiz2k0gr6h4hvm13-systemd-boot", line 354, in remove_old_entries
    os.unlink(disk_entry.path)
FileNotFoundError: [Errno 2] No such file or directory: '/boot/efi/loader/entries/nixos-generation-802-specialisation-nvidia.conf'
```

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
