### PR TITLE
treewide: modernize python packages

### DIFF
--- a/pkgs/development/python-modules/hydrus-api/default.nix
+++ b/pkgs/development/python-modules/hydrus-api/default.nix
@@ -10,7 +10,7 @@
 buildPythonPackage rec {
   pname = "hydrus-api";
   version = "5.0.1";
-  format = "pyproject";
+  pyproject = true;
 
   disabled = pythonOlder "3.9";
 
@@ -20,15 +20,9 @@ buildPythonPackage rec {
     hash = "sha256-3Roeab9/woGF/aZYm9nbqrcyYN8CKA1k66cTRxx6jM4=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml --replace \
-      "poetry.masonry.api" \
-      "poetry.core.masonry.api"
-  '';
+  build-system = [ poetry-core ];
 
-  nativeBuildInputs = [ poetry-core ];
-
-  propagatedBuildInputs = [ requests ];
+  dependencies = [ requests ];
 
   pythonImportsCheck = [ "hydrus_api" ];
 

--- a/pkgs/development/python-modules/imagecorruptions/default.nix
+++ b/pkgs/development/python-modules/imagecorruptions/default.nix
@@ -1,6 +1,7 @@
 {
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   numpy,
   scikit-image,
   lib,
@@ -10,19 +11,18 @@
 buildPythonPackage rec {
   pname = "imagecorruptions";
   version = "1.1.2";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "044e173f24d5934899bdbf3596bfbec917e8083e507eed583ab217abebbe084d";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "'opencv-python >= 3.4.5'," ""
-  '';
+  pythonRemoveDeps = [ "opencv-python" ];
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     numpy
     scikit-image
     opencv4

--- a/pkgs/development/python-modules/imantics/default.nix
+++ b/pkgs/development/python-modules/imantics/default.nix
@@ -2,6 +2,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   lib,
+  setuptools,
   numpy,
   opencv4,
   lxml,
@@ -12,7 +13,7 @@
 buildPythonPackage rec {
   pname = "imantics";
   version = "0.1.12";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jsbroks";
@@ -21,17 +22,16 @@ buildPythonPackage rec {
     sha256 = "1zv2gj8cbakhh2fyr2611cbqhfk37a56x973ny9n43y70n26pzm8";
   };
 
-  propagatedBuildInputs = [
+  pythonRemoveDeps = [ "opencv-python" ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [
     numpy
     opencv4
     lxml
     xmljson
   ];
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "'opencv-python>=3'," ""
-  '';
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/jupyter-c-kernel/default.nix
+++ b/pkgs/development/python-modules/jupyter-c-kernel/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildPythonPackage,
+  setuptools,
   fetchPypi,
   ipykernel,
   gcc,
@@ -9,7 +10,7 @@
 buildPythonPackage rec {
   pname = "jupyter-c-kernel";
   version = "1.2.2";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "jupyter_c_kernel";
@@ -19,10 +20,12 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace jupyter_c_kernel/kernel.py \
-      --replace "'gcc'" "'${gcc}/bin/gcc'"
+      --replace-fail "'gcc'" "'${gcc}/bin/gcc'"
   '';
 
-  propagatedBuildInputs = [ ipykernel ];
+  build-system = [ setuptools ];
+
+  dependencies = [ ipykernel ];
 
   # no tests in repository
   doCheck = false;

--- a/pkgs/development/python-modules/jupyterhub-systemdspawner/default.nix
+++ b/pkgs/development/python-modules/jupyterhub-systemdspawner/default.nix
@@ -5,13 +5,14 @@
   fetchFromGitHub,
   jupyterhub,
   pythonOlder,
+  setuptools,
   tornado,
 }:
 
 buildPythonPackage rec {
   pname = "jupyterhub-systemdspawner";
   version = "1.0.1";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.8";
 
@@ -23,16 +24,13 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace systemdspawner/systemd.py \
-      --replace "/bin/bash" "${bash}/bin/bash"
-
     substituteInPlace systemdspawner/systemdspawner.py \
-      --replace "/bin/bash" "${bash}/bin/bash"
+      --replace-fail "/bin/bash" "${bash}/bin/bash"
   '';
 
-  buildInputs = [ bash ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     jupyterhub
     tornado
   ];

--- a/pkgs/development/python-modules/jupyterlab-execute-time/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-execute-time/default.nix
@@ -1,8 +1,9 @@
-{ lib
-, buildPythonPackage
-, fetchPypi
-, jupyterlab
-, jupyter-packaging
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  jupyterlab,
+  jupyter-packaging,
 }:
 
 buildPythonPackage rec {
@@ -19,7 +20,7 @@ buildPythonPackage rec {
   # jupyterlab is required to build from source but we use the pre-build package
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace '"jupyterlab~=4.0.0"' ""
+      --replace-fail '"jupyterlab~=4.0.0"' ""
   '';
 
   dependencies = [

--- a/pkgs/development/python-modules/karton-autoit-ripper/default.nix
+++ b/pkgs/development/python-modules/karton-autoit-ripper/default.nix
@@ -3,6 +3,7 @@
   autoit-ripper,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   karton-core,
   malduck,
   pythonOlder,
@@ -12,30 +13,31 @@
 buildPythonPackage rec {
   pname = "karton-autoit-ripper";
   version = "1.2.0";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "CERT-Polska";
-    repo = pname;
+    repo = "karton-autoit-ripper";
     rev = "refs/tags/v${version}";
     hash = "sha256-D+M3JsIN8LUWg8GVweEzySHI7KaBb6cNHHn4pXoq55M=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  pythonRelaxDeps = [
+    "autoit-ripper"
+    "malduck"
+    "regex"
+  ];
+
+  dependencies = [
     autoit-ripper
     karton-core
     malduck
     regex
   ];
-
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace "autoit-ripper==" "autoit-ripper>=" \
-      --replace "malduck==" "malduck>=" \
-      --replace "regex==" "regex>="
-  '';
 
   # Module has no tests
   doCheck = false;

--- a/pkgs/development/python-modules/karton-classifier/default.nix
+++ b/pkgs/development/python-modules/karton-classifier/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   chardet,
   fetchFromGitHub,
+  setuptools,
   karton-core,
   pytestCheckHook,
   python-magic,
@@ -12,30 +13,31 @@
 buildPythonPackage rec {
   pname = "karton-classifier";
   version = "2.0.0";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "CERT-Polska";
-    repo = pname;
+    repo = "karton-classifier";
     rev = "refs/tags/v${version}";
     hash = "sha256-DH8I4Lbbs2TVMvYlvh/P2I/7O4+VechP2JDDVHNsTSg=";
   };
 
-  propagatedBuildInputs = [
+  pythonRelaxDeps = [
+    "chardet"
+    "python-magic"
+  ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [
     chardet
     karton-core
     python-magic
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
-
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace "chardet==3.0.4" "chardet" \
-      --replace "python-magic==0.4.18" "python-magic"
-  '';
 
   pythonImportsCheck = [ "karton.classifier" ];
 

--- a/pkgs/development/python-modules/keyring-pass/default.nix
+++ b/pkgs/development/python-modules/keyring-pass/default.nix
@@ -24,10 +24,10 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace keyring_pass/__init__.py \
-      --replace 'pass_binary = "pass"' 'pass_binary = "${lib.getExe pass}"'
+      --replace-fail 'pass_binary = "pass"' 'pass_binary = "${lib.getExe pass}"'
   '';
 
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [ poetry-core ];
 
   nativeCheckInputs = [
     keyring

--- a/pkgs/development/python-modules/keyrings-cryptfile/default.nix
+++ b/pkgs/development/python-modules/keyrings-cryptfile/default.nix
@@ -3,16 +3,18 @@
   argon2-cffi,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   keyring,
   pycryptodome,
   pytestCheckHook,
+  pytest-cov-stub,
   pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "keyrings-cryptfile";
   version = "1.3.9";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.5";
 
@@ -22,12 +24,9 @@ buildPythonPackage rec {
     hash = "sha256-fCpFPKuZhUJrjCH3rVSlfkn/joGboY4INAvYgBrPAJE=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "-s --cov=keyrings/cryptfile" ""
-  '';
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     argon2-cffi
     keyring
     pycryptodome
@@ -35,7 +34,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "keyrings.cryptfile" ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
 
   disabledTests = [
     # FileNotFoundError: [Errno 2] No such file or directory: '/build/...

--- a/pkgs/development/python-modules/kneed/default.nix
+++ b/pkgs/development/python-modules/kneed/default.nix
@@ -7,12 +7,13 @@
   scipy,
   matplotlib,
   pytestCheckHook,
+  pytest-cov-stub,
 }:
 
 buildPythonPackage rec {
   pname = "kneed";
   version = "0.8.5";
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "arvkevi";
@@ -21,20 +22,16 @@ buildPythonPackage rec {
     sha256 = "sha256-oakP6NkdvTzMZcoXS6cKNsRo//K+CoPLlhvbQLGij00=";
   };
 
-  postPatch = ''
-    substituteInPlace pytest.ini \
-      --replace "--cov=kneed" ""
-  '';
+  build-system = [ hatchling ];
 
-  nativeBuildInputs = [ hatchling ];
-
-  propagatedBuildInputs = [
+  dependencies = [
     numpy
     scipy
   ];
 
   checkInputs = [
     pytestCheckHook
+    pytest-cov-stub
     matplotlib
   ];
 

--- a/pkgs/development/python-modules/libais/default.nix
+++ b/pkgs/development/python-modules/libais/default.nix
@@ -4,13 +4,14 @@
   fetchPypi,
   pytestCheckHook,
   pythonOlder,
+  setuptools,
   six,
 }:
 
 buildPythonPackage rec {
   pname = "libais";
   version = "0.17";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -19,12 +20,9 @@ buildPythonPackage rec {
     hash = "sha256-6yrqIpjF6XaSfXSOTA0B4f3aLcHXkgA/3WBZBBNQ018=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "'pytest-runner'," ""
-  '';
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [ six ];
+  dependencies = [ six ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/libpurecool/default.nix
+++ b/pkgs/development/python-modules/libpurecool/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   netifaces,
   paho-mqtt,
   pycryptodome,
@@ -13,7 +14,7 @@
 buildPythonPackage rec {
   pname = "libpurecool";
   version = "0.6.4";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
@@ -24,10 +25,12 @@ buildPythonPackage rec {
   postPatch = ''
     rm libpurecool/zeroconf.py
     substituteInPlace libpurecool/dyson_pure_cool_link.py \
-      --replace "from .zeroconf import ServiceBrowser, Zeroconf" "from zeroconf import ServiceBrowser, Zeroconf"
+      --replace-fail "from .zeroconf import ServiceBrowser, Zeroconf" "from zeroconf import ServiceBrowser, Zeroconf"
   '';
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     netifaces
     paho-mqtt
     pycryptodome

--- a/pkgs/development/python-modules/limnoria/default.nix
+++ b/pkgs/development/python-modules/limnoria/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildPythonPackage,
+  setuptools,
   chardet,
   cryptography,
   feedparser,
@@ -17,7 +18,7 @@
 buildPythonPackage rec {
   pname = "limnoria";
   version = "2024.5.30";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.6";
 
@@ -26,7 +27,9 @@ buildPythonPackage rec {
     hash = "sha256-uKJMeC1dXhQp1CGbtdnqmELFO64VWblhABGfpKHGCZQ=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     chardet
     cryptography
     feedparser
@@ -40,7 +43,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "version=version" 'version="${version}"'
+      --replace-fail "version=version" 'version="${version}"'
   '';
 
   checkPhase = ''

--- a/pkgs/development/python-modules/markdown-macros/default.nix
+++ b/pkgs/development/python-modules/markdown-macros/default.nix
@@ -3,13 +3,14 @@
   buildPythonPackage,
   fetchPypi,
   fetchpatch,
+  setuptools,
   markdown,
 }:
 
 buildPythonPackage rec {
   pname = "markdown-macros";
   version = "0.1.2";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
@@ -27,10 +28,12 @@ buildPythonPackage rec {
   ];
 
   prePatch = ''
-    substituteInPlace setup.py --replace "distribute" "setuptools"
+    substituteInPlace setup.py --replace-fail "distribute" "setuptools"
   '';
 
-  propagatedBuildInputs = [ markdown ];
+  build-system = [ setuptools ];
+
+  dependencies = [ markdown ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/marshmallow-polyfield/default.nix
+++ b/pkgs/development/python-modules/marshmallow-polyfield/default.nix
@@ -5,6 +5,7 @@
   marshmallow,
   pythonOlder,
   pytestCheckHook,
+  pytest-cov-stub,
   setuptools,
 }:
 
@@ -22,16 +23,14 @@ buildPythonPackage rec {
     hash = "sha256-jbpeyih2Ccw1Rk+QcXRO9AfN5B/DhZmxa/M6FzXHqqs=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "--cov=marshmallow_polyfield" ""
-  '';
+  build-system = [ setuptools ];
 
-  nativeBuildInputs = [ setuptools ];
+  dependencies = [ marshmallow ];
 
-  propagatedBuildInputs = [ marshmallow ];
-
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
 
   pythonImportsCheck = [ "marshmallow" ];
 

--- a/pkgs/development/python-modules/matplotlib-sixel/default.nix
+++ b/pkgs/development/python-modules/matplotlib-sixel/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   imagemagick,
   matplotlib,
 }:
@@ -9,18 +10,20 @@
 buildPythonPackage rec {
   pname = "matplotlib-sixel";
   version = "0.0.2";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-JXOb1/IacJV8bhDvF+OPs2Yg1tgRDOqwiAQfiSKTlew=";
   };
 
-  propagatedBuildInputs = [ matplotlib ];
+  build-system = [ setuptools ];
+
+  dependencies = [ matplotlib ];
 
   postPatch = ''
     substituteInPlace sixel/sixel.py \
-      --replace 'Popen(["convert",' 'Popen(["${imagemagick}/bin/convert",'
+      --replace-fail 'Popen(["convert",' 'Popen(["${imagemagick}/bin/convert",'
   '';
 
   pythonImportsCheck = [ "sixel" ];

--- a/pkgs/development/python-modules/mayim/default.nix
+++ b/pkgs/development/python-modules/mayim/default.nix
@@ -11,6 +11,7 @@
 
   # test
   pytest-asyncio,
+  pytest-cov-stub,
 
   pytestCheckHook,
 }:
@@ -27,15 +28,10 @@ buildPythonPackage rec {
     hash = "sha256-nb0E9kMEJUihaCp8RnqGh0nSyDQo50eL1C4K5lBPlPQ=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
     wheel
   ];
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace "--cov=src --cov-append --cov-report term-missing" ""
-  '';
 
   passthru.optional-dependencies = {
     postgres = [ psycopg ] ++ psycopg.optional-dependencies.pool;
@@ -47,6 +43,7 @@ buildPythonPackage rec {
     [
       pytestCheckHook
       pytest-asyncio
+      pytest-cov-stub
     ]
     ++ (with passthru.optional-dependencies; [
       postgres

--- a/pkgs/development/python-modules/mesonpep517/default.nix
+++ b/pkgs/development/python-modules/mesonpep517/default.nix
@@ -14,7 +14,7 @@
 buildPythonPackage rec {
   pname = "mesonpep517";
   version = "0.2";
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
@@ -26,15 +26,15 @@ buildPythonPackage rec {
   #
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'backend-path = "."' 'backend-path = ["."]'
+      --replace-fail 'backend-path = "."' 'backend-path = ["."]'
   '';
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
     wheel
   ];
 
-  propagatedBuildInputs = [ toml ];
+  dependencies = [ toml ];
 
   propagatedNativeBuildInputs = [
     meson

--- a/pkgs/development/python-modules/mkdocs-jupyter/default.nix
+++ b/pkgs/development/python-modules/mkdocs-jupyter/default.nix
@@ -10,13 +10,14 @@
   nbconvert,
   pygments,
   pytestCheckHook,
+  pytest-cov-stub,
   pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "mkdocs-jupyter";
   version = "0.24.8";
-  format = "pyproject";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -26,19 +27,11 @@ buildPythonPackage rec {
     hash = "sha256-Cadi9ITVQNnA6UTTSyjLU2oyhp4iS0YOL8eRsUP3aUA=";
   };
 
-  postPatch = ''
-    sed -i "/--cov/d" pyproject.toml
-    substituteInPlace src/mkdocs_jupyter/tests/test_base_usage.py \
-      --replace "[\"mkdocs\"," "[\"${mkdocs.out}/bin/mkdocs\","
-  '';
-
   pythonRelaxDeps = [ "nbconvert" ];
 
-  nativeBuildInputs = [
-    hatchling
-  ];
+  build-system = [ hatchling ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     ipykernel
     jupytext
     mkdocs
@@ -47,7 +40,10 @@ buildPythonPackage rec {
     pygments
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
 
   pythonImportsCheck = [ "mkdocs_jupyter" ];
 

--- a/pkgs/development/python-modules/mlrose/default.nix
+++ b/pkgs/development/python-modules/mlrose/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
+  setuptools,
   scikit-learn,
   pytestCheckHook,
   pytest-randomly,
@@ -12,7 +13,7 @@
 buildPythonPackage rec {
   pname = "mlrose";
   version = "1.3.0";
-  format = "setuptools";
+  pyproject = true;
   disabled = isPy27;
 
   src = fetchFromGitHub {
@@ -30,14 +31,15 @@ buildPythonPackage rec {
     })
   ];
 
-  propagatedBuildInputs = [ scikit-learn ];
+  build-system = [ setuptools ];
+  dependencies = [ scikit-learn ];
   nativeCheckInputs = [
     pytest-randomly
     pytestCheckHook
   ];
 
   postPatch = ''
-    substituteInPlace setup.py --replace sklearn scikit-learn
+    substituteInPlace setup.py --replace-fail sklearn scikit-learn
   '';
 
   pythonImportsCheck = [ "mlrose" ];

--- a/pkgs/development/python-modules/monai-deploy/default.nix
+++ b/pkgs/development/python-modules/monai-deploy/default.nix
@@ -31,15 +31,15 @@ buildPythonPackage rec {
     # Asked in https://github.com/Project-MONAI/monai-deploy-app-sdk/issues/450
     # if this patch can be incorporated upstream.
     substituteInPlace pyproject.toml \
-      --replace 'versioneer-518' 'versioneer'
+      --replace-fail 'versioneer-518' 'versioneer'
   '';
 
-  nativeBuildInputs = [
+  build-system = [
     versioneer
     setuptools
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     numpy
     networkx
     colorama

--- a/pkgs/development/python-modules/nameko/default.nix
+++ b/pkgs/development/python-modules/nameko/default.nix
@@ -32,12 +32,12 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace setup.py --replace "path.py" "path"
+    substituteInPlace setup.py --replace-fail "path.py" "path"
   '';
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     dnspython
     eventlet
     kombu

--- a/pkgs/development/python-modules/niworkflows/default.nix
+++ b/pkgs/development/python-modules/niworkflows/default.nix
@@ -40,16 +40,14 @@ buildPythonPackage rec {
     hash = "sha256-29ZxLuKrvgCIOMMCUpi0HHhlNlgqUrUrSCiikwecmKw=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml --replace '"traits < 6.4"' '"traits"'
-  '';
+  pythonRelaxDeps = [ "traits" ];
 
-  nativeBuildInputs = [
+  build-system = [
     hatch-vcs
     hatchling
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     attrs
     importlib-resources
     jinja2

--- a/pkgs/development/python-modules/nix-kernel/default.nix
+++ b/pkgs/development/python-modules/nix-kernel/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   isPy3k,
   pexpect,
   notebook,
@@ -11,7 +12,7 @@
 buildPythonPackage rec {
   pname = "nix-kernel";
   version = "unstable-2020-04-26";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = !isPy3k;
 
@@ -24,14 +25,16 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace nix-kernel/kernel.py \
-      --replace "'nix'" "'${nix}/bin/nix'" \
-      --replace "'nix repl'" "'${nix}/bin/nix repl'"
+      --replace-fail "'nix'" "'${nix}/bin/nix'" \
+      --replace-fail "'nix repl'" "'${nix}/bin/nix repl'"
 
     substituteInPlace setup.py \
-      --replace "cmdclass={'install': install_with_kernelspec}," ""
+      --replace-fail "cmdclass={'install': install_with_kernelspec}," ""
   '';
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     pexpect
     notebook
   ];

--- a/pkgs/development/python-modules/packet-python/default.nix
+++ b/pkgs/development/python-modules/packet-python/default.nix
@@ -4,6 +4,7 @@
   fetchPypi,
   pytestCheckHook,
   pythonOlder,
+  setuptools,
   requests,
   requests-mock,
 }:
@@ -11,7 +12,7 @@
 buildPythonPackage rec {
   pname = "packet-python";
   version = "1.44.3";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -22,10 +23,12 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "pytest-runner" ""
+      --replace-fail "pytest-runner" ""
   '';
 
-  propagatedBuildInputs = [ requests ];
+  build-system = [ setuptools ];
+
+  dependencies = [ requests ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/pglast/default.nix
+++ b/pkgs/development/python-modules/pglast/default.nix
@@ -5,12 +5,13 @@
   pythonOlder,
   setuptools,
   pytest,
+  pytest-cov-stub,
 }:
 
 buildPythonPackage rec {
   pname = "pglast";
   version = "6.2";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -19,14 +20,14 @@ buildPythonPackage rec {
     hash = "sha256-mGP7o52Wun6AdE2jMAJBmLR10EmN50qzbMzB06BFXMg=";
   };
 
-  propagatedBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "--cov=pglast --cov-report term-missing" ""
-  '';
+  dependencies = [ setuptools ];
 
-  nativeCheckInputs = [ pytest ];
+  nativeCheckInputs = [
+    pytest
+    pytest-cov-stub
+  ];
 
   # pytestCheckHook doesn't work
   # ImportError: cannot import name 'parse_sql' from 'pglast'

--- a/pkgs/development/python-modules/pika-pool/default.nix
+++ b/pkgs/development/python-modules/pika-pool/default.nix
@@ -2,27 +2,28 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   pika,
 }:
 
 buildPythonPackage rec {
   pname = "pika-pool";
   version = "0.1.3";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "f3985888cc2788cdbd293a68a8b5702a9c955db6f7b8b551aeac91e7f32da397";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py --replace "pika >=0.9,<0.11" "pika"
-  '';
+  pythonRelaxDeps = [ "pika" ];
+
+  build-system = [ setuptools ];
 
   # Tests require database connections
   doCheck = false;
 
-  propagatedBuildInputs = [ pika ];
+  dependencies = [ pika ];
   meta = with lib; {
     homepage = "https://github.com/bninja/pika-pool";
     license = licenses.bsdOriginal;

--- a/pkgs/development/python-modules/podcats/default.nix
+++ b/pkgs/development/python-modules/podcats/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   flask,
   mutagen,
 }:
@@ -9,7 +10,7 @@
 buildPythonPackage rec {
   pname = "podcats";
   version = "0.5.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jakubroztocil";
@@ -18,12 +19,14 @@ buildPythonPackage rec {
     sha256 = "0zjdgry5n209rv19kj9yaxy7c7zq5gxr488izrgs4sc75vdzz8xc";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace podcats.py \
-      --replace 'debug=True' 'debug=True, use_reloader=False'
+      --replace-fail 'debug=True' 'debug=True, use_reloader=False'
   '';
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     flask
     mutagen
   ];


### PR DESCRIPTION
## Description of changes

I grepped for `--replace ` and:

* use `pyproject = true;`
* use `build-system` and `dependencies`
* use `--replace-fail`, or either delete or use other means ...
* like `pytest-cov-stub` and `pythonRelaxDeps`
* remove `repo = pname;`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
