### PR TITLE
python3Packages.ziafont: 0.8 -> 0.9, python3Packages.ziamath: 0.10 -> 0.11

### DIFF
--- a/pkgs/development/python-modules/ziafont/checkfonts.nix
+++ b/pkgs/development/python-modules/ziafont/checkfonts.nix
@@ -1,0 +1,88 @@
+# Based on the calls to testfont(url) in test/manyfonts.ipynb
+# Note that Tinos-Regular is also needed for test/test.ipynb
+[
+  {
+    url = "https://mirrors.ctan.org/fonts/qualitype/opentype/QTAbbie.otf";
+    hash = "sha256-/Lu7EGtF7kZgP0dYyaIFPIO7jWCbtc3iT0ux3bFhe9w=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/qualitype/opentype/QTJupiter.otf";
+    hash = "sha256-BocJZnrGGt1fpq5Jmnl1fiuo7YllN5xCF6lgWZyVcXE=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/qualitype/opentype/QTVagaRound.otf";
+    hash = "sha256-JffWcGdBN2OIZXdZxf7G3G+kZRZi2cKFUIOAOCuR8gM=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/qualitype/opentype/QTBlackForest.otf";
+    hash = "sha256-P4TQSCBHPfty3l+IhY1CuVkr0KNk2t6bbeieT21fz9A=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/punknova/punknova-regular.otf";
+    hash = "sha256-UC4Zdh647wTBYXRyOzFDliVA0ukK88K8CcIS8nzxeoo=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/qualitype/opentype/QTSnowCaps.otf";
+    hash = "sha256-XtZbEhCcHlc1eHEkR+52tuVoA6GTf//5mU/ehHq/H8g=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/qualitype/opentype/QTStoryTimeCaps.otf";
+    hash = "sha256-bwW8KZD40i8rpGqZuoVBeosfjk/tWHex4KPm8mlQ4po=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/alegreya/opentype/Alegreya-Regular.otf";
+    hash = "sha256-oZo6XeaTcnaSymYWrkl71t3JsWvLuKgKsNAirONNax4=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/nimbus15/opentype/zco-Oblique.otf";
+    hash = "sha256-j7WbsSnLGh+OdpdBwIlp3cPL8rpYS3OcW3jtxltgArE=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/merriweather/opentype/Merriweather-Black.otf";
+    hash = "sha256-3pQdqHw1eRUVCRwnVbZBbftrZ7fJ7USD+CyNfA41u3g=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/qualitype/opentype/QTArtiston.otf";
+    hash = "sha256-6bfL3Po4erta9q49EgzYZXZs9NtdoWFjnpR3WT1y+vU=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/nunito/opentype/Nunito-Black.otf";
+    hash = "sha256-/QJud/q2MVwrXEibDDe/gty3a3x2weodNBqCOkVV7fA=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/kurier/fonts/opentype/nowacki/kurier/KurierHeavy-Regular.otf";
+    hash = "sha256-ynFz+IIntQeEK2+Cu64wJRTffZvmuYdx1IrKKDe1VA0=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/clearsans/truetype/ClearSans-MediumItalic.ttf";
+    hash = "sha256-Bv+6I2ClJo71iZbj3XmUpJ3NHBZ/+8h07azt7ucbmyE=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/tinos/truetype/Tinos-Regular.ttf";
+    hash = "sha256-/03rOV/yQmu9CNt0ywBbIjJhdd8A8KFWuH5tKu8e9Qg=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/gofonts/truetype/Go-Medium.ttf";
+    hash = "sha256-GvMsI34wBeBQUC9RQjVNS6TukXf5faoVrPoI9L9qPEY=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/comfortaa/truetype/Comfortaa-Regular.ttf";
+    hash = "sha256-eu7K9MeZ8k8i6HGm9UbKiRFs8RKIx6j/QvEUAd1URcY=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/quattrocento/truetype/Quattrocento-Regular.ttf";
+    hash = "sha256-kv5NsgyBybySJha4xJ4VIEaCdMfJwyz19VRCJOwVeHs=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/kurier/fonts/opentype/nowacki/kurier/KurierCond-Regular.otf";
+    hash = "sha256-y9gD/ovTuZeh5/OaQelhGLuTPFjLcPSMLfIUyHe1QXI=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/garamond-math/Garamond-Math.otf";
+    hash = "sha256-xhYTd+lwhBUrlI9iq+h0y+J0BZOJVjRrVKTGSIpQCfE=";
+  }
+  {
+    url = "https://github.com/google/fonts/raw/main/ofl/arizonia/Arizonia-Regular.ttf";
+    hash = "sha256-jfHBC8FdCroUXUWZwlyvrYPbaG0s76QmGfBptvG7zmI=";
+  }
+]

--- a/pkgs/development/python-modules/ziamath/checkfonts.nix
+++ b/pkgs/development/python-modules/ziamath/checkfonts.nix
@@ -1,0 +1,19 @@
+# Based on the calls to testfont(url) in test/styles.ipynb
+[
+  {
+    url = "https://mirrors.ctan.org/fonts/libertinus-fonts/otf/LibertinusMath-Regular.otf";
+    hash = "sha256-PY4QUzxz9/vO4k2rl5GBfno0r3/Zh1FAhif1OPDic7w=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/firamath/FiraMath-Regular.otf";
+    hash = "sha256-ICjL091NjAzxYIUg60dZlWqDpnkx17bY58MTUgGG41s=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/erewhon-math/Erewhon-Math.otf";
+    hash = "sha256-7SjKC+XP9KpFAWtZxc+FZZ4VETnDxokUGz+nZ/CWIbI=";
+  }
+  {
+    url = "https://mirrors.ctan.org/fonts/concmath-otf/Concrete-Math.otf";
+    hash = "sha256-YCukkUgNQoBlotuD0vF1ts9JL8x6xaEW9JxK++GVGZ4=";
+  }
+]

--- a/pkgs/development/python-modules/ziamath/default.nix
+++ b/pkgs/development/python-modules/ziamath/default.nix
@@ -8,20 +8,20 @@
   pytestCheckHook,
   nbval,
   latex2mathml,
+  fetchurl,
 }:
-
 buildPythonPackage rec {
   pname = "ziamath";
-  version = "0.10";
+  version = "0.11";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "cdelker";
-    repo = pname;
-    rev = version;
-    hash = "sha256-Drssi+YySh4OhVYAOvgIwzeeu5dQbUUXuhwTedhUUt8=";
+    repo = "ziamath";
+    rev = "refs/tags/${version}";
+    hash = "sha256-DLpbidQEeQVKxGCbS2jeeCvmVK9ElDIDQMj5bh/x7/Q=";
   };
 
   build-system = [ setuptools ];
@@ -34,22 +34,24 @@ buildPythonPackage rec {
     latex2mathml
   ];
 
-  pytestFlagsArray = [ "--nbval-lax" ];
+  preCheck =
+    let
+      # The test notebooks try to download font files, unless they already exist in the test directory,
+      # so we prepare them in advance.
+      checkFonts = lib.map fetchurl (import ./checkfonts.nix);
+      copyFontCmd = font: "cp ${font} test/${lib.last (lib.splitString "/" font.url)}\n";
+    in
+    lib.concatMapStrings copyFontCmd checkFonts;
 
-  # Prevent the test suite from attempting to download fonts
-  postPatch = ''
-    substituteInPlace test/styles.ipynb \
-      --replace '"def testfont(exprs, fonturl):\n",' '"def testfont(exprs, fonturl):\n", "    return\n",' \
-      --replace "mathfont='FiraMath-Regular.otf', " ""
-  '';
+  pytestFlagsArray = [ "--nbval-lax" ];
 
   pythonImportsCheck = [ "ziamath" ];
 
-  meta = with lib; {
+  meta = {
     description = "Render MathML and LaTeX Math to SVG without Latex installation";
     homepage = "https://ziamath.readthedocs.io/en/latest/";
     changelog = "https://ziamath.readthedocs.io/en/latest/changes.html";
-    license = licenses.mit;
-    maintainers = with maintainers; [ sfrijters ];
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.sfrijters ];
   };
 }


### PR DESCRIPTION
## Description of changes

Upstream updates:

https://github.com/cdelker/ziafont/releases/tag/0.9
https://github.com/cdelker/ziamath/releases/tag/0.11

The ziafont test suite now tries to download a font file in another test notebook. Since this package is about typesetting I think it makes sense to download the fonts files ourselves instead of reducing the test suite even more.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
