### PR TITLE
python312Packages.ignite: refactor

### DIFF
--- a/pkgs/development/python-modules/ignite/default.nix
+++ b/pkgs/development/python-modules/ignite/default.nix
@@ -2,22 +2,23 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonOlder,
+  setuptools,
   pytestCheckHook,
   pytest-xdist,
   torchvision,
-  pythonOlder,
   matplotlib,
   mock,
   packaging,
   torch,
-  scikit-learn,
-  tqdm,
 }:
 
 buildPythonPackage rec {
   pname = "ignite";
   version = "0.5.1";
-  format = "setuptools";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "pytorch";
@@ -26,18 +27,19 @@ buildPythonPackage rec {
     hash = "sha256-J0xrqAGwH0bAs59T7zA8irMWOGbE2+Zd9kwqxYUYYMA=";
   };
 
+  build-system = [ setuptools ];
+
+  dependencies = [
+    packaging
+    torch
+  ];
+
   nativeCheckInputs = [
     pytestCheckHook
     matplotlib
     mock
     pytest-xdist
     torchvision
-  ];
-  propagatedBuildInputs = [
-    packaging
-    torch
-    scikit-learn
-    tqdm
   ];
 
   # runs successfully in 3.9, however, async isn't correctly closed so it will fail after test suite.
@@ -76,10 +78,22 @@ buildPythonPackage rec {
     "visdom"
   ];
 
-  meta = with lib; {
+  pythonImportsCheck = [
+    "ignite"
+    "ignite.engine"
+    "ignite.handlers"
+    "ignite.metrics"
+    "ignite.distributed"
+    "ignite.exceptions"
+    "ignite.utils"
+    "ignite.contrib"
+  ];
+
+  meta = {
     description = "High-level training library for PyTorch";
-    homepage = "https://pytorch.org/ignite";
-    license = licenses.bsd3;
-    maintainers = [ maintainers.bcdarwin ];
+    homepage = "https://pytorch-ignite.ai";
+    changelog = "https://github.com/pytorch/ignite/releases/tag/v${version}";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.bcdarwin ];
   };
 }


### PR DESCRIPTION
## Description of changes

Add changelog, refactor meta, update homepage, add `nativeImportsCheck`, add `disabled`, etc.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
