### PR TITLE
python312Packages.napari-nifti: init at 0.0.17

### DIFF
--- a/pkgs/development/python-modules/medvol/default.nix
+++ b/pkgs/development/python-modules/medvol/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  setuptools,
+  numpy,
+  simpleitk,
+}:
+
+buildPythonPackage rec {
+  pname = "medvol";
+  version = "0.0.15";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "MIC-DKFZ";
+    repo = "medvol";
+    rev = "v${version}";
+    hash = "sha256-JOw0ODx5yuBY5FyXy9z5C/NE/iok5GwiInalgXW/1J8=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    numpy
+    simpleitk
+  ];
+
+  doCheck = false; # no tests
+
+  pythonImportsCheck = [ "medvol" ];
+
+  meta = {
+    description = "Wrapper for loading medical 3D image volumes such as NIFTI or NRRD images";
+    homepage = "https://github.com/MIC-DKFZ/medvol";
+    changelog = "https://github.com/MIC-DKFZ/MedVol/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/napari-nifti/default.nix
+++ b/pkgs/development/python-modules/napari-nifti/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  setuptools,
+  medvol,
+}:
+
+buildPythonPackage rec {
+  pname = "napari-nifti";
+  version = "0.0.17";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "MIC-DKFZ";
+    repo = "napari-nifti";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-JDyJMg6rsGkfEHBwqKc2L6oRO5Y1MJJlEjUuuqp7URQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ medvol ];
+
+  pythonImportsCheck = [ "napari_nifti" ];
+
+  doCheck = false; # no tests
+
+  meta = {
+    description = "Napari plugin for reading and writing NIFTI files";
+    homepage = "https://github.com/MIC-DKFZ/napari-nifti";
+    changelog = "https://github.com/MIC-DKFZ/napari-nifti/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8964,6 +8964,8 @@ self: super: with self; {
 
   napari-console = callPackage ../development/python-modules/napari-console { };
 
+  napari-nifti = callPackage ../development/python-modules/napari-nifti { };
+
   napari-npe2 = callPackage ../development/python-modules/napari-npe2 { };
 
   napari-plugin-engine = callPackage ../development/python-modules/napari-plugin-engine { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7975,6 +7975,8 @@ self: super: with self; {
 
   medpy = callPackage ../development/python-modules/medpy { };
 
+  medvol = callPackage ../development/python-modules/medvol { };
+
   meeko = callPackage ../development/python-modules/meeko { };
 
   meep = callPackage ../development/python-modules/meep { };


### PR DESCRIPTION
python312Packages.medvol: init at 0.0.6

## Description of changes

Init [napari-nifti](https://github.com/MIC-DKFZ/napari-nifti), a Napari plugin for viewing NIFTI-format files.

Tested manually from a Jupyter shell and able to load and view images via Napari as expected.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
