### PR TITLE
cc-wrapper: add support for `ibt` hardening flag on aarch64 & x86_64

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1560,6 +1560,14 @@ This should be turned off or fixed for build errors such as:
 sorry, unimplemented: __builtin_clear_padding not supported for variable length aggregates
 ```
 
+#### `ibt` {#ibt}
+
+This flag adds the `-fcf-protection=branch` compiler option on x86_64-linux targets and the `-mbranch-protection=bti` compiler option on aarch64-linux. This enabled "Indirect Branch Tracking" which adds "landing pad" instructions at all points in the code where an indirect branch could potentially land. Hardened indirect branch instructions are then used which will, on supporting processors, throw an error if the destination instruction is not one of these "landing pad" instructions. This makes it much harder for an attacker to hijack one of the indirect branches instructions to jump to an unexpected point in code and ultimately gain arbitrary code execution.
+
+This is currently only supported on some newer Intel processors as part of the Intel CET set of features and on ARM v8.5+ processors (where the feature is known as BTI - Branch Target Indication). However, the generated code should continue to work on older processors which will simply omit any of this checking, treating "landing pad" instructions as no-ops and the hardened indirect branch instrutions will be treated as normal indirect branches.
+
+If enabling this hardening flag it is important to test the result on a system that has known working and runtime-enabled IBT support, so that any such breakage can be discovered.
+
 #### `stackclashprotection` {#stackclashprotection}
 
 This flag adds the `-fstack-clash-protection` compiler option, which causes growth of a program's stack to access each successive page in order. This should force the guard page to be accessed and cause an attempt to "jump over" this guard page to crash.

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -332,6 +332,8 @@
 
 - `lib.misc.mapAttrsFlatten` is now formally deprecated and will be removed in future releases; use the identical [`lib.attrsets.mapAttrsToList`](https://nixos.org/manual/nixpkgs/unstable#function-library-lib.attrsets.mapAttrsToList) instead.
 
+- The `ibt` hardening flag has been added, though disabled by default.
+
 - `nixosTests` now provide a working IPv6 setup for VLAN 1 by default.
 
 - To facilitate dependency injection, the `imgui` package now builds a static archive using vcpkg' CMake rules.

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -745,6 +745,7 @@ stdenvNoCC.mkDerivation {
     inherit libc_bin libc_dev libc_lib;
     inherit darwinPlatformForCC darwinMinVersion darwinMinVersionVariable;
     default_hardening_flags_str = builtins.toString defaultHardeningFlags;
+    isMBranchProtectionTarget = targetPlatform.isAarch64;
   };
 
   meta =

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -442,6 +442,7 @@ pipe ((callFile ./common/builder.nix {}) ({
         && targetPlatform.libc == "glibc"
       )) "shadowstack"
       ++ optional (!(atLeast9 && targetPlatform.isLinux && targetPlatform.isAarch64)) "pacret"
+      ++ optional (!(atLeast9 && targetPlatform.isLinux && targetPlatform.isAarch64)) "ibt"
       ++ optionals (langFortran) [ "fortify" "format" ];
   };
 

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -442,7 +442,12 @@ pipe ((callFile ./common/builder.nix {}) ({
         && targetPlatform.libc == "glibc"
       )) "shadowstack"
       ++ optional (!(atLeast9 && targetPlatform.isLinux && targetPlatform.isAarch64)) "pacret"
-      ++ optional (!(atLeast9 && targetPlatform.isLinux && targetPlatform.isAarch64)) "ibt"
+      ++ optional (
+        (!atLeast8)
+        || (targetPlatform.isAarch64 && !atLeast9)
+        || !(targetPlatform.isAarch64 || targetPlatform.isx86_64)
+        || !targetPlatform.isLinux
+      ) "ibt"
       ++ optionals (langFortran) [ "fortify" "format" ];
   };
 

--- a/pkgs/development/compilers/gcc/patches/aarch64-crtstuff-cflags-bti.patch
+++ b/pkgs/development/compilers/gcc/patches/aarch64-crtstuff-cflags-bti.patch
@@ -1,0 +1,18 @@
+Ensure crtbegin, crtend et al are built with BTI on aarch64. Otherwise
+no executables using these files will be granted the BTI ELF note.
+
+gcc has built-in provisions to do the equivalent for intel's CET/IBT on x86_64
+
+diff --git a/libgcc/config/aarch64/t-aarch64 b/libgcc/config/aarch64/t-aarch64
+index b70e7b94edd..763af47777e 100644
+--- a/libgcc/config/aarch64/t-aarch64
++++ b/libgcc/config/aarch64/t-aarch64
+@@ -18,6 +18,8 @@
+ # along with GCC; see the file COPYING3.  If not see
+ # <http://www.gnu.org/licenses/>.
+ 
++CRTSTUFF_T_CFLAGS += -mbranch-protection=bti
++
+ LIB2ADD += $(srcdir)/config/aarch64/sync-cache.c
+ LIB2ADD += $(srcdir)/config/aarch64/cpuinfo.c
+ 

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -77,6 +77,7 @@ in
 ++ optional langFortran (if atLeast12 then ./gcc-12-gfortran-driving.patch else ./gfortran-driving.patch)
 ++ optional atLeast7 ./ppc-musl.patch
 ++ optional (atLeast9 && langD) ./libphobos.patch
+++ optional atLeast9 ./aarch64-crtstuff-cflags-bti.patch
 
 
 

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -149,6 +149,11 @@ let
           || !targetPlatform.isLinux
         ) "pacret"
         ++ lib.optional (
+          (lib.versionOlder release_version "8")
+          || !targetPlatform.isAarch64
+          || !targetPlatform.isLinux
+        ) "ibt"
+        ++ lib.optional (
           (lib.versionOlder release_version "11")
           || (targetPlatform.isAarch64 && (lib.versionOlder release_version "18.1"))
           || (targetPlatform.isFreeBSD && (lib.versionOlder release_version "15"))

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -149,8 +149,9 @@ let
           || !targetPlatform.isLinux
         ) "pacret"
         ++ lib.optional (
-          (lib.versionOlder release_version "8")
-          || !targetPlatform.isAarch64
+          (lib.versionOlder release_version "7")
+          || (targetPlatform.isAarch64 && (lib.versionOlder release_version "8"))
+          || !(targetPlatform.isAarch64 || targetPlatform.isx86_64)
           || !targetPlatform.isLinux
         ) "ibt"
         ++ lib.optional (

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -102,6 +102,15 @@ stdenv.mkDerivation ({
          & https://github.com/NixOS/nixpkgs/pull/188492#issuecomment-1233802991
       */
       ./reenable_DT_HASH.patch
+
+      /* Attempting to force all linker output to be marked BTI
+         causes failures, and for now we're mostly concerned with
+         getting crt1.o et al built with BTI, which isn't something
+         that needs forcing
+
+         Related thread for debian: https://lists.debian.org/debian-glibc/2023/12/msg00022.html
+      */
+      ./dont-force-bti-aarch64.patch
     ]
     /* NVCC does not support ARM intrinsics. Since <math.h> is pulled in by almost
        every HPC piece of software, without this patch CUDA compilation on ARM

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -49,6 +49,12 @@ in
     # invocation does not work.
     hardeningDisable = [ "fortify" "pie" "stackprotector" ];
 
+    # Without at least the crt files built with ibt ("BTI" on aarch64), no
+    # executables built against glibc will be granted the BTI ELF note.
+    # glibc has built-in provisions to do the equivalent for intel's CET/IBT
+    # on x86_64.
+    hardeningEnable = lib.optional stdenv.hostPlatform.isAarch64 "ibt";
+
     env = (previousAttrs.env or { }) // {
       NIX_CFLAGS_COMPILE = (previousAttrs.env.NIX_CFLAGS_COMPILE or "") + lib.concatStringsSep " "
         (builtins.concatLists [

--- a/pkgs/development/libraries/glibc/dont-force-bti-aarch64.patch
+++ b/pkgs/development/libraries/glibc/dont-force-bti-aarch64.patch
@@ -1,0 +1,18 @@
+diff --git a/sysdeps/aarch64/Makefile b/sysdeps/aarch64/Makefile
+index 141d7d9cc2..37e70d1c89 100644
+--- a/sysdeps/aarch64/Makefile
++++ b/sysdeps/aarch64/Makefile
+@@ -1,13 +1,5 @@
+ long-double-fcts = yes
+ 
+-ifeq (yes,$(aarch64-bti))
+-# Mark linker output BTI compatible, it warns on non-BTI inputs.
+-sysdep-LDFLAGS += -Wl,-z,force-bti
+-# Make warnings fatal outside the test system.
+-LDFLAGS-lib.so += -Wl,--fatal-warnings
+-LDFLAGS-rtld += -Wl,-z,force-bti,--fatal-warnings
+-endif
+-
+ ifeq ($(subdir),elf)
+ sysdep-dl-routines += dl-bti
+ 

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -434,6 +434,7 @@ in
                 hardeningUnsupportedFlags = [
                   "fortify3"
                   "shadowstack"
+                  "ibt"
                   "stackclashprotection"
                   "zerocallusedregs"
                 ];

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -116,6 +116,7 @@ let
     "fortify"
     "fortify3"
     "shadowstack"
+    "ibt"
     "pacret"
     "pic"
     "pie"

--- a/pkgs/stdenv/linux/bootstrap-tools/glibc.nix
+++ b/pkgs/stdenv/linux/bootstrap-tools/glibc.nix
@@ -27,6 +27,7 @@ derivation (
     hardeningUnsupportedFlags = [
       "fortify3"
       "shadowstack"
+      "ibt"
       "pacret"
       "stackclashprotection"
       "trivialautovarinit"

--- a/pkgs/stdenv/linux/bootstrap-tools/musl.nix
+++ b/pkgs/stdenv/linux/bootstrap-tools/musl.nix
@@ -27,6 +27,7 @@ derivation (
     hardeningUnsupportedFlags = [
       "fortify3"
       "shadowstack"
+      "ibt"
       "pacret"
       "zerocallusedregs"
       "trivialautovarinit"

--- a/pkgs/test/cc-wrapper/hardening.nix
+++ b/pkgs/test/cc-wrapper/hardening.nix
@@ -3,6 +3,7 @@
 , runCommand
 , runCommandWith
 , runCommandCC
+, bintools
 , hello
 , debian-devscripts
 }:
@@ -130,6 +131,56 @@ let
   '';
 
   brokenIf = cond: drv: if cond then drv.overrideAttrs (old: { meta = old.meta or {} // { broken = true; }; }) else drv;
+  overridePlatforms = platforms: drv: drv.overrideAttrs (old: { meta = old.meta or {} // { inherit platforms; }; });
+
+  instructionPresenceTest = label: mnemonicPattern: testBin: expectFailure: runCommand "${label}-instr-test" {
+    nativeBuildInputs = [
+      bintools
+    ];
+    buildInputs = [
+      testBin
+    ];
+  } ''
+    touch $out
+    if $OBJDUMP -d \
+      --no-addresses \
+      --no-show-raw-insn \
+      "$(PATH=$HOST_PATH type -P test-bin)" \
+      | grep -E '${mnemonicPattern}' > /dev/null ; then
+      echo "Found ${label} instructions" >&2
+      ${lib.optionalString expectFailure "exit 1"}
+    else
+      echo "Did not find ${label} instructions" >&2
+      ${lib.optionalString (!expectFailure) "exit 1"}
+    fi
+  '';
+
+  pacRetTest = testBin: expectFailure: overridePlatforms [ "aarch64-linux" ] (
+    instructionPresenceTest "pacret" "\\bpaciasp\\b" testBin expectFailure
+  );
+
+  elfNoteTest = label: pattern: testBin: expectFailure: runCommand "${label}-elf-note-test" {
+    nativeBuildInputs = [
+      bintools
+    ];
+    buildInputs = [
+      testBin
+    ];
+  } ''
+    touch $out
+    if $READELF -n "$(PATH=$HOST_PATH type -P test-bin)" \
+      | grep -E '${pattern}' > /dev/null ; then
+      echo "Found ${label} note" >&2
+      ${lib.optionalString expectFailure "exit 1"}
+    else
+      echo "Did not find ${label} note" >&2
+      ${lib.optionalString (!expectFailure) "exit 1"}
+    fi
+  '';
+
+  shadowStackTest = testBin: expectFailure: brokenIf stdenv.hostPlatform.isMusl (overridePlatforms [ "x86_64-linux" ] (
+    elfNoteTest "shadowstack" "\\bSHSTK\\b" testBin expectFailure
+  ));
 
 in nameDrvAfterAttrName ({
   bindNowExplicitEnabled = brokenIf stdenv.hostPlatform.isStatic (checkTestBin (f2exampleWithStdEnv stdenv {
@@ -197,6 +248,14 @@ in nameDrvAfterAttrName ({
     ignoreStackClashProtection = false;
   });
 
+  pacRetExplicitEnabled = pacRetTest (helloWithStdEnv stdenv {
+    hardeningEnable = [ "pacret" ];
+  }) false;
+
+  shadowStackExplicitEnabled = shadowStackTest (f1exampleWithStdEnv stdenv {
+    hardeningEnable = [ "shadowstack" ];
+  }) false;
+
   bindNowExplicitDisabled = checkTestBin (f2exampleWithStdEnv stdenv {
     hardeningDisable = [ "bindnow" ];
   }) {
@@ -263,6 +322,14 @@ in nameDrvAfterAttrName ({
     ignoreStackClashProtection = false;
     expectFailure = true;
   };
+
+  pacRetExplicitDisabled = pacRetTest (helloWithStdEnv stdenv {
+    hardeningDisable = [ "pacret" ];
+  }) true;
+
+  shadowStackExplicitDisabled = shadowStackTest (f1exampleWithStdEnv stdenv {
+    hardeningDisable = [ "shadowstack" ];
+  }) true;
 
   # most flags can't be "unsupported" by compiler alone and
   # binutils doesn't have an accessible hardeningUnsupportedFlags
@@ -465,4 +532,12 @@ in {
     ignoreStackClashProtection = false;
     expectFailure = true;
   };
+
+  allExplicitDisabledPacRet = pacRetTest (helloWithStdEnv stdenv {
+    hardeningDisable = [ "all" ];
+  }) true;
+
+  allExplicitDisabledShadowStack = shadowStackTest (f1exampleWithStdEnv stdenv {
+    hardeningDisable = [ "all" ];
+  }) true;
 }))

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -323,6 +323,7 @@ let
           stdenv = super'.withDefaultHardeningFlags (
             super'.stdenv.cc.defaultHardeningFlags ++ [
               "shadowstack"
+              "ibt"
               "pacret"
               "stackclashprotection"
               "trivialautovarinit"


### PR DESCRIPTION
## Description of changes

This sits on top of #331596 so perhaps review that first?

Background: https://en.wikipedia.org/wiki/Indirect_branch_tracking

Individual commit comments contain more detail on specific choices.

For IBT to be enabled at runtime, a binary's ELF files need to be marked as supporting IBT, and the linker won't mark them as such unless all their constituent `.o` files are marked as such. This includes the c runtime files `crti.o`, `crtn.o`, `crtbegin.o` et al. So for IBT to be usable at all on a toolchain, these files (belonging to glibc and gcc) must be built with IBT enabled. For x86_64, this is handled automagically by glibc and gcc's build systems. But for aarch64, it is not.

So, perhaps controversially, this patches glibc and gcc for all systems (not just `pkgsExtraHardening`) to build these crt files with IBT on aarch64. My reasoning is that this is _safe_ because it's basically what is being done on x86_64 anyway and if we don't do this, the `ibt` hardening flag will have no real effect on individual packages in normal package sets, leaving people unable to try it out gradually. *Also*, because these changes rely on patches, I fear they would become bitrotted if they were made optional.

"Tested" this (via the added feature tests) extensively on x86_64 (clang & gcc, cross-building for aarch64 with clang & gcc) and aarch64 (clang & gcc, cross-building for x86_64 with clang & gcc).

However, as before **I have not been able to test this on IBT-supporting hardware** because I don't have access to any. This requires ~a recent Intel/AMD processor or~, on aarch64, an ARM v8.5+-based machine (a Graviton 4 or Apple M1 might do). So again I'm going to need some community help in trying to build as many packages as possible from `pkgsExtraHardening` on some of these systems.

TODO: release notes, manual additions...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
