### PR TITLE
openbao: init at 2.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10023,6 +10023,12 @@
     github = "jooooscha";
     githubId = 57965027;
   };
+  joseph-flinn = {
+    name = "Joseph Flinn";
+    email = "joseph.s.flinn@gmail.com";
+    github = "joseph-flinn";
+    githubId = 58369717;
+  };
   josephst = {
     name = "Joseph Stahl";
     email = "hello@josephstahl.com";

--- a/pkgs/by-name/op/openbao/package.nix
+++ b/pkgs/by-name/op/openbao/package.nix
@@ -1,0 +1,83 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  installShellFiles,
+  nixosTests,
+  makeWrapper,
+  gawk,
+  glibc,
+  testers,
+  openbao,
+}:
+
+buildGoModule rec {
+  pname = "openbao";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "openbao";
+    repo = "openbao";
+    rev = "v${version}";
+    hash = "sha256-2dylOra/XuAQMIeb05Lp2nqLxXhPmSK+4poSaZ0GzJs=";
+  };
+
+  vendorHash = "sha256-vdjoYw0VWNdMYJERFj2RAO63WbDShgeyNili5BFEPUk=";
+
+  proxyVendor = true;
+
+  subPackages = [ "." ];
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ];
+
+  tags = [
+    "openbao"
+    "bao"
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/openbao/openbao/version.GitCommit=${src.rev}"
+  ];
+
+  postInstall =
+    ''
+      mv $out/bin/openbao $out/bin/bao
+      echo "complete -C $out/bin/bao bao" > bao.bash
+      installShellCompletion bao.bash
+    ''
+    + lib.optionalString stdenv.isLinux ''
+      wrapProgram $out/bin/bao \
+        --prefix PATH ${
+          lib.makeBinPath [
+            gawk
+            glibc
+          ]
+        }
+    '';
+
+  # TODO: Enable the NixOS tests after adding OpenBao as a NixOS service in an upcoming PR and
+  # adding NixOS tests
+  #
+  # passthru.tests = { inherit (nixosTests) vault vault-postgresql vault-dev vault-agent; };
+
+  passthru.tests.version = testers.testVersion {
+    package = openbao;
+    command = "HOME=$(mktemp -d) bao --version";
+    version = "v${version}";
+  };
+
+  meta = with lib; {
+    homepage = "https://www.openbao.org/";
+    description = "Open source, community-driven fork of Vault managed by the Linux Foundation";
+    changelog = "https://github.com/openbao/openbao/blob/v${version}/CHANGELOG.md";
+    license = licenses.mpl20;
+    mainProgram = "bao";
+    maintainers = with maintainers; [ joseph-flinn ];
+  };
+}


### PR DESCRIPTION
## Description of changes
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add OpenBao as a package with the initial version as 2.0.0.

Homepage: https://openbao.org
GitHub: https://github.com/openbao/openbao
Changelog: https://github.com/openbao/openbao/blob/main/CHANGELOG.md

### Request for specific review
This is my first addition to `nixpkgs` and there are two areas that I would like to call out for specific review.

#### Applicable Tests
Included in this change is a simple inline package test as a stand-in until OpenBao is added as a NixOS service in upcoming PR. A `TODO` has been left with hints to the tests that have yet to be ported over from Vault. Since there is currently only minimal NixOS testing and only the default `checkPhase` testing from `buildGoModule`, I have left the "Tested, as applicable" unchecked for now. Is this sufficient until OpenBao can be added to NixOS as a service?

### Resolves
- https://github.com/NixOS/nixpkgs/issues/300943

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
