### PR TITLE
doxygen: clean + python3Packages.doxmlparser: init at 1.12.0

### DIFF
--- a/pkgs/development/tools/documentation/doxygen/default.nix
+++ b/pkgs/development/tools/documentation/doxygen/default.nix
@@ -13,14 +13,14 @@
   sqlite,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "doxygen";
   version = "1.13.2";
 
   src = fetchFromGitHub {
     owner = "doxygen";
     repo = "doxygen";
-    tag = "Release_${lib.replaceStrings [ "." ] [ "_" ] version}";
+    tag = "Release_${lib.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
     hash = "sha256-tet2Ep2Mvucg2QBJbo9A6531cJhQ9L7+ZMmo07S8cwY=";
   };
 
@@ -87,4 +87,4 @@ stdenv.mkDerivation rec {
     '';
     platforms = if qt5 != null then lib.platforms.linux else lib.platforms.unix;
   };
-}
+})

--- a/pkgs/development/tools/documentation/doxygen/default.nix
+++ b/pkgs/development/tools/documentation/doxygen/default.nix
@@ -55,7 +55,6 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ CoreServices ];
 
   cmakeFlags = [
-    "-DICONV_INCLUDE_DIR=${libiconv}/include"
     "-Duse_sys_spdlog=ON"
     "-Duse_sys_sqlite3=ON"
   ] ++ lib.optional (qt5 != null) "-Dbuild_wizard=YES";

--- a/pkgs/development/tools/documentation/doxygen/doxmlparser.nix
+++ b/pkgs/development/tools/documentation/doxygen/doxmlparser.nix
@@ -1,0 +1,32 @@
+{
+  buildPythonPackage,
+  doxygen,
+  lxml,
+  setuptools,
+  six,
+}:
+buildPythonPackage rec {
+  inherit (doxygen) version src;
+  pname = "doxmlparser";
+
+  sourceRoot = "${src.name}/addon/doxmlparser";
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    lxml
+    six
+  ];
+
+  pythonImportsCheck = [ "doxmlparser" ];
+
+  meta = {
+    inherit (doxygen.meta)
+      license
+      homepage
+      changelog
+      platforms
+      ;
+    description = "Library to parse the XML output produced by doxygen";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4058,6 +4058,8 @@ self: super: with self; {
 
   downloader-cli = callPackage ../development/python-modules/downloader-cli { };
 
+  doxmlparser = callPackage ../development/tools/documentation/doxygen/doxmlparser.nix { };
+
   dparse = callPackage ../development/python-modules/dparse { };
 
   dparse2 = callPackage ../development/python-modules/dparse2 { };


### PR DESCRIPTION
## Description of changes

This update doxygen to 1.12 (ref. https://www.doxygen.nl/manual/changelog.html).

One patch is removed because it was merged upstream: https://github.com/doxygen/doxygen/commit/0df6da616f01057d28b11c8bee28443c102dd424

One CMake flag is removed because changelog claim iconv is now properly found, thanks to CMake, and configure logs both on x86_64-linux & aarch64-darwin says `Found Iconv: built in to C library`.

While here, move from rec to finalAttrs.

This also add the python `doxmlparser` module, which is in-tree inside doxygen, and can be used by other packages to make it easier to parse the XML output produced by doxygen.

EDIT: doxygen was updated to 1.12 as part of a clang 19 work in https://github.com/NixOS/nixpkgs/pull/355080. This now only include minor cleaning for it, and also add doxymlparser.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
