### PR TITLE
lixVersions.lix_2_91: init

### DIFF
--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -4,6 +4,7 @@
   boehmgc,
   callPackage,
   fetchFromGitHub,
+  fetchpatch,
   Security,
 
   storeDir ? "/nix/store",
@@ -33,6 +34,9 @@ let
         requiredSystemFeatures = [ ];
       };
 
+  # Since Lix 2.91 does not use boost coroutines, it does not need boehmgc patches either.
+  needsBoehmgcPatches = version: lib.versionOlder version "2.91";
+
   common =
     args:
     callPackage (import ./common.nix ({ inherit lib fetchFromGitHub; } // args)) {
@@ -42,11 +46,11 @@ let
         stateDir
         confDir
         ;
-      boehmgc = boehmgc-nix;
+      boehmgc = if needsBoehmgcPatches args.version then boehmgc-nix else boehmgc-nix_2_3;
       aws-sdk-cpp = aws-sdk-cpp-nix;
     };
 in
-lib.makeExtensible (self: ({
+lib.makeExtensible (self: {
   buildLix = common;
 
   lix_2_90 = (
@@ -57,6 +61,31 @@ lib.makeExtensible (self: ({
     }
   );
 
-  latest = self.lix_2_90;
-  stable = self.lix_2_90;
-}))
+  lix_2_91 = (
+    common {
+      version = "2.91.0";
+      hash = "sha256-Rosl9iA9MybF5Bud4BTAQ9adbY81aGmPfV8dDBGl34s=";
+      docCargoHash = "sha256-KOn1fXF7k7c/0e5ZCNZwt3YZmjL1oi5A2mhwxQWKaUo=";
+
+      patches = [
+        # Fix meson to not use target_machine, fixing cross. This commit is in release-2.91: remove when updating to 2.91.1 (if any).
+        # https://gerrit.lix.systems/c/lix/+/1781
+        # https://git.lix.systems/lix-project/lix/commit/ca2b514e20de12b75088b06b8e0e316482516401
+        (fetchpatch {
+          url = "https://git.lix.systems/lix-project/lix/commit/ca2b514e20de12b75088b06b8e0e316482516401.patch";
+          hash = "sha256-TZauU4RIsn07xv9vZ33amrDvCLMbrtcHs1ozOTLgu98=";
+        })
+        # Fix musl builds. This commit is in release-2.91: remove when updating to 2.91.1 (if any).
+        # https://gerrit.lix.systems/c/lix/+/1823
+        # https://git.lix.systems/lix-project/lix/commit/ed51a172c69996fc6f3b7dfaa86015bff50c8ba8
+        (fetchpatch {
+          url = "https://git.lix.systems/lix-project/lix/commit/ed51a172c69996fc6f3b7dfaa86015bff50c8ba8.patch";
+          hash = "sha256-X59N+tOQ2GN17p9sXvo9OiuEexzB23ieuOvtq2sre5c=";
+        })
+      ];
+    }
+  );
+
+  latest = self.lix_2_91;
+  stable = self.lix_2_91;
+})


### PR DESCRIPTION
This adds Lix 2.91.0 to nixpkgs and sets it as the default Lix release.

## Description of changes

Blog post:
https://lix.systems/blog/2024-08-12-lix-2.91-release/

Release notes:
https://docs.lix.systems/manual/lix/stable/release-notes/rl-2.91.html


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
