### PR TITLE
nixos/tt-rss: add email.passwordFile option, reformat

### DIFF
--- a/nixos/modules/services/web-apps/tt-rss.nix
+++ b/nixos/modules/services/web-apps/tt-rss.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 with lib;
 let
@@ -8,122 +13,155 @@ let
 
   configVersion = 26;
 
-  dbPort = if cfg.database.port == null
-    then (if cfg.database.type == "pgsql" then 5432 else 3306)
-    else cfg.database.port;
+  dbPort =
+    if cfg.database.port == null then
+      (if cfg.database.type == "pgsql" then 5432 else 3306)
+    else
+      cfg.database.port;
 
   poolName = "tt-rss";
 
   mysqlLocal = cfg.database.createLocally && cfg.database.type == "mysql";
   pgsqlLocal = cfg.database.createLocally && cfg.database.type == "pgsql";
 
-  tt-rss-config = let
-    dbPassword =
-      if (cfg.database.password != null) then
-        "'${(escape ["'" "\\"] cfg.database.password)}'"
-      else if (cfg.database.passwordFile != null) then
-        "file_get_contents('${cfg.database.passwordFile}')"
-      else
-        null
-      ;
-    smtpPassword =
-      if (cfg.email.password != null) then
-        "'${(escape ["'" "\\"] cfg.email.password)}'"
-      else if (cfg.email.passwordFile != null) then
-        "file_get_contents('${cfg.email.passwordFile}')"
-      else
-        null
-      ;
-  in pkgs.writeText "config.php" ''
-    <?php
-      putenv('TTRSS_PHP_EXECUTABLE=${phpPackage}/bin/php');
+  tt-rss-config =
+    let
+      dbPassword =
+        if (cfg.database.password != null) then
+          "'${
+            (escape [
+              "'"
+              "\\"
+            ] cfg.database.password)
+          }'"
+        else if (cfg.database.passwordFile != null) then
+          "file_get_contents('${cfg.database.passwordFile}')"
+        else
+          null;
+      smtpPassword =
+        if (cfg.email.password != null) then
+          "'${
+            (escape [
+              "'"
+              "\\"
+            ] cfg.email.password)
+          }'"
+        else if (cfg.email.passwordFile != null) then
+          "file_get_contents('${cfg.email.passwordFile}')"
+        else
+          null;
+    in
+    pkgs.writeText "config.php" ''
+      <?php
+        putenv('TTRSS_PHP_EXECUTABLE=${phpPackage}/bin/php');
 
-      putenv('TTRSS_LOCK_DIRECTORY=${cfg.root}/lock');
-      putenv('TTRSS_CACHE_DIR=${cfg.root}/cache');
-      putenv('TTRSS_ICONS_DIR=${cfg.root}/feed-icons');
-      putenv('TTRSS_ICONS_URL=feed-icons');
-      putenv('TTRSS_SELF_URL_PATH=${cfg.selfUrlPath}');
+        putenv('TTRSS_LOCK_DIRECTORY=${cfg.root}/lock');
+        putenv('TTRSS_CACHE_DIR=${cfg.root}/cache');
+        putenv('TTRSS_ICONS_DIR=${cfg.root}/feed-icons');
+        putenv('TTRSS_ICONS_URL=feed-icons');
+        putenv('TTRSS_SELF_URL_PATH=${cfg.selfUrlPath}');
 
-      putenv('TTRSS_MYSQL_CHARSET=UTF8');
+        putenv('TTRSS_MYSQL_CHARSET=UTF8');
 
-      putenv('TTRSS_DB_TYPE=${cfg.database.type}');
-      putenv('TTRSS_DB_HOST=${optionalString (cfg.database.host != null) cfg.database.host}');
-      putenv('TTRSS_DB_USER=${cfg.database.user}');
-      putenv('TTRSS_DB_NAME=${cfg.database.name}');
-      putenv('TTRSS_DB_PASS=' ${optionalString (dbPassword != null) ". ${dbPassword}"});
-      putenv('TTRSS_DB_PORT=${toString dbPort}');
+        putenv('TTRSS_DB_TYPE=${cfg.database.type}');
+        putenv('TTRSS_DB_HOST=${optionalString (cfg.database.host != null) cfg.database.host}');
+        putenv('TTRSS_DB_USER=${cfg.database.user}');
+        putenv('TTRSS_DB_NAME=${cfg.database.name}');
+        putenv('TTRSS_DB_PASS=' ${optionalString (dbPassword != null) ". ${dbPassword}"});
+        putenv('TTRSS_DB_PORT=${toString dbPort}');
 
-      putenv('TTRSS_AUTH_AUTO_CREATE=${boolToString cfg.auth.autoCreate}');
-      putenv('TTRSS_AUTH_AUTO_LOGIN=${boolToString cfg.auth.autoLogin}');
+        putenv('TTRSS_AUTH_AUTO_CREATE=${boolToString cfg.auth.autoCreate}');
+        putenv('TTRSS_AUTH_AUTO_LOGIN=${boolToString cfg.auth.autoLogin}');
 
-      putenv('TTRSS_FEED_CRYPT_KEY=${escape ["'" "\\"] cfg.feedCryptKey}');
-
-
-      putenv('TTRSS_SINGLE_USER_MODE=${boolToString cfg.singleUserMode}');
-
-      putenv('TTRSS_SIMPLE_UPDATE_MODE=${boolToString cfg.simpleUpdateMode}');
-
-      # Never check for updates - the running version of the code should
-      # be controlled entirely by the version of TT-RSS active in the
-      # current Nix profile. If TT-RSS updates itself to a version
-      # requiring a database schema upgrade, and then the SystemD
-      # tt-rss.service is restarted, the old code copied from the Nix
-      # store will overwrite the updated version, causing the code to
-      # detect the need for a schema "upgrade" (since the schema version
-      # in the database is different than in the code), but the update
-      # schema operation in TT-RSS will do nothing because the schema
-      # version in the database is newer than that in the code.
-      putenv('TTRSS_CHECK_FOR_UPDATES=false');
-
-      putenv('TTRSS_FORCE_ARTICLE_PURGE=${toString cfg.forceArticlePurge}');
-      putenv('TTRSS_SESSION_COOKIE_LIFETIME=${toString cfg.sessionCookieLifetime}');
-      putenv('TTRSS_ENABLE_GZIP_OUTPUT=${boolToString cfg.enableGZipOutput}');
-
-      putenv('TTRSS_PLUGINS=${builtins.concatStringsSep "," cfg.plugins}');
-
-      putenv('TTRSS_LOG_DESTINATION=${cfg.logDestination}');
-      putenv('TTRSS_CONFIG_VERSION=${toString configVersion}');
+        putenv('TTRSS_FEED_CRYPT_KEY=${
+          escape [
+            "'"
+            "\\"
+          ] cfg.feedCryptKey
+        }');
 
 
-      putenv('TTRSS_PUBSUBHUBBUB_ENABLED=${boolToString cfg.pubSubHubbub.enable}');
-      putenv('TTRSS_PUBSUBHUBBUB_HUB=${cfg.pubSubHubbub.hub}');
+        putenv('TTRSS_SINGLE_USER_MODE=${boolToString cfg.singleUserMode}');
 
-      putenv('TTRSS_SPHINX_SERVER=${cfg.sphinx.server}');
-      putenv('TTRSS_SPHINX_INDEX=${builtins.concatStringsSep "," cfg.sphinx.index}');
+        putenv('TTRSS_SIMPLE_UPDATE_MODE=${boolToString cfg.simpleUpdateMode}');
 
-      putenv('TTRSS_ENABLE_REGISTRATION=${boolToString cfg.registration.enable}');
-      putenv('TTRSS_REG_NOTIFY_ADDRESS=${cfg.registration.notifyAddress}');
-      putenv('TTRSS_REG_MAX_USERS=${toString cfg.registration.maxUsers}');
+        # Never check for updates - the running version of the code should
+        # be controlled entirely by the version of TT-RSS active in the
+        # current Nix profile. If TT-RSS updates itself to a version
+        # requiring a database schema upgrade, and then the SystemD
+        # tt-rss.service is restarted, the old code copied from the Nix
+        # store will overwrite the updated version, causing the code to
+        # detect the need for a schema "upgrade" (since the schema version
+        # in the database is different than in the code), but the update
+        # schema operation in TT-RSS will do nothing because the schema
+        # version in the database is newer than that in the code.
+        putenv('TTRSS_CHECK_FOR_UPDATES=false');
 
-      putenv('TTRSS_SMTP_SERVER=${cfg.email.server}');
-      putenv('TTRSS_SMTP_LOGIN=${cfg.email.login}');
-      putenv('TTRSS_SMTP_PASSWORD=${optionalString (smtpPassword != null) ". ${smtpPassword}"}');
-      putenv('TTRSS_SMTP_SECURE=${cfg.email.security}');
+        putenv('TTRSS_FORCE_ARTICLE_PURGE=${toString cfg.forceArticlePurge}');
+        putenv('TTRSS_SESSION_COOKIE_LIFETIME=${toString cfg.sessionCookieLifetime}');
+        putenv('TTRSS_ENABLE_GZIP_OUTPUT=${boolToString cfg.enableGZipOutput}');
 
-      putenv('TTRSS_SMTP_FROM_NAME=${escape ["'" "\\"] cfg.email.fromName}');
-      putenv('TTRSS_SMTP_FROM_ADDRESS=${escape ["'" "\\"] cfg.email.fromAddress}');
-      putenv('TTRSS_DIGEST_SUBJECT=${escape ["'" "\\"] cfg.email.digestSubject}');
+        putenv('TTRSS_PLUGINS=${builtins.concatStringsSep "," cfg.plugins}');
 
-      ${cfg.extraConfig}
-  '';
+        putenv('TTRSS_LOG_DESTINATION=${cfg.logDestination}');
+        putenv('TTRSS_CONFIG_VERSION=${toString configVersion}');
+
+
+        putenv('TTRSS_PUBSUBHUBBUB_ENABLED=${boolToString cfg.pubSubHubbub.enable}');
+        putenv('TTRSS_PUBSUBHUBBUB_HUB=${cfg.pubSubHubbub.hub}');
+
+        putenv('TTRSS_SPHINX_SERVER=${cfg.sphinx.server}');
+        putenv('TTRSS_SPHINX_INDEX=${builtins.concatStringsSep "," cfg.sphinx.index}');
+
+        putenv('TTRSS_ENABLE_REGISTRATION=${boolToString cfg.registration.enable}');
+        putenv('TTRSS_REG_NOTIFY_ADDRESS=${cfg.registration.notifyAddress}');
+        putenv('TTRSS_REG_MAX_USERS=${toString cfg.registration.maxUsers}');
+
+        putenv('TTRSS_SMTP_SERVER=${cfg.email.server}');
+        putenv('TTRSS_SMTP_LOGIN=${cfg.email.login}');
+        putenv('TTRSS_SMTP_PASSWORD=${optionalString (smtpPassword != null) ". ${smtpPassword}"}');
+        putenv('TTRSS_SMTP_SECURE=${cfg.email.security}');
+
+        putenv('TTRSS_SMTP_FROM_NAME=${
+          escape [
+            "'"
+            "\\"
+          ] cfg.email.fromName
+        }');
+        putenv('TTRSS_SMTP_FROM_ADDRESS=${
+          escape [
+            "'"
+            "\\"
+          ] cfg.email.fromAddress
+        }');
+        putenv('TTRSS_DIGEST_SUBJECT=${
+          escape [
+            "'"
+            "\\"
+          ] cfg.email.digestSubject
+        }');
+
+        ${cfg.extraConfig}
+    '';
 
   # tt-rss and plugins and themes and config.php
-  servedRoot = pkgs.runCommand "tt-rss-served-root" {} ''
+  servedRoot = pkgs.runCommand "tt-rss-served-root" { } ''
     cp --no-preserve=mode -r ${pkgs.tt-rss} $out
     cp ${tt-rss-config} $out/config.php
-    ${optionalString (cfg.pluginPackages != []) ''
-    for plugin in ${concatStringsSep " " cfg.pluginPackages}; do
-    cp -r "$plugin"/* "$out/plugins.local/"
-    done
+    ${optionalString (cfg.pluginPackages != [ ]) ''
+      for plugin in ${concatStringsSep " " cfg.pluginPackages}; do
+      cp -r "$plugin"/* "$out/plugins.local/"
+      done
     ''}
-    ${optionalString (cfg.themePackages != []) ''
-    for theme in ${concatStringsSep " " cfg.themePackages}; do
-    cp -r "$theme"/* "$out/themes.local/"
-    done
+    ${optionalString (cfg.themePackages != [ ]) ''
+      for theme in ${concatStringsSep " " cfg.themePackages}; do
+      cp -r "$theme"/* "$out/themes.local/"
+      done
     ''}
   '';
 
- in {
+in
+{
 
   ###### interface
 
@@ -169,7 +207,10 @@ let
 
       database = {
         type = mkOption {
-          type = types.enum ["pgsql" "mysql"];
+          type = types.enum [
+            "pgsql"
+            "mysql"
+          ];
           default = "pgsql";
           description = ''
             Database to store feeds. Supported are pgsql and mysql.
@@ -286,7 +327,10 @@ let
 
         index = mkOption {
           type = types.listOf types.str;
-          default = ["ttrss" "delta"];
+          default = [
+            "ttrss"
+            "delta"
+          ];
           description = ''
             Index names in Sphinx configuration. Example configuration
             files are available on tt-rss wiki.
@@ -360,7 +404,11 @@ let
         };
 
         security = mkOption {
-          type = types.enum ["" "ssl" "tls"];
+          type = types.enum [
+            ""
+            "ssl"
+            "tls"
+          ];
           default = "";
           description = ''
             Used to select a secure SMTP connection. Allowed values: ssl, tls,
@@ -485,7 +533,10 @@ let
 
       plugins = mkOption {
         type = types.listOf types.str;
-        default = ["auth_internal" "note"];
+        default = [
+          "auth_internal"
+          "note"
+        ];
         description = ''
           List of plugins to load automatically for all users.
           System plugins have to be specified here. Please enable at least one
@@ -499,7 +550,7 @@ let
 
       pluginPackages = mkOption {
         type = types.listOf types.package;
-        default = [];
+        default = [ ];
         description = ''
           List of plugins to install. The list elements are expected to
           be derivations. All elements in this derivation are automatically
@@ -509,7 +560,7 @@ let
 
       themePackages = mkOption {
         type = types.listOf types.package;
-        default = [];
+        default = [ ];
         description = ''
           List of themes to install. The list elements are expected to
           be derivations. All elements in this derivation are automatically
@@ -518,7 +569,11 @@ let
       };
 
       logDestination = mkOption {
-        type = types.enum ["" "sql" "syslog"];
+        type = types.enum [
+          ""
+          "sql"
+          "syslog"
+        ];
         default = "sql";
         description = ''
           Log destination to use. Possible values: sql (uses internal logging
@@ -539,12 +594,19 @@ let
   };
 
   imports = [
-    (mkRemovedOptionModule ["services" "tt-rss" "checkForUpdates"] ''
-      This option was removed because setting this to true will cause TT-RSS
-      to be unable to start if an automatic update of the code in
-      services.tt-rss.root leads to a database schema upgrade that is not
-      supported by the code active in the Nix store.
-    '')
+    (mkRemovedOptionModule
+      [
+        "services"
+        "tt-rss"
+        "checkForUpdates"
+      ]
+      ''
+        This option was removed because setting this to true will cause TT-RSS
+        to be unable to start if an automatic update of the code in
+        services.tt-rss.root leads to a database schema upgrade that is not
+        supported by the code active in the Nix store.
+      ''
+    )
   ];
 
   ###### implementation
@@ -561,7 +623,8 @@ let
         message = "Cannot set both email password and passwordFile";
       }
       {
-        assertion = cfg.database.createLocally -> cfg.database.name == cfg.user && cfg.database.user == cfg.user;
+        assertion =
+          cfg.database.createLocally -> cfg.database.name == cfg.user && cfg.database.user == cfg.user;
         message = ''
           When creating a database via NixOS, the db user and db name must be equal!
           If you already have an existing DB+user and this assertion is new, you can safely set
@@ -628,9 +691,7 @@ let
     ];
 
     systemd.services = {
-      phpfpm-tt-rss = mkIf (cfg.pool == "${poolName}") {
-        restartTriggers = [ servedRoot ];
-      };
+      phpfpm-tt-rss = mkIf (cfg.pool == "${poolName}") { restartTriggers = [ servedRoot ]; };
 
       tt-rss = {
         description = "Tiny Tiny RSS feeds update daemon";
@@ -650,7 +711,9 @@ let
 
         wantedBy = [ "multi-user.target" ];
         requires = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.service";
-        after = [ "network.target" ] ++ optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.service";
+        after = [
+          "network.target"
+        ] ++ optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.service";
       };
     };
 
@@ -672,7 +735,8 @@ let
       enable = mkDefault true;
       ensureDatabases = [ cfg.database.name ];
       ensureUsers = [
-        { name = cfg.database.user;
+        {
+          name = cfg.database.user;
           ensureDBOwnership = true;
         }
       ];
@@ -684,6 +748,6 @@ let
       group = "tt_rss";
     };
 
-    users.groups.tt_rss = {};
+    users.groups.tt_rss = { };
   };
 }


### PR DESCRIPTION
## Description of changes

Add new `option services.tt-rss.email.passwordFile` as an alternative to `option services.tt-rss.email.password` to enable more secure password distribution methods.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
