### PR TITLE
k3s_1_30: 1.30.2+k3s2 -> 1.30.3+k3s1

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/1_30/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_30/images-versions.json
@@ -1,18 +1,18 @@
 {
   "airgap-images-amd64": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.2%2Bk3s2/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "1d1adpjxxgkflm4xqzynsib67pga85r1qmhkhh540nl0rppbq7gr"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.3%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "1ym7cdm3a2f05wgh4vba2g7q1zihrfvvm2zngcs0gm8djj7hy4d9"
   },
   "airgap-images-arm": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.2%2Bk3s2/k3s-airgap-images-arm.tar.zst",
-    "sha256": "1hjhlj4b5ddaqhpmqbbvhvgzryi5j84i8bmpl3yij87yjkz3kld7"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.3%2Bk3s1/k3s-airgap-images-arm.tar.zst",
+    "sha256": "15mj949msrd30xhqryhpsvx1bi3pywm1z5bmi0h40qyzc1mcfvjk"
   },
   "airgap-images-arm64": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.2%2Bk3s2/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "1r9rd70qp8x57j3hdpgwgkzchykphw0x4yd8c1jwjfaqm5df1w0d"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.3%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "1k2q6rzczajnrkj57p97fdr7lgmrfv7x54by2syngfwb5in8fhd5"
   },
   "images-list": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.2%2Bk3s2/k3s-images.txt",
-    "sha256": "0245zra2h8756kq2v8nwl6gji749xlvy1y1bkab8vz5b0vpqhfxy"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.3%2Bk3s1/k3s-images.txt",
+    "sha256": "1my3lfs5rfazcnnpsc9dj84dfnxx88xydrl86z6yw5n5p84x4nif"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_30/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_30/versions.nix
@@ -1,12 +1,12 @@
 {
-  k3sVersion = "1.30.2+k3s2";
-  k3sCommit = "faeaf1b01b2a708a46cae2a67c1b4d381ee1ba6b";
-  k3sRepoSha256 = "0hy0f44hj5n5nscr0p52dbklvj2ki2vs7k0cgh1r8xlg4p6fn1b0";
-  k3sVendorHash = "sha256-Mj9Q3TgqZoJluG4/nyuw2WHnB3OJ+/mlV7duzWt1B1A=";
+  k3sVersion = "1.30.3+k3s1";
+  k3sCommit = "f646604010affc6a1d3233a8a0870bca46bf80cf";
+  k3sRepoSha256 = "1sqa4cx5rihrqcnriq7if7sm4hx73ma975yyr5k9nvhg71dvlig3";
+  k3sVendorHash = "sha256-HMlYdWDUoELpwsfCtyCxVIcFULdvu5gna83lc79AUWc=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
-  k3sRootVersion = "0.13.0";
-  k3sRootSha256 = "1jq5f0lm08abx5ikarf92z56fvx4kjpy2nmzaazblb34lajw87vj";
+  k3sRootVersion = "0.14.0";
+  k3sRootSha256 = "15cs9faw3jishsb5nhgmb5ldjc47hkwf7hz2126fp8ahf80m0fcl";
   k3sCNIVersion = "1.4.0-k3s2";
   k3sCNISha256 = "17dg6jgjx18nrlyfmkv14dhzxsljz4774zgwz5dchxcf38bvarqa";
   containerdVersion = "1.7.17-k3s1";


### PR DESCRIPTION
https://github.com/k3s-io/k3s/releases/tag/v1.30.3%2Bk3s1

It would appear r-ryantm is having a little trouble updating the 1_30 package: https://r.ryantm.com/log/k3s/2024-08-08.log

Going ahead and getting the update out as its about 2 weeks old. 

Result of `nixpkgs-review pr 334425` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>k3s</li>
  </ul>
</details>

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
