### PR TITLE
fetchPypiLegacy: pass NETRC via impureEnvVars if inPureEval

### DIFF
--- a/pkgs/build-support/fetchpypilegacy/default.nix
+++ b/pkgs/build-support/fetchpypilegacy/default.nix
@@ -1,7 +1,8 @@
 # Fetch from PyPi legacy API as documented in https://warehouse.pypa.io/api-reference/legacy.html
-{ runCommand
-, lib
-, python3
+{
+  runCommand,
+  lib,
+  python3,
 }:
 {
   # package name
@@ -21,25 +22,27 @@ let
   urls' = urls ++ lib.optional (url != null) url;
 
   pathParts = lib.filter ({ prefix, path }: "NETRC" == prefix) builtins.nixPath;
-  netrc_file =
-    if (pathParts != [ ])
-    then (lib.head pathParts).path
-    else "";
+  netrc_file = if (pathParts != [ ]) then (lib.head pathParts).path else "";
 
 in
 # Assert that we have at least one URL
-assert urls' != [ ]; runCommand file
-  ({
-    nativeBuildInputs = [ python3 ];
-    impureEnvVars = lib.fetchers.proxyImpureEnvVars;
-    outputHashMode = "flat";
-    # if hash is empty select a default algo to let nix propose the actual hash.
-    outputHashAlgo = if hash == "" then "sha256" else null;
-    outputHash = hash;
-    NETRC = netrc_file;
-  }
-  // (lib.optionalAttrs (name != null) {inherit name;}))
+assert urls' != [ ];
+runCommand file
+  (
+    {
+      nativeBuildInputs = [ python3 ];
+      impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+      outputHashMode = "flat";
+      # if hash is empty select a default algo to let nix propose the actual hash.
+      outputHashAlgo = if hash == "" then "sha256" else null;
+      outputHash = hash;
+      NETRC = netrc_file;
+    }
+    // (lib.optionalAttrs (name != null) { inherit name; })
+  )
   ''
-    python ${./fetch-legacy.py} ${lib.concatStringsSep " " (map (url: "--url ${lib.escapeShellArg url}") urls')} --pname ${pname} --filename ${file}
+    python ${./fetch-legacy.py} ${
+      lib.concatStringsSep " " (map (url: "--url ${lib.escapeShellArg url}") urls')
+    } --pname ${pname} --filename ${file}
     mv ${file} $out
   ''

--- a/pkgs/build-support/fetchpypilegacy/tests.nix
+++ b/pkgs/build-support/fetchpypilegacy/tests.nix
@@ -1,4 +1,5 @@
-{ testers, fetchPypiLegacy, ... }: {
+{ testers, fetchPypiLegacy, ... }:
+{
   # Tests that we can send custom headers with spaces in them
   fetchSimple = testers.invalidateFetcherByDrvHash fetchPypiLegacy {
     pname = "requests";


### PR DESCRIPTION
## Description of changes

Co-authored-by: @MatthewCroughan (originally in https://github.com/nix-community/poetry2nix/pull/1612/commits/f625ae2e51ec04a648e8108700f63864e0029db4)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
