### PR TITLE
pkgs.writers: improve documentation on {makeScriptWriter,makeScriptWriterBin}

### DIFF
--- a/pkgs/build-support/writers/scripts.nix
+++ b/pkgs/build-support/writers/scripts.nix
@@ -22,17 +22,17 @@ let
 in
 rec {
   /**
-    A generic function that returns a derivation which, when beeing built outputs the script in an executable format.
+    `makeScriptWriter` returns a derivation which creates an executable script.
 
     # Inputs
 
     config (AttrSet)
     : `interpreter` (String)
-      : the interpreter to use for the script
+      : the [interpreter](https://en.wikipedia.org/wiki/Shebang_(Unix)) to use for the script.
     : `check` (String)
-      : A command to check the script. I.e. some linting check.
+      : A command to check the script. For example, this could be a linting check.
     : `makeWrapperArgs` (Optional, [ String ], Default: [])
-      : Arguments forwarded to (`makeWrapper`)[#fun-makeWrapper]
+      : Arguments forwarded to (`makeWrapper`)[#fun-makeWrapper].
 
     `nameOrPath` (String)
     : The name of the script or the path to the script.
@@ -40,8 +40,8 @@ rec {
       When a `string` starting with "/" is passed, the script will be created at the specified path in $out.
       I.e. `"/bin/hello"` will create a script at `$out/bin/hello`.
 
-      Any other `string` is interpreted as filename.
-      It must be a simple unix filename starting with a letter, digit, dot, or underscore.
+      Any other `string` is interpreted as a filename.
+      It must be a [POSIX filename](https://en.wikipedia.org/wiki/Filename) starting with a letter, digit, dot, or underscore.
       Spaces or special characters are not allowed.
 
     `content` (String)
@@ -51,6 +51,7 @@ rec {
     This function is used as base implementation for other high-level writer functions.
 
     For example, `writeBash` can (roughly) be implemented as:
+
     ```nix
     writeBash = makeScriptWriter { interpreter = "${pkgs.bash}/bin/bash"; }
     ```
@@ -103,7 +104,8 @@ rec {
       name = last (builtins.split "/" nameOrPath);
       path = if nameIsPath then nameOrPath else "/bin/${name}";
       # The inner derivation which creates the executable under $out/bin (never at $out directly)
-      # This is required in order to support wrapping, as wrapped programs consist of at least two files: the executable and the wrapper.
+      # This is required in order to support wrapping, as wrapped programs consist of
+      # at least two files: the executable and the wrapper.
       inner =
         pkgs.runCommandLocal name
           (
@@ -178,11 +180,10 @@ rec {
       '';
 
   /**
-    This is a generic function that returns a derivation which, when built, compiles the given script into an executable format.
+    `makeBinWriter` returns a derivation which compiles the given script into an executable format.
 
     :::{.note}
-    This function is the base implementation for other compile language `writers`.
-    i.e. `writeHaskell`, `writeRust`.
+    This function is the base implementation for other compile language `writers`, such as `writeHaskell` and `writeRust`.
     :::
 
     # Inputs
@@ -192,7 +193,7 @@ rec {
       : The script that compiles the given content into an executable.
 
     : `strip` (Boolean, Default: true)
-      : Whether to strip the executable or not.
+      : Whether to [strip](https://nixos.org/manual/nixpkgs/stable/#ssec-fixup-phase) the executable or not.
 
     : `makeWrapperArgs` (Optional, [ String ], Default: [])
       : Arguments forwarded to (`makeWrapper`)[#fun-makeWrapper]
@@ -201,10 +202,10 @@ rec {
     : The name of the script or the path to the script.
 
       When a `string` starting with "/" is passed, the script will be created at the specified path in $out.
-      I.e. `"/bin/hello"` will create a script at `$out/bin/hello`.
+      For example, `"/bin/hello"` will create a script at `$out/bin/hello`.
 
-      Any other `string` is interpreted as filename.
-      It must be a simple unix filename starting with a letter, digit, dot, or underscore.
+      Any other `string` is interpreted as a filename.
+      It must be a [POSIX filename](https://en.wikipedia.org/wiki/Filename) starting with a letter, digit, dot, or underscore.
       Spaces or special characters are not allowed.
 
     # Examples


### PR DESCRIPTION
## Description of changes

This is a follow-up PR to
- #333270

I saw the PR go through while I was out camping, and had a few editorial suggestions.

- [x] Name the function in the introductory sentence.
- [x] Simplify by removing "being built" or "generic function". None of this adds to the documentation.
- [x] Add links to relevant Wikipedia pages and nixpkgs-manual pages.
- [x] Consistently add periods at the end of sentences.
- [x] Wrap a few non-documentation comments.

## Things done

- [x] Tested that the Nix parsed output was the same on both this branch and master, showing that only the comments changed. 
  ```
  $ nix-instantiate --parse pkgs/build-support/writers/scripts.nix | sha256sum
  ef0f47d01ae268cd1f16e536b168813f44abbe6278d253a7ee115a83c3cbcc6a  -
  $ git checkout master
  $ nix-instantiate --parse pkgs/build-support/writers/scripts.nix | sha256sum
  ef0f47d01ae268cd1f16e536b168813f44abbe6278d253a7ee115a83c3cbcc6a  -
  ```
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).