### PR TITLE
screenly-cli: 0.2.7 -> 0.2.8

### DIFF
--- a/pkgs/by-name/sc/screenly-cli/package.nix
+++ b/pkgs/by-name/sc/screenly-cli/package.nix
@@ -1,12 +1,13 @@
-{ darwin
-, fetchFromGitHub
-, lib
-, perl
-, pkg-config
-, openssl
-, rustPlatform
-, stdenv
-, nix-update-script
+{
+  darwin,
+  fetchFromGitHub,
+  lib,
+  perl,
+  pkg-config,
+  openssl,
+  rustPlatform,
+  stdenv,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -27,14 +28,14 @@ rustPlatform.buildRustPackage rec {
     perl
   ];
 
-  buildInputs = [
-    openssl
-  ] ++ lib.optionals stdenv.isDarwin [
-    darwin.apple_sdk.frameworks.CoreFoundation
-    darwin.apple_sdk.frameworks.CoreServices
-    darwin.apple_sdk.frameworks.Security
-    darwin.apple_sdk.frameworks.SystemConfiguration
-  ];
+  buildInputs =
+    [ openssl ]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.apple_sdk.frameworks.CoreFoundation
+      darwin.apple_sdk.frameworks.CoreServices
+      darwin.apple_sdk.frameworks.Security
+      darwin.apple_sdk.frameworks.SystemConfiguration
+    ];
 
   passthru.updateScript = nix-update-script { };
 
@@ -44,6 +45,9 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/Screenly/cli/releases/tag/v${version}";
     license = lib.licenses.mit;
     mainProgram = "screenly";
-    maintainers = with lib.maintainers; [ jnsgruk vpetersson ];
+    maintainers = with lib.maintainers; [
+      jnsgruk
+      vpetersson
+    ];
   };
 }

--- a/pkgs/by-name/sc/screenly-cli/package.nix
+++ b/pkgs/by-name/sc/screenly-cli/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "screenly-cli";
-  version = "0.2.7";
+  version = "0.2.8";
 
   src = fetchFromGitHub {
     owner = "screenly";
     repo = "cli";
     rev = "refs/tags/v${version}";
-    hash = "sha256-ls8QnOfWRBAkW3q7eFKyoxvHlcI6j/zwIZNn8SMNzy8=";
+    hash = "sha256-WAdQWOrrC85DBgkZ0bU91TJgYOTdxNukis5DJngHI1s=";
   };
 
-  cargoHash = "sha256-rRH9bmsVylGZqMy7qIZlOk4kWBzj7uCruj30/z1nqEE=";
+  cargoHash = "sha256-fGUwMDSs5jJsAZmeHwYghXuOZFWHG6/NClhV0YcPQVg=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
## Description of changes

Bumps Screenly to the latest upstream version, which fixes the build issues when using rust >= 1.80.0.

See: https://github.com/NixOS/nixpkgs/issues/332957

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
