### PR TITLE
qdiskinfo: init at 0.2

### DIFF
--- a/pkgs/by-name/qd/qdiskinfo/package.nix
+++ b/pkgs/by-name/qd/qdiskinfo/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall = ''
     wrapProgram $out/bin/QDiskInfo \
-      --prefix PATH : ${smartmontools}/bin
+      --suffix PATH : ${smartmontools}/bin
   '';
 
   meta = {

--- a/pkgs/by-name/qd/qdiskinfo/package.nix
+++ b/pkgs/by-name/qd/qdiskinfo/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  smartmontools,
+  fetchFromGitHub,
+  cmake,
+  qt6,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "QDiskInfo";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "edisionnano";
+    repo = "QDiskInfo";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-YLNpQOmh/exBJDuYRUEvzNv/El4x+PttEoj+aCur9wg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtwayland
+    smartmontools
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE:STRING=MinSizeRel"
+    "-DQT_VERSION_MAJOR=6"
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/QDiskInfo \
+      --prefix PATH : ${smartmontools}/bin
+  '';
+
+  meta = {
+    description = "CrystalDiskInfo alternative for Linux";
+    homepage = "https://github.com/edisionnano/QDiskInfo";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ roydubnium ];
+    platforms = lib.platforms.linux;
+    mainProgram = "QDiskInfo";
+  };
+})


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
A native linux alternative to CrystalDiskInfo. Provides SMART information about ATA and NVMe drives.
https://github.com/edisionnano/QDiskInfo

Resubmit of #325304
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc