### PR TITLE
electrum-ltc: mark as broken

### DIFF
--- a/pkgs/applications/misc/electrum/ltc.nix
+++ b/pkgs/applications/misc/electrum/ltc.nix
@@ -157,5 +157,7 @@ python3.pkgs.buildPythonApplication {
     license = licenses.mit;
     platforms = platforms.all;
     maintainers = with maintainers; [ bbjubjub ];
+    # test "test_reestablish_with_old_state" hangs indefinitely, 2 other tests fail
+    broken = true;
   };
 }


### PR DESCRIPTION
## Description of changes

- mark package as broken, so it does not waste time on hydra.

It does not build on all platforms since `2024-07-14` and build hangs on tests for 2 hours:
https://hydra.nixos.org/build/268388551
https://hydra.nixos.org/build/268359057
https://hydra.nixos.org/build/268387334
https://hydra.nixos.org/build/268358892

Logs at the point where it hangs:
```text
Running phase: pytestCheckPhase
Executing pytestCheckPhase
============================= test session starts ==============================
platform linux -- Python 3.12.4, pytest-8.2.2, pluggy-1.5.0
rootdir: /build/Electrum-LTC-4.2.2.1
collected 568 items / 2 deselected / 566 selected                              

electrum_ltc/tests/test_bitcoin.py ..................................... [  6%]
.........................                                                [ 10%]
electrum_ltc/tests/test_blockchain.py ...........                        [ 12%]
electrum_ltc/tests/test_bolt11.py ........                               [ 14%]
electrum_ltc/tests/test_coinchooser.py .                                 [ 14%]
electrum_ltc/tests/test_commands.py ...................                  [ 17%]
electrum_ltc/tests/test_lnchannel.py .s.....s.                           [ 19%]
electrum_ltc/tests/test_lnhtlc.py .....                                  [ 20%]
electrum_ltc/tests/test_lnmsg.py ...........                             [ 22%]
``` 

Tried to investigate:
- adding `"test_reestablish_with_old_state"` to `disabledTests` fixes hang, but fails on 2 other tests with:
`electrum_ltc.lnutil.RemoteMisbehaving: received commitment_signed without pending changes`
- adding additional 2 tests to `disabledTests`:
`"test_reestablish_replay_messages_rev_then_sig"`
`"test_reestablish_replay_messages_sig_then_rev"`
fixes build, but may indicate something wrong with runtime.

Log with hanging test disabled and 2 other failing for future reference:
https://gist.github.com/ghpzin/32192f7ce6c19f65faf62949ce1d0516
 



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
