### PR TITLE
kata-runtime: init at 3.7.0

### DIFF
--- a/pkgs/by-name/ka/kata-runtime/kata-images.nix
+++ b/pkgs/by-name/ka/kata-runtime/kata-images.nix
@@ -1,0 +1,49 @@
+# Derived from https://github.com/colemickens/nixpkgs-kubernetes
+{
+  fetchzip,
+  lib,
+  stdenv,
+  version,
+}:
+
+let
+  imageSuffix =
+    {
+      "x86_64-linux" = "amd64";
+      "aarch64-linux" = "arm64";
+    }
+    ."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  imageHash =
+    {
+      "x86_64-linux" = "sha256-6ySKAqrbHDRgVlI7wm2p4Uw96ZMzUpP00liujxlruSM=";
+      "aarch64-linux" = "sha256-pEPkDXT4OunfN2sGb8Ru05tFHaBsYUcmG5Iy7yH4kX8=";
+    }
+    ."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+in
+fetchzip {
+  name = "kata-images-${version}";
+  url = "https://github.com/kata-containers/kata-containers/releases/download/${version}/kata-static-${version}-${imageSuffix}.tar.xz";
+  hash = imageHash;
+
+  postFetch = ''
+    mv $out/kata/share/kata-containers kata-containers
+    rm -r $out
+    mkdir -p $out/share
+    mv kata-containers $out/share/kata-containers
+  '';
+
+  meta = {
+    description = "Lightweight Virtual Machines like containers that provide the workload isolation and security of VMs";
+    homepage = "https://github.com/kata-containers/kata-containers";
+    changelog = "https://github.com/kata-containers/kata-containers/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ thomasjm ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/ka/kata-runtime/package.nix
+++ b/pkgs/by-name/ka/kata-runtime/package.nix
@@ -1,0 +1,92 @@
+# Derived from https://github.com/colemickens/nixpkgs-kubernetes
+{
+  buildGoModule,
+  callPackage,
+  fetchFromGitHub,
+  lib,
+  qemu_kvm,
+  stdenv,
+  virtiofsd,
+  yq-go,
+}:
+
+let
+  version = "3.7.0";
+
+  kata-images = callPackage ./kata-images.nix { inherit version; };
+
+  qemuSystemBinary =
+    {
+      "x86_64-linux" = "qemu-system-x86_64";
+      "aarch64-linux" = "qemu-system-aarch64";
+    }
+    ."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+in
+buildGoModule rec {
+  pname = "kata-runtime";
+  inherit version;
+
+  # https://github.com/NixOS/nixpkgs/issues/25959
+  hardeningDisable = [ "fortify" ];
+
+  src = fetchFromGitHub {
+    owner = "kata-containers";
+    repo = "kata-containers";
+    rev = version;
+    hash = "sha256-Ir+/ZZJHm6E+044wczU3UvL+Py9Wprgw2QKJaYyDrKU=";
+  };
+
+  sourceRoot = "source/src/runtime";
+
+  vendorHash = null;
+
+  dontConfigure = true;
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "DEFAULT_HYPERVISOR=qemu"
+    "HYPERVISORS=qemu"
+    "QEMUPATH=${qemu_kvm}/bin/${qemuSystemBinary}"
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    mkdir -p $TMPDIR/gopath/bin
+    ln -s ${yq-go}/bin/yq $TMPDIR/gopath/bin/yq
+    HOME=$TMPDIR GOPATH=$TMPDIR/gopath make ${toString makeFlags}
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    HOME=$TMPDIR GOPATH=$TMPDIR/gopath make ${toString makeFlags} install
+    ln -s $out/bin/containerd-shim-kata-v2 $out/bin/containerd-shim-kata-qemu-v2
+    ln -s $out/bin/containerd-shim-kata-v2 $out/bin/containerd-shim-kata-clh-v2
+
+    # Update a few paths to the Nix-provided versions: kata-images, virtiofsd, and qemu_kvm
+    sed -i \
+      -e "s!$out/share/kata-containers!${kata-images}/share/kata-containers!" \
+      -e "s!^virtio_fs_daemon.*!virtio_fs_daemon=\"${virtiofsd}/bin/virtiofsd\"!" \
+      -e "s!^valid_virtio_fs_daemon_paths.*!valid_virtio_fs_daemon_paths=[\"${qemu_kvm}/libexec/virtiofsd\"]!" \
+      "$out/share/defaults/kata-containers/"*.toml
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit kata-images;
+  };
+
+  meta = {
+    description = "Lightweight Virtual Machines like containers that provide the workload isolation and security of VMs";
+    homepage = "https://github.com/kata-containers/kata-containers";
+    changelog = "https://github.com/kata-containers/kata-containers/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ thomasjm ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This is the runtime needed by [Kata Containers](https://github.com/kata-containers/kata-containers), a project providing lightweight virtual machines that behave like containers.

This is my second PR working toward enabling Kata Containers with K3S on NixOS. I have this working on my home cluster and am working on merging all the pieces to Nixpkgs.

The code is heavily based on https://github.com/colemickens/nixpkgs-kubernetes, which was a very helpful starting point. (CC @colemickens).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
