### PR TITLE
lib/licenses: some corrections

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -862,8 +862,6 @@ lib.mapAttrs mkLicense ({
     url = "https://opensource.org/licenses/MirOS";
   };
 
-  # spdx.org does not (yet) differentiate between the X11 and Expat versions
-  # for details see https://en.wikipedia.org/wiki/MIT_License#Various_versions
   mit = {
     spdxId = "MIT";
     fullName = "MIT License";

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -229,6 +229,7 @@ lib.mapAttrs mkLicense ({
   };
 
   bsl11 = {
+    spdxId = "BUSL-1.1";
     fullName = "Business Source License 1.1";
     url = "https://mariadb.com/bsl11";
     free = false;

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -821,11 +821,6 @@ lib.mapAttrs mkLicense ({
     fullName = "PNG Reference Library version 2";
   };
 
-  libssh2 = {
-    fullName = "libssh2 License";
-    url = "https://www.libssh2.org/license.html";
-  };
-
   libtiff = {
     spdxId = "libtiff";
     fullName = "libtiff License";

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -879,6 +879,12 @@ lib.mapAttrs mkLicense ({
     fullName = "feh License";
   };
 
+  mit-modern = {
+    # Also known as Zsh license
+    spdxId = "MIT-Modern-Variant";
+    fullName = "MIT License Modern Variant";
+  };
+
   mitAdvertising = {
     spdxId = "MIT-advertising";
     fullName = "Enlightenment License (e16)";
@@ -1309,11 +1315,6 @@ lib.mapAttrs mkLicense ({
   zlib = {
     spdxId = "Zlib";
     fullName = "zlib License";
-  };
-
-  zsh = {
-    url = "https://github.com/zsh-users/zsh/blob/master/LICENCE";
-    fullName = "Zsh License";
   };
 
   zpl20 = {

--- a/pkgs/by-name/fr/freefilesync/package.nix
+++ b/pkgs/by-name/fr/freefilesync/package.nix
@@ -131,7 +131,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     description = "Open Source File Synchronization & Backup Software";
     homepage = "https://freefilesync.org";
-    license = [ licenses.gpl3Only licenses.openssl licenses.curl licenses.libssh2 ];
+    license = [ licenses.gpl3Only licenses.openssl licenses.curl licenses.bsd3 ];
     maintainers = with maintainers; [ wegank ];
     platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/libssh2/default.nix
+++ b/pkgs/development/libraries/libssh2/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     description = "Client-side C library implementing the SSH2 protocol";
     homepage = "https://www.libssh2.org";
     platforms = platforms.all;
-    license = with licenses; [ bsd3 libssh2 ];
+    license = with licenses; [ bsd3 ];
     maintainers = with maintainers; [ SuperSandro2000 ];
   };
 }

--- a/pkgs/shells/zsh/zsh-completions/default.nix
+++ b/pkgs/shells/zsh/zsh-completions/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
       bsd3
       isc
       mit
-      zsh
+      mit-modern
     ];
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.olejorgenb ];


### PR DESCRIPTION
## Description of changes
Did the following corrections in lib.licenses:

- Business Software License add SpdxID
- rename zsh license to mit-modern because that's what it actually is.
- remove libssh2 as it is just the BSD3 license
- removed incorrect comment about MIT and X11

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
