### PR TITLE
xgboost: 2.0.3 -> 2.1.1

### DIFF
--- a/pkgs/development/libraries/xgboost/default.nix
+++ b/pkgs/development/libraries/xgboost/default.nix
@@ -71,7 +71,9 @@ effectiveStdenv.mkDerivation rec {
     ++ lib.optionals cudaSupport [ autoAddDriverRunpath ]
     ++ lib.optionals rLibrary [ R ];
 
-  buildInputs = [ gtest ] ++ lib.optional cudaSupport cudaPackages.cudatoolkit
+  buildInputs = [ gtest ]
+    ++ lib.optional cudaSupport cudaPackages.cudatoolkit
+    ++ lib.optional cudaSupport cudaPackages.cuda_cudart
     ++ lib.optional ncclSupport cudaPackages.nccl;
 
   propagatedBuildInputs = lib.optionals rLibrary [

--- a/pkgs/development/libraries/xgboost/default.nix
+++ b/pkgs/development/libraries/xgboost/default.nix
@@ -48,14 +48,14 @@ effectiveStdenv.mkDerivation rec {
   #   in \
   #   rWrapper.override{ packages = [ xgb ]; }"
   pname = lib.optionalString rLibrary "r-" + pnameBase;
-  version = "2.0.3";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
     owner = "dmlc";
     repo = pnameBase;
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-LWco3A6zwdnAf8blU4qjW7PFEeZaTcJlVTwVrs7nwWM=";
+    hash = "sha256-qkTCQ257ZwQ2q4VPYqdEVqFQR1tf/qrur3hR54Uvqio=";
   };
 
   patches = lib.optionals (cudaSupport && cudaPackages.cudaMajorMinorVersion == "12.4") [


### PR DESCRIPTION
## Description of changes

Updates xgboost to 2.1.1. Release notes:
- https://github.com/dmlc/xgboost/releases/tag/v2.1.1
- https://github.com/dmlc/xgboost/releases/tag/v2.1.0

The build with cudaSupport is failing, and the NCCL support option needs an update because the package switched to sourcing from pypi.

```
nix build --expr "with import ./. { }; xgboost.override{ cudaSupport = true; }" --impure
```

```
...
-- xgboost VERSION: 2.1.1
-- Configured CUDA host compiler: /nix/store/sv0iw9ywmg44qp6i6iiizh51lnkkwx4a-gcc-wrapper-12.4.0/bin/g++
CMake Error at /nix/store/aqckch626lg0vxh41dabyzrq0jx7gdk5-cmake-3.29.6/share/cmake-3.29/Modules/CMakeDetermineCompilerId.cmake:814 (message):
  Compiling the CUDA compiler identification source file
  "CMakeCUDACompilerId.cu" failed.

  Compiler:
  /nix/store/sivx7lk3c3pirp851g8rkgaqf0khx87f-cuda-merged-12.2/bin/nvcc
...
  /nix/store/qsx2xqqm0lp6d8hi86r4y0rz5v9m62wn-binutils-2.42/bin/ld: cannot
  find -lcudadevrt: No such file or directory

  /nix/store/qsx2xqqm0lp6d8hi86r4y0rz5v9m62wn-binutils-2.42/bin/ld: cannot
  find -lcudart_static: No such file or directory


  collect2: error: ld returned 1 exit status

  # --error 0x1 --





Call Stack (most recent call first):
  /nix/store/aqckch626lg0vxh41dabyzrq0jx7gdk5-cmake-3.29.6/share/cmake-3.29/Modules/CMakeDetermineCompilerId.cmake:8 (CMAKE_DETERMINE_COMPILER_ID_BUILD)
  /nix/store/aqckch626lg0vxh41dabyzrq0jx7gdk5-cmake-3.29.6/share/cmake-3.29/Modules/CMakeDetermineCompilerId.cmake:53 (__determine_compiler_id_test)
  /nix/store/aqckch626lg0vxh41dabyzrq0jx7gdk5-cmake-3.29.6/share/cmake-3.29/Modules/CMakeDetermineCUDACompiler.cmake:131 (CMAKE_DETERMINE_COMPILER_ID)
  CMakeLists.txt:217 (enable_language)


-- Configuring incomplete, errors occurred!
```

@SomeoneSerge - The cuda build is newly failing, but nothing appears to have changed in the xgboost build instructions or nixpkgs derivation. Any tips on what I should look at in the build? Looks like cudatoolkit isn't getting picked up by the linker.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
