### PR TITLE
x265: fix build on x86_64-darwin

### DIFF
--- a/pkgs/development/libraries/x265/darwin-__rdtsc.patch
+++ b/pkgs/development/libraries/x265/darwin-__rdtsc.patch
@@ -1,0 +1,29 @@
+From 5ad351f7d271d0be0611797542c831898b2f531c Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Sun, 11 Aug 2024 22:09:34 +0100
+Subject: [PATCH] source/test/testharness.h: don't redefine `__rdtsc()` builtin
+
+On darwin clang-16 provides `__rdtsc()` builtin. As a result the build
+fails in `nixpkgs` as:
+
+    source/test/testharness.h:78:24: error: static declaration of '__rdtsc' follows non-static declaration
+    static inline uint32_t __rdtsc(void)
+                           ^
+    x265_3.6/source/test/testharness.h:78:24: note: '__rdtsc' is a builtin with type 2
+
+The change avoid redefinition on targets that define `__rdtsc()` builtin.
+---
+ source/test/testharness.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/test/testharness.h
++++ b/test/testharness.h
+@@ -69,6 +69,8 @@ protected:
+ #include <intrin.h>
+ #elif HAVE_RDTSC
+ #include <intrin.h>
++#elif defined(__has_builtin) && __has_builtin(__rdtsc)
++/* compiler-provided builtin */
+ #elif (!defined(__APPLE__) && (defined (__GNUC__) && (defined(__x86_64__) || defined(__i386__))))
+ #include <x86intrin.h>
+ #elif ( !defined(__APPLE__) && defined (__GNUC__) && defined(__ARM_NEON__))

--- a/pkgs/development/libraries/x265/default.nix
+++ b/pkgs/development/libraries/x265/default.nix
@@ -41,6 +41,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-ZjUx80HFOJ9GDXMOYuEKT8yjQoyiyhCWk4Z7xf4uKAc=";
   };
 
+  # TODO: apply patch unconditionally in staging. It's conditional to
+  # save rebuild on staging-next.
+  patches = lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [
+    ./darwin-__rdtsc.patch
+  ];
+
   sourceRoot = "x265_${version}/source";
 
   postPatch = ''


### PR DESCRIPTION
Update to 3.6 pulled in local definition of `__rdtsc()` symbol in the test suite and caused symbol clash:

    /tmp/nix-build-x265-3.6.drv-0/x265_3.6/source/test/testharness.h:78:24: error: static declaration of '__rdtsc' follows non-static declaration
    static inline uint32_t __rdtsc(void)
                           ^
    /tmp/nix-build-x265-3.6.drv-0/x265_3.6/source/test/testharness.h:78:24: note: '__rdtsc' is a builtin with type 2

The change avoids redefinition if the compiler already provides the builtin.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
