### PR TITLE
python312Pakcages.python-fx: 0.3.1 -> 0.3.2, enable tests

### DIFF
--- a/pkgs/development/python-modules/python-fx/default.nix
+++ b/pkgs/development/python-modules/python-fx/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   antlr4-python3-runtime,
   asciimatics,
   buildPythonPackage,
@@ -30,7 +31,7 @@
 
 buildPythonPackage rec {
   pname = "python-fx";
-  version = "0.3.1";
+  version = "0.3.2";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
@@ -39,12 +40,13 @@ buildPythonPackage rec {
     owner = "cielong";
     repo = "pyfx";
     rev = "refs/tags/v${version}";
-    hash = "sha256-BXKH3AlYMNbMREW5Qx72PrbuZdXlmVS+knWWu/y9PsA=";
+    hash = "sha256-Q5ihWnoa7nf4EkrY4SgrwjaNvTva4RdW9GRbnbsPXPc=";
   };
 
   postPatch = ''
-    rm src/pyfx/model/common/jsonpath/*.{g4,interp,tokens}
-    antlr -Dlanguage=Python3 -visitor -o src/pyfx/model/common/jsonpath/ *.g4
+    rm src/pyfx/model/common/jsonpath/*.py # upstream checks in generated files, remove to ensure they were regenerated
+    antlr -Dlanguage=Python3 -visitor src/pyfx/model/common/jsonpath/*.g4
+    rm src/pyfx/model/common/jsonpath/*.{g4,interp,tokens} # no need to install
   '';
 
   pythonRelaxDeps = true;
@@ -81,13 +83,10 @@ buildPythonPackage rec {
     parameterized
   ];
 
-  # antlr4 issue prevents us from running the tests
-  # https://github.com/antlr/antlr4/issues/4041
-  doCheck = false;
+  # FAILED tests/test_event_loops.py::TwistedEventLoopTest::test_run - AssertionError: 'callback called with future outcome: True' not found in ['...
+  doCheck = !stdenv.isDarwin;
 
-  # pythonImportsCheck = [
-  #   "pyfx"
-  # ];
+  pythonImportsCheck = [ "pyfx" ];
 
   meta = with lib; {
     description = "Module to view JSON in a TUI";

--- a/pkgs/development/python-modules/python-fx/default.nix
+++ b/pkgs/development/python-modules/python-fx/default.nix
@@ -22,7 +22,6 @@
   antlr4,
   pyyaml,
   setuptools,
-  six,
   urwid,
   parameterized,
   wcwidth,
@@ -32,7 +31,7 @@
 buildPythonPackage rec {
   pname = "python-fx";
   version = "0.3.2";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.8";
 
@@ -51,10 +50,9 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = true;
 
-  nativeBuildInputs = [
-    antlr4
-    setuptools
-  ];
+  build-system = [ setuptools ];
+
+  nativeBuildInputs = [ antlr4 ];
 
   propagatedBuildInputs = [
     antlr4-python3-runtime
@@ -72,7 +70,6 @@ buildPythonPackage rec {
     pyfiglet
     pyperclip
     pyyaml
-    six
     urwid
     wcwidth
     yamale
@@ -90,10 +87,10 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Module to view JSON in a TUI";
-    mainProgram = "pyfx";
     homepage = "https://github.com/cielong/pyfx";
     changelog = "https://github.com/cielong/pyfx/releases/tag/v${version}";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
+    mainProgram = "pyfx";
   };
 }


### PR DESCRIPTION
## Description of changes

This fixes #333173 by ~~patching~~updating to a version that fixes incompatibilities with dependency versions from nixpkgs, and enables tests and import checks.

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>8 packages built:</summary>
  <ul>
    <li>python311Packages.python-fx</li>
    <li>python311Packages.python-fx.dist</li>
    <li>python311Packages.qiling</li>
    <li>python311Packages.qiling.dist</li>
    <li>python312Packages.python-fx</li>
    <li>python312Packages.python-fx.dist</li>
    <li>python312Packages.qiling</li>
    <li>python312Packages.qiling.dist</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
