### PR TITLE
screenconfig: init at 0.1.0

### DIFF
--- a/pkgs/by-name/sc/screenconfig/package.nix
+++ b/pkgs/by-name/sc/screenconfig/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  xrandr,
+  srandrd,
+  feh,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "screenconfig";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jceb";
+    repo = "screenconfig";
+    tag = "v${version}";
+    hash = "sha256-X1Mz8UbOOW/4LM9IZoG/kbwv2G0EppTsacKapQMChkc=";
+  };
+  build-system = [ python3.pkgs.setuptools ];
+  dependencies = with python3.pkgs; [
+    toml
+  ];
+
+  propagatedBuildInputs = [
+    xrandr
+    srandrd
+    feh
+  ];
+
+  meta = {
+    description = "Automatic configuration of connected screens/monitors";
+    homepage = "https://github.com/jceb/screenconfig";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jceb ];
+    mainProgram = "screenconfig";
+  };
+}


### PR DESCRIPTION
## Description of changes

Add screenconfig, a script for the automatic configuration of connected screens/monitors.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
