### PR TITLE
komika-fonts: init at 0-unstable-2024-08-12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15539,6 +15539,11 @@
     githubId = 686076;
     name = "Vitalii Voloshyn";
   };
+  pancaek = {
+    github = "pancaek";
+    githubId = 20342389;
+    name = "paneku";
+  };
   panda2134 = {
     email = "me+nixpkgs@panda2134.site";
     github = "panda2134";

--- a/pkgs/by-name/ko/komika-fonts/package.nix
+++ b/pkgs/by-name/ko/komika-fonts/package.nix
@@ -1,0 +1,120 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchzip,
+  variants ? [
+    "display"
+    "hand"
+    "poster"
+    "text"
+    "title"
+    "komikahuna"
+    "komikandy"
+    "komikazba"
+    "komikaze"
+    "komikazoom"
+  ],
+}:
+
+let
+  fetchFont =
+    {
+      url,
+      hash,
+      curlOptsList ? [ ],
+    }:
+    fetchzip {
+      inherit url hash curlOptsList;
+      name = lib.nameFromURL url ".";
+      stripRoot = false;
+    };
+  fontMap = {
+    "display" = {
+      url = "https://www.1001fonts.com/download/komika-display.zip";
+      hash = "sha256-6oNKuaoV+a/cFCKFXRV8gtWqvFtPGtrqg+vt8hQREMI=";
+    };
+    "hand" = {
+      url = "https://www.1001fonts.com/download/komika.zip";
+      hash = "sha256-yb5SWQj7BRCLYHL31m25bhCOuo8qAvkRzGH6UIo3Bbs=";
+    };
+    "poster" = {
+      url = "https://www.1001freefonts.com/d/5010/komika-poster.zip";
+      hash = "sha256-k1uUfHSh9kymCJrfuPtKHejFeZGl2PxL4C/3hpoPIc4=";
+      curlOptsList = [
+        "-H"
+        "Referer: https://www.1001freefonts.com/komika-poster.font"
+      ];
+    };
+    "text" = {
+      url = "https://www.1001fonts.com/download/komika-text.zip";
+      hash = "sha256-FdeFGw6MlYVTiYdvbfjSlQYq+UlKZTJ79HAdEEjMPQs=";
+    };
+    "title" = {
+      url = "https://www.1001freefonts.com/d/5011/komika-title.zip";
+      hash = "sha256-M/1NgsHjLR/w/ZxWEb5cebqEI1VKgPvtk75bhAPaw20=";
+      curlOptsList = [
+        "-H"
+        "Referer: https://www.1001freefonts.com/komika-title.font"
+      ];
+    };
+    "komikahuna" = {
+      url = "https://www.1001fonts.com/download/komikahuna.zip";
+      hash = "sha256-TjGxQA3ZyIOyJUNP+MVkYiSDk9WDIDPy3d2ttWC1aoc=";
+    };
+    "komikandy" = {
+      url = "https://www.1001fonts.com/download/komikandy.zip";
+      hash = "sha256-NqpR+gM2giTHGUBYoJlO8vkzOD0ep7LzAry3nIagjLY=";
+    };
+    "komikazba" = {
+      url = "https://www.1001fonts.com/download/komikazba.zip";
+      hash = "sha256-SGJMP0OdZ/AEImN5S3QshCbWSLXO4qTjHnSQYqoy3Pc=";
+    };
+    "komikaze" = {
+      url = "https://www.1001fonts.com/download/komikaze.zip";
+      hash = "sha256-daJRwgkzL5v224KwkaGMK2FqVnfin8+8WvMTvXTkCGE=";
+    };
+    "komikazoom" = {
+      url = "https://www.1001fonts.com/download/komikazoom.zip";
+      hash = "sha256-/o2QPPPiQBkNU0XRxJyI0+5CKFEv4FKU3A5ku1zyVX4=";
+    };
+
+  };
+  knownFonts = lib.attrNames fontMap;
+  selectedFonts =
+    if (variants == [ ]) then
+      lib.warn "No variants selected, installing all instead" knownFonts
+    else
+      let
+        unknown = lib.subtractLists knownFonts variants;
+      in
+      if (unknown != [ ]) then
+        throw "Unknown variant(s): ${lib.concatStringsSep " " unknown}"
+      else
+        variants;
+
+in
+stdenvNoCC.mkDerivation {
+  pname = "komika-fonts";
+  version = "0-unstable-2024-08-12";
+  sourceRoot = ".";
+
+  srcs = map (variant: fetchFont fontMap.${variant}) selectedFonts;
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/fonts/ttf
+    mv **/*.ttf $out/share/fonts/ttf
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://moorstation.org/typoasis/designers/lab/index.htm";
+    # description from archive here: http://web.archive.org/web/20030422173903fw_/http://www.hardcovermedia.com/lab/Pages/Fontpages/komikahands.html
+    description = "First ever comic lettering super family";
+    longDescription = ''
+      50 fonts, covering everything the comic artist needs when it comes to lettering. 10 text faces, 10 display faces, 10 tiling faces, 10 hand variations, 9 poster faces, and 20 balloons in a font.
+    '';
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ pancaek ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes
Added the komika font family, with extensive styles for comic artists.

The homepage, which is an archive of the Lab project Komika was a part of: http://moorstation.org/typoasis/designers/lab

Font sources: https://www.1001fonts.com and https://www.1001freefonts.com (while the archive in the homepage contains most fonts, it is entirely missing the Komika Text set, and these should be far less prone to going defunct).
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
