### PR TITLE
postgresql: Implement automatic extension preloading

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/citus.nix
+++ b/pkgs/servers/sql/postgresql/ext/citus.nix
@@ -37,6 +37,10 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  passthru = {
+    shared_preload_library = "citus";
+  };
+
   meta = with lib; {
     # "Our soft policy for Postgres version compatibility is to support Citus'
     # latest release with Postgres' 3 latest releases."

--- a/pkgs/servers/sql/postgresql/ext/cstore_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/cstore_fdw.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, postgresql, protobufc }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "cstore_fdw";
   version = "unstable-2022-03-08";
 
@@ -21,6 +21,10 @@ stdenv.mkDerivation rec {
     cp *.sql     $out/share/postgresql/extension
     cp *.control $out/share/postgresql/extension
   '';
+
+  passthru = {
+    shared_preload_library = "cstore_fdw";
+  };
 
   meta = with lib; {
     broken      = versionAtLeast postgresql.version "14";

--- a/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
@@ -20,6 +20,10 @@ stdenv.mkDerivation rec {
     install -D -t $out/share/postgresql/extension src/monitor/pgautofailover.control
   '';
 
+  passthru = {
+    shared_preload_library = "pgautofailover";
+  };
+
   meta = with lib; {
     description = "PostgreSQL extension and service for automated failover and high-availability";
     mainProgram = "pg_autoctl";

--- a/pkgs/servers/sql/postgresql/ext/pg_bigm.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_bigm.nix
@@ -29,6 +29,10 @@ stdenv.mkDerivation rec {
     install -D -t $out/share/postgresql/extension *.control
   '';
 
+  passthru = {
+    shared_preload_library = "pg_bigm";
+  };
+
   meta = with lib; {
     description = "Text similarity measurement and index searching based on bigrams";
     homepage = "https://pgbigm.osdn.jp/";

--- a/pkgs/servers/sql/postgresql/ext/pg_cron.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_cron.nix
@@ -21,6 +21,10 @@ stdenv.mkDerivation rec {
     cp *.control $out/share/postgresql/extension
   '';
 
+  passthru = {
+    shared_preload_library = "pg_cron";
+  };
+
   meta = with lib; {
     description = "Run Cron jobs through PostgreSQL";
     homepage    = "https://github.com/citusdata/pg_cron";

--- a/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
@@ -48,6 +48,10 @@ stdenv.mkDerivation {
     install -D -t $out/share/postgresql/extension *.control
   '';
 
+  passthru = {
+    shared_preload_library = "pg_hint_plan";
+  };
+
   meta = with lib; {
     description = "Extension to tweak PostgreSQL execution plans using so-called 'hints' in SQL comments";
     homepage = "https://github.com/ossc-db/pg_hint_plan";

--- a/pkgs/servers/sql/postgresql/ext/pg_ivm.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_ivm.nix
@@ -19,6 +19,10 @@ stdenv.mkDerivation rec {
     install -D -t $out/share/postgresql/extension *.control
   '';
 
+  passthru = {
+    shared_preload_library = "pg_ivm";
+  };
+
   meta = with lib; {
     description = "Materialized views with IVM (Incremental View Maintenance) for PostgreSQL";
     homepage = "https://github.com/sraoss/pg_ivm";

--- a/pkgs/servers/sql/postgresql/ext/pg_net.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_net.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation rec {
     cp *.control $out/share/postgresql/extension
   '';
 
+  passthru = {
+    shared_preload_library = "pg_net";
+  };
+
   meta = with lib; {
     description = "Async networking for Postgres";
     homepage    = "https://github.com/supabase/pg_net";

--- a/pkgs/servers/sql/postgresql/ext/pg_partman.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_partman.nix
@@ -22,6 +22,10 @@ stdenv.mkDerivation rec {
     cp *.control     $out/share/postgresql/extension
   '';
 
+  passthru = {
+    shared_preload_library = "pg_partman_bgw";
+  };
+
   meta = with lib; {
     description = "Partition management extension for PostgreSQL";
     homepage    = "https://github.com/pgpartman/pg_partman";

--- a/pkgs/servers/sql/postgresql/ext/pg_relusage.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_relusage.nix
@@ -19,6 +19,10 @@ stdenv.mkDerivation rec {
     install -D -t $out/share/postgresql/extension *.control
   '';
 
+  passthru = {
+    shared_preload_library = "pg_relusage";
+  };
+
   meta = with lib; {
     description = "pg_relusage extension for PostgreSQL: discover and log the relations used in your statements";
     homepage    = "https://github.com/adept/pg_relusage";

--- a/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
@@ -40,6 +40,10 @@ stdenv.mkDerivation rec {
     install -D safeupdate${postgresql.dlSuffix} -t $out/lib
   '';
 
+  passthru = {
+    shared_preload_library = "safeupdate";
+  };
+
   meta = with lib; {
     description = "Simple extension to PostgreSQL that requires criteria for UPDATE and DELETE";
     homepage    = "https://github.com/eradman/pg-safeupdate";

--- a/pkgs/servers/sql/postgresql/ext/pg_similarity.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_similarity.nix
@@ -20,6 +20,10 @@ stdenv.mkDerivation {
     install -D ./{pg_similarity--unpackaged--1.0.sql,pg_similarity--1.0.sql,pg_similarity.control} -t $out/share/postgresql/extension
   '';
 
+  passthru = {
+    shared_preload_library = "pg_similarity";
+  };
+
   meta = {
     description = "Extension to support similarity queries on PostgreSQL";
     longDescription = ''

--- a/pkgs/servers/sql/postgresql/ext/pgaudit.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgaudit.nix
@@ -45,6 +45,10 @@ stdenv.mkDerivation {
     install -D -t $out/share/postgresql/extension *.control
   '';
 
+  passthru = {
+    shared_preload_library = "pgaudit";
+  };
+
   meta = with lib; {
     description = "Open Source PostgreSQL Audit Logging";
     homepage = "https://github.com/pgaudit/pgaudit";

--- a/pkgs/servers/sql/postgresql/ext/pgvecto-rs/default.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgvecto-rs/default.nix
@@ -85,6 +85,10 @@ in
   usePgTestCheckFeature = false;
 
   passthru = {
+    # This looks odd but is correct according to the documentation
+    # https://docs.pgvecto.rs/getting-started/installation.html#from-zip-package
+    shared_preload_library = "vectors.so";
+
     updateScript = nix-update-script { };
     tests = {
       pgvecto-rs = nixosTests.pgvecto-rs;

--- a/pkgs/servers/sql/postgresql/ext/plpgsql_check.nix
+++ b/pkgs/servers/sql/postgresql/ext/plpgsql_check.nix
@@ -19,20 +19,24 @@ stdenv.mkDerivation rec {
     install -D -t $out/share/postgresql/extension *.control
   '';
 
-  passthru.tests.extension = stdenv.mkDerivation {
-    name = "plpgsql-check-test";
-    dontUnpack = true;
-    doCheck = true;
-    buildInputs = [ postgresqlTestHook ];
-    nativeCheckInputs = [ (postgresql.withPackages (ps: [ ps.plpgsql_check ])) ];
-    postgresqlTestUserOptions = "LOGIN SUPERUSER";
-    failureHook = "postgresqlStop";
-    checkPhase = ''
-      runHook preCheck
-      psql -a -v ON_ERROR_STOP=1 -c "CREATE EXTENSION plpgsql_check;"
-      runHook postCheck
-    '';
-    installPhase = "touch $out";
+  passthru = {
+    shared_preload_library = "plpgsql_check";
+
+    tests.extension = stdenv.mkDerivation {
+      name = "plpgsql-check-test";
+      dontUnpack = true;
+      doCheck = true;
+      buildInputs = [ postgresqlTestHook ];
+      nativeCheckInputs = [ (postgresql.withPackages (ps: [ ps.plpgsql_check ])) ];
+      postgresqlTestUserOptions = "LOGIN SUPERUSER";
+      failureHook = "postgresqlStop";
+      checkPhase = ''
+        runHook preCheck
+        psql -a -v ON_ERROR_STOP=1 -c "CREATE EXTENSION plpgsql_check;"
+        runHook postCheck
+      '';
+      installPhase = "touch $out";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/servers/sql/postgresql/ext/postgis.nix
+++ b/pkgs/servers/sql/postgresql/ext/postgis.nix
@@ -113,7 +113,10 @@ stdenv.mkDerivation rec {
     mv doc/* $doc/share/doc/postgis/
   '';
 
-  passthru.tests.postgis = nixosTests.postgis;
+  passthru = {
+    shared_preload_library = "postgis-3";
+    tests.postgis = nixosTests.postgis;
+  };
 
   meta = with lib; {
     description = "Geographic Objects for PostgreSQL";

--- a/pkgs/servers/sql/postgresql/ext/repmgr.nix
+++ b/pkgs/servers/sql/postgresql/ext/repmgr.nix
@@ -31,6 +31,10 @@ stdenv.mkDerivation rec {
     cp *.control  $out/share/postgresql/extension
   '';
 
+  passthru = {
+    shared_preload_library = "repmgr";
+  };
+
   meta = with lib; {
     homepage = "https://repmgr.org/";
     description = "Replication manager for PostgreSQL cluster";

--- a/pkgs/servers/sql/postgresql/ext/timescaledb.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb.nix
@@ -32,7 +32,10 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  passthru.tests = { inherit (nixosTests) timescaledb; };
+  passthru = {
+    shared_preload_library = "timescaledb";
+    tests = { inherit (nixosTests) timescaledb; };
+  };
 
   meta = with lib; {
     description = "Scales PostgreSQL for time-series data via automatic partitioning across time and space";

--- a/pkgs/servers/sql/postgresql/ext/wal2json.nix
+++ b/pkgs/servers/sql/postgresql/ext/wal2json.nix
@@ -20,10 +20,13 @@ stdenv.mkDerivation rec {
     install -D -t $out/share/postgresql/extension sql/*.sql
   '';
 
-  passthru.tests.wal2json = lib.recurseIntoAttrs (callPackage ../../../../../nixos/tests/postgresql-wal2json.nix {
-    inherit (stdenv) system;
-    inherit postgresql;
-  });
+  passthru = {
+    shared_preload_library = "wal2json";
+    tests.wal2json = lib.recurseIntoAttrs (callPackage ../../../../../nixos/tests/postgresql-wal2json.nix {
+      inherit (stdenv) system;
+      inherit postgresql;
+    });
+  };
 
   meta = with lib; {
     description = "PostgreSQL JSON output plugin for changeset extraction";


### PR DESCRIPTION
## Description of changes

Implement `passthru.shared_preload_library` -> `services.postgresql.settings.shared_preload_libraries` with option to disable.
This is good because you don't have to wade through documentation just to enable an extension, making it easier for newcomers to have a really pimped out postgresql. A pimped postgres makes for happy nerds!

So for those reading that don't know what shared_preload_libraries is. Some pg extensions require being loaded when pg starts rather than arbitrarily (global state <3). If they have these requirements I see no reason not to export this information to the end user by automating the process entirely. My implementation is subject to change if a nixos module master swings by.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@markuskowa This is one of those things i said "meta" was underutilized for! 😄 