### PR TITLE
lib/tests/modules.sh: Report failure location and improve format

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -13,7 +13,7 @@ set -o errexit -o noclobber -o nounset -o pipefail
 shopt -s failglob inherit_errexit
 
 # https://stackoverflow.com/a/246128/6605742
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 cd "$DIR"/modules
 
@@ -40,7 +40,7 @@ reportFailure() {
     local attr=$1
     shift
     local script="import ./default.nix { modules = [ $* ];}"
-    echo 2>&1 "$ nix-instantiate -E '$script' -A '$attr' --eval-only --json"
+    echo "$ nix-instantiate -E '$script' -A '$attr' --eval-only --json"
     evalConfig "$attr" "$@" || true
     ((++fail))
 }
@@ -52,7 +52,7 @@ checkConfigOutput() {
         ((++pass))
     else
         echo "test failure at $(loc):"
-        echo 2>&1 "error: Expected result matching '$outputContains', while evaluating"
+        echo "error: Expected result matching '$outputContains', while evaluating"
         reportFailure "$@"
     fi
 }
@@ -63,14 +63,14 @@ checkConfigError() {
     shift
     if err="$(evalConfig "$@" 2>&1 >/dev/null)"; then
         echo "test failure at $(loc):"
-        echo 2>&1 "error: Expected error code, got exit code 0, while evaluating"
+        echo "error: Expected error code, got exit code 0, while evaluating"
         reportFailure "$@"
     else
         if echo "$err" | grep -zP --silent "$errorContains" ; then
             ((++pass))
         else
             echo "test failure at $(loc):"
-            echo 2>&1 "error: Expected error matching '$errorContains', while evaluating"
+            echo "error: Expected error matching '$errorContains', while evaluating"
             reportFailure "$@"
         fi
     fi

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -20,10 +20,16 @@ cd "$DIR"/modules
 pass=0
 fail=0
 
-# prints the location of the call of to the function that calls it
+# loc
+#   prints the location of the call of to the function that calls it
+# loc n
+#   prints the location n levels up the call stack
 loc() {
     local caller depth
     depth=1
+    if [[ $# -gt 0 ]]; then
+        depth=$1
+    fi
     # ( lineno fnname file ) of the caller
     caller=( $(caller $depth) )
     echo "${caller[2]}:${caller[0]}"

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -35,6 +35,22 @@ loc() {
     echo "${caller[2]}:${caller[0]}"
 }
 
+line() {
+    echo "----------------------------------------"
+}
+logStartFailure() {
+    line
+}
+logEndFailure() {
+    line
+    echo
+}
+
+logFailure() {
+    # bold red
+    printf '\033[1;31mTEST FAILED\033[0m at %s\n' "$(loc 2)"
+}
+
 evalConfig() {
     local attr=$1
     shift
@@ -57,9 +73,12 @@ checkConfigOutput() {
     if evalConfig "$@" 2>/dev/null | grep -E --silent "$outputContains" ; then
         ((++pass))
     else
-        echo "test failure at $(loc):"
-        echo "error: Expected result matching '$outputContains', while evaluating"
+        logStartFailure
+        echo "ACTUAL:"
         reportFailure "$@"
+        echo "EXPECTED: result matching '$outputContains'"
+        logFailure
+        logEndFailure
     fi
 }
 
@@ -68,16 +87,22 @@ checkConfigError() {
     local err=""
     shift
     if err="$(evalConfig "$@" 2>&1 >/dev/null)"; then
-        echo "test failure at $(loc):"
-        echo "error: Expected error code, got exit code 0, while evaluating"
+        logStartFailure
+        echo "ACTUAL: exit code 0, output:"
         reportFailure "$@"
+        echo "EXPECTED: non-zero exit code"
+        logFailure
+        logEndFailure
     else
         if echo "$err" | grep -zP --silent "$errorContains" ; then
             ((++pass))
         else
-            echo "test failure at $(loc):"
-            echo "error: Expected error matching '$errorContains', while evaluating"
+            logStartFailure
+            echo "ACTUAL:"
             reportFailure "$@"
+            echo "EXPECTED: error matching '$errorContains'"
+            logFailure
+            logEndFailure
         fi
     fi
 }


### PR DESCRIPTION
## Description of changes

See commit messages for details, but notably

<blockquote>

- Clear separation between failures
- Move error regex close to error message, which is at the bottom
  of a fairly long trace
- Move most relevant and consistent info to bottom of terminal:
  the location of the failure.
  Some editors including vscode heuristically resolve file paths
  on Ctrl+click.
- Less wordy - easy to glance
- Capitalized prefixes to distinguish from Nix's own logging

</blockquote>

Example log output (without color):

```
$ ./lib/tests/modules.sh
----------------------------------------
ACTUAL:
$ nix-instantiate -E 'import ./default.nix { modules = [ ./gvariant.nix ];}' -A 'config.assertion' --eval-only --json
true
EXPECTED: result matching '^tru$'
TEST FAILED at ./lib/tests/modules.sh:138
----------------------------------------

----------------------------------------
ACTUAL: exit code 0, output:
$ nix-instantiate -E 'import ./default.nix { modules = [ ./specialArgs-lib.nix ];}' -A 'config.result' --eval-only --json
"ok"
EXPECTED: non-zero exit code
TEST FAILED at ./lib/tests/modules.sh:140
----------------------------------------

----------------------------------------
ACTUAL:
$ nix-instantiate -E 'import ./default.nix { modules = [ ./types-attrTag.nix ];}' -A 'config.intStrings.syntaxError3' --eval-only --json
error:
       … while calling anonymous lambda
         at /home/user/h/nixpkgs/lib/types.nix:583:22:
          582|       merge = loc: defs:
          583|         mapAttrs (n: v: v.value) (filterAttrs (n: v: v ? value) (zipAttrsWith (name: defs:
             |                      ^
          584|             (mergeDefinitions (loc ++ [name]) elemType defs).optionalValue

       … while evaluating the attribute 'value'
         at /home/user/h/nixpkgs/lib/modules.nix:869:27:
          868|     optionalValue =
          869|       if isDefined then { value = mergedValue; }
             |                           ^
          870|       else {};

       … while calling the 'throw' builtin
         at /home/user/h/nixpkgs/lib/modules.nix:860:12:
          859|         else let allInvalid = filter (def: ! type.check def.value) defsFinal;
          860|         in throw "A definition for option `${showOption loc}' is not of type `${type.description}'. Definition values:${showDefs allInvalid}"
             |            ^
          861|       else

       error: A definition for option `intStrings.syntaxError3' is not of type `attribute-tagged union'. Definition values:
       - In `/home/user/h/nixpkgs/lib/tests/modules/types-attrTag.nix':
           {
             a = true;
             b = true;
           }
EXPECTED: error matching 'A definition or option .intStrings\.syntaxError3. is not of type .attribute-tagged union'
TEST FAILED at ./lib/tests/modules.sh:155
----------------------------------------

====== module tests ======
247 Pass
3 Fail

```

<details><summary><code>modules.sh</code> diff to produce the above errors</summary>

```diff
diff --git a/lib/tests/modules.sh b/lib/tests/modules.sh
index 3a23766a17f5..cea2d9067eb3 100755
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -135,9 +135,9 @@ checkConfigOutput '^true$' config.result ./test-mergeAttrDefinitionsWithPrio.nix
 checkConfigOutput '^true$' config.result ./module-argument-default.nix
 
 # gvariant
-checkConfigOutput '^true$' config.assertion ./gvariant.nix
+checkConfigOutput '^tru$' config.assertion ./gvariant.nix
 
-checkConfigOutput '"ok"' config.result ./specialArgs-lib.nix
+checkConfigError '"ok"' config.result ./specialArgs-lib.nix
 
 # https://github.com/NixOS/nixpkgs/pull/131205
 # We currently throw this error already in `config`, but throwing in `config.wrong1` would be acceptable.
@@ -152,7 +152,7 @@ checkConfigError '.*A definition for option .bad. is not of type .non-empty .lis
 checkConfigOutput '^true$' config.okChecks ./types-attrTag.nix
 checkConfigError 'A definition for option .intStrings\.syntaxError. is not of type .attribute-tagged union' config.intStrings.syntaxError ./types-attrTag.nix
 checkConfigError 'A definition for option .intStrings\.syntaxError2. is not of type .attribute-tagged union' config.intStrings.syntaxError2 ./types-attrTag.nix
-checkConfigError 'A definition for option .intStrings\.syntaxError3. is not of type .attribute-tagged union' config.intStrings.syntaxError3 ./types-attrTag.nix
+checkConfigError 'A definition or option .intStrings\.syntaxError3. is not of type .attribute-tagged union' config.intStrings.syntaxError3 ./types-attrTag.nix
 checkConfigError 'A definition for option .intStrings\.syntaxError4. is not of type .attribute-tagged union' config.intStrings.syntaxError4 ./types-attrTag.nix
 checkConfigError 'A definition for option .intStrings\.mergeError. is not of type .attribute-tagged union' config.intStrings.mergeError ./types-attrTag.nix
 checkConfigError 'A definition for option .intStrings\.badTagError. is not of type .attribute-tagged union' config.intStrings.badTagError ./types-attrTag.nix
```

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
