### PR TITLE
libs3: fix cross compilation, pkgs/by-name migration

### DIFF
--- a/pkgs/by-name/li/libs3/package.nix
+++ b/pkgs/by-name/li/libs3/package.nix
@@ -1,4 +1,12 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, curl, libxml2 }:
+{
+  curl,
+  fetchFromGitHub,
+  fetchpatch,
+  lib,
+  libxml2,
+  pkg-config,
+  stdenv,
+}:
 
 stdenv.mkDerivation {
   pname = "libs3";
@@ -12,21 +20,35 @@ stdenv.mkDerivation {
   };
 
   patches = [
-    (fetchpatch { # Fix compilation with openssl 3.0
+    (fetchpatch {
+      # Fix compilation with openssl 3.0
       url = "https://github.com/bji/libs3/pull/112/commits/3c3a1cf915e62b730db854d8007ba835cb38677c.patch";
       hash = "sha256-+rWRh8dOznHlamc/T9qbgN0E2Rww3Hn94UeErxNDccs=";
     })
   ];
 
-  buildInputs = [ curl libxml2 ];
+  postPatch = ''
+    substituteInPlace GNUmakefile \
+      --replace-fail curl-config "$PKG_CONFIG libcurl" \
+      --replace-fail xml2-config "$PKG_CONFIG libxml-2.0"
+  '';
 
   makeFlags = [ "DESTDIR=${placeholder "out"}" ];
 
-  meta = with lib; {
-    homepage = "https://github.com/bji/libs3";
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    curl
+    libxml2
+  ];
+
+  meta = {
     description = "Library for interfacing with amazon s3";
+    homepage = "https://github.com/bji/libs3";
+    license = lib.licenses.lgpl3Plus;
     mainProgram = "s3";
-    license = licenses.lgpl3Plus;
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22200,8 +22200,6 @@ with pkgs;
 
   librttopo = callPackage ../development/libraries/librttopo { };
 
-  libs3 = callPackage ../development/libraries/libs3 { };
-
   libschrift = callPackage ../development/libraries/libschrift { };
 
   libsciter = callPackage ../development/libraries/libsciter { };


### PR DESCRIPTION
libs3: fix cross compilation
- refactor:
  - migrate to pkgs/by-name
  - remove nested with
  - order derivation attributes by phases order and attrs by alphabetical order
  - minor format adaptations

Tested with:
> nix build .#pkgsCross.aarch64-multiplatform.libs3

CC @NickCao (for liking cross compilation fixes)