### PR TITLE
lib: fix merging of functions

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -246,7 +246,7 @@ rec {
   mergeDefaultOption = loc: defs:
     let list = getValues defs; in
     if length list == 1 then head list
-    else if all isFunction list then x: mergeDefaultOption loc (map (f: f x) list)
+    else if all isFunction list then x: mergeDefaultOption loc (map (def: def // { value = def.value x; }) defs)
     else if all isList list then concatLists list
     else if all isAttrs list then foldl' lib.mergeAttrs {} list
     else if all isBool list then foldl' lib.or false list


### PR DESCRIPTION
## Description of changes

When trying to merge to functions, the module system errors with something like:
```
error
… while calling anonymous lambda
         at /nix/store/3ghy6irqjf72xmvzvi7j5amy6qp1b347-source/lib/options.nix:122:38:
          121|     if length list == 1 then head list
          122|     else if all isFunction list then x: mergeDefaultOption loc (map (f: f x) list)
             |                                      ^
          123|     else if all isList list then concatLists list

       … from call site
         at /nix/store/3ghy6irqjf72xmvzvi7j5amy6qp1b347-source/lib/options.nix:122:41:
          121|     if length list == 1 then head list
          122|     else if all isFunction list then x: mergeDefaultOption loc (map (f: f x) list)
             |                                         ^
          123|     else if all isList list then concatLists list

       … while calling 'mergeDefaultOption'
         at /nix/store/3ghy6irqjf72xmvzvi7j5amy6qp1b347-source/lib/options.nix:119:29:
          118|
          119|   mergeDefaultOption = loc: defs:
             |                             ^
          120|     let list = getValues defs; in

       … while evaluating a branch condition
         at /nix/store/3ghy6irqjf72xmvzvi7j5amy6qp1b347-source/lib/options.nix:122:10:
          121|     if length list == 1 then head list
          122|     else if all isFunction list then x: mergeDefaultOption loc (map (f: f x) list)
             |          ^
          123|     else if all isList list then concatLists list
            class = "IN";
       … while calling the 'all' builtin
         at /nix/store/3ghy6irqjf72xmvzvi7j5amy6qp1b347-source/lib/options.nix:122:13:
          121|     if length list == 1 then head list
          122|     else if all isFunction list then x: mergeDefaultOption loc (map (f: f x) list)
             |             ^
          123|     else if all isList list then concatLists list
          };
       … while calling 'isFunction'
         at /nix/store/3ghy6irqjf72xmvzvi7j5amy6qp1b347-source/lib/trivial.nix:339:16:
          338|   */
          339|   isFunction = f: builtins.isFunction f ||
             |                ^
          340|     (f ? __functor && isFunction (f.__functor f));
            "404.julienmalka.me" = {
       … in the left operand of the OR (||) operator
         at /nix/store/3ghy6irqjf72xmvzvi7j5amy6qp1b347-source/lib/trivial.nix:339:41:
          338|   */
          339|   isFunction = f: builtins.isFunction f ||
             |                                         ^
          340|     (f ? __functor && isFunction (f.__functor f));
              CAA = [ ];
       … while calling the 'isFunction' builtin
         at /nix/store/3ghy6irqjf72xmvzvi7j5amy6qp1b347-source/lib/trivial.nix:339:19:
          338|   */
          339|   isFunction = f: builtins.isFunction f ||
             |                   ^
          340|     (f ? __functor && isFunction (f.__functor f));
              MX = [ ];
       … while calling anonymous lambda
         at /nix/store/3ghy6irqjf72xmvzvi7j5amy6qp1b347-source/lib/options.nix:157:20:
          156|   */
          157|   getValues = map (x: x.value);
             |                    ^
          158|

       … while selecting an attribute
         at /nix/store/3ghy6irqjf72xmvzvi7j5amy6qp1b347-source/lib/options.nix:157:23:
          156|   */
          157|   getValues = map (x: x.value);
             |                       ^
          158|

       error: expected a set but found a string:
```

The semantics of function merging is, given parameter `x`, apply all functions to `x` and merge the results. 
Looks like the current implementation of `mergeDefaultOption`  gets the value of `x`, applies the functions to `x` and then recursively calls `mergeDefaultOption`. 
The problem is that `mergeDefaultOption` will try to get the value of `x` again, which is not possible. 
This is my tentative to fix this, but as I am not an expert with the module system, this might be a little clumsy. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
