### PR TITLE
darwin.stdenv: format with nixfmt-rfc-style

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -159,3 +159,6 @@ fbdcdde04a7caa007e825a8b822c75fab9adb2d6
 
 # step-cli: format package.nix with nixfmt (#331629)
 fc7a83f8b62e90de5679e993d4d49ca014ea013d
+
+# darwin.stdenv: format with nixfmt-rfc-style (#333962)
+93c10ac9e561c6594d3baaeaff2341907390d9b8

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -7,17 +7,19 @@
 # See also the top comments of the Linux stdenv `../linux/default.nix` for a good overview of
 # the bootstrap process and working with it.
 
-{ lib
-, localSystem
-, crossSystem
-, config
-, overlays
-, crossOverlays ? [ ]
+{
+  lib,
+  localSystem,
+  crossSystem,
+  config,
+  overlays,
+  crossOverlays ? [ ],
   # Allow passing in bootstrap files directly so we can test the stdenv bootstrap process when changing the bootstrap tools
-, bootstrapFiles ? if localSystem.isAarch64 then
-    import ./bootstrap-files/aarch64-apple-darwin.nix
-  else
-    import ./bootstrap-files/x86_64-apple-darwin.nix
+  bootstrapFiles ?
+    if localSystem.isAarch64 then
+      import ./bootstrap-files/aarch64-apple-darwin.nix
+    else
+      import ./bootstrap-files/x86_64-apple-darwin.nix,
 }:
 
 assert crossSystem == localSystem;
@@ -34,12 +36,9 @@ let
   ];
 
   isFromNixpkgs = pkg: !(isFromBootstrapFiles pkg);
-  isFromBootstrapFiles =
-    pkg: pkg.passthru.isFromBootstrapFiles or false;
-  isBuiltByNixpkgsCompiler =
-    pkg: isFromNixpkgs pkg && isFromNixpkgs pkg.stdenv.cc.cc;
-  isBuiltByBootstrapFilesCompiler =
-    pkg: isFromNixpkgs pkg && isFromBootstrapFiles pkg.stdenv.cc.cc;
+  isFromBootstrapFiles = pkg: pkg.passthru.isFromBootstrapFiles or false;
+  isBuiltByNixpkgsCompiler = pkg: isFromNixpkgs pkg && isFromNixpkgs pkg.stdenv.cc.cc;
+  isBuiltByBootstrapFilesCompiler = pkg: isFromNixpkgs pkg && isFromBootstrapFiles pkg.stdenv.cc.cc;
 
   commonPreHook = ''
     export NIX_ENFORCE_NO_NATIVE=''${NIX_ENFORCE_NO_NATIVE-1}
@@ -48,84 +47,97 @@ let
     unset SDKROOT
   '';
 
-  bootstrapTools = derivation ({
-    inherit system;
+  bootstrapTools =
+    derivation (
+      {
+        inherit system;
 
-    name = "bootstrap-tools";
-    builder = "${bootstrapFiles.unpack}/bin/bash";
+        name = "bootstrap-tools";
+        builder = "${bootstrapFiles.unpack}/bin/bash";
 
-    args = [
-      "${bootstrapFiles.unpack}/bootstrap-tools-unpack.sh"
-        bootstrapFiles.bootstrapTools
-    ];
-
-    PATH = lib.makeBinPath [
-      (placeholder "out")
-      bootstrapFiles.unpack
-    ];
-
-    __impureHostDeps = commonImpureHostDeps;
-  } // lib.optionalAttrs config.contentAddressedByDefault {
-    __contentAddressed = true;
-    outputHashAlgo = "sha256";
-    outputHashMode = "recursive";
-  }) // { passthru.isFromBootstrapFiles = true; };
-
-  stageFun = prevStage:
-    { name, overrides ? (self: super: { }), extraNativeBuildInputs ? [ ], extraPreHook ? "" }:
-
-    let
-      cc = if prevStage.llvmPackages.clang-unwrapped == null
-           then null else
-           lib.makeOverridable (import ../../build-support/cc-wrapper) {
-        name = "${name}-clang-wrapper";
-
-        nativeTools = false;
-        nativeLibc = false;
-
-        expand-response-params = lib.optionalString
-          (prevStage.stdenv.hasCC or false && prevStage.stdenv.cc != "/dev/null")
-          prevStage.expand-response-params;
-
-        extraPackages = [
-          prevStage.llvmPackages.compiler-rt
+        args = [
+          "${bootstrapFiles.unpack}/bootstrap-tools-unpack.sh"
+          bootstrapFiles.bootstrapTools
         ];
 
-        extraBuildCommands =
-          let
-            inherit (prevStage.llvmPackages) clang-unwrapped compiler-rt release_version;
-          in
-          ''
-            function clangResourceRootIncludePath() {
-              clangLib="$1/lib/clang"
-              if (( $(ls "$clangLib" | wc -l) > 1 )); then
-                echo "Multiple LLVM versions were found at "$clangLib", but there must only be one used when building the stdenv." >&2
-                exit 1
-              fi
-              echo "$clangLib/$(ls -1 "$clangLib")/include"
-            }
+        PATH = lib.makeBinPath [
+          (placeholder "out")
+          bootstrapFiles.unpack
+        ];
 
-            rsrc="$out/resource-root"
-            mkdir "$rsrc"
-            ln -s "$(clangResourceRootIncludePath "${clang-unwrapped.lib}")" "$rsrc"
-            ln -s "${compiler-rt.out}/lib"   "$rsrc/lib"
-            ln -s "${compiler-rt.out}/share" "$rsrc/share"
-            echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
-          '';
+        __impureHostDeps = commonImpureHostDeps;
+      }
+      // lib.optionalAttrs config.contentAddressedByDefault {
+        __contentAddressed = true;
+        outputHashAlgo = "sha256";
+        outputHashMode = "recursive";
+      }
+    )
+    // {
+      passthru.isFromBootstrapFiles = true;
+    };
 
-        cc = prevStage.llvmPackages.clang-unwrapped;
-        bintools = prevStage.darwin.binutils;
+  stageFun =
+    prevStage:
+    {
+      name,
+      overrides ? (self: super: { }),
+      extraNativeBuildInputs ? [ ],
+      extraPreHook ? "",
+    }:
 
-        isClang = true;
-        libc = prevStage.darwin.Libsystem;
-        inherit (prevStage.llvmPackages) libcxx;
+    let
+      cc =
+        if prevStage.llvmPackages.clang-unwrapped == null then
+          null
+        else
+          lib.makeOverridable (import ../../build-support/cc-wrapper) {
+            name = "${name}-clang-wrapper";
 
-        inherit lib;
-        inherit (prevStage) coreutils gnugrep;
+            nativeTools = false;
+            nativeLibc = false;
 
-        stdenvNoCC = prevStage.ccWrapperStdenv;
-        runtimeShell = prevStage.ccWrapperStdenv.shell;
-      };
+            expand-response-params = lib.optionalString (
+              prevStage.stdenv.hasCC or false && prevStage.stdenv.cc != "/dev/null"
+            ) prevStage.expand-response-params;
+
+            extraPackages = [ prevStage.llvmPackages.compiler-rt ];
+
+            extraBuildCommands =
+              let
+                inherit (prevStage.llvmPackages) clang-unwrapped compiler-rt release_version;
+              in
+              ''
+                function clangResourceRootIncludePath() {
+                  clangLib="$1/lib/clang"
+                  if (( $(ls "$clangLib" | wc -l) > 1 )); then
+                    echo "Multiple LLVM versions were found at "$clangLib", but there must only be one used when building the stdenv." >&2
+                    exit 1
+                  fi
+                  echo "$clangLib/$(ls -1 "$clangLib")/include"
+                }
+
+                rsrc="$out/resource-root"
+                mkdir "$rsrc"
+                ln -s "$(clangResourceRootIncludePath "${clang-unwrapped.lib}")" "$rsrc"
+                ln -s "${compiler-rt.out}/lib"   "$rsrc/lib"
+                ln -s "${compiler-rt.out}/share" "$rsrc/share"
+                echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
+              '';
+
+            cc = prevStage.llvmPackages.clang-unwrapped;
+            bintools = prevStage.darwin.binutils;
+
+            isClang = true;
+            libc = prevStage.darwin.Libsystem;
+            inherit (prevStage.llvmPackages) libcxx;
+
+            inherit lib;
+            inherit (prevStage) coreutils gnugrep;
+
+            stdenvNoCC = prevStage.ccWrapperStdenv;
+            runtimeShell = prevStage.ccWrapperStdenv.shell;
+          };
 
       bash = prevStage.bash or bootstrapTools;
 
@@ -139,22 +151,27 @@ let
         inherit config;
 
         extraBuildInputs = [ prevStage.darwin.CF ];
-        extraNativeBuildInputs = extraNativeBuildInputs
-          ++ [ prevStage.darwin.apple_sdk.sdkRoot ];
+        extraNativeBuildInputs = extraNativeBuildInputs ++ [ prevStage.darwin.apple_sdk.sdkRoot ];
 
-        preHook = lib.optionalString (!isBuiltByNixpkgsCompiler bash) ''
-          # Don't patch #!/interpreter because it leads to retained
-          # dependencies on the bootstrapTools in the final stdenv.
-          dontPatchShebangs=1
-        '' + ''
-          ${commonPreHook}
-          ${extraPreHook}
-        '' + lib.optionalString (prevStage.darwin ? locale) ''
-          export PATH_LOCALE=${prevStage.darwin.locale}/share/locale
-        '';
+        preHook =
+          lib.optionalString (!isBuiltByNixpkgsCompiler bash) ''
+            # Don't patch #!/interpreter because it leads to retained
+            # dependencies on the bootstrapTools in the final stdenv.
+            dontPatchShebangs=1
+          ''
+          + ''
+            ${commonPreHook}
+            ${extraPreHook}
+          ''
+          + lib.optionalString (prevStage.darwin ? locale) ''
+            export PATH_LOCALE=${prevStage.darwin.locale}/share/locale
+          '';
 
         shell = bash + "/bin/bash";
-        initialPath = [ bash bootstrapTools ];
+        initialPath = [
+          bash
+          bootstrapTools
+        ];
 
         fetchurlBoot = import ../../build-support/fetchurl {
           inherit lib;
@@ -171,11 +188,14 @@ let
         # Using the bootstrap tools curl for fetchers allows the stdenv bootstrap to avoid
         # having a dependency on curl, allowing curl to be updated without triggering a
         # new stdenv bootstrap on Darwin.
-        overrides = self: super: (overrides self super) // {
-          fetchurl = thisStdenv.fetchurlBoot;
-          fetchpatch = super.fetchpatch.override { inherit (self) fetchurl; };
-          fetchzip = super.fetchzip.override { inherit (self) fetchurl; };
-        };
+        overrides =
+          self: super:
+          (overrides self super)
+          // {
+            fetchurl = thisStdenv.fetchurlBoot;
+            fetchpatch = super.fetchpatch.override { inherit (self) fetchurl; };
+            fetchzip = super.fetchzip.override { inherit (self) fetchurl; };
+          };
       };
 
     in
@@ -184,533 +204,783 @@ let
       stdenv = thisStdenv;
     };
 in
-  assert bootstrapTools.passthru.isFromBootstrapFiles or false;  # sanity check
+assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
 [
-  ({}: {
-    __raw = true;
+  (
+    { }:
+    {
+      __raw = true;
 
-    cctools = true;
-    ld64 = true;
+      cctools = true;
+      ld64 = true;
 
-    coreutils = null;
-    gnugrep = null;
+      coreutils = null;
+      gnugrep = null;
 
-    pbzx = null;
-    cpio = null;
+      pbzx = null;
+      cpio = null;
 
-    darwin = {
-      apple_sdk.sdkRoot = null;
-      binutils = null;
-      binutils-unwrapped = null;
-      print-reexports = null;
-      rewrite-tbd = null;
-      sigtool = null;
-      CF = null;
-      Libsystem = null;
-    };
+      darwin = {
+        apple_sdk.sdkRoot = null;
+        binutils = null;
+        binutils-unwrapped = null;
+        print-reexports = null;
+        rewrite-tbd = null;
+        sigtool = null;
+        CF = null;
+        Libsystem = null;
+      };
 
-    llvmPackages = {
-      clang-unwrapped = null;
-      libllvm = null;
-      libcxx = null;
-      compiler-rt = null;
-    };
-  })
+      llvmPackages = {
+        clang-unwrapped = null;
+        libllvm = null;
+        libcxx = null;
+        compiler-rt = null;
+      };
+    }
+  )
 
   # Create a stage with the bootstrap tools. This will be used to build the subsequent stages and
   # build up the standard environment.
   #
   # Note: Each stage depends only on the the packages in `prevStage`. If a package is not to be
   # rebuilt, it should be passed through by inheriting it.
-  (prevStage: stageFun prevStage {
-    name = "bootstrap-stage0";
+  (
+    prevStage:
+    stageFun prevStage {
+      name = "bootstrap-stage0";
 
-    overrides = self: super: {
-      # We thread stage0's stdenv through under this name so downstream stages
-      # can use it for wrapping gcc too. This way, downstream stages don't need
-      # to refer to this stage directly, which violates the principle that each
-      # stage should only access the stage that came before it.
-      ccWrapperStdenv = self.stdenv;
+      overrides = self: super: {
+        # We thread stage0's stdenv through under this name so downstream stages
+        # can use it for wrapping gcc too. This way, downstream stages don't need
+        # to refer to this stage directly, which violates the principle that each
+        # stage should only access the stage that came before it.
+        ccWrapperStdenv = self.stdenv;
 
-      bash = bootstrapTools // {
-        shellPath = "/bin/bash";
-      };
-
-      coreutils = bootstrapTools;
-      cpio = bootstrapTools;
-      gnugrep = bootstrapTools;
-      pbzx = bootstrapTools;
-
-      cctools = super.stdenv.mkDerivation {
-        pname = "bootstrap-stage0-cctools";
-        version = "boot";
-
-        buildCommand = ''
-          declare -a cctools=(
-            ar
-            bitcode_strip
-            check_dylib
-            checksyms
-            cmpdylib
-            codesign_allocate
-            ctf_insert
-            depinfo
-            diagtest
-            gas
-            gprof
-            install_name_tool
-            libtool
-            lipo
-            mtoc
-            mtor
-            nm
-            nmedit
-            otool
-            pagestuff
-            ranlib
-            redo_prebinding
-            seg_addr_table
-            seg_hack
-            segedit
-            size
-            strings
-            strip
-            vtool
-          )
-
-          mkdir -p "$out/bin"
-          for tool in "''${cctools[@]}"; do
-            toolsrc="${bootstrapTools}/bin/$tool"
-            if [ -e "$toolsrc" ]; then
-              ln -s "$toolsrc" "$out/bin"
-            fi
-          done
-
-          # Copy only the required headers to avoid accidentally linking headers that belong to other packages,
-          # which can cause problems when building Libsystem in the source-based SDK.
-          declare -a machohdrs=(
-            arch.h
-            fat.h
-            fixup-chains.h
-            getsect.h
-            ldsyms.h
-            loader.h
-            nlist.h
-            ranlib.h
-            reloc.h
-            stab.h
-            swap.h
-            arm
-            arm64
-            hppa
-            i386
-            i860
-            m68k
-            m88k
-            ppc
-            sparc
-            x86_64
-          )
-
-          mkdir -p "$out/include/mach-o"
-          for header in "''${machohdrs[@]}"; do
-            machosrc="${bootstrapTools}/include-Libsystem/mach-o/$header"
-            if [ -e "$machosrc" ]; then
-              cp -r "$machosrc" "$out/include/mach-o/$header"
-            fi
-          done
-        '';
-
-        passthru = {
-          isFromBootstrapFiles = true;
-          targetPrefix = "";
-        };
-      };
-
-      ld64 = bootstrapTools // {
-        targetPrefix = "";
-        version = "boot";
-      };
-
-      darwin = super.darwin.overrideScope (selfDarwin: superDarwin: {
-        # Prevent CF from being propagated to the initial stdenv. Packages that require it
-        # will have to manually add it to their build inputs.
-        CF = null;
-
-        binutils = super.wrapBintoolsWith {
-          name = "bootstrap-stage0-binutils-wrapper";
-
-          nativeTools = false;
-          nativeLibc = false;
-
-          expand-response-params = "";
-          libc = selfDarwin.Libsystem;
-
-          inherit lib;
-          inherit (self) stdenvNoCC coreutils gnugrep;
-          runtimeShell = self.stdenvNoCC.shell;
-
-          bintools = selfDarwin.binutils-unwrapped;
-
-          # Bootstrap tools cctools needs the hook and wrappers to make sure things are signed properly.
-          # This can be dropped once the bootstrap tools cctools has been updated to 1010.6.
-          extraBuildCommands = ''
-            echo 'source ${selfDarwin.postLinkSignHook}' >> $out/nix-support/post-link-hook
-
-            export signingUtils=${selfDarwin.signingUtils}
-
-            wrap \
-              install_name_tool ${../../build-support/bintools-wrapper/darwin-install_name_tool-wrapper.sh} \
-              "${selfDarwin.binutils-unwrapped}/bin/install_name_tool"
-
-            wrap \
-              strip ${../../build-support/bintools-wrapper/darwin-strip-wrapper.sh} \
-              "${selfDarwin.binutils-unwrapped}/bin/strip"
-          '';
+        bash = bootstrapTools // {
+          shellPath = "/bin/bash";
         };
 
-        binutils-unwrapped = (superDarwin.binutils-unwrapped.overrideAttrs (old: {
+        coreutils = bootstrapTools;
+        cpio = bootstrapTools;
+        gnugrep = bootstrapTools;
+        pbzx = bootstrapTools;
+
+        cctools = super.stdenv.mkDerivation {
+          pname = "bootstrap-stage0-cctools";
           version = "boot";
-          passthru = (old.passthru or { }) // {
-            isFromBootstrapFiles = true;
-          };
-        })).override { enableManpages = false; };
 
-        locale = self.stdenv.mkDerivation {
-          name = "bootstrap-stage0-locale";
           buildCommand = ''
-            mkdir -p $out/share/locale
-          '';
-        };
+            declare -a cctools=(
+              ar
+              bitcode_strip
+              check_dylib
+              checksyms
+              cmpdylib
+              codesign_allocate
+              ctf_insert
+              depinfo
+              diagtest
+              gas
+              gprof
+              install_name_tool
+              libtool
+              lipo
+              mtoc
+              mtor
+              nm
+              nmedit
+              otool
+              pagestuff
+              ranlib
+              redo_prebinding
+              seg_addr_table
+              seg_hack
+              segedit
+              size
+              strings
+              strip
+              vtool
+            )
 
-        print-reexports = bootstrapTools;
-
-        rewrite-tbd = bootstrapTools;
-
-        sigtool = bootstrapTools;
-      } // lib.optionalAttrs (! useAppleSDKLibs) {
-        Libsystem = self.stdenv.mkDerivation {
-          name = "bootstrap-stage0-Libsystem";
-          buildCommand = ''
-            mkdir -p $out
-
-            cp -r ${selfDarwin.darwin-stubs}/usr/lib $out/lib
-            chmod -R +w $out/lib
-            substituteInPlace $out/lib/libSystem.B.tbd --replace /usr/lib/system $out/lib/system
-
-            ln -s libSystem.B.tbd $out/lib/libSystem.tbd
-
-            for name in c dbm dl info m mx poll proc pthread rpcsvc util gcc_s.10.4 gcc_s.10.5; do
-              ln -s libSystem.tbd $out/lib/lib$name.tbd
+            mkdir -p "$out/bin"
+            for tool in "''${cctools[@]}"; do
+              toolsrc="${bootstrapTools}/bin/$tool"
+              if [ -e "$toolsrc" ]; then
+                ln -s "$toolsrc" "$out/bin"
+              fi
             done
 
-            ln -s ${bootstrapTools}/lib/*.o $out/lib
+            # Copy only the required headers to avoid accidentally linking headers that belong to other packages,
+            # which can cause problems when building Libsystem in the source-based SDK.
+            declare -a machohdrs=(
+              arch.h
+              fat.h
+              fixup-chains.h
+              getsect.h
+              ldsyms.h
+              loader.h
+              nlist.h
+              ranlib.h
+              reloc.h
+              stab.h
+              swap.h
+              arm
+              arm64
+              hppa
+              i386
+              i860
+              m68k
+              m88k
+              ppc
+              sparc
+              x86_64
+            )
 
-            ln -s ${bootstrapTools}/lib/libresolv.9.dylib $out/lib
-            ln -s libresolv.9.dylib $out/lib/libresolv.dylib
-
-            ln -s ${bootstrapTools}/include-Libsystem $out/include
+            mkdir -p "$out/include/mach-o"
+            for header in "''${machohdrs[@]}"; do
+              machosrc="${bootstrapTools}/include-Libsystem/mach-o/$header"
+              if [ -e "$machosrc" ]; then
+                cp -r "$machosrc" "$out/include/mach-o/$header"
+              fi
+            done
           '';
-          passthru.isFromBootstrapFiles = true;
+
+          passthru = {
+            isFromBootstrapFiles = true;
+            targetPrefix = "";
+          };
         };
-      });
 
-      llvmPackages = super.llvmPackages // (
-        let
-          tools = super.llvmPackages.tools.extend (selfTools: _: {
-            libclang = self.stdenv.mkDerivation {
-              name = "bootstrap-stage0-clang";
-              version = "boot";
-              outputs = [ "out" "lib" ];
-              buildCommand = ''
-                mkdir -p $out/lib
-                ln -s $out $lib
-                ln -s ${bootstrapTools}/bin       $out/bin
-                ln -s ${bootstrapTools}/lib/clang $out/lib
-                ln -s ${bootstrapTools}/include   $out
+        ld64 = bootstrapTools // {
+          targetPrefix = "";
+          version = "boot";
+        };
+
+        darwin = super.darwin.overrideScope (
+          selfDarwin: superDarwin:
+          {
+            # Prevent CF from being propagated to the initial stdenv. Packages that require it
+            # will have to manually add it to their build inputs.
+            CF = null;
+
+            binutils = super.wrapBintoolsWith {
+              name = "bootstrap-stage0-binutils-wrapper";
+
+              nativeTools = false;
+              nativeLibc = false;
+
+              expand-response-params = "";
+              libc = selfDarwin.Libsystem;
+
+              inherit lib;
+              inherit (self) stdenvNoCC coreutils gnugrep;
+              runtimeShell = self.stdenvNoCC.shell;
+
+              bintools = selfDarwin.binutils-unwrapped;
+
+              # Bootstrap tools cctools needs the hook and wrappers to make sure things are signed properly.
+              # This can be dropped once the bootstrap tools cctools has been updated to 1010.6.
+              extraBuildCommands = ''
+                echo 'source ${selfDarwin.postLinkSignHook}' >> $out/nix-support/post-link-hook
+
+                export signingUtils=${selfDarwin.signingUtils}
+
+                wrap \
+                  install_name_tool ${../../build-support/bintools-wrapper/darwin-install_name_tool-wrapper.sh} \
+                  "${selfDarwin.binutils-unwrapped}/bin/install_name_tool"
+
+                wrap \
+                  strip ${../../build-support/bintools-wrapper/darwin-strip-wrapper.sh} \
+                  "${selfDarwin.binutils-unwrapped}/bin/strip"
               '';
-              passthru = {
-                isFromBootstrapFiles = true;
-                hardeningUnsupportedFlags = [
-                  "fortify3"
-                  "shadowstack"
-                  "stackclashprotection"
-                  "zerocallusedregs"
-                ];
-              };
             };
-            libllvm = self.stdenv.mkDerivation {
-              name = "bootstrap-stage0-llvm";
-              outputs = [ "out" "lib" ];
+
+            binutils-unwrapped =
+              (superDarwin.binutils-unwrapped.overrideAttrs (old: {
+                version = "boot";
+                passthru = (old.passthru or { }) // {
+                  isFromBootstrapFiles = true;
+                };
+              })).override
+                { enableManpages = false; };
+
+            locale = self.stdenv.mkDerivation {
+              name = "bootstrap-stage0-locale";
               buildCommand = ''
-                mkdir -p $out/bin $out/lib
-                ln -s $out $lib
-                for tool in ${toString super.darwin.binutils-unwrapped.llvm_cmds}; do
-                  cctoolsTool=''${tool//-/_}
-                  toolsrc="${bootstrapTools}/bin/$cctoolsTool"
-                  if [ -e "$toolsrc" ]; then
-                    ln -s "$toolsrc" $out/bin/llvm-$tool
-                  fi
+                mkdir -p $out/share/locale
+              '';
+            };
+
+            print-reexports = bootstrapTools;
+
+            rewrite-tbd = bootstrapTools;
+
+            sigtool = bootstrapTools;
+          }
+          // lib.optionalAttrs (!useAppleSDKLibs) {
+            Libsystem = self.stdenv.mkDerivation {
+              name = "bootstrap-stage0-Libsystem";
+              buildCommand = ''
+                mkdir -p $out
+
+                cp -r ${selfDarwin.darwin-stubs}/usr/lib $out/lib
+                chmod -R +w $out/lib
+                substituteInPlace $out/lib/libSystem.B.tbd --replace /usr/lib/system $out/lib/system
+
+                ln -s libSystem.B.tbd $out/lib/libSystem.tbd
+
+                for name in c dbm dl info m mx poll proc pthread rpcsvc util gcc_s.10.4 gcc_s.10.5; do
+                  ln -s libSystem.tbd $out/lib/lib$name.tbd
                 done
-                ln -s ${bootstrapTools}/bin/dsymutil $out/bin/dsymutil
-                ln -s ${bootstrapTools}/lib/libLLVM* $out/lib
-              '';
-              passthru.isFromBootstrapFiles = true;
-            };
-          });
-          libraries = super.llvmPackages.libraries.extend (_: _: {
-            libcxx = self.stdenv.mkDerivation {
-              name = "bootstrap-stage0-libcxx";
-              buildCommand = ''
-                mkdir -p $out/lib $out/include
-                ln -s ${bootstrapTools}/lib/libc++.dylib $out/lib
-                ln -s ${bootstrapTools}/include/c++      $out/include
-              '';
-              passthru = {
-                isLLVM = true;
-                isFromBootstrapFiles = true;
-              };
-            };
-            compiler-rt = self.stdenv.mkDerivation {
-              name = "bootstrap-stage0-compiler-rt";
-              buildCommand = ''
-                mkdir -p $out/lib $out/share
-                ln -s ${bootstrapTools}/lib/libclang_rt* $out/lib
-                ln -s ${bootstrapTools}/lib/darwin       $out/lib
-              '';
-              passthru.isFromBootstrapFiles = true;
-            };
-          });
-        in
-        { inherit tools libraries; } // tools // libraries
-      );
-    };
 
-    extraPreHook = ''
-      stripDebugFlags="-S" # llvm-strip does not support "-p" for Mach-O
-    '';
-  })
+                ln -s ${bootstrapTools}/lib/*.o $out/lib
+
+                ln -s ${bootstrapTools}/lib/libresolv.9.dylib $out/lib
+                ln -s libresolv.9.dylib $out/lib/libresolv.dylib
+
+                ln -s ${bootstrapTools}/include-Libsystem $out/include
+              '';
+              passthru.isFromBootstrapFiles = true;
+            };
+          }
+        );
+
+        llvmPackages =
+          super.llvmPackages
+          // (
+            let
+              tools = super.llvmPackages.tools.extend (
+                selfTools: _: {
+                  libclang = self.stdenv.mkDerivation {
+                    name = "bootstrap-stage0-clang";
+                    version = "boot";
+                    outputs = [
+                      "out"
+                      "lib"
+                    ];
+                    buildCommand = ''
+                      mkdir -p $out/lib
+                      ln -s $out $lib
+                      ln -s ${bootstrapTools}/bin       $out/bin
+                      ln -s ${bootstrapTools}/lib/clang $out/lib
+                      ln -s ${bootstrapTools}/include   $out
+                    '';
+                    passthru = {
+                      isFromBootstrapFiles = true;
+                      hardeningUnsupportedFlags = [
+                        "fortify3"
+                        "shadowstack"
+                        "stackclashprotection"
+                        "zerocallusedregs"
+                      ];
+                    };
+                  };
+                  libllvm = self.stdenv.mkDerivation {
+                    name = "bootstrap-stage0-llvm";
+                    outputs = [
+                      "out"
+                      "lib"
+                    ];
+                    buildCommand = ''
+                      mkdir -p $out/bin $out/lib
+                      ln -s $out $lib
+                      for tool in ${toString super.darwin.binutils-unwrapped.llvm_cmds}; do
+                        cctoolsTool=''${tool//-/_}
+                        toolsrc="${bootstrapTools}/bin/$cctoolsTool"
+                        if [ -e "$toolsrc" ]; then
+                          ln -s "$toolsrc" $out/bin/llvm-$tool
+                        fi
+                      done
+                      ln -s ${bootstrapTools}/bin/dsymutil $out/bin/dsymutil
+                      ln -s ${bootstrapTools}/lib/libLLVM* $out/lib
+                    '';
+                    passthru.isFromBootstrapFiles = true;
+                  };
+                }
+              );
+              libraries = super.llvmPackages.libraries.extend (
+                _: _: {
+                  libcxx = self.stdenv.mkDerivation {
+                    name = "bootstrap-stage0-libcxx";
+                    buildCommand = ''
+                      mkdir -p $out/lib $out/include
+                      ln -s ${bootstrapTools}/lib/libc++.dylib $out/lib
+                      ln -s ${bootstrapTools}/include/c++      $out/include
+                    '';
+                    passthru = {
+                      isLLVM = true;
+                      isFromBootstrapFiles = true;
+                    };
+                  };
+                  compiler-rt = self.stdenv.mkDerivation {
+                    name = "bootstrap-stage0-compiler-rt";
+                    buildCommand = ''
+                      mkdir -p $out/lib $out/share
+                      ln -s ${bootstrapTools}/lib/libclang_rt* $out/lib
+                      ln -s ${bootstrapTools}/lib/darwin       $out/lib
+                    '';
+                    passthru.isFromBootstrapFiles = true;
+                  };
+                }
+              );
+            in
+            { inherit tools libraries; } // tools // libraries
+          );
+      };
+
+      extraPreHook = ''
+        stripDebugFlags="-S" # llvm-strip does not support "-p" for Mach-O
+      '';
+    }
+  )
 
   # This stage is primarily responsible for setting up versions of certain dependencies needed
   # by the rest of the build process. This stage also builds CF and Libsystem to simplify assertions
   # and assumptions for later by making sure both packages are present on x86_64-darwin and aarch64-darwin.
-  (prevStage:
+  (
+    prevStage:
     # previous stage0 stdenv:
     assert lib.all isFromBootstrapFiles (
-      with prevStage; [ bash cctools coreutils cpio gnugrep ld64 ] ++ lib.optionals useAppleSDKLibs [ pbzx ]
+      with prevStage;
+      [
+        bash
+        cctools
+        coreutils
+        cpio
+        gnugrep
+        ld64
+      ]
+      ++ lib.optionals useAppleSDKLibs [ pbzx ]
     );
 
-    assert lib.all isFromBootstrapFiles (with prevStage.darwin; [
-      binutils-unwrapped print-reexports rewrite-tbd sigtool
-    ]);
+    assert lib.all isFromBootstrapFiles (
+      with prevStage.darwin;
+      [
+        binutils-unwrapped
+        print-reexports
+        rewrite-tbd
+        sigtool
+      ]
+    );
 
-    assert (! useAppleSDKLibs) -> lib.all isFromBootstrapFiles (with prevStage.darwin; [ Libsystem ]);
-    assert    useAppleSDKLibs  -> lib.all        isFromNixpkgs (with prevStage.darwin; [ Libsystem ]);
-    assert lib.all isFromNixpkgs (with prevStage.darwin; [ dyld launchd xnu ]);
-    assert (with prevStage.darwin; (! useAppleSDKLibs) -> CF == null);
+    assert (!useAppleSDKLibs) -> lib.all isFromBootstrapFiles (with prevStage.darwin; [ Libsystem ]);
+    assert useAppleSDKLibs -> lib.all isFromNixpkgs (with prevStage.darwin; [ Libsystem ]);
+    assert lib.all isFromNixpkgs (
+      with prevStage.darwin;
+      [
+        dyld
+        launchd
+        xnu
+      ]
+    );
+    assert (with prevStage.darwin; (!useAppleSDKLibs) -> CF == null);
 
-    assert lib.all isFromBootstrapFiles (with prevStage.llvmPackages; [
-      clang-unwrapped libclang libllvm llvm compiler-rt libcxx
-    ]);
+    assert lib.all isFromBootstrapFiles (
+      with prevStage.llvmPackages;
+      [
+        clang-unwrapped
+        libclang
+        libllvm
+        llvm
+        compiler-rt
+        libcxx
+      ]
+    );
 
     stageFun prevStage {
-    name = "bootstrap-stage1";
+      name = "bootstrap-stage1";
 
-    overrides = self: super: {
-      inherit (prevStage) ccWrapperStdenv
-        cctools coreutils gnugrep ld64;
+      overrides = self: super: {
+        inherit (prevStage)
+          ccWrapperStdenv
+          cctools
+          coreutils
+          gnugrep
+          ld64
+          ;
 
-      binutils-unwrapped = builtins.throw "nothing in the Darwin bootstrap should depend on GNU binutils";
-      curl = builtins.throw "nothing in the Darwin bootstrap can depend on curl";
+        binutils-unwrapped = builtins.throw "nothing in the Darwin bootstrap should depend on GNU binutils";
+        curl = builtins.throw "nothing in the Darwin bootstrap can depend on curl";
 
-      # Use this stage’s CF to build CMake. It’s required but can’t be included in the stdenv.
-      cmake = self.cmakeMinimal;
-      cmakeMinimal = super.cmakeMinimal.overrideAttrs (old: {
-        buildInputs = old.buildInputs ++ [ self.darwin.CF ];
-      });
-
-      # Disable tests because they use dejagnu, which fails to run.
-      libffi = super.libffi.override { doCheck = false; };
-
-      # Use libconvReal to break an infinite recursion. It will be dropped in the next stage.
-      libiconv = super.libiconvReal;
-
-      # Avoid pulling in a full python and its extra dependencies for the llvm/clang builds.
-      libxml2 = super.libxml2.override { pythonSupport = false; };
-
-      ninja = super.ninja.override { buildDocs = false; };
-
-      # Use this stage’s CF to build Python. It’s required, but it can’t be included in the stdenv.
-      python3 = self.python3Minimal;
-      python3Minimal = (super.python3Minimal.override {
-        self = self.python3Minimal;
-      }).overrideAttrs (old: {
-        buildInputs = old.buildInputs or [ ] ++ [ self.darwin.CF ];
-      });
-
-      scons = super.scons.override { python3Packages = self.python3Minimal.pkgs; };
-
-      darwin = super.darwin.overrideScope (selfDarwin: superDarwin: {
-        apple_sdk = superDarwin.apple_sdk // {
-          inherit (prevStage.darwin.apple_sdk) sdkRoot;
-        };
-
-        # Use this stage’s CF to build configd. It’s required, but it can’t be included in the stdenv.
-        configd = superDarwin.configd.overrideAttrs (old: {
-          buildInputs = old.buildInputs or [ ] ++ [ self.darwin.CF ];
+        # Use this stage’s CF to build CMake. It’s required but can’t be included in the stdenv.
+        cmake = self.cmakeMinimal;
+        cmakeMinimal = super.cmakeMinimal.overrideAttrs (old: {
+          buildInputs = old.buildInputs ++ [ self.darwin.CF ];
         });
 
-        signingUtils = prevStage.darwin.signingUtils.override {
-          inherit (selfDarwin) sigtool;
-        };
+        # Disable tests because they use dejagnu, which fails to run.
+        libffi = super.libffi.override { doCheck = false; };
 
-        postLinkSignHook = prevStage.darwin.postLinkSignHook.override {
-          inherit (selfDarwin) sigtool;
-        };
+        # Use libconvReal to break an infinite recursion. It will be dropped in the next stage.
+        libiconv = super.libiconvReal;
 
-        # Rewrap binutils with the real Libsystem
-        binutils = superDarwin.binutils.override {
-          inherit (self) coreutils;
-          bintools = selfDarwin.binutils-unwrapped;
-          libc = selfDarwin.Libsystem;
-          # TODO(@sternenseemann): can this be removed?
-          runtimeShell = "${bootstrapTools}/bin/bash";
+        # Avoid pulling in a full python and its extra dependencies for the llvm/clang builds.
+        libxml2 = super.libxml2.override { pythonSupport = false; };
 
-          # Bootstrap tools cctools needs the hook to make sure things are signed properly.
-          # This can be dropped once the bootstrap tools cctools has been updated to 1010.6.
-          extraBuildCommands = ''
-            echo 'source ${selfDarwin.postLinkSignHook}' >> $out/nix-support/post-link-hook
+        ninja = super.ninja.override { buildDocs = false; };
 
-            export signingUtils=${selfDarwin.signingUtils}
+        # Use this stage’s CF to build Python. It’s required, but it can’t be included in the stdenv.
+        python3 = self.python3Minimal;
+        python3Minimal =
+          (super.python3Minimal.override { self = self.python3Minimal; }).overrideAttrs
+            (old: {
+              buildInputs = old.buildInputs or [ ] ++ [ self.darwin.CF ];
+            });
 
-            wrap \
-              install_name_tool ${../../build-support/bintools-wrapper/darwin-install_name_tool-wrapper.sh} \
-              "${selfDarwin.binutils-unwrapped}/bin/install_name_tool"
+        scons = super.scons.override { python3Packages = self.python3Minimal.pkgs; };
 
-            wrap \
-              strip ${../../build-support/bintools-wrapper/darwin-strip-wrapper.sh} \
-              "${selfDarwin.binutils-unwrapped}/bin/strip"
-          '';
-        };
+        darwin = super.darwin.overrideScope (
+          selfDarwin: superDarwin: {
+            apple_sdk = superDarwin.apple_sdk // {
+              inherit (prevStage.darwin.apple_sdk) sdkRoot;
+            };
 
-        # Avoid building unnecessary Python dependencies due to building LLVM manpages.
-        binutils-unwrapped = superDarwin.binutils-unwrapped.override {
-          inherit (self) cctools ld64;
-          enableManpages = false;
-        };
-      });
+            # Use this stage’s CF to build configd. It’s required, but it can’t be included in the stdenv.
+            configd = superDarwin.configd.overrideAttrs (old: {
+              buildInputs = old.buildInputs or [ ] ++ [ self.darwin.CF ];
+            });
 
-      llvmPackages = super.llvmPackages // (
-        let
-          tools = super.llvmPackages.tools.extend (_: _: {
-            inherit (prevStage.llvmPackages) clang-unwrapped libclang libllvm llvm;
-          });
-          libraries = super.llvmPackages.libraries.extend (_: _: {
-            inherit (prevStage.llvmPackages) compiler-rt libcxx;
-          });
-        in
-        { inherit tools libraries; inherit (prevStage.llvmPackages) release_version; } // tools // libraries
-      );
-    };
+            signingUtils = prevStage.darwin.signingUtils.override { inherit (selfDarwin) sigtool; };
 
-    extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
-      prevStage.updateAutotoolsGnuConfigScriptsHook
-      prevStage.gnu-config
-    ];
+            postLinkSignHook = prevStage.darwin.postLinkSignHook.override { inherit (selfDarwin) sigtool; };
 
+            # Rewrap binutils with the real Libsystem
+            binutils = superDarwin.binutils.override {
+              inherit (self) coreutils;
+              bintools = selfDarwin.binutils-unwrapped;
+              libc = selfDarwin.Libsystem;
+              # TODO(@sternenseemann): can this be removed?
+              runtimeShell = "${bootstrapTools}/bin/bash";
 
-    extraPreHook = ''
-      stripDebugFlags="-S" # llvm-strip does not support "-p" for Mach-O
-    '';
-  })
+              # Bootstrap tools cctools needs the hook to make sure things are signed properly.
+              # This can be dropped once the bootstrap tools cctools has been updated to 1010.6.
+              extraBuildCommands = ''
+                echo 'source ${selfDarwin.postLinkSignHook}' >> $out/nix-support/post-link-hook
+
+                export signingUtils=${selfDarwin.signingUtils}
+
+                wrap \
+                  install_name_tool ${../../build-support/bintools-wrapper/darwin-install_name_tool-wrapper.sh} \
+                  "${selfDarwin.binutils-unwrapped}/bin/install_name_tool"
+
+                wrap \
+                  strip ${../../build-support/bintools-wrapper/darwin-strip-wrapper.sh} \
+                  "${selfDarwin.binutils-unwrapped}/bin/strip"
+              '';
+            };
+
+            # Avoid building unnecessary Python dependencies due to building LLVM manpages.
+            binutils-unwrapped = superDarwin.binutils-unwrapped.override {
+              inherit (self) cctools ld64;
+              enableManpages = false;
+            };
+          }
+        );
+
+        llvmPackages =
+          super.llvmPackages
+          // (
+            let
+              tools = super.llvmPackages.tools.extend (
+                _: _: {
+                  inherit (prevStage.llvmPackages)
+                    clang-unwrapped
+                    libclang
+                    libllvm
+                    llvm
+                    ;
+                }
+              );
+              libraries = super.llvmPackages.libraries.extend (
+                _: _: { inherit (prevStage.llvmPackages) compiler-rt libcxx; }
+              );
+            in
+            {
+              inherit tools libraries;
+              inherit (prevStage.llvmPackages) release_version;
+            }
+            // tools
+            // libraries
+          );
+      };
+
+      extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
+        prevStage.updateAutotoolsGnuConfigScriptsHook
+        prevStage.gnu-config
+      ];
+
+      extraPreHook = ''
+        stripDebugFlags="-S" # llvm-strip does not support "-p" for Mach-O
+      '';
+    }
+  )
 
   # Build sysctl for use by LLVM’s check phase. It must be built separately to avoid an infinite recursion.
-  (prevStage:
+  (
+    prevStage:
     # previous stage1 stdenv:
-    assert lib.all isFromBootstrapFiles (with prevStage; [ cctools coreutils gnugrep ld64 ]);
+    assert lib.all isFromBootstrapFiles (
+      with prevStage;
+      [
+        cctools
+        coreutils
+        gnugrep
+        ld64
+      ]
+    );
 
-    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
-      autoconf automake bash bison brotli cmake cpio cyrus_sasl db
-      ed expat flex gettext gmp groff icu libedit libffi libiconv libidn2 libkrb5 libssh2
-      libtool libunistring libxml2 m4 ncurses nghttp2 ninja openldap openssh openssl
-      patchutils pbzx perl pkg-config.pkg-config python3 python3Minimal scons serf sqlite
-      subversion texinfo unzip which xz zlib zstd
-    ]);
+    assert lib.all isBuiltByBootstrapFilesCompiler (
+      with prevStage;
+      [
+        autoconf
+        automake
+        bash
+        bison
+        brotli
+        cmake
+        cpio
+        cyrus_sasl
+        db
+        ed
+        expat
+        flex
+        gettext
+        gmp
+        groff
+        icu
+        libedit
+        libffi
+        libiconv
+        libidn2
+        libkrb5
+        libssh2
+        libtool
+        libunistring
+        libxml2
+        m4
+        ncurses
+        nghttp2
+        ninja
+        openldap
+        openssh
+        openssl
+        patchutils
+        pbzx
+        perl
+        pkg-config.pkg-config
+        python3
+        python3Minimal
+        scons
+        serf
+        sqlite
+        subversion
+        texinfo
+        unzip
+        which
+        xz
+        zlib
+        zstd
+      ]
+    );
 
-    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [
-      locale print-reexports rewrite-tbd sigtool
-    ]);
+    assert lib.all isBuiltByBootstrapFilesCompiler (
+      with prevStage.darwin;
+      [
+        locale
+        print-reexports
+        rewrite-tbd
+        sigtool
+      ]
+    );
 
-    assert (! useAppleSDKLibs) -> lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [ Libsystem configd ]);
-    assert (! useAppleSDKLibs) -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF ]);
-    assert    useAppleSDKLibs  -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF Libsystem libobjc]);
-    assert lib.all isFromNixpkgs (with prevStage.darwin; [ binutils-unwrapped dyld launchd xnu ]);
+    assert
+      (!useAppleSDKLibs)
+      -> lib.all isBuiltByBootstrapFilesCompiler (
+        with prevStage.darwin;
+        [
+          Libsystem
+          configd
+        ]
+      );
+    assert (!useAppleSDKLibs) -> lib.all isFromNixpkgs (with prevStage.darwin; [ CF ]);
+    assert
+      useAppleSDKLibs
+      -> lib.all isFromNixpkgs (
+        with prevStage.darwin;
+        [
+          CF
+          Libsystem
+          libobjc
+        ]
+      );
+    assert lib.all isFromNixpkgs (
+      with prevStage.darwin;
+      [
+        binutils-unwrapped
+        dyld
+        launchd
+        xnu
+      ]
+    );
 
-    assert lib.all isFromBootstrapFiles (with prevStage.llvmPackages; [
-      clang-unwrapped libclang libllvm llvm compiler-rt libcxx
-    ]);
+    assert lib.all isFromBootstrapFiles (
+      with prevStage.llvmPackages;
+      [
+        clang-unwrapped
+        libclang
+        libllvm
+        llvm
+        compiler-rt
+        libcxx
+      ]
+    );
 
     assert lib.getVersion prevStage.stdenv.cc.bintools.bintools == "boot";
 
     stageFun prevStage {
-    name = "bootstrap-stage1-sysctl";
+      name = "bootstrap-stage1-sysctl";
 
-    overrides = self: super: {
-      inherit (prevStage) ccWrapperStdenv
-        autoconf automake bash binutils-unwrapped bison brotli cctools cmake cmakeMinimal
-        coreutils cpio curl cyrus_sasl db ed expat flex gettext gmp gnugrep groff icu ld64
-        libedit libffi libidn2 libkrb5 libssh2 libtool libunistring libxml2 m4
-        ncurses nghttp2 ninja openldap openssh openssl patchutils pbzx perl pkg-config
-        python3Minimal scons sed serf sharutils sqlite subversion texinfo unzip which xz
-        zlib zstd;
+      overrides = self: super: {
+        inherit (prevStage)
+          ccWrapperStdenv
+          autoconf
+          automake
+          bash
+          binutils-unwrapped
+          bison
+          brotli
+          cctools
+          cmake
+          cmakeMinimal
+          coreutils
+          cpio
+          curl
+          cyrus_sasl
+          db
+          ed
+          expat
+          flex
+          gettext
+          gmp
+          gnugrep
+          groff
+          icu
+          ld64
+          libedit
+          libffi
+          libidn2
+          libkrb5
+          libssh2
+          libtool
+          libunistring
+          libxml2
+          m4
+          ncurses
+          nghttp2
+          ninja
+          openldap
+          openssh
+          openssl
+          patchutils
+          pbzx
+          perl
+          pkg-config
+          python3Minimal
+          scons
+          sed
+          serf
+          sharutils
+          sqlite
+          subversion
+          texinfo
+          unzip
+          which
+          xz
+          zlib
+          zstd
+          ;
 
-      # Avoid pulling in openldap just to run Meson’s tests.
-      meson = super.meson.overrideAttrs {
-        doInstallCheck = false;
-      };
+        # Avoid pulling in openldap just to run Meson’s tests.
+        meson = super.meson.overrideAttrs { doInstallCheck = false; };
 
-      # The bootstrap Python needs its own `pythonAttr` to make sure the override works properly.
-      python3 = self.python3-bootstrap;
-      python3-bootstrap = super.python3.override {
-        self = self.python3-bootstrap;
-        pythonAttr = "python3-bootstrap";
-        enableLTO = false;
-      };
-
-      darwin = super.darwin.overrideScope (_: superDarwin: {
-        inherit (prevStage.darwin)
-          CF sdkRoot Libsystem binutils binutils-unwrapped configd darwin-stubs dtrace dyld
-          launchd libclosure libdispatch libobjc locale objc4 postLinkSignHook
-          print-reexports rewrite-tbd signingUtils sigtool;
-
-        apple_sdk = superDarwin.apple_sdk // {
-          inherit (prevStage.darwin.apple_sdk) sdkRoot;
+        # The bootstrap Python needs its own `pythonAttr` to make sure the override works properly.
+        python3 = self.python3-bootstrap;
+        python3-bootstrap = super.python3.override {
+          self = self.python3-bootstrap;
+          pythonAttr = "python3-bootstrap";
+          enableLTO = false;
         };
-      });
 
-      llvmPackages = super.llvmPackages // (
-        let
-          tools = super.llvmPackages.tools.extend (_: _: {
-            inherit (prevStage.llvmPackages) clang-unwrapped libclang libllvm llvm;
-            clang = prevStage.stdenv.cc;
-          });
-          libraries = super.llvmPackages.libraries.extend (_: _: {
-            inherit (prevStage.llvmPackages) compiler-rt libcxx;
-          });
-        in
-        { inherit tools libraries; inherit (prevStage.llvmPackages) release_version; } // tools // libraries
-      );
-    };
+        darwin = super.darwin.overrideScope (
+          _: superDarwin: {
+            inherit (prevStage.darwin)
+              CF
+              sdkRoot
+              Libsystem
+              binutils
+              binutils-unwrapped
+              configd
+              darwin-stubs
+              dtrace
+              dyld
+              launchd
+              libclosure
+              libdispatch
+              libobjc
+              locale
+              objc4
+              postLinkSignHook
+              print-reexports
+              rewrite-tbd
+              signingUtils
+              sigtool
+              ;
 
-    extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
-      prevStage.updateAutotoolsGnuConfigScriptsHook
-      prevStage.gnu-config
-    ];
+            apple_sdk = superDarwin.apple_sdk // {
+              inherit (prevStage.darwin.apple_sdk) sdkRoot;
+            };
+          }
+        );
 
-    extraPreHook = ''
-      stripDebugFlags="-S" # llvm-strip does not support "-p" for Mach-O
-    '';
-  })
+        llvmPackages =
+          super.llvmPackages
+          // (
+            let
+              tools = super.llvmPackages.tools.extend (
+                _: _: {
+                  inherit (prevStage.llvmPackages)
+                    clang-unwrapped
+                    libclang
+                    libllvm
+                    llvm
+                    ;
+                  clang = prevStage.stdenv.cc;
+                }
+              );
+              libraries = super.llvmPackages.libraries.extend (
+                _: _: { inherit (prevStage.llvmPackages) compiler-rt libcxx; }
+              );
+            in
+            {
+              inherit tools libraries;
+              inherit (prevStage.llvmPackages) release_version;
+            }
+            // tools
+            // libraries
+          );
+      };
+
+      extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
+        prevStage.updateAutotoolsGnuConfigScriptsHook
+        prevStage.gnu-config
+      ];
+
+      extraPreHook = ''
+        stripDebugFlags="-S" # llvm-strip does not support "-p" for Mach-O
+      '';
+    }
+  )
 
   # First rebuild of LLVM. While this LLVM is linked to a bunch of junk from the bootstrap tools,
   # the libc++ and libc++abi it produces are not. The compiler will be rebuilt in a later stage,
@@ -720,450 +990,1114 @@ in
   #
   # The first build of cctools is deferred until this stage because it depends on LLVM headers
   # that are not included in the bootstrap tools tarball.
-  (prevStage:
+  (
+    prevStage:
     # previous stage-sysctl stdenv:
-    assert lib.all isFromBootstrapFiles (with prevStage; [ cctools coreutils gnugrep ld64 ]);
+    assert lib.all isFromBootstrapFiles (
+      with prevStage;
+      [
+        cctools
+        coreutils
+        gnugrep
+        ld64
+      ]
+    );
 
-    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
-      atf autoconf automake bash bison brotli cmake cpio cyrus_sasl db
-      ed expat flex gettext gmp groff icu kyua libedit libffi libiconv libidn2 libkrb5 libssh2
-      libtapi libtool libunistring libxml2 m4 meson ncurses nghttp2 ninja openldap openssh openssl
-      patchutils pbzx perl pkg-config.pkg-config python3 python3Minimal scons serf sqlite
-      subversion sysctl.provider texinfo unzip which xz zlib zstd
-    ]);
+    assert lib.all isBuiltByBootstrapFilesCompiler (
+      with prevStage;
+      [
+        atf
+        autoconf
+        automake
+        bash
+        bison
+        brotli
+        cmake
+        cpio
+        cyrus_sasl
+        db
+        ed
+        expat
+        flex
+        gettext
+        gmp
+        groff
+        icu
+        kyua
+        libedit
+        libffi
+        libiconv
+        libidn2
+        libkrb5
+        libssh2
+        libtapi
+        libtool
+        libunistring
+        libxml2
+        m4
+        meson
+        ncurses
+        nghttp2
+        ninja
+        openldap
+        openssh
+        openssl
+        patchutils
+        pbzx
+        perl
+        pkg-config.pkg-config
+        python3
+        python3Minimal
+        scons
+        serf
+        sqlite
+        subversion
+        sysctl.provider
+        texinfo
+        unzip
+        which
+        xz
+        zlib
+        zstd
+      ]
+    );
 
-    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [
-      locale print-reexports rewrite-tbd sigtool
-    ]);
+    assert lib.all isBuiltByBootstrapFilesCompiler (
+      with prevStage.darwin;
+      [
+        locale
+        print-reexports
+        rewrite-tbd
+        sigtool
+      ]
+    );
 
-    assert (! useAppleSDKLibs) -> lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [ Libsystem configd ]);
-    assert (! useAppleSDKLibs) -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF ]);
-    assert    useAppleSDKLibs  -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF Libsystem libobjc ]);
-    assert lib.all isFromNixpkgs (with prevStage.darwin; [ binutils-unwrapped dyld launchd xnu ]);
+    assert
+      (!useAppleSDKLibs)
+      -> lib.all isBuiltByBootstrapFilesCompiler (
+        with prevStage.darwin;
+        [
+          Libsystem
+          configd
+        ]
+      );
+    assert (!useAppleSDKLibs) -> lib.all isFromNixpkgs (with prevStage.darwin; [ CF ]);
+    assert
+      useAppleSDKLibs
+      -> lib.all isFromNixpkgs (
+        with prevStage.darwin;
+        [
+          CF
+          Libsystem
+          libobjc
+        ]
+      );
+    assert lib.all isFromNixpkgs (
+      with prevStage.darwin;
+      [
+        binutils-unwrapped
+        dyld
+        launchd
+        xnu
+      ]
+    );
 
-    assert lib.all isFromBootstrapFiles (with prevStage.llvmPackages; [
-      clang-unwrapped libclang libllvm llvm compiler-rt libcxx
-    ]);
+    assert lib.all isFromBootstrapFiles (
+      with prevStage.llvmPackages;
+      [
+        clang-unwrapped
+        libclang
+        libllvm
+        llvm
+        compiler-rt
+        libcxx
+      ]
+    );
 
     stageFun prevStage {
-    name = "bootstrap-stage-xclang";
+      name = "bootstrap-stage-xclang";
 
-    overrides = self: super: {
-      inherit (prevStage) ccWrapperStdenv
-        atf autoconf automake bash binutils-unwrapped bison brotli cmake cmakeMinimal
-        cpio curl cyrus_sasl db ed expat flex gettext gmp groff icu kyua libedit libffi libiconv
-        libidn2 libkrb5 libssh2 libtool libunistring libxml2 m4 meson ncurses nghttp2 ninja
-        openldap openssh openssl patchutils pbzx perl pkg-config python3 python3Minimal
-        scons sed serf sharutils sqlite subversion sysctl texinfo unzip which xz zlib zstd;
+      overrides = self: super: {
+        inherit (prevStage)
+          ccWrapperStdenv
+          atf
+          autoconf
+          automake
+          bash
+          binutils-unwrapped
+          bison
+          brotli
+          cmake
+          cmakeMinimal
+          cpio
+          curl
+          cyrus_sasl
+          db
+          ed
+          expat
+          flex
+          gettext
+          gmp
+          groff
+          icu
+          kyua
+          libedit
+          libffi
+          libiconv
+          libidn2
+          libkrb5
+          libssh2
+          libtool
+          libunistring
+          libxml2
+          m4
+          meson
+          ncurses
+          nghttp2
+          ninja
+          openldap
+          openssh
+          openssl
+          patchutils
+          pbzx
+          perl
+          pkg-config
+          python3
+          python3Minimal
+          scons
+          sed
+          serf
+          sharutils
+          sqlite
+          subversion
+          sysctl
+          texinfo
+          unzip
+          which
+          xz
+          zlib
+          zstd
+          ;
 
-      # Disable ld64’s install check phase because the required LTO libraries are not built yet.
-      ld64 = super.ld64.overrideAttrs { doInstallCheck = false; };
+        # Disable ld64’s install check phase because the required LTO libraries are not built yet.
+        ld64 = super.ld64.overrideAttrs { doInstallCheck = false; };
 
-      darwin = super.darwin.overrideScope (selfDarwin: superDarwin: {
-        inherit (prevStage.darwin)
-          CF Libsystem configd darwin-stubs dyld launchd libclosure libdispatch libobjc
-          locale objc4 postLinkSignHook print-reexports rewrite-tbd signingUtils sigtool;
+        darwin = super.darwin.overrideScope (
+          selfDarwin: superDarwin: {
+            inherit (prevStage.darwin)
+              CF
+              Libsystem
+              configd
+              darwin-stubs
+              dyld
+              launchd
+              libclosure
+              libdispatch
+              libobjc
+              locale
+              objc4
+              postLinkSignHook
+              print-reexports
+              rewrite-tbd
+              signingUtils
+              sigtool
+              ;
 
-        apple_sdk = superDarwin.apple_sdk // {
-          inherit (prevStage.darwin.apple_sdk) sdkRoot;
-        };
+            apple_sdk = superDarwin.apple_sdk // {
+              inherit (prevStage.darwin.apple_sdk) sdkRoot;
+            };
 
-        binutils = superDarwin.binutils.override {
-          inherit (prevStage) expand-response-params;
-          libc = selfDarwin.Libsystem;
-        };
+            binutils = superDarwin.binutils.override {
+              inherit (prevStage) expand-response-params;
+              libc = selfDarwin.Libsystem;
+            };
 
-        # Avoid building unnecessary Python dependencies due to building LLVM manpages.
-        binutils-unwrapped = superDarwin.binutils-unwrapped.override { enableManpages = false; };
-      });
+            # Avoid building unnecessary Python dependencies due to building LLVM manpages.
+            binutils-unwrapped = superDarwin.binutils-unwrapped.override { enableManpages = false; };
+          }
+        );
 
-      llvmPackages = super.llvmPackages // (
-        let
-          llvmMajor = lib.versions.major super.llvmPackages.release_version;
+        llvmPackages =
+          super.llvmPackages
+          // (
+            let
+              llvmMajor = lib.versions.major super.llvmPackages.release_version;
 
-          # libc++, and libc++abi do not need CoreFoundation. Avoid propagating the CF from prior
-          # stages to the final stdenv via rpath by dropping it from `extraBuildInputs`.
-          stdenvNoCF = self.stdenv.override {
-            extraBuildInputs = [ ];
-          };
+              # libc++, and libc++abi do not need CoreFoundation. Avoid propagating the CF from prior
+              # stages to the final stdenv via rpath by dropping it from `extraBuildInputs`.
+              stdenvNoCF = self.stdenv.override { extraBuildInputs = [ ]; };
 
-          libcxxBootstrapStdenv = self.overrideCC stdenvNoCF (self.llvmPackages.clangNoCompilerRtWithLibc.override {
-            nixSupport.cc-cflags = [ "-nostdlib" ];
-            nixSupport.cc-ldflags = [ "-lSystem" ];
-          });
+              libcxxBootstrapStdenv = self.overrideCC stdenvNoCF (
+                self.llvmPackages.clangNoCompilerRtWithLibc.override {
+                  nixSupport.cc-cflags = [ "-nostdlib" ];
+                  nixSupport.cc-ldflags = [ "-lSystem" ];
+                }
+              );
 
-          tools = super.llvmPackages.tools.extend (selfTools: superTools: {
-            # LLVM’s check phase takes a while to run, so disable it in the first LLVM build to speed up the bootstrap.
-            libllvm = superTools.libllvm.override { doCheck = false; };
-          });
+              tools = super.llvmPackages.tools.extend (
+                selfTools: superTools: {
+                  # LLVM’s check phase takes a while to run, so disable it in the first LLVM build to speed up the bootstrap.
+                  libllvm = superTools.libllvm.override { doCheck = false; };
+                }
+              );
 
-          libraries = super.llvmPackages.libraries.extend (selfLib: superLib: {
-            compiler-rt = null;
-            libcxx = superLib.libcxx.override ({
-              stdenv = libcxxBootstrapStdenv;
-            });
-          });
-        in
-        { inherit tools libraries; } // tools // libraries
-      );
-    };
+              libraries = super.llvmPackages.libraries.extend (
+                selfLib: superLib: {
+                  compiler-rt = null;
+                  libcxx = superLib.libcxx.override ({ stdenv = libcxxBootstrapStdenv; });
+                }
+              );
+            in
+            { inherit tools libraries; } // tools // libraries
+          );
+      };
 
-    extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
-      prevStage.updateAutotoolsGnuConfigScriptsHook
-      prevStage.gnu-config
-    ];
+      extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
+        prevStage.updateAutotoolsGnuConfigScriptsHook
+        prevStage.gnu-config
+      ];
 
-    extraPreHook = ''
-      stripDebugFlags="-S" # llvm-strip does not support "-p" for Mach-O
-    '';
-  })
+      extraPreHook = ''
+        stripDebugFlags="-S" # llvm-strip does not support "-p" for Mach-O
+      '';
+    }
+  )
 
   # This stage rebuilds Libsystem. It also rebuilds bash, which will be needed in later stages
   # to use in patched shebangs (e.g., to make sure `icu-config` uses bash from nixpkgs).
-  (prevStage:
+  (
+    prevStage:
     # previous stage-xclang stdenv:
-    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
-      atf autoconf automake bash bison cctools cmake cmakeMinimal coreutils cpio
-      cyrus_sasl db ed expat flex gettext gmp gnugrep groff icu kyua ld64 libedit libtapi libtool m4 meson ninja
-      openbsm openldap openpam openssh patchutils pbzx perl pkg-config.pkg-config python3
-      python3Minimal scons serf sqlite subversion sysctl.provider texinfo unzip which xz
-    ]);
+    assert lib.all isBuiltByBootstrapFilesCompiler (
+      with prevStage;
+      [
+        atf
+        autoconf
+        automake
+        bash
+        bison
+        cctools
+        cmake
+        cmakeMinimal
+        coreutils
+        cpio
+        cyrus_sasl
+        db
+        ed
+        expat
+        flex
+        gettext
+        gmp
+        gnugrep
+        groff
+        icu
+        kyua
+        ld64
+        libedit
+        libtapi
+        libtool
+        m4
+        meson
+        ninja
+        openbsm
+        openldap
+        openpam
+        openssh
+        patchutils
+        pbzx
+        perl
+        pkg-config.pkg-config
+        python3
+        python3Minimal
+        scons
+        serf
+        sqlite
+        subversion
+        sysctl.provider
+        texinfo
+        unzip
+        which
+        xz
+      ]
+    );
 
-    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
-      brotli libffi libiconv libidn2 libkrb5 libssh2 libunistring libxml2 ncurses
-      nghttp2 openssl zlib zstd
-    ]);
+    assert lib.all isBuiltByBootstrapFilesCompiler (
+      with prevStage;
+      [
+        brotli
+        libffi
+        libiconv
+        libidn2
+        libkrb5
+        libssh2
+        libunistring
+        libxml2
+        ncurses
+        nghttp2
+        openssl
+        zlib
+        zstd
+      ]
+    );
 
-    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [
-      locale print-reexports rewrite-tbd sigtool
-    ]);
+    assert lib.all isBuiltByBootstrapFilesCompiler (
+      with prevStage.darwin;
+      [
+        locale
+        print-reexports
+        rewrite-tbd
+        sigtool
+      ]
+    );
 
-    assert (! useAppleSDKLibs) -> lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [ Libsystem configd ]);
-    assert (! useAppleSDKLibs) -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF ]);
-    assert    useAppleSDKLibs  -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF Libsystem libobjc ]);
-    assert lib.all isFromNixpkgs (with prevStage.darwin; [ binutils-unwrapped dyld launchd libclosure libdispatch xnu ]);
+    assert
+      (!useAppleSDKLibs)
+      -> lib.all isBuiltByBootstrapFilesCompiler (
+        with prevStage.darwin;
+        [
+          Libsystem
+          configd
+        ]
+      );
+    assert (!useAppleSDKLibs) -> lib.all isFromNixpkgs (with prevStage.darwin; [ CF ]);
+    assert
+      useAppleSDKLibs
+      -> lib.all isFromNixpkgs (
+        with prevStage.darwin;
+        [
+          CF
+          Libsystem
+          libobjc
+        ]
+      );
+    assert lib.all isFromNixpkgs (
+      with prevStage.darwin;
+      [
+        binutils-unwrapped
+        dyld
+        launchd
+        libclosure
+        libdispatch
+        xnu
+      ]
+    );
 
-    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.llvmPackages; [
-      clang-unwrapped libclang libllvm llvm
-    ]);
+    assert lib.all isBuiltByBootstrapFilesCompiler (
+      with prevStage.llvmPackages;
+      [
+        clang-unwrapped
+        libclang
+        libllvm
+        llvm
+      ]
+    );
     assert lib.all isBuiltByNixpkgsCompiler (with prevStage.llvmPackages; [ libcxx ]);
     assert prevStage.llvmPackages.compiler-rt == null;
 
     stageFun prevStage {
 
-    name = "bootstrap-stage2";
+      name = "bootstrap-stage2";
 
-    overrides = self: super: {
-      inherit (prevStage) ccWrapperStdenv
-        atf autoconf automake binutils-unwrapped bison brotli cctools cmake cmakeMinimal coreutils
-        cpio curl cyrus_sasl db ed expat flex gettext gmp gnugrep groff icu kyua ld64 libedit libffi
-        libiconv libidn2 libkrb5 libssh2 libtapi libtool libunistring libxml2 m4 meson ncurses nghttp2
-        ninja openbsm openldap openpam openssh openssl patchutils pbzx perl pkg-config
-        python3 python3Minimal scons serf sqlite subversion sysctl texinfo unzip which xz
-        zlib zstd;
+      overrides = self: super: {
+        inherit (prevStage)
+          ccWrapperStdenv
+          atf
+          autoconf
+          automake
+          binutils-unwrapped
+          bison
+          brotli
+          cctools
+          cmake
+          cmakeMinimal
+          coreutils
+          cpio
+          curl
+          cyrus_sasl
+          db
+          ed
+          expat
+          flex
+          gettext
+          gmp
+          gnugrep
+          groff
+          icu
+          kyua
+          ld64
+          libedit
+          libffi
+          libiconv
+          libidn2
+          libkrb5
+          libssh2
+          libtapi
+          libtool
+          libunistring
+          libxml2
+          m4
+          meson
+          ncurses
+          nghttp2
+          ninja
+          openbsm
+          openldap
+          openpam
+          openssh
+          openssl
+          patchutils
+          pbzx
+          perl
+          pkg-config
+          python3
+          python3Minimal
+          scons
+          serf
+          sqlite
+          subversion
+          sysctl
+          texinfo
+          unzip
+          which
+          xz
+          zlib
+          zstd
+          ;
 
-      # Bash must be linked against the system CoreFoundation instead of the open-source one.
-      # Otherwise, there will be a dependency cycle: bash -> CF -> icu -> bash (for icu^dev).
-      bash = super.bash.overrideAttrs (super: {
-        buildInputs = super.buildInputs ++ [ self.darwin.apple_sdk.frameworks.CoreFoundation ];
-      });
-
-      darwin = super.darwin.overrideScope (selfDarwin: superDarwin: {
-        inherit (prevStage.darwin)
-          binutils-unwrapped configd darwin-stubs launchd locale postLinkSignHook
-          print-reexports rewrite-tbd signingUtils sigtool;
-
-        apple_sdk = superDarwin.apple_sdk // {
-          inherit (prevStage.darwin.apple_sdk) sdkRoot;
-        };
-
-        # Rewrap binutils so it uses the rebuilt Libsystem.
-        binutils = superDarwin.binutils.override {
-          inherit (prevStage) expand-response-params;
-          libc = selfDarwin.Libsystem;
-        } // {
-          passthru = { inherit (prevStage.bintools.passthru) isFromBootstrapFiles; };
-        };
-      });
-
-      llvmPackages = super.llvmPackages // (
-        let
-          tools = super.llvmPackages.tools.extend (_: _: {
-            inherit (prevStage.llvmPackages) clang-unwrapped clangNoCompilerRtWithLibc libclang lld libllvm llvm;
-          });
-
-          libraries = super.llvmPackages.libraries.extend (selfLib: superLib: {
-            inherit (prevStage.llvmPackages) libcxx;
-
-            # Make sure compiler-rt is linked against the CF from this stage, which can be
-            # propagated to the final stdenv. CF is required by ASAN.
-            compiler-rt = superLib.compiler-rt.override ({
-              inherit (self.llvmPackages) libllvm;
-              stdenv = self.stdenv.override {
-                extraBuildInputs = [ self.darwin.CF ];
-              };
-            });
-          });
-        in
-        { inherit tools libraries; inherit (prevStage.llvmPackages) release_version; } // tools // libraries
-      );
-
-      # Don’t link anything in this stage against CF to prevent propagating CF from prior stages to
-      # the final stdenv, which happens because of the rpath hook.
-      stdenv =
-        let
-          stdenvNoCF = super.stdenv.override {
-            extraBuildInputs = [ ];
-          };
-        in
-        self.overrideCC stdenvNoCF (self.llvmPackages.clangNoCompilerRtWithLibc.override {
-          inherit (self.llvmPackages) libcxx;
+        # Bash must be linked against the system CoreFoundation instead of the open-source one.
+        # Otherwise, there will be a dependency cycle: bash -> CF -> icu -> bash (for icu^dev).
+        bash = super.bash.overrideAttrs (super: {
+          buildInputs = super.buildInputs ++ [ self.darwin.apple_sdk.frameworks.CoreFoundation ];
         });
-    };
 
-    extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
-      prevStage.updateAutotoolsGnuConfigScriptsHook
-      prevStage.gnu-config
-    ];
+        darwin = super.darwin.overrideScope (
+          selfDarwin: superDarwin: {
+            inherit (prevStage.darwin)
+              binutils-unwrapped
+              configd
+              darwin-stubs
+              launchd
+              locale
+              postLinkSignHook
+              print-reexports
+              rewrite-tbd
+              signingUtils
+              sigtool
+              ;
 
-    extraPreHook = ''
-      stripDebugFlags="-S" # llvm-strip does not support "-p" for Mach-O
-    '';
-  })
+            apple_sdk = superDarwin.apple_sdk // {
+              inherit (prevStage.darwin.apple_sdk) sdkRoot;
+            };
+
+            # Rewrap binutils so it uses the rebuilt Libsystem.
+            binutils =
+              superDarwin.binutils.override {
+                inherit (prevStage) expand-response-params;
+                libc = selfDarwin.Libsystem;
+              }
+              // {
+                passthru = {
+                  inherit (prevStage.bintools.passthru) isFromBootstrapFiles;
+                };
+              };
+          }
+        );
+
+        llvmPackages =
+          super.llvmPackages
+          // (
+            let
+              tools = super.llvmPackages.tools.extend (
+                _: _: {
+                  inherit (prevStage.llvmPackages)
+                    clang-unwrapped
+                    clangNoCompilerRtWithLibc
+                    libclang
+                    lld
+                    libllvm
+                    llvm
+                    ;
+                }
+              );
+
+              libraries = super.llvmPackages.libraries.extend (
+                selfLib: superLib: {
+                  inherit (prevStage.llvmPackages) libcxx;
+
+                  # Make sure compiler-rt is linked against the CF from this stage, which can be
+                  # propagated to the final stdenv. CF is required by ASAN.
+                  compiler-rt = superLib.compiler-rt.override ({
+                    inherit (self.llvmPackages) libllvm;
+                    stdenv = self.stdenv.override { extraBuildInputs = [ self.darwin.CF ]; };
+                  });
+                }
+              );
+            in
+            {
+              inherit tools libraries;
+              inherit (prevStage.llvmPackages) release_version;
+            }
+            // tools
+            // libraries
+          );
+
+        # Don’t link anything in this stage against CF to prevent propagating CF from prior stages to
+        # the final stdenv, which happens because of the rpath hook.
+        stdenv =
+          let
+            stdenvNoCF = super.stdenv.override { extraBuildInputs = [ ]; };
+          in
+          self.overrideCC stdenvNoCF (
+            self.llvmPackages.clangNoCompilerRtWithLibc.override { inherit (self.llvmPackages) libcxx; }
+          );
+      };
+
+      extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
+        prevStage.updateAutotoolsGnuConfigScriptsHook
+        prevStage.gnu-config
+      ];
+
+      extraPreHook = ''
+        stripDebugFlags="-S" # llvm-strip does not support "-p" for Mach-O
+      '';
+    }
+  )
 
   # Rebuild LLVM with LLVM. This stage also rebuilds certain dependencies needed by LLVM.
   #
   # LLVM requires: libcxx libffi libiconv libxml2 ncurses python3 zlib
-  (prevStage:
+  (
+    prevStage:
     # previous stage2 stdenv:
-    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
-      autoconf automake bison brotli cctools cmake cmakeMinimal coreutils cpio cyrus_sasl
-      db ed expat flex gettext gmp gnugrep groff icu ld64 libedit libffi libiconv libidn2 libkrb5 libssh2 libtool
-      libtapi libunistring libxml2 m4 meson ncurses nghttp2 ninja openbsm openldap openpam openssh openssl
-      patchutils pbzx perl pkg-config.pkg-config python3 python3Minimal scons serf sqlite
-      subversion sysctl.provider texinfo unzip which xz zstd zlib
-    ]);
+    assert lib.all isBuiltByBootstrapFilesCompiler (
+      with prevStage;
+      [
+        autoconf
+        automake
+        bison
+        brotli
+        cctools
+        cmake
+        cmakeMinimal
+        coreutils
+        cpio
+        cyrus_sasl
+        db
+        ed
+        expat
+        flex
+        gettext
+        gmp
+        gnugrep
+        groff
+        icu
+        ld64
+        libedit
+        libffi
+        libiconv
+        libidn2
+        libkrb5
+        libssh2
+        libtool
+        libtapi
+        libunistring
+        libxml2
+        m4
+        meson
+        ncurses
+        nghttp2
+        ninja
+        openbsm
+        openldap
+        openpam
+        openssh
+        openssl
+        patchutils
+        pbzx
+        perl
+        pkg-config.pkg-config
+        python3
+        python3Minimal
+        scons
+        serf
+        sqlite
+        subversion
+        sysctl.provider
+        texinfo
+        unzip
+        which
+        xz
+        zstd
+        zlib
+      ]
+    );
     assert lib.all isBuiltByNixpkgsCompiler (with prevStage; [ bash ]);
 
-    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [
-      locale print-reexports rewrite-tbd sigtool
-    ]);
+    assert lib.all isBuiltByBootstrapFilesCompiler (
+      with prevStage.darwin;
+      [
+        locale
+        print-reexports
+        rewrite-tbd
+        sigtool
+      ]
+    );
 
-    assert (! useAppleSDKLibs) -> lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [ configd ]);
-    assert (! useAppleSDKLibs) -> lib.all        isBuiltByNixpkgsCompiler (with prevStage.darwin; [ Libsystem ]);
-    assert (! useAppleSDKLibs) -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF ]);
-    assert    useAppleSDKLibs  -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF Libsystem libobjc ]);
-    assert lib.all isFromNixpkgs (with prevStage.darwin; [ binutils-unwrapped dyld launchd libclosure libdispatch xnu ]);
+    assert
+      (!useAppleSDKLibs) -> lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [ configd ]);
+    assert
+      (!useAppleSDKLibs) -> lib.all isBuiltByNixpkgsCompiler (with prevStage.darwin; [ Libsystem ]);
+    assert (!useAppleSDKLibs) -> lib.all isFromNixpkgs (with prevStage.darwin; [ CF ]);
+    assert
+      useAppleSDKLibs
+      -> lib.all isFromNixpkgs (
+        with prevStage.darwin;
+        [
+          CF
+          Libsystem
+          libobjc
+        ]
+      );
+    assert lib.all isFromNixpkgs (
+      with prevStage.darwin;
+      [
+        binutils-unwrapped
+        dyld
+        launchd
+        libclosure
+        libdispatch
+        xnu
+      ]
+    );
 
-    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.llvmPackages; [
-      clang-unwrapped libclang libllvm llvm
-    ]);
+    assert lib.all isBuiltByBootstrapFilesCompiler (
+      with prevStage.llvmPackages;
+      [
+        clang-unwrapped
+        libclang
+        libllvm
+        llvm
+      ]
+    );
     assert lib.all isBuiltByNixpkgsCompiler (with prevStage.llvmPackages; [ libcxx ]);
 
     stageFun prevStage {
 
-    name = "bootstrap-stage3";
+      name = "bootstrap-stage3";
 
-    overrides = self: super: {
-      inherit (prevStage) ccWrapperStdenv
-        autoconf automake bash binutils-unwrapped bison brotli cmake cmakeMinimal
-        coreutils cpio curl cyrus_sasl db ed expat flex gettext gmp gnugrep groff libedit
-        libidn2 libkrb5 libssh2 libtool libunistring m4 meson nghttp2 ninja openbsm openldap
-        openpam openssh openssl patchutils pbzx perl pkg-config python3 python3Minimal scons
-        sed serf sharutils sqlite subversion sysctl texinfo unzip which xz zstd;
+      overrides = self: super: {
+        inherit (prevStage)
+          ccWrapperStdenv
+          autoconf
+          automake
+          bash
+          binutils-unwrapped
+          bison
+          brotli
+          cmake
+          cmakeMinimal
+          coreutils
+          cpio
+          curl
+          cyrus_sasl
+          db
+          ed
+          expat
+          flex
+          gettext
+          gmp
+          gnugrep
+          groff
+          libedit
+          libidn2
+          libkrb5
+          libssh2
+          libtool
+          libunistring
+          m4
+          meson
+          nghttp2
+          ninja
+          openbsm
+          openldap
+          openpam
+          openssh
+          openssl
+          patchutils
+          pbzx
+          perl
+          pkg-config
+          python3
+          python3Minimal
+          scons
+          sed
+          serf
+          sharutils
+          sqlite
+          subversion
+          sysctl
+          texinfo
+          unzip
+          which
+          xz
+          zstd
+          ;
 
-      # Disable tests because they use dejagnu, which fails to run.
-      libffi = super.libffi.override { doCheck = false; };
+        # Disable tests because they use dejagnu, which fails to run.
+        libffi = super.libffi.override { doCheck = false; };
 
-      # Avoid pulling in a full python and its extra dependencies for the llvm/clang builds.
-      libxml2 = super.libxml2.override { pythonSupport = false; };
+        # Avoid pulling in a full python and its extra dependencies for the llvm/clang builds.
+        libxml2 = super.libxml2.override { pythonSupport = false; };
 
-      darwin = super.darwin.overrideScope (selfDarwin: superDarwin: {
-        inherit (prevStage.darwin)
-          CF Libsystem binutils binutils-unwrapped configd
-          darwin-stubs dyld launchd libclosure libdispatch libobjc locale objc4
-          postLinkSignHook print-reexports rewrite-tbd signingUtils sigtool;
+        darwin = super.darwin.overrideScope (
+          selfDarwin: superDarwin: {
+            inherit (prevStage.darwin)
+              CF
+              Libsystem
+              binutils
+              binutils-unwrapped
+              configd
+              darwin-stubs
+              dyld
+              launchd
+              libclosure
+              libdispatch
+              libobjc
+              locale
+              objc4
+              postLinkSignHook
+              print-reexports
+              rewrite-tbd
+              signingUtils
+              sigtool
+              ;
 
-        apple_sdk = superDarwin.apple_sdk // {
-          inherit (prevStage.darwin.apple_sdk) sdkRoot;
-        };
-      });
+            apple_sdk = superDarwin.apple_sdk // {
+              inherit (prevStage.darwin.apple_sdk) sdkRoot;
+            };
+          }
+        );
 
-      llvmPackages = super.llvmPackages // (
-        let
-          libraries = super.llvmPackages.libraries.extend (_: _: {
-           inherit (prevStage.llvmPackages) compiler-rt libcxx;
-          });
-        in
-        { inherit libraries; } // libraries
-      );
-    };
+        llvmPackages =
+          super.llvmPackages
+          // (
+            let
+              libraries = super.llvmPackages.libraries.extend (
+                _: _: { inherit (prevStage.llvmPackages) compiler-rt libcxx; }
+              );
+            in
+            { inherit libraries; } // libraries
+          );
+      };
 
-    extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
-      prevStage.updateAutotoolsGnuConfigScriptsHook
-      prevStage.gnu-config
-    ];
+      extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
+        prevStage.updateAutotoolsGnuConfigScriptsHook
+        prevStage.gnu-config
+      ];
 
-    extraPreHook = ''
-      stripDebugFlags="-S" # llvm-strip does not support "-p" for Mach-O
-    '';
-  })
+      extraPreHook = ''
+        stripDebugFlags="-S" # llvm-strip does not support "-p" for Mach-O
+      '';
+    }
+  )
 
   # Construct a standard environment with the new clang. Also use the new compiler to rebuild
   # everything that will be part of the final stdenv and isn’t required by it, CF, or Libsystem.
-  (prevStage:
+  (
+    prevStage:
     # previous stage3 stdenv:
-    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
-      autoconf automake bison brotli cmake cmakeMinimal coreutils cpio cyrus_sasl
-      db ed expat flex gettext gmp gnugrep groff libedit libidn2 libkrb5 libssh2 libtool
-      libunistring m4 meson nghttp2 ninja openbsm openldap openpam openssh openssl patchutils pbzx
-      perl pkg-config.pkg-config python3 python3Minimal scons serf sqlite subversion
-      sysctl.provider texinfo unzip which xz zstd
-    ]);
+    assert lib.all isBuiltByBootstrapFilesCompiler (
+      with prevStage;
+      [
+        autoconf
+        automake
+        bison
+        brotli
+        cmake
+        cmakeMinimal
+        coreutils
+        cpio
+        cyrus_sasl
+        db
+        ed
+        expat
+        flex
+        gettext
+        gmp
+        gnugrep
+        groff
+        libedit
+        libidn2
+        libkrb5
+        libssh2
+        libtool
+        libunistring
+        m4
+        meson
+        nghttp2
+        ninja
+        openbsm
+        openldap
+        openpam
+        openssh
+        openssl
+        patchutils
+        pbzx
+        perl
+        pkg-config.pkg-config
+        python3
+        python3Minimal
+        scons
+        serf
+        sqlite
+        subversion
+        sysctl.provider
+        texinfo
+        unzip
+        which
+        xz
+        zstd
+      ]
+    );
 
-    assert lib.all isBuiltByNixpkgsCompiler (with prevStage; [
-      bash cctools icu ld64 libtapi libffi libiconv libxml2 zlib
-    ]);
+    assert lib.all isBuiltByNixpkgsCompiler (
+      with prevStage;
+      [
+        bash
+        cctools
+        icu
+        ld64
+        libtapi
+        libffi
+        libiconv
+        libxml2
+        zlib
+      ]
+    );
 
-    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [
-      locale print-reexports rewrite-tbd sigtool
-    ]);
+    assert lib.all isBuiltByBootstrapFilesCompiler (
+      with prevStage.darwin;
+      [
+        locale
+        print-reexports
+        rewrite-tbd
+        sigtool
+      ]
+    );
 
-    assert (! useAppleSDKLibs) -> lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [ configd ]);
-    assert (! useAppleSDKLibs) -> lib.all        isBuiltByNixpkgsCompiler (with prevStage.darwin; [ Libsystem ]);
-    assert (! useAppleSDKLibs) -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF ]);
-    assert    useAppleSDKLibs  -> lib.all                   isFromNixpkgs (with prevStage.darwin; [ CF Libsystem libobjc ]);
-    assert lib.all isFromNixpkgs (with prevStage.darwin; [ binutils-unwrapped dyld launchd libclosure libdispatch xnu ]);
+    assert
+      (!useAppleSDKLibs) -> lib.all isBuiltByBootstrapFilesCompiler (with prevStage.darwin; [ configd ]);
+    assert
+      (!useAppleSDKLibs) -> lib.all isBuiltByNixpkgsCompiler (with prevStage.darwin; [ Libsystem ]);
+    assert (!useAppleSDKLibs) -> lib.all isFromNixpkgs (with prevStage.darwin; [ CF ]);
+    assert
+      useAppleSDKLibs
+      -> lib.all isFromNixpkgs (
+        with prevStage.darwin;
+        [
+          CF
+          Libsystem
+          libobjc
+        ]
+      );
+    assert lib.all isFromNixpkgs (
+      with prevStage.darwin;
+      [
+        binutils-unwrapped
+        dyld
+        launchd
+        libclosure
+        libdispatch
+        xnu
+      ]
+    );
 
-    assert lib.all isBuiltByNixpkgsCompiler (with prevStage.llvmPackages; [
-      clang-unwrapped libclang libllvm llvm compiler-rt libcxx
-    ]);
+    assert lib.all isBuiltByNixpkgsCompiler (
+      with prevStage.llvmPackages;
+      [
+        clang-unwrapped
+        libclang
+        libllvm
+        llvm
+        compiler-rt
+        libcxx
+      ]
+    );
 
     stageFun prevStage {
 
-    name = "bootstrap-stage4";
+      name = "bootstrap-stage4";
 
-    overrides = self: super: {
-      inherit (prevStage) ccWrapperStdenv
-        autoconf automake bash binutils-unwrapped bison cmake cmakeMinimal curl cyrus_sasl db expat flex groff
-        libedit libtool m4 meson ninja openldap openssh patchutils perl pkg-config python3 python3Minimal scons
-        serf sqlite subversion sysctl texinfo unzip which
+      overrides = self: super: {
+        inherit (prevStage)
+          ccWrapperStdenv
+          autoconf
+          automake
+          bash
+          binutils-unwrapped
+          bison
+          cmake
+          cmakeMinimal
+          curl
+          cyrus_sasl
+          db
+          expat
+          flex
+          groff
+          libedit
+          libtool
+          m4
+          meson
+          ninja
+          openldap
+          openssh
+          patchutils
+          perl
+          pkg-config
+          python3
+          python3Minimal
+          scons
+          serf
+          sqlite
+          subversion
+          sysctl
+          texinfo
+          unzip
+          which
 
-        # CF dependencies - don’t rebuild them.
-        icu
-
-        # LLVM dependencies - don’t rebuild them.
-        libffi libiconv libiconv-darwin libxml2 ncurses zlib;
-
-      darwin = super.darwin.overrideScope (selfDarwin: superDarwin: {
-        inherit (prevStage.darwin) dyld CF Libsystem darwin-stubs
           # CF dependencies - don’t rebuild them.
-          libobjc objc4;
+          icu
 
-        apple_sdk = superDarwin.apple_sdk // {
-          inherit (prevStage.darwin.apple_sdk) sdkRoot;
-        };
+          # LLVM dependencies - don’t rebuild them.
+          libffi
+          libiconv
+          libiconv-darwin
+          libxml2
+          ncurses
+          zlib
+          ;
 
-        signingUtils = superDarwin.signingUtils.override {
-          inherit (selfDarwin) sigtool;
-        };
+        darwin = super.darwin.overrideScope (
+          selfDarwin: superDarwin: {
+            inherit (prevStage.darwin)
+              dyld
+              CF
+              Libsystem
+              darwin-stubs
+              # CF dependencies - don’t rebuild them.
+              libobjc
+              objc4
+              ;
 
-        binutils = superDarwin.binutils.override {
-          inherit (prevStage) expand-response-params;
+            apple_sdk = superDarwin.apple_sdk // {
+              inherit (prevStage.darwin.apple_sdk) sdkRoot;
+            };
 
-          bintools = selfDarwin.binutils-unwrapped;
-          libc = selfDarwin.Libsystem;
-        };
+            signingUtils = superDarwin.signingUtils.override { inherit (selfDarwin) sigtool; };
 
-        # binutils-unwrapped needs to build the LLVM man pages, which requires a lot of Python stuff
-        # that ultimately ends up depending on git. Fortunately, the git dependency is only for check
-        # inputs. The following set of overrides allow the LLVM documentation to be built without
-        # pulling curl (and other packages like ffmpeg) into the stdenv bootstrap.
-        binutils-unwrapped = superDarwin.binutils-unwrapped.override (old: {
-          llvm-manpages = super.llvmPackages.llvm-manpages.override {
-            python3Packages = self.python3.pkgs.overrideScope (_: superPython: {
-              hatch-vcs = superPython.hatch-vcs.overrideAttrs {
-                doInstallCheck = false;
-              };
-              markdown-it-py = superPython.markdown-it-py.overrideAttrs {
-                doInstallCheck = false;
-              };
-              mdit-py-plugins = superPython.mdit-py-plugins.overrideAttrs {
-                doInstallCheck = false;
-              };
-              myst-parser = superPython.myst-parser.overrideAttrs {
-                doInstallCheck = false;
-              };
-            });
-          };
-        });
-      });
-
-      llvmPackages = super.llvmPackages // (
-        let
-          tools = super.llvmPackages.tools.extend (_: _: {
-            inherit (prevStage.llvmPackages) clang-unwrapped libclang libllvm llvm;
-            libcxxClang = lib.makeOverridable (import ../../build-support/cc-wrapper) {
-              nativeTools = false;
-              nativeLibc = false;
-
+            binutils = superDarwin.binutils.override {
               inherit (prevStage) expand-response-params;
 
-              extraPackages = [
-                self.llvmPackages.compiler-rt
-              ];
-
-              extraBuildCommands =
-                let
-                  inherit (self.llvmPackages) clang-unwrapped compiler-rt release_version;
-
-                  # Clang 16+ uses only the major version in resource-root, but older versions use the complete one.
-                  clangResourceRootIncludePath = clangLib: clangRelease:
-                    let
-                      clangVersion =
-                        if lib.versionAtLeast clangRelease "16"
-                        then lib.versions.major clangRelease
-                        else clangRelease;
-                    in
-                    "${clangLib}/lib/clang/${clangVersion}/include";
-                in
-                ''
-                  rsrc="$out/resource-root"
-                  mkdir "$rsrc"
-                  ln -s "${clangResourceRootIncludePath clang-unwrapped.lib release_version}" "$rsrc"
-                  ln -s "${compiler-rt.out}/lib"   "$rsrc/lib"
-                  ln -s "${compiler-rt.out}/share" "$rsrc/share"
-                  echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
-                '';
-
-              cc = self.llvmPackages.clang-unwrapped;
-              bintools = self.darwin.binutils;
-
-              isClang = true;
-              libc = self.darwin.Libsystem;
-              inherit (self.llvmPackages) libcxx;
-
-              inherit lib;
-              inherit (self) stdenvNoCC coreutils gnugrep runtimeShell;
+              bintools = selfDarwin.binutils-unwrapped;
+              libc = selfDarwin.Libsystem;
             };
-          });
-          libraries = super.llvmPackages.libraries.extend (_: _:{
-            inherit (prevStage.llvmPackages) compiler-rt libcxx;
-          });
-        in
-        { inherit tools libraries; } // tools // libraries
-      );
-    };
 
-    extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
-      prevStage.updateAutotoolsGnuConfigScriptsHook
-      prevStage.gnu-config
-    ];
+            # binutils-unwrapped needs to build the LLVM man pages, which requires a lot of Python stuff
+            # that ultimately ends up depending on git. Fortunately, the git dependency is only for check
+            # inputs. The following set of overrides allow the LLVM documentation to be built without
+            # pulling curl (and other packages like ffmpeg) into the stdenv bootstrap.
+            binutils-unwrapped = superDarwin.binutils-unwrapped.override (old: {
+              llvm-manpages = super.llvmPackages.llvm-manpages.override {
+                python3Packages = self.python3.pkgs.overrideScope (
+                  _: superPython: {
+                    hatch-vcs = superPython.hatch-vcs.overrideAttrs { doInstallCheck = false; };
+                    markdown-it-py = superPython.markdown-it-py.overrideAttrs { doInstallCheck = false; };
+                    mdit-py-plugins = superPython.mdit-py-plugins.overrideAttrs { doInstallCheck = false; };
+                    myst-parser = superPython.myst-parser.overrideAttrs { doInstallCheck = false; };
+                  }
+                );
+              };
+            });
+          }
+        );
 
-    extraPreHook = ''
-      stripDebugFlags="-S" # llvm-strip does not support "-p" for Mach-O
-    '';
-  })
+        llvmPackages =
+          super.llvmPackages
+          // (
+            let
+              tools = super.llvmPackages.tools.extend (
+                _: _: {
+                  inherit (prevStage.llvmPackages)
+                    clang-unwrapped
+                    libclang
+                    libllvm
+                    llvm
+                    ;
+                  libcxxClang = lib.makeOverridable (import ../../build-support/cc-wrapper) {
+                    nativeTools = false;
+                    nativeLibc = false;
+
+                    inherit (prevStage) expand-response-params;
+
+                    extraPackages = [ self.llvmPackages.compiler-rt ];
+
+                    extraBuildCommands =
+                      let
+                        inherit (self.llvmPackages) clang-unwrapped compiler-rt release_version;
+
+                        # Clang 16+ uses only the major version in resource-root, but older versions use the complete one.
+                        clangResourceRootIncludePath =
+                          clangLib: clangRelease:
+                          let
+                            clangVersion =
+                              if lib.versionAtLeast clangRelease "16" then lib.versions.major clangRelease else clangRelease;
+                          in
+                          "${clangLib}/lib/clang/${clangVersion}/include";
+                      in
+                      ''
+                        rsrc="$out/resource-root"
+                        mkdir "$rsrc"
+                        ln -s "${clangResourceRootIncludePath clang-unwrapped.lib release_version}" "$rsrc"
+                        ln -s "${compiler-rt.out}/lib"   "$rsrc/lib"
+                        ln -s "${compiler-rt.out}/share" "$rsrc/share"
+                        echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
+                      '';
+
+                    cc = self.llvmPackages.clang-unwrapped;
+                    bintools = self.darwin.binutils;
+
+                    isClang = true;
+                    libc = self.darwin.Libsystem;
+                    inherit (self.llvmPackages) libcxx;
+
+                    inherit lib;
+                    inherit (self)
+                      stdenvNoCC
+                      coreutils
+                      gnugrep
+                      runtimeShell
+                      ;
+                  };
+                }
+              );
+              libraries = super.llvmPackages.libraries.extend (
+                _: _: { inherit (prevStage.llvmPackages) compiler-rt libcxx; }
+              );
+            in
+            { inherit tools libraries; } // tools // libraries
+          );
+      };
+
+      extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
+        prevStage.updateAutotoolsGnuConfigScriptsHook
+        prevStage.gnu-config
+      ];
+
+      extraPreHook = ''
+        stripDebugFlags="-S" # llvm-strip does not support "-p" for Mach-O
+      '';
+    }
+  )
 
   # Construct the final stdenv. The version of LLVM provided should match the one defined in
   # `all-packages.nix` for Darwin. Nothing should depend on the bootstrap tools or originate from
@@ -1171,189 +2105,371 @@ in
   #
   # When updating the Darwin stdenv, make sure that the result has no dependency (`nix-store -qR`)
   # on `bootstrapTools` or the binutils built in stage 1.
-  (prevStage:
+  (
+    prevStage:
     # previous stage4 stdenv:
-    assert lib.all isBuiltByNixpkgsCompiler (with prevStage; [
-      bash brotli bzip2 cctools cpio diffutils ed file findutils gawk
-      gettext gmp gnugrep gnumake gnused gnutar gzip icu ld64 libffi libiconv libidn2 libkrb5
-      libssh2 libtapi libunistring libxml2 libyaml ncurses nghttp2 openbsm openpam openssl patch
-      pbzx pcre xar xz zlib zstd
-    ]);
-
-    assert lib.all isBuiltByNixpkgsCompiler (with prevStage.darwin; [ locale print-reexports rewrite-tbd sigtool ]);
-
-    assert (! useAppleSDKLibs) -> lib.all isBuiltByNixpkgsCompiler (with prevStage.darwin; [ Libsystem configd ]);
-    assert (! useAppleSDKLibs) -> lib.all            isFromNixpkgs (with prevStage.darwin; [ CF ]);
-    assert    useAppleSDKLibs  -> lib.all            isFromNixpkgs (with prevStage.darwin; [ CF Libsystem libobjc ]);
-    assert lib.all isFromNixpkgs (with prevStage.darwin; [ binutils-unwrapped dyld launchd libclosure libdispatch xnu ]);
-
-    assert lib.all isBuiltByNixpkgsCompiler (with prevStage.llvmPackages; [
-      clang-unwrapped libclang libllvm llvm compiler-rt libcxx
-    ]);
-
-    assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
-      autoconf automake bison cmake cmakeMinimal cyrus_sasl db expat flex groff libedit
-      libtool m4 meson ninja openldap openssh patchutils perl pkg-config.pkg-config python3 python3Minimal scons
-      serf sqlite subversion sysctl.provider texinfo unzip which
-    ]);
-
-    let
-      cc = prevStage.llvmPackages.clang;
-    in
-    {
-    inherit config overlays;
-    stdenv = import ../generic {
-      name = "stdenv-darwin";
-
-      buildPlatform = localSystem;
-      hostPlatform = localSystem;
-      targetPlatform = localSystem;
-
-      inherit config;
-
-      preHook = ''
-        ${commonPreHook}
-        stripDebugFlags="-S" # llvm-strip does not support "-p" for Mach-O
-        export PATH_LOCALE=${prevStage.darwin.locale}/share/locale
-      '';
-
-      initialPath = ((import ../generic/common-path.nix) { pkgs = prevStage; });
-
-      extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
-        prevStage.updateAutotoolsGnuConfigScriptsHook
-      ] ++ [ prevStage.darwin.apple_sdk.sdkRoot ];
-
-      extraBuildInputs = [ prevStage.darwin.CF ];
-
-      inherit cc;
-
-      shell = cc.shell;
-
-      inherit (prevStage.stdenv) fetchurlBoot;
-
-      extraAttrs = {
-        inherit bootstrapTools;
-        libc = prevStage.darwin.Libsystem;
-        shellPackage = prevStage.bash;
-      } // lib.optionalAttrs useAppleSDKLibs {
-        # This objc4 will be propagated to all builds using the final stdenv,
-        # and we shouldn't mix different builds, because they would be
-        # conflicting LLVM modules. Export it here so we can grab it later.
-        inherit (prevStage.darwin) objc4;
-      };
-
-      disallowedRequisites = [ bootstrapTools.out ];
-
-      allowedRequisites = (with prevStage; [
+    assert lib.all isBuiltByNixpkgsCompiler (
+      with prevStage;
+      [
         bash
-        bzip2.bin
-        bzip2.out
-        cc.expand-response-params
+        brotli
+        bzip2
         cctools
-        ld64.out
-        ld64.lib
-        libtapi.out
-        coreutils
-        darwin.binutils
-        darwin.binutils.bintools
+        cpio
         diffutils
         ed
         file
         findutils
         gawk
         gettext
-        gmp.out
+        gmp
         gnugrep
-        gnugrep.pcre2.out
         gnumake
         gnused
         gnutar
         gzip
-        icu.out
-        libffi.out
+        icu
+        ld64
+        libffi
         libiconv
-        libunistring.out
-        libxml2.out
-        ncurses.dev
-        ncurses.man
-        ncurses.out
+        libidn2
+        libkrb5
+        libssh2
+        libtapi
+        libunistring
+        libxml2
+        libyaml
+        ncurses
+        nghttp2
         openbsm
         openpam
-        openssl.out
+        openssl
         patch
+        pbzx
+        pcre
         xar
-        xz.bin
-        xz.out
-        zlib.dev
-        zlib.out
-      ])
-      ++ lib.optionals localSystem.isAarch64 [
-        prevStage.updateAutotoolsGnuConfigScriptsHook
-        prevStage.gnu-config
+        xz
+        zlib
+        zstd
       ]
-      ++ (with prevStage.llvmPackages; [
-        bintools-unwrapped
-        clang-unwrapped
-        clang-unwrapped.lib
-        compiler-rt
-        compiler-rt.dev
-        libcxx
-        libcxx.dev
-        lld
-        llvm
-        llvm.lib
-      ])
-      ++ (with prevStage.darwin; [
-        CF
-        Libsystem
-        dyld
+    );
+
+    assert lib.all isBuiltByNixpkgsCompiler (
+      with prevStage.darwin;
+      [
         locale
-        apple_sdk.sdkRoot
+        print-reexports
+        rewrite-tbd
+        sigtool
       ]
-      ++ lib.optionals useAppleSDKLibs [ objc4 ]);
+    );
 
-      __stdenvImpureHostDeps = commonImpureHostDeps;
-      __extraImpureHostDeps = commonImpureHostDeps;
+    assert
+      (!useAppleSDKLibs)
+      -> lib.all isBuiltByNixpkgsCompiler (
+        with prevStage.darwin;
+        [
+          Libsystem
+          configd
+        ]
+      );
+    assert (!useAppleSDKLibs) -> lib.all isFromNixpkgs (with prevStage.darwin; [ CF ]);
+    assert
+      useAppleSDKLibs
+      -> lib.all isFromNixpkgs (
+        with prevStage.darwin;
+        [
+          CF
+          Libsystem
+          libobjc
+        ]
+      );
+    assert lib.all isFromNixpkgs (
+      with prevStage.darwin;
+      [
+        binutils-unwrapped
+        dyld
+        launchd
+        libclosure
+        libdispatch
+        xnu
+      ]
+    );
 
-      overrides = self: super: {
-        inherit (prevStage)
-          bash brotli bzip2 coreutils cpio diffutils ed file findutils gawk
-          gettext gmp gnugrep gnumake gnused gnutar gzip icu libffi libiconv libiconv-darwin
-          libidn2 libssh2 libunistring libxml2 libyaml ncurses nghttp2 openbsm openpam
-          openssl patch pbzx pcre python3Minimal xar xz zlib zstd;
+    assert lib.all isBuiltByNixpkgsCompiler (
+      with prevStage.llvmPackages;
+      [
+        clang-unwrapped
+        libclang
+        libllvm
+        llvm
+        compiler-rt
+        libcxx
+      ]
+    );
 
-        darwin = super.darwin.overrideScope (_: superDarwin: {
-          inherit (prevStage.darwin)
-            CF Libsystem darwin-stubs dyld locale libobjc rewrite-tbd xnu;
+    assert lib.all isBuiltByBootstrapFilesCompiler (
+      with prevStage;
+      [
+        autoconf
+        automake
+        bison
+        cmake
+        cmakeMinimal
+        cyrus_sasl
+        db
+        expat
+        flex
+        groff
+        libedit
+        libtool
+        m4
+        meson
+        ninja
+        openldap
+        openssh
+        patchutils
+        perl
+        pkg-config.pkg-config
+        python3
+        python3Minimal
+        scons
+        serf
+        sqlite
+        subversion
+        sysctl.provider
+        texinfo
+        unzip
+        which
+      ]
+    );
 
-          apple_sdk = superDarwin.apple_sdk // {
-            inherit (prevStage.darwin.apple_sdk) sdkRoot;
+    let
+      cc = prevStage.llvmPackages.clang;
+    in
+    {
+      inherit config overlays;
+      stdenv = import ../generic {
+        name = "stdenv-darwin";
+
+        buildPlatform = localSystem;
+        hostPlatform = localSystem;
+        targetPlatform = localSystem;
+
+        inherit config;
+
+        preHook = ''
+          ${commonPreHook}
+          stripDebugFlags="-S" # llvm-strip does not support "-p" for Mach-O
+          export PATH_LOCALE=${prevStage.darwin.locale}/share/locale
+        '';
+
+        initialPath = ((import ../generic/common-path.nix) { pkgs = prevStage; });
+
+        extraNativeBuildInputs =
+          lib.optionals localSystem.isAarch64 [ prevStage.updateAutotoolsGnuConfigScriptsHook ]
+          ++ [ prevStage.darwin.apple_sdk.sdkRoot ];
+
+        extraBuildInputs = [ prevStage.darwin.CF ];
+
+        inherit cc;
+
+        shell = cc.shell;
+
+        inherit (prevStage.stdenv) fetchurlBoot;
+
+        extraAttrs =
+          {
+            inherit bootstrapTools;
+            libc = prevStage.darwin.Libsystem;
+            shellPackage = prevStage.bash;
+          }
+          // lib.optionalAttrs useAppleSDKLibs {
+            # This objc4 will be propagated to all builds using the final stdenv,
+            # and we shouldn't mix different builds, because they would be
+            # conflicting LLVM modules. Export it here so we can grab it later.
+            inherit (prevStage.darwin) objc4;
           };
-        } // lib.optionalAttrs (super.stdenv.targetPlatform == localSystem) {
-          inherit (prevStage.darwin) binutils binutils-unwrapped;
-        });
-      } // lib.optionalAttrs (super.stdenv.targetPlatform == localSystem) {
-        inherit (prevStage) cctools ld64 libtapi;
-        inherit (prevStage.llvmPackages) clang llvm;
 
-        # Need to get rid of these when cross-compiling.
-        llvmPackages = super.llvmPackages // (
-          let
-            tools = super.llvmPackages.tools.extend (_: _: {
-              inherit (prevStage.llvmPackages) clang clang-unwrapped libclang libllvm llvm;
-            });
-            libraries = super.llvmPackages.libraries.extend (_: _: {
-              inherit (prevStage.llvmPackages) compiler-rt libcxx;
-            });
-          in
-          { inherit tools libraries; } // tools // libraries
-        );
+        disallowedRequisites = [ bootstrapTools.out ];
+
+        allowedRequisites =
+          (with prevStage; [
+            bash
+            bzip2.bin
+            bzip2.out
+            cc.expand-response-params
+            cctools
+            ld64.out
+            ld64.lib
+            libtapi.out
+            coreutils
+            darwin.binutils
+            darwin.binutils.bintools
+            diffutils
+            ed
+            file
+            findutils
+            gawk
+            gettext
+            gmp.out
+            gnugrep
+            gnugrep.pcre2.out
+            gnumake
+            gnused
+            gnutar
+            gzip
+            icu.out
+            libffi.out
+            libiconv
+            libunistring.out
+            libxml2.out
+            ncurses.dev
+            ncurses.man
+            ncurses.out
+            openbsm
+            openpam
+            openssl.out
+            patch
+            xar
+            xz.bin
+            xz.out
+            zlib.dev
+            zlib.out
+          ])
+          ++ lib.optionals localSystem.isAarch64 [
+            prevStage.updateAutotoolsGnuConfigScriptsHook
+            prevStage.gnu-config
+          ]
+          ++ (with prevStage.llvmPackages; [
+            bintools-unwrapped
+            clang-unwrapped
+            clang-unwrapped.lib
+            compiler-rt
+            compiler-rt.dev
+            libcxx
+            libcxx.dev
+            lld
+            llvm
+            llvm.lib
+          ])
+          ++ (
+            with prevStage.darwin;
+            [
+              CF
+              Libsystem
+              dyld
+              locale
+              apple_sdk.sdkRoot
+            ]
+            ++ lib.optionals useAppleSDKLibs [ objc4 ]
+          );
+
+        __stdenvImpureHostDeps = commonImpureHostDeps;
+        __extraImpureHostDeps = commonImpureHostDeps;
+
+        overrides =
+          self: super:
+          {
+            inherit (prevStage)
+              bash
+              brotli
+              bzip2
+              coreutils
+              cpio
+              diffutils
+              ed
+              file
+              findutils
+              gawk
+              gettext
+              gmp
+              gnugrep
+              gnumake
+              gnused
+              gnutar
+              gzip
+              icu
+              libffi
+              libiconv
+              libiconv-darwin
+              libidn2
+              libssh2
+              libunistring
+              libxml2
+              libyaml
+              ncurses
+              nghttp2
+              openbsm
+              openpam
+              openssl
+              patch
+              pbzx
+              pcre
+              python3Minimal
+              xar
+              xz
+              zlib
+              zstd
+              ;
+
+            darwin = super.darwin.overrideScope (
+              _: superDarwin:
+              {
+                inherit (prevStage.darwin)
+                  CF
+                  Libsystem
+                  darwin-stubs
+                  dyld
+                  locale
+                  libobjc
+                  rewrite-tbd
+                  xnu
+                  ;
+
+                apple_sdk = superDarwin.apple_sdk // {
+                  inherit (prevStage.darwin.apple_sdk) sdkRoot;
+                };
+              }
+              // lib.optionalAttrs (super.stdenv.targetPlatform == localSystem) {
+                inherit (prevStage.darwin) binutils binutils-unwrapped;
+              }
+            );
+          }
+          // lib.optionalAttrs (super.stdenv.targetPlatform == localSystem) {
+            inherit (prevStage) cctools ld64 libtapi;
+            inherit (prevStage.llvmPackages) clang llvm;
+
+            # Need to get rid of these when cross-compiling.
+            llvmPackages =
+              super.llvmPackages
+              // (
+                let
+                  tools = super.llvmPackages.tools.extend (
+                    _: _: {
+                      inherit (prevStage.llvmPackages)
+                        clang
+                        clang-unwrapped
+                        libclang
+                        libllvm
+                        llvm
+                        ;
+                    }
+                  );
+                  libraries = super.llvmPackages.libraries.extend (
+                    _: _: { inherit (prevStage.llvmPackages) compiler-rt libcxx; }
+                  );
+                in
+                { inherit tools libraries; } // tools // libraries
+              );
+          };
       };
-    };
-  })
+    }
+  )
 
   # This "no-op" stage is just a place to put the assertions about the final stage.
-  (prevStage:
+  (
+    prevStage:
     # previous final stage stdenv:
     assert isBuiltByNixpkgsCompiler prevStage.cctools;
     assert isBuiltByNixpkgsCompiler prevStage.ld64;
@@ -1361,9 +2477,9 @@ in
     assert isBuiltByNixpkgsCompiler prevStage.darwin.print-reexports;
     assert isBuiltByNixpkgsCompiler prevStage.darwin.rewrite-tbd;
 
-    assert            isFromNixpkgs prevStage.darwin.CF;
-    assert            isFromNixpkgs prevStage.darwin.Libsystem;
-    assert            isFromNixpkgs prevStage.darwin.binutils-unwrapped;
+    assert isFromNixpkgs prevStage.darwin.CF;
+    assert isFromNixpkgs prevStage.darwin.Libsystem;
+    assert isFromNixpkgs prevStage.darwin.binutils-unwrapped;
 
     assert isBuiltByNixpkgsCompiler prevStage.llvmPackages.clang-unwrapped;
     assert isBuiltByNixpkgsCompiler prevStage.llvmPackages.libllvm;
@@ -1372,8 +2488,11 @@ in
 
     # Make sure these evaluate since they were disabled explicitly in the bootstrap.
     assert isBuiltByNixpkgsCompiler prevStage.binutils-unwrapped;
-    assert            isFromNixpkgs prevStage.binutils-unwrapped.src;
+    assert isFromNixpkgs prevStage.binutils-unwrapped.src;
     assert isBuiltByNixpkgsCompiler prevStage.curl;
 
-    { inherit (prevStage) config overlays stdenv; })
+    {
+      inherit (prevStage) config overlays stdenv;
+    }
+  )
 ]


### PR DESCRIPTION
## Description of changes

I’m going to be doing a lot of work on the Darwin stdenv. Rather than risk merge conflicts, I’d like to get it reformatted before I start working. I confirmed with `nix-instantiate` that the resulting hash for the stdenv is the same, so it should not cause rebuilds. This is targeting staging-next because staging-next will merge in a few days. Currently, staging and staging-next have the same base commit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
