### PR TITLE
moonlight-qt: add libdrm to buildInputs

### DIFF
--- a/pkgs/by-name/mo/moonlight-qt/package.nix
+++ b/pkgs/by-name/mo/moonlight-qt/package.nix
@@ -20,6 +20,7 @@
   libvdpau,
   libxkbcommon,
   wayland,
+  libdrm,
   nix-update-script,
 }:
 
@@ -80,6 +81,7 @@ stdenv'.mkDerivation rec {
       libxkbcommon
       qt6.qtwayland
       wayland
+      libdrm
     ]
     ++ lib.optionals stdenv.isDarwin [
       AVFoundation


### PR DESCRIPTION
Listed as build requirement in source repo's README. Required (at least in some cases) for hardware-accelerated video decoding to work.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->
libdrm is listed as a build requirement in moonligh-qt's README.

On my system (nixos-unstable on i5-1240p with Intel iGPU), this is required to use hardware accelerated video decoding.
Without libdrm, I get the following errors on the console output:
```
00:00:01 - SDL Info (0): Using DRM renderer
00:00:01 - FFmpeg: [h264_mp4toannexb @ 0x7f5d0849c080] The input looks like it is Annex B already
00:00:01 - FFmpeg: [h264_cuvid @ 0x7f5d081678c0] ff_get_format failed: -1
00:00:01 - SDL Error (0): Unable to open decoder for format: 1
00:00:01 - SDL Warn (0): No renderer can handle output from decoder: h264_cuvid
00:00:01 - SDL Error (0): Unable to open Wayland display for VAAPI
00:00:01 - SDL Info (0): Skipping VAAPI fallback driver names on libva 2.20+
00:00:01 - SDL Error (0): Failed to initialize VAAPI: 3
00:00:01 - SDL Error (0): Unable to open Wayland display for VAAPI
00:00:01 - SDL Info (0): Skipping VAAPI fallback driver names on libva 2.20+
00:00:01 - SDL Error (0): Failed to initialize VAAPI: 3
00:00:01 - SDL Warn (0): VDPAU is not supported on Wayland
00:00:01 - SDL Warn (0): VDPAU is not supported on Wayland
00:00:01 - SDL Info (0): Using SDL renderer
```
Also there's a big UI popup about HW acceleration not working.

With libdrm added, HW acceleration works (confirmed by forcing hardware acceleration in the settings, which would throw an error before).

I've confirmed that VAAPI video acceleration is correctly set up on my system according to the [wiki](https://wiki.nixos.org/wiki/Accelerated_Video_Playback). Other applications also work fine (tested with vainfo and mpv).
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
