### PR TITLE
nixos/ceph: lower memory requirements for tests

### DIFF
--- a/nixos/tests/ceph-single-node-bluestore.nix
+++ b/nixos/tests/ceph-single-node-bluestore.nix
@@ -109,6 +109,14 @@ let
     monA.wait_until_succeeds("ceph -s | grep 'quorum ${cfg.monA.name}'")
     monA.wait_until_succeeds("ceph -s | grep 'mgr: ${cfg.monA.name}(active,'")
 
+    # reduce memory usage in CI
+    monA.succeed(
+        # autotune has a minimum target of ~1Gi, manual cache management is required for lower values
+        "ceph config set osd bluestore_cache_autotune false",
+        # 16MiB should be enough for writing literally no data
+        "ceph config set osd bluestore_cache_size 16Mi",
+    )
+
     # Bootstrap OSDs
     monA.succeed(
         "mkdir -p /var/lib/ceph/osd/ceph-${cfg.osd0.name}",


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The defaults for Ceph OSDs are usually in the mid single digit Gibibyte range, which runs into some issues with the 1GiB memory test VMs. These changes to the OSD memory usage should fix most test failures.

Specifically [*nixos.tests.ceph-single-node-bluestore.aarch64-linux*](https://hydra.nixos.org/job/nixos/release-24.05/nixos.tests.ceph-single-node-bluestore.aarch64-linux) has its usage down to being able to run on my test node.
~~However the only aarch64 machine I have is very low power and doesn't have hardware virtualisation so I had to increase the `--global-timeout` just to get it to run to the point where this becomes relevant (however looking at the upstream numbers of 30s for a step that takes me 600s I assume this will be fine upstream), which means this is only *somewhat* tested I guess?
This change causes the tests to not have any OOM or memory pressure logs, so I assume it's at least better.~~
*Edit*: see first comment

I am also not sure why this hits the aarch64 machines so much more reliable than the x86_64 ones, and maybe there is something else going on, but either way reducing the memory usage should be a net positive.

This should probably be backported to 24.05 too.

One additional note: [*nixos.tests.ceph-single-node.aarch64-linux*](https://hydra.nixos.org/job/nixos/release-24.05/nixos.tests.ceph-single-node.aarch64-linux) has the same issue with filestore, but I'm not sure how to fix that.
In either case the majority of the memory usage comes from the mgr daemon anyway.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] ~~x86_64-darwin~~
  - [ ] ~~aarch64-darwin~~
- ~~For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~~
  - [ ] ~~`sandbox = relaxed`~~
  - [ ] ~~`sandbox = true`~~
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] ~~Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)~~
- [ ] ~~Tested basic functionality of all binary files (usually in `./result/bin/`)~~
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] ~~(Package updates) Added a release notes entry if the change is major or breaking~~
  - [ ] ~~(Module updates) Added a release notes entry if the change is significant~~
  - [ ] ~~(Module addition) Added a release notes entry if adding a new NixOS module~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
