### PR TITLE
whitesur-gtk-theme: add feature

### DIFF
--- a/pkgs/data/themes/whitesur/default.nix
+++ b/pkgs/data/themes/whitesur/default.nix
@@ -21,6 +21,7 @@
 , roundedMaxWindow ? false # default: false
 , nordColor ? false # default = false
 , darkerColor ? false # default = false
+, montereyStyle ? false # default = false
 }:
 
 let
@@ -72,6 +73,9 @@ stdenv.mkDerivation rec {
 
     # Provides a dummy home directory
     substituteInPlace shell/lib-core.sh --replace 'MY_HOME=$(getent passwd "''${MY_USERNAME}" | cut -d: -f6)' 'MY_HOME=/tmp'
+
+    # Place libadwaita files in a directory to be able to link them to ~/.config/gtk-4.0 correctly
+    substituteInPlace shell/lib-install.sh --replace "\''${HOME}/.config/gtk-4.0" "$out/gtk4"
   '';
 
   dontBuild = true;
@@ -82,6 +86,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/themes
 
     ./install.sh  \
+      --libadwaita \
       ${toString (map (x: "--alt " + x) altVariants)} \
       ${toString (map (x: "--color " + x) colorVariants)} \
       ${toString (map (x: "--opacity " + x) opacityVariants)} \
@@ -94,6 +99,7 @@ stdenv.mkDerivation rec {
       ${lib.optionalString (roundedMaxWindow == true) "--roundedmaxwindow"} \
       ${lib.optionalString (nordColor == true) "--nordcolor"} \
       ${lib.optionalString (darkerColor == true) "--darkercolor"} \
+      ${lib.optionalString (montereyStyle == true) "--monterey"} \
       --dest $out/share/themes
 
     jdupes --quiet --link-soft --recurse $out/share


### PR DESCRIPTION
This change was made due to the missing option "--monterey" and since libadwaita applications (e.g. GNOME's Nautilus) were not adapting their appearance to this theme. Using the "--libadwaita" option was not possible before because - on the one hand - it was not one of the function's parameters and - on the other hand - the install script can - of course - not access the user's home directory.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
