### PR TITLE
nixos/systemd-boot-builder: Allow characters like before

### DIFF
--- a/nixos/modules/system/activation/specialisation.nix
+++ b/nixos/modules/system/activation/specialisation.nix
@@ -2,13 +2,9 @@
 
 let
   inherit (lib)
-    attrNames
     concatStringsSep
-    filter
-    length
     mapAttrs
     mapAttrsToList
-    match
     mkOption
     types
     ;
@@ -77,19 +73,6 @@ in
   };
 
   config = {
-    assertions = [(
-      let
-        invalidNames = filter (name: match "[[:alnum:]_]+" name == null) (attrNames config.specialisation);
-      in
-      {
-        assertion = length invalidNames == 0;
-        message = ''
-          Specialisation names can only contain alphanumeric characters and underscores
-          Invalid specialisation names: ${concatStringsSep ", " invalidNames}
-        '';
-      }
-    )];
-
     system.systemBuilderCommands = ''
       mkdir $out/specialisation
       ${concatStringsSep "\n"

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -65,7 +65,7 @@ class Entry:
         # Matching nixos*-generation-$number*.conf
         rex_generation = re.compile(r"^nixos.*-generation-([0-9]+).*\.conf$")
         # Matching nixos*-generation-$number-specialisation-$specialisation_name*.conf
-        rex_specialisation = re.compile(r"^nixos.*-generation-([0-9]+)-specialisation-([a-zA-Z0-9_]+).*\.conf$")
+        rex_specialisation = re.compile(r"^nixos.*-generation-([0-9]+)-specialisation-(.+?)(\+\d(-\d)?)?\.conf$")
         profile = rex_profile.sub(r"\1", filename) if rex_profile.match(filename) else None
         specialisation = rex_specialisation.sub(r"\2", filename) if rex_specialisation.match(filename) else None
         try:

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -382,6 +382,24 @@ in {
         assertion = cfg.installDeviceTree -> config.hardware.deviceTree.enable -> config.hardware.deviceTree.name != null;
         message = "Cannot install devicetree without 'config.hardware.deviceTree.enable' enabled and 'config.hardware.deviceTree.name' set";
       }
+      (let
+        invalidNames = filter (name: match ".*\\+[[:digit:]]+(-[[:digit:]]+)?$" name != null) (attrNames config.specialisation);
+      in {
+        assertion = length invalidNames == 0;
+        message = ''
+          Specialisation names may not end in valid boot counts when systemd-boot is enabled. See https://uapi-group.org/specifications/specs/boot_loader_specification/#boot-counting
+          Invalid specialisation names: ${concatStringsSep ", " invalidNames}
+        '';
+      })
+      (let
+        invalidNames = filter (name: match ".*\\+.*" name != null) (attrNames config.specialisation);
+      in {
+        assertion = cfg.bootCounting.enable -> length invalidNames == 0;
+        message = ''
+          Specialisation names may not contain '+' when boot counting is enabled, as systemd-boot does not behave correctly.
+          Invalid specialisation names: ${concatStringsSep ", " invalidNames}
+        '';
+      })
     ] ++ concatMap (filename: [
       {
         assertion = !(hasInfix "/" filename);

--- a/nixos/tests/nixos-rebuild-specialisations.nix
+++ b/nixos/tests/nixos-rebuild-specialisations.nix
@@ -78,11 +78,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
             <nixpkgs/nixos/modules/testing/test-instrumentation.nix>
           ];
 
-          boot.loader.grub = {
-            enable = true;
-            device = "/dev/vda";
-            forceInstall = true;
-          };
+          boot.loader.systemd-boot.enable = true;
 
           documentation.enable = false;
 
@@ -90,7 +86,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
             (pkgs.writeShellScriptBin "parent" "")
           ];
 
-          specialisation.foo-bar = {
+          specialisation."foo+3" = {
             inheritParentConfig = true;
 
             configuration = { ... }: { };
@@ -148,6 +144,8 @@ import ./make-test-python.nix ({ pkgs, ... }: {
           "/etc/nixos/configuration.nix",
       )
       with subtest("Make sure that invalid specialisation names are rejected"):
-          machine.fail("nixos-rebuild switch")
+          output = machine.fail("nixos-rebuild switch 2>&1")
+          print("output was: " + output)
+          assert "Specialisation names may not end in valid boot counts" in output
     '';
 })


### PR DESCRIPTION
## Description of changes

Reverts #333952

Modify the regex in `systemd-boot-builder.py` to match specialisation names correctly.

Similar to #333857, but this regex works with boot counting, I've reverted the faulty mitigation that was merged in the meantime, and I've added a test.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
