### PR TITLE
kak-tree-sitter: init at 1.1.2

### DIFF
--- a/pkgs/by-name/ka/kak-tree-sitter-unwrapped/package.nix
+++ b/pkgs/by-name/ka/kak-tree-sitter-unwrapped/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromSourcehut,
+  nix-update-script,
+  testers,
+  kak-tree-sitter-unwrapped,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "kak-tree-sitter-unwrapped";
+  version = "1.1.2";
+
+  src = fetchFromSourcehut {
+    owner = "~hadronized";
+    repo = "kak-tree-sitter";
+    rev = "kak-tree-sitter-v${version}";
+    hash = "sha256-wBWfSyR8LGtug/mCD0bJ4lbdN3trIA/03AnCxZoEOSA=";
+  };
+
+  cargoHash = "sha256-v0DNcWPoHdquOlyPoPLoFulz66yCPR1W1Z3uuTjli5k=";
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion { package = kak-tree-sitter-unwrapped; };
+  };
+
+  meta = {
+    homepage = "https://git.sr.ht/~hadronized/kak-tree-sitter";
+    description = "Server that interfaces tree-sitter with kakoune";
+    mainProgram = "kak-tree-sitter";
+    license = with lib.licenses; [ bsd3 ];
+    maintainers = with lib.maintainers; [ lelgenio ];
+  };
+}

--- a/pkgs/by-name/ka/kak-tree-sitter/package.nix
+++ b/pkgs/by-name/ka/kak-tree-sitter/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  makeWrapper,
+  symlinkJoin,
+  tinycc,
+  kak-tree-sitter-unwrapped,
+}:
+
+symlinkJoin rec {
+  pname = lib.replaceStrings [ "-unwrapped" ] [ "" ] kak-tree-sitter-unwrapped.pname;
+  inherit (kak-tree-sitter-unwrapped) version;
+  name = "${pname}-${version}";
+
+  paths = [ kak-tree-sitter-unwrapped ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  # Tree-Sitter grammars are C programs that need to be compiled
+  # Use tinycc as cc to reduce closure size
+  postBuild = ''
+    mkdir -p $out/libexec/tinycc/bin
+    ln -s ${lib.getExe tinycc} $out/libexec/tinycc/bin/cc
+    wrapProgram "$out/bin/ktsctl" \
+      --suffix PATH : $out/libexec/tinycc/bin
+  '';
+
+  inherit (kak-tree-sitter-unwrapped) meta;
+}


### PR DESCRIPTION
## Description of changes

Kakoune extension that adds support for tree-sitter grammars, instead of the basic regex-based default.

Home: https://git.sr.ht/~hadronized/kak-tree-sitter

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
