### PR TITLE
lib.meta.licensesSpdx: mapping from SPDX ID to compatible licenses

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -123,7 +123,8 @@ let
     inherit (self.derivations) lazyDerivation optionalDrvAttr;
     inherit (self.meta) addMetaAttrs dontDistribute setName updateName
       appendToName mapDerivationAttrset setPrio lowPrio lowPrioSet hiPrio
-      hiPrioSet getLicenseFromSpdxId getLicenseFromSpdxIdOr getExe getExe';
+      hiPrioSet licensesSpdx getLicenseFromSpdxId getLicenseFromSpdxIdOr
+      getExe getExe';
     inherit (self.filesystem) pathType pathIsDirectory pathIsRegularFile
       packagesFromDirectoryRecursive;
     inherit (self.sources) cleanSourceFilter

--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -7,6 +7,7 @@
 
 let
   inherit (lib) matchAttrs any all isDerivation getBin assertMsg;
+  inherit (lib.attrsets) mapAttrs' filterAttrs;
   inherit (builtins) isString match typeOf;
 
 in
@@ -289,7 +290,8 @@ rec {
   /**
     Mapping of SPDX ID to the attributes in lib.licenses.
 
-    For SPDX IDs, see https://spdx.org/licenses
+    For SPDX IDs, see https://spdx.org/licenses.
+    Note that some SPDX licenses might be missing.
 
     # Examples
     :::{.example}
@@ -305,18 +307,19 @@ rec {
     :::
   */
   licensesSpdx =
-    lib.attrsets.mapAttrs'
+    mapAttrs'
     (_key: license: {
       name = license.spdxId;
       value = license;
     })
-    (lib.attrsets.filterAttrs (_key: license: license ? spdxId) lib.licenses);
+    (filterAttrs (_key: license: license ? spdxId) lib.licenses);
 
   /**
     Get the corresponding attribute in lib.licenses from the SPDX ID
     or warn and fallback to `{ shortName = <license string>; }`.
 
-    For SPDX IDs, see https://spdx.org/licenses
+    For SPDX IDs, see https://spdx.org/licenses.
+    Note that some SPDX licenses might be missing.
 
     # Type
 
@@ -351,7 +354,8 @@ rec {
     Get the corresponding attribute in lib.licenses from the SPDX ID
     or fallback to the given default value.
 
-    For SPDX IDs, see https://spdx.org/licenses
+    For SPDX IDs, see https://spdx.org/licenses.
+    Note that some SPDX licenses might be missing.
 
     # Inputs
 


### PR DESCRIPTION
## Description of changes

Adds a mapping from SPDX IDs to the licenses defined in `lib.licenses`, available in `lib.licenses-spdx`.

I've needed this several times, so figured I'd add it to the lib. Do let me know if this is appropriate! :)

This is my first non-package contribution to Nix, so of course any and all feedback is welcome! :) (although hopefully there isn't much to say about such a simple change)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
