### PR TITLE
fprintd: disable flaky test

### DIFF
--- a/pkgs/tools/security/fprintd/default.nix
+++ b/pkgs/tools/security/fprintd/default.nix
@@ -88,6 +88,12 @@ stdenv.mkDerivation rec {
     "--no-suite" "fprintd:TestPamFprintd"
   ];
 
+  patches = [
+    # Skip flaky test "test_removal_during_enroll"
+    # https://gitlab.freedesktop.org/libfprint/fprintd/-/issues/129
+    ./skip-test-test_removal_during_enroll.patch
+  ];
+
   postPatch = ''
     patchShebangs \
       po/check-translations.sh \

--- a/pkgs/tools/security/fprintd/skip-test-test_removal_during_enroll.patch
+++ b/pkgs/tools/security/fprintd/skip-test-test_removal_during_enroll.patch
@@ -1,0 +1,12 @@
+diff --git a/tests/fprintd.py b/tests/fprintd.py
+index 370d7bb..4e4d78c 100644
+--- a/tests/fprintd.py
++++ b/tests/fprintd.py
+@@ -1609,6 +1609,7 @@ class FPrintdVirtualDeviceTest(FPrintdVirtualDeviceBaseTest):
+         time.sleep(1)
+ 
+     def test_removal_during_enroll(self):
++        self.skipTest("flaky test")
+         if not self._has_hotplug:
+             self.skipTest("libfprint is too old for hotplug")
+ 


### PR DESCRIPTION
## Description of changes
- disable flaky test "test_removal_during_enroll"

Patch with `skipTest` is needed because meson does not support disabling individual tests:
https://github.com/mesonbuild/meson/issues/6999
and there are other tests in that suite.

Upstream issue:
https://gitlab.freedesktop.org/libfprint/fprintd/-/issues/129

Fixes #333946 (Build failure: fprintd)

Log:
```text
stderr:
test_removal_during_enroll (__main__.FPrintdVirtualDeviceTest.test_removal_during_enroll) ... FAIL

======================================================================
FAIL: test_removal_during_enroll (__main__.FPrintdVirtualDeviceTest.test_removal_during_enroll)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/build/source/tests/fprintd.py", line 1632, in test_removal_during_enroll
    self.assertNotIn(self.device.get_object_path(), devices)
AssertionError: '/net/reactivated/Fprint/Device/0' unexpectedly found in ['/net/reactivated/Fprint/Device/0']

----------------------------------------------------------------------
Ran 1 test in 1.277s

FAILED (failures=1)
```

Including case from that issue hydra builds failed that test at least 2 times in the past (including current unstable):
https://hydra.nixos.org/build/268452290
https://hydra.nixos.org/build/264762179

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
