### PR TITLE
fishnet: 2.7.1 -> 2.9.3

### DIFF
--- a/pkgs/servers/fishnet/default.nix
+++ b/pkgs/servers/fishnet/default.nix
@@ -5,41 +5,43 @@
 }:
 
 let
-  nnueFile = "nn-5af11540bbfe.nnue";
-  nnue = fetchurl {
-    url = "https://tests.stockfishchess.org/api/nn/${nnueFile}";
-    hash = "sha256-WvEVQLv+/LVOOMXdAAyrS0ad+nWZodVb5dJyLCCokps=";
+  # These files can be found in Stockfish/src/evaluate.h
+  nnueBigFile = "nn-31337bea577c.nnue";
+  nnueBig = fetchurl {
+    url = "https://tests.stockfishchess.org/api/nn/${nnueBigFile}";
+    sha256 = "sha256-MTN76ld8W00LPlQYGGGJ7k9Yuq6rjX9vO9BXisp/d9k=";
   };
-in
-rustPlatform.buildRustPackage rec {
+  nnueSmallFile = "nn-37f18f62d772.nnue";
+  nnueSmall = fetchurl {
+    url = "https://tests.stockfishchess.org/api/nn/${nnueSmallFile}";
+    sha256 = "sha256-N/GPYtdy8xB+HWqso4mMEww8hvKrY+ZVX7vKIGNaiZ0=";
+  };
+in rustPlatform.buildRustPackage rec {
   pname = "fishnet";
-  version = "2.7.1";
+  version = "2.9.3";
 
   src = fetchFromGitHub {
     owner = "lichess-org";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-q73oGQYSWx1aFy9IvbGpecOoc0wLEY2IzJH9GufnvCs=";
+    hash = "sha256-HlCnUJBhIhooBvQVz1SDfiifXIBkBlH2dEq+C9al7qI=";
     fetchSubmodules = true;
   };
 
   postPatch = ''
-    cp -v '${nnue}' 'Stockfish/src/${nnueFile}'
-    cp -v '${nnue}' 'Fairy-Stockfish/src/${nnueFile}'
+    cp -v '${nnueBig}' 'Stockfish/src/${nnueBigFile}'
+    cp -v '${nnueBig}' 'Fairy-Stockfish/src/${nnueBigFile}'
+    cp -v '${nnueSmall}' 'Stockfish/src/${nnueSmallFile}'
+    cp -v '${nnueSmall}' 'Fairy-Stockfish/src/${nnueSmallFile}'
   '';
 
-  # Copying again bacause the file is deleted during build.
-  postBuild = ''
-    cp -v '${nnue}' 'Stockfish/src/${nnueFile}'
-  '';
-
-  cargoHash = "sha256-NO3u2ZXSiDQnZ/FFZLOtTnQoGMyN9pSI4sqGIXtjEcI=";
+  cargoHash = "sha256-Fb28XNhCt88PFnJ4s0I80L/rLJtBTEZ8Xd/68MYFoLs=";
 
   meta = with lib; {
     description = "Distributed Stockfish analysis for lichess.org";
     homepage = "https://github.com/lichess-org/fishnet";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ tu-maurice ];
+    maintainers = with maintainers; [ tu-maurice thibaultd ];
     platforms = [ "aarch64-linux" "x86_64-linux" ];
     mainProgram = "fishnet";
   };


### PR DESCRIPTION
Fishnet now uses 2 NNUE files.
The `postBuild` hook is now superfluous, I removed it.

In my [previous attempt](https://github.com/NixOS/nixpkgs/pull/330860) I used pre-compiled binaries, but here I sticked to compilation from sources instead.


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
